### PR TITLE
chore: fix fuzz-found parser safety issues (stack overflow + OOM)

### DIFF
--- a/src/indexer/parser/mod.rs
+++ b/src/indexer/parser/mod.rs
@@ -3,6 +3,7 @@ mod ts_walker;
 
 use super::chunker::{Chunk, sliding_window};
 use anyhow::Result;
+use std::ops::ControlFlow;
 
 /// All languages recognised by the indexer (tree-sitter, text, and document formats).
 pub const SUPPORTED_LANGUAGES: &[&str] = &[
@@ -143,11 +144,31 @@ impl SourceParser {
         let mut parser = tree_sitter::Parser::new();
         parser.set_language(&ts_lang)?;
 
-        let tree = parser
-            .parse(source, None)
-            .ok_or_else(|| anyhow::anyhow!("tree-sitter produced no parse tree for {file_path}"))?;
-
+        // Prevent pathological inputs (adversarial or deeply ambiguous) from
+        // consuming unbounded memory/time during GLR parsing.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut on_progress = |_: &tree_sitter::ParseState| -> ControlFlow<()> {
+            if std::time::Instant::now() >= deadline {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        };
         let bytes = source.as_bytes();
+        let len = bytes.len();
+        let mut opts = tree_sitter::ParseOptions::new().progress_callback(&mut on_progress);
+        let tree = match parser.parse_with_options(
+            &mut |i, _| (i < len).then(|| &bytes[i..]).unwrap_or_default(),
+            None,
+            Some(opts.reborrow()),
+        ) {
+            Some(t) => t,
+            None => {
+                tracing::warn!("{file_path}: tree-sitter parse exceeded time budget, using sliding window");
+                return Ok(sliding_window(source, file_path, language, 120, 15));
+            }
+        };
+
         let specs = ts_walker::node_specs(language);
         let mut chunks = Vec::new();
 

--- a/src/indexer/parser/mod.rs
+++ b/src/indexer/parser/mod.rs
@@ -159,6 +159,7 @@ impl SourceParser {
             &specs,
             None,
             &mut chunks,
+            0,
         );
 
         if chunks.is_empty() {

--- a/src/indexer/parser/mod.rs
+++ b/src/indexer/parser/mod.rs
@@ -158,7 +158,7 @@ impl SourceParser {
         let len = bytes.len();
         let mut opts = tree_sitter::ParseOptions::new().progress_callback(&mut on_progress);
         let tree = match parser.parse_with_options(
-            &mut |i, _| (i < len).then(|| &bytes[i..]).unwrap_or_default(),
+            &mut |i, _| if i < len { &bytes[i..] } else { &[] },
             None,
             Some(opts.reborrow()),
         ) {
@@ -172,18 +172,15 @@ impl SourceParser {
         };
 
         let specs = ts_walker::node_specs(language);
-        let mut chunks = Vec::new();
-
-        ts_walker::walk_node(
-            tree.root_node(),
-            bytes,
+        let ctx = ts_walker::WalkCtx {
+            src: bytes,
             file_path,
             language,
-            &specs,
-            None,
-            &mut chunks,
-            0,
-        );
+            specs: &specs,
+        };
+        let mut chunks = Vec::new();
+
+        ts_walker::walk_node(tree.root_node(), &ctx, None, &mut chunks, 0);
 
         if chunks.is_empty() {
             tracing::debug!("{file_path}: no semantic nodes found, using sliding window");

--- a/src/indexer/parser/mod.rs
+++ b/src/indexer/parser/mod.rs
@@ -164,7 +164,9 @@ impl SourceParser {
         ) {
             Some(t) => t,
             None => {
-                tracing::warn!("{file_path}: tree-sitter parse exceeded time budget, using sliding window");
+                tracing::warn!(
+                    "{file_path}: tree-sitter parse exceeded time budget, using sliding window"
+                );
                 return Ok(sliding_window(source, file_path, language, 120, 15));
             }
         };

--- a/src/indexer/parser/ts_walker.rs
+++ b/src/indexer/parser/ts_walker.rs
@@ -142,7 +142,7 @@ pub(super) fn node_specs(language: &str) -> Vec<NodeSpec> {
 }
 
 /// Maximum AST recursion depth.  Deeply-nested or pathological parse trees
-/// (common with fuzz inputs) would otherwise overflow the stack.
+/// (common with adversarial inputs) would otherwise overflow the stack.
 const MAX_WALK_DEPTH: usize = 512;
 
 /// Maximum number of chunks collected in a single walk.  A file with millions

--- a/src/indexer/parser/ts_walker.rs
+++ b/src/indexer/parser/ts_walker.rs
@@ -150,12 +150,27 @@ const MAX_WALK_DEPTH: usize = 512;
 /// allocate unbounded memory.
 const MAX_CHUNKS: usize = 100_000;
 
+/// Immutable per-file context threaded through the AST walk.
+pub(super) struct WalkCtx<'a> {
+    pub src: &'a [u8],
+    pub file_path: &'a str,
+    pub language: &'a str,
+    pub specs: &'a [NodeSpec],
+}
+
 pub(super) fn walk_node(
     node: tree_sitter::Node<'_>,
-    src: &[u8],
-    file_path: &str,
-    language: &str,
-    specs: &[NodeSpec],
+    ctx: &WalkCtx<'_>,
+    parent_scope: Option<&str>,
+    out: &mut Vec<Chunk>,
+    depth: usize,
+) {
+    walk_node_inner(node, ctx, parent_scope, out, depth);
+}
+
+fn walk_node_inner(
+    node: tree_sitter::Node<'_>,
+    ctx: &WalkCtx<'_>,
     parent_scope: Option<&str>,
     out: &mut Vec<Chunk>,
     depth: usize,
@@ -163,34 +178,25 @@ pub(super) fn walk_node(
     if depth >= MAX_WALK_DEPTH || out.len() >= MAX_CHUNKS {
         return;
     }
-    if let Some(spec) = specs.iter().find(|s| s.kind == node.kind()) {
+    if let Some(spec) = ctx.specs.iter().find(|s| s.kind == node.kind()) {
         // Skip keyword leaf tokens: grammars like proto reuse the node kind
         // name for both the keyword token ("message") and the structural block.
         // Structural nodes always have named children; keyword leaves do not.
         if node.named_child_count() == 0 {
             for i in 0..node.child_count() {
                 if let Some(child) = node.child(i as u32) {
-                    walk_node(
-                        child,
-                        src,
-                        file_path,
-                        language,
-                        specs,
-                        parent_scope,
-                        out,
-                        depth + 1,
-                    );
+                    walk_node_inner(child, ctx, parent_scope, out, depth + 1);
                 }
             }
             return;
         }
 
-        let name = extract_name(&node, src, language, spec);
+        let name = extract_name(&node, ctx.src, ctx.language, spec);
 
-        let content = node.utf8_text(src).unwrap_or("").to_owned();
+        let content = node.utf8_text(ctx.src).unwrap_or("").to_owned();
 
         // Look for a doc comment immediately before this node
-        let docstring = preceding_comment(&node, src);
+        let docstring = preceding_comment(&node, ctx.src);
 
         // Build scope label for impl/class containers
         let scope_label: Option<String> = match spec.chunk_kind {
@@ -201,8 +207,8 @@ pub(super) fn walk_node(
         };
 
         out.push(Chunk {
-            file_path: file_path.to_owned(),
-            language: language.to_owned(),
+            file_path: ctx.file_path.to_owned(),
+            language: ctx.language.to_owned(),
             kind: spec.chunk_kind.clone(),
             name,
             start_line: node.start_position().row + 1,
@@ -216,32 +222,14 @@ pub(super) fn walk_node(
         // Recurse into children with the updated scope
         for i in 0..node.child_count() {
             if let Some(child) = node.child(i as u32) {
-                walk_node(
-                    child,
-                    src,
-                    file_path,
-                    language,
-                    specs,
-                    scope_label.as_deref(),
-                    out,
-                    depth + 1,
-                );
+                walk_node_inner(child, ctx, scope_label.as_deref(), out, depth + 1);
             }
         }
     } else {
         // Not a target node — recurse with same parent scope
         for i in 0..node.child_count() {
             if let Some(child) = node.child(i as u32) {
-                walk_node(
-                    child,
-                    src,
-                    file_path,
-                    language,
-                    specs,
-                    parent_scope,
-                    out,
-                    depth + 1,
-                );
+                walk_node_inner(child, ctx, parent_scope, out, depth + 1);
             }
         }
     }

--- a/src/indexer/parser/ts_walker.rs
+++ b/src/indexer/parser/ts_walker.rs
@@ -170,7 +170,16 @@ pub(super) fn walk_node(
         if node.named_child_count() == 0 {
             for i in 0..node.child_count() {
                 if let Some(child) = node.child(i as u32) {
-                    walk_node(child, src, file_path, language, specs, parent_scope, out, depth + 1);
+                    walk_node(
+                        child,
+                        src,
+                        file_path,
+                        language,
+                        specs,
+                        parent_scope,
+                        out,
+                        depth + 1,
+                    );
                 }
             }
             return;
@@ -223,7 +232,16 @@ pub(super) fn walk_node(
         // Not a target node — recurse with same parent scope
         for i in 0..node.child_count() {
             if let Some(child) = node.child(i as u32) {
-                walk_node(child, src, file_path, language, specs, parent_scope, out, depth + 1);
+                walk_node(
+                    child,
+                    src,
+                    file_path,
+                    language,
+                    specs,
+                    parent_scope,
+                    out,
+                    depth + 1,
+                );
             }
         }
     }

--- a/src/indexer/parser/ts_walker.rs
+++ b/src/indexer/parser/ts_walker.rs
@@ -145,6 +145,11 @@ pub(super) fn node_specs(language: &str) -> Vec<NodeSpec> {
 /// (common with fuzz inputs) would otherwise overflow the stack.
 const MAX_WALK_DEPTH: usize = 512;
 
+/// Maximum number of chunks collected in a single walk.  A file with millions
+/// of matched AST nodes (possible with adversarial input) would otherwise
+/// allocate unbounded memory.
+const MAX_CHUNKS: usize = 100_000;
+
 pub(super) fn walk_node(
     node: tree_sitter::Node<'_>,
     src: &[u8],
@@ -155,7 +160,7 @@ pub(super) fn walk_node(
     out: &mut Vec<Chunk>,
     depth: usize,
 ) {
-    if depth >= MAX_WALK_DEPTH {
+    if depth >= MAX_WALK_DEPTH || out.len() >= MAX_CHUNKS {
         return;
     }
     if let Some(spec) = specs.iter().find(|s| s.kind == node.kind()) {

--- a/src/indexer/parser/ts_walker.rs
+++ b/src/indexer/parser/ts_walker.rs
@@ -141,6 +141,10 @@ pub(super) fn node_specs(language: &str) -> Vec<NodeSpec> {
     }
 }
 
+/// Maximum AST recursion depth.  Deeply-nested or pathological parse trees
+/// (common with fuzz inputs) would otherwise overflow the stack.
+const MAX_WALK_DEPTH: usize = 512;
+
 pub(super) fn walk_node(
     node: tree_sitter::Node<'_>,
     src: &[u8],
@@ -149,7 +153,11 @@ pub(super) fn walk_node(
     specs: &[NodeSpec],
     parent_scope: Option<&str>,
     out: &mut Vec<Chunk>,
+    depth: usize,
 ) {
+    if depth >= MAX_WALK_DEPTH {
+        return;
+    }
     if let Some(spec) = specs.iter().find(|s| s.kind == node.kind()) {
         // Skip keyword leaf tokens: grammars like proto reuse the node kind
         // name for both the keyword token ("message") and the structural block.
@@ -157,7 +165,7 @@ pub(super) fn walk_node(
         if node.named_child_count() == 0 {
             for i in 0..node.child_count() {
                 if let Some(child) = node.child(i as u32) {
-                    walk_node(child, src, file_path, language, specs, parent_scope, out);
+                    walk_node(child, src, file_path, language, specs, parent_scope, out, depth + 1);
                 }
             }
             return;
@@ -202,6 +210,7 @@ pub(super) fn walk_node(
                     specs,
                     scope_label.as_deref(),
                     out,
+                    depth + 1,
                 );
             }
         }
@@ -209,7 +218,7 @@ pub(super) fn walk_node(
         // Not a target node — recurse with same parent scope
         for i in 0..node.child_count() {
             if let Some(child) = node.child(i as u32) {
-                walk_node(child, src, file_path, language, specs, parent_scope, out);
+                walk_node(child, src, file_path, language, specs, parent_scope, out, depth + 1);
             }
         }
     }
@@ -317,13 +326,23 @@ fn c_function_name<'a>(node: &tree_sitter::Node<'a>, src: &'a [u8]) -> Option<St
     find_identifier(decl, src)
 }
 
+/// Maximum recursion depth for identifier search inside declarator subtrees.
+const MAX_IDENT_DEPTH: usize = 64;
+
 pub(super) fn find_identifier(node: tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
+    find_identifier_inner(node, src, 0)
+}
+
+fn find_identifier_inner(node: tree_sitter::Node<'_>, src: &[u8], depth: usize) -> Option<String> {
+    if depth >= MAX_IDENT_DEPTH {
+        return None;
+    }
     if node.kind() == "identifier" || node.kind() == "field_identifier" {
         return node.utf8_text(src).ok().map(str::to_owned);
     }
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i as u32)
-            && let Some(name) = find_identifier(child, src)
+            && let Some(name) = find_identifier_inner(child, src, depth + 1)
         {
             return Some(name);
         }


### PR DESCRIPTION
## Summary

- **Stack overflow** (`fix: stack overflow from unbounded recursion in walk_node`, already committed): `walk_node` and `find_identifier` had no depth limit; malformed tree-sitter ASTs from binary fuzz input caused unbounded recursion. Fixed by adding `MAX_WALK_DEPTH = 512` and `MAX_IDENT_DEPTH = 64` guards with a `depth` parameter threaded through both functions.

- **Out-of-memory** (this commit): a single ~3.8 KB adversarial input caused RSS to spike from 541 MB to 2 GB in one `SourceParser::parse` call. Two guards close the window:
  - **Parse timeout** (5 s via `ParseOptions::progress_callback`): aborts tree-sitter's GLR phase if it overruns and falls back to sliding-window chunking, preventing the parser from allocating unbounded memory on ambiguous input.
  - **Chunk cap** (`MAX_CHUNKS = 100 000` in `walk_node`): returns early if the output `Vec` reaches the limit, bounding memory for pathologically wide parse trees.

All three fuzz artifacts (`crash-*` × 3, `oom-*` × 2) are addressed by these changes.

## Test plan

- [ ] `cargo test` passes (all suites green)
- [ ] `cargo build --release` succeeds
- [ ] Re-run fuzzer against the artifact inputs: `cargo +nightly fuzz run fuzz_parser fuzz/artifacts/fuzz_parser/` — no crashes or OOMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)