### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,78 @@
+# Changelog
+
+All notable changes to spelunk are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+spelunk uses [Semantic Versioning](https://semver.org/).
+
+---
+
+## [0.5.0] — 2026-04-21
+
+### Added
+
+- **Unix plumbing/porcelain architecture** — 8 new `spelunk spelunk` plumbing
+  subcommands emit machine-readable NDJSON to stdout and use conventional exit
+  codes (0 = ok, 1 = no results, 2 = error). All porcelain commands now accept
+  `--format text|json|ndjson` for structured output in scripts and agents.
+  Plumbing commands: `cat-chunks`, `embed`, `graph-edges`, `hash-file`, `knn`,
+  `ls-files`, `parse-file`, `read-memory`.
+
+- **`spelunk memory harvest --source claude-code`** — mines Claude Code session
+  history files (`.claude/projects/*/sessions/*.jsonl`) for decisions, notes,
+  and requirements; deduplicates against already-stored entries; stores the
+  results directly in the memory index.
+
+- **`intent` memory kind** — agents record work-in-progress intent entries so
+  collaborating agents (and humans) can see what is actively being changed.
+  `spelunk check` now shows active agent sessions alongside the index health
+  summary, and warns when any intent's linked files overlap with files recently
+  modified in the current worktree.
+
+- **Server-side conflict detection** — `spelunk-server` runs a KNN similarity
+  search before storing each new memory entry; entries that closely contradict
+  an existing active entry are flagged with a `contradicts` edge and the HTTP
+  response includes a `409 Conflict` status with the conflicting entry IDs.
+  A `--conflict-threshold` flag controls the cosine-distance trigger.
+
+- **`spelunk memory since` / `spelunk memory watch`** — incremental memory feed
+  (`since`) and a long-running SSE stream (`watch`) for agents that want to be
+  notified of new memory entries in real time. _(coming soon in 0.5.x — not
+  yet merged as of this release)_
+
+- **Benchmark scripts** (`bench/`) for evaluating search quality across
+  indexing configurations.
+
+### Changed
+
+- `--format text|json` standardised across all porcelain commands (`ask`,
+  `explore`, `search`, `graph`, `memory list`, `memory search`). The legacy
+  `--json` flag is kept as a hidden deprecated alias.
+
+- `storage/memory.rs` split into focused sub-modules
+  (`storage/memory/`, `storage/db/`) to reduce file size and improve
+  navigability, as part of the broader Unix-architecture refactor.
+
+### Fixed / Security
+
+- **XML escaping in LLM prompts** — spec titles and paths interpolated into
+  `<spec_context>` blocks are now escaped with `escape_xml()`, closing a
+  prompt-injection vector.
+
+- **Expanded secret scanner** — `src/indexer/secrets.rs` now recognises
+  OpenAI, Anthropic, and Stripe API keys; npm automation tokens; and database
+  connection URLs containing inline credentials. Patterns compile once via
+  `OnceLock`.
+
+- **Atomic memory transactions** — `NoteStore` archive and supersede operations
+  now run inside a single SQLite transaction; partial writes on crash are no
+  longer possible.
+
+- Resolved all security-audit findings from `cargo audit` (#136, #137, #138,
+  #145) by upgrading affected dependency versions.
+
+---
+
+## [0.4.1] — 2026-03-21
+
+Initial public release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4031,7 +4031,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 default-run = "spelunk"
 description = "Local context engine for AI coding agents — tree-sitter AST chunking, semantic search, code graph"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,23 +6,23 @@ Download the latest binary for your platform from the [releases page](https://gi
 
 ```bash
 # macOS (Apple Silicon) — universal binary also available
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-aarch64-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-aarch64-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # macOS (Intel)
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-x86_64-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-x86_64-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # macOS (universal — works on both Intel and Apple Silicon)
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-universal-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-universal-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Linux x86_64
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-x86_64-unknown-linux-gnu.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-x86_64-unknown-linux-gnu.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Linux ARM64
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-aarch64-unknown-linux-gnu.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-aarch64-unknown-linux-gnu.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Verify

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,7 +33,7 @@ Edit the `version` field in `Cargo.toml`:
 ```toml
 [package]
 name = "spelunk"
-version = "0.4.1"   # <-- update this
+version = "0.5.0"   # <-- update this
 ```
 
 ### 1a. Update version references in docs
@@ -52,15 +52,15 @@ Commit everything together:
 
 ```bash
 git add Cargo.toml Cargo.lock docs/getting-started.md
-git commit -m "chore: bump version to 0.4.1"
+git commit -m "chore: bump version to 0.5.0"
 git push origin main
 ```
 
 ### 2. Tag and push
 
 ```bash
-git tag v0.4.1
-git push origin v0.4.1
+git tag v0.5.0
+git push origin v0.5.0
 ```
 
 That's it. The release workflow triggers automatically on the pushed tag.
@@ -71,7 +71,7 @@ Watch progress at:
 `https://github.com/usercise/spelunk/actions/workflows/release.yml`
 
 Once all jobs pass, the release appears at:
-`https://github.com/usercise/spelunk/releases/tag/v0.4.1`
+`https://github.com/usercise/spelunk/releases/tag/v0.5.0`
 
 ## Pre-releases
 
@@ -80,8 +80,8 @@ GitHub Release as a pre-release when the tag contains `-rc`, `-beta`, or
 `-alpha`:
 
 ```bash
-git tag v0.4.1-rc.1
-git push origin v0.4.1-rc.1
+git tag v0.5.0-rc.1
+git push origin v0.5.0-rc.1
 ```
 
 ## Download URLs
@@ -96,16 +96,16 @@ Examples:
 
 ```bash
 # macOS Apple Silicon
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-aarch64-apple-darwin.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-aarch64-apple-darwin.tar.gz
 
 # macOS universal (x86_64 + Apple Silicon)
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-universal-apple-darwin.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-universal-apple-darwin.tar.gz
 
 # Linux x86_64
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-x86_64-unknown-linux-gnu.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-x86_64-unknown-linux-gnu.tar.gz
 
 # Linux ARM64
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.4.1-aarch64-unknown-linux-gnu.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-aarch64-unknown-linux-gnu.tar.gz
 ```
 
 ## Deleting a bad release
@@ -114,11 +114,11 @@ If a release needs to be pulled:
 
 ```bash
 # Delete the tag locally and on remote
-git tag -d v0.4.1
-git push origin :refs/tags/v0.4.1
+git tag -d v0.5.0
+git push origin :refs/tags/v0.5.0
 
 # Delete the GitHub Release (requires gh CLI)
-gh release delete v0.4.1 --yes
+gh release delete v0.5.0 --yes
 ```
 
 Then fix the issue, re-commit, and re-tag.


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml` version from 0.4.1 → 0.5.0
- Updates 5 download URL version strings in `docs/getting-started.md`
- Updates version references in `docs/releasing.md`
- Creates `CHANGELOG.md` with a 0.5.0 entry

## What's in 0.5.0
- **Unix plumbing/porcelain architecture** — 8 NDJSON plumbing subcommands, `--format text|json|ndjson` standardised across porcelain commands
- **`spelunk memory harvest --source claude-code`** — mines Claude Code session history for decisions/notes/requirements
- **`intent` memory kind** — agents signal WIP; `spelunk check` surfaces active sessions and file-overlap warnings
- **Server-side conflict detection** — KNN similarity check on write; `contradicts` edges, HTTP 409, `--conflict-threshold` flag
- **`spelunk memory since` / `spelunk memory watch`** — incremental poll and SSE stream (pending #148)
- **Security hardening** — XML escaping in LLM prompts, expanded secret scanner (OpenAI/Anthropic/Stripe/NPM/DB URLs), atomic memory transactions
- **Module splits** — `storage/memory` refactored into focused sub-modules
- Resolved all `cargo audit` findings (#136–#138, #145)

## Test plan
- [ ] `cargo clippy -- -D warnings` passes (verified)
- [ ] `cargo fmt --check` passes (verified)
- [ ] Version shows as 0.5.0 in `cargo check` output (verified)
- [ ] All 5 curl URLs in `docs/getting-started.md` updated
- [ ] `CHANGELOG.md` present with correct date and feature list

🤖 Generated with [Claude Code](https://claude.com/claude-code)