### PR TITLE
feat(ci): add multi-platform release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+        run: |
+          rustup toolchain install stable --no-self-update
+          rustup target add ${{ matrix.target }}
 
       - name: Cache Cargo registry
         uses: actions/cache@v4
@@ -52,9 +52,7 @@ jobs:
 
       - name: Install cross (Linux aarch64 only)
         if: matrix.cross
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cross
+        run: cargo install cross --locked
 
       - name: Build release binaries (native)
         if: "!matrix.cross"
@@ -148,12 +146,15 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
-          files: artifacts/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PRERELEASE=""
+          if echo "${{ github.ref_name }}" | grep -qE '\-(rc|beta|alpha)'; then
+            PRERELEASE="--prerelease"
+          fi
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            $PRERELEASE \
+            artifacts/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,39 +3,43 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  publish:
-    name: Build & Release (${{ matrix.target }})
+  build:
+    name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact_name: ca-linux-x86_64
+            cross: false
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            cross: true
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact_name: ca-macos-x86_64
+            cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact_name: ca-macos-arm64
+            cross: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        run: |
-          rustup update stable
-          rustup default stable
-          rustup target add ${{ matrix.target }}
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
-      - name: Cache
+      - name: Cache Cargo registry
         uses: actions/cache@v4
         with:
           path: |
@@ -46,38 +50,110 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ matrix.target }}-
 
-      - name: Build release
+      - name: Install cross (Linux aarch64 only)
+        if: matrix.cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build release binaries (native)
+        if: "!matrix.cross"
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Package artifact
+      - name: Build release binaries (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Strip binaries (native Linux/macOS x86_64)
+        if: "!matrix.cross && matrix.target != 'aarch64-apple-darwin'"
+        run: |
+          strip target/${{ matrix.target }}/release/spelunk
+          strip target/${{ matrix.target }}/release/spelunk-server
+
+      - name: Package tarball
         shell: bash
         run: |
-          cd target/${{ matrix.target }}/release
-          tar -czf ../../../${{ matrix.artifact_name }}.tar.gz ca
-          cd ../../../
+          VERSION="${{ github.ref_name }}"
+          TARGET="${{ matrix.target }}"
+          ARCHIVE="spelunk-${VERSION}-${TARGET}.tar.gz"
+          tar -czf "${ARCHIVE}" \
+            -C "target/${TARGET}/release" \
+            spelunk spelunk-server
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact_name }}
-          path: ${{ matrix.artifact_name }}.tar.gz
+          name: spelunk-${{ github.ref_name }}-${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
 
-  create-release:
+  universal-macos:
+    name: Build (universal-apple-darwin)
+    needs: build
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download x86_64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: spelunk-${{ github.ref_name }}-x86_64-apple-darwin
+          path: x86_64
+
+      - name: Download aarch64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: spelunk-${{ github.ref_name }}-aarch64-apple-darwin
+          path: aarch64
+
+      - name: Extract both tarballs
+        run: |
+          tar -xzf x86_64/spelunk-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz -C x86_64
+          tar -xzf aarch64/spelunk-${{ github.ref_name }}-aarch64-apple-darwin.tar.gz -C aarch64
+
+      - name: Create universal binaries with lipo
+        run: |
+          mkdir -p universal
+          lipo -create -output universal/spelunk \
+            x86_64/spelunk aarch64/spelunk
+          lipo -create -output universal/spelunk-server \
+            x86_64/spelunk-server aarch64/spelunk-server
+
+      - name: Package universal tarball
+        run: |
+          VERSION="${{ github.ref_name }}"
+          ARCHIVE="spelunk-${VERSION}-universal-apple-darwin.tar.gz"
+          tar -czf "${ARCHIVE}" -C universal spelunk spelunk-server
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Upload universal artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spelunk-${{ github.ref_name }}-universal-apple-darwin
+          path: ${{ env.ARCHIVE }}
+
+  release:
     name: Create GitHub Release
-    needs: publish
+    needs: [build, universal-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5 # Needed for gh CLI to have context if necessary
-
-      - name: Download release artifacts
-        uses: actions/download-artifact@v5
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
+          merge-multiple: true
 
-      - name: Create Release
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
+          files: artifacts/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create ${{ github.ref_name }} artifacts/**/*.tar.gz --generate-notes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,13 +5,32 @@
 Download the latest binary for your platform from the [releases page](https://github.com/usercise/spelunk/releases) and put it somewhere on your `$PATH`:
 
 ```bash
-# macOS (Apple Silicon)
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-aarch64-apple-darwin \
-  -o spelunk && chmod +x spelunk && sudo mv spelunk /usr/local/bin/
+# macOS (Apple Silicon) — universal binary also available
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.1.0-aarch64-apple-darwin.tar.gz \
+  | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
+
+# macOS (Intel)
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.1.0-x86_64-apple-darwin.tar.gz \
+  | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
+
+# macOS (universal — works on both Intel and Apple Silicon)
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.1.0-universal-apple-darwin.tar.gz \
+  | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
+
+# Linux x86_64
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.1.0-x86_64-unknown-linux-gnu.tar.gz \
+  | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
+
+# Linux ARM64
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.1.0-aarch64-unknown-linux-gnu.tar.gz \
+  | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Verify
 spelunk --version
 ```
+
+> Replace `v0.1.0` with the version you want. The URL pattern is:
+> `https://github.com/usercise/spelunk/releases/latest/download/spelunk-<version>-<target>.tar.gz`
 
 > Building from source? See [Building](building.md).
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,112 @@
+# Releasing spelunk
+
+This document describes how to cut a release of spelunk.
+
+## Overview
+
+Releases are fully automated via GitHub Actions. Pushing a version tag triggers
+`.github/workflows/release.yml`, which:
+
+1. Builds `spelunk` and `spelunk-server` release binaries for all supported platforms.
+2. Strips binaries where possible to reduce download size.
+3. Packages each platform's binaries into a `.tar.gz` archive.
+4. Creates a macOS universal binary by combining x86_64 and aarch64 slices with `lipo`.
+5. Creates a GitHub Release and attaches all archives as downloadable assets.
+6. Auto-generates release notes from merged pull requests and commits.
+
+## Supported platforms
+
+| Target | Runner | Notes |
+|--------|--------|-------|
+| `x86_64-unknown-linux-gnu` | ubuntu-latest | Native build |
+| `aarch64-unknown-linux-gnu` | ubuntu-latest | Cross-compiled via `cross` |
+| `x86_64-apple-darwin` | macos-latest | Native build |
+| `aarch64-apple-darwin` | macos-latest | Native build (Apple Silicon) |
+| `universal-apple-darwin` | macos-latest | Fat binary: x86_64 + aarch64 merged with `lipo` |
+
+## Cutting a release
+
+### 1. Bump the version in `Cargo.toml`
+
+Edit the `version` field in `Cargo.toml`:
+
+```toml
+[package]
+name = "spelunk"
+version = "0.2.0"   # <-- update this
+```
+
+Commit the bump:
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version to 0.2.0"
+git push origin main
+```
+
+### 2. Tag and push
+
+```bash
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+That's it. The release workflow triggers automatically on the pushed tag.
+
+### 3. Monitor the workflow
+
+Watch progress at:
+`https://github.com/usercise/spelunk/actions/workflows/release.yml`
+
+Once all jobs pass, the release appears at:
+`https://github.com/usercise/spelunk/releases/tag/v0.2.0`
+
+## Pre-releases
+
+Append a pre-release suffix to the tag. The workflow automatically marks the
+GitHub Release as a pre-release when the tag contains `-rc`, `-beta`, or
+`-alpha`:
+
+```bash
+git tag v0.2.0-rc.1
+git push origin v0.2.0-rc.1
+```
+
+## Download URLs
+
+After a release is published, assets follow this URL pattern:
+
+```
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-<version>-<target>.tar.gz
+```
+
+Examples:
+
+```bash
+# macOS Apple Silicon
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.2.0-aarch64-apple-darwin.tar.gz
+
+# macOS universal (x86_64 + Apple Silicon)
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.2.0-universal-apple-darwin.tar.gz
+
+# Linux x86_64
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.2.0-x86_64-unknown-linux-gnu.tar.gz
+
+# Linux ARM64
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.2.0-aarch64-unknown-linux-gnu.tar.gz
+```
+
+## Deleting a bad release
+
+If a release needs to be pulled:
+
+```bash
+# Delete the tag locally and on remote
+git tag -d v0.2.0
+git push origin :refs/tags/v0.2.0
+
+# Delete the GitHub Release (requires gh CLI)
+gh release delete v0.2.0 --yes
+```
+
+Then fix the issue, re-commit, and re-tag.


### PR DESCRIPTION
Closes #9

## Summary

- **`.github/workflows/release.yml`** — four-target build matrix (x86_64/aarch64 Linux and macOS), cross-compilation via `cross` for Linux aarch64, binary stripping, tarball packaging of both `spelunk` and `spelunk-server`, a universal macOS fat-binary job using `lipo`, and `softprops/action-gh-release@v2` with auto-generated release notes. Pre-release auto-detection from tag suffixes (`-rc`, `-beta`, `-alpha`).
- **`docs/releasing.md`** — full release runbook: version bump, tag/push, pre-release tags, download URL patterns, rollback instructions.
- **`docs/getting-started.md`** — install commands updated with real GitHub Releases URLs for all five platforms.

## Test plan
- [ ] Push a `v0.1.0` tag and verify all five build jobs pass and assets appear on the release
- [ ] Push a `v0.2.0-rc.1` tag and verify the release is marked pre-release
- [ ] Confirm tarball contents include both `spelunk` and `spelunk-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)