### PR TITLE
fix(harvest): split batches that exceed LLM context window

### DIFF
--- a/src/cli/cmd/memory.rs
+++ b/src/cli/cmd/memory.rs
@@ -579,27 +579,50 @@ async fn memory_harvest(
 
     let mut stored = 0usize;
 
-    // ── Step 4: process each batch ────────────────────────────────────────────
-    for (batch_idx, batch) in new_commits.chunks(batch_size).enumerate() {
-        if num_batches > 1 {
-            println!(
-                "\nBatch {}/{} ({} commits)…",
-                batch_idx + 1,
-                num_batches,
-                batch.len()
-            );
-        }
+    // Rough token estimator: ~3 chars per token for mixed code+prose.
+    let estimate_tokens = |s: &str| s.len() / 3;
+    let context_length = cfg.llm_context_length;
+    // Reserve tokens for the output: 400 per commit (title + body + tags), min 256.
+    let output_budget = |n: usize| (n * 400).clamp(256, context_length / 2);
 
-        // Truncate each commit body so a single large commit message can't
-        // blow the context window regardless of batch size.
-        const MAX_BODY_CHARS: usize = 400;
+    // ── Step 4: process each batch ────────────────────────────────────────────
+    // Work queue: each entry is a Vec of commits to process together.
+    // If a batch's prompt would overflow the context window it is split in half
+    // and both halves pushed back to the front of the queue. A single commit
+    // that is still too large has its body truncated further.
+    let mut work: std::collections::VecDeque<Vec<(String, String, String)>> = new_commits
+        .chunks(batch_size)
+        .map(|c| {
+            c.iter()
+                .map(|(a, b, c)| (a.clone(), b.clone(), c.clone()))
+                .collect()
+        })
+        .collect();
+
+    let mut batch_num = 0usize;
+
+    while let Some(batch) = work.pop_front() {
+        batch_num += 1;
+
+        // Build commit list, truncating bodies. For a single-commit batch that
+        // still overflows, we shrink MAX_BODY_CHARS proportionally.
+        let max_body = if batch.len() == 1 {
+            // Leave half the context for output; the rest minus prompt overhead is
+            // available for the commit body.
+            let overhead = estimate_tokens(system) + 600; // ~600 chars of static prompt
+            let available_chars = context_length.saturating_sub(overhead) * 3;
+            available_chars.clamp(120, 400)
+        } else {
+            400
+        };
+
         let commit_list = batch
             .iter()
             .map(|(sha, subject, body)| {
                 if body.is_empty() {
                     format!("COMMIT {sha}\n{subject}")
                 } else {
-                    let boundary = body.floor_char_boundary(MAX_BODY_CHARS);
+                    let boundary = body.floor_char_boundary(max_body);
                     let trimmed_body = &body[..boundary];
                     format!("COMMIT {sha}\n{subject}\n\n{trimmed_body}")
                 }
@@ -621,13 +644,36 @@ async fn memory_harvest(
              Commits:\n{commit_list}"
         );
 
+        let input_tokens = estimate_tokens(system) + estimate_tokens(&user);
+        let out_budget = output_budget(batch.len());
+
+        // If the prompt is too large and the batch has more than one commit,
+        // split in half and retry — both halves go to the front of the queue.
+        if input_tokens + out_budget > context_length && batch.len() > 1 {
+            println!(
+                "\n  Batch {} too large (~{} input + {} output > {} token context), splitting…",
+                batch_num, input_tokens, out_budget, context_length
+            );
+            batch_num -= 1; // don't count the unsent attempt
+            let mid = batch.len() / 2;
+            work.push_front(batch[mid..].to_vec());
+            work.push_front(batch[..mid].to_vec());
+            continue;
+        }
+
+        let max_tokens = context_length
+            .saturating_sub(input_tokens)
+            .min(out_budget)
+            .max(128);
+
+        if num_batches > 1 || work.front().is_some() {
+            println!("\nBatch {} ({} commits)…", batch_num, batch.len());
+        }
+
         let messages = vec![
             crate::llm::Message::system(system),
             crate::llm::Message::user(user),
         ];
-
-        // Scale max_tokens with batch size so larger batches get more room.
-        let max_tokens = (batch.len() * 150).clamp(512, 4096);
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::llm::Token>(256);
         let generate = llm.generate(&messages, max_tokens, tx, Some(schema.clone()));
@@ -643,10 +689,7 @@ async fn memory_harvest(
         let raw_json = crate::utils::strip_ansi(&raw_json);
 
         let parsed: serde_json::Value = serde_json::from_str(&raw_json).with_context(|| {
-            format!(
-                "parsing LLM harvest response (batch {}):\n{raw_json}",
-                batch_idx + 1
-            )
+            format!("parsing LLM harvest response (batch {batch_num}):\n{raw_json}")
         })?;
 
         let entries = parsed["entries"].as_array().cloned().unwrap_or_default();
@@ -697,7 +740,7 @@ async fn memory_harvest(
             println!("  + [{kind}] #{note_id}: {title}");
             stored += 1;
         }
-    } // end batch loop
+    } // end work queue
 
     let skipped = new_commits.len().saturating_sub(stored);
     println!("\nStored {stored} memory entries. Skipped {skipped} routine commits.");

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,13 @@ pub struct Config {
     /// Default: `docs/specs`
     #[serde(default = "Config::default_specs_dir")]
     pub specs_dir: PathBuf,
+
+    /// Context-window size (tokens) of the LLM used for `memory harvest` and `ask`.
+    /// spelunk uses this to split harvest batches that would overflow the model's window.
+    /// Set to match the `n_ctx` / context-length of the model you have loaded.
+    /// Default: 8192
+    #[serde(default = "Config::default_llm_context_length")]
+    pub llm_context_length: usize,
 }
 
 impl Config {
@@ -157,6 +164,9 @@ impl Config {
     fn default_specs_dir() -> PathBuf {
         PathBuf::from("docs/specs")
     }
+    fn default_llm_context_length() -> usize {
+        8192
+    }
 }
 
 impl Default for Config {
@@ -173,6 +183,7 @@ impl Default for Config {
             project_id: None,
             plans_dir: Self::default_plans_dir(),
             specs_dir: Self::default_specs_dir(),
+            llm_context_length: Self::default_llm_context_length(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fixes JSON truncation errors during `spelunk memory harvest` caused by `max_tokens` being too small (3 commits × 150 = 512 — not enough for detailed entries)
- Adds `llm_context_length` (default: 8192) to `Config` so users can match their model's actual `n_ctx`
- Replaces the fixed `max_tokens` formula with a budget derived from the context window: `(context_length − estimated_input_tokens).min(batch_len × 400)`
- Replaces the `for` batch loop with a `VecDeque` work queue: if a batch's estimated prompt + output would overflow the context, it is split in half and both halves are re-queued automatically
- Single commits that are still too large have their body truncated proportionally to available context instead of a hard 400-char cap

Also includes: `cargo update` (13 crates), Dependabot config, and dependency bumps for rusqlite 0.31→0.39, tree-sitter 0.25→0.26, calamine 0.24→0.34, lopdf 0.34→0.40 with all required call-site fixes.

## Test plan

- [ ] CI passes
- [ ] Run `spelunk memory harvest --branch main` on a repo with many commits — confirm no truncation errors
- [ ] Set `llm_context_length = 2048` in config, confirm batches auto-split with the splitting message

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)