### PR TITLE
feat(usage): track search, explore and memory search invocations

### DIFF
--- a/migrations/011_usage.sql
+++ b/migrations/011_usage.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS usage (
+    command   TEXT    NOT NULL,
+    called_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_called_at ON usage(called_at);

--- a/src/cli/cmd/explore.rs
+++ b/src/cli/cmd/explore.rs
@@ -19,6 +19,7 @@ pub async fn explore(args: ExploreArgs, cfg: Config) -> Result<()> {
 
     let (db_path, _db) = open_project_db(args.db.as_deref(), &cfg.db_path)?;
     maybe_warn_stale(&db_path);
+    crate::storage::record_usage_at(&db_path, "explore");
 
     let sp = spinner("Loading models…");
     let embedder = crate::backends::ActiveEmbedder::load(&cfg).await?;

--- a/src/cli/cmd/memory.rs
+++ b/src/cli/cmd/memory.rs
@@ -209,6 +209,9 @@ async fn memory_search(
     mem_path: &std::path::Path,
     cfg: &Config,
 ) -> Result<()> {
+    let index_db_path = crate::config::resolve_db(None, &cfg.db_path);
+    crate::storage::record_usage_at(&index_db_path, "memory search");
+
     let sp = spinner("Embedding query…");
     let embedder = crate::backends::ActiveEmbedder::load(cfg)
         .await

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -13,6 +13,7 @@ use crate::{
 
 pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
     let (db_path, dep_projects) = resolve_project_and_deps(args.db.as_ref(), &cfg)?;
+    crate::storage::record_usage_at(&db_path, "search");
 
     // Apply --local-only: discard linked deps.
     let dep_projects = if args.local_only {

--- a/src/cli/cmd/status.rs
+++ b/src/cli/cmd/status.rs
@@ -17,11 +17,14 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
         let db = Database::open(&db_path)?;
         let stats = db.stats()?;
         let drift = db.drift_candidates(30, 10).unwrap_or_default();
+        let usage = db.usage_last_7_days().unwrap_or_default();
         let mem_path = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
         let memory_count = match open_memory_backend(&cfg, &mem_path).ok() {
             Some(b) => b.count().await.unwrap_or(0),
             None => 0,
         };
+        let usage_map: std::collections::HashMap<&str, i64> =
+            usage.iter().map(|(c, n)| (c.as_str(), *n)).collect();
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -31,6 +34,11 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
                 "last_indexed_unix": stats.last_indexed,
                 "memory_entry_count": memory_count,
                 "drift_candidates": drift,
+                "usage_7d": {
+                    "search": usage_map.get("search").copied().unwrap_or(0),
+                    "explore": usage_map.get("explore").copied().unwrap_or(0),
+                    "memory_search": usage_map.get("memory search").copied().unwrap_or(0),
+                }
             }))?
         );
         return Ok(());
@@ -172,6 +180,24 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
         println!(
             "  \x1b[2mRun `spelunk search \"<topic>\"` to check if these are still relevant.\x1b[0m"
         );
+    }
+
+    // Usage summary (last 7 days)
+    let usage = db.usage_last_7_days().unwrap_or_default();
+    let total: i64 = usage.iter().map(|(_, n)| n).sum();
+    if total > 0 {
+        const COMMANDS: &[&str] = &["search", "explore", "memory search"];
+        println!("\nUsage (last 7 days)");
+        for cmd in COMMANDS {
+            let count = usage
+                .iter()
+                .find(|(c, _)| c == cmd)
+                .map(|(_, n)| *n)
+                .unwrap_or(0);
+            if count > 0 {
+                println!("  {:<16}  {} calls", cmd, count);
+            }
+        }
     }
 
     Ok(())

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -33,6 +33,7 @@ impl Database {
         db.apply_token_count_migration()?;
         db.apply_graph_rank_migration()?;
         db.apply_summary_migration()?;
+        db.apply_usage_migration()?;
         Ok(db)
     }
 
@@ -112,6 +113,46 @@ impl Database {
             .conn
             .execute_batch(include_str!("../../migrations/010_summaries.sql"));
         Ok(())
+    }
+
+    /// Create the usage table. Idempotent (`IF NOT EXISTS`).
+    pub fn apply_usage_migration(&self) -> Result<()> {
+        self.conn
+            .execute_batch(include_str!("../../migrations/011_usage.sql"))
+            .context("running usage migration")?;
+        Ok(())
+    }
+
+    /// Record a command invocation. Fire-and-forget: errors are silently discarded.
+    pub fn record_usage(&self, command: &str) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let _ = self.conn.execute(
+            "INSERT INTO usage (command, called_at) VALUES (?1, ?2)",
+            rusqlite::params![command, now],
+        );
+    }
+
+    /// Return `(command, count)` rows for the last 7 days, ordered by count descending.
+    pub fn usage_last_7_days(&self) -> Result<Vec<(String, i64)>> {
+        let cutoff = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0)
+            - 7 * 24 * 3600;
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT command, COUNT(*) FROM usage \
+             WHERE called_at > ?1 \
+             GROUP BY command \
+             ORDER BY COUNT(*) DESC",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![cutoff], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .context("querying usage stats")
     }
 
     /// Update the LLM-generated summary for a single chunk.
@@ -1126,4 +1167,21 @@ pub struct StalenessReport {
     /// Unix timestamp of the most recently indexed file, or `None` if the
     /// index is empty.
     pub last_indexed_at: Option<i64>,
+}
+
+/// Record a command invocation at `db_path` without requiring a `Database` handle.
+/// Opens a raw connection (bypasses full migration stack) and inserts into the
+/// `usage` table. Completely fire-and-forget — all errors are silently discarded.
+pub fn record_usage_at(db_path: &Path, command: &str) {
+    let Ok(conn) = Connection::open(db_path) else {
+        return;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let _ = conn.execute(
+        "INSERT INTO usage (command, called_at) VALUES (?1, ?2)",
+        rusqlite::params![command, now],
+    );
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,7 +4,7 @@ pub mod memory;
 pub mod remote;
 
 pub use backend::{LocalMemoryBackend, MemoryBackend, NoteInput};
-pub use db::Database;
+pub use db::{Database, record_usage_at};
 pub use memory::MemoryStore;
 pub use remote::RemoteMemoryBackend;
 


### PR DESCRIPTION
Closes #57.

> **Note:** this branch is based on `feat/explore` (#56). Merge #56 first, then rebase this branch onto main before merging.

## Summary

- New migration `011_usage.sql` — `usage(command TEXT, called_at INTEGER)` table in the existing `index.db`, with an index on `called_at`
- `Database::record_usage(cmd)` — best-effort INSERT, errors silently discarded
- `record_usage_at(path, cmd)` — lightweight free function for callers that don't hold a `Database` handle (opens a raw connection, no migration overhead)
- `search`, `explore`, and `memory search` each call `record_usage_at` on invocation — one row, no query content, no PII
- `spelunk status` shows a "Usage (last 7 days)" section when any calls exist; hidden entirely if all counts are zero:
  ```
  Usage (last 7 days)
    search            42 calls
    explore            7 calls
    memory search      3 calls
  ```
- `spelunk status --json` includes `usage_7d: {search, explore, memory_search}`

## Test plan

- [ ] Run `spelunk search "foo"` a few times, then `spelunk status` — search count appears
- [ ] Run `spelunk memory search "bar"`, verify `memory search` count appears
- [ ] `spelunk status` shows nothing for a fresh index (zero counts, section hidden)
- [ ] `spelunk status --json` includes `usage_7d` with correct counts
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)