### PR TITLE
chore(ci): add cargo build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Check
         run: cargo check --all-targets
 
+      - name: Build
+        run: cargo build --all-targets
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

- Adds `cargo build --all-targets` to the Check & Lint job in `ci.yml`

`cargo check` only performs type-checking without generating machine code. While `cargo test` does compile implicitly, having an explicit build step makes the intent clear and catches linker errors or feature-flag issues independently of the test run.

## Test plan

- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)