### PR TITLE
docs: update SKILL.md and docs for v0.5.0

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -30,7 +30,7 @@ spelunk check                  # verify the index is fresh before starting work
 spelunk search "<query>"
 spelunk search "<query>" --limit 20
 spelunk search "<query>" --graph          # include call-graph neighbours
-spelunk search "<query>" --format json
+spelunk search "<query>" --format text|json|ndjson
 
 # Deep search — iterative, uses LLM (requires llm_model in config)
 spelunk explore "<question>"
@@ -40,15 +40,49 @@ spelunk explore "<question>" --json       # {answer, sources, steps}
 # Call/import graph
 spelunk graph <symbol-or-file>
 spelunk graph <symbol> --kind calls       # calls | imports | extends | implements
-spelunk graph <file> --format json
+spelunk graph <file> --format text|json|ndjson
+
+# Status and checks
+spelunk status --format text|json|ndjson
+spelunk check --format text|json|ndjson
 
 # Inspect what was indexed for a file
 spelunk chunks <file-path>
-spelunk chunks <file-path> --format json
+spelunk chunks <file-path> --format text|json|ndjson
 ```
 
 Use `search` for targeted lookups. Use `explore` when the answer requires
 tracing across multiple files — it runs autonomously and reports back.
+
+---
+
+## Plumbing commands
+
+Plumbing commands emit NDJSON and are designed for scripts and pipelines.
+Exit codes: `0` = success, `1` = no results, `2` = error. See [Plumbing and Porcelain](docs/plumbing-and-porcelain.md) for full details.
+
+```bash
+# Emit indexed chunks for a file
+spelunk plumbing cat-chunks <file>
+
+# List all indexed files (optionally filtered by prefix or staleness)
+spelunk plumbing ls-files [--prefix <p>] [--stale]
+
+# Parse a file without writing to the index
+spelunk plumbing parse-file <file>
+
+# Compute and verify file hash
+spelunk plumbing hash-file <file>
+
+# Read embedding from stdin, return nearest chunks by similarity
+echo "your query" | spelunk plumbing embed --query | spelunk plumbing knn --limit 10
+
+# Emit code graph edges (imports, calls, extends)
+spelunk plumbing graph-edges --file <f> | --symbol <s>
+
+# Emit memory entries as NDJSON
+spelunk plumbing read-memory [--kind <k>] [--limit N]
+```
 
 ---
 
@@ -76,7 +110,7 @@ spelunk memory add --kind note --title "Follow-up observation" --body "..." \
   --relates-to <other-id>
 ```
 
-**Kinds:** `decision` · `context` · `requirement` · `note`
+**Kinds:** `decision` · `context` · `requirement` · `note` · `intent` · `answer` · `handoff` · `question`
 
 ### Query
 
@@ -90,20 +124,24 @@ spelunk memory list --as-of 2026-01-01   # point-in-time snapshot
 spelunk memory show <id>                  # full entry + relationships
 spelunk memory graph <id>                 # relationship graph for an entry
 spelunk memory timeline "<topic>"         # topic evolution across all entries (ASC time)
+spelunk memory since <epoch>              # poll for entries newer than Unix timestamp
+spelunk memory watch                      # stream new entries as they arrive (SSE; requires memory_server_url)
 spelunk memory search "<q>" --format json
 ```
 
-### Harvest from git history
+### Harvest from git history or Claude Code history
 
 ```bash
 spelunk memory harvest                    # analyse HEAD~10..HEAD
 spelunk memory harvest --git-range v0.1.0..HEAD
 spelunk memory harvest --branch main      # full branch history
+spelunk memory harvest --source claude-code --confirm  # extract from ~/.claude/history.jsonl
 ```
 
-Extracts decisions, requirements, and non-obvious notes from commit messages.
+Extracts decisions, requirements, and non-obvious notes. From git, analyzes commit messages.
+From `claude-code`, reads agent session transcripts from `~/.claude/history.jsonl`.
 Run at the start of a session on a new repo, or after a batch of significant commits.
-Requires `llm_model` in config.
+Requires `llm_model` in config. The `--source claude-code` requires `--confirm` flag.
 
 ---
 
@@ -113,6 +151,10 @@ Requires `llm_model` in config.
 spelunk status                 # index health for current project
 spelunk status --all           # all registered projects
 spelunk status --list          # one-line table
+spelunk status --format json   # machine-readable output
+
+spelunk check                  # verify index is fresh; shows active intents and file-overlap warnings
+spelunk check --format json    # machine-readable output
 
 spelunk autoclean              # remove stale registry entries (deleted/moved projects)
 spelunk link <path>            # include another project's index in searches
@@ -152,9 +194,10 @@ AGENT=true spelunk graph src/storage/db.rs
 
 **Start of every session:**
 ```bash
-spelunk check
+spelunk check                              # includes active intents and overlapping work
 spelunk memory list --kind decision --limit 10
 spelunk memory list --kind handoff --limit 3
+spelunk memory list --kind intent          # see what teammates are working on
 spelunk memory list --kind question
 ```
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -162,13 +162,14 @@ spelunk memory add \
 
 ## Signalling intent
 
-Use the `intent` kind to broadcast to teammates (human or agent) that you are actively working on a given area. Active intents are surfaced by `spelunk check` so collaborators see ongoing work before starting overlapping changes.
+Use the `intent` kind to broadcast to teammates (human or agent) that you are actively working on a given area. Active intents are surfaced by `spelunk check` along with file overlap warnings, so collaborators see ongoing work before starting overlapping changes.
 
 ```bash
 spelunk memory add \
   --title "Refactoring auth middleware to support OAuth2" \
   --kind intent \
-  --tags auth,middleware
+  --tags auth,middleware \
+  --files src/auth/middleware.rs
 ```
 
 When the work is done, archive the intent:
@@ -193,6 +194,20 @@ At the start of the next session, read it:
 ```bash
 AGENT=true spelunk memory list --kind handoff --limit 3
 ```
+
+## Multi-agent coordination
+
+When using a shared memory server (`memory_server_url` in config), agents can coordinate without stepping on each other's toes:
+
+```bash
+# Poll for new entries since a given timestamp
+spelunk memory since <epoch>
+
+# Stream entries as they arrive (requires memory_server_url)
+spelunk memory watch
+```
+
+Conflict detection: If you write an entry semantically similar to an existing one (cosine ≥ 0.92), the server returns HTTP 409 (advisory). The entry is stored with a `contradicts` edge linking to the conflicting entry. Check `spelunk memory show <id>` to review related entries before proceeding.
 
 ## Cross-project search
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -145,5 +145,43 @@ POST   /v1/projects/{project_id}/memory/search
 DELETE /v1/projects/{project_id}/memory/{id}
 POST   /v1/projects/{project_id}/memory/{id}/archive
 POST   /v1/projects/{project_id}/memory/{id}/supersede
+GET    /v1/projects/{project_id}/memory/since     ?t=<epoch>&limit=
+GET    /v1/projects/{project_id}/memory/stream    (Server-Sent Events)
 GET    /v1/projects/{project_id}/stats
 ```
+
+### Conflict detection
+
+When `POST /v1/projects/{project_id}/memory`, the server checks if a semantically similar entry already exists (cosine similarity >= 0.92). If a conflict is detected, the response is **HTTP 409** with a JSON body:
+
+```json
+{
+  "status": "created_with_conflict",
+  "entry_id": 42,
+  "conflict_id": 37,
+  "conflict_title": "Previous similar entry",
+  "message": "Entry created but conflicts with existing memory"
+}
+```
+
+The new entry is stored with a `contradicts` edge to the conflicting entry. Clients should log or display this warning. Configure the threshold with `--conflict-threshold` flag (0.0–1.0, default 0.92).
+
+### Polling for new entries
+
+Use `GET /memory/since?t=<epoch>&limit=N` to retrieve entries created after a Unix timestamp:
+
+```bash
+spelunk memory since 1700000000
+```
+
+Returns up to N entries (default 50) created after the given epoch, sorted ascending by creation time.
+
+### Streaming entries
+
+Use `GET /memory/stream` (Server-Sent Events) to subscribe to new entries as they arrive:
+
+```bash
+spelunk memory watch
+```
+
+Each line is a JSON object representing a newly added entry. The stream persists until the client disconnects.


### PR DESCRIPTION
## Summary

Updates docs to reflect all changes since v0.4.1. Intended to merge before or alongside the v0.5.0 version bump (PR #165).

### `SKILL.md`
- Added **Plumbing commands** quick-reference section (all 8 commands)
- Added `--format text|json|ndjson` examples to search/graph/status/check
- Added `memory since` and `memory watch` commands
- Added `memory harvest --source claude-code --confirm` example
- Added `intent` to the memory kinds list
- Updated `spelunk check` description to mention active intent display and file-overlap warnings

### `docs/agent-guide.md`
- Enhanced intent/check section with file-overlap warning detail
- Added **Multi-agent coordination** section: `memory since`, `memory watch`, conflict detection (409 = stored but conflicts, `contradicts` edge created, review before proceeding)

### `docs/server.md`
- Added `GET /memory/since?t=&limit=` endpoint documentation
- Added `GET /memory/stream` SSE endpoint documentation
- Added conflict detection section: 409 response schema, `--conflict-threshold` config, `contradicts` edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)