### PR TITLE
fix(index): recover gracefully from a corrupt index database

### DIFF
--- a/src/cli/cmd/index.rs
+++ b/src/cli/cmd/index.rs
@@ -30,7 +30,27 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         .db
         .clone()
         .unwrap_or_else(|| args.path.join(".spelunk").join("index.db"));
-    let db = Database::open(&db_path)?;
+    let db = match Database::open(&db_path) {
+        Ok(db) => db,
+        Err(e) => {
+            if args.force && db_path.exists() {
+                tracing::warn!("corrupt index detected, deleting and rebuilding: {e}");
+                std::fs::remove_file(&db_path)
+                    .with_context(|| format!("removing corrupt index at {}", db_path.display()))?;
+                Database::open(&db_path)?
+            } else {
+                return Err(e).with_context(|| {
+                    format!(
+                        "failed to open index at {}\n\
+                         The database may be corrupt. Run with --force to delete it and rebuild from scratch:\n\
+                         \n  spelunk index {} --force\n",
+                        db_path.display(),
+                        args.path.display(),
+                    )
+                });
+            }
+        }
+    };
 
     // --recount: backfill token_count for existing chunks, then exit.
     if args.recount {


### PR DESCRIPTION
## Problem

A malformed/corrupt SQLite index produced a raw low-level error with no guidance on how to fix it:

```
Error: database disk image is malformed
Caused by:
    Error code 267: Content in the virtual table is corrupt
```

## Fix

- **Without `--force`**: wraps the error with a clear message pointing to the fix:
  ```
  failed to open index at .spelunk/index.db
  The database may be corrupt. Run with --force to delete it and rebuild from scratch:

    spelunk index . --force
  ```
- **With `--force`**: deletes the corrupt file automatically and rebuilds from scratch (logs a warning via `tracing::warn!`)

## Test plan
- [ ] Corrupt an index (`echo x >> .spelunk/index.db`) and confirm the helpful error appears
- [ ] Run with `--force` and confirm the index is deleted and rebuilt cleanly
- [ ] Normal indexing unaffected (happy path still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)