### PR TITLE
fix(index): store root-relative paths for portable incremental indexing

### DIFF
--- a/src/cli/cmd/index.rs
+++ b/src/cli/cmd/index.rs
@@ -52,6 +52,22 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         }
     };
 
+    // ── Registry update ───────────────────────────────────────────────────────
+    // Keep the global registry in sync with the current location. This ensures
+    // that moving a project and running `spelunk index .` from the new location
+    // is enough to re-register it — no manual `spelunk init` required.
+    // root_canonical is not yet computed here; derive it from args.path.
+    {
+        let root_now = args
+            .path
+            .canonicalize()
+            .unwrap_or_else(|_| args.path.clone());
+        let db_now = db_path.canonicalize().unwrap_or_else(|_| db_path.clone());
+        if let Ok(reg) = Registry::open() {
+            let _ = reg.register(&root_now, &db_now);
+        }
+    }
+
     // --recount: backfill token_count for existing chunks, then exit.
     if args.recount {
         let updated = db.backfill_token_counts()?;
@@ -89,9 +105,9 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         "!.netrc",
         "!.npmrc",
     ];
-    let mut walk = WalkBuilder::new(&args.path);
+    let mut walk = WalkBuilder::new(&root_canonical);
     walk.standard_filters(true);
-    let mut ob = ignore::overrides::OverrideBuilder::new(&args.path);
+    let mut ob = ignore::overrides::OverrideBuilder::new(&root_canonical);
     for pat in &sensitive_patterns {
         ob.add(pat).ok();
     }
@@ -112,7 +128,10 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         .collect();
 
     if files.is_empty() {
-        println!("No supported source files found in {}", args.path.display());
+        println!(
+            "No supported source files found in {}",
+            root_canonical.display()
+        );
         return Ok(());
     }
 
@@ -132,7 +151,10 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
 
     for entry in &files {
         let path = entry.path();
-        let path_str = path.to_string_lossy();
+        // Store paths relative to the project root so the index is portable
+        // (moving the folder doesn't invalidate every hash lookup).
+        let rel = path.strip_prefix(&root_canonical).unwrap_or(path);
+        let path_str = rel.to_string_lossy();
         parse_bar.set_message(short_path(&path_str));
 
         // ── Binary document formats (DOCX, XLSX, …) ──────────────────────────
@@ -344,12 +366,19 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
 
     // ── Stale file cleanup ────────────────────────────────────────────────────
     // Remove index records for files that no longer exist under the project root.
-    let root_str = args.path.to_string_lossy().to_string();
+    // Paths in the DB are root-relative, so visited uses the same relative form.
     let visited: std::collections::HashSet<String> = files
         .iter()
-        .map(|e| e.path().to_string_lossy().to_string())
+        .map(|e| {
+            let p = e.path();
+            p.strip_prefix(&root_canonical)
+                .unwrap_or(p)
+                .to_string_lossy()
+                .to_string()
+        })
         .collect();
-    let all_indexed = db.file_paths_under(&root_str)?;
+    // Pass "" so file_paths_under returns all files in this DB (paths are relative).
+    let all_indexed = db.file_paths_under("")?;
     let mut removed = 0u64;
     for (id, path) in all_indexed {
         if !visited.contains(&path) {


### PR DESCRIPTION
## Summary

Fixes two related issues:

### Bug: incremental indexing re-indexed every file on every run

`spelunk init` passes an absolute `project_root` to `IndexArgs`; `spelunk index .` passes a relative `.`. The `WalkBuilder` used `args.path` directly, so stored paths differed between the two invocations:
- After `spelunk init`: `files.path = /abs/path/src/main.rs`
- After `spelunk index .`: `files.path = ./src/main.rs`

`file_hash` lookup always missed → nothing skipped → plain `INSERT` doubled every chunk on every subsequent run.

### Fix: root-relative paths

- `WalkBuilder` and `OverrideBuilder` now use `root_canonical` (`args.path.canonicalize()`) so the walker always starts from a stable absolute root
- `path_str` strips the root prefix → DB stores `src/main.rs` regardless of how the command is invoked
- Stale-file cleanup uses the same relative form; `file_paths_under("")` returns all files in the per-project DB
- Paths are now portable: moving the project folder doesn't invalidate the index

### Registry: moved projects auto-register

`spelunk index` now calls `reg.register()` after opening the DB. Moving a project and running `spelunk index .` from the new location is enough to re-register it — no manual `spelunk init` needed. The old stale entry is removed by `spelunk autoclean`.

## Migration note

Existing indexes with absolute paths will re-index once on next run (hashes won't match the new relative-path keys). If chunks were already doubled from the bug, run `spelunk index . --force` once to clear and rebuild cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)