### PR TITLE
feat(ux): de-emphasise ask command, make llm_model optional (#5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,10 @@ spelunk memory list --kind question              # check open questions
 **Before reading any file, search first:**
 ```bash
 spelunk search "<topic>"          # find relevant chunks by meaning
-spelunk ask "<question>"          # get a synthesised answer with citations
 spelunk graph <symbol>            # trace callers/callees when needed
 ```
+
+spelunk retrieves context — you synthesise the answer.
 
 **Store decisions as you make them** — don't wait until the end:
 ```bash
@@ -44,11 +45,14 @@ Full reference: `SKILL.md` and `docs/agent-guide.md`.
 
 `spelunk` (`spelunk`) is a Rust CLI that indexes a source tree using
 tree-sitter AST chunking, embeds every chunk via the LM Studio API
-(EmbeddingGemma 300M), stores vectors in SQLite, and answers natural language
-questions via a RAG pipeline backed by any chat model loaded in LM Studio.
+(EmbeddingGemma 300M), and stores vectors in SQLite for semantic search.
+
+It is a **context retrieval engine** for AI agents like you. You search with
+spelunk, then reason over the results yourself.
 
 **Requirement**: LM Studio running at `http://127.0.0.1:1234` (configurable)
-with an embedding model and a chat model loaded.
+with an **embedding model** loaded. A chat model is optional (enables `memory harvest`
+and `plan create`).
 
 ---
 
@@ -127,9 +131,7 @@ EmbeddingGemma's recommended document retrieval format:
 ```
 title: {name | "none"} | text: {content}
 ```
-Query-side prefixes are task-specific:
-- `spelunk search` → `task: code retrieval | query: {q}`
-- `spelunk ask`    → `task: question answering | query: {q}`
+Query-side prefix: `task: code retrieval | query: {q}`
 
 See `Chunk::embedding_text()` in `src/indexer/chunker.rs`.
 
@@ -144,8 +146,8 @@ Changed files: delete old chunks + embeddings, reparse, re-embed.
 
 ### Multi-project registry
 `~/.config/spelunk/registry.db` tracks all indexed projects and their
-dependency links. `spelunk search` and `spelunk ask` automatically query all linked
-project DBs and merge results by distance.
+dependency links. `spelunk search` automatically queries all linked project DBs
+and merges results by distance.
 
 ### Secret scanning
 `src/indexer/secrets.rs` runs before each chunk is stored. Chunks matching
@@ -184,8 +186,6 @@ cargo build --release
 # Run the CLI
 cargo run -- index ./some/project
 cargo run -- search "how does authentication work"
-cargo run -- ask "explain the error handling strategy"
-cargo run -- ask "what files handle auth" --json
 cargo run -- status
 cargo run -- status --all
 cargo run -- graph <symbol>

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,15 +1,19 @@
 # spelunk — AI Agent Skill Reference
 
-How to use `spelunk` as an AI agent to understand, search, and answer questions
-about a codebase — and to build up a persistent memory of why it was built
+How to use `spelunk` as an AI agent to understand, search, and query
+a codebase — and to build up a persistent memory of why it was built
 the way it was.
+
+spelunk is a **context retrieval tool** for AI agents. You are the reasoning
+engine. Use spelunk to find the right code and prior decisions, then reason
+over that context yourself.
 
 ---
 
 ## Prerequisites
 
 - `spelunk` installed and in PATH (`cargo install --path .` or copy the binary)
-- LM Studio running with an embedding model and a chat model loaded
+- LM Studio running with an **embedding model** loaded (required for all search)
 - Default endpoint: `http://127.0.0.1:1234` (override with `lmstudio_base_url`
   in `~/.config/spelunk/config.toml`)
 
@@ -44,19 +48,9 @@ spelunk search "<query>" --graph             # enrich with call-graph neighbours
 Returns ranked chunks with file path, line range, language, symbol name, and
 a content preview. Use `--format json` for programmatic access.
 
-### Ask — answer a question
-
-```bash
-spelunk ask "<question>"
-spelunk ask "<question>" --context-chunks 30     # retrieve more context (max 100)
-spelunk ask "<question>" --json                  # structured output
-```
-
-`--json` returns: `{"answer": "...", "relevant_files": [...], "confidence": "high|medium|low"}`
-
-`spelunk ask` automatically includes both code context (HOW the system is built) and
-memory context (WHAT was decided and WHY) when both are available. No extra flags
-needed — if `memory.db` exists and has relevant entries, they are included.
+**This is the primary tool.** Use it to retrieve context, then reason over the
+results yourself — the same way `spelunk ask` does internally, but you are the
+reasoning engine.
 
 ### Chunks — inspect what was indexed
 
@@ -177,8 +171,8 @@ spelunk index <project-root>
 If you changed the embedding model or prompt format, add `--force` to
 regenerate all embeddings from scratch.
 
-Not re-indexing means searches and `spelunk ask` will miss new code and may
-surface deleted code. Make it the last step of any commit workflow.
+Not re-indexing means searches will miss new code and may surface deleted code.
+Make it the last step of any commit workflow.
 
 ---
 
@@ -245,7 +239,7 @@ Store a memory entry whenever any of the following occurs:
 2. Read the files at the reported line ranges
 3. `spelunk graph <symbol>` to trace call chains or imports
 4. `spelunk memory search "<topic>"` — check if there's recorded context explaining *why*
-5. `spelunk ask "<question>"` for a synthesised answer when needed
+5. Synthesise an answer from the retrieved context yourself
 
 **For code changes:**
 1. Search and read before changing
@@ -253,9 +247,9 @@ Store a memory entry whenever any of the following occurs:
 3. If the human explains a constraint that shaped your approach, store it too
 4. After committing, re-index: `spelunk index <project-root>`
 
-**For structured answers (pipelines):**
+**For structured context retrieval (pipelines):**
 ```bash
-spelunk ask "<question>" --json | jq '.answer'
+spelunk search "<topic>" --format json | jq '.[].content'
 spelunk memory search "<topic>" --format json | jq '.[].body'
 ```
 
@@ -270,8 +264,8 @@ spelunk unlink <path-to-B>
 spelunk autoclean        # remove registry entries for deleted projects
 ```
 
-Once linked, `spelunk search` and `spelunk ask` query both indexes and merge results
-by semantic distance. Memory is always per-project.
+Once linked, `spelunk search` queries both indexes and merges results by semantic
+distance. Memory is always per-project.
 
 ---
 
@@ -282,15 +276,12 @@ machine-readable output without extra flags:
 
 ```bash
 AGENT=true spelunk search "authentication flow"        # → JSON, no spinner
-AGENT=true spelunk ask "how does the indexer work"     # → JSON schema output, no spinner
 AGENT=true spelunk graph src/storage/db.rs             # → JSON
 AGENT=true spelunk memory search "storage decisions"   # → JSON
 ```
 
 What changes when `AGENT=true` is set:
 - All `--format text` defaults become `--format json` automatically.
-- `spelunk ask` behaves as if `--json` was passed: returns
-  `{"answer":"...","relevant_files":[...],"confidence":"..."}`.
 - Progress spinners and animated progress bars are suppressed, keeping stdout
   clean for downstream parsing.
 
@@ -306,6 +297,5 @@ You can still pass `--format text` explicitly to override even in agent mode.
   regenerate all embeddings. Also re-run `spelunk memory add` for important entries
   so their embeddings reflect the new model.
 - `spelunk search` and `spelunk memory search` only need the embedding model.
-  `spelunk ask` requires both the embedding model and a chat model.
 - Secret-containing chunks (AWS keys, PEM headers, tokens, etc.) are
   automatically skipped during indexing and will not appear in results.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -2,6 +2,8 @@
 
 `spelunk` is designed to work as infrastructure for AI coding agents, not just as a human developer tool. This guide covers the patterns that make agents most effective when paired with `spelunk`.
 
+**The key mental model**: spelunk retrieves context; you reason over it. Use `spelunk search` to find the right code, read the results, then synthesise the answer yourself — just as you would after reading documentation. spelunk is a fast, semantic grep with memory, not an oracle.
+
 ## The core loop
 
 A productive agentic session with `spelunk` looks like this:
@@ -22,7 +24,6 @@ Set `AGENT=true` and every `spelunk` command returns JSON:
 export AGENT=true
 
 spelunk search "error handling"          # → JSON array of results
-spelunk ask "what does the indexer do"   # → { answer, relevant_files, confidence }
 spelunk status                           # → { files, chunks, embeddings, ... }
 spelunk memory list                      # → JSON array of notes
 spelunk memory search "auth decisions"   # → JSON array of notes with distance scores
@@ -65,14 +66,17 @@ AGENT=true spelunk graph validate_token
 
 The `--graph` flag on `spelunk search` adds 1-hop callers and callees to the result set, which is often exactly the context needed to understand blast radius before a change.
 
-## Asking targeted questions
+## Retrieving targeted context
+
+Use `spelunk search` with a focused query, then read the returned chunks and reason over them yourself:
 
 ```bash
-# Structured answer with confidence score
-AGENT=true spelunk ask "what would break if I change the embedding format?" --json
+# Find what touches the embedding format
+AGENT=true spelunk search "embedding format storage" --graph --format json
 
-# Adjust context window size for complex questions
-AGENT=true spelunk ask "describe the full request lifecycle" --context-chunks 30 --json
+# Trace call chains across the request lifecycle
+AGENT=true spelunk graph handle_request
+AGENT=true spelunk search "request lifecycle middleware" --limit 20 --format json
 ```
 
 ## Creating plans
@@ -170,7 +174,7 @@ spelunk link ../shared-utils
 spelunk link ../api-contracts
 ```
 
-Now `spelunk search` and `spelunk ask` query all three indexes and merge results by distance.
+Now `spelunk search` queries all three indexes and merges results by distance.
 
 ## CI integration
 
@@ -190,9 +194,9 @@ spelunk check
 AGENT=true spelunk memory list --kind handoff --limit 3
 AGENT=true spelunk memory list --kind question
 
-# Before writing code
+# Before writing code — retrieve context, then reason yourself
 AGENT=true spelunk search "<topic>" --graph --format json
-AGENT=true spelunk ask "<question>" --json
+AGENT=true spelunk memory search "<topic>" --format json
 
 # Planning
 spelunk plan create "<description>"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -53,31 +53,6 @@ spelunk search "authentication middleware" --graph
 
 ---
 
-## spelunk ask
-
-Answer a natural language question using your indexed codebase.
-
-```
-spelunk ask <question> [options]
-```
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--context-chunks <n>` | 20 | Number of chunks to retrieve as context |
-| `--json` | false | Return structured JSON: `{ answer, relevant_files, confidence }` |
-| `-d, --db <path>` | auto | Override database path |
-
-**Example:**
-
-```bash
-spelunk ask "How does the indexer handle binary files?"
-spelunk ask "What is the retry strategy for failed embeddings?" --json
-```
-
-Setting `AGENT=true` in the environment forces JSON output regardless of `--json`.
-
----
-
 ## spelunk status
 
 Show indexing statistics for the current project (or all projects).
@@ -204,7 +179,7 @@ spelunk languages
 
 ## spelunk link / spelunk unlink
 
-Add or remove a project dependency. When linked, `spelunk search` and `spelunk ask` also query the linked project's index.
+Add or remove a project dependency. When linked, `spelunk search` also queries the linked project's index.
 
 ```
 spelunk link <path>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,9 @@ lmstudio_base_url = "http://127.0.0.1:1234"
 
 # Must match the "API Identifier" shown in LM Studio for each model
 embedding_model = "text-embedding-embeddinggemma-300m-qat"
-llm_model       = "google/gemma-3n-e4b"
+
+# Optional: set a chat model to enable `memory harvest` and `plan create`
+# llm_model = "google/gemma-3n-e4b"
 
 # Embedding batch size — lower this if you run out of memory
 batch_size = 32
@@ -77,11 +79,6 @@ spelunk search "authentication" --graph
 
 # Return JSON instead of text
 spelunk search "database migrations" --format json
-```
-
-```bash
-spelunk ask "How does the incremental indexing work?"
-spelunk ask "What files handle user authentication?" --json
 ```
 
 ## 6. Check index health

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -125,9 +125,9 @@ Install the git hook and harvesting happens on every commit:
 spelunk hooks install
 ```
 
-## Using memory in `spelunk ask`
+## Using memory as context
 
-Memory context is automatically included when you run `spelunk ask`. The LLM receives both the retrieved code chunks and relevant memory entries, so it can factor in design decisions and requirements when answering.
+`spelunk memory search` results are best consumed alongside `spelunk search` results — they answer the *why* while the code search answers the *how*. Pass both to your reasoning model for a complete picture.
 
 ## Machine-readable output
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -576,11 +576,12 @@ If the answer cannot be determined from the provided context, say so clearly rat
     ];
 
     // ── Step 4: load LLM + stream answer ─────────────────────────────────────
-    let sp2 = spinner(format!("Loading LLM ({})…", cfg.llm_model));
+    let llm_model_name = cfg.llm_model.as_deref().unwrap_or("<not configured>");
+    let sp2 = spinner(format!("Loading LLM ({llm_model_name})…"));
 
     let llm = crate::backends::ActiveLlm::load(&cfg)
         .await
-        .with_context(|| format!("loading LLM '{}'", cfg.llm_model))?;
+        .with_context(|| format!("loading LLM '{llm_model_name}'"))?;
 
     sp2.finish_and_clear();
     println!();

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,11 +73,11 @@ pub struct Config {
     #[serde(default = "Config::default_embedding_model")]
     pub embedding_model: String,
 
-    /// Model ID for the LLM used by `ask`.
+    /// Model ID for the LLM used by `ask`, `memory harvest`, and `plan create`.
     /// LM Studio: the model's API key (e.g. `google/gemma-3n-e4b`).
-    /// Metal: HuggingFace repo ID (e.g. `google/gemma-3-1b-it`).
-    #[serde(default = "Config::default_llm_model")]
-    pub llm_model: String,
+    /// When unset, commands that require a chat model are unavailable.
+    #[serde(default)]
+    pub llm_model: Option<String>,
 
     /// Default embedding batch size
     pub batch_size: usize,
@@ -110,9 +110,6 @@ impl Config {
     fn default_embedding_model() -> String {
         "text-embedding-embeddinggemma-300m-qat".to_string()
     }
-    fn default_llm_model() -> String {
-        "google/gemma-3n-e4b".to_string()
-    }
     fn default_lmstudio_base_url() -> String {
         "http://127.0.0.1:1234".to_string()
     }
@@ -128,7 +125,7 @@ impl Default for Config {
             db_path: base.join("index.db"),
             models_dir: base.join("models"),
             embedding_model: Self::default_embedding_model(),
-            llm_model: Self::default_llm_model(),
+            llm_model: None,
             batch_size: 32,
             lmstudio_base_url: Self::default_lmstudio_base_url(),
             memory_server_url: None,

--- a/src/llm/lmstudio.rs
+++ b/src/llm/lmstudio.rs
@@ -20,6 +20,13 @@ pub struct LmStudioLlm {
 
 impl LmStudioLlm {
     pub async fn load(cfg: &crate::config::Config) -> Result<Self> {
+        let model = cfg.llm_model.as_deref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "llm_model is not configured.\n\
+                 Add 'llm_model = \"<model-id>\"' to ~/.config/spelunk/config.toml\n\
+                 to enable commands that require a chat model."
+            )
+        })?;
         // No warmup needed — the model is already loaded in LM Studio.
         let client = Client::builder()
             // Allow long responses without timeout during streaming.
@@ -29,12 +36,12 @@ impl LmStudioLlm {
         tracing::info!(
             "LM Studio LLM: {} model={}",
             cfg.lmstudio_base_url,
-            cfg.llm_model
+            model
         );
         Ok(Self {
             client,
             base_url: cfg.lmstudio_base_url.clone(),
-            model: cfg.llm_model.clone(),
+            model: model.to_string(),
         })
     }
 }

--- a/src/llm/lmstudio.rs
+++ b/src/llm/lmstudio.rs
@@ -33,11 +33,7 @@ impl LmStudioLlm {
             .timeout(std::time::Duration::from_secs(300))
             .build()
             .context("building HTTP client for LM Studio LLM")?;
-        tracing::info!(
-            "LM Studio LLM: {} model={}",
-            cfg.lmstudio_base_url,
-            model
-        );
+        tracing::info!("LM Studio LLM: {} model={}", cfg.lmstudio_base_url, model);
         Ok(Self {
             client,
             base_url: cfg.lmstudio_base_url.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 mod cli;
 
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches};
 use cli::{Cli, Command};
 use spelunk::{backends, config, embeddings, indexer, llm, registry, search, storage, utils};
 
@@ -25,7 +25,24 @@ async fn main() -> Result<()> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let cli = Cli::parse();
+    // Pre-check: does the config have llm_model set?
+    // Scan args for --config/-c to find the right config file before full parse.
+    let pre_config_path = {
+        let args: Vec<String> = std::env::args().collect();
+        args.windows(2)
+            .find(|w| w[0] == "--config" || w[0] == "-c")
+            .map(|w| std::path::PathBuf::from(&w[1]))
+    };
+    let llm_configured = config::Config::load(pre_config_path.as_deref())
+        .map(|c| c.llm_model.is_some())
+        .unwrap_or(false);
+
+    // Hide `ask` from help when no chat model is configured.
+    let matches = Cli::command()
+        .mut_subcommand("ask", |c| c.hide(!llm_configured))
+        .get_matches();
+    let cli = Cli::from_arg_matches(&matches)?;
+
     let cfg = config::Config::load(cli.config.as_deref())?;
 
     match cli.command {


### PR DESCRIPTION
## Summary

- **Reframes spelunk as a context retrieval tool** — agents should use `spelunk search` to retrieve context and reason over the results themselves, not rely on `spelunk ask` as an oracle
- **Makes `llm_model` optional** — changing it from `String` with a default to `Option<String>` with no default. When unset, `ask`, `memory harvest`, and `plan create` bail with a clear configuration message
- **Hides `ask` from CLI help** when `llm_model` is not configured — it acts as a feature flag; power users who configure a chat model will see and use it normally
- **Updates all docs** (SKILL.md, CLAUDE.md, docs/agent-guide.md, docs/commands.md, docs/getting-started.md, docs/memory.md) to remove `spelunk ask` from recommended agent workflows and clarify that spelunk retrieves context, the agent reasons

## Key behaviour changes

| Scenario | Before | After |
|---|---|---|
| `llm_model` not set, run `spelunk --help` | Shows `ask` | `ask` hidden |
| `llm_model` not set, run `spelunk ask "..."` | Error from HTTP call | Clear config error |
| `llm_model` set | Same as before | Same as before |

## Test plan

- [ ] `cargo test` passes
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `spelunk --help` without `llm_model` in config does not show `ask`
- [ ] `spelunk --help` with `llm_model` in config shows `ask`
- [ ] `spelunk ask "..."` without `llm_model` prints helpful error about configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)