### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 default-run = "spelunk"
 description = "Local context engine for AI coding agents — tree-sitter AST chunking, semantic search, code graph"

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,6 +21,8 @@ spelunk index <path> --force   # full re-index (after changing embedding model)
 spelunk check                  # verify the index is fresh before starting work
 ```
 
+Add a `.spelunkignore` file (same syntax as `.gitignore`) to exclude paths from indexing. Takes higher precedence than `.gitignore`.
+
 ---
 
 ## Code search
@@ -31,6 +33,7 @@ spelunk search "<query>"
 spelunk search "<query>" --limit 20
 spelunk search "<query>" --graph          # include call-graph neighbours
 spelunk search "<query>" --format text|json|ndjson
+spelunk search "<query>" --mode text      # FTS only, no embedding model needed
 
 # Deep search — iterative, uses LLM (requires llm_model in config)
 spelunk explore "<question>"

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -47,6 +47,9 @@ AGENT=true spelunk memory list --kind handoff --limit 5
 
 # Understand what's been decided
 AGENT=true spelunk memory search "architecture decisions"
+
+# Check antipatterns — things to avoid repeating
+AGENT=true spelunk memory failures
 ```
 
 ## Searching before writing
@@ -114,6 +117,8 @@ spelunk verify src/auth/middleware.rs
 # Re-index to incorporate changes
 spelunk index .
 ```
+
+To exclude files or directories from indexing, add a `.spelunkignore` file (same syntax as `.gitignore`) to any directory. It takes higher precedence than `.gitignore`.
 
 ## Storing decisions
 
@@ -443,7 +448,7 @@ Emit memory entries as NDJSON. Use `--kind` to filter by entry type or `--id` to
 
 | Flag | Description |
 |------|-------------|
-| `--kind <kind>` | Filter by memory kind: `decision`, `question`, `note`, `answer`, `requirement`, `handoff`. |
+| `--kind <kind>` | Filter by memory kind: `decision`, `question`, `note`, `answer`, `requirement`, `handoff`, `antipattern`. |
 | `--id <n>` | Fetch a single entry by its integer id. Exits `1` if not found. |
 | `--limit N` | Maximum number of entries (default: `50`). |
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,6 +18,8 @@ spelunk index <path> [options]
 | `--batch-size <n>` | 32 | Embedding batch size |
 | `--force` | false | Re-index all files regardless of hash |
 
+Add a `.spelunkignore` file (same syntax as `.gitignore`) to any directory to exclude files from indexing. Takes higher precedence than `.gitignore`.
+
 **Example:**
 
 ```bash
@@ -38,10 +40,13 @@ spelunk search <query> [options]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-l, --limit <n>` | 10 | Number of results (max 100) |
-| `--format text\|json` | text | Output format |
+| `--format text\|json\|ndjson` | text | Output format |
 | `-g, --graph` | false | Enrich results with 1-hop call-graph neighbours |
 | `--graph-limit <n>` | 10 | Max graph-expanded results to add |
+| `--mode text\|hybrid` | hybrid | `text` uses FTS only (no embedding model); `hybrid` uses LinearRAG (default) |
 | `-d, --db <path>` | auto | Override database path |
+
+Search uses LinearRAG by default: a two-stage entity-activation + personalised PageRank pipeline that improves multi-hop recall significantly over raw KNN.
 
 **Example:**
 
@@ -49,6 +54,7 @@ spelunk search <query> [options]
 spelunk search "where is the JWT token validated"
 spelunk search "database schema migration" --limit 5 --format json
 spelunk search "authentication middleware" --graph
+spelunk search "TODO fix me" --mode text    # FTS only, no embedding model needed
 ```
 
 ---
@@ -246,7 +252,13 @@ spelunk memory search <query> [--limit 10] [--format text|json]
 spelunk memory list [--kind decision] [--limit 20] [--format text|json]
 spelunk memory show <id> [--format text|json]
 spelunk memory harvest [--git-range HEAD~10..HEAD]
+spelunk memory harvest --source failures   # extract antipatterns from revert/bugfix commits
+spelunk memory failures                    # list all antipatterns
 ```
+
+**Memory kinds:** `decision` · `context` · `requirement` · `note` · `intent` · `answer` · `handoff` · `question` · `antipattern`
+
+Use `--kind antipattern` to store things to avoid. `spelunk memory failures` is a shortcut for `spelunk memory list --kind antipattern`.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,23 +6,23 @@ Download the latest binary for your platform from the [releases page](https://gi
 
 ```bash
 # macOS (Apple Silicon) — universal binary also available
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-aarch64-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-aarch64-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # macOS (Intel)
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-x86_64-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-x86_64-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # macOS (universal — works on both Intel and Apple Silicon)
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-universal-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-universal-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Linux x86_64
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-x86_64-unknown-linux-gnu.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-x86_64-unknown-linux-gnu.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Linux ARM64
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-aarch64-unknown-linux-gnu.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-aarch64-unknown-linux-gnu.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Verify

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -59,8 +59,8 @@ git push origin main
 ### 2. Tag and push
 
 ```bash
-git tag v0.5.0
-git push origin v0.5.0
+git tag v0.6.0
+git push origin v0.6.0
 ```
 
 That's it. The release workflow triggers automatically on the pushed tag.
@@ -71,7 +71,7 @@ Watch progress at:
 `https://github.com/usercise/spelunk/actions/workflows/release.yml`
 
 Once all jobs pass, the release appears at:
-`https://github.com/usercise/spelunk/releases/tag/v0.5.0`
+`https://github.com/usercise/spelunk/releases/tag/v0.6.0`
 
 ## Pre-releases
 
@@ -80,8 +80,8 @@ GitHub Release as a pre-release when the tag contains `-rc`, `-beta`, or
 `-alpha`:
 
 ```bash
-git tag v0.5.0-rc.1
-git push origin v0.5.0-rc.1
+git tag v0.6.0-rc.1
+git push origin v0.6.0-rc.1
 ```
 
 ## Download URLs
@@ -96,16 +96,16 @@ Examples:
 
 ```bash
 # macOS Apple Silicon
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-aarch64-apple-darwin.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-aarch64-apple-darwin.tar.gz
 
 # macOS universal (x86_64 + Apple Silicon)
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-universal-apple-darwin.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-universal-apple-darwin.tar.gz
 
 # Linux x86_64
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-x86_64-unknown-linux-gnu.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-x86_64-unknown-linux-gnu.tar.gz
 
 # Linux ARM64
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.5.0-aarch64-unknown-linux-gnu.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-aarch64-unknown-linux-gnu.tar.gz
 ```
 
 ## Deleting a bad release
@@ -114,11 +114,11 @@ If a release needs to be pulled:
 
 ```bash
 # Delete the tag locally and on remote
-git tag -d v0.5.0
-git push origin :refs/tags/v0.5.0
+git tag -d v0.6.0
+git push origin :refs/tags/v0.6.0
 
 # Delete the GitHub Release (requires gh CLI)
-gh release delete v0.5.0 --yes
+gh release delete v0.6.0 --yes
 ```
 
 Then fix the issue, re-commit, and re-tag.


### PR DESCRIPTION
## v0.6.0

### ⚠️ Breaking: `spelunk index --force` required after upgrading

v0.6.0 introduces LinearRAG retrieval, which stores mention edges in `graph_edges` and relies on two new compound indexes (migration 018). Existing indexes built with v0.5.x do not have these edges or indexes. Run a full re-index after upgrading:

```bash
spelunk index <your-project> --force
```

---

### What's new

**LinearRAG two-stage retrieval (now default)**
All `spelunk search`, `spelunk ask`, and `spelunk plan` queries now use LinearRAG: an entity-activation + personalised PageRank pipeline that improves multi-hop recall by ~34% at ~1.7× the latency of raw KNN. The old `--retrieval` flag has been removed; hybrid/LinearRAG is always on.

**`.spelunkignore` support**
Drop a `.spelunkignore` file in any directory to exclude files or directories from indexing, with higher precedence than `.gitignore`.

**Failure patterns memory**
- New `antipattern` memory kind
- `spelunk memory harvest --source failures` — mines revert/bugfix commits with an LLM to extract "Never…/Avoid…/Don't…" rules
- `spelunk memory failures` — lists all stored antipatterns

**Fixes**
- `spelunk check` no longer panics with "Cannot start a runtime from within a runtime" (made async)
- LinearRAG e2e test was silently returning no results due to missing migration 018 registration in `Database::open` — fixed

**Performance**
- PageRank power iterations: dangling node indices precomputed once instead of re-filtered each step
- Compound indexes on `graph_edges(source_name, kind)` and `(target_name, kind)` for LinearRAG mention lookups

---

## Test results

All 131 tests pass. `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)