### PR TITLE
qa: add E2E tests and improve config robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -482,6 +498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +642,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1339,6 +1370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1538,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1975,6 +2042,7 @@ name = "spelunk"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-trait",
  "axum",
  "blake3",
@@ -1985,6 +2053,7 @@ dependencies = [
  "futures-util",
  "ignore",
  "indicatif",
+ "predicates",
  "pretty_assertions",
  "regex",
  "reqwest",
@@ -2117,6 +2186,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -2664,6 +2739,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"
+
 
 # Temporary files/directories for integration tests
 tempfile = "3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,9 +61,11 @@ pub fn resolve_db(explicit: Option<&Path>, cfg_default: &Path) -> PathBuf {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// Path to the SQLite database file
+    #[serde(default = "Config::default_db_path")]
     pub db_path: PathBuf,
 
     /// Directory where model weights are cached (used by backend-metal)
+    #[serde(default = "Config::default_models_dir")]
     pub models_dir: PathBuf,
 
     /// Model ID for embeddings.
@@ -80,6 +82,7 @@ pub struct Config {
     pub llm_model: Option<String>,
 
     /// Default embedding batch size
+    #[serde(default = "Config::default_batch_size")]
     pub batch_size: usize,
 
     /// Base URL for the OpenAI-compatible API server (e.g. LM Studio, Ollama, vLLM).
@@ -120,11 +123,26 @@ pub struct Config {
 }
 
 impl Config {
+    fn default_db_path() -> PathBuf {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("spelunk")
+            .join("index.db")
+    }
+    fn default_models_dir() -> PathBuf {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("spelunk")
+            .join("models")
+    }
     fn default_embedding_model() -> String {
         "text-embedding-embeddinggemma-300m-qat".to_string()
     }
     fn default_api_base_url() -> String {
         "http://127.0.0.1:1234".to_string()
+    }
+    fn default_batch_size() -> usize {
+        32
     }
     fn default_plans_dir() -> PathBuf {
         PathBuf::from("docs/plans")
@@ -136,16 +154,12 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Self {
-        let base = dirs::config_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("spelunk");
-
         Self {
-            db_path: base.join("index.db"),
-            models_dir: base.join("models"),
+            db_path: Self::default_db_path(),
+            models_dir: Self::default_models_dir(),
             embedding_model: Self::default_embedding_model(),
             llm_model: None,
-            batch_size: 32,
+            batch_size: Self::default_batch_size(),
             api_base_url: Self::default_api_base_url(),
             memory_server_url: None,
             memory_server_key: None,

--- a/tests/e2e_cli.rs
+++ b/tests/e2e_cli.rs
@@ -1,7 +1,7 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
-use tempfile::tempdir;
 use std::fs;
+use tempfile::tempdir;
 
 #[test]
 fn test_help_output() {
@@ -9,7 +9,9 @@ fn test_help_output() {
     cmd.arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Usage: spelunk [OPTIONS] <COMMAND>"))
+        .stdout(predicate::str::contains(
+            "Usage: spelunk [OPTIONS] <COMMAND>",
+        ))
         .stdout(predicate::str::contains("Commands:"));
 }
 
@@ -28,7 +30,9 @@ fn test_invalid_command() {
     cmd.arg("nonexistent-command")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error: unrecognized subcommand 'nonexistent-command'"));
+        .stderr(predicate::str::contains(
+            "error: unrecognized subcommand 'nonexistent-command'",
+        ));
 }
 
 #[test]
@@ -56,39 +60,44 @@ fn test_status_empty_project() {
         .arg("status")
         .assert()
         .success()
-        .stdout(predicate::str::contains("No index found for the current directory"));
+        .stdout(predicate::str::contains(
+            "No index found for the current directory",
+        ));
 }
 
-use wiremock::{MockServer, Mock, ResponseTemplate};
 use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
 async fn test_index_and_status() {
     let mock_server = MockServer::start().await;
-    
+
     // Mock for index (1 file -> 1 chunk -> 1 request)
     Mock::given(method("POST"))
         .and(path("/v1/embeddings"))
-        .respond_with(ResponseTemplate::new(200)
-            .set_body_json(serde_json::json!({
-                "data": [{ "embedding": vec![0.1; 768], "index": 0 }],
-                "model": "test-model",
-                "object": "list",
-                "usage": { "prompt_tokens": 10, "total_tokens": 10 }
-            })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [{ "embedding": vec![0.1; 768], "index": 0 }],
+            "model": "test-model",
+            "object": "list",
+            "usage": { "prompt_tokens": 10, "total_tokens": 10 }
+        })))
         .mount(&mock_server)
         .await;
 
     let temp = tempdir().unwrap();
     let project_dir = temp.path().join("my-project");
     fs::create_dir(&project_dir).unwrap();
-    fs::write(project_dir.join("main.rs"), "fn main() { println!(\"hello\"); }").unwrap();
+    fs::write(
+        project_dir.join("main.rs"),
+        "fn main() { println!(\"hello\"); }",
+    )
+    .unwrap();
 
     let config_path = temp.path().join("config.toml");
     let db_path = temp.path().join("test_index.db");
-    
+
     fs::write(&config_path, format!(
-        "db_path = {:?}\nlmstudio_base_url = {:?}\nembedding_model = \"test-model\"\nllm_model = \"test-chat-model\"\n",
+        "db_path = {:?}\napi_base_url = {:?}\nembedding_model = \"test-model\"\nllm_model = \"test-chat-model\"\n",
         db_path, mock_server.uri()
     )).unwrap();
 

--- a/tests/e2e_cli.rs
+++ b/tests/e2e_cli.rs
@@ -1,0 +1,146 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+use std::fs;
+
+#[test]
+fn test_help_output() {
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Usage: spelunk [OPTIONS] <COMMAND>"))
+        .stdout(predicate::str::contains("Commands:"));
+}
+
+#[test]
+fn test_version_output() {
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("spelunk 0.1.0"));
+}
+
+#[test]
+fn test_invalid_command() {
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("nonexistent-command")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error: unrecognized subcommand 'nonexistent-command'"));
+}
+
+#[test]
+fn test_languages_output() {
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("languages")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Supported languages:"))
+        .stdout(predicate::str::contains("rust"))
+        .stdout(predicate::str::contains("python"))
+        .stdout(predicate::str::contains("javascript"));
+}
+
+#[test]
+fn test_status_empty_project() {
+    let temp = tempdir().unwrap();
+    let config_path = temp.path().join("config.toml");
+    fs::write(&config_path, "llm_model = \"test-model\"\n").unwrap();
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.current_dir(temp.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No index found for the current directory"));
+}
+
+use wiremock::{MockServer, Mock, ResponseTemplate};
+use wiremock::matchers::{method, path};
+
+#[tokio::test]
+async fn test_index_and_status() {
+    let mock_server = MockServer::start().await;
+    
+    // Mock for index (1 file -> 1 chunk -> 1 request)
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200)
+            .set_body_json(serde_json::json!({
+                "data": [{ "embedding": vec![0.1; 768], "index": 0 }],
+                "model": "test-model",
+                "object": "list",
+                "usage": { "prompt_tokens": 10, "total_tokens": 10 }
+            })))
+        .mount(&mock_server)
+        .await;
+
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("my-project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("main.rs"), "fn main() { println!(\"hello\"); }").unwrap();
+
+    let config_path = temp.path().join("config.toml");
+    let db_path = temp.path().join("test_index.db");
+    
+    fs::write(&config_path, format!(
+        "db_path = {:?}\nlmstudio_base_url = {:?}\nembedding_model = \"test-model\"\nllm_model = \"test-chat-model\"\n",
+        db_path, mock_server.uri()
+    )).unwrap();
+
+    // 1. Index the project
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    // 2. Check status
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Project:"))
+        .stdout(predicate::str::contains("my-project"))
+        .stdout(predicate::str::contains("Files:      1"))
+        .stdout(predicate::str::contains("Chunks:     1"));
+
+    // 3. Search for the function
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("search")
+        .arg("hello")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("main.rs"))
+        .stdout(predicate::str::contains("fn main()"));
+
+    // 4. Ask a question
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200)
+            .set_body_string("data: {\"choices\": [{\"delta\": {\"content\": \"The main function \"}}]}\n\ndata: {\"choices\": [{\"delta\": {\"content\": \"prints hello.\"}}]}\n\ndata: [DONE]\n\n"))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("ask")
+        .arg("what does the main function do?")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("The main function prints hello."));
+}


### PR DESCRIPTION
This PR fixes Issue #25 by adding end-to-end tests for the  CLI using  and  to mock the LM Studio API. 

It also improves the  struct by making its fields optional in  (using Serde defaults), which makes the CLI more robust when users provide incomplete configuration files.