### PR TITLE
test: expand fuzzer to cover secrets, chunker, escape_xml, NDJSON, and history entry parsing

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,6 +9,8 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dependencies.spelunk]
 path = ".."
@@ -21,5 +23,35 @@ codegen-units = 4
 [[bin]]
 name = "fuzz_parser"
 path = "fuzz_targets/fuzz_parser.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_secret_scanner"
+path = "fuzz_targets/fuzz_secret_scanner.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_chunker"
+path = "fuzz_targets/fuzz_chunker.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_escape_xml"
+path = "fuzz_targets/fuzz_escape_xml.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_ndjson_parse"
+path = "fuzz_targets/fuzz_ndjson_parse.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cli_history_entry"
+path = "fuzz_targets/fuzz_cli_history_entry.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/fuzz_chunker.rs
+++ b/fuzz/fuzz_targets/fuzz_chunker.rs
@@ -1,0 +1,20 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use spelunk::indexer::chunker::sliding_window;
+
+/// Fuzz the sliding-window chunker with arbitrary text input.
+///
+/// Run with:
+///   cargo +nightly fuzz run fuzz_chunker -- -max_total_time=600
+///
+/// Goal: find panics or out-of-bounds accesses in the chunking logic across
+/// a range of window sizes and overlap values.
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else { return };
+    // Vary window_size and overlap using prefix bytes so many combinations
+    // are exercised without needing separate targets.
+    let window = 40 + (data.first().copied().unwrap_or(0) as usize % 200);
+    let overlap = data.get(1).copied().unwrap_or(0) as usize % (window / 2).max(1);
+    let _ = sliding_window(s, "fuzz_input", "text", window, overlap);
+});

--- a/fuzz/fuzz_targets/fuzz_cli_history_entry.rs
+++ b/fuzz/fuzz_targets/fuzz_cli_history_entry.rs
@@ -1,0 +1,38 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Fuzz deserialization of `ClaudeHistoryEntry` from `~/.claude/history.jsonl`.
+///
+/// Run with:
+///   cargo +nightly fuzz run fuzz_cli_history_entry -- -max_total_time=600
+///
+/// `ClaudeHistoryEntry` and `PastedContent` in
+/// `src/cli/cmd/memory/harvest_claude.rs` are private, so they are replicated
+/// here.  Goal: confirm serde deserialization doesn't panic on arbitrary JSON.
+#[derive(Deserialize)]
+struct PastedContent {
+    #[serde(default)]
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct ClaudeHistoryEntry {
+    #[serde(default)]
+    display: String,
+    #[serde(rename = "pastedContents", default)]
+    pasted_contents: HashMap<String, PastedContent>,
+    #[serde(default)]
+    timestamp: i64,
+    #[serde(default)]
+    project: String,
+    #[serde(rename = "sessionId", default)]
+    session_id: String,
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else { return };
+    let _ = serde_json::from_str::<ClaudeHistoryEntry>(s);
+});

--- a/fuzz/fuzz_targets/fuzz_escape_xml.rs
+++ b/fuzz/fuzz_targets/fuzz_escape_xml.rs
@@ -1,0 +1,17 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz the XML-escaping transformation used in `spelunk ask` prompt building.
+///
+/// Run with:
+///   cargo +nightly fuzz run fuzz_escape_xml -- -max_total_time=600
+///
+/// `escape_xml` in src/cli/cmd/ask.rs is a private function, so the equivalent
+/// transformation is replicated inline.  Goal: confirm no panic on arbitrary
+/// UTF-8 input.
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else { return };
+    // Mirrors the private `escape_xml` in src/cli/cmd/ask.rs exactly.
+    let _ = s.replace('<', "&lt;").replace('>', "&gt;");
+});

--- a/fuzz/fuzz_targets/fuzz_ndjson_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_ndjson_parse.rs
@@ -1,0 +1,17 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz NDJSON parsing used throughout the `spelunk spelunk` plumbing layer.
+///
+/// Run with:
+///   cargo +nightly fuzz run fuzz_ndjson_parse -- -max_total_time=600
+///
+/// Goal: confirm `serde_json` doesn't panic on malformed or adversarial input
+/// when lines are fed one at a time as NDJSON.
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else { return };
+    for line in s.lines() {
+        let _ = serde_json::from_str::<serde_json::Value>(line);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_parser.rs
+++ b/fuzz/fuzz_targets/fuzz_parser.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use spelunk::indexer::parser::{detect_language, SourceParser};
+use spelunk::indexer::parser::SourceParser;
 
 /// Fuzz `SourceParser::parse` with arbitrary bytes across all supported languages.
 ///
@@ -13,11 +13,13 @@ use spelunk::indexer::parser::{detect_language, SourceParser};
 fuzz_target!(|data: &[u8]| {
     let Ok(s) = std::str::from_utf8(data) else { return };
 
-    // Rotate through languages based on a prefix byte so every grammar
-    // gets exercised without needing separate fuzz targets.
+    // Rotate through all supported languages based on a prefix byte so every
+    // grammar gets exercised without needing separate fuzz targets.
+    // Kept in sync with SUPPORTED_LANGUAGES in src/indexer/parser/mod.rs.
     let languages = &[
-        "rust", "python", "javascript", "typescript", "go",
-        "java", "c", "cpp", "markdown", "text",
+        "rust", "python", "javascript", "jsx", "typescript", "tsx",
+        "go", "java", "c", "cpp", "json", "html", "css", "hcl",
+        "sql", "proto", "markdown", "text", "notebook",
     ];
     let lang_idx = data.first().copied().unwrap_or(0) as usize % languages.len();
     let language = languages[lang_idx];

--- a/fuzz/fuzz_targets/fuzz_secret_scanner.rs
+++ b/fuzz/fuzz_targets/fuzz_secret_scanner.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use spelunk::indexer::secrets::contains_secret;
+
+/// Fuzz `contains_secret` with arbitrary UTF-8 text.
+///
+/// Run with:
+///   cargo +nightly fuzz run fuzz_secret_scanner -- -max_total_time=600
+///
+/// Goal: find panics or infinite loops in regex matching.
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else { return };
+    let _ = contains_secret(s);
+});


### PR DESCRIPTION
## Summary

Expands from 1 fuzz target to 6, covering the main attack surfaces added since v0.4.1.

| Target | What it fuzzes |
|---|---|
| `fuzz_parser` | `SourceParser::parse` — now covers all 19 languages (was 10) |
| `fuzz_secret_scanner` | `contains_secret()` — regex panics / infinite loops |
| `fuzz_chunker` | `sliding_window()` — varying window/overlap derived from input |
| `fuzz_escape_xml` | XML-escape transform — panics on arbitrary UTF-8 |
| `fuzz_ndjson_parse` | `serde_json::from_str` line-by-line — plumbing NDJSON pipeline |
| `fuzz_cli_history_entry` | `ClaudeHistoryEntry` deserialization — `~/.claude/history.jsonl` parsing |

## Run a target
```bash
cargo +nightly fuzz run fuzz_secret_scanner -- -max_total_time=3600
cargo +nightly fuzz run fuzz_chunker
cargo +nightly fuzz run fuzz_parser   # now all 19 languages
```

## Test plan
- [x] `cargo +nightly fuzz build` succeeds for all 6 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)