### PR TITLE
chore: reduce duplication with shared CLI helpers

### DIFF
--- a/src/cli/cmd/ask.rs
+++ b/src/cli/cmd/ask.rs
@@ -2,11 +2,11 @@ use anyhow::{Context, Result};
 use std::io::Write;
 
 use super::super::AskArgs;
+use super::helpers::{embed_query, load_llm};
 use super::search::{maybe_warn_stale, resolve_project_and_deps, search_all_dbs};
 use super::ui::spinner;
 use crate::{
     config::{Config, resolve_db},
-    embeddings::{EmbeddingBackend as _, vec_to_blob},
     storage::{Database, open_memory_backend},
 };
 
@@ -27,9 +27,7 @@ pub async fn ask(args: AskArgs, cfg: Config) -> Result<()> {
         .with_context(|| format!("loading embedding model '{}'", cfg.embedding_model))?;
 
     sp.set_message("Searching for relevant context…");
-    let query_text = format!("task: question answering | query: {}", args.question);
-    let vecs = embedder.embed(&[&query_text]).await?;
-    let query_blob = vec_to_blob(vecs.first().context("no embedding")?);
+    let query_blob = embed_query(&embedder, "question answering", &args.question).await?;
 
     let mut results = search_all_dbs(
         &db_path,
@@ -230,14 +228,7 @@ If the answer cannot be determined from the provided context, say so clearly rat
     ];
 
     // ── Step 4: load LLM + stream answer ─────────────────────────────────────
-    let llm_model_name = cfg.llm_model.as_deref().unwrap_or("<not configured>");
-    let sp2 = spinner(format!("Loading LLM ({llm_model_name})…"));
-
-    let llm = crate::backends::ActiveLlm::load(&cfg)
-        .await
-        .with_context(|| format!("loading LLM '{llm_model_name}'"))?;
-
-    sp2.finish_and_clear();
+    let llm = load_llm(&cfg).await?;
     println!();
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::llm::Token>(128);

--- a/src/cli/cmd/graph.rs
+++ b/src/cli/cmd/graph.rs
@@ -1,26 +1,16 @@
 use anyhow::Result;
 
 use super::super::GraphArgs;
+use super::helpers::open_project_db;
 use super::search::maybe_warn_stale;
-use crate::{
-    config::{Config, resolve_db},
-    storage::Database,
-};
+use crate::config::Config;
 
 pub fn graph(args: GraphArgs, cfg: Config) -> Result<()> {
-    let db_path = resolve_db(args.db.as_deref(), &cfg.db_path);
-    if !db_path.exists() {
-        anyhow::bail!(
-            "No index found (checked current directory and parents).\n\
-             Run `spelunk index <path>` inside your project first."
-        );
-    }
+    let (db_path, db) = open_project_db(args.db.as_deref(), &cfg.db_path)?;
 
     if !args.no_stale_check {
         maybe_warn_stale(&db_path);
     }
-
-    let db = Database::open(&db_path)?;
     let symbol = &args.symbol;
 
     // Decide whether the query looks like a file path or a symbol name.

--- a/src/cli/cmd/helpers.rs
+++ b/src/cli/cmd/helpers.rs
@@ -1,0 +1,69 @@
+use anyhow::{Context, Result};
+
+use super::ui::spinner;
+use crate::{
+    config::{Config, resolve_db},
+    embeddings::{EmbeddingBackend as _, vec_to_blob},
+    storage::Database,
+};
+
+/// Resolve the DB path via `resolve_db`, error if not found, open and return
+/// both the path and the opened database.
+pub(crate) fn open_project_db(
+    db: Option<&std::path::Path>,
+    cfg_path: &std::path::Path,
+) -> Result<(std::path::PathBuf, Database)> {
+    let db_path = resolve_db(db, cfg_path);
+    if !db_path.exists() {
+        anyhow::bail!(
+            "No index found (checked current directory and parents).\n\
+             Run `spelunk index <path>` inside your project first."
+        );
+    }
+    let database = Database::open(&db_path)?;
+    Ok((db_path, database))
+}
+
+/// Show a "Loading embedding model…" spinner, load `ActiveEmbedder`, clear
+/// the spinner, and return the embedder.
+pub(crate) async fn load_embedder(cfg: &Config) -> Result<crate::backends::ActiveEmbedder> {
+    let sp = spinner("Loading embedding model…");
+    let embedder = crate::backends::ActiveEmbedder::load(cfg)
+        .await
+        .with_context(|| format!("loading embedding model '{}'", cfg.embedding_model))?;
+    sp.finish_and_clear();
+    Ok(embedder)
+}
+
+/// Show a "Loading LLM (…)…" spinner, load `ActiveLlm`, clear the spinner,
+/// and return the LLM.
+pub(crate) async fn load_llm(cfg: &Config) -> Result<crate::backends::ActiveLlm> {
+    let model_name = cfg.llm_model.as_deref().unwrap_or("<not configured>");
+    let sp = spinner(format!("Loading LLM ({model_name})…"));
+    let llm = crate::backends::ActiveLlm::load(cfg)
+        .await
+        .with_context(|| format!("loading LLM '{model_name}'"))?;
+    sp.finish_and_clear();
+    Ok(llm)
+}
+
+/// Embed a query with the given task prefix and return the blob bytes suitable
+/// for KNN search.
+pub(crate) async fn embed_query(
+    embedder: &crate::backends::ActiveEmbedder,
+    task: &str,
+    query: &str,
+) -> Result<Vec<u8>> {
+    let query_text = format!("task: {task} | query: {query}");
+    let vecs = embedder.embed(&[&query_text]).await?;
+    let blob = vec_to_blob(vecs.first().context("no embedding returned")?);
+    Ok(blob)
+}
+
+/// Return the final path component of `path` as a display name, falling back
+/// to the full path string if there is no file name component.
+pub(crate) fn project_display_name(path: &std::path::Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string_lossy().into_owned())
+}

--- a/src/cli/cmd/links.rs
+++ b/src/cli/cmd/links.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use super::super::{LinksArgs, LinksCommand};
+use super::helpers::project_display_name;
 use crate::{config::Config, registry::Registry, storage::Database};
 
 pub async fn links(args: LinksArgs, _cfg: Config) -> Result<()> {
@@ -38,11 +39,7 @@ async fn links_list(format: String) -> Result<()> {
     let mut infos: Vec<LinkedProjectInfo> = Vec::new();
 
     for dep in &deps {
-        let name = dep
-            .root_path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| dep.root_path.to_string_lossy().into_owned());
+        let name = project_display_name(&dep.root_path);
 
         let db_exists = dep.db_path.exists();
 
@@ -141,11 +138,7 @@ async fn links_check() -> Result<()> {
     let mut problems: Vec<String> = Vec::new();
 
     for dep in &deps {
-        let name = dep
-            .root_path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| dep.root_path.to_string_lossy().into_owned());
+        let name = project_display_name(&dep.root_path);
 
         if !dep.db_path.exists() {
             all_ok = false;

--- a/src/cli/cmd/memory.rs
+++ b/src/cli/cmd/memory.rs
@@ -4,6 +4,7 @@ use super::super::{
     MemoryAddArgs, MemoryArchiveArgs, MemoryArgs, MemoryCommand, MemoryHarvestArgs, MemoryListArgs,
     MemoryPushArgs, MemorySearchArgs, MemoryShowArgs, MemorySupersededArgs,
 };
+use super::helpers::embed_query;
 use super::status::format_age;
 use super::ui::spinner;
 use crate::{
@@ -208,15 +209,13 @@ async fn memory_search(
     mem_path: &std::path::Path,
     cfg: &Config,
 ) -> Result<()> {
-    let query_text = format!("task: question answering | query: {}", args.query);
     let sp = spinner("Embedding query…");
     let embedder = crate::backends::ActiveEmbedder::load(cfg)
         .await
         .context("loading embedding model")?;
-    let vecs = embedder.embed(&[&query_text]).await?;
+    let blob = embed_query(&embedder, "question answering", &args.query).await?;
     sp.finish_and_clear();
 
-    let blob = vec_to_blob(vecs.first().context("no embedding returned")?);
     let backend = open_memory_backend(cfg, mem_path)?;
     let notes = backend.search(&blob, args.limit).await?;
 

--- a/src/cli/cmd/misc.rs
+++ b/src/cli/cmd/misc.rs
@@ -1,11 +1,9 @@
 use anyhow::Result;
 
 use super::super::ChunksArgs;
+use super::helpers::open_project_db;
 use super::ui::print_chunks_text;
-use crate::{
-    config::{Config, resolve_db},
-    storage::Database,
-};
+use crate::config::Config;
 
 pub fn languages() -> Result<()> {
     let langs = crate::indexer::parser::SUPPORTED_LANGUAGES;
@@ -17,15 +15,7 @@ pub fn languages() -> Result<()> {
 }
 
 pub fn chunks(args: ChunksArgs, cfg: Config) -> Result<()> {
-    let db_path = resolve_db(args.db.as_deref(), &cfg.db_path);
-    if !db_path.exists() {
-        anyhow::bail!(
-            "No index found (checked current directory and parents).\n\
-             Run `spelunk index <path>` inside your project first."
-        );
-    }
-
-    let db = Database::open(&db_path)?;
+    let (_db_path, db) = open_project_db(args.db.as_deref(), &cfg.db_path)?;
     let results = db.chunks_for_file(&args.path)?;
 
     if results.is_empty() {

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -1,6 +1,7 @@
 mod ask;
 mod check;
 mod graph;
+pub mod helpers;
 mod hooks;
 mod index;
 mod init;

--- a/src/cli/cmd/plan.rs
+++ b/src/cli/cmd/plan.rs
@@ -1,11 +1,11 @@
 use anyhow::{Context, Result};
 
 use super::super::{PlanArgs, PlanCommand};
+use super::helpers::embed_query;
 use super::search::{resolve_project_and_deps, search_all_dbs};
 use super::ui::spinner;
 use crate::{
     config::{Config, resolve_db},
-    embeddings::{EmbeddingBackend as _, vec_to_blob},
     storage::open_memory_backend,
 };
 
@@ -28,9 +28,7 @@ async fn plan_create(
     let embedder = crate::backends::ActiveEmbedder::load(cfg)
         .await
         .context("loading embedder")?;
-    let query_text = format!("task: question answering | query: {}", args.description);
-    let vecs = embedder.embed(&[&query_text]).await?;
-    let blob = vec_to_blob(vecs.first().context("no embedding")?);
+    let blob = embed_query(&embedder, "question answering", &args.description).await?;
 
     let chunks = search_all_dbs(&db_path, &dep_paths, &blob, 15)?;
     sp.finish_and_clear();
@@ -38,7 +36,7 @@ async fn plan_create(
     // Gather memory context if available.
     let mem_path = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
     let memory_context = {
-        let mblob = vec_to_blob(vecs.first().context("no embedding")?);
+        let mblob = blob.clone();
         match open_memory_backend(cfg, &mem_path).ok() {
             Some(b) => b.search(&mblob, 5).await.ok().and_then(|notes| {
                 if notes.is_empty() {

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 
 use super::super::SearchArgs;
+use super::helpers::project_display_name;
 use super::ui::{print_results_text, spinner};
 use crate::{
     config::{Config, resolve_db},
@@ -219,6 +220,36 @@ pub(crate) fn resolve_project_and_deps(
     Ok((db_path, vec![]))
 }
 
+/// Annotate results with governing specs from the primary DB, and set
+/// `project_name` / `project_path` on dep results.
+fn annotate_dep_results(
+    results: &mut [SearchResult],
+    project_name: Option<String>,
+    project_path: String,
+) {
+    for r in results.iter_mut() {
+        r.project_name = project_name.clone();
+        r.project_path = Some(project_path.clone());
+    }
+}
+
+/// Populate `governing_specs` on each result using the primary DB.
+fn annotate_specs(all: &mut [SearchResult], primary_db_path: &std::path::Path) {
+    if let Ok(primary_db) = Database::open(primary_db_path) {
+        let file_paths: Vec<String> = all.iter().map(|r| r.file_path.clone()).collect();
+        if let Ok(all_specs) = primary_db.specs_for_files(&file_paths)
+            && !all_specs.is_empty()
+        {
+            for result in all.iter_mut() {
+                if let Ok(per) = primary_db.specs_for_files(std::slice::from_ref(&result.file_path))
+                {
+                    result.governing_specs = per.into_iter().map(|(p, _)| p).collect();
+                }
+            }
+        }
+    }
+}
+
 /// Search a primary DB and any dep projects, merge results by distance, return top `limit`.
 pub(crate) fn search_all_dbs(
     primary_db_path: &std::path::Path,
@@ -235,15 +266,9 @@ pub(crate) fn search_all_dbs(
         match Database::open(&dep.db_path) {
             Ok(dep_db) => match dep_db.search_similar(query_blob, fetch) {
                 Ok(mut dep_results) => {
-                    let name = dep
-                        .root_path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().into_owned());
+                    let name = project_display_name(&dep.root_path);
                     let root = dep.root_path.to_string_lossy().into_owned();
-                    for r in &mut dep_results {
-                        r.project_name = name.clone();
-                        r.project_path = Some(root.clone());
-                    }
+                    annotate_dep_results(&mut dep_results, Some(name), root);
                     all.append(&mut dep_results);
                 }
                 Err(e) => tracing::warn!("search failed on dep {}: {e}", dep.db_path.display()),
@@ -262,20 +287,7 @@ pub(crate) fn search_all_dbs(
     all.retain(|r| seen.insert((r.file_path.clone(), r.start_line, r.end_line)));
     all.truncate(limit);
 
-    // Annotate results with governing specs from the primary DB.
-    if let Ok(primary_db) = Database::open(primary_db_path) {
-        let file_paths: Vec<String> = all.iter().map(|r| r.file_path.clone()).collect();
-        if let Ok(all_specs) = primary_db.specs_for_files(&file_paths)
-            && !all_specs.is_empty()
-        {
-            for result in &mut all {
-                if let Ok(per) = primary_db.specs_for_files(std::slice::from_ref(&result.file_path))
-                {
-                    result.governing_specs = per.into_iter().map(|(p, _)| p).collect();
-                }
-            }
-        }
-    }
+    annotate_specs(&mut all, primary_db_path);
 
     Ok(all)
 }
@@ -301,15 +313,9 @@ pub(crate) fn search_all_dbs_hybrid(
         match Database::open(&dep.db_path) {
             Ok(dep_db) => match dep_db.search_hybrid(query, embedding, fetch) {
                 Ok(mut dep_results) => {
-                    let name = dep
-                        .root_path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().into_owned());
+                    let name = project_display_name(&dep.root_path);
                     let root = dep.root_path.to_string_lossy().into_owned();
-                    for r in &mut dep_results {
-                        r.project_name = name.clone();
-                        r.project_path = Some(root.clone());
-                    }
+                    annotate_dep_results(&mut dep_results, Some(name), root);
                     all.append(&mut dep_results);
                 }
                 Err(e) => {
@@ -330,20 +336,7 @@ pub(crate) fn search_all_dbs_hybrid(
     all.retain(|r| seen.insert((r.file_path.clone(), r.start_line, r.end_line)));
     all.truncate(limit);
 
-    // Annotate results with governing specs from the primary DB.
-    if let Ok(primary_db) = Database::open(primary_db_path) {
-        let file_paths: Vec<String> = all.iter().map(|r| r.file_path.clone()).collect();
-        if let Ok(all_specs) = primary_db.specs_for_files(&file_paths)
-            && !all_specs.is_empty()
-        {
-            for result in &mut all {
-                if let Ok(per) = primary_db.specs_for_files(std::slice::from_ref(&result.file_path))
-                {
-                    result.governing_specs = per.into_iter().map(|(p, _)| p).collect();
-                }
-            }
-        }
-    }
+    annotate_specs(&mut all, primary_db_path);
 
     Ok(all)
 }

--- a/src/cli/cmd/verify.rs
+++ b/src/cli/cmd/verify.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 
 use super::super::VerifyArgs;
+use super::helpers::load_embedder;
 use super::search::resolve_project_and_deps;
 use super::ui::spinner;
 use crate::{
@@ -24,10 +25,8 @@ pub async fn verify(args: VerifyArgs, cfg: Config) -> Result<()> {
     }
 
     // Build embedder and re-embed each chunk's current content.
+    let embedder = load_embedder(&cfg).await?;
     let sp = spinner(format!("Verifying {target}…"));
-    let embedder = crate::backends::ActiveEmbedder::load(&cfg)
-        .await
-        .context("loading embedder")?;
 
     let mut results: Vec<serde_json::Value> = Vec::new();
 


### PR DESCRIPTION
## Summary

Extracts repeated inline patterns across the CLI command modules into a new `src/cli/cmd/helpers.rs` module.

**New helpers:**
- `open_project_db` — resolve path + existence check + open, with the standard error message
- `load_embedder` — spinner + `ActiveEmbedder::load` + clear
- `load_llm` — spinner + `ActiveLlm::load` + clear
- `embed_query` — format task/query string + embed + `vec_to_blob`
- `project_display_name` — `file_name()` with path fallback

**Call sites updated:** `graph.rs`, `misc.rs`, `ask.rs`, `search.rs`, `plan.rs`, `memory.rs`, `verify.rs`, `links.rs`

**Patterns intentionally skipped:**
- `check.rs` / `spec.rs` — their DB-open logic differs subtly (no existence check in spec; different error text in check)
- Spinner-wrapping in `search.rs` / `plan.rs` main paths — those use single long-lived spinners that transition through messages; splitting them would produce overlapping spinners

No behaviour changes — error messages, output format, and command semantics are identical.

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo clippy` clean
- [ ] Spot-check `spelunk search`, `spelunk ask`, `spelunk graph` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)