### PR TITLE
feat(search): hybrid FTS5 + vector search

### DIFF
--- a/migrations/007_fts.sql
+++ b/migrations/007_fts.sql
@@ -1,0 +1,28 @@
+CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+    name,
+    content,
+    node_type,
+    content=chunks,
+    content_rowid=id
+);
+
+-- Keep FTS in sync with chunks table
+CREATE TRIGGER IF NOT EXISTS chunks_fts_insert
+AFTER INSERT ON chunks BEGIN
+    INSERT INTO chunks_fts(rowid, name, content, node_type)
+    VALUES (new.id, new.name, new.content, new.node_type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS chunks_fts_delete
+BEFORE DELETE ON chunks BEGIN
+    INSERT INTO chunks_fts(chunks_fts, rowid, name, content, node_type)
+    VALUES ('delete', old.id, old.name, old.content, old.node_type);
+END;
+
+CREATE TRIGGER IF NOT EXISTS chunks_fts_update
+AFTER UPDATE ON chunks BEGIN
+    INSERT INTO chunks_fts(chunks_fts, rowid, name, content, node_type)
+    VALUES ('delete', old.id, old.name, old.content, old.node_type);
+    INSERT INTO chunks_fts(rowid, name, content, node_type)
+    VALUES (new.id, new.name, new.content, new.node_type);
+END;

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -17,20 +17,46 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
         maybe_warn_stale(&db_path);
     }
 
-    let sp = spinner("Loading model…");
+    let mode = args.mode.as_str();
 
-    let embedder = crate::backends::ActiveEmbedder::load(&cfg)
-        .await
-        .with_context(|| format!("loading embedding model '{}'", cfg.embedding_model))?;
+    let mut results = if mode == "text" {
+        // Text mode: FTS5 only, no embedding model required.
+        let sp = spinner("Searching (text)…");
+        let db = Database::open(&db_path)?;
+        let res = db
+            .search_text(&args.query, args.limit.min(100))
+            .unwrap_or_default();
+        sp.finish_and_clear();
+        res
+    } else {
+        // semantic or hybrid: need an embedding.
+        let sp = spinner("Loading model…");
+        let embedder = crate::backends::ActiveEmbedder::load(&cfg)
+            .await
+            .with_context(|| format!("loading embedding model '{}'", cfg.embedding_model))?;
 
-    sp.set_message("Embedding query…");
-    let query_text = format!("task: code retrieval | query: {}", args.query);
-    let vecs = embedder.embed(&[&query_text]).await?;
-    let query_blob = vec_to_blob(vecs.first().context("no embedding returned")?);
+        sp.set_message("Embedding query…");
+        let query_text = format!("task: code retrieval | query: {}", args.query);
+        let vecs = embedder.embed(&[&query_text]).await?;
+        let query_vec = vecs.first().context("no embedding returned")?.clone();
+        let query_blob = vec_to_blob(&query_vec);
 
-    sp.set_message("Searching…");
-    let mut results = search_all_dbs(&db_path, &dep_dbs, &query_blob, args.limit.min(100))?;
-    sp.finish_and_clear();
+        sp.set_message("Searching…");
+        let res = if mode == "hybrid" {
+            search_all_dbs_hybrid(
+                &db_path,
+                &dep_dbs,
+                &args.query,
+                &query_vec,
+                args.limit.min(100),
+            )?
+        } else {
+            // semantic
+            search_all_dbs(&db_path, &dep_dbs, &query_blob, args.limit.min(100))?
+        };
+        sp.finish_and_clear();
+        res
+    };
 
     if results.is_empty() {
         println!("No results found. Make sure the index has embeddings (`spelunk index <path>`).");
@@ -157,6 +183,61 @@ pub(crate) fn search_all_dbs(
     }
 
     // Sort by distance (ascending), deduplicate by (file_path, start_line, end_line).
+    all.sort_by(|a, b| {
+        a.distance
+            .partial_cmp(&b.distance)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut seen = std::collections::HashSet::new();
+    all.retain(|r| seen.insert((r.file_path.clone(), r.start_line, r.end_line)));
+    all.truncate(limit);
+
+    // Annotate results with governing specs from the primary DB.
+    if let Ok(primary_db) = Database::open(primary_db_path) {
+        let file_paths: Vec<String> = all.iter().map(|r| r.file_path.clone()).collect();
+        if let Ok(all_specs) = primary_db.specs_for_files(&file_paths)
+            && !all_specs.is_empty()
+        {
+            for result in &mut all {
+                if let Ok(per) = primary_db.specs_for_files(std::slice::from_ref(&result.file_path))
+                {
+                    result.governing_specs = per.into_iter().map(|(p, _)| p).collect();
+                }
+            }
+        }
+    }
+
+    Ok(all)
+}
+
+/// Hybrid search across a primary DB and any dep DBs.
+/// Each DB is searched independently with `search_hybrid`; results are merged
+/// by deduplicating on (file_path, start_line, end_line) and re-sorting by
+/// ascending `distance` (lower = better RRF score).
+pub(crate) fn search_all_dbs_hybrid(
+    primary_db_path: &std::path::Path,
+    dep_db_paths: &[std::path::PathBuf],
+    query: &str,
+    embedding: &[f32],
+    limit: usize,
+) -> Result<Vec<SearchResult>> {
+    let primary_db = Database::open(primary_db_path)?;
+    let fetch = (limit * 2).max(limit + 10);
+    let mut all = primary_db
+        .search_hybrid(query, embedding, fetch)
+        .unwrap_or_default();
+
+    for dep_path in dep_db_paths {
+        match Database::open(dep_path) {
+            Ok(dep_db) => match dep_db.search_hybrid(query, embedding, fetch) {
+                Ok(mut dep_results) => all.append(&mut dep_results),
+                Err(e) => tracing::warn!("hybrid search failed on dep {}: {e}", dep_path.display()),
+            },
+            Err(e) => tracing::warn!("could not open dep DB {}: {e}", dep_path.display()),
+        }
+    }
+
+    // Sort by ascending distance (lower RRF reciprocal = better score).
     all.sort_by(|a, b| {
         a.distance
             .partial_cmp(&b.distance)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,6 +90,10 @@ pub struct SearchArgs {
     #[arg(long, default_value = "10")]
     pub graph_limit: usize,
 
+    /// Search mode: hybrid (default), semantic, text
+    #[arg(long, default_value = "hybrid")]
+    pub mode: String,
+
     /// Path to the SQLite database (overrides config)
     #[arg(short, long)]
     pub db: Option<PathBuf>,

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -29,6 +29,7 @@ impl Database {
         db.apply_vector_migration()?;
         db.apply_graph_migration()?;
         db.apply_spec_migration()?;
+        db.apply_fts_migration()?;
         Ok(db)
     }
 
@@ -60,6 +61,23 @@ impl Database {
         self.conn
             .execute_batch(include_str!("../../migrations/006_specs.sql"))
             .context("running spec migration")?;
+        Ok(())
+    }
+
+    /// Create the FTS5 virtual table and sync triggers. Idempotent (`IF NOT EXISTS`).
+    /// Also backfills any existing chunks not yet in the FTS index.
+    pub fn apply_fts_migration(&self) -> Result<()> {
+        self.conn
+            .execute_batch(include_str!("../../migrations/007_fts.sql"))
+            .context("running FTS migration")?;
+        // Backfill existing chunks that predate the FTS table.
+        self.conn
+            .execute_batch(
+                "INSERT INTO chunks_fts(rowid, name, content, node_type)
+                 SELECT id, name, content, node_type FROM chunks
+                 WHERE id NOT IN (SELECT rowid FROM chunks_fts);",
+            )
+            .context("backfilling FTS index")?;
         Ok(())
     }
 
@@ -290,6 +308,108 @@ impl Database {
 
         rows.collect::<rusqlite::Result<Vec<_>>>()
             .map_err(Into::into)
+    }
+
+    /// FTS5 full-text search. Returns results ranked by BM25 (best match first).
+    ///
+    /// BM25 in FTS5 returns negative values (more negative = better match).
+    /// We negate the score so that higher `distance` values indicate better matches,
+    /// consistent with the convention used in `SearchResult`.
+    pub fn search_text(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<crate::search::SearchResult>> {
+        let limit = limit.min(1_000);
+        let mut stmt = self.conn.prepare(
+            "SELECT c.id, c.node_type, c.name,
+                    CAST(c.start_line AS INTEGER), CAST(c.end_line AS INTEGER),
+                    c.content, f.path, f.language,
+                    bm25(chunks_fts) AS score
+             FROM chunks_fts
+             JOIN chunks c ON chunks_fts.rowid = c.id
+             JOIN files  f ON c.file_id = f.id
+             WHERE chunks_fts MATCH ?1
+             ORDER BY score
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![query, limit as i64], |row| {
+            let bm25_score: f64 = row.get(8)?;
+            Ok(crate::search::SearchResult {
+                chunk_id: row.get(0)?,
+                node_type: row.get(1)?,
+                name: row.get(2)?,
+                start_line: row.get::<_, i64>(3)? as usize,
+                end_line: row.get::<_, i64>(4)? as usize,
+                content: row.get(5)?,
+                file_path: row.get(6)?,
+                language: row.get(7)?,
+                // Negate so that more-relevant results have a lower (closer to 0) distance,
+                // matching the ascending-distance convention of vector search.
+                distance: (-bm25_score) as f32,
+                from_graph: false,
+                governing_specs: vec![],
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// Hybrid search: fuses FTS5 BM25 ranking with vector KNN via Reciprocal Rank Fusion.
+    ///
+    /// RRF score: `Σ 1 / (k + rank_i)` where `k = 60` and `rank_i` is 1-based rank
+    /// within each result list. Candidates are merged by chunk ID, scores summed,
+    /// and the top `limit` returned in descending RRF score order.
+    pub fn search_hybrid(
+        &self,
+        query: &str,
+        embedding: &[f32],
+        limit: usize,
+    ) -> Result<Vec<crate::search::SearchResult>> {
+        use std::collections::HashMap;
+
+        let candidates = (limit * 3).max(20);
+        let query_blob = crate::embeddings::vec_to_blob(embedding);
+
+        let vec_results = self.search_similar(&query_blob, candidates)?;
+        let text_results = self.search_text(query, candidates).unwrap_or_default();
+
+        const K: f64 = 60.0;
+
+        // Map chunk_id -> RRF score accumulator and the SearchResult to return.
+        let mut scores: HashMap<i64, f64> = HashMap::new();
+        let mut by_id: HashMap<i64, crate::search::SearchResult> = HashMap::new();
+
+        for (rank, result) in vec_results.into_iter().enumerate() {
+            let rrf = 1.0 / (K + (rank + 1) as f64);
+            *scores.entry(result.chunk_id).or_insert(0.0) += rrf;
+            by_id.entry(result.chunk_id).or_insert(result);
+        }
+
+        for (rank, result) in text_results.into_iter().enumerate() {
+            let rrf = 1.0 / (K + (rank + 1) as f64);
+            *scores.entry(result.chunk_id).or_insert(0.0) += rrf;
+            by_id.entry(result.chunk_id).or_insert(result);
+        }
+
+        // Sort by descending RRF score, take top `limit`.
+        let mut ranked: Vec<(i64, f64)> = scores.into_iter().collect();
+        ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        ranked.truncate(limit);
+
+        let results = ranked
+            .into_iter()
+            .filter_map(|(id, rrf_score)| {
+                by_id.remove(&id).map(|mut r| {
+                    // Store the inverted RRF score as `distance` so that callers
+                    // can still sort ascending (lower = better).
+                    r.distance = (1.0 / rrf_score) as f32;
+                    r
+                })
+            })
+            .collect();
+
+        Ok(results)
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds SQLite FTS5 full-text index (`chunks_fts`) with triggers to stay in sync with the `chunks` table automatically
- New `Database` methods: `search_text` (BM25) and `search_hybrid` (Reciprocal Rank Fusion over vector KNN + FTS5)
- New `--mode` flag on `spelunk search`: `hybrid` (default), `semantic`, `text`
- `--mode text` skips the embedding API entirely — works without LM Studio running

## Test plan
- [ ] `cargo test` passes
- [ ] `spelunk search "query"` uses hybrid mode by default
- [ ] `spelunk search "query" --mode text` works with LM Studio offline
- [ ] `spelunk search "query" --mode semantic` behaves like the old default
- [ ] Re-indexing populates FTS for new/changed chunks via triggers
- [ ] Existing DBs get FTS backfilled on first open after upgrade

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)