### PR TITLE
refactor: standardize --format flags across porcelain commands (#127)

### DIFF
--- a/src/cli/cmd/ask.rs
+++ b/src/cli/cmd/ask.rs
@@ -17,8 +17,12 @@ pub struct AskArgs {
     #[arg(long, default_value = "20")]
     pub context_chunks: usize,
 
-    /// Return structured JSON: { answer, relevant_files, confidence }
-    #[arg(long)]
+    /// Output format: text or json
+    #[arg(long, default_value = "text")]
+    pub format: String,
+
+    /// Return structured JSON (deprecated — use --format json)
+    #[arg(long, hide = true)]
     pub json: bool,
 
     /// Path to the SQLite database (overrides config)
@@ -220,7 +224,12 @@ You have up to three sources of context:\n\
 Use all available sources together to give accurate, grounded answers. \
 If the answer cannot be determined from the provided context, say so clearly rather than guessing.";
 
-    let use_json = args.json || crate::utils::is_agent_mode();
+    let fmt = if args.json {
+        "json".to_string()
+    } else {
+        args.format.clone()
+    };
+    let use_json = crate::utils::effective_format(&fmt) == "json" || crate::utils::is_agent_mode();
     let (system_prompt, json_schema) = if use_json {
         (
             concat!(
@@ -325,4 +334,35 @@ fn ask_json_schema() -> serde_json::Value {
             "additionalProperties": false
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_xml;
+
+    #[test]
+    fn escape_xml_less_than() {
+        assert_eq!(escape_xml("<"), "&lt;");
+    }
+
+    #[test]
+    fn escape_xml_greater_than() {
+        assert_eq!(escape_xml(">"), "&gt;");
+    }
+
+    #[test]
+    fn escape_xml_both_present() {
+        assert_eq!(escape_xml("a < b > c"), "a &lt; b &gt; c");
+    }
+
+    #[test]
+    fn escape_xml_closing_tag() {
+        assert_eq!(escape_xml("</code_context>"), "&lt;/code_context&gt;");
+    }
+
+    #[test]
+    fn escape_xml_no_angle_brackets_unchanged() {
+        let clean = "no special characters here";
+        assert_eq!(escape_xml(clean), clean);
+    }
 }

--- a/src/cli/cmd/check.rs
+++ b/src/cli/cmd/check.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 #[derive(Args, Debug)]
 pub struct CheckArgs {
-    /// Output format: text or json
+    /// Output format: text, json, or porcelain
     #[arg(long, default_value = "text")]
     pub format: String,
 
@@ -16,8 +16,8 @@ pub struct CheckArgs {
     #[arg(long)]
     pub files: bool,
 
-    /// Machine-readable output: `stale=N total=M last_indexed=T`
-    #[arg(long)]
+    /// Machine-readable output (deprecated — use --format porcelain)
+    #[arg(long, hide = true)]
     pub porcelain: bool,
 }
 
@@ -56,11 +56,15 @@ pub fn check(args: CheckArgs, cfg: Config) -> Result<()> {
         }
     }
 
-    let fmt = crate::utils::effective_format(&args.format);
+    let effective = if args.porcelain {
+        "porcelain"
+    } else {
+        crate::utils::effective_format(&args.format)
+    };
     let fresh = stale.is_empty();
     let last_indexed: Option<i64> = db.stats().ok().and_then(|s| s.last_indexed);
 
-    if args.porcelain {
+    if effective == "porcelain" {
         let last_ts = last_indexed.unwrap_or(0);
         println!(
             "stale={} total={} last_indexed={}",
@@ -73,7 +77,7 @@ pub fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                 println!("{p}");
             }
         }
-    } else if fmt == "json" {
+    } else if effective == "json" {
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({

--- a/src/cli/cmd/explore.rs
+++ b/src/cli/cmd/explore.rs
@@ -19,8 +19,12 @@ pub struct ExploreArgs {
     #[arg(long)]
     pub verbose: bool,
 
-    /// Output result as JSON (answer + sources + step log)
-    #[arg(long)]
+    /// Output format: text or json
+    #[arg(long, default_value = "text")]
+    pub format: String,
+
+    /// Output result as JSON (deprecated — use --format json)
+    #[arg(long, hide = true)]
     pub json: bool,
 }
 
@@ -50,7 +54,12 @@ pub async fn explore(args: ExploreArgs, cfg: Config) -> Result<()> {
     sp.finish_and_clear();
 
     let verbose = args.verbose || crate::utils::is_agent_mode();
-    let use_json = args.json || crate::utils::is_agent_mode();
+    let fmt = if args.json {
+        "json".to_string()
+    } else {
+        args.format.clone()
+    };
+    let use_json = crate::utils::effective_format(&fmt) == "json" || crate::utils::is_agent_mode();
 
     if !use_json {
         eprintln!("Exploring: {}\n", args.question);

--- a/src/cli/cmd/graph.rs
+++ b/src/cli/cmd/graph.rs
@@ -11,7 +11,7 @@ pub struct GraphArgs {
     #[arg(long)]
     pub kind: Option<String>,
 
-    /// Output format: text or json
+    /// Output format: text, json, or ndjson
     #[arg(long, default_value = "text")]
     pub format: String,
 
@@ -63,6 +63,11 @@ pub fn graph(args: GraphArgs, cfg: Config) -> Result<()> {
 
     match crate::utils::effective_format(&args.format) {
         "json" => println!("{}", serde_json::to_string_pretty(&edges)?),
+        "ndjson" => {
+            for edge in &edges {
+                println!("{}", serde_json::to_string(edge)?);
+            }
+        }
         _ => print_edges(&edges, symbol),
     }
 

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -15,7 +15,7 @@ pub struct SearchArgs {
     #[arg(long, conflicts_with = "limit")]
     pub budget: Option<usize>,
 
-    /// Output format: text or json
+    /// Output format: text, json, or ndjson
     #[arg(long, default_value = "text")]
     pub format: String,
 
@@ -212,6 +212,11 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
                 };
                 println!("{}", serde_json::to_string_pretty(&resp)?);
             }
+            "ndjson" => {
+                for item in &packed {
+                    println!("{}", serde_json::to_string(item)?);
+                }
+            }
             _ => {
                 print_results_text(&packed);
                 println!("tokens used: {tokens_used}/{budget}");
@@ -222,6 +227,11 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
 
     match crate::utils::effective_format(&args.format) {
         "json" => println!("{}", serde_json::to_string_pretty(&results)?),
+        "ndjson" => {
+            for item in &results {
+                println!("{}", serde_json::to_string(item)?);
+            }
+        }
         _ => print_results_text(&results),
     }
 

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -628,3 +628,157 @@ fn split_csv(s: Option<&str>) -> Vec<String> {
             .collect(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::MemoryStore;
+    use std::sync::OnceLock;
+
+    /// Register the sqlite-vec extension exactly once per test process.
+    /// `MemoryStore::migrate()` creates a `vec0` virtual table, which
+    /// requires the extension to be loaded before any connection is opened.
+    fn register_sqlite_vec() {
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            #[allow(clippy::missing_transmute_annotations)]
+            unsafe {
+                rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                    sqlite_vec::sqlite3_vec_init as *const (),
+                )));
+            }
+        });
+    }
+
+    fn open_store() -> MemoryStore {
+        register_sqlite_vec();
+        MemoryStore::open(std::path::Path::new(":memory:"))
+            .expect("failed to open in-memory MemoryStore")
+    }
+
+    fn count_edges(store: &MemoryStore, from_id: i64, to_id: i64, kind: &str) -> i64 {
+        store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_edges WHERE from_id = ?1 AND to_id = ?2 AND kind = ?3",
+                rusqlite::params![from_id, to_id, kind],
+                |r| r.get(0),
+            )
+            .unwrap_or(0)
+    }
+
+    // ── supersede() ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn supersede_happy_path() {
+        let store = open_store();
+
+        let old_id = store
+            .add_note("decision", "Old decision", "old body", &[], &[], None, None)
+            .unwrap();
+        let new_id = store
+            .add_note("decision", "New decision", "new body", &[], &[], None, None)
+            .unwrap();
+
+        let changed = store.supersede(old_id, new_id).unwrap();
+        assert!(changed, "supersede() should return true on first call");
+
+        // (a) old note must be archived with superseded_by set
+        let old_note = store.get(old_id).unwrap().expect("old note must exist");
+        assert_eq!(old_note.status, "archived");
+        assert_eq!(old_note.superseded_by, Some(new_id));
+
+        // (b) a memory_edges row must exist linking new → old
+        assert_eq!(
+            count_edges(&store, new_id, old_id, "supersedes"),
+            1,
+            "expected exactly one supersedes edge"
+        );
+    }
+
+    #[test]
+    fn supersede_idempotent() {
+        let store = open_store();
+
+        let old_id = store
+            .add_note("note", "Alpha", "body", &[], &[], None, None)
+            .unwrap();
+        let new_id = store
+            .add_note("note", "Beta", "body", &[], &[], None, None)
+            .unwrap();
+
+        let first = store.supersede(old_id, new_id).unwrap();
+        assert!(first);
+
+        // Second call on an already-archived note must return false
+        let second = store.supersede(old_id, new_id).unwrap();
+        assert!(
+            !second,
+            "supersede() should return false when note is already archived"
+        );
+
+        // Must not have inserted a duplicate edge
+        assert_eq!(
+            count_edges(&store, new_id, old_id, "supersedes"),
+            1,
+            "duplicate supersedes edge must not be inserted"
+        );
+    }
+
+    // ── add_edge() ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn add_edge_valid_kinds_accepted() {
+        let store = open_store();
+        let a = store
+            .add_note("note", "A", "", &[], &[], None, None)
+            .unwrap();
+        let b = store
+            .add_note("note", "B", "", &[], &[], None, None)
+            .unwrap();
+
+        for kind in ["supersedes", "relates_to", "contradicts"] {
+            store
+                .add_edge(a, b, kind)
+                .unwrap_or_else(|e| panic!("add_edge with kind '{kind}' failed: {e}"));
+        }
+    }
+
+    #[test]
+    fn add_edge_invalid_kind_returns_err() {
+        let store = open_store();
+        let a = store
+            .add_note("note", "A", "", &[], &[], None, None)
+            .unwrap();
+        let b = store
+            .add_note("note", "B", "", &[], &[], None, None)
+            .unwrap();
+
+        let err = store
+            .add_edge(a, b, "invented")
+            .expect_err("add_edge with invalid kind must return Err");
+        assert!(
+            err.to_string().contains("invented"),
+            "error message must mention the invalid kind; got: {err}"
+        );
+    }
+
+    #[test]
+    fn add_edge_duplicate_silently_ignored() {
+        let store = open_store();
+        let a = store
+            .add_note("note", "A", "", &[], &[], None, None)
+            .unwrap();
+        let b = store
+            .add_note("note", "B", "", &[], &[], None, None)
+            .unwrap();
+
+        store.add_edge(a, b, "relates_to").unwrap();
+        store.add_edge(a, b, "relates_to").unwrap(); // second call must not error
+
+        assert_eq!(
+            count_edges(&store, a, b, "relates_to"),
+            1,
+            "duplicate edge must not produce a second row"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Standardises `--format` flags across all porcelain commands per issue #127.

- **`spelunk ask`**: replaces `--json` bool with `--format text|json`; keeps `--json` as a hidden deprecated alias
- **`spelunk explore`**: same pattern as `ask`
- **`spelunk check`**: consolidates separate `--porcelain` bool into `--format text|json|porcelain`; `--porcelain` kept as hidden alias
- **`spelunk search`**: adds `ndjson` as a third format option — emits one `SearchResult` JSON object per line
- **`spelunk graph`**: adds `ndjson` as a third format option — emits one edge/node JSON object per line

No breaking changes: all deprecated aliases still work. Commands already using `--format text|json` correctly (`status`, `verify`, `history`, `memory list`, etc.) are untouched.

## Test plan

- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test` — all tests pass
- [ ] `spelunk ask "question" --format json` works; `spelunk ask "question" --json` still works (hidden alias)
- [ ] `spelunk check --format porcelain` works; `spelunk check --porcelain` still works (hidden alias)
- [ ] `spelunk search "query" --format ndjson` emits one JSON object per line
- [ ] `spelunk graph symbol --format ndjson` emits one JSON object per line

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)