### PR TITLE
feat(ci): add scheduled fuzzing workflow for parser

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,44 @@
+name: Fuzz
+
+on:
+  schedule:
+    # Run weekly on Monday at 09:00 UTC (after the security scan at 08:00).
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+jobs:
+  fuzz-parser:
+    name: cargo-fuzz fuzz_parser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        run: |
+          rustup update nightly
+          rustup default nightly
+
+      - name: Cache cargo registry and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            target
+          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-fuzz-
+
+      - name: Install cargo-fuzz
+        run: cargo-fuzz --version 2>/dev/null || cargo +nightly install cargo-fuzz --locked
+
+      - name: Run fuzzer (60 s)
+        run: cargo +nightly fuzz run fuzz_parser -- -max_total_time=60
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crashes-${{ github.run_id }}
+          path: fuzz/artifacts/fuzz_parser/


### PR DESCRIPTION
Closes #23

## Summary

Integrates the existing `fuzz/fuzz_targets/fuzz_parser.rs` fuzzer into GitHub Actions as a scheduled weekly job.

## What the fuzzer covers
Rotates across 10 languages (Rust, Python, JS, TS, Go, Java, C, C++, Markdown, plain text) on each fuzz input, exercising `SourceParser::parse`. Guards against non-UTF-8 input.

## Workflow (`.github/workflows/fuzz.yml`)
- **Schedule**: Monday 09:00 UTC (one hour after the security scan)
- **Manual trigger**: `workflow_dispatch`
- Installs nightly Rust via `rustup update nightly` (consistent with rest of CI — no third-party actions)
- Idempotent cargo-fuzz install: `cargo-fuzz --version 2>/dev/null || cargo +nightly install cargo-fuzz --locked`
- Runs for **60 seconds**: `cargo +nightly fuzz run fuzz_parser -- -max_total_time=60`
- On failure: uploads `fuzz/artifacts/fuzz_parser/` as `fuzz-crashes-<run_id>` artifact

## Test plan
- [ ] Trigger manually via `workflow_dispatch` and confirm it completes in ~2 min
- [ ] Confirm crash artifacts upload on a forced failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)