### PR TITLE
fix(summariser): avoid panic on multi-byte char boundary truncation

### DIFF
--- a/src/indexer/summariser.rs
+++ b/src/indexer/summariser.rs
@@ -27,8 +27,10 @@ pub async fn summarise_batch(
         body.push_str(&format!("===CHUNK {id}===\n"));
         body.push_str(&format!("name: {name}\nkind: {kind}\n"));
         // Truncate very long chunks to avoid blowing the context window.
+        // Use floor_char_boundary so we never split a multi-byte codepoint.
         let trimmed = if content.len() > 1500 {
-            &content[..1500]
+            let boundary = content.floor_char_boundary(1500);
+            &content[..boundary]
         } else {
             content.as_str()
         };


### PR DESCRIPTION
## Summary

- `&content[..1500]` in `summariser.rs` panics when byte 1500 falls inside a multi-byte codepoint (e.g. the UTF-8 box-drawing character `─` is 3 bytes, not 1)
- Fixes by using `floor_char_boundary(1500)` which rounds down to the nearest valid char boundary before slicing

## Test plan

- [ ] Run `cargo run -- index . --force` on a project that contains Rust source with box-drawing characters in comments/docs — should complete without panic
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)