### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4031,7 +4031,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk"
-version = "0.3.0"
+version = "0.4.1"
 edition = "2024"
 default-run = "spelunk"
 description = "Local context engine for AI coding agents — tree-sitter AST chunking, semantic search, code graph"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,23 +6,23 @@ Download the latest binary for your platform from the [releases page](https://gi
 
 ```bash
 # macOS (Apple Silicon) — universal binary also available
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.3.0-aarch64-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-aarch64-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # macOS (Intel)
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.3.0-x86_64-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-x86_64-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # macOS (universal — works on both Intel and Apple Silicon)
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.3.0-universal-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-universal-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Linux x86_64
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.3.0-x86_64-unknown-linux-gnu.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-x86_64-unknown-linux-gnu.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Linux ARM64
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.3.0-aarch64-unknown-linux-gnu.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-aarch64-unknown-linux-gnu.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Verify

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,7 +33,7 @@ Edit the `version` field in `Cargo.toml`:
 ```toml
 [package]
 name = "spelunk"
-version = "0.3.0"   # <-- update this
+version = "0.4.1"   # <-- update this
 ```
 
 ### 1a. Update version references in docs
@@ -52,15 +52,15 @@ Commit everything together:
 
 ```bash
 git add Cargo.toml Cargo.lock docs/getting-started.md
-git commit -m "chore: bump version to 0.3.0"
+git commit -m "chore: bump version to 0.4.1"
 git push origin main
 ```
 
 ### 2. Tag and push
 
 ```bash
-git tag v0.3.0
-git push origin v0.3.0
+git tag v0.4.1
+git push origin v0.4.1
 ```
 
 That's it. The release workflow triggers automatically on the pushed tag.
@@ -71,7 +71,7 @@ Watch progress at:
 `https://github.com/usercise/spelunk/actions/workflows/release.yml`
 
 Once all jobs pass, the release appears at:
-`https://github.com/usercise/spelunk/releases/tag/v0.3.0`
+`https://github.com/usercise/spelunk/releases/tag/v0.4.1`
 
 ## Pre-releases
 
@@ -80,8 +80,8 @@ GitHub Release as a pre-release when the tag contains `-rc`, `-beta`, or
 `-alpha`:
 
 ```bash
-git tag v0.3.0-rc.1
-git push origin v0.3.0-rc.1
+git tag v0.4.1-rc.1
+git push origin v0.4.1-rc.1
 ```
 
 ## Download URLs
@@ -96,16 +96,16 @@ Examples:
 
 ```bash
 # macOS Apple Silicon
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.3.0-aarch64-apple-darwin.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-aarch64-apple-darwin.tar.gz
 
 # macOS universal (x86_64 + Apple Silicon)
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.3.0-universal-apple-darwin.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-universal-apple-darwin.tar.gz
 
 # Linux x86_64
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.3.0-x86_64-unknown-linux-gnu.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-x86_64-unknown-linux-gnu.tar.gz
 
 # Linux ARM64
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.3.0-aarch64-unknown-linux-gnu.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-aarch64-unknown-linux-gnu.tar.gz
 ```
 
 ## Deleting a bad release
@@ -114,11 +114,11 @@ If a release needs to be pulled:
 
 ```bash
 # Delete the tag locally and on remote
-git tag -d v0.3.0
-git push origin :refs/tags/v0.3.0
+git tag -d v0.4.1
+git push origin :refs/tags/v0.4.1
 
 # Delete the GitHub Release (requires gh CLI)
-gh release delete v0.3.0 --yes
+gh release delete v0.4.1 --yes
 ```
 
 Then fix the issue, re-commit, and re-tag.


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` version from `0.3.0` to `0.4.1`
- Update `Cargo.lock`
- Update hardcoded version strings in `docs/getting-started.md` (download URLs)
- Update version examples in `docs/releasing.md`

## After merge

Tag the release:
```bash
git tag v0.4.1
git push origin v0.4.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)