### PR TITLE
test(props): add proptest property-based tests for core logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18464ccbb85e5dede30d70cc7676dc9950a0fb7dbf595a43d765be9123c616a2"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3161,10 +3176,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -3297,6 +3337,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -3633,6 +3682,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3941,6 +4002,7 @@ dependencies = [
  "lopdf",
  "predicates",
  "pretty_assertions",
+ "proptest",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
@@ -4177,7 +4239,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -4695,6 +4757,12 @@ checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
+proptest = "1"
 assert_cmd = "2.0"
 predicates = "3.1"
 

--- a/tests/prop_chunker.rs
+++ b/tests/prop_chunker.rs
@@ -1,0 +1,52 @@
+use proptest::prelude::*;
+use spelunk::indexer::chunker::sliding_window;
+
+proptest! {
+    // Every chunk's content must be a substring of the original source
+    #[test]
+    fn chunks_are_substrings_of_source(
+        source in "([a-z ]+\n){1,50}",
+        window in 5usize..=50,
+        overlap in 0usize..=10,
+    ) {
+        let overlap = overlap.min(window - 1);
+        let chunks = sliding_window(&source, "test.txt", "text", window, overlap);
+        for chunk in &chunks {
+            prop_assert!(
+                source.contains(chunk.content.trim()),
+                "chunk content not found in source"
+            );
+        }
+    }
+
+    // No chunk should exceed window size (in lines)
+    #[test]
+    fn chunks_respect_window_size(
+        source in "([a-z ]+\n){1,100}",
+        window in 5usize..=30,
+        overlap in 0usize..=5,
+    ) {
+        let overlap = overlap.min(window - 1);
+        let chunks = sliding_window(&source, "test.txt", "text", window, overlap);
+        for chunk in &chunks {
+            let line_count = chunk.content.lines().count();
+            prop_assert!(
+                line_count <= window,
+                "chunk has {} lines, window is {}",
+                line_count,
+                window
+            );
+        }
+    }
+
+    // Empty source always yields no chunks
+    #[test]
+    fn empty_source_yields_no_chunks(
+        window in 1usize..=50,
+        overlap in 0usize..=10,
+    ) {
+        let overlap = overlap.min(window - 1);
+        let chunks = sliding_window("", "test.txt", "text", window, overlap);
+        prop_assert!(chunks.is_empty());
+    }
+}

--- a/tests/prop_embeddings.rs
+++ b/tests/prop_embeddings.rs
@@ -1,0 +1,31 @@
+use proptest::prelude::*;
+use spelunk::embeddings::{blob_to_vec, vec_to_blob};
+
+proptest! {
+    // Roundtrip: blob_to_vec(vec_to_blob(v)) == v
+    #[test]
+    fn vec_blob_roundtrip(
+        values in prop::collection::vec(-1e6f32..1e6f32, 0..=512)
+    ) {
+        let blob = vec_to_blob(&values);
+        let recovered = blob_to_vec(&blob);
+        prop_assert_eq!(values.len(), recovered.len());
+        for (a, b) in values.iter().zip(recovered.iter()) {
+            prop_assert!(
+                (a - b).abs() < 1e-6,
+                "value {} recovered as {}",
+                a,
+                b
+            );
+        }
+    }
+
+    // blob length is always 4 * vec length
+    #[test]
+    fn blob_length_is_four_bytes_per_float(
+        values in prop::collection::vec(-1.0f32..1.0f32, 0..=256)
+    ) {
+        let blob = vec_to_blob(&values);
+        prop_assert_eq!(blob.len(), values.len() * 4);
+    }
+}

--- a/tests/prop_token_budget.rs
+++ b/tests/prop_token_budget.rs
@@ -1,0 +1,27 @@
+use proptest::prelude::*;
+use spelunk::search::tokens::estimate_tokens;
+
+proptest! {
+    // estimate_tokens always returns >= 1
+    #[test]
+    fn estimate_tokens_always_positive(s in ".*") {
+        prop_assert!(estimate_tokens(&s) >= 1);
+    }
+
+    // Longer strings always produce >= token count of shorter prefix
+    #[test]
+    fn estimate_tokens_monotone(
+        base in "[a-z]{4,100}",
+        extra in "[a-z]{1,50}",
+    ) {
+        let combined = format!("{}{}", base, extra);
+        prop_assert!(estimate_tokens(&combined) >= estimate_tokens(&base));
+    }
+
+    // Token count scales with length (roughly chars/4)
+    #[test]
+    fn estimate_tokens_chars_div_4(s in "[a-z]{1,200}") {
+        let expected = (s.chars().count() / 4).max(1);
+        prop_assert_eq!(estimate_tokens(&s), expected);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `proptest = "1"` to dev-dependencies
- `tests/prop_chunker.rs` — 3 properties for `sliding_window`: chunks are substrings of source, respect window size, empty source yields no chunks
- `tests/prop_embeddings.rs` — 2 properties for `vec_to_blob`/`blob_to_vec`: full roundtrip fidelity, blob length is always 4× vec length
- `tests/prop_token_budget.rs` — 3 properties for `estimate_tokens`: always ≥ 1, monotone with string length, matches chars/4 formula

All 8 property tests pass.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)