### PR TITLE
feat(search): proactive stale-index warnings

### DIFF
--- a/src/cli/cmd/ask.rs
+++ b/src/cli/cmd/ask.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use std::io::Write;
 
 use super::super::AskArgs;
-use super::search::{resolve_project_and_deps, search_all_dbs};
+use super::search::{maybe_warn_stale, resolve_project_and_deps, search_all_dbs};
 use super::ui::spinner;
 use crate::{
     config::{Config, resolve_db},
@@ -14,6 +14,10 @@ pub async fn ask(args: AskArgs, cfg: Config) -> Result<()> {
     use crate::llm::LlmBackend;
 
     let (db_path, dep_dbs) = resolve_project_and_deps(args.db.as_ref(), &cfg)?;
+
+    if !args.no_stale_check {
+        maybe_warn_stale(&db_path);
+    }
 
     // ── Step 1: embed the question + search ──────────────────────────────────
     let sp = spinner("Loading embedding model…");

--- a/src/cli/cmd/check.rs
+++ b/src/cli/cmd/check.rs
@@ -38,8 +38,22 @@ pub fn check(args: CheckArgs, cfg: Config) -> Result<()> {
 
     let fmt = crate::utils::effective_format(&args.format);
     let fresh = stale.is_empty();
+    let last_indexed: Option<i64> = db.stats().ok().and_then(|s| s.last_indexed);
 
-    if fmt == "json" {
+    if args.porcelain {
+        let last_ts = last_indexed.unwrap_or(0);
+        println!(
+            "stale={} total={} last_indexed={}",
+            stale.len(),
+            stored.len(),
+            last_ts
+        );
+        if args.files {
+            for p in &stale {
+                println!("{p}");
+            }
+        }
+    } else if fmt == "json" {
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -47,6 +61,7 @@ pub fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                 "indexed_files": stored.len(),
                 "stale_files": stale.len(),
                 "stale": stale,
+                "last_indexed_at": last_indexed,
             }))?
         );
     } else if fresh {

--- a/src/cli/cmd/graph.rs
+++ b/src/cli/cmd/graph.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 use super::super::GraphArgs;
+use super::search::maybe_warn_stale;
 use crate::{
     config::{Config, resolve_db},
     storage::Database,
@@ -13,6 +14,10 @@ pub fn graph(args: GraphArgs, cfg: Config) -> Result<()> {
             "No index found (checked current directory and parents).\n\
              Run `spelunk index <path>` inside your project first."
         );
+    }
+
+    if !args.no_stale_check {
+        maybe_warn_stale(&db_path);
     }
 
     let db = Database::open(&db_path)?;

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -13,6 +13,10 @@ use crate::{
 pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
     let (db_path, dep_dbs) = resolve_project_and_deps(args.db.as_ref(), &cfg)?;
 
+    if !args.no_stale_check {
+        maybe_warn_stale(&db_path);
+    }
+
     let sp = spinner("Loading model…");
 
     let embedder = crate::backends::ActiveEmbedder::load(&cfg)
@@ -66,6 +70,24 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Emit a staleness warning to stderr if the index appears out of date.
+/// Silently skips if the DB doesn't exist or the probe returns an error.
+pub(crate) fn maybe_warn_stale(db_path: &std::path::Path) {
+    if !db_path.exists() {
+        return;
+    }
+    if let Ok(db) = Database::open(db_path)
+        && let Ok(report) = db.sample_staleness_check(20)
+        && report.stale > 0
+    {
+        eprintln!(
+            "warning: index may be stale ({}/{} sampled files changed). \
+             Run `spelunk index .` to refresh.",
+            report.stale, report.sampled
+        );
+    }
 }
 
 /// Resolve the primary DB path and any dep DB paths via the registry.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -93,6 +93,10 @@ pub struct SearchArgs {
     /// Path to the SQLite database (overrides config)
     #[arg(short, long)]
     pub db: Option<PathBuf>,
+
+    /// Skip the lightweight staleness probe (suppress stale-index warning)
+    #[arg(long)]
+    pub no_stale_check: bool,
 }
 
 #[derive(Args, Debug)]
@@ -111,6 +115,10 @@ pub struct AskArgs {
     /// Path to the SQLite database (overrides config)
     #[arg(short, long)]
     pub db: Option<PathBuf>,
+
+    /// Skip the lightweight staleness probe (suppress stale-index warning)
+    #[arg(long)]
+    pub no_stale_check: bool,
 }
 
 #[derive(Args, Debug)]
@@ -129,6 +137,10 @@ pub struct GraphArgs {
     /// Path to the SQLite database (overrides config)
     #[arg(short, long)]
     pub db: Option<PathBuf>,
+
+    /// Skip the lightweight staleness probe (suppress stale-index warning)
+    #[arg(long)]
+    pub no_stale_check: bool,
 }
 
 #[derive(Args, Debug)]
@@ -169,6 +181,14 @@ pub struct CheckArgs {
     /// Path to the SQLite database (overrides auto-detect)
     #[arg(short, long)]
     pub db: Option<PathBuf>,
+
+    /// List the stale file paths (one per line) in addition to the summary
+    #[arg(long)]
+    pub files: bool,
+
+    /// Machine-readable output: `stale=N total=M last_indexed=T`
+    #[arg(long)]
+    pub porcelain: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -457,6 +457,69 @@ impl Database {
     }
 
     // -----------------------------------------------------------------------
+    // Staleness probe
+    // -----------------------------------------------------------------------
+
+    /// Sample up to `n` random files and compare their on-disk blake3 hashes
+    /// against the stored hashes to estimate index staleness.
+    ///
+    /// Designed to be fast (<10 ms for n=20): only a small random sample is
+    /// hashed, not the entire index.
+    pub fn sample_staleness_check(&self, n: usize) -> Result<StalenessReport> {
+        let last_indexed_at: Option<i64> = self
+            .conn
+            .query_row("SELECT MAX(indexed_at) FROM files", [], |r| r.get(0))
+            .ok()
+            .flatten();
+
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id, path, hash FROM files ORDER BY RANDOM() LIMIT ?1")?;
+        let rows = stmt.query_map(rusqlite::params![n as i64], |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+            ))
+        })?;
+
+        let sampled_rows: Vec<(i64, String, String)> =
+            rows.collect::<rusqlite::Result<Vec<_>>>()?;
+        let sampled = sampled_rows.len();
+
+        let mut stale = 0usize;
+        let mut stale_paths: Vec<String> = Vec::new();
+
+        for (_id, path, stored_hash) in &sampled_rows {
+            let is_stale = match std::fs::read(path) {
+                Ok(bytes) => {
+                    let current = format!("{}", blake3::hash(&bytes));
+                    current != *stored_hash
+                }
+                Err(_) => true, // missing file counts as stale
+            };
+            if is_stale {
+                stale += 1;
+                stale_paths.push(path.clone());
+            }
+        }
+
+        let estimated_stale_pct = if sampled == 0 {
+            0.0
+        } else {
+            stale as f32 / sampled as f32 * 100.0
+        };
+
+        Ok(StalenessReport {
+            sampled,
+            stale,
+            stale_paths,
+            estimated_stale_pct,
+            last_indexed_at,
+        })
+    }
+
+    // -----------------------------------------------------------------------
     // Stats
     // -----------------------------------------------------------------------
 
@@ -764,4 +827,22 @@ pub struct DriftCandidate {
     pub days_behind: i64,
     /// Number of distinct files that call/import symbols from this file.
     pub caller_count: i64,
+}
+
+/// Result of a lightweight random-sample staleness probe.
+#[derive(Debug, serde::Serialize)]
+pub struct StalenessReport {
+    /// Number of files sampled.
+    pub sampled: usize,
+    /// Number of sampled files whose on-disk hash differs from the stored hash
+    /// (or that are missing from disk entirely).
+    pub stale: usize,
+    /// Paths of the stale files in the sample.
+    pub stale_paths: Vec<String>,
+    /// Estimated percentage of files in the full index that are stale,
+    /// extrapolated from the sample (0–100).
+    pub estimated_stale_pct: f32,
+    /// Unix timestamp of the most recently indexed file, or `None` if the
+    /// index is empty.
+    pub last_indexed_at: Option<i64>,
 }


### PR DESCRIPTION
## Summary
- `Database::sample_staleness_check(n)` samples up to N random indexed files, compares blake3 hashes against disk, returns a `StalenessReport`
- `spelunk search`, `spelunk ask`, `spelunk graph` warn on stderr when stale files are detected; suppressed with `--no-stale-check`
- `spelunk check` gains `--porcelain` (machine-readable `stale=N total=M last_indexed=T`) and `--files` (list stale paths) flags

## Test plan
- [ ] `spelunk search "..."` shows warning on stderr when files changed since last index
- [ ] `spelunk search "..." --no-stale-check` suppresses the warning
- [ ] `spelunk ask` and `spelunk graph` show the same warning
- [ ] `spelunk check --porcelain` outputs `stale=N total=M last_indexed=T`
- [ ] `spelunk check --porcelain --files` also lists stale paths
- [ ] `cargo test` passes

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)