### PR TITLE
docs: plumbing command reference and explainer (#132 #133)

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -198,6 +198,238 @@ spelunk check || { echo "Run spelunk index"; exit 1; }
 spelunk hooks install --ci
 ```
 
+## Plumbing Commands
+
+Plumbing commands emit NDJSON to stdout and follow a strict exit-code convention, making them safe to use in scripts and pipelines. See [Plumbing and Porcelain](plumbing-and-porcelain.md) for a full explanation of the design philosophy.
+
+Exit codes across all plumbing commands:
+- **0** — success, results emitted
+- **1** — no results (empty set, not an error)
+- **2** — hard error (bad flags, missing DB, I/O failure) — diagnostics on stderr
+
+### cat-chunks
+
+```
+spelunk plumbing cat-chunks <file>
+```
+
+Emit all indexed chunks for a given file as NDJSON.
+
+| Flag | Description |
+|------|-------------|
+| `<file>` | Project-relative path of the file to retrieve chunks for (required). |
+
+Exit codes: `0` = chunks found, `1` = file has no indexed chunks, `2` = error.
+
+Example:
+
+```bash
+spelunk plumbing cat-chunks src/indexer/chunker.rs \
+  | jq '{name: .name, lines: "\(.start_line)-\(.end_line)"}'
+```
+
+```json
+{"name":"sliding_window","lines":"45-78"}
+{"name":"Chunk","lines":"12-32"}
+```
+
+---
+
+### ls-files
+
+```
+spelunk plumbing ls-files [--prefix <prefix>] [--stale] [--root <dir>]
+```
+
+List every indexed file as NDJSON. With `--stale`, only files whose on-disk blake3 hash differs from the stored hash are emitted.
+
+| Flag | Description |
+|------|-------------|
+| `--prefix <prefix>` | Restrict output to files whose path starts with this string. |
+| `--stale` | Only emit files that are out of date (on-disk hash ≠ stored hash). |
+| `--root <dir>` | Project root for resolving relative paths (defaults to CWD). |
+
+Exit codes: `0` = at least one file emitted, `1` = no files matched, `2` = error.
+
+Example:
+
+```bash
+spelunk plumbing ls-files --stale --root .
+```
+
+```json
+{"path":"src/indexer/chunker.rs","language":"rust","chunk_count":12,"indexed_at":1713528000,"stale":true}
+```
+
+---
+
+### parse-file
+
+```
+spelunk plumbing parse-file <file>
+```
+
+Parse a file with tree-sitter and emit chunks as NDJSON without writing anything to the index. Useful for previewing how spelunk will chunk a file.
+
+| Flag | Description |
+|------|-------------|
+| `<file>` | Path to the file to parse (required). |
+
+Exit codes: `0` = chunks emitted, `1` = unsupported file type or empty parse result, `2` = read error.
+
+Example:
+
+```bash
+spelunk plumbing parse-file src/config.rs | jq '{kind, name, start_line}'
+```
+
+```json
+{"kind":"struct","name":"Config","start_line":8}
+{"kind":"impl","name":"Config","start_line":42}
+```
+
+---
+
+### hash-file
+
+```
+spelunk plumbing hash-file <file>
+```
+
+Compute the blake3 hash of a file and check whether it matches the hash stored in the index, emitting a single JSON object.
+
+| Flag | Description |
+|------|-------------|
+| `<file>` | Path to the file to hash (required). |
+
+Exit codes: `0` = always (unless read error), `2` = file not readable.
+
+Example:
+
+```bash
+spelunk plumbing hash-file src/config.rs
+```
+
+```json
+{"path":"src/config.rs","hash":"a3f1...","indexed_hash":"a3f1...","is_current":true}
+```
+
+---
+
+### knn
+
+```
+spelunk plumbing knn [--limit N] [--min-score F] [--lang <lang>]
+```
+
+Read a JSON embedding object from stdin (as produced by `spelunk plumbing embed`) and return the *N* nearest indexed chunks by cosine similarity.
+
+| Flag | Description |
+|------|-------------|
+| `--limit N` | Maximum number of results (default: `10`). |
+| `--min-score F` | Drop results with cosine similarity below this threshold (0.0–1.0, default: `0.0`). |
+| `--lang <lang>` | Restrict results to chunks from files of this language (e.g. `rust`, `python`). |
+
+Exit codes: `0` = results found, `1` = no results pass the filters, `2` = error.
+
+Compose with `embed` for a full semantic search pipeline:
+
+```bash
+echo "authentication" | spelunk plumbing embed --query | spelunk plumbing knn --limit 5
+```
+
+Example output:
+
+```json
+{"chunk_id":42,"file_path":"src/auth/middleware.rs","language":"rust","node_type":"function","name":"validate_token","start_line":18,"end_line":54,"content":"...","distance":0.12,"score":0.88}
+```
+
+---
+
+### embed
+
+```
+spelunk plumbing embed [--query]
+```
+
+Read lines from stdin and emit one NDJSON embedding vector per line. Each output object contains the model name, vector dimensionality, and the float vector.
+
+| Flag | Description |
+|------|-------------|
+| `--query` | Apply the query retrieval prefix (`task: code retrieval | query: …`). Use this flag when the output will be piped into `knn`. Omit it when embedding document text for storage. |
+
+Exit codes: `0` = at least one vector emitted, `2` = stdin is a terminal (not a pipe) or embedding backend unreachable.
+
+Compose with `knn`:
+
+```bash
+echo "authentication" | spelunk plumbing embed --query | spelunk plumbing knn --limit 5
+```
+
+Example output:
+
+```json
+{"model":"text-embedding-gemma-3","dimensions":1024,"vector":[0.021,-0.043,...]}
+```
+
+---
+
+### graph-edges
+
+```
+spelunk plumbing graph-edges --file <file> | --symbol <symbol>
+```
+
+Emit code graph edges (imports, calls, extends/implements) for a file or symbol. At least one of `--file` or `--symbol` is required. When both are provided, results are merged and deduplicated.
+
+| Flag | Description |
+|------|-------------|
+| `--file <file>` | Project-relative path; emit all edges originating from this file. |
+| `--symbol <symbol>` | Symbol name; emit edges where this name appears as source or target. |
+
+Exit codes: `0` = edges found, `1` = no edges matched, `2` = neither flag supplied or DB error.
+
+Example:
+
+```bash
+spelunk plumbing graph-edges --symbol validate_token
+```
+
+```json
+{"source_file":"src/auth/middleware.rs","source_name":"handle_request","target_name":"validate_token","kind":"calls","line":28}
+```
+
+---
+
+### read-memory
+
+```
+spelunk plumbing read-memory [--kind <kind>] [--id <n>] [--limit N]
+```
+
+Emit memory entries as NDJSON. Use `--kind` to filter by entry type or `--id` to fetch a single entry.
+
+| Flag | Description |
+|------|-------------|
+| `--kind <kind>` | Filter by memory kind: `decision`, `question`, `note`, `answer`, `requirement`, `handoff`. |
+| `--id <n>` | Fetch a single entry by its integer id. Exits `1` if not found. |
+| `--limit N` | Maximum number of entries (default: `50`). |
+
+Exit codes: `0` = entries found, `1` = no entries matched, `2` = error.
+
+Example:
+
+```bash
+spelunk plumbing read-memory --kind decision --limit 5 | jq '{id, title}'
+```
+
+```json
+{"id":17,"title":"Chose sqlite-vec over hnswlib for vector search"}
+{"id":22,"title":"Incremental index skips unchanged files via blake3 hash"}
+```
+
+---
+
 ## Summary: agent workflow at a glance
 
 ```bash

--- a/docs/plumbing-and-porcelain.md
+++ b/docs/plumbing-and-porcelain.md
@@ -1,0 +1,90 @@
+# Plumbing and Porcelain
+
+## What is plumbing vs porcelain?
+
+Git popularised the distinction: *porcelain* commands are polished, human-friendly interfaces (coloured output, progress bars, readable prose), while *plumbing* commands are low-level, composable building blocks designed for scripts and pipelines. spelunk follows the same pattern. Porcelain commands like `spelunk search` and `spelunk memory list` format output for reading in a terminal; plumbing commands under `spelunk plumbing` emit raw NDJSON to stdout and are designed to be piped into other processes.
+
+## When to use plumbing
+
+Use plumbing commands when you are:
+
+- **Writing agent scripts** — parse NDJSON directly rather than scraping human-readable text.
+- **Composing pipelines** — chain plumbing commands with `jq`, `xargs`, or other plumbing commands.
+- **Running in CI** — exit codes are unambiguous (see table below); no ANSI codes pollute logs.
+- **Building reproducible queries** — the same plumbing invocation always produces the same schema, regardless of terminal width or colour settings.
+- **Integrating spelunk output into another tool** — NDJSON is trivially parsed in any language.
+
+## When to use porcelain
+
+Use porcelain commands for:
+
+- **Day-to-day developer use** — `spelunk search`, `spelunk ask`, `spelunk memory list` are readable and interactive.
+- **Interactive exploration** — `spelunk explore` drives a multi-step agentic loop with formatted summaries.
+- **Quick status checks** — `spelunk status`, `spelunk check` give human-readable health reports.
+
+## Exit code convention
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Command succeeded; one or more results were emitted. |
+| `1` | No results found (not an error — treat as empty set). |
+| `2` | Hard error — a flag was missing, the DB was not found, or an I/O failure occurred. Diagnostics are written to stderr. |
+
+Scripts should distinguish `1` (empty) from `2` (broken) rather than treating any non-zero exit as fatal.
+
+## Output format
+
+All plumbing commands write **one JSON object per line** (NDJSON) to **stdout**. Errors and warnings go to **stderr** only — stdout is always machine-parseable. There are no progress bars, no ANSI escape codes, and no trailing commas or array wrappers.
+
+Example: reading five results from `knn` into a shell array:
+
+```bash
+mapfile -t results < <(
+  echo "auth flow" \
+    | spelunk plumbing embed --query \
+    | spelunk plumbing knn --limit 5
+)
+# Each element of $results is a self-contained JSON object.
+```
+
+## Composition examples
+
+### Semantic search via embed + knn
+
+Embed a query string and pipe the vector directly into KNN search:
+
+```bash
+echo "auth flow" \
+  | spelunk plumbing embed --query \
+  | spelunk plumbing knn --limit 5 \
+  | jq -r '"\(.score | . * 100 | round)%  \(.file_path):\(.start_line)  \(.name // "(anon)")"'
+```
+
+`embed --query` prepends the retrieval prefix expected by EmbeddingGemma, producing a JSON object with a `vector` field. `knn` reads that object from stdin and emits one result object per line, sorted by similarity score descending.
+
+### List stale files and re-index only those
+
+```bash
+spelunk plumbing ls-files --stale --root . \
+  | jq -r '.path' \
+  | xargs -I{} spelunk index {}
+```
+
+`ls-files --stale` exits `1` if nothing is stale (safe to check `$?` before proceeding). Each emitted object's `.path` field is the project-relative path stored in the index.
+
+## All 8 plumbing commands
+
+| Command | Synopsis | Description |
+|---------|----------|-------------|
+| `cat-chunks` | `spelunk plumbing cat-chunks <file>` | Emit all indexed chunks for a file as NDJSON. Exits `1` if the file has no indexed chunks. |
+| `ls-files` | `spelunk plumbing ls-files [--prefix <p>] [--stale] [--root <dir>]` | List every indexed file as NDJSON. `--stale` restricts output to files whose on-disk hash differs from the stored hash. Exits `1` if no files match. |
+| `parse-file` | `spelunk plumbing parse-file <file>` | Parse a file using tree-sitter and emit chunks as NDJSON without writing to the index. |
+| `hash-file` | `spelunk plumbing hash-file <file>` | Compute the blake3 hash of a file and compare it to the stored hash, reporting whether the index is current for that file. |
+| `knn` | `spelunk plumbing knn [--limit N] [--min-score F] [--lang <lang>]` | Read a JSON embedding object from stdin and return the *N* nearest indexed chunks by cosine similarity. Exits `1` if no results pass the filters. |
+| `embed` | `spelunk plumbing embed [--query]` | Read lines from stdin and emit one NDJSON embedding vector per line. Pass `--query` to apply the query retrieval prefix (use this before piping into `knn`). |
+| `graph-edges` | `spelunk plumbing graph-edges --file <f> \| --symbol <s>` | Emit code graph edges (imports, calls, extends) for a file or symbol as NDJSON. At least one of `--file` or `--symbol` is required. Exits `1` if no edges found. |
+| `read-memory` | `spelunk plumbing read-memory [--kind <k>] [--id <n>] [--limit N]` | Emit memory entries as NDJSON. Filter by kind (`decision`, `question`, `note`, etc.) or fetch a single entry by id. |
+
+---
+
+See also: [Agent Guide](agent-guide.md) for the broader context on using spelunk in agentic workflows.


### PR DESCRIPTION
## Summary

Phase 5 documentation for the Unix plumbing/porcelain architecture.

**Issue #132 — new `docs/plumbing-and-porcelain.md`:**
Explains the plumbing vs porcelain design (with Git reference), when to use each, exit-code convention table (0/1/2), NDJSON output contract, two real pipeline composition examples, and a synopsis table of all 8 plumbing commands. Links back to `docs/agent-guide.md`.

**Issue #133 — `## Plumbing Commands` section in `docs/agent-guide.md`:**
Full reference for all 8 plumbing commands: `cat-chunks`, `ls-files`, `parse-file`, `hash-file`, `knn`, `embed`, `graph-edges`, `read-memory`. Each entry has synopsis, one-sentence description, flags table, exit codes, and a worked example. `embed` and `knn` include the compose-via-pipe example. Links to the new `plumbing-and-porcelain.md`.

## Test plan

- [ ] `docs/plumbing-and-porcelain.md` renders correctly in GitHub markdown
- [ ] `docs/agent-guide.md` Plumbing Commands section renders correctly  
- [ ] All flag names match `spelunk plumbing <cmd> --help` output
- [ ] `cargo fmt --check` passes (no Rust files touched)

Closes #132
Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)