### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 default-run = "spelunk"
 description = "Local context engine for AI coding agents — tree-sitter AST chunking, semantic search, code graph"

--- a/tests/e2e_cli.rs
+++ b/tests/e2e_cli.rs
@@ -21,7 +21,7 @@ fn test_version_output() {
     cmd.arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("spelunk 0.2.0"));
+        .stdout(predicate::str::contains("spelunk 0.2.1"));
 }
 
 #[test]


### PR DESCRIPTION
Version bump for the v0.2.1 release (includes rustls-tls cross-compilation fix from #60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)