### PR TITLE
[#128] refactor: share embed helper between search and plumbing embed

### DIFF
--- a/src/cli/cmd/helpers.rs
+++ b/src/cli/cmd/helpers.rs
@@ -47,6 +47,17 @@ pub(crate) async fn load_llm(cfg: &Config) -> Result<crate::backends::ActiveLlm>
     Ok(llm)
 }
 
+/// Embed a query with the given task prefix and return the raw float vector.
+pub(crate) async fn embed_query_vec(
+    embedder: &crate::backends::ActiveEmbedder,
+    task: &str,
+    query: &str,
+) -> Result<Vec<f32>> {
+    let query_text = format!("task: {task} | query: {query}");
+    let vecs = embedder.embed(&[&query_text]).await?;
+    vecs.into_iter().next().context("no embedding returned")
+}
+
 /// Embed a query with the given task prefix and return the blob bytes suitable
 /// for KNN search.
 pub(crate) async fn embed_query(
@@ -54,10 +65,8 @@ pub(crate) async fn embed_query(
     task: &str,
     query: &str,
 ) -> Result<Vec<u8>> {
-    let query_text = format!("task: {task} | query: {query}");
-    let vecs = embedder.embed(&[&query_text]).await?;
-    let blob = vec_to_blob(vecs.first().context("no embedding returned")?);
-    Ok(blob)
+    let vec = embed_query_vec(embedder, task, query).await?;
+    Ok(vec_to_blob(&vec))
 }
 
 /// Return the final path component of `path` as a display name, falling back

--- a/src/cli/cmd/plumbing/embed_cmd.rs
+++ b/src/cli/cmd/plumbing/embed_cmd.rs
@@ -2,7 +2,9 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 use std::io::{BufRead as _, IsTerminal as _};
 
-use crate::{config::Config, embeddings::EmbeddingBackend as _};
+use crate::{
+    cli::cmd::helpers::embed_query_vec, config::Config, embeddings::EmbeddingBackend as _,
+};
 
 #[derive(Serialize)]
 struct EmbedOutput {
@@ -31,16 +33,18 @@ pub(super) async fn embed_cmd(cfg: &Config, query_mode: bool) -> Result<()> {
         if text.trim().is_empty() {
             continue;
         }
-        let input = if query_mode {
-            format!("task: code retrieval | query: {text}")
+        let vector = if query_mode {
+            embed_query_vec(&embedder, "code retrieval", &text)
+                .await
+                .with_context(|| format!("embedding line {idx}"))?
         } else {
-            format!("title: none | text: {text}")
+            let input = format!("title: none | text: {text}");
+            let mut vecs = embedder
+                .embed(&[input.as_str()])
+                .await
+                .with_context(|| format!("embedding line {idx}"))?;
+            vecs.remove(0)
         };
-        let mut vecs = embedder
-            .embed(&[input.as_str()])
-            .await
-            .with_context(|| format!("embedding line {idx}"))?;
-        let vector = vecs.remove(0);
         let dimensions = vector.len();
         println!(
             "{}",

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Args;
 use std::path::PathBuf;
 
@@ -48,11 +48,11 @@ pub struct SearchArgs {
     pub as_of: Option<String>,
 }
 
-use super::helpers::project_display_name;
+use super::helpers::{embed_query_vec, load_embedder, project_display_name};
 use super::ui::{print_results_text, spinner};
 use crate::{
     config::{Config, resolve_db},
-    embeddings::{EmbeddingBackend as _, vec_to_blob},
+    embeddings::vec_to_blob,
     registry::{Project, Registry},
     search::SearchResult,
     storage::Database,
@@ -105,14 +105,10 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
     } else {
         // semantic, hybrid, or snapshot search: need an embedding.
         let sp = spinner("Loading model…");
-        let embedder = crate::backends::ActiveEmbedder::load(&cfg)
-            .await
-            .with_context(|| format!("loading embedding model '{}'", cfg.embedding_model))?;
+        let embedder = load_embedder(&cfg).await?;
 
         sp.set_message("Embedding query…");
-        let query_text = format!("task: code retrieval | query: {}", args.query);
-        let vecs = embedder.embed(&[&query_text]).await?;
-        let query_vec = vecs.first().context("no embedding returned")?.clone();
+        let query_vec = embed_query_vec(&embedder, "code retrieval", &args.query).await?;
         let query_blob = vec_to_blob(&query_vec);
 
         // Budget mode overfetches a candidate pool; limit is applied after packing.


### PR DESCRIPTION
## Summary
- Extracted `embed_query_vec(embedder, task, query) -> Result<Vec<f32>>` in `src/cli/cmd/helpers.rs` as the single source of truth for query embedding
- `embed_query` now delegates to it (no breaking change for existing callers)
- `spelunk search` (semantic/hybrid paths) and `spelunk plumbing embed --query` now share the same code path — no drift possible

## Why
Issue #128: plumbing and porcelain were independently formatting the `"task: code retrieval | query: {text}"` prefix and loading the embedder. Any future change to embedding format only needs to happen in one place.

## Test plan
- [ ] `cargo test` passes (verified in agent)
- [ ] `spelunk search "auth flow"` produces identical results before/after
- [ ] `spelunk plumbing embed --query` still works

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)