### PR TITLE
feat(index): auto-symlink .spelunk in git worktrees for shared index

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -269,6 +269,49 @@ spelunk memory search "<topic>" --format json | jq '.[].body'
 
 ---
 
+## Git worktree support
+
+spelunk shares one index across all git worktrees of the same repository.
+SQLite WAL mode allows multiple processes to read and write the same
+database safely — reads are never blocked, and concurrent writes are
+serialised automatically by the file lock.
+
+**How it works:**
+
+When you run `spelunk index .` inside a git worktree that has no `.spelunk`
+folder yet, spelunk detects the worktree (`.git` is a file, not a directory),
+locates the main worktree's `.spelunk` folder, and creates a symlink:
+
+```
+<worktree>/.spelunk  →  <main-worktree>/.spelunk
+```
+
+All subsequent commands in the worktree — search, memory, graph — resolve
+through the symlink and operate on the same shared index and memory store.
+
+**Workflow:**
+
+```bash
+# 1. Index the main worktree first (creates .spelunk/index.db)
+git worktree add ../my-feature my-feature-branch
+cd ../my-feature
+
+# 2. Run any spelunk command — symlink is created automatically on first index
+spelunk index .
+# → Created .spelunk symlink → /path/to/main/.spelunk (shared worktree index)
+
+# 3. All commands now work normally from the worktree
+spelunk search "authentication flow"
+spelunk memory list
+```
+
+**Cleanup:**
+
+`spelunk autoclean` removes registry entries for worktrees whose directories
+have been deleted (including those that only have a leftover `.spelunk` symlink).
+
+---
+
 ## Multi-project search
 
 ```bash

--- a/src/cli/cmd/index.rs
+++ b/src/cli/cmd/index.rs
@@ -25,6 +25,10 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     // Compile secret-scanning regexes once before the hot loop.
     crate::indexer::secrets::init();
 
+    // If running inside a git worktree, symlink .spelunk to the main worktree's
+    // .spelunk so all worktrees share one index (SQLite WAL handles concurrent access).
+    ensure_spelunk_symlink(&args.path);
+
     // Default DB lives inside the indexed directory, scoping the index to the project.
     let db_path = args
         .db
@@ -520,6 +524,61 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// If `root` is a git worktree (`.git` is a file, not a directory), ensure that
+/// `.spelunk` is a symlink pointing at the main worktree's `.spelunk` folder so
+/// all worktrees share one index.  SQLite WAL mode handles concurrent access from
+/// multiple processes safely.
+///
+/// No-ops if the symlink (or a real `.spelunk` dir) already exists, or if the main
+/// worktree hasn't been indexed yet (its `.spelunk` folder doesn't exist).
+fn ensure_spelunk_symlink(root: &std::path::Path) {
+    let spelunk = root.join(".spelunk");
+    // Already present (real dir or existing symlink) — nothing to do.
+    if spelunk.exists() || spelunk.is_symlink() {
+        return;
+    }
+
+    // A git worktree has a `.git` *file* (not a directory) containing a pointer
+    // to the worktrees entry inside the main repo's .git directory.
+    let git = root.join(".git");
+    if !git.is_file() {
+        return;
+    }
+
+    let Ok(content) = std::fs::read_to_string(&git) else {
+        return;
+    };
+    // Content is: "gitdir: /abs/path/to/main/.git/worktrees/<name>\n"
+    let Some(gitdir_str) = content.strip_prefix("gitdir:") else {
+        return;
+    };
+    let gitdir = std::path::PathBuf::from(gitdir_str.trim());
+
+    // Walk up two levels: worktrees/<name> → .git → main worktree root
+    let Some(main_root) = gitdir
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+    else {
+        return;
+    };
+    let main_spelunk = main_root.join(".spelunk");
+    if !main_spelunk.exists() {
+        return; // main worktree not yet indexed — skip
+    }
+
+    #[cfg(unix)]
+    {
+        match std::os::unix::fs::symlink(&main_spelunk, &spelunk) {
+            Ok(()) => eprintln!(
+                "Created .spelunk symlink → {} (shared worktree index)",
+                main_spelunk.display()
+            ),
+            Err(e) => tracing::warn!("could not create .spelunk symlink in worktree: {e}"),
+        }
+    }
 }
 
 /// Run the optional LLM summary generation pass.


### PR DESCRIPTION
## Summary

SQLite WAL mode allows multiple processes to safely share one database (concurrent reads never blocked; concurrent writes serialised by the file lock), so all worktrees of the same repo can share a single index.

**What changed:**

- `spelunk index .` now detects when it is running inside a git worktree (`.git` is a file, not a directory), locates the main worktree's `.spelunk` folder via the `gitdir` pointer, and creates a symlink:
  ```
  <worktree>/.spelunk  →  <main-worktree>/.spelunk
  ```
- No-ops if `.spelunk` already exists or if the main worktree hasn't been indexed yet
- Unix-only (`std::os::unix::fs::symlink`)
- SKILL.md updated with a _Git worktree support_ section documenting the WAL concurrency model and expected workflow

**Workflow after this change:**

```bash
git worktree add ../my-feature my-feature-branch
cd ../my-feature
spelunk index .
# → Created .spelunk symlink → /path/to/main/.spelunk (shared worktree index)
spelunk search "authentication flow"   # works immediately
```

## Test plan

- [ ] CI passes
- [ ] Create a worktree, run `spelunk index .` inside it, confirm symlink is created
- [ ] Confirm `spelunk search` in worktree returns results from main index
- [ ] Confirm running `spelunk index .` again (symlink exists) does not re-create or error

🤖 Generated with [Claude Code](https://claude.com/claude-code)