### PR TITLE
feat: support .spelunkignore files

### DIFF
--- a/src/cli/cmd/index/parse_phase.rs
+++ b/src/cli/cmd/index/parse_phase.rs
@@ -140,6 +140,7 @@ fn collect_files(root: &std::path::Path) -> Result<Vec<ignore::DirEntry>> {
     ];
     let mut walk = WalkBuilder::new(root);
     walk.standard_filters(true);
+    walk.add_custom_ignore_filename(".spelunkignore");
     let mut ob = ignore::overrides::OverrideBuilder::new(root);
     for pat in &sensitive_patterns {
         ob.add(pat).ok();


### PR DESCRIPTION
## Summary

- Adds `.spelunkignore` as a custom ignore filename recognised by the `WalkBuilder` during `spelunk index`
- Follows standard `.gitignore` glob syntax and has **higher precedence** than all other ignore files (`.gitignore`, `.ignore`, global gitignore)
- One-line change: `walk.add_custom_ignore_filename(".spelunkignore")` in `src/cli/cmd/index/parse_phase.rs`

## Usage

Create a `.spelunkignore` at the project root (or any subdirectory):

```
# .spelunkignore
bench/linearrag/results.json
bench/linearrag/labels.json
target/
generated/
```

Files and directories matching these patterns will be excluded from indexing.

## Test plan

- [ ] Add a `.spelunkignore` with a known file pattern and verify `spelunk index` skips those files (`spelunk chunks <file>` returns nothing for excluded files)
- [ ] Verify `.gitignore`-tracked files are still excluded independently (no regression)
- [ ] Verify no change to indexing behaviour when `.spelunkignore` does not exist

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)