### PR TITLE
feat(specs): add spec files as first-class indexed citizens

### DIFF
--- a/migrations/006_specs.sql
+++ b/migrations/006_specs.sql
@@ -1,0 +1,16 @@
+-- Spec files: human-authored markdown documents that govern code paths.
+-- A spec is linked to one or more file/directory prefixes; when search
+-- returns results from a linked path the governing specs are surfaced.
+
+CREATE TABLE IF NOT EXISTS specs (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    path    TEXT    NOT NULL UNIQUE,   -- path as indexed (relative to project root)
+    title   TEXT    NOT NULL DEFAULT '',
+    is_auto INTEGER NOT NULL DEFAULT 0 -- 1 = auto-discovered by convention / frontmatter
+);
+
+CREATE TABLE IF NOT EXISTS spec_links (
+    spec_id     INTEGER NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
+    linked_path TEXT    NOT NULL,      -- file path or directory prefix (e.g. "src/auth/")
+    PRIMARY KEY (spec_id, linked_path)
+);

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -327,6 +327,31 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         stats.file_count, stats.chunk_count, stats.embedding_count
     );
 
+    // ── Phase 3: auto-discover spec files ────────────────────────────────────
+    // Any indexed markdown file that lives under docs/specs/ or specs/, or
+    // declares `spelunk_spec: true` in its frontmatter, is registered in the
+    // specs table so agents can find and link it.
+    let mut specs_found = 0u32;
+    for entry in &files {
+        let path = entry.path();
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if ext != "md" {
+            continue;
+        }
+        if is_spec_file(path) {
+            let path_str = path.to_string_lossy().into_owned();
+            let title = extract_spec_title(path).unwrap_or_default();
+            if let Err(e) = db.upsert_spec(&path_str, &title, true) {
+                tracing::warn!("spec registration failed for {path_str}: {e}");
+            } else {
+                specs_found += 1;
+            }
+        }
+    }
+    if specs_found > 0 {
+        eprintln!("Registered {specs_found} spec file(s).");
+    }
+
     // Register / update this project in the global registry.
     if let Ok(reg) = Registry::open() {
         let db_canonical = db_path.canonicalize().unwrap_or(db_path.clone());
@@ -468,7 +493,54 @@ pub async fn ask(args: AskArgs, cfg: Config) -> Result<()> {
         .collect::<Vec<_>>()
         .join("\n\n");
 
-    // ── Step 2b: memory context (decisions / requirements / background) ──────
+    // ── Step 2b: spec context (governing specs for the retrieved files) ─────
+    let spec_context: Option<String> = {
+        let file_paths: Vec<String> = results.iter().map(|r| r.file_path.clone()).collect();
+        if let Ok(primary_db) = Database::open(&db_path) {
+            if let Ok(specs) = primary_db.specs_for_files(&file_paths) {
+                if specs.is_empty() {
+                    None
+                } else {
+                    // Fetch up to 5 spec file contents from chunks.
+                    let mut sections: Vec<String> = Vec::new();
+                    'spec_loop: for (spec_path, title) in &specs {
+                        if sections.len() >= 5 {
+                            break 'spec_loop;
+                        }
+                        // Fetch chunks for this spec file from the DB.
+                        if let Ok(file_id_row) = primary_db.file_id_for_path(spec_path) {
+                            if let Some(file_id) = file_id_row {
+                                if let Ok(chunks) = primary_db.chunks_content_for_file_id(file_id) {
+                                    let text = chunks
+                                        .iter()
+                                        .map(|(_, t)| t.as_str())
+                                        .collect::<Vec<_>>()
+                                        .join("\n\n");
+                                    let display = if title.is_empty() {
+                                        spec_path.clone()
+                                    } else {
+                                        format!("{title} ({spec_path})")
+                                    };
+                                    sections.push(format!("### Spec: {display}\n{text}"));
+                                }
+                            }
+                        }
+                    }
+                    if sections.is_empty() {
+                        None
+                    } else {
+                        Some(sections.join("\n\n"))
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    };
+
+    // ── Step 2c: memory context (decisions / requirements / background) ──────
     let mem_path = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
     let memory_context: Option<String> = if let Ok(backend) = open_memory_backend(&cfg, &mem_path) {
         match backend.search(&query_blob, 5).await {
@@ -524,14 +596,15 @@ pub async fn ask(args: AskArgs, cfg: Config) -> Result<()> {
     const SYSTEM_BASE: &str = "\
 You are an expert software analyst helping a developer understand a codebase.\n\
 \n\
-You have two sources of context:\n\
+You have up to three sources of context:\n\
 - Code context: excerpts from the source code showing HOW the system is built.\n\
   Reference specific file paths and line numbers when they are relevant.\n\
+- Spec context: human-authored design docs and contracts that govern the code.\n\
+  These capture intent, constraints, and API contracts — check for conflicts.\n\
 - Memory context: recorded decisions, requirements, and background explaining\n\
   WHAT was built and WHY those choices were made.\n\
-  Reference these when they explain the reasoning behind the code.\n\
 \n\
-Use both sources together to give accurate, grounded answers. \
+Use all available sources together to give accurate, grounded answers. \
 If the answer cannot be determined from the provided context, say so clearly rather than guessing.";
 
     let use_json = args.json || crate::utils::is_agent_mode();
@@ -552,23 +625,21 @@ If the answer cannot be determined from the provided context, say so clearly rat
         (SYSTEM_BASE, None)
     };
 
-    let user_message = if let Some(mem) = &memory_context {
-        format!(
-            "<code_context>\n{code}\n</code_context>\n\n\
-             <memory_context>\n{mem}\n</memory_context>\n\n\
-             <question>\n{q}\n</question>",
-            code = code_context,
-            mem = mem,
-            q = args.question,
-        )
-    } else {
-        format!(
-            "<code_context>\n{code}\n</code_context>\n\n\
-             <question>\n{q}\n</question>",
-            code = code_context,
-            q = args.question,
-        )
-    };
+    let spec_section = spec_context
+        .as_deref()
+        .map(|s| format!("\n\n<spec_context>\n{s}\n</spec_context>"))
+        .unwrap_or_default();
+    let mem_section = memory_context
+        .as_deref()
+        .map(|m| format!("\n\n<memory_context>\n{m}\n</memory_context>"))
+        .unwrap_or_default();
+    let user_message = format!(
+        "<code_context>\n{code}\n</code_context>{spec}{mem}\n\n<question>\n{q}\n</question>",
+        code = code_context,
+        spec = spec_section,
+        mem = mem_section,
+        q = args.question,
+    );
 
     let messages = vec![
         crate::llm::Message::system(system_prompt),
@@ -2290,6 +2361,21 @@ fn search_all_dbs(
     let mut seen = std::collections::HashSet::new();
     all.retain(|r| seen.insert((r.file_path.clone(), r.start_line, r.end_line)));
     all.truncate(limit);
+
+    // Annotate results with governing specs from the primary DB.
+    if let Ok(primary_db) = Database::open(primary_db_path) {
+        let file_paths: Vec<String> = all.iter().map(|r| r.file_path.clone()).collect();
+        if let Ok(all_specs) = primary_db.specs_for_files(&file_paths) {
+            if !all_specs.is_empty() {
+                for result in &mut all {
+                    if let Ok(per) = primary_db.specs_for_files(&[result.file_path.clone()]) {
+                        result.governing_specs = per.into_iter().map(|(p, _)| p).collect();
+                    }
+                }
+            }
+        }
+    }
+
     Ok(all)
 }
 
@@ -2361,6 +2447,10 @@ fn print_results_text(results: &[crate::search::SearchResult]) {
             suffix,
         );
 
+        if !r.governing_specs.is_empty() {
+            println!("    \x1b[2mSpec: {}\x1b[0m", r.governing_specs.join(", "));
+        }
+
         let lines: Vec<&str> = r.content.lines().collect();
         let preview_lines = lines.len().min(6);
         for line in &lines[..preview_lines] {
@@ -2426,6 +2516,199 @@ fn ask_json_schema() -> serde_json::Value {
             "additionalProperties": false
         }
     })
+}
+
+// ── Spec commands ─────────────────────────────────────────────────────────────
+
+pub fn spec(args: super::SpecArgs, cfg: Config) -> Result<()> {
+    let db_path = resolve_db(args.db.as_deref(), &cfg.db_path);
+    let db = Database::open(&db_path)?;
+    match args.command {
+        super::SpecCommand::Link(a) => spec_link(a, &db),
+        super::SpecCommand::Unlink(a) => spec_unlink(a, &db),
+        super::SpecCommand::List(a) => spec_list(a, &db),
+        super::SpecCommand::Check(a) => spec_check(a, &db),
+    }
+}
+
+fn spec_link(args: super::SpecLinkArgs, db: &Database) -> Result<()> {
+    let spec_path = args
+        .spec
+        .to_str()
+        .context("spec path is not valid UTF-8")?
+        .to_owned();
+
+    // Extract title from first `# Heading` in the file (best-effort).
+    let title = extract_spec_title(&args.spec).unwrap_or_default();
+
+    let spec_id = db.upsert_spec(&spec_path, &title, false)?;
+
+    for path in &args.paths {
+        db.add_spec_link(spec_id, path)?;
+        println!("Linked  {spec_path}  →  {path}");
+    }
+    Ok(())
+}
+
+fn spec_unlink(args: super::SpecUnlinkArgs, db: &Database) -> Result<()> {
+    let spec_path = args
+        .spec
+        .to_str()
+        .context("spec path is not valid UTF-8")?
+        .to_owned();
+
+    let record = db
+        .spec_by_path(&spec_path)?
+        .with_context(|| format!("spec not found: {spec_path}"))?;
+
+    match args.path {
+        Some(p) => {
+            db.remove_spec_link(record.id, &p)?;
+            println!("Unlinked  {spec_path}  →  {p}");
+        }
+        None => {
+            db.delete_spec(record.id)?;
+            println!("Removed spec (and all links): {spec_path}");
+        }
+    }
+    Ok(())
+}
+
+fn spec_list(args: super::SpecListArgs, db: &Database) -> Result<()> {
+    let specs = db.all_specs()?;
+
+    if specs.is_empty() {
+        println!(
+            "No specs registered. Run `spelunk spec link` or re-index a project with docs/specs/."
+        );
+        return Ok(());
+    }
+
+    #[derive(serde::Serialize)]
+    struct SpecOut<'a> {
+        path: &'a str,
+        title: &'a str,
+        is_auto: bool,
+        links: Vec<String>,
+    }
+
+    let mut out: Vec<SpecOut<'_>> = Vec::with_capacity(specs.len());
+    for s in &specs {
+        let links = db.spec_links(s.id)?;
+        out.push(SpecOut {
+            path: &s.path,
+            title: &s.title,
+            is_auto: s.is_auto,
+            links,
+        });
+    }
+
+    match crate::utils::effective_format(&args.format) {
+        "json" => println!("{}", serde_json::to_string_pretty(&out)?),
+        _ => {
+            for s in &out {
+                let auto = if s.is_auto {
+                    " \x1b[2m(auto)\x1b[0m"
+                } else {
+                    ""
+                };
+                let title = if s.title.is_empty() {
+                    String::new()
+                } else {
+                    format!(" — {}", s.title)
+                };
+                println!("\x1b[1m{}\x1b[0m{}{}", s.path, title, auto);
+                if s.links.is_empty() {
+                    println!("  \x1b[2m(no links)\x1b[0m");
+                }
+                for l in &s.links {
+                    println!("  → {l}");
+                }
+                println!();
+            }
+        }
+    }
+    Ok(())
+}
+
+fn spec_check(args: super::SpecCheckArgs, db: &Database) -> Result<()> {
+    let stale = db.stale_specs()?;
+
+    if stale.is_empty() {
+        println!("All specs are up to date with their linked code.");
+        return Ok(());
+    }
+
+    match crate::utils::effective_format(&args.format) {
+        "json" => println!("{}", serde_json::to_string_pretty(&stale)?),
+        _ => {
+            println!(
+                "\x1b[33mWarning:\x1b[0m {} spec(s) may be out of date:\n",
+                stale.len()
+            );
+            let mut last_spec = "";
+            for s in &stale {
+                if s.spec_path != last_spec {
+                    let title = if s.title.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" — {}", s.title)
+                    };
+                    println!("\x1b[1m{}\x1b[0m{}", s.spec_path, title);
+                    last_spec = &s.spec_path;
+                }
+                let days = (s.code_indexed_at - s.spec_indexed_at) / 86400;
+                println!(
+                    "  → {} \x1b[2m(code re-indexed ~{} day(s) after spec)\x1b[0m",
+                    s.linked_path, days
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Extract the first ATX heading (`# Title`) from a markdown file as a title string.
+fn extract_spec_title(path: &std::path::Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    content.lines().find_map(|line| {
+        let stripped = line.strip_prefix("# ")?;
+        let title = stripped.trim().to_owned();
+        if title.is_empty() { None } else { Some(title) }
+    })
+}
+
+/// Return true if a markdown file declares itself as a spec via frontmatter
+/// (`spelunk_spec: true`) or lives under a conventional spec directory.
+pub fn is_spec_file(path: &std::path::Path) -> bool {
+    // Directory convention: docs/specs/ or specs/
+    let path_str = path.to_string_lossy();
+    if path_str.contains("/specs/") || path_str.starts_with("specs/") {
+        return true;
+    }
+
+    // Frontmatter detection: look for `spelunk_spec: true` in the first 20 lines.
+    if let Ok(content) = std::fs::read_to_string(path) {
+        let mut in_frontmatter = false;
+        for (i, line) in content.lines().enumerate() {
+            if i == 0 && line.trim_end() == "---" {
+                in_frontmatter = true;
+                continue;
+            }
+            if in_frontmatter {
+                if line.trim_end() == "---" || line.trim_end() == "..." {
+                    break;
+                }
+                if line.trim() == "spelunk_spec: true" {
+                    return true;
+                }
+            }
+            if i >= 20 {
+                break;
+            }
+        }
+    }
+    false
 }
 
 fn print_edges(edges: &[crate::storage::db::GraphEdge], query: &str) {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -2365,12 +2365,13 @@ fn search_all_dbs(
     // Annotate results with governing specs from the primary DB.
     if let Ok(primary_db) = Database::open(primary_db_path) {
         let file_paths: Vec<String> = all.iter().map(|r| r.file_path.clone()).collect();
-        if let Ok(all_specs) = primary_db.specs_for_files(&file_paths) {
-            if !all_specs.is_empty() {
-                for result in &mut all {
-                    if let Ok(per) = primary_db.specs_for_files(&[result.file_path.clone()]) {
-                        result.governing_specs = per.into_iter().map(|(p, _)| p).collect();
-                    }
+        if let Ok(all_specs) = primary_db.specs_for_files(&file_paths)
+            && !all_specs.is_empty()
+        {
+            for result in &mut all {
+                if let Ok(per) = primary_db.specs_for_files(std::slice::from_ref(&result.file_path))
+                {
+                    result.governing_specs = per.into_iter().map(|(p, _)| p).collect();
                 }
             }
         }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -496,44 +496,36 @@ pub async fn ask(args: AskArgs, cfg: Config) -> Result<()> {
     // ── Step 2b: spec context (governing specs for the retrieved files) ─────
     let spec_context: Option<String> = {
         let file_paths: Vec<String> = results.iter().map(|r| r.file_path.clone()).collect();
-        if let Ok(primary_db) = Database::open(&db_path) {
-            if let Ok(specs) = primary_db.specs_for_files(&file_paths) {
-                if specs.is_empty() {
-                    None
-                } else {
-                    // Fetch up to 5 spec file contents from chunks.
-                    let mut sections: Vec<String> = Vec::new();
-                    'spec_loop: for (spec_path, title) in &specs {
-                        if sections.len() >= 5 {
-                            break 'spec_loop;
-                        }
-                        // Fetch chunks for this spec file from the DB.
-                        if let Ok(file_id_row) = primary_db.file_id_for_path(spec_path) {
-                            if let Some(file_id) = file_id_row {
-                                if let Ok(chunks) = primary_db.chunks_content_for_file_id(file_id) {
-                                    let text = chunks
-                                        .iter()
-                                        .map(|(_, t)| t.as_str())
-                                        .collect::<Vec<_>>()
-                                        .join("\n\n");
-                                    let display = if title.is_empty() {
-                                        spec_path.clone()
-                                    } else {
-                                        format!("{title} ({spec_path})")
-                                    };
-                                    sections.push(format!("### Spec: {display}\n{text}"));
-                                }
-                            }
-                        }
-                    }
-                    if sections.is_empty() {
-                        None
-                    } else {
-                        Some(sections.join("\n\n"))
-                    }
+        if let Ok(primary_db) = Database::open(&db_path)
+            && let Ok(specs) = primary_db.specs_for_files(&file_paths)
+            && !specs.is_empty()
+        {
+            // Fetch up to 5 spec file contents from chunks.
+            let mut sections: Vec<String> = Vec::new();
+            'spec_loop: for (spec_path, title) in &specs {
+                if sections.len() >= 5 {
+                    break 'spec_loop;
                 }
-            } else {
+                if let Ok(Some(file_id)) = primary_db.file_id_for_path(spec_path)
+                    && let Ok(chunks) = primary_db.chunks_content_for_file_id(file_id)
+                {
+                    let text = chunks
+                        .iter()
+                        .map(|(_, t)| t.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n\n");
+                    let display = if title.is_empty() {
+                        spec_path.clone()
+                    } else {
+                        format!("{title} ({spec_path})")
+                    };
+                    sections.push(format!("### Spec: {display}\n{text}"));
+                }
+            }
+            if sections.is_empty() {
                 None
+            } else {
+                Some(sections.join("\n\n"))
             }
         } else {
             None

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -47,6 +47,8 @@ pub enum Command {
     Hooks(HooksArgs),
     /// Create and track codebase plans as markdown checklists in docs/plans/
     Plan(PlanArgs),
+    /// Manage spec files: link human-authored docs to the code they govern
+    Spec(SpecArgs),
 }
 
 #[derive(Args, Debug)]
@@ -396,6 +398,63 @@ pub struct PlanStatusArgs {
     /// Show only this plan (by filename stem, e.g. add-rate-limiting)
     pub name: Option<String>,
 
+    /// Output format: text or json
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+// ── Spec ──────────────────────────────────────────────────────────────────────
+
+#[derive(Args, Debug)]
+pub struct SpecArgs {
+    #[command(subcommand)]
+    pub command: SpecCommand,
+
+    /// Path to the SQLite database (overrides auto-detect)
+    #[arg(long, global = true)]
+    pub db: Option<PathBuf>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SpecCommand {
+    /// Link a spec file to one or more code paths it governs
+    Link(SpecLinkArgs),
+    /// Remove a link between a spec and a code path
+    Unlink(SpecUnlinkArgs),
+    /// List all registered spec files and their links
+    List(SpecListArgs),
+    /// Show specs whose linked code has been re-indexed since the spec was last indexed
+    Check(SpecCheckArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SpecLinkArgs {
+    /// Path to the spec file (markdown)
+    pub spec: PathBuf,
+
+    /// One or more file paths or directory prefixes this spec governs
+    #[arg(required = true)]
+    pub paths: Vec<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct SpecUnlinkArgs {
+    /// Path to the spec file
+    pub spec: PathBuf,
+
+    /// Path prefix to remove (leave empty to remove all links for this spec)
+    pub path: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct SpecListArgs {
+    /// Output format: text or json
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+#[derive(Args, Debug)]
+pub struct SpecCheckArgs {
     /// Output format: text or json
     #[arg(long, default_value = "text")]
     pub format: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,5 +61,6 @@ async fn main() -> Result<()> {
         Command::Memory(args) => cli::commands::memory(args, cfg).await,
         Command::Hooks(args) => cli::commands::hooks(args),
         Command::Plan(args) => cli::commands::plan(args, cfg).await,
+        Command::Spec(args) => cli::commands::spec(args, cfg),
     }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -20,4 +20,8 @@ pub struct SearchResult {
     /// vector similarity — only set when `--graph` is used with `search`.
     #[serde(default)]
     pub from_graph: bool,
+    /// Spec files that govern the file this result came from (via spec_links).
+    /// Empty when no specs are linked to the result's file path.
+    #[serde(default)]
+    pub governing_specs: Vec<String>,
 }

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -28,6 +28,7 @@ impl Database {
         db.migrate()?;
         db.apply_vector_migration()?;
         db.apply_graph_migration()?;
+        db.apply_spec_migration()?;
         Ok(db)
     }
 
@@ -51,6 +52,14 @@ impl Database {
         self.conn
             .execute_batch(include_str!("../../migrations/003_graph.sql"))
             .context("running graph migration")?;
+        Ok(())
+    }
+
+    /// Create the specs and spec_links tables. Idempotent (`IF NOT EXISTS`).
+    pub fn apply_spec_migration(&self) -> Result<()> {
+        self.conn
+            .execute_batch(include_str!("../../migrations/006_specs.sql"))
+            .context("running spec migration")?;
         Ok(())
     }
 
@@ -167,15 +176,24 @@ impl Database {
                 file_path: row.get(7)?,
                 language: row.get(8)?,
                 from_graph: false,
+                governing_specs: vec![],
             })
         })?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
             .map_err(Into::into)
     }
 
-    /// Return all chunk IDs and their embedding text for a given file.
-    #[allow(dead_code)]
-    pub fn chunks_for_embedding(&self, file_id: i64) -> Result<Vec<(i64, String)>> {
+    /// Look up the file id for a given path, or None if not indexed.
+    pub fn file_id_for_path(&self, path: &str) -> Result<Option<i64>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT id FROM files WHERE path = ?1")?;
+        let mut rows = stmt.query(rusqlite::params![path])?;
+        Ok(rows.next()?.map(|r| r.get(0)).transpose()?)
+    }
+
+    /// Return all chunk IDs and their content for a given file id.
+    pub fn chunks_content_for_file_id(&self, file_id: i64) -> Result<Vec<(i64, String)>> {
         let mut stmt = self
             .conn
             .prepare_cached("SELECT id, content FROM chunks WHERE file_id = ?1 ORDER BY id")?;
@@ -266,6 +284,7 @@ impl Database {
                 file_path: row.get(7)?,
                 language: row.get(8)?,
                 from_graph: false,
+                governing_specs: vec![],
             })
         })?;
 
@@ -386,6 +405,7 @@ impl Database {
                 file_path: row.get(6)?,
                 language: row.get(7)?,
                 from_graph: false,
+                governing_specs: vec![],
             })
         })?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -526,6 +546,187 @@ impl Database {
 
         Ok(candidates)
     }
+
+    // -----------------------------------------------------------------------
+    // Specs
+    // -----------------------------------------------------------------------
+
+    /// Register or update a spec file. Returns the spec id.
+    pub fn upsert_spec(&self, path: &str, title: &str, is_auto: bool) -> Result<i64> {
+        self.conn.execute(
+            "INSERT INTO specs (path, title, is_auto)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(path) DO UPDATE SET
+                title   = excluded.title,
+                is_auto = excluded.is_auto",
+            rusqlite::params![path, title, is_auto as i64],
+        )?;
+        let id: i64 = self.conn.query_row(
+            "SELECT id FROM specs WHERE path = ?1",
+            rusqlite::params![path],
+            |r| r.get(0),
+        )?;
+        Ok(id)
+    }
+
+    /// Look up a spec by its path. Returns None if not registered.
+    pub fn spec_by_path(&self, path: &str) -> Result<Option<SpecRecord>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT id, path, title, is_auto FROM specs WHERE path = ?1")?;
+        let mut rows = stmt.query(rusqlite::params![path])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(SpecRecord {
+                id: row.get(0)?,
+                path: row.get(1)?,
+                title: row.get(2)?,
+                is_auto: row.get::<_, i64>(3)? != 0,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Return all registered specs with their linked paths.
+    pub fn all_specs(&self) -> Result<Vec<SpecRecord>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT id, path, title, is_auto FROM specs ORDER BY path")?;
+        let rows = stmt.query_map([], |r| {
+            Ok(SpecRecord {
+                id: r.get(0)?,
+                path: r.get(1)?,
+                title: r.get(2)?,
+                is_auto: r.get::<_, i64>(3)? != 0,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// Return all linked paths for a spec.
+    pub fn spec_links(&self, spec_id: i64) -> Result<Vec<String>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT linked_path FROM spec_links WHERE spec_id = ?1 ORDER BY linked_path",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![spec_id], |r| r.get(0))?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// Add a link from a spec to a path prefix (idempotent).
+    pub fn add_spec_link(&self, spec_id: i64, linked_path: &str) -> Result<()> {
+        self.conn.execute(
+            "INSERT OR IGNORE INTO spec_links (spec_id, linked_path) VALUES (?1, ?2)",
+            rusqlite::params![spec_id, linked_path],
+        )?;
+        Ok(())
+    }
+
+    /// Remove a specific link from a spec.
+    pub fn remove_spec_link(&self, spec_id: i64, linked_path: &str) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM spec_links WHERE spec_id = ?1 AND linked_path = ?2",
+            rusqlite::params![spec_id, linked_path],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a spec and all its links.
+    pub fn delete_spec(&self, spec_id: i64) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM specs WHERE id = ?1",
+            rusqlite::params![spec_id],
+        )?;
+        Ok(())
+    }
+
+    /// For a set of file paths, return the specs that govern them (via linked_path prefix match).
+    /// Returns deduplicated (spec_path, title) pairs.
+    pub fn specs_for_files(&self, file_paths: &[String]) -> Result<Vec<(String, String)>> {
+        if file_paths.is_empty() {
+            return Ok(vec![]);
+        }
+        // We match each file path against each spec_link prefix using LIKE.
+        // SQLite doesn't support IN with a subquery on parameterised lists easily,
+        // so we query all links and filter in Rust.
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT s.path, s.title, sl.linked_path
+             FROM spec_links sl
+             JOIN specs s ON s.id = sl.spec_id",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+            ))
+        })?;
+
+        let mut seen = std::collections::HashSet::new();
+        let mut result = Vec::new();
+        for row in rows {
+            let (spec_path, title, linked_path) = row?;
+            for fp in file_paths {
+                if fp.starts_with(&linked_path) || fp == &linked_path {
+                    if seen.insert(spec_path.clone()) {
+                        result.push((spec_path.clone(), title.clone()));
+                    }
+                    break;
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    /// Return specs whose linked code has been indexed more recently than the spec itself.
+    /// Uses the files table indexed_at to compare timestamps.
+    pub fn stale_specs(&self) -> Result<Vec<StaleSpec>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT DISTINCT s.id, s.path, s.title, sl.linked_path,
+                    sf.indexed_at  AS spec_indexed_at,
+                    lf.indexed_at  AS code_indexed_at
+             FROM specs s
+             JOIN spec_links sl ON sl.spec_id = s.id
+             JOIN files sf      ON sf.path = s.path
+             JOIN files lf      ON (lf.path = sl.linked_path
+                                    OR lf.path LIKE sl.linked_path || '%')
+             WHERE lf.indexed_at > sf.indexed_at
+             ORDER BY s.path",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok(StaleSpec {
+                spec_id: r.get(0)?,
+                spec_path: r.get(1)?,
+                title: r.get(2)?,
+                linked_path: r.get(3)?,
+                spec_indexed_at: r.get(4)?,
+                code_indexed_at: r.get(5)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+}
+
+/// A registered spec file.
+#[derive(Debug, serde::Serialize)]
+pub struct SpecRecord {
+    pub id: i64,
+    pub path: String,
+    pub title: String,
+    pub is_auto: bool,
+}
+
+/// A spec that is potentially out-of-date with its linked code.
+#[derive(Debug, serde::Serialize)]
+pub struct StaleSpec {
+    pub spec_id: i64,
+    pub spec_path: String,
+    pub title: String,
+    pub linked_path: String,
+    pub spec_indexed_at: i64,
+    pub code_indexed_at: i64,
 }
 
 /// A graph edge as returned by query methods.


### PR DESCRIPTION
## Summary

- **`spelunk spec link <spec> <path...>`** — explicitly link a markdown spec to the code paths it governs
- **`spelunk spec unlink <spec> [path]`** — remove a link or all links for a spec
- **`spelunk spec list`** — show all registered specs with their linked paths
- **`spelunk spec check`** — flag specs whose linked code has been re-indexed more recently (potential drift)
- **Auto-discovery during `spelunk index`** — spec files are registered automatically by directory convention (`docs/specs/*.md`, `specs/*.md`) or frontmatter (`spelunk_spec: true`)
- **Search annotation** — `spelunk search` results now show which specs govern each file (text + JSON)
- **Ask injection** — `spelunk ask` injects governing spec content as a `<spec_context>` block alongside code and memory (up to 5 specs, separate from code chunks)

## Schema

Migration `006_specs.sql` adds:
- `specs(id, path, title, is_auto)` — registered spec files
- `spec_links(spec_id, linked_path)` — prefix-match links from specs to code paths

Staleness detection compares `files.indexed_at` for the spec vs linked code — no extra timestamp tracking needed.

## Rebasing note

This branch is off `main` (pre-refactor). Once PR #16 merges I'll rebase onto the new `src/cli/cmd/` structure — the changes in `commands.rs` will split across `cmd/search.rs`, `cmd/ask.rs`, and a new `cmd/spec.rs`.

## Test plan

- [x] `cargo build` passes cleanly
- [x] `cargo test` — all 49 tests pass
- [x] `cargo fmt` — no diff
- [ ] Manual: `spelunk spec link docs/plans/spec-files.md src/` then `spelunk spec list`
- [ ] Manual: `spelunk search "chunking"` shows spec annotation
- [ ] Manual: `spelunk spec check` after touching a linked file

🤖 Generated with [Claude Code](https://claude.com/claude-code)