### PR TITLE
docs: Rewrite public-facing docs for OSS launch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,12 @@ name = "spelunk"
 version = "0.1.0"
 edition = "2024"
 default-run = "spelunk"
-description = "Local code intelligence via RAG — indexed with tree-sitter, stored in SQLite"
+description = "Local context engine for AI coding agents — tree-sitter AST chunking, semantic search, code graph"
 license = "MIT"
 repository = "https://github.com/usercise/spelunk"
+homepage = "https://github.com/usercise/spelunk"
+keywords = ["code-search", "semantic-search", "tree-sitter", "ai-agents", "embeddings"]
+categories = ["command-line-utilities", "development-tools", "text-processing"]
 
 [lib]
 name = "spelunk"

--- a/README.md
+++ b/README.md
@@ -1,72 +1,136 @@
-# spelunk — local code intelligence
+# spelunk
 
-spelunk gives individual developers and AI agents context-aware code understanding without sending your code anywhere. Your codebase, your models, your machine.
+**A local context engine for AI coding agents.** Grep finds strings — spelunk finds meaning.
+
+spelunk indexes your codebase using tree-sitter AST parsing and semantic embeddings, then serves that context to AI agents (or you) via fast CLI queries. Your code never leaves your machine.
+
+```bash
+spelunk index .                                    # index the project
+spelunk search "how does authentication work"      # semantic search
+spelunk graph validate_token                       # callers, callees, imports
+```
 
 ## Why spelunk?
 
-Most code intelligence tools require your source code to leave your machine — indexed on someone else's servers, processed by someone else's models, subject to someone else's terms. That's a non-starter for proprietary codebases, regulated industries, or anyone who simply doesn't want their IP analysed by a third party.
+AI coding agents are only as good as the context they can see. Most context tools either upload your code to a cloud service or rely on grep, which only finds exact strings.
 
-spelunk keeps everything local:
+spelunk is different:
 
-- **Your code never leaves your machine** — the index is a SQLite file that lives in your project, backed up with your repo, owned by you
-- **Any model, your choice** — runs against any model loaded in [LM Studio](https://lmstudio.ai/); no API keys, no billing, no rate limits
-- **Works offline** — no internet required after setup
-- **No lock-in** — switch models, move machines, or stop using spelunk without losing anything
+- **Semantic search** — find code by what it *does*, not what it's called. Ask for "authentication" and find `validate_hmac_sha256` even though the word "authentication" appears nowhere in the file.
+- **Code graph** — trace callers, callees, and imports across file boundaries. Understand not just *where* code is, but *how it connects*.
+- **Multi-project search** — link local dependency projects and search across your entire stack in one query.
+- **100% local** — no cloud, no API keys for core features, no telemetry. The index is a SQLite file in your project directory.
+- **Any embedding model** — runs against any OpenAI-compatible embedding endpoint (LM Studio, Ollama, vLLM). Swap in a better model and get better results without waiting for a spelunk release.
+- **Agent-native** — built to be called by AI agents, not to replace them. JSON output, git hooks for auto-indexing, and a structured memory system for cross-session context.
 
-## What it does
+### When to use spelunk vs grep
 
-**Semantic search** — find code by what it does, not what it's called. spelunk uses AST-based chunking (tree-sitter) to index functions, structs, and classes as discrete units, then embeds them for meaning-based retrieval.
+| You want to... | Use |
+|---|---|
+| Find an exact function name | `rg "fn validate_token"` |
+| Find code related to a concept | `spelunk search "request authentication"` |
+| See what calls a function | `spelunk graph validate_token` |
+| Search across linked projects | `spelunk search "connection pooling"` |
+| Store a design decision for future sessions | `spelunk memory add --kind decision ...` |
+
+spelunk complements agentic search tools (grep, file reading) — it handles the queries they can't.
+
+## Quick start
+
+**1. Install**
 
 ```bash
+cargo install spelunk
+```
+
+> Or download a binary from the [releases page](https://github.com/usercise/spelunk/releases). See [Getting Started](docs/getting-started.md) for full instructions.
+
+**2. Start an embedding model**
+
+spelunk needs an embedding model running on any OpenAI-compatible endpoint. The easiest option is [LM Studio](https://lmstudio.ai/):
+
+```bash
+# Load google/embeddinggemma-300m-qat in LM Studio and start the server (port 1234)
+```
+
+**3. Index and search**
+
+```bash
+spelunk index .
 spelunk search "error handling in the HTTP layer"
-spelunk search "database connection pooling" --graph   # enrich with callers/callees
+spelunk search "database migrations" --graph    # include callers/callees
 ```
 
-**Natural language Q&A** — ask questions about your codebase and get answers with source citations.
+## Core features
+
+### Semantic search
 
 ```bash
-spelunk ask "how does incremental re-indexing work?"
-spelunk ask "what would break if I changed the embedding format?" --json
+spelunk search "how are errors propagated to the user"
+spelunk search "database connection pooling" --graph --format json
 ```
 
-**Project memory** — a structured alternative to CLAUDE.md files
+Tree-sitter extracts functions, structs, classes, and methods as discrete chunks — not naive line splits. Each chunk is embedded and stored in a local SQLite database with the [sqlite-vec](https://github.com/asg017/sqlite-vec) extension for fast KNN search.
 
-> Research shows that static context files like CLAUDE.md [reduce agent task success rates](https://arxiv.org/abs/2501.12599) — agents misread them, ignore irrelevant sections, or get confused by stale information. spelunk memory fixes this: context is retrieved semantically at query time, so each agent call gets only the entries most relevant to the current task.
+### Code graph
+
+```bash
+spelunk graph RagPipeline                        # all edges for a symbol
+spelunk graph src/storage/db.rs --kind imports   # imports in a file
+```
+
+spelunk extracts import, call, extends, and implements edges from the AST. Use `--graph` on search to automatically expand results with 1-hop callers and callees.
+
+### Project memory
+
+Store decisions, requirements, and context that persist across agent sessions:
 
 ```bash
 spelunk memory add --kind decision --title "Chose sqlite-vec over pgvector" \
   --body "Must run without a Postgres server. Revisit if we need filtering + ANN."
 spelunk memory search "why did we choose this database"
-spelunk memory add --from-url https://github.com/owner/repo/issues/42  # pull in ticket context
+spelunk memory harvest   # auto-extract decisions from recent commits
 ```
 
-**Agent-ready** — `AGENT=true` forces JSON output on every command. Pair with git hooks to auto-index and harvest memory on every commit.
+Memory entries are embedded and retrieved semantically — each query gets only the entries relevant to the current task, not the entire context file.
+
+### Multi-project search
+
+```bash
+spelunk link ../shared-utils
+spelunk search "connection pooling"   # searches both projects, merges by relevance
+```
+
+### Agent integration
+
+Set `AGENT=true` for JSON output on every command. Install git hooks for automatic indexing:
 
 ```bash
 spelunk hooks install   # post-commit: auto-index + auto-harvest memory
 AGENT=true spelunk search "auth flow" | jq '.[0].file_path'
 ```
 
-## Getting started
-
-→ **[Getting Started](docs/getting-started.md)** — install, configure LM Studio, index your first project
-
-## Documentation
-
-- [Getting Started](docs/getting-started.md)
-- [Commands](docs/commands.md) — full reference for every subcommand
-- [Memory](docs/memory.md) — decisions, context, and requirements across sessions
-- [Agent Guide](docs/agent-guide.md) — spelunk as infrastructure for AI coding agents
-- [Examples](docs/examples/)
+spelunk ships with a [Claude Code skill](SKILL.md) and [agent guide](docs/agent-guide.md) for integration with AI coding agents.
 
 ## Supported languages
 
-The following languages get **AST-aware indexing** — spelunk uses tree-sitter to extract semantic chunks (functions, classes, methods) rather than raw line splits:
+Tree-sitter AST-aware chunking for: **Rust**, **Go**, **Python**, **TypeScript**, **JavaScript**, **JSX**, **TSX**, **Java**, **C**, **C++**, **Ruby**, **Swift**, **Kotlin**, **JSON**, **HTML**, **CSS**, **HCL**, **Proto**, **SQL**, **Markdown**.
 
-Rust, Go, Python, TypeScript, JavaScript, JSX, TSX, Java, C, C++, Ruby, Swift, Kotlin, JSON, HTML, CSS, HCL, Proto, SQL, Markdown.
+All other file types are indexed as plain text with a sliding-window chunker.
 
-Any other file type is indexed as plain text using a sliding-window chunker, so it still shows up in search results.
+## Documentation
+
+- [Getting Started](docs/getting-started.md) — install, configure, index your first project
+- [Commands](docs/commands.md) — full reference for every subcommand
+- [Memory](docs/memory.md) — decisions, context, and requirements across sessions
+- [Agent Guide](docs/agent-guide.md) — using spelunk with AI coding agents
+- [Architecture](docs/architecture.md) — system design for contributors
+- [Examples](docs/examples/) — real-world workflows
+
+## Contributing
+
+Contributions welcome. See [Building from source](docs/building.md) for setup instructions.
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/docs/adr/001-scope-boundaries.md
+++ b/docs/adr/001-scope-boundaries.md
@@ -1,0 +1,60 @@
+# ADR-001: Scope Boundaries — What spelunk Is and Isn't
+
+**Status:** Accepted
+**Date:** 2026-03-28
+**Context:** Competitive landscape analysis against DeepWiki, Augment Code, Cursor, Greptile, Sourcegraph Cody, Aider, Bloop, and Zoekt.
+
+## Decision
+
+spelunk is a **context retrieval engine** for AI agents. The following boundaries define what it will and will not become.
+
+### 1. Context retrieval, not code generation
+
+spelunk retrieves and ranks code context. It does not generate, modify, or refactor code.
+
+The `ask` and `explore` commands use an LLM to synthesise answers *about* code, but the output is explanatory text, never a code patch or file modification. Code generation is the agent's job. spelunk feeds the agent; the agent acts.
+
+**Why:** Coupling retrieval and generation creates a monolith that competes with every AI coding assistant. Staying retrieval-only makes spelunk composable — it works with Claude Code, Aider, Cursor, or any future agent. The moment spelunk writes code, it becomes one more agent instead of infrastructure.
+
+**Boundary test:** If a proposed feature would modify a source file in the indexed project, it belongs in the agent, not in spelunk.
+
+### 2. SQLite is the storage layer
+
+All persistent state — chunks, embeddings, graph edges, memory, registry — lives in SQLite databases. The sqlite-vec extension provides vector KNN search. FTS5 (bundled with SQLite) provides full-text search.
+
+spelunk will not adopt a separate vector database (Qdrant, Milvus, Turbopuffer, etc.) or a separate search engine (Tantivy, Elasticsearch, etc.).
+
+**Why:** SQLite is zero-configuration, single-file, and embedded. It eliminates an entire category of operational complexity (servers, ports, connection strings, version compatibility). sqlite-vec and FTS5 are sufficient for the scale spelunk targets — single developer, local machine, repos up to ~100K files. If a user's codebase outgrows SQLite's capabilities, they likely need Sourcegraph, not spelunk.
+
+**Boundary test:** If a proposed storage change requires the user to run a separate process or manage a separate data directory, reject it.
+
+### 3. Embedding-model agnostic, not embedding-model provider
+
+spelunk calls an embedding API. It does not bundle, host, fine-tune, or distribute embedding models.
+
+The backend trait (`EmbeddingBackend`) accepts any service that speaks the OpenAI-compatible `/v1/embeddings` protocol. LM Studio is the default because it runs locally, but any compatible endpoint works (Ollama, vLLM, OpenAI, etc.).
+
+**Why:** Embedding models improve rapidly. Bundling a model locks spelunk to a quality ceiling and adds a multi-hundred-MB binary. Staying agnostic means users get better retrieval for free by loading a better model, without waiting for a spelunk release.
+
+**Boundary test:** If a proposed feature requires a specific model architecture, weights file, or tokenizer, it belongs in the backend, not in spelunk core.
+
+### 4. Complement agentic search, don't replace grep
+
+The 2026 industry trend is agentic search: LLMs driving iterative grep/file-read loops. This works well for exact symbol lookup and is always fresh. spelunk's value is in what grep *cannot* do:
+
+- **Semantic search** — finding code by concept when you don't know the symbol name
+- **Structural graph queries** — "what calls this function" across file boundaries
+- **Cross-project search** — querying linked dependency projects
+- **Ranked context selection** — returning the most important code within a token budget
+
+spelunk should never try to be a faster grep. When an agent knows the exact string, `rg` is the right tool. spelunk is for when the agent doesn't know what to grep for.
+
+**Why:** Competing with grep on exact match is a losing proposition — it's instant, zero-setup, and universally available. Investing in "spelunk grep" dilutes focus from the semantic and structural capabilities that are genuinely differentiated.
+
+**Boundary test:** If a proposed search feature would be better served by `rg --type rust "pattern"`, it doesn't belong in spelunk.
+
+## Consequences
+
+- Feature proposals are evaluated against these four boundaries before planning.
+- The CLAUDE.md agent guide references this ADR for architectural context.
+- These boundaries may be revised via a new ADR if the competitive landscape or project goals change materially.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,152 @@
+# Architecture
+
+This document describes spelunk's system design for contributors and anyone integrating with the codebase.
+
+## Overview
+
+spelunk is a Rust CLI that:
+
+1. **Indexes** source trees using tree-sitter AST parsing
+2. **Embeds** each code chunk via an external embedding model
+3. **Stores** vectors, chunks, and graph edges in SQLite
+4. **Serves** semantic search, graph queries, and memory retrieval via CLI
+
+```
+┌─────────────┐     ┌──────────────┐     ┌────────────────┐
+│  Source tree │────>│   Indexer    │────>│   SQLite DB    │
+│  (.rs, .py,  │     │  tree-sitter │     │  chunks        │
+│   .ts, ...)  │     │  + chunker   │     │  embeddings    │
+└─────────────┘     └──────┬───────┘     │  graph_edges   │
+                           │             │  notes         │
+                    ┌──────▼───────┐     └───────┬────────┘
+                    │  Embedding   │             │
+                    │  Backend     │     ┌───────▼────────┐
+                    │  (LM Studio, │     │   Search /     │
+                    │   Ollama,    │     │   Graph /      │
+                    │   any OAI)   │     │   Memory       │
+                    └──────────────┘     └��──────┬────────┘
+                                                │
+                                        ┌───────▼───────��┐
+                                        │   CLI output   │
+                                        │  (text / JSON) │
+                                        └────────────��───┘
+```
+
+## Module structure
+
+```
+src/
+  main.rs              Entry point: CLI parse, sqlite-vec init, command dispatch
+  lib.rs               Library root: re-exports for tests and server binary
+
+  cli/
+    mod.rs             Clap structs (Cli, Command, *Args)
+    cmd/               One file per subcommand (index.rs, search.rs, etc.)
+
+  config.rs            Config struct, loads from ~/.config/spelunk/config.toml
+
+  backends.rs          Re-exports ActiveEmbedder / ActiveLlm (feature-gated)
+
+  embeddings/
+    mod.rs             EmbeddingBackend trait, vec_to_blob/blob_to_vec helpers
+    lmstudio.rs        LmStudioEmbedder: POST /v1/embeddings
+
+  llm/
+    mod.rs             LlmBackend trait, Message struct
+    lmstudio.rs        LmStudioLlm: POST /v1/chat/completions (SSE streaming)
+
+  indexer/
+    mod.rs             Re-exports
+    chunker.rs         Chunk / ChunkKind structs, embedding_text(), sliding_window
+    parser.rs          SourceParser (tree-sitter), detect_language, SUPPORTED_LANGUAGES
+    graph.rs           EdgeExtractor: import/call/extends edges via tree-sitter
+    secrets.rs         Regex-based credential scanner, drops matching chunks
+
+  storage/
+    mod.rs             Re-exports
+    db.rs              Database struct: open/migrate, CRUD, KNN search
+
+  search/
+    mod.rs             SearchResult struct
+    rag.rs             RagPipeline: search + ask methods
+
+  registry.rs          Global project registry (~/.config/spelunk/registry.db)
+
+migrations/            SQL migration files applied in order at DB open
+```
+
+## Key design decisions
+
+Architectural decisions are recorded in [docs/adr/](adr/). Key ones:
+
+### Chunking: tree-sitter AST nodes, not line splits
+
+Tree-sitter parses source code into an AST and spelunk extracts named semantic nodes (functions, structs, classes, methods, traits, impls) as individual chunks. This means each chunk is a meaningful unit of code with a name, type, and scope — not an arbitrary 100-line window.
+
+Fallback: sliding window (120 lines, 15-line overlap) for unsupported languages. Markdown uses heading-based chunking.
+
+### Storage: SQLite + sqlite-vec, nothing else
+
+All data lives in a single SQLite file per project. The sqlite-vec extension adds a `vec0` virtual table for KNN vector search. No separate vector database, no separate search engine.
+
+This is a deliberate constraint — see [ADR-001](adr/001-scope-boundaries.md). SQLite is zero-configuration, single-file, and sufficient for the scale spelunk targets.
+
+### Incremental indexing via blake3
+
+Each file is hashed with blake3. On re-index, unchanged files are skipped entirely. Changed files get their old chunks and embeddings deleted, then re-parsed and re-embedded.
+
+### Embedding format
+
+Chunks are embedded using EmbeddingGemma's recommended format:
+```
+title: {name} | text: {content}
+```
+
+Queries use: `task: code retrieval | query: {q}`
+
+See `Chunk::embedding_text()` in `src/indexer/chunker.rs`.
+
+### Backend abstraction
+
+The `EmbeddingBackend` and `LlmBackend` traits are the only interface between spelunk and inference. The concrete implementation (LM Studio) is gated behind a feature flag and re-exported in `src/backends.rs`.
+
+To add a new backend: implement the trait, add a feature flag, gate the re-export. Nothing outside `src/embeddings/`, `src/llm/`, and `src/backends.rs` imports a concrete backend.
+
+### Secret scanning
+
+`src/indexer/secrets.rs` runs regex patterns against every chunk before storage. Chunks matching known credential patterns (AWS keys, PEM headers, GitHub PATs) are silently dropped and a warning is logged.
+
+### Multi-project registry
+
+`~/.config/spelunk/registry.db` tracks all indexed projects. `spelunk link` connects projects so that `spelunk search` queries multiple databases and merges results by vector distance.
+
+## Data flow: index
+
+```
+files on disk
+  → SourceParser (tree-sitter AST → Chunk[])
+  → SecretScanner (drop credential chunks)
+  → EmbeddingBackend.embed(batch of chunk texts)
+  → Database.store(chunks + embeddings)
+  → EdgeExtractor (AST → graph_edges)
+  → Database.store(edges)
+```
+
+## Data flow: search
+
+```
+query string
+  → EmbeddingBackend.embed(formatted query)
+  → Database.search_similar(query_vec, limit)  // sqlite-vec KNN
+  → [optional] Database.graph_neighbor_chunks() // 1-hop expansion
+  → [optional] query linked project DBs via registry
+  → merge + deduplicate by (file_path, start_line, end_line)
+  → return Vec<SearchResult>
+```
+
+## Adding a new language
+
+1. Add the `tree-sitter-{lang}` crate to `Cargo.toml`
+2. Register the language in `src/indexer/parser.rs` (`detect_language` + `SUPPORTED_LANGUAGES`)
+3. Add extraction patterns in `src/indexer/graph/edges.rs` for graph edge support
+4. Add tests


### PR DESCRIPTION
## Summary

- Rewrite README with sharper positioning as "a local context engine for AI coding agents", quick-start section, grep-vs-spelunk comparison table, and feature showcase
- Update Cargo.toml with crates.io metadata (keywords, categories, homepage)
- Update GitHub repo description and topics
- Add `docs/architecture.md` — contributor-facing system design doc
- Add `docs/adr/001-scope-boundaries.md` — codifies four scope constraints: context retrieval not code gen, SQLite only, embedding-model agnostic, complement grep don't replace it

## Context

Preparing for public OSS launch and dev conference demo.

## Test plan

- [ ] Verify all doc links resolve (Getting Started, Commands, Memory, Agent Guide, Architecture, Examples, Building)
- [ ] Confirm GitHub repo description and topics display correctly
- [ ] Review README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)