### PR TITLE
feat: /memory/since endpoint, SSE stream, and CLI watch/since (#148)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,10 @@ futures-util = { version = "0.3", optional = true }
 axum = { version = "0.8", features = ["macros"] }
 tower-http = { version = "0.6", features = ["auth"] }
 
+# SSE stream helpers for /memory/stream endpoint
+async-stream = "0.3"
+tokio-stream = "0.1"
+
 # OpenAPI documentation
 utoipa = { version = "5", features = ["axum_extras"] }
 

--- a/src/cli/cmd/memory/mod.rs
+++ b/src/cli/cmd/memory/mod.rs
@@ -34,6 +34,10 @@ pub enum MemoryCommand {
     Timeline(MemoryTimelineArgs),
     /// Show the relationship graph for a memory entry
     Graph(MemoryGraphArgs),
+    /// List memory entries created after a given Unix timestamp
+    Since(MemorySinceArgs),
+    /// Stream new memory entries from the server in real time (requires memory_server_url)
+    Watch(MemoryWatchArgs),
 }
 
 #[derive(Args, Debug)]
@@ -224,6 +228,27 @@ pub struct MemorySupersededArgs {
     pub new_id: i64,
 }
 
+#[derive(Args, Debug)]
+pub struct MemorySinceArgs {
+    /// Unix epoch seconds (exclusive lower bound for `created_at`)
+    pub since: i64,
+
+    /// Maximum number of results to return
+    #[arg(short, long, default_value_t = 100)]
+    pub limit: usize,
+
+    /// Output format: text, json, or ndjson
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+#[derive(Args, Debug)]
+pub struct MemoryWatchArgs {
+    /// Output format: text or json
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
 use super::status::format_age;
 
 mod add;
@@ -235,8 +260,10 @@ mod list;
 mod push;
 mod search;
 mod show;
+mod since;
 mod supersede;
 mod timeline;
+mod watch;
 
 pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> {
     cfg.validate()?;
@@ -254,6 +281,8 @@ pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> 
         MemoryCommand::Push(a) => push::memory_push(a, &mem_path, &cfg).await,
         MemoryCommand::Timeline(a) => timeline::memory_timeline(a, &mem_path, &cfg).await,
         MemoryCommand::Graph(a) => graph_cmd::memory_graph(a, &mem_path, &cfg).await,
+        MemoryCommand::Since(a) => since::memory_since(a, &mem_path, &cfg).await,
+        MemoryCommand::Watch(a) => watch::memory_watch(a, &cfg).await,
     }
 }
 

--- a/src/cli/cmd/memory/since.rs
+++ b/src/cli/cmd/memory/since.rs
@@ -1,0 +1,149 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use super::MemorySinceArgs;
+use crate::config::Config;
+
+/// Wire type that matches the server's `ServerNote` JSON schema.
+#[derive(Debug, serde::Serialize, Deserialize)]
+struct NoteResponse {
+    id: i64,
+    kind: String,
+    title: String,
+    body: String,
+    tags: Vec<String>,
+    linked_files: Vec<String>,
+    created_at: i64,
+    status: String,
+    superseded_by: Option<i64>,
+    #[serde(default)]
+    distance: Option<f64>,
+}
+
+pub(super) async fn memory_since(
+    args: MemorySinceArgs,
+    mem_path: &std::path::Path,
+    cfg: &Config,
+) -> Result<()> {
+    // ── Remote path ───────────────────────────────────────────────────────────
+    if let (Some(base_url), Some(project_id)) =
+        (cfg.memory_server_url.as_deref(), cfg.project_id.as_deref())
+    {
+        let limit = args.limit.min(500);
+        let url = format!(
+            "{}/v1/projects/{}/memory/since",
+            base_url.trim_end_matches('/'),
+            project_id,
+        );
+        let client = reqwest::Client::new();
+        let mut req = client
+            .get(&url)
+            .query(&[("t", args.since.to_string()), ("limit", limit.to_string())]);
+        if let Some(key) = cfg.memory_server_key.as_deref() {
+            req = req.header("Authorization", format!("Bearer {key}"));
+        }
+        let notes: Vec<NoteResponse> = req
+            .send()
+            .await
+            .context("GET /memory/since")?
+            .error_for_status()
+            .context("server returned error for GET /memory/since")?
+            .json()
+            .await
+            .context("parsing /memory/since response")?;
+
+        print_notes(&notes, &args.format);
+        return Ok(());
+    }
+
+    // ── Local path ────────────────────────────────────────────────────────────
+    let backend = crate::storage::open_memory_backend(cfg, mem_path)?;
+    let all = backend
+        .list(None, args.limit, false, None)
+        .await
+        .context("listing local memory entries")?;
+
+    // Filter client-side by created_at > since.
+    let filtered: Vec<_> = all
+        .into_iter()
+        .filter(|n| n.created_at > args.since)
+        .collect();
+
+    match crate::utils::effective_format(&args.format) {
+        "json" => println!("{}", serde_json::to_string_pretty(&filtered)?),
+        "ndjson" => {
+            for n in &filtered {
+                println!("{}", serde_json::to_string(n)?);
+            }
+        }
+        _ => {
+            if filtered.is_empty() {
+                println!("No memory entries found after timestamp {}.", args.since);
+            } else {
+                for n in &filtered {
+                    super::print_note_summary(n);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_notes(notes: &[NoteResponse], format: &str) {
+    match crate::utils::effective_format(format) {
+        "json" => println!(
+            "{}",
+            serde_json::to_string_pretty(notes).unwrap_or_default()
+        ),
+        "ndjson" => {
+            for n in notes {
+                println!("{}", serde_json::to_string(n).unwrap_or_default());
+            }
+        }
+        _ => {
+            if notes.is_empty() {
+                println!("No memory entries found.");
+                return;
+            }
+            for n in notes {
+                let dist = n
+                    .distance
+                    .map(|d| format!("  \x1b[2mdist: {d:.4}\x1b[0m"))
+                    .unwrap_or_default();
+                let archived_badge = if n.status == "archived" {
+                    " \x1b[31m[archived]\x1b[0m"
+                } else {
+                    ""
+                };
+                println!(
+                    "\x1b[1m#{id}\x1b[0m  \x1b[33m[{kind}]\x1b[0m  {title}{archived}{dist}",
+                    id = n.id,
+                    kind = n.kind,
+                    title = n.title,
+                    archived = archived_badge,
+                );
+                println!(
+                    "     \x1b[2m{}\x1b[0m",
+                    super::super::status::format_age(n.created_at)
+                );
+                if let Some(sup) = n.superseded_by {
+                    println!("     \x1b[2msuperseded by #{sup}\x1b[0m");
+                }
+                if !n.tags.is_empty() {
+                    println!("     tags: {}", n.tags.join(", "));
+                }
+                if !n.linked_files.is_empty() {
+                    println!("     files: {}", n.linked_files.join(", "));
+                }
+                let preview: Vec<&str> = n.body.lines().take(2).collect();
+                for line in &preview {
+                    println!("     \x1b[2m{line}\x1b[0m");
+                }
+                if n.body.lines().count() > 2 {
+                    println!("     \x1b[2m…\x1b[0m");
+                }
+                println!();
+            }
+        }
+    }
+}

--- a/src/cli/cmd/memory/watch.rs
+++ b/src/cli/cmd/memory/watch.rs
@@ -1,0 +1,114 @@
+use anyhow::{Context, Result};
+
+use super::MemoryWatchArgs;
+use crate::config::Config;
+
+pub(super) async fn memory_watch(args: MemoryWatchArgs, cfg: &Config) -> Result<()> {
+    let base_url = cfg.memory_server_url.as_deref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "`memory_server_url` is not configured. \
+             Set it in `.spelunk/config.toml` or via `SPELUNK_SERVER_URL`."
+        )
+    })?;
+    let project_id = cfg.project_id.as_deref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "`project_id` is not configured. \
+             Set it in `.spelunk/config.toml` or via `SPELUNK_PROJECT_ID`."
+        )
+    })?;
+
+    let url = format!(
+        "{}/v1/projects/{}/memory/stream",
+        base_url.trim_end_matches('/'),
+        project_id,
+    );
+
+    eprintln!("Watching {url} — press Ctrl-C to stop.");
+
+    let client = reqwest::Client::new();
+    let mut req = client.get(&url);
+    if let Some(key) = cfg.memory_server_key.as_deref() {
+        req = req.header("Authorization", format!("Bearer {key}"));
+    }
+
+    let resp = req.send().await.context("connecting to /memory/stream")?;
+    resp.error_for_status_ref()
+        .context("server returned error for GET /memory/stream")?;
+
+    let is_json = matches!(crate::utils::effective_format(&args.format), "json");
+    let mut stream = resp.bytes_stream();
+
+    use futures_util::StreamExt;
+
+    let mut buf = String::new();
+    loop {
+        match stream.next().await {
+            None => {
+                // Server closed the connection.
+                eprintln!("Stream closed by server.");
+                break;
+            }
+            Some(Err(e)) => {
+                eprintln!("Stream error: {e}");
+                break;
+            }
+            Some(Ok(chunk)) => {
+                let text = String::from_utf8_lossy(&chunk);
+                buf.push_str(&text);
+                // Process all complete SSE lines in the buffer.
+                while let Some(pos) = buf.find('\n') {
+                    let line = buf[..pos].to_string();
+                    buf = buf[pos + 1..].to_string();
+                    let line = line.trim_end_matches('\r');
+                    if let Some(data) = line.strip_prefix("data: ") {
+                        if data.is_empty() {
+                            continue;
+                        }
+                        if is_json {
+                            // Pretty-print the raw JSON.
+                            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data) {
+                                println!("{}", serde_json::to_string_pretty(&v)?);
+                            } else {
+                                println!("{data}");
+                            }
+                        } else {
+                            print_sse_note(data);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_sse_note(data: &str) {
+    #[derive(serde::Deserialize)]
+    struct Slim {
+        id: i64,
+        kind: String,
+        title: String,
+        created_at: i64,
+        #[serde(default)]
+        tags: Vec<String>,
+    }
+    if let Ok(n) = serde_json::from_str::<Slim>(data) {
+        println!(
+            "\x1b[1m#{id}\x1b[0m  \x1b[33m[{kind}]\x1b[0m  {title}",
+            id = n.id,
+            kind = n.kind,
+            title = n.title,
+        );
+        println!(
+            "     \x1b[2m{}\x1b[0m",
+            super::super::status::format_age(n.created_at)
+        );
+        if !n.tags.is_empty() {
+            println!("     tags: {}", n.tags.join(", "));
+        }
+        println!();
+    } else {
+        println!("{data}");
+    }
+}

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -371,6 +371,31 @@ impl ServerDb {
         Ok(changed > 0)
     }
 
+    /// Return notes created after `since_secs` (exclusive), ordered ASC by `created_at`.
+    /// Archived entries are excluded. `limit` is capped at 500.
+    pub fn notes_since(
+        &self,
+        project_id: i64,
+        since_secs: i64,
+        limit: i64,
+    ) -> Result<Vec<ServerNote>> {
+        let limit = limit.clamp(1, 500);
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT id, kind, title, body, tags, linked_files, created_at, status, superseded_by
+             FROM notes
+             WHERE project_id = ?1 AND created_at > ?2 AND status != 'archived'
+             ORDER BY created_at ASC
+             LIMIT ?3",
+        )?;
+        let notes = stmt
+            .query_map(
+                rusqlite::params![project_id, since_secs, limit],
+                row_to_note,
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(notes)
+    }
+
     pub fn delete_note(&self, project_id: i64, note_id: i64) -> Result<bool> {
         self.conn.execute(
             "DELETE FROM note_embeddings WHERE note_id = ?1",

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1,9 +1,16 @@
+use std::convert::Infallible;
+use std::time::Duration;
+
 use anyhow::Result;
+use async_stream::stream;
 use axum::{
     Json,
     extract::{Path, Query, State},
     http::StatusCode,
-    response::{IntoResponse, Response},
+    response::{
+        IntoResponse, Response,
+        sse::{Event, KeepAlive, Sse},
+    },
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -444,6 +451,129 @@ pub async fn harvested_shas(
     let project = require_project(&db, &project_id)?;
     let shas = db.harvested_shas(project.id)?;
     Ok(Json(shas))
+}
+
+// ── Poll / SSE endpoints ──────────────────────────────────────────────────────
+
+#[derive(Deserialize, ToSchema, utoipa::IntoParams)]
+pub struct SinceQuery {
+    /// Unix epoch seconds (exclusive lower bound).
+    pub t: i64,
+    /// Maximum number of results (default: 100, max: 500).
+    #[serde(default = "default_since_limit")]
+    pub limit: i64,
+}
+fn default_since_limit() -> i64 {
+    100
+}
+
+#[derive(Deserialize, ToSchema, utoipa::IntoParams)]
+pub struct StreamQuery {
+    /// Unix epoch seconds to start from (inclusive). Defaults to now.
+    pub t: Option<i64>,
+}
+
+/// Return notes created after a given Unix timestamp. Archived entries are
+/// excluded. Results are ordered `created_at ASC`.
+#[utoipa::path(
+    get,
+    path = "/v1/projects/{project_id}/memory/since",
+    params(
+        ("project_id" = String, Path, description = "Project slug"),
+        SinceQuery,
+    ),
+    responses(
+        (status = 200, description = "Notes newer than `t`", body = Vec<super::db::ServerNote>),
+        (status = 400, description = "Missing or invalid `t` parameter"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Project not found"),
+    ),
+    security(("bearer_auth" = [])),
+    tag = "memory"
+)]
+pub async fn memory_since(
+    State(state): State<AppState>,
+    Path(project_id): Path<String>,
+    Query(params): Query<SinceQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let db = state.db.lock().await;
+    let project = require_project(&db, &project_id)?;
+    let notes = db.notes_since(project.id, params.t, params.limit)?;
+    Ok(Json(notes))
+}
+
+/// Stream new memory entries as Server-Sent Events. Each event carries a
+/// single `ServerNote` serialised as JSON. The stream polls the database once
+/// per second and stays open indefinitely — close the connection to stop it.
+///
+/// Pass `?t=<unix_secs>` to replay entries written after a known timestamp.
+/// Omit it to receive only entries written after the connection opens.
+#[utoipa::path(
+    get,
+    path = "/v1/projects/{project_id}/memory/stream",
+    params(
+        ("project_id" = String, Path, description = "Project slug"),
+        StreamQuery,
+    ),
+    responses(
+        (status = 200, description = "SSE stream of new memory entries"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Project not found"),
+    ),
+    security(("bearer_auth" = [])),
+    tag = "memory"
+)]
+pub async fn memory_stream(
+    State(state): State<AppState>,
+    Path(project_id): Path<String>,
+    Query(params): Query<StreamQuery>,
+) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, AppError> {
+    // Validate the project exists before opening the stream.
+    {
+        let db = state.db.lock().await;
+        require_project(&db, &project_id)?;
+    }
+
+    let start_t = params.t.unwrap_or_else(|| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64
+    });
+
+    let s = stream! {
+        let mut last_seen = start_t;
+        loop {
+            // Lock, query, immediately release.
+            let notes = {
+                let db = state.db.lock().await;
+                // Re-fetch the project each iteration so the stream survives
+                // project creation that may have happened after the handshake.
+                let pid = match db.get_project(&project_id) {
+                    Ok(Some(p)) => p.id,
+                    _ => {
+                        drop(db);
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        continue;
+                    }
+                };
+                // Ignore DB errors mid-stream; keep the connection alive.
+                db.notes_since(pid, last_seen, 50).unwrap_or_default()
+            };
+
+            for note in notes {
+                if note.created_at > last_seen {
+                    last_seen = note.created_at;
+                }
+                let data = serde_json::to_string(&note).unwrap_or_default();
+                yield Ok::<Event, Infallible>(Event::default().data(data));
+            }
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    };
+
+    Ok(Sse::new(s).keep_alive(KeepAlive::default()))
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -53,6 +53,8 @@ pub fn default_conflict_threshold() -> f32 {
         handlers::supersede_note,
         handlers::project_stats,
         handlers::harvested_shas,
+        handlers::memory_since,
+        handlers::memory_stream,
     ),
     components(schemas(
         handlers::AddNoteRequest,
@@ -63,6 +65,8 @@ pub fn default_conflict_threshold() -> f32 {
         handlers::BoolResponse,
         handlers::CountResponse,
         handlers::SupersedeRequest,
+        handlers::SinceQuery,
+        handlers::StreamQuery,
         db::Project,
         db::ServerNote,
         db::ProjectStats,
@@ -118,6 +122,14 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/v1/projects/{project_id}/memory/harvested-shas",
             get(handlers::harvested_shas),
+        )
+        .route(
+            "/v1/projects/{project_id}/memory/since",
+            get(handlers::memory_since),
+        )
+        .route(
+            "/v1/projects/{project_id}/memory/stream",
+            get(handlers::memory_stream),
         )
         .route(
             "/v1/projects/{project_id}/memory/{note_id}",

--- a/tests/integration_server.rs
+++ b/tests/integration_server.rs
@@ -326,6 +326,73 @@ async fn search_returns_closest_note() {
     assert_eq!(notes[0]["title"], "alpha");
 }
 
+// ── /memory/since ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial]
+async fn since_endpoint_returns_entries_after_timestamp() {
+    use spelunk::server::db::ServerDb;
+
+    common::register_sqlite_vec();
+
+    // Build a DB and insert two notes with known timestamps.
+    let db = ServerDb::open(std::path::Path::new(":memory:"), 4).expect("open in-memory server db");
+
+    // Insert a project manually so we control created_at timing.
+    db.conn
+        .execute(
+            "INSERT INTO projects (slug, embedding_dim) VALUES ('ts-proj', 4)",
+            [],
+        )
+        .unwrap();
+    let project_id = db.conn.last_insert_rowid();
+
+    // Note at t=1000.
+    db.conn
+        .execute(
+            "INSERT INTO notes (project_id, kind, title, body, created_at) VALUES (?1, 'note', 'old note', '', 1000)",
+            rusqlite::params![project_id],
+        )
+        .unwrap();
+
+    // Note at t=2000.
+    db.conn
+        .execute(
+            "INSERT INTO notes (project_id, kind, title, body, created_at) VALUES (?1, 'note', 'new note', '', 2000)",
+            rusqlite::params![project_id],
+        )
+        .unwrap();
+
+    let state = AppState {
+        db: Arc::new(tokio::sync::Mutex::new(db)),
+        api_key: None,
+        conflict_threshold: spelunk::server::default_conflict_threshold(),
+    };
+
+    // Query with t=1500 — should return only the note at t=2000.
+    let resp = send(
+        state,
+        "GET",
+        "/v1/projects/ts-proj/memory/since?t=1500",
+        Body::empty(),
+        false,
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let notes: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let arr = notes.as_array().expect("expected array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "expected exactly 1 note after t=1500; got {arr:?}"
+    );
+    assert_eq!(arr[0]["title"], "new note");
+    assert_eq!(arr[0]["created_at"], 2000);
+}
+
 // ── stats ─────────────────────────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `GET /v1/projects/{id}/memory/since?t=<epoch>&limit=` — poll endpoint returning notes newer than timestamp, ordered ASC
- `GET /v1/projects/{id}/memory/stream` — SSE endpoint streaming new entries in real time (1s poll, keep-alive)
- `spelunk memory since <epoch>` — one-shot poll (queries server or local DB fallback)
- `spelunk memory watch` — connects to SSE stream, prints entries as they arrive

## Changes
- `src/server/db.rs` — `notes_since()` method
- `src/server/handlers.rs` — `/since` and `/stream` route handlers
- `src/server/mod.rs` — routes wired into router
- `src/cli/cmd/memory/since.rs` + `watch.rs` — new CLI subcommands
- `src/cli/cmd/memory/mod.rs` — `Since` and `Watch` arms in `MemoryCommand`
- `tests/integration_server.rs` — `since_endpoint_returns_entries_after_timestamp` test

## Test plan
- [x] `since_endpoint_returns_entries_after_timestamp` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` passes

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)