### PR TITLE
feat: add DOCX, XLSX, .ipynb, and .rmd/.qmd indexing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /models
 .spelunk/
 .claude/settings.local.json
+.claude/worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,10 +162,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "calamine"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3a315226fdc5b1c3e33521073e1712a05944bc0664d665ff1f6ff0396334da"
+dependencies = [
+ "byteorder",
+ "chrono",
+ "codepage",
+ "encoding_rs",
+ "log",
+ "once_cell",
+ "quick-xml",
+ "serde",
+ "zip",
+]
 
 [[package]]
 name = "cc"
@@ -170,6 +217,16 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "clap"
@@ -210,6 +267,21 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -263,6 +335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +367,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dirs"
@@ -317,6 +404,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "docx-rs"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70395eb132dcc1761533e62c54878a9deb2b637863ecb52e9c5f66148616398e"
+dependencies = [
+ "base64",
+ "image",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "xml-rs",
+ "zip",
 ]
 
 [[package]]
@@ -369,10 +471,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -495,6 +636,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +675,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -808,6 +970,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +1137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1155,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -991,6 +1191,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1109,6 +1318,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1365,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,7 +1418,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1479,6 +1723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,8 +1757,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "blake3",
+ "calamine",
  "clap",
  "dirs",
+ "docx-rs",
  "futures-util",
  "ignore",
  "indicatif",
@@ -1518,7 +1770,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlite-vec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "toml",
  "tracing",
@@ -1644,7 +1896,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1659,12 +1920,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2287,6 +2573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +2883,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,7 +2992,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +458,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,12 +659,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -638,6 +688,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -674,6 +735,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -799,6 +861,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -1289,6 +1357,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1501,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -1669,6 +1757,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1779,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -1789,6 +1892,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,15 +1985,19 @@ dependencies = [
  "futures-util",
  "ignore",
  "indicatif",
+ "pretty_assertions",
  "regex",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "sqlite-vec",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -1884,6 +2017,7 @@ dependencies = [
  "tree-sitter-sequel",
  "tree-sitter-typescript",
  "utoipa",
+ "wiremock",
 ]
 
 [[package]]
@@ -2908,6 +3042,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3163,12 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,26 @@ indicatif = "0.18"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[dev-dependencies]
+
+# Temporary files/directories for integration tests
+tempfile = "3"
+
+# HTTP mock server for LM Studio API tests
+wiremock = "0.6"
+
+# Cleaner assertion diffs
+pretty_assertions = "1"
+
+# Serialise assertions stay serial (sqlite-vec auto_extension is process-global)
+serial_test = "3"
+
+# axum oneshot testing
+tower = { version = "0.5", features = ["util"] }
+
+# OpenAPI docs
+utoipa = { version = "5", features = ["axum_extras"] }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ regex = { version = "1", default-features = false, features = ["std"] }
 # Content hashing (change detection for incremental indexing)
 blake3 = "1"
 
+# Document format parsers
+docx-rs  = "0.4"
+calamine = { version = "0.24", features = ["dates"] }
+
 # Filesystem traversal + .gitignore support
 ignore = "0.4"
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -7,7 +7,11 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use crate::{
     config::{resolve_db, Config},
     embeddings::{vec_to_blob, EmbeddingBackend as _},
-    indexer::{graph::EdgeExtractor, parser::{detect_language, detect_text_language, is_binary_file, SourceParser}},
+    indexer::{
+        docparser::parse_doc,
+        graph::EdgeExtractor,
+        parser::{detect_doc_language, detect_language, detect_text_language, is_binary_file, SourceParser},
+    },
     registry::Registry,
     search::SearchResult,
     storage::{Database, MemoryStore},
@@ -70,7 +74,9 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
         .filter(|e| {
             let p = e.path();
-            detect_language(p).is_some() || detect_text_language(p).is_some()
+            detect_language(p).is_some()
+                || detect_text_language(p).is_some()
+                || detect_doc_language(p).is_some()
         })
         .collect();
 
@@ -98,6 +104,60 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         let path_str = path.to_string_lossy();
         parse_bar.set_message(short_path(&path_str));
 
+        // ── Binary document formats (DOCX, XLSX, …) ──────────────────────────
+        // These cannot be read with read_to_string and have no call graph.
+        if let Some(doc_lang) = detect_doc_language(path) {
+            let bytes = match std::fs::read(path) {
+                Ok(b)  => b,
+                Err(e) => {
+                    tracing::warn!("read error for {path_str}: {e}");
+                    parse_bar.inc(1);
+                    continue;
+                }
+            };
+            let hash = format!("{}", blake3::hash(&bytes));
+            if !args.force {
+                if let Some(existing) = db.file_hash(&path_str)? {
+                    if existing == hash {
+                        skipped += 1;
+                        parse_bar.inc(1);
+                        continue;
+                    }
+                }
+            }
+            let chunks = parse_doc(&bytes, &path_str, doc_lang);
+            let file_id = db.upsert_file(&path_str, Some(doc_lang), &hash)?;
+            db.delete_embeddings_for_file(file_id)?;
+            db.delete_chunks_for_file(file_id)?;
+            for chunk in &chunks {
+                if crate::indexer::secrets::contains_secret(&chunk.content) {
+                    tracing::warn!(
+                        "skipping chunk '{}' in {path_str} (possible secret detected)",
+                        chunk.name.as_deref().unwrap_or("<anonymous>"),
+                    );
+                    continue;
+                }
+                let metadata = serde_json::json!({
+                    "docstring": chunk.docstring,
+                    "parent_scope": chunk.parent_scope,
+                });
+                let chunk_id = db.insert_chunk(
+                    file_id,
+                    &chunk.kind.to_string(),
+                    chunk.name.as_deref(),
+                    chunk.start_line,
+                    chunk.end_line,
+                    &chunk.content,
+                    Some(&metadata.to_string()),
+                )?;
+                chunk_ids_and_texts.push((chunk_id, chunk.embedding_text()));
+            }
+            indexed += 1;
+            parse_bar.inc(1);
+            continue;
+        }
+
+        // ── Text / code formats ───────────────────────────────────────────────
         let language = detect_language(path)
             .or_else(|| detect_text_language(path))
             .unwrap(); // safe: files were filtered to only include detectable files

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -15,7 +15,10 @@ use crate::{
     indexer::{
         docparser::parse_doc,
         graph::EdgeExtractor,
-        parser::{detect_doc_language, detect_language, detect_text_language, is_binary_file, SourceParser},
+        parser::{
+            SourceParser, detect_doc_language, detect_language, detect_text_language,
+            is_binary_file,
+        },
     },
     registry::Registry,
     search::SearchResult,
@@ -128,7 +131,7 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         // These cannot be read with read_to_string and have no call graph.
         if let Some(doc_lang) = detect_doc_language(path) {
             let bytes = match std::fs::read(path) {
-                Ok(b)  => b,
+                Ok(b) => b,
                 Err(e) => {
                     tracing::warn!("read error for {path_str}: {e}");
                     parse_bar.inc(1);
@@ -136,14 +139,13 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
                 }
             };
             let hash = format!("{}", blake3::hash(&bytes));
-            if !args.force {
-                if let Some(existing) = db.file_hash(&path_str)? {
-                    if existing == hash {
-                        skipped += 1;
-                        parse_bar.inc(1);
-                        continue;
-                    }
-                }
+            if !args.force
+                && let Some(existing) = db.file_hash(&path_str)?
+                && existing == hash
+            {
+                skipped += 1;
+                parse_bar.inc(1);
+                continue;
             }
             let chunks = parse_doc(&bytes, &path_str, doc_lang);
             let file_id = db.upsert_file(&path_str, Some(doc_lang), &hash)?;

--- a/src/indexer/docparser.rs
+++ b/src/indexer/docparser.rs
@@ -1,0 +1,177 @@
+//! Parsers for binary document formats: DOCX and spreadsheets (XLSX/XLS/ODS).
+//!
+//! These formats cannot be read with `std::fs::read_to_string` and bypass the
+//! tree-sitter pipeline entirely.  Each parser extracts plain text and returns
+//! chunks suitable for embedding.
+
+use super::chunker::{sliding_window, Chunk, ChunkKind};
+
+// ---------------------------------------------------------------------------
+// Public dispatch
+// ---------------------------------------------------------------------------
+
+/// Parse a binary document and return embeddable chunks.
+/// `language` must be `"docx"` or `"spreadsheet"`.
+pub fn parse_doc(bytes: &[u8], file_path: &str, language: &str) -> Vec<Chunk> {
+    match language {
+        "docx"        => parse_docx(bytes, file_path),
+        "spreadsheet" => parse_spreadsheet(bytes, file_path),
+        other => {
+            tracing::warn!("docparser: unknown doc language '{other}' for {file_path}");
+            vec![]
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DOCX
+// ---------------------------------------------------------------------------
+
+/// Extract text from a DOCX file and return as sliding-window chunks.
+fn parse_docx(bytes: &[u8], file_path: &str) -> Vec<Chunk> {
+    let doc = match docx_rs::read_docx(bytes) {
+        Ok(d)  => d,
+        Err(e) => {
+            tracing::warn!("failed to parse DOCX {file_path}: {e}");
+            return vec![];
+        }
+    };
+
+    let mut lines: Vec<String> = Vec::new();
+    collect_doc_text(&doc.document.children, &mut lines);
+
+    if lines.is_empty() {
+        return vec![];
+    }
+
+    sliding_window(&lines.join("\n"), file_path, "docx", 120, 15)
+}
+
+/// Recursively collect plain text lines from document children.
+fn collect_doc_text(children: &[docx_rs::DocumentChild], out: &mut Vec<String>) {
+    for child in children {
+        match child {
+            docx_rs::DocumentChild::Paragraph(p) => {
+                let text = para_text(p);
+                if !text.trim().is_empty() {
+                    out.push(text);
+                }
+            }
+            docx_rs::DocumentChild::Table(table) => {
+                for docx_rs::TableChild::TableRow(row) in &table.rows {
+                    let mut cells: Vec<String> = Vec::new();
+                    for docx_rs::TableRowChild::TableCell(cell) in &row.cells {
+                        let cell_text: Vec<String> = cell.children.iter()
+                            .filter_map(|tc| {
+                                if let docx_rs::TableCellContent::Paragraph(p) = tc {
+                                    let t = para_text(p);
+                                    if t.trim().is_empty() { None } else { Some(t) }
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+                        if !cell_text.is_empty() {
+                            cells.push(cell_text.join(" "));
+                        }
+                    }
+                    if !cells.is_empty() {
+                        out.push(cells.join(" | "));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Extract plain text from a single paragraph's runs.
+fn para_text(p: &docx_rs::Paragraph) -> String {
+    p.children.iter().filter_map(|child| {
+        if let docx_rs::ParagraphChild::Run(run) = child {
+            Some(run_text(run))
+        } else {
+            None
+        }
+    }).collect()
+}
+
+fn run_text(run: &docx_rs::Run) -> String {
+    run.children.iter().filter_map(|rc| {
+        if let docx_rs::RunChild::Text(t) = rc { Some(t.text.as_str()) } else { None }
+    }).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Spreadsheets (XLSX / XLS / ODS via calamine)
+// ---------------------------------------------------------------------------
+
+/// Extract spreadsheet data and return one chunk per sheet (or sliding-window
+/// chunks for sheets with more than 120 rows).
+fn parse_spreadsheet(bytes: &[u8], file_path: &str) -> Vec<Chunk> {
+    use calamine::{open_workbook_auto_from_rs, Reader};
+    use std::io::Cursor;
+
+    let cursor = Cursor::new(bytes.to_vec());
+    let mut wb = match open_workbook_auto_from_rs(cursor) {
+        Ok(w)  => w,
+        Err(e) => {
+            tracing::warn!("failed to open spreadsheet {file_path}: {e}");
+            return vec![];
+        }
+    };
+
+    let sheet_names = wb.sheet_names().to_vec();
+    let mut chunks = Vec::new();
+
+    for sheet_name in &sheet_names {
+        let range: calamine::Range<calamine::Data> = match wb.worksheet_range(sheet_name) {
+            Ok(r)  => r,
+            Err(e) => {
+                tracing::warn!("failed to read sheet '{sheet_name}' in {file_path}: {e}");
+                continue;
+            }
+        };
+
+        let lines: Vec<String> = range
+            .rows()
+            .map(|row| {
+                row.iter()
+                    .map(|cell: &calamine::Data| cell.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\t")
+            })
+            .filter(|line: &String| !line.trim().is_empty())
+            .collect();
+
+        if lines.is_empty() {
+            continue;
+        }
+
+        let content = lines.join("\n");
+        let total   = lines.len();
+
+        if total <= 120 {
+            chunks.push(Chunk {
+                file_path:    file_path.to_owned(),
+                language:     "spreadsheet".to_owned(),
+                kind:         ChunkKind::Section,
+                name:         Some(sheet_name.clone()),
+                start_line:   1,
+                end_line:     total,
+                content,
+                docstring:    None,
+                parent_scope: None,
+            });
+        } else {
+            for mut chunk in sliding_window(&content, file_path, "spreadsheet", 120, 15) {
+                chunk.name = Some(format!(
+                    "{} (rows {}–{})", sheet_name, chunk.start_line, chunk.end_line
+                ));
+                chunks.push(chunk);
+            }
+        }
+    }
+
+    chunks
+}

--- a/src/indexer/docparser.rs
+++ b/src/indexer/docparser.rs
@@ -4,7 +4,7 @@
 //! tree-sitter pipeline entirely.  Each parser extracts plain text and returns
 //! chunks suitable for embedding.
 
-use super::chunker::{sliding_window, Chunk, ChunkKind};
+use super::chunker::{Chunk, ChunkKind, sliding_window};
 
 // ---------------------------------------------------------------------------
 // Public dispatch
@@ -14,7 +14,7 @@ use super::chunker::{sliding_window, Chunk, ChunkKind};
 /// `language` must be `"docx"` or `"spreadsheet"`.
 pub fn parse_doc(bytes: &[u8], file_path: &str, language: &str) -> Vec<Chunk> {
     match language {
-        "docx"        => parse_docx(bytes, file_path),
+        "docx" => parse_docx(bytes, file_path),
         "spreadsheet" => parse_spreadsheet(bytes, file_path),
         other => {
             tracing::warn!("docparser: unknown doc language '{other}' for {file_path}");
@@ -30,7 +30,7 @@ pub fn parse_doc(bytes: &[u8], file_path: &str, language: &str) -> Vec<Chunk> {
 /// Extract text from a DOCX file and return as sliding-window chunks.
 fn parse_docx(bytes: &[u8], file_path: &str) -> Vec<Chunk> {
     let doc = match docx_rs::read_docx(bytes) {
-        Ok(d)  => d,
+        Ok(d) => d,
         Err(e) => {
             tracing::warn!("failed to parse DOCX {file_path}: {e}");
             return vec![];
@@ -61,7 +61,9 @@ fn collect_doc_text(children: &[docx_rs::DocumentChild], out: &mut Vec<String>) 
                 for docx_rs::TableChild::TableRow(row) in &table.rows {
                     let mut cells: Vec<String> = Vec::new();
                     for docx_rs::TableRowChild::TableCell(cell) in &row.cells {
-                        let cell_text: Vec<String> = cell.children.iter()
+                        let cell_text: Vec<String> = cell
+                            .children
+                            .iter()
                             .filter_map(|tc| {
                                 if let docx_rs::TableCellContent::Paragraph(p) = tc {
                                     let t = para_text(p);
@@ -87,19 +89,29 @@ fn collect_doc_text(children: &[docx_rs::DocumentChild], out: &mut Vec<String>) 
 
 /// Extract plain text from a single paragraph's runs.
 fn para_text(p: &docx_rs::Paragraph) -> String {
-    p.children.iter().filter_map(|child| {
-        if let docx_rs::ParagraphChild::Run(run) = child {
-            Some(run_text(run))
-        } else {
-            None
-        }
-    }).collect()
+    p.children
+        .iter()
+        .filter_map(|child| {
+            if let docx_rs::ParagraphChild::Run(run) = child {
+                Some(run_text(run))
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn run_text(run: &docx_rs::Run) -> String {
-    run.children.iter().filter_map(|rc| {
-        if let docx_rs::RunChild::Text(t) = rc { Some(t.text.as_str()) } else { None }
-    }).collect()
+    run.children
+        .iter()
+        .filter_map(|rc| {
+            if let docx_rs::RunChild::Text(t) = rc {
+                Some(t.text.as_str())
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -109,12 +121,12 @@ fn run_text(run: &docx_rs::Run) -> String {
 /// Extract spreadsheet data and return one chunk per sheet (or sliding-window
 /// chunks for sheets with more than 120 rows).
 fn parse_spreadsheet(bytes: &[u8], file_path: &str) -> Vec<Chunk> {
-    use calamine::{open_workbook_auto_from_rs, Reader};
+    use calamine::{Reader, open_workbook_auto_from_rs};
     use std::io::Cursor;
 
     let cursor = Cursor::new(bytes.to_vec());
     let mut wb = match open_workbook_auto_from_rs(cursor) {
-        Ok(w)  => w,
+        Ok(w) => w,
         Err(e) => {
             tracing::warn!("failed to open spreadsheet {file_path}: {e}");
             return vec![];
@@ -126,7 +138,7 @@ fn parse_spreadsheet(bytes: &[u8], file_path: &str) -> Vec<Chunk> {
 
     for sheet_name in &sheet_names {
         let range: calamine::Range<calamine::Data> = match wb.worksheet_range(sheet_name) {
-            Ok(r)  => r,
+            Ok(r) => r,
             Err(e) => {
                 tracing::warn!("failed to read sheet '{sheet_name}' in {file_path}: {e}");
                 continue;
@@ -149,24 +161,25 @@ fn parse_spreadsheet(bytes: &[u8], file_path: &str) -> Vec<Chunk> {
         }
 
         let content = lines.join("\n");
-        let total   = lines.len();
+        let total = lines.len();
 
         if total <= 120 {
             chunks.push(Chunk {
-                file_path:    file_path.to_owned(),
-                language:     "spreadsheet".to_owned(),
-                kind:         ChunkKind::Section,
-                name:         Some(sheet_name.clone()),
-                start_line:   1,
-                end_line:     total,
+                file_path: file_path.to_owned(),
+                language: "spreadsheet".to_owned(),
+                kind: ChunkKind::Section,
+                name: Some(sheet_name.clone()),
+                start_line: 1,
+                end_line: total,
                 content,
-                docstring:    None,
+                docstring: None,
                 parent_scope: None,
             });
         } else {
             for mut chunk in sliding_window(&content, file_path, "spreadsheet", 120, 15) {
                 chunk.name = Some(format!(
-                    "{} (rows {}–{})", sheet_name, chunk.start_line, chunk.end_line
+                    "{} (rows {}–{})",
+                    sheet_name, chunk.start_line, chunk.end_line
                 ));
                 chunks.push(chunk);
             }

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1,4 +1,5 @@
 pub mod chunker;
+pub mod docparser;
 pub mod graph;
 pub mod parser;
 pub mod secrets;

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -5,6 +5,6 @@ pub mod parser;
 pub mod secrets;
 
 #[allow(unused_imports)]
-pub use chunker::{Chunk, ChunkKind};
+pub use chunker::{Chunk, ChunkKind, sliding_window};
 #[allow(unused_imports)]
 pub use parser::SourceParser;

--- a/src/indexer/parser.rs
+++ b/src/indexer/parser.rs
@@ -1,12 +1,16 @@
 use anyhow::{bail, Result};
 use super::chunker::{sliding_window, Chunk, ChunkKind};
 
-/// All languages with tree-sitter grammar support.
+/// All languages recognised by the indexer (tree-sitter, text, and document formats).
 pub const SUPPORTED_LANGUAGES: &[&str] =
     &["rust", "python", "javascript", "jsx", "typescript", "tsx", "go", "java",
       "c", "cpp", "json", "html", "css", "hcl", "sql", "proto",
       // text formats (sliding-window / heading-based, no tree-sitter)
-      "markdown", "text"];
+      "markdown", "text",
+      // structured text (custom parsers, no tree-sitter)
+      "notebook",
+      // binary document formats (docparser, no tree-sitter)
+      "docx", "spreadsheet"];
 
 /// Detect language from file extension.
 pub fn detect_language(path: &std::path::Path) -> Option<&'static str> {
@@ -35,14 +39,18 @@ pub(crate) fn ts_language_pub(name: &str) -> Result<tree_sitter::Language> {
     ts_language(name)
 }
 
-/// Detect text-format languages (markdown, plain text) from file path.
+/// Detect text-format languages (markdown, plain text, notebooks) from file path.
 /// These are handled without tree-sitter.
 pub fn detect_text_language(path: &std::path::Path) -> Option<&'static str> {
     // Check extension first
     if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
         return match ext.to_lowercase().as_str() {
-            "md" | "mdx" | "markdown" => Some("markdown"),
+            "md" | "mdx" | "markdown"           => Some("markdown"),
+            // R Markdown / Quarto documents are markdown with fenced code blocks.
+            "rmd" | "qmd"                        => Some("markdown"),
             "txt" | "rst" | "adoc" | "asciidoc" => Some("text"),
+            // Jupyter notebooks: custom JSON-based parser.
+            "ipynb"                              => Some("notebook"),
             _ => None,
         };
     }
@@ -52,6 +60,16 @@ pub fn detect_text_language(path: &std::path::Path) -> Option<&'static str> {
         "README" | "CHANGELOG" | "CHANGES" | "CONTRIBUTING"
         | "NOTICE" | "AUTHORS" | "HISTORY" => Some("text"),
         _ => None,
+    }
+}
+
+/// Detect binary document formats (DOCX, spreadsheets) from file extension.
+/// These are handled by `docparser` — they cannot be read with `read_to_string`.
+pub fn detect_doc_language(path: &std::path::Path) -> Option<&'static str> {
+    match path.extension()?.to_str()?.to_lowercase().as_str() {
+        "docx"                     => Some("docx"),
+        "xlsx" | "xls" | "ods"    => Some("spreadsheet"),
+        _                          => None,
     }
 }
 
@@ -218,6 +236,9 @@ impl SourceParser {
         }
         if language == "text" {
             return Ok(sliding_window(source, file_path, language, 120, 15));
+        }
+        if language == "notebook" {
+            return Ok(parse_notebook(source, file_path));
         }
 
         let ts_lang = ts_language(language)?;
@@ -469,6 +490,100 @@ fn sql_object_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
         }
     }
     None
+}
+
+// ---------------------------------------------------------------------------
+// Jupyter notebook chunker
+// ---------------------------------------------------------------------------
+
+/// Parse a `.ipynb` notebook into per-cell chunks.
+///
+/// Code cells become `Verbatim` chunks tagged with the kernel language.
+/// Markdown/raw cells become `Section` chunks.  Falls back to sliding-window
+/// if the JSON is malformed.
+fn parse_notebook(source: &str, file_path: &str) -> Vec<Chunk> {
+    #[derive(serde::Deserialize)]
+    struct Notebook {
+        cells: Vec<Cell>,
+        #[serde(default)]
+        metadata: NotebookMeta,
+    }
+    #[derive(serde::Deserialize, Default)]
+    struct NotebookMeta {
+        #[serde(default)]
+        kernelspec: Kernelspec,
+    }
+    #[derive(serde::Deserialize, Default)]
+    struct Kernelspec {
+        #[serde(default)]
+        language: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct Cell {
+        cell_type: String,
+        source: CellSource,
+    }
+    /// The `source` field is either a JSON string or an array of strings.
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum CellSource {
+        Lines(Vec<String>),
+        Blob(String),
+    }
+    impl CellSource {
+        fn text(&self) -> String {
+            match self {
+                Self::Lines(v) => v.join(""),
+                Self::Blob(s)  => s.clone(),
+            }
+        }
+    }
+
+    let nb: Notebook = match serde_json::from_str(source) {
+        Ok(n)  => n,
+        Err(e) => {
+            tracing::warn!("failed to parse notebook {file_path}: {e}");
+            return sliding_window(source, file_path, "notebook", 120, 15);
+        }
+    };
+
+    let kernel_lang = if nb.metadata.kernelspec.language.is_empty() {
+        "python".to_owned()
+    } else {
+        nb.metadata.kernelspec.language.clone()
+    };
+
+    let mut chunks = Vec::new();
+    let mut line   = 1usize;
+
+    for (idx, cell) in nb.cells.iter().enumerate() {
+        let text = cell.source.text();
+        if text.trim().is_empty() {
+            continue;
+        }
+        let line_count = text.lines().count().max(1);
+        let (kind, lang) = match cell.cell_type.as_str() {
+            "markdown" | "raw" => (ChunkKind::Section,  "markdown"),
+            _                   => (ChunkKind::Verbatim, kernel_lang.as_str()),
+        };
+        chunks.push(Chunk {
+            file_path:    file_path.to_owned(),
+            language:     lang.to_owned(),
+            kind,
+            name:         Some(format!("cell {}", idx + 1)),
+            start_line:   line,
+            end_line:     line + line_count - 1,
+            content:      text,
+            docstring:    None,
+            parent_scope: None,
+        });
+        line += line_count;
+    }
+
+    if chunks.is_empty() {
+        return sliding_window(source, file_path, "notebook", 120, 15);
+    }
+    chunks
 }
 
 // ---------------------------------------------------------------------------

--- a/src/indexer/parser.rs
+++ b/src/indexer/parser.rs
@@ -62,12 +62,12 @@ pub fn detect_text_language(path: &std::path::Path) -> Option<&'static str> {
     // Check extension first
     if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
         return match ext.to_lowercase().as_str() {
-            "md" | "mdx" | "markdown"           => Some("markdown"),
+            "md" | "mdx" | "markdown" => Some("markdown"),
             // R Markdown / Quarto documents are markdown with fenced code blocks.
-            "rmd" | "qmd"                        => Some("markdown"),
+            "rmd" | "qmd" => Some("markdown"),
             "txt" | "rst" | "adoc" | "asciidoc" => Some("text"),
             // Jupyter notebooks: custom JSON-based parser.
-            "ipynb"                              => Some("notebook"),
+            "ipynb" => Some("notebook"),
             _ => None,
         };
     }
@@ -85,9 +85,9 @@ pub fn detect_text_language(path: &std::path::Path) -> Option<&'static str> {
 /// These are handled by `docparser` — they cannot be read with `read_to_string`.
 pub fn detect_doc_language(path: &std::path::Path) -> Option<&'static str> {
     match path.extension()?.to_str()?.to_lowercase().as_str() {
-        "docx"                     => Some("docx"),
-        "xlsx" | "xls" | "ods"    => Some("spreadsheet"),
-        _                          => None,
+        "docx" => Some("docx"),
+        "xlsx" | "xls" | "ods" => Some("spreadsheet"),
+        _ => None,
     }
 }
 
@@ -580,13 +580,13 @@ fn parse_notebook(source: &str, file_path: &str) -> Vec<Chunk> {
         fn text(&self) -> String {
             match self {
                 Self::Lines(v) => v.join(""),
-                Self::Blob(s)  => s.clone(),
+                Self::Blob(s) => s.clone(),
             }
         }
     }
 
     let nb: Notebook = match serde_json::from_str(source) {
-        Ok(n)  => n,
+        Ok(n) => n,
         Err(e) => {
             tracing::warn!("failed to parse notebook {file_path}: {e}");
             return sliding_window(source, file_path, "notebook", 120, 15);
@@ -600,7 +600,7 @@ fn parse_notebook(source: &str, file_path: &str) -> Vec<Chunk> {
     };
 
     let mut chunks = Vec::new();
-    let mut line   = 1usize;
+    let mut line = 1usize;
 
     for (idx, cell) in nb.cells.iter().enumerate() {
         let text = cell.source.text();
@@ -609,18 +609,18 @@ fn parse_notebook(source: &str, file_path: &str) -> Vec<Chunk> {
         }
         let line_count = text.lines().count().max(1);
         let (kind, lang) = match cell.cell_type.as_str() {
-            "markdown" | "raw" => (ChunkKind::Section,  "markdown"),
-            _                   => (ChunkKind::Verbatim, kernel_lang.as_str()),
+            "markdown" | "raw" => (ChunkKind::Section, "markdown"),
+            _ => (ChunkKind::Verbatim, kernel_lang.as_str()),
         };
         chunks.push(Chunk {
-            file_path:    file_path.to_owned(),
-            language:     lang.to_owned(),
+            file_path: file_path.to_owned(),
+            language: lang.to_owned(),
             kind,
-            name:         Some(format!("cell {}", idx + 1)),
-            start_line:   line,
-            end_line:     line + line_count - 1,
-            content:      text,
-            docstring:    None,
+            name: Some(format!("cell {}", idx + 1)),
+            start_line: line,
+            end_line: line + line_count - 1,
+            content: text,
+            docstring: None,
             parent_scope: None,
         });
         line += line_count;


### PR DESCRIPTION
## Summary

- **DOCX** (`.docx`): extracts paragraphs and table rows via `docx-rs`, then applies sliding-window chunking. Uses a separate bytes-read path in the indexer (skips `EdgeExtractor` — documents have no call graph).
- **Spreadsheets** (`.xlsx`/`.xls`/`.ods`): reads all sheets via `calamine` (`open_workbook_auto_from_rs`). Each sheet → one `Section` chunk; sheets >120 rows are split by sliding window with the sheet name preserved.
- **Jupyter notebooks** (`.ipynb`): JSON-parsed with `serde_json`. Code cells → `Verbatim` chunks tagged with the kernel language; markdown/raw cells → `Section` chunks. Falls back to sliding window on malformed JSON.
- **R Markdown / Quarto** (`.rmd`/`.qmd`): mapped to `"markdown"` in `detect_text_language` — reuses the existing ATX heading-based chunker with no new code.

## Architecture notes

Binary formats (`.docx`, `.xlsx`/`.xls`/`.ods`) go through a new `detect_doc_language()` and a dedicated bytes-read branch at the top of the indexing loop in `commands.rs`. Text-based formats (`.ipynb`, `.rmd`, `.qmd`) flow through the existing `detect_text_language()` → `SourceParser::parse()` path unchanged.

## Files changed

| File | Change |
|---|---|
| `Cargo.toml` | Add `docx-rs = "0.4"` and `calamine = "0.24"` |
| `src/indexer/docparser.rs` | **New** — `parse_doc()`, `parse_docx()`, `parse_spreadsheet()` |
| `src/indexer/parser.rs` | New extensions in `detect_text_language`; new `detect_doc_language`; `parse_notebook`; `"notebook"/"docx"/"spreadsheet"` in `SUPPORTED_LANGUAGES` |
| `src/indexer/mod.rs` | Register `pub mod docparser` |
| `src/cli/commands.rs` | Binary-doc branch (bytes read, no edge extraction); doc files included in walk filter |

## Test plan

- [ ] `cargo build` passes cleanly (verified locally)
- [ ] Index a directory containing `.docx` files — confirm chunks appear in `spelunk chunks`
- [ ] Index a `.xlsx` workbook — confirm one chunk per sheet
- [ ] Index a `.ipynb` notebook — confirm code cells and markdown cells produce separate chunks with correct language tags
- [ ] Index a `.rmd` file — confirm heading-based sections are produced
- [ ] Re-index unchanged files — confirm they are skipped (hash cache)
- [ ] `spelunk languages` lists `notebook`, `docx`, `spreadsheet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)