### PR TITLE
docs(skill): revise SKILL.md — terse, command-focused

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,358 +1,180 @@
 # spelunk — AI Agent Skill Reference
 
-How to use `spelunk` as an AI agent to understand, search, and query
-a codebase — and to build up a persistent memory of why it was built
-the way it was.
-
-spelunk is a **context retrieval tool** for AI agents. You are the reasoning
-engine. Use spelunk to find the right code and prior decisions, then reason
-over that context yourself.
+spelunk is a **context retrieval tool** for AI agents. Use it to find relevant
+code and prior decisions, then reason over the results yourself.
 
 ---
 
-## Prerequisites
+## Setup
 
-- `spelunk` installed and in PATH (`cargo install --path .` or copy the binary)
-- Any OpenAI-compatible server (LM Studio, Ollama, vLLM, …) running with an
-  **embedding model** loaded (required for all search)
-- Default endpoint: `http://127.0.0.1:1234` (override with `api_base_url`
-  in `~/.config/spelunk/config.toml`)
+- `spelunk` in PATH
+- OpenAI-compatible server at `http://127.0.0.1:1234` with an **embedding model** loaded
+  (override with `api_base_url` in `~/.config/spelunk/config.toml`)
 
 ---
 
-## Indexing a project
+## Indexing
 
 ```bash
-# Index a project (run once; subsequent runs are incremental)
-spelunk index <path>
-
-# Force full re-index (after changing embedding model or config)
-spelunk index <path> --force
+spelunk index <path>           # index (subsequent runs are incremental)
+spelunk index <path> --force   # full re-index (after changing embedding model)
+spelunk check                  # verify the index is fresh before starting work
 ```
-
-The index is stored at `<path>/.spelunk/index.db` and auto-discovered
-when running any other command from inside the project directory.
 
 ---
 
-## Core commands
-
-### Search — find relevant code
+## Code search
 
 ```bash
-spelunk search "<query>"                     # top 10 results
-spelunk search "<query>" --limit 20          # more results (max 100)
-spelunk search "<query>" --format json       # machine-readable output
-spelunk search "<query>" --graph             # enrich with call-graph neighbours
-```
+# Semantic search — primary lookup
+spelunk search "<query>"
+spelunk search "<query>" --limit 20
+spelunk search "<query>" --graph          # include call-graph neighbours
+spelunk search "<query>" --format json
 
-Returns ranked chunks with file path, line range, language, symbol name, and
-a content preview. Use `--format json` for programmatic access.
+# Deep search — iterative, uses LLM (requires llm_model in config)
+spelunk explore "<question>"
+spelunk explore "<question>" --max-steps 5
+spelunk explore "<question>" --json       # {answer, sources, steps}
 
-**This is the primary tool.** Use it to retrieve context, then reason over the
-results yourself — the same way `spelunk ask` does internally, but you are the
-reasoning engine.
+# Call/import graph
+spelunk graph <symbol-or-file>
+spelunk graph <symbol> --kind calls       # calls | imports | extends | implements
+spelunk graph <file> --format json
 
-### Explore — agentic deep search
-
-```bash
-spelunk explore "<question>"                 # iterative tool-use loop, prints answer
-spelunk explore "<question>" --verbose       # show tool calls on stderr
-spelunk explore "<question>" --max-steps 5   # limit iterations
-spelunk explore "<question>" --json          # {answer, sources, steps}
-```
-
-Use `explore` when a single `search` call is unlikely to be enough — for example when the answer requires tracing through several files or understanding why something was built a certain way. The LLM calls `search`, `graph`, `read_chunk`, and `read_file` iteratively until it can answer confidently.
-
-Requires `llm_model` to be set in config. For fast, targeted lookups, prefer `search`.
-
-### Chunks — inspect what was indexed
-
-```bash
-spelunk chunks <file-path>                   # exact or suffix match
+# Inspect what was indexed for a file
+spelunk chunks <file-path>
 spelunk chunks <file-path> --format json
 ```
 
-Use this when search results seem wrong — shows exactly what the indexer
-extracted and what text each chunk embeds as.
-
-### Graph — call/import relationships
-
-```bash
-spelunk graph <symbol-or-file>
-spelunk graph <symbol> --kind calls          # filter: calls, imports, extends, implements
-spelunk graph <file.rs> --format json
-```
-
-### Status — index health
-
-```bash
-spelunk status                   # current project
-spelunk status --all             # all registered projects
-spelunk status --list            # brief one-line-per-project table
-```
+Use `search` for targeted lookups. Use `explore` when the answer requires
+tracing across multiple files — it runs autonomously and reports back.
 
 ---
 
-## Project memory
+## Memory
 
-The memory store is a semantic database of decisions, context, and
-requirements that persists alongside the code index. It answers the question
-"why was this built this way?" rather than "what does this code do?".
+Stores decisions, context, and requirements that persist across sessions.
+Answers "why was this built this way?" alongside the code index.
 
-Memory lives at `<project>/.spelunk/memory.db`, separate from the code
-index, and is never overwritten by re-indexing.
-
-### Storing a memory entry
+### Add an entry
 
 ```bash
-# Record an architectural decision
 spelunk memory add \
   --kind decision \
-  --title "Use sqlite-vec for KNN instead of a separate vector DB" \
-  --body "Evaluated Qdrant and Chroma. Chose sqlite-vec to keep the tool
-self-contained with no external process dependency. Acceptable at our
-scale (<1M chunks). Revisit if we need filtering + ANN at the same time." \
-  --tags "architecture,storage,embeddings" \
-  --files "src/storage/db.rs,migrations/002_vectors.sql"
-
-# Record context or requirements from a human
-spelunk memory add \
-  --kind context \
-  --title "Target users are solo developers and small teams" \
-  --body "Primary use case is a single developer understanding a codebase
-they didn't write. Multi-user / concurrent write is out of scope for v1."
-
-# Record a requirement
-spelunk memory add \
-  --kind requirement \
-  --title "Must work offline — no cloud API calls during search" \
-  --body "All inference must be local. LM Studio is acceptable as a local
-server. No Anthropic/OpenAI API keys should be required."
-
-# General note
-spelunk memory add \
-  --kind note \
-  --title "Tree-sitter grammar version pinning" \
-  --body "Grammar versions must match the tree-sitter core version. Bumping
-core without checking grammars produces silent parse failures."
+  --title "Chose sqlite-vec over Qdrant" \
+  --body "Keeps spelunk self-contained; no external process. Revisit if >1M chunks." \
+  --tags "architecture,storage" \
+  --files "src/storage/db.rs"
 ```
 
-**Kinds:**
-- `decision` — an architectural or design choice and the reasoning behind it
-- `context` — background, constraints, or requirements from a human
-- `requirement` — a hard constraint the codebase must satisfy
-- `note` — anything that doesn't fit the above but should be remembered
+**Kinds:** `decision` · `context` · `requirement` · `note`
 
-### Querying memory
+### Query
 
 ```bash
-# Semantic search — finds entries by meaning, not keywords
-spelunk memory search "why did we choose this database"
-spelunk memory search "authentication approach"
-spelunk memory search "what constraints did the user specify"
-
-# List recent entries
-spelunk memory list
-spelunk memory list --kind decision
-spelunk memory list --kind context --limit 5
-
-# Show full content of an entry
-spelunk memory show 3
-
-# Machine-readable output
-spelunk memory search "storage decisions" --format json
-spelunk memory list --format json
-```
-
----
-
-## Agent obligations — keeping the index current
-
-Re-indexing is incremental: only files whose content has changed since the
-last run are re-parsed and re-embedded, so it is fast enough to run routinely.
-
-**Re-index after:**
-- Every `git commit` — even small changes move the index out of sync
-- Any refactor that renames, moves, or restructures files
-- Adding a significant new feature (new files, new symbols)
-- Updating dependencies that change generated or vendored code
-
-```bash
-spelunk index <project-root>
-```
-
-If you changed the embedding model or prompt format, add `--force` to
-regenerate all embeddings from scratch.
-
-Not re-indexing means searches will miss new code and may surface deleted code.
-Make it the last step of any commit workflow.
-
----
-
-## Agent obligations — memory
-
-**These are not optional.** Building up project memory is part of the agent's
-responsibility on every session.
-
-### At the start of a session
-Before beginning any significant work, check what has already been recorded:
-
-```bash
+spelunk memory search "<question>"        # semantic search over stored entries
+spelunk memory list                       # recent entries
+spelunk memory list --kind decision       # filter by kind
 spelunk memory list --kind decision --limit 10
-spelunk memory search "<topic you are about to work on>"
+spelunk memory show <id>                  # full entry
+spelunk memory search "<q>" --format json
 ```
 
-This prevents re-litigating decisions that have already been made and gives
-context for why the code looks the way it does.
+### Harvest from git history
 
-### During a session — what to store
+```bash
+spelunk memory harvest                    # analyse HEAD~10..HEAD
+spelunk memory harvest --git-range v0.1.0..HEAD
+spelunk memory harvest --branch main      # full branch history
+```
 
-Store a memory entry whenever any of the following occurs:
-
-1. **A human states a constraint or requirement** — even informally.
-   > "we don't want external API calls" → `spelunk memory add --kind requirement …`
-
-2. **A significant design decision is made** — especially when alternatives
-   were considered and rejected.
-   > Chose X over Y because Z → `spelunk memory add --kind decision …`
-
-3. **A surprising or non-obvious fact is discovered** — about the codebase,
-   its dependencies, or its environment.
-   > "tree-sitter grammar versions must match core" → `spelunk memory add --kind note …`
-
-4. **A human provides background context** about the project, its users, or
-   its goals.
-   > "this is used by solo developers" → `spelunk memory add --kind context …`
-
-**What NOT to store:**
-- Things already visible in the code or git history
-- Ephemeral task state ("currently working on X")
-- Debugging steps that didn't lead to a conclusion
-
-### Writing good memory entries
-
-- **Title**: one sentence, past tense for decisions ("Chose X"), present tense
-  for context ("Target users are…")
-- **Body**: include *why*, not just *what*. What alternatives were considered?
-  What constraint drove the choice? What will break if someone ignores this?
-- **Tags**: use consistent tags so `spelunk memory list --kind decision` stays useful
-- **Files**: link to the files most affected so future searches surface this
-  entry when those files are relevant
+Extracts decisions, requirements, and non-obvious notes from commit messages.
+Run at the start of a session on a new repo, or after a batch of significant commits.
+Requires `llm_model` in config.
 
 ---
 
-## Recommended agent workflow
+## Status & registry
 
-**At the start of any session:**
-1. `spelunk memory list --kind decision` — review prior decisions
-2. `spelunk memory search "<topic>"` — find relevant context before starting
-
-**For code understanding questions:**
-1. `spelunk search "<topic>"` — find the most relevant code chunks
-2. Read the files at the reported line ranges
-3. `spelunk graph <symbol>` to trace call chains or imports
-4. `spelunk memory search "<topic>"` — check if there's recorded context explaining *why*
-5. Synthesise an answer from the retrieved context yourself
-
-**For code changes:**
-1. Search and read before changing
-2. After making a significant decision, store it: `spelunk memory add --kind decision …`
-3. If the human explains a constraint that shaped your approach, store it too
-4. After committing, re-index: `spelunk index <project-root>`
-
-**For structured context retrieval (pipelines):**
 ```bash
-spelunk search "<topic>" --format json | jq '.[].content'
-spelunk memory search "<topic>" --format json | jq '.[].body'
+spelunk status                 # index health for current project
+spelunk status --all           # all registered projects
+spelunk status --list          # one-line table
+
+spelunk autoclean              # remove stale registry entries (deleted/moved projects)
+spelunk link <path>            # include another project's index in searches
+spelunk unlink <path>
 ```
 
 ---
 
-## Git worktree support
+## Git worktrees
 
-spelunk shares one index across all git worktrees of the same repository.
-SQLite WAL mode allows multiple processes to read and write the same
-database safely — reads are never blocked, and concurrent writes are
-serialised automatically by the file lock.
-
-**How it works:**
-
-When you run `spelunk index .` inside a git worktree that has no `.spelunk`
-folder yet, spelunk detects the worktree (`.git` is a file, not a directory),
-locates the main worktree's `.spelunk` folder, and creates a symlink:
-
-```
-<worktree>/.spelunk  →  <main-worktree>/.spelunk
-```
-
-All subsequent commands in the worktree — search, memory, graph — resolve
-through the symlink and operate on the same shared index and memory store.
-
-**Workflow:**
+Worktrees automatically share the main worktree's index. Just run
+`spelunk index .` from inside the worktree — spelunk creates the link for you:
 
 ```bash
-# 1. Index the main worktree first (creates .spelunk/index.db)
 git worktree add ../my-feature my-feature-branch
 cd ../my-feature
+spelunk index .    # links to main worktree's index; all commands work immediately
+```
 
-# 2. Run any spelunk command — symlink is created automatically on first index
+Run `spelunk autoclean` after removing a worktree to tidy up the registry.
+
+---
+
+## Agent mode
+
+Set `AGENT=true` for clean machine-readable output on all commands:
+
+```bash
+AGENT=true spelunk search "authentication flow"
+AGENT=true spelunk memory search "storage decisions"
+AGENT=true spelunk graph src/storage/db.rs
+```
+
+---
+
+## Agent workflow
+
+**Start of every session:**
+```bash
+spelunk check
+spelunk memory list --kind decision --limit 10
+spelunk memory list --kind handoff --limit 3
+spelunk memory list --kind question
+```
+
+**Understanding code:**
+1. `spelunk search "<topic>"` — find relevant chunks
+2. Read reported file/line ranges
+3. `spelunk graph <symbol>` — trace call chains
+4. `spelunk memory search "<topic>"` — check recorded context for *why*
+
+**Making changes:**
+1. Search and read before changing
+2. Store significant decisions: `spelunk memory add --kind decision …`
+3. Store constraints the human states: `spelunk memory add --kind requirement …`
+4. After committing: `spelunk index <project-root>`
+
+**End of session:**
+```bash
+spelunk memory add --kind handoff --title "Handoff: <summary>" \
+  --body "what's done, what's next, open questions"
 spelunk index .
-# → Created .spelunk symlink → /path/to/main/.spelunk (shared worktree index)
-
-# 3. All commands now work normally from the worktree
-spelunk search "authentication flow"
-spelunk memory list
 ```
 
-**Cleanup:**
-
-`spelunk autoclean` removes registry entries for worktrees whose directories
-have been deleted (including those that only have a leftover `.spelunk` symlink).
-
----
-
-## Multi-project search
-
-```bash
-# Make searches in project A also return results from project B
-spelunk link <path-to-B>
-spelunk unlink <path-to-B>
-spelunk autoclean        # remove registry entries for deleted projects
-```
-
-Once linked, `spelunk search` queries both indexes and merges results by semantic
-distance. Memory is always per-project.
-
----
-
-## Agent mode (`AGENT=true`)
-
-Set `AGENT=true` in the environment before running any `spelunk` command to enable
-machine-readable output without extra flags:
-
-```bash
-AGENT=true spelunk search "authentication flow"        # → JSON, no spinner
-AGENT=true spelunk graph src/storage/db.rs             # → JSON
-AGENT=true spelunk memory search "storage decisions"   # → JSON
-```
-
-What changes when `AGENT=true` is set:
-- All `--format text` defaults become `--format json` automatically.
-- Progress spinners and animated progress bars are suppressed, keeping stdout
-  clean for downstream parsing.
-
-You can still pass `--format text` explicitly to override even in agent mode.
+**Writing good memory entries:**
+- **Title**: one sentence — past tense for decisions, present tense for context
+- **Body**: include *why*, what alternatives were rejected, what breaks if ignored
+- **Tags**: keep consistent so `list --kind decision` stays useful
+- **Files**: link affected files so entries surface in related searches
 
 ---
 
 ## Tips
 
-- `spelunk index` must be pointed at the project root; all other commands can be
-  run from any subdirectory — the DB is auto-discovered by walking up.
-- After changing the embedding model, run `spelunk index <path> --force` to
-  regenerate all embeddings. Also re-run `spelunk memory add` for important entries
-  so their embeddings reflect the new model.
-- `spelunk search` and `spelunk memory search` only need the embedding model.
-- Secret-containing chunks (AWS keys, PEM headers, tokens, etc.) are
-  automatically skipped during indexing and will not appear in results.
+- All commands except `spelunk index` can be run from any subdirectory — the index is found automatically.
+- After changing the embedding model, run `spelunk index <path> --force`.
+- `spelunk search` only needs the embedding model; `spelunk explore`, `spelunk memory harvest`, and LLM summaries also require `llm_model`.


### PR DESCRIPTION
## Summary

359 → 180 lines. Focused on what to run, not how it works internally.

**Removed:**
- SQLite WAL internals from the worktree section
- Explanations of what flags do under the hood
- Over-long memory `add` examples (three full examples → one)
- "What changes when AGENT=true" prose → replaced with a code block
- "Returns ranked chunks with file path, line range..." and similar

**Added:**
- `spelunk check` (was in CLAUDE.md but not here)
- `spelunk memory harvest` with usage and when to run it
- `spelunk status --list` and `spelunk autoclean`
- End-of-session workflow (handoff + re-index)

**Reordered:**
- Code search → Memory (add / query / harvest) → Status & registry → Worktrees → Agent mode → Workflow → Tips

🤖 Generated with [Claude Code](https://claude.com/claude-code)