### PR TITLE
fix: resolve fuzzer crashes, OOMs, and doc_comment skip bug

### DIFF
--- a/src/indexer/parser/mod.rs
+++ b/src/indexer/parser/mod.rs
@@ -140,6 +140,19 @@ impl SourceParser {
             return Ok(text::parse_notebook(source, file_path));
         }
 
+        // Guard against adversarial inputs that cause tree-sitter's GLR parser to
+        // allocate exponential memory (e.g. deeply-nested pointer declarators).
+        // The 5-second time budget only bounds CPU time; memory can still spike
+        // before the first progress callback fires.
+        const MAX_PARSE_BYTES: usize = 512 * 1024;
+        if source.len() > MAX_PARSE_BYTES {
+            tracing::warn!(
+                "{file_path}: input too large ({} bytes > {MAX_PARSE_BYTES}), using sliding window",
+                source.len()
+            );
+            return Ok(sliding_window(source, file_path, language, 120, 15));
+        }
+
         let ts_lang = ts_walker::ts_language(language)?;
         let mut parser = tree_sitter::Parser::new();
         parser.set_language(&ts_lang)?;

--- a/src/indexer/parser/ts_walker.rs
+++ b/src/indexer/parser/ts_walker.rs
@@ -424,6 +424,7 @@ pub(super) fn preceding_comment(node: &tree_sitter::Node<'_>, src: &[u8]) -> Opt
             && prev.kind() != "comment"
             && prev.kind() != "line_comment"
             && prev.kind() != "block_comment"
+            && prev.kind() != "doc_comment"
     {
         prev = prev.prev_sibling()?;
     }


### PR DESCRIPTION
## Summary
- Add 512 KiB input size guard before tree-sitter parsing to prevent OOM on adversarial inputs — the existing 5-second CPU timeout cannot bound memory spikes that occur before the first progress callback fires
- Fix `preceding_comment()` logic: `doc_comment` nodes (Rust `///` comments) were missing from the skip-exclusion set, causing them to be walked past rather than captured

## Artifacts addressed
All six `fuzz/artifacts/fuzz_parser/*` artifacts now execute cleanly with `-runs=1`:
- `crash-*` (3) — ceased reproducing after `tree-sitter-c` 0.24.1→0.24.2 (upstream grammar fix)
- `oom-*` (2) — no longer trigger; OOM guard provides defence-in-depth
- `leak-*` (1) — no longer triggers

## Test plan
- [x] `cargo test` passes
- [x] All six `fuzz/artifacts/fuzz_parser/*` artifacts pass `-runs=1` clean
- [x] `cargo build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)