### PR TITLE
fix(harvest): lower default batch size to 3 and cap commit body length

### DIFF
--- a/src/cli/cmd/memory.rs
+++ b/src/cli/cmd/memory.rs
@@ -587,13 +587,18 @@ async fn memory_harvest(
             );
         }
 
+        // Truncate each commit body so a single large commit message can't
+        // blow the context window regardless of batch size.
+        const MAX_BODY_CHARS: usize = 400;
         let commit_list = batch
             .iter()
             .map(|(sha, subject, body)| {
                 if body.is_empty() {
                     format!("COMMIT {sha}\n{subject}")
                 } else {
-                    format!("COMMIT {sha}\n{subject}\n\n{body}")
+                    let boundary = body.floor_char_boundary(MAX_BODY_CHARS);
+                    let trimmed_body = &body[..boundary];
+                    format!("COMMIT {sha}\n{subject}\n\n{trimmed_body}")
                 }
             })
             .collect::<Vec<_>>()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -381,8 +381,8 @@ pub struct MemoryHarvestArgs {
     pub branch: Option<String>,
 
     /// Number of commits to send to the LLM in each request.
-    /// Reduce this if you hit context-window limits (default: 20).
-    #[arg(long, default_value_t = 20)]
+    /// Smaller values are more stable; larger values risk hitting context-window limits.
+    #[arg(long, default_value_t = 3)]
     pub batch_size: usize,
 }
 


### PR DESCRIPTION
## Summary

- Lowers `--batch-size` default from 20 → 3; smaller batches are faster and much more stable with local models that have small context windows
- Truncates each commit body to 400 chars before building the prompt, so a single verbose commit can't overflow the context window regardless of batch size (uses `floor_char_boundary` for safe UTF-8 slicing)

## Test plan

- [ ] `spelunk memory harvest` with no flags processes in batches of 3
- [ ] `spelunk memory harvest --batch-size 1` still works
- [ ] A commit with a very long body (>400 chars) doesn't cause a context overflow
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)