### PR TITLE
fix: GitNotesBackend unsupported methods return typed BackendUnsupported error

### DIFF
--- a/bench/git_notes_perf.sh
+++ b/bench/git_notes_perf.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# bench/git_notes_perf.sh — performance benchmark for GitNotesBackend
+#
+# Creates a synthetic git repo with ~5000 commits and ~50 spelunk notes
+# (1% density), then times `spelunk memory list --backend git-notes`.
+#
+# Success criterion (from issue #186): <500ms for `list --limit 10` on a
+# 5k-commit repo.
+#
+# Usage:
+#   ./bench/git_notes_perf.sh [COMMITS] [NOTE_PCT]
+#
+# Examples:
+#   ./bench/git_notes_perf.sh            # default: 5000 commits, 1% notes
+#   ./bench/git_notes_perf.sh 1000 5     # 1000 commits, 5% notes
+#
+# Prerequisites:
+#   - spelunk binary in PATH (cargo install --path . or cargo build --release)
+#   - git
+
+set -euo pipefail
+
+COMMITS="${1:-5000}"
+NOTE_PCT="${2:-1}"
+SPELUNK="${SPELUNK:-spelunk}"
+
+# ── locate binary ────────────────────────────────────────────────────────────
+if ! command -v "$SPELUNK" &>/dev/null; then
+    # Try the release binary in the cargo target directory
+    REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || echo .)"
+    if [ -x "$REPO_ROOT/target/release/spelunk" ]; then
+        SPELUNK="$REPO_ROOT/target/release/spelunk"
+    elif [ -x "$REPO_ROOT/target/debug/spelunk" ]; then
+        SPELUNK="$REPO_ROOT/target/debug/spelunk"
+    else
+        echo "ERROR: spelunk not found. Build with: cargo build --release" >&2
+        exit 1
+    fi
+fi
+
+echo "Using: $SPELUNK"
+echo "Parameters: COMMITS=$COMMITS, NOTE_PCT=$NOTE_PCT"
+echo
+
+# ── create fixture repo ──────────────────────────────────────────────────────
+FIXTURE_DIR="$(mktemp -d)"
+echo "Fixture repo: $FIXTURE_DIR"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+cd "$FIXTURE_DIR"
+git init -b main -q
+git config user.email "bench@example.com"
+git config user.name "Bench"
+
+# Create initial commit
+echo "benchmark fixture" > README.md
+git add .
+git commit --no-gpg-sign -q -m "init"
+
+NOTE_INTERVAL=$(( 100 / NOTE_PCT ))  # attach a note every N commits
+NOTES_WRITTEN=0
+
+echo "Creating $COMMITS commits (attaching a note every $NOTE_INTERVAL commits)…"
+
+for i in $(seq 1 "$COMMITS"); do
+    echo "$i" > "file_$i.txt"
+    git add . -q
+    git commit --no-gpg-sign -q --allow-empty -m "commit $i" 2>/dev/null
+
+    if (( i % NOTE_INTERVAL == 0 )); then
+        SHA=$(git rev-parse HEAD)
+        NOTE_JSON="{\"id\":$i,\"kind\":\"decision\",\"title\":\"decision $i\",\"body\":\"body for commit $i\",\"tags\":[],\"linked_files\":[],\"created_at\":$(date +%s),\"status\":\"active\"}"
+        git notes --ref=spelunk add -f -m "$NOTE_JSON" "$SHA" 2>/dev/null
+        NOTES_WRITTEN=$((NOTES_WRITTEN + 1))
+    fi
+done
+
+echo "Created $COMMITS commits, attached $NOTES_WRITTEN notes."
+echo
+
+# ── benchmarks ───────────────────────────────────────────────────────────────
+run_timed() {
+    local label="$1"; shift
+    local start end elapsed_ms
+
+    start=$(date +%s%3N 2>/dev/null || python3 -c "import time; print(int(time.time()*1000))")
+    "$SPELUNK" "$@" --backend git-notes > /dev/null
+    end=$(date +%s%3N 2>/dev/null || python3 -c "import time; print(int(time.time()*1000))")
+    elapsed_ms=$(( end - start ))
+
+    printf "%-55s %4dms\n" "$label" "$elapsed_ms"
+
+    if [[ "$label" == *"(primary)"* ]] && (( elapsed_ms > 500 )); then
+        echo "  ⚠️  EXCEEDS 500ms threshold — see issue #186 for mitigations"
+    fi
+}
+
+echo "=== Benchmark results ==="
+run_timed "memory list --kind decision --limit 10  (primary)" \
+    -C "$FIXTURE_DIR" memory list --kind decision --limit 10
+
+run_timed "memory list --limit 10" \
+    -C "$FIXTURE_DIR" memory list --limit 10
+
+run_timed "memory list  (no limit, worst-case)" \
+    -C "$FIXTURE_DIR" memory list --limit 9999
+
+echo
+echo "=== Notes ==="
+echo "  $NOTES_WRITTEN notes across $COMMITS commits ($NOTE_PCT% density)"
+echo "  500ms is the target for 'list --limit 10' on a 5k-commit repo."
+echo
+echo "  Mitigation options if threshold is exceeded:"
+echo "  A) Index file: maintain .git/notes/spelunk-index.ndjson"
+echo "  B) Reverse log with early exit: --max-count=<limit*20> + early-exit"
+echo "  C) Ref-per-kind: store under refs/notes/spelunk/<kind>/<sha>"

--- a/bench/git_notes_perf.sh
+++ b/bench/git_notes_perf.sh
@@ -64,8 +64,8 @@ echo "Creating $COMMITS commits (attaching a note every $NOTE_INTERVAL commits)�
 
 for i in $(seq 1 "$COMMITS"); do
     echo "$i" > "file_$i.txt"
-    git add . -q
-    git commit --no-gpg-sign -q --allow-empty -m "commit $i" 2>/dev/null
+    git add . >/dev/null 2>&1
+    git commit --no-gpg-sign -q --allow-empty -m "commit $i" >/dev/null 2>&1
 
     if (( i % NOTE_INTERVAL == 0 )); then
         SHA=$(git rev-parse HEAD)
@@ -79,13 +79,17 @@ echo "Created $COMMITS commits, attached $NOTES_WRITTEN notes."
 echo
 
 # ── benchmarks ───────────────────────────────────────────────────────────────
+ms_now() {
+    python3 -c "import time; print(int(time.time()*1000))"
+}
+
 run_timed() {
     local label="$1"; shift
     local start end elapsed_ms
 
-    start=$(date +%s%3N 2>/dev/null || python3 -c "import time; print(int(time.time()*1000))")
-    "$SPELUNK" "$@" --backend git-notes > /dev/null
-    end=$(date +%s%3N 2>/dev/null || python3 -c "import time; print(int(time.time()*1000))")
+    start=$(ms_now)
+    ( cd "$FIXTURE_DIR" && "$SPELUNK" memory "$@" --backend git-notes > /dev/null )
+    end=$(ms_now)
     elapsed_ms=$(( end - start ))
 
     printf "%-55s %4dms\n" "$label" "$elapsed_ms"
@@ -97,13 +101,13 @@ run_timed() {
 
 echo "=== Benchmark results ==="
 run_timed "memory list --kind decision --limit 10  (primary)" \
-    -C "$FIXTURE_DIR" memory list --kind decision --limit 10
+    list --kind decision --limit 10
 
 run_timed "memory list --limit 10" \
-    -C "$FIXTURE_DIR" memory list --limit 10
+    list --limit 10
 
 run_timed "memory list  (no limit, worst-case)" \
-    -C "$FIXTURE_DIR" memory list --limit 9999
+    list --limit 9999
 
 echo
 echo "=== Notes ==="

--- a/src/cli/cmd/ask.rs
+++ b/src/cli/cmd/ask.rs
@@ -161,34 +161,35 @@ pub async fn ask(args: AskArgs, cfg: Config) -> Result<()> {
 
     // ── Step 2c: memory context (decisions / requirements / background) ──────
     let mem_path = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
-    let memory_context: Option<String> = if let Ok(backend) = open_memory_backend(&cfg, &mem_path) {
-        match backend.search(&vec_to_blob(&query_vec), 5, None).await {
-            Ok(notes) if !notes.is_empty() => {
-                let text = notes
-                    .iter()
-                    .map(|n| {
-                        let tags = if n.tags.is_empty() {
-                            String::new()
-                        } else {
-                            format!("  [{}]", n.tags.join(", "))
-                        };
-                        format!(
-                            "### [{kind}] {title}{tags}\n{body}",
-                            kind = escape_xml(&n.kind),
-                            title = escape_xml(&n.title),
-                            tags = escape_xml(&tags),
-                            body = escape_xml(&n.body)
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n\n");
-                Some(text)
+    let memory_context: Option<String> =
+        if let Ok(backend) = open_memory_backend(&cfg, &mem_path, None) {
+            match backend.search(&vec_to_blob(&query_vec), 5, None).await {
+                Ok(notes) if !notes.is_empty() => {
+                    let text = notes
+                        .iter()
+                        .map(|n| {
+                            let tags = if n.tags.is_empty() {
+                                String::new()
+                            } else {
+                                format!("  [{}]", n.tags.join(", "))
+                            };
+                            format!(
+                                "### [{kind}] {title}{tags}\n{body}",
+                                kind = escape_xml(&n.kind),
+                                title = escape_xml(&n.title),
+                                tags = escape_xml(&tags),
+                                body = escape_xml(&n.body)
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n\n");
+                    Some(text)
+                }
+                _ => None,
             }
-            _ => None,
-        }
-    } else {
-        None
-    };
+        } else {
+            None
+        };
 
     // ── Step 2c: prompt injection pre-flight ─────────────────────────────────
     const INJECTION_PATTERNS: &[&str] = &[

--- a/src/cli/cmd/check.rs
+++ b/src/cli/cmd/check.rs
@@ -102,7 +102,7 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
     // Show active intent entries (text mode only; silently skip if memory unavailable).
     if effective == "text" || effective == "porcelain" {
         let mem_path = resolve_db(args.db.as_deref(), &cfg.db_path).with_file_name("memory.db");
-        if let Ok(backend) = open_memory_backend(&cfg, &mem_path)
+        if let Ok(backend) = open_memory_backend(&cfg, &mem_path, None)
             && let Ok(intents) = backend.list(Some("intent"), 20, false, None).await
             && !intents.is_empty()
         {

--- a/src/cli/cmd/memory/add.rs
+++ b/src/cli/cmd/memory/add.rs
@@ -3,7 +3,6 @@ use anyhow::{Context, Result};
 use super::MemoryAddArgs;
 use crate::{
     config::Config,
-    embeddings::{EmbeddingBackend as _, vec_to_blob},
     storage::{NoteInput, open_memory_backend},
 };
 
@@ -11,6 +10,7 @@ pub(super) async fn memory_add(
     args: MemoryAddArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
     let (title, body) = if let Some(url) = &args.from_url {
         let (fetched_title, fetched_body) = fetch_url_content(url)
@@ -50,22 +50,9 @@ pub(super) async fn memory_add(
         .unwrap_or_default();
 
     let embed_text = format!("title: {title} | text: {body}");
-    let sp = super::super::ui::spinner("Embedding…");
-    let embedder = crate::backends::ActiveEmbedder::load(cfg)
-        .await
-        .context("loading embedding model")?;
-    let vecs = embedder
-        .embed(&[&embed_text])
-        .await
-        .context("embedding memory entry")?;
-    let blob = vecs
-        .into_iter()
-        .next()
-        .map(|v| vec_to_blob(&v))
-        .context("embedding returned empty")?;
-    sp.finish_and_clear();
+    let embedding = try_embed(cfg, &embed_text).await;
 
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     let id = backend
         .add(NoteInput {
             kind: args.kind.clone(),
@@ -73,7 +60,7 @@ pub(super) async fn memory_add(
             body: body.clone(),
             tags: tags.clone(),
             linked_files: files.clone(),
-            embedding: Some(blob),
+            embedding,
             source_ref: None,
             valid_at: args
                 .valid_at
@@ -173,4 +160,39 @@ fn html_unescape(s: &str) -> String {
         .replace("&quot;", "\"")
         .replace("&#39;", "'")
         .replace("&nbsp;", " ")
+}
+
+/// Try to embed `text` using the configured model.
+///
+/// Returns `None` (with a log warning) if no model is reachable, so that
+/// callers can store entries without embeddings rather than failing outright.
+/// Semantic search will not surface unembedded entries.
+async fn try_embed(cfg: &Config, text: &str) -> Option<Vec<u8>> {
+    use crate::embeddings::{EmbeddingBackend as _, vec_to_blob};
+    let sp = super::super::ui::spinner("Embedding…");
+    let result: anyhow::Result<Vec<u8>> = async {
+        let embedder = crate::backends::ActiveEmbedder::load(cfg)
+            .await
+            .context("loading embedding model")?;
+        let vecs = embedder
+            .embed(&[text])
+            .await
+            .context("embedding memory entry")?;
+        vecs.into_iter()
+            .next()
+            .map(|v| vec_to_blob(&v))
+            .context("embedding returned empty")
+    }
+    .await;
+    sp.finish_and_clear();
+    match result {
+        Ok(blob) => Some(blob),
+        Err(e) => {
+            tracing::warn!(
+                "No embedding model configured — entry stored without vector; \
+                 semantic search will not surface it. ({e})"
+            );
+            None
+        }
+    }
 }

--- a/src/cli/cmd/memory/archive.rs
+++ b/src/cli/cmd/memory/archive.rs
@@ -7,8 +7,9 @@ pub(super) async fn memory_archive(
     args: MemoryArchiveArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     if backend.archive(args.id).await? {
         println!("Archived memory entry #{}.", args.id);
     } else {

--- a/src/cli/cmd/memory/failures.rs
+++ b/src/cli/cmd/memory/failures.rs
@@ -7,8 +7,9 @@ pub(super) async fn memory_failures(
     args: MemoryFailuresArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     let as_of = parse_as_of(args.as_of.as_deref())?;
     let notes = backend
         .list(Some("antipattern"), args.limit, false, as_of)

--- a/src/cli/cmd/memory/graph_cmd.rs
+++ b/src/cli/cmd/memory/graph_cmd.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use super::MemoryGraphArgs;
+use super::{MemoryGraphArgs, backend_err};
 use crate::{config::Config, storage::open_memory_backend};
 
 pub(super) async fn memory_graph(
@@ -15,7 +15,7 @@ pub(super) async fn memory_graph(
         .await?
         .ok_or_else(|| anyhow::anyhow!("No memory entry with id {}.", args.id))?;
 
-    let (outgoing, incoming) = backend.get_edges(args.id).await?;
+    let (outgoing, incoming) = backend.get_edges(args.id).await.map_err(backend_err)?;
 
     if crate::utils::effective_format(&args.format) == "json" {
         #[derive(serde::Serialize)]

--- a/src/cli/cmd/memory/graph_cmd.rs
+++ b/src/cli/cmd/memory/graph_cmd.rs
@@ -7,8 +7,9 @@ pub(super) async fn memory_graph(
     args: MemoryGraphArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     let root = backend
         .get(args.id)
         .await?

--- a/src/cli/cmd/memory/harvest.rs
+++ b/src/cli/cmd/memory/harvest.rs
@@ -11,11 +11,14 @@ pub(super) async fn memory_harvest(
     args: MemoryHarvestArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
     match args.source.as_str() {
-        "git" => memory_harvest_git(args, mem_path, cfg).await,
-        "claude-code" => super::harvest_claude::harvest_claude_code(args, mem_path, cfg).await,
-        "failures" => memory_harvest_failures(args, mem_path, cfg).await,
+        "git" => memory_harvest_git(args, mem_path, cfg, backend_override).await,
+        "claude-code" => {
+            super::harvest_claude::harvest_claude_code(args, mem_path, cfg, backend_override).await
+        }
+        "failures" => memory_harvest_failures(args, mem_path, cfg, backend_override).await,
         other => {
             anyhow::bail!("Unknown --source '{other}'. Valid values: git, claude-code, failures")
         }
@@ -26,6 +29,7 @@ async fn memory_harvest_git(
     args: MemoryHarvestArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
     use crate::llm::LlmBackend;
 
@@ -66,7 +70,7 @@ async fn memory_harvest_git(
         return Ok(());
     }
 
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     let known_shas = backend.harvested_shas().await?;
     let new_commits: Vec<_> = commits
         .iter()
@@ -390,6 +394,7 @@ async fn memory_harvest_failures(
     args: MemoryHarvestArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
     use crate::llm::LlmBackend;
 
@@ -442,7 +447,7 @@ async fn memory_harvest_failures(
         return Ok(());
     }
 
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     let known_shas = backend.harvested_shas().await?;
     let new_commits: Vec<_> = failure_commits
         .into_iter()

--- a/src/cli/cmd/memory/harvest.rs
+++ b/src/cli/cmd/memory/harvest.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 
-use super::MemoryHarvestArgs;
+use super::{MemoryHarvestArgs, backend_err};
 use crate::{
     config::Config,
     embeddings::{EmbeddingBackend as _, vec_to_blob},
@@ -71,7 +71,7 @@ async fn memory_harvest_git(
     }
 
     let backend = open_memory_backend(cfg, mem_path, backend_override)?;
-    let known_shas = backend.harvested_shas().await?;
+    let known_shas = backend.harvested_shas().await.map_err(backend_err)?;
     let new_commits: Vec<_> = commits
         .iter()
         .filter(|(sha, _, _)| !known_shas.contains(sha.as_str()))
@@ -285,7 +285,11 @@ async fn memory_harvest_git(
                 .map(|(s, _, _)| s.clone())
                 .unwrap_or(sha_short.clone());
 
-            if backend.has_source_ref(&full_sha).await? {
+            if backend
+                .has_source_ref(&full_sha)
+                .await
+                .map_err(backend_err)?
+            {
                 println!("  [skip] already harvested {full_sha}");
                 continue;
             }
@@ -448,7 +452,7 @@ async fn memory_harvest_failures(
     }
 
     let backend = open_memory_backend(cfg, mem_path, backend_override)?;
-    let known_shas = backend.harvested_shas().await?;
+    let known_shas = backend.harvested_shas().await.map_err(backend_err)?;
     let new_commits: Vec<_> = failure_commits
         .into_iter()
         .filter(|(sha, _, _)| !known_shas.contains(sha.as_str()))
@@ -622,7 +626,11 @@ async fn memory_harvest_failures(
                 .map(|(s, _, _)| s.clone())
                 .unwrap_or(sha_short.clone());
 
-            if backend.has_source_ref(&full_sha).await? {
+            if backend
+                .has_source_ref(&full_sha)
+                .await
+                .map_err(backend_err)?
+            {
                 println!("  [skip] already harvested {full_sha}");
                 continue;
             }

--- a/src/cli/cmd/memory/harvest_claude.rs
+++ b/src/cli/cmd/memory/harvest_claude.rs
@@ -9,7 +9,7 @@ use std::io::BufRead as _;
 
 use anyhow::{Context, Result};
 
-use super::MemoryHarvestArgs;
+use super::{MemoryHarvestArgs, backend_err};
 use crate::{
     config::Config,
     embeddings::{EmbeddingBackend as _, vec_to_blob},
@@ -100,7 +100,7 @@ pub(super) async fn harvest_claude_code(
 
     // 5. Load known source_refs.
     let backend = open_memory_backend(cfg, mem_path, backend_override)?;
-    let known_refs = backend.harvested_shas().await?;
+    let known_refs = backend.harvested_shas().await.map_err(backend_err)?;
 
     // 6. Stream-read history file; accumulate sessions relevant to this repo.
     let file = std::fs::File::open(&history_path)
@@ -364,7 +364,11 @@ pub(super) async fn harvest_claude_code(
 
             let source_ref = format!("claude-code:{session_id}");
 
-            if backend.has_source_ref(&source_ref).await? {
+            if backend
+                .has_source_ref(&source_ref)
+                .await
+                .map_err(backend_err)?
+            {
                 println!("  [skip] already harvested session {session_id}");
                 continue;
             }

--- a/src/cli/cmd/memory/harvest_claude.rs
+++ b/src/cli/cmd/memory/harvest_claude.rs
@@ -42,6 +42,7 @@ pub(super) async fn harvest_claude_code(
     args: MemoryHarvestArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
     use crate::llm::LlmBackend;
 
@@ -98,7 +99,7 @@ pub(super) async fn harvest_claude_code(
     };
 
     // 5. Load known source_refs.
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     let known_refs = backend.harvested_shas().await?;
 
     // 6. Stream-read history file; accumulate sessions relevant to this repo.

--- a/src/cli/cmd/memory/list.rs
+++ b/src/cli/cmd/memory/list.rs
@@ -8,8 +8,9 @@ pub(super) async fn memory_list(
     args: MemoryListArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     let as_of = parse_as_of(args.as_of.as_deref())?;
     let notes = if let Some(ref sha_prefix) = args.source_ref {
         backend

--- a/src/cli/cmd/memory/mod.rs
+++ b/src/cli/cmd/memory/mod.rs
@@ -10,6 +10,10 @@ pub struct MemoryArgs {
     /// Path to the memory database (overrides auto-detect)
     #[arg(long, global = true)]
     pub db: Option<PathBuf>,
+
+    /// Storage backend: sqlite (default) or git-notes
+    #[arg(long, global = true, default_value = "sqlite", value_name = "BACKEND")]
+    pub backend: String,
 }
 
 #[derive(Subcommand, Debug)]
@@ -288,20 +292,30 @@ pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> 
     let mem_path = args.db.clone().unwrap_or_else(|| {
         crate::config::resolve_db(None, &cfg.db_path).with_file_name("memory.db")
     });
+    let be = backend_override(&args.backend);
     match args.command {
-        MemoryCommand::Add(a) => add::memory_add(a, &mem_path, &cfg).await,
-        MemoryCommand::Search(a) => search::memory_search(a, &mem_path, &cfg).await,
-        MemoryCommand::List(a) => list::memory_list(a, &mem_path, &cfg).await,
-        MemoryCommand::Show(a) => show::memory_show(a, &mem_path, &cfg).await,
-        MemoryCommand::Harvest(a) => harvest::memory_harvest(a, &mem_path, &cfg).await,
-        MemoryCommand::Archive(a) => archive::memory_archive(a, &mem_path, &cfg).await,
-        MemoryCommand::Supersede(a) => supersede::memory_supersede(a, &mem_path, &cfg).await,
-        MemoryCommand::Push(a) => push::memory_push(a, &mem_path, &cfg).await,
-        MemoryCommand::Timeline(a) => timeline::memory_timeline(a, &mem_path, &cfg).await,
-        MemoryCommand::Graph(a) => graph_cmd::memory_graph(a, &mem_path, &cfg).await,
-        MemoryCommand::Since(a) => since::memory_since(a, &mem_path, &cfg).await,
+        MemoryCommand::Add(a) => add::memory_add(a, &mem_path, &cfg, be).await,
+        MemoryCommand::Search(a) => search::memory_search(a, &mem_path, &cfg, be).await,
+        MemoryCommand::List(a) => list::memory_list(a, &mem_path, &cfg, be).await,
+        MemoryCommand::Show(a) => show::memory_show(a, &mem_path, &cfg, be).await,
+        MemoryCommand::Harvest(a) => harvest::memory_harvest(a, &mem_path, &cfg, be).await,
+        MemoryCommand::Archive(a) => archive::memory_archive(a, &mem_path, &cfg, be).await,
+        MemoryCommand::Supersede(a) => supersede::memory_supersede(a, &mem_path, &cfg, be).await,
+        MemoryCommand::Push(a) => push::memory_push(a, &mem_path, &cfg, be).await,
+        MemoryCommand::Timeline(a) => timeline::memory_timeline(a, &mem_path, &cfg, be).await,
+        MemoryCommand::Graph(a) => graph_cmd::memory_graph(a, &mem_path, &cfg, be).await,
+        MemoryCommand::Since(a) => since::memory_since(a, &mem_path, &cfg, be).await,
         MemoryCommand::Watch(a) => watch::memory_watch(a, &cfg).await,
-        MemoryCommand::Failures(a) => failures::memory_failures(a, &mem_path, &cfg).await,
+        MemoryCommand::Failures(a) => failures::memory_failures(a, &mem_path, &cfg, be).await,
+    }
+}
+
+/// Convert the `--backend` string to a static override token for `open_memory_backend`.
+/// Returns `None` for the default "sqlite" to fall through to config-based dispatch.
+fn backend_override(s: &str) -> Option<&'static str> {
+    match s {
+        "git-notes" => Some("git-notes"),
+        _ => None,
     }
 }
 

--- a/src/cli/cmd/memory/mod.rs
+++ b/src/cli/cmd/memory/mod.rs
@@ -420,3 +420,18 @@ pub(super) fn open_editor_for_body(title: &str) -> Result<String> {
 
 // Re-export from the shared dates module for use within this submodule tree.
 pub(super) use crate::utils::dates::parse_as_of;
+
+/// Convert a `BackendUnsupported` error into a user-friendly message.
+/// Pass as `.map_err(backend_err)?` at each call site that invokes an
+/// unsupported git-notes method.
+pub(super) fn backend_err(e: anyhow::Error) -> anyhow::Error {
+    if e.downcast_ref::<crate::error::SpelunkError>()
+        .is_some_and(|s| matches!(s, crate::error::SpelunkError::BackendUnsupported(_)))
+    {
+        anyhow::anyhow!(
+            "This operation requires the sqlite backend. Re-run without --backend git-notes."
+        )
+    } else {
+        e
+    }
+}

--- a/src/cli/cmd/memory/push.rs
+++ b/src/cli/cmd/memory/push.rs
@@ -10,6 +10,7 @@ pub(super) async fn memory_push(
     args: MemoryPushArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
     if cfg.memory_server_url.is_none() {
         anyhow::bail!(
@@ -28,7 +29,7 @@ pub(super) async fn memory_push(
         return Ok(());
     }
 
-    let remote = open_memory_backend(cfg, mem_path)?;
+    let remote = open_memory_backend(cfg, mem_path, backend_override)?;
     println!(
         "Pushing {} entries to {}…",
         notes.len(),

--- a/src/cli/cmd/memory/search.rs
+++ b/src/cli/cmd/memory/search.rs
@@ -9,12 +9,13 @@ pub(super) async fn memory_search(
     args: MemorySearchArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
     let index_db_path = crate::config::resolve_db(None, &cfg.db_path);
     crate::storage::record_usage_at(&index_db_path, "memory search");
 
     let mode = args.mode.as_str();
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     let as_of = parse_as_of(args.as_of.as_deref())?;
 
     let notes = if mode == "text" {

--- a/src/cli/cmd/memory/search.rs
+++ b/src/cli/cmd/memory/search.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 
 use super::super::helpers::embed_query;
 use super::MemorySearchArgs;
-use super::{parse_as_of, print_note_summary};
+use super::{backend_err, parse_as_of, print_note_summary};
 use crate::{config::Config, storage::open_memory_backend};
 
 pub(super) async fn memory_search(
@@ -20,7 +20,10 @@ pub(super) async fn memory_search(
 
     let notes = if mode == "text" {
         let sp = super::super::ui::spinner("Searching (text)…");
-        let result = backend.search_text(&args.query, args.limit, as_of).await?;
+        let result = backend
+            .search_text(&args.query, args.limit, as_of)
+            .await
+            .map_err(backend_err)?;
         sp.finish_and_clear();
         result
     } else {
@@ -32,11 +35,15 @@ pub(super) async fn memory_search(
         sp.finish_and_clear();
 
         if mode == "semantic" {
-            backend.search(&blob, args.limit, as_of).await?
+            backend
+                .search(&blob, args.limit, as_of)
+                .await
+                .map_err(backend_err)?
         } else {
             backend
                 .search_hybrid(&blob, &args.query, args.limit, as_of)
-                .await?
+                .await
+                .map_err(backend_err)?
         }
     };
 
@@ -50,7 +57,7 @@ pub(super) async fn memory_search(
         let mut expanded = notes;
         let mut neighbours = vec![];
         for n in &expanded {
-            let (outgoing, incoming) = backend.get_edges(n.id).await?;
+            let (outgoing, incoming) = backend.get_edges(n.id).await.map_err(backend_err)?;
             for e in outgoing.iter().chain(incoming.iter()) {
                 if e.kind != "relates_to" {
                     continue;

--- a/src/cli/cmd/memory/show.rs
+++ b/src/cli/cmd/memory/show.rs
@@ -8,8 +8,9 @@ pub(super) async fn memory_show(
     args: MemoryShowArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     match backend.get(args.id).await? {
         None => anyhow::bail!("No memory entry with id {}.", args.id),
         Some(n) => match crate::utils::effective_format(&args.format) {

--- a/src/cli/cmd/memory/since.rs
+++ b/src/cli/cmd/memory/since.rs
@@ -24,6 +24,7 @@ pub(super) async fn memory_since(
     args: MemorySinceArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
     // ── Remote path ───────────────────────────────────────────────────────────
     if let (Some(base_url), Some(project_id)) =
@@ -57,7 +58,7 @@ pub(super) async fn memory_since(
     }
 
     // ── Local path ────────────────────────────────────────────────────────────
-    let backend = crate::storage::open_memory_backend(cfg, mem_path)?;
+    let backend = crate::storage::open_memory_backend(cfg, mem_path, backend_override)?;
     let all = backend
         .list(None, args.limit, false, None)
         .await

--- a/src/cli/cmd/memory/supersede.rs
+++ b/src/cli/cmd/memory/supersede.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use super::MemorySupersededArgs;
+use super::{MemorySupersededArgs, backend_err};
 use crate::{config::Config, storage::open_memory_backend};
 
 pub(super) async fn memory_supersede(
@@ -13,7 +13,11 @@ pub(super) async fn memory_supersede(
     if backend.get(args.new_id).await?.is_none() {
         anyhow::bail!("No memory entry with id {} (new).", args.new_id);
     }
-    if backend.supersede(args.old_id, args.new_id).await? {
+    if backend
+        .supersede(args.old_id, args.new_id)
+        .await
+        .map_err(backend_err)?
+    {
         println!(
             "Archived #{old} → superseded by #{new}.",
             old = args.old_id,

--- a/src/cli/cmd/memory/supersede.rs
+++ b/src/cli/cmd/memory/supersede.rs
@@ -7,8 +7,9 @@ pub(super) async fn memory_supersede(
     args: MemorySupersededArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     if backend.get(args.new_id).await?.is_none() {
         anyhow::bail!("No memory entry with id {} (new).", args.new_id);
     }

--- a/src/cli/cmd/memory/timeline.rs
+++ b/src/cli/cmd/memory/timeline.rs
@@ -9,6 +9,7 @@ pub(super) async fn memory_timeline(
     args: MemoryTimelineArgs,
     mem_path: &std::path::Path,
     cfg: &Config,
+    backend_override: Option<&str>,
 ) -> Result<()> {
     let sp = super::super::ui::spinner("Embedding query…");
     let embedder = crate::backends::ActiveEmbedder::load(cfg)
@@ -17,7 +18,7 @@ pub(super) async fn memory_timeline(
     let blob = embed_query(&embedder, "question answering", &args.query).await?;
     sp.finish_and_clear();
 
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     let notes = backend.search_timeline(&blob, args.limit).await?;
 
     if notes.is_empty() {

--- a/src/cli/cmd/memory/timeline.rs
+++ b/src/cli/cmd/memory/timeline.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 
 use super::super::helpers::embed_query;
 use super::super::status::format_age;
-use super::MemoryTimelineArgs;
+use super::{MemoryTimelineArgs, backend_err};
 use crate::{config::Config, storage::open_memory_backend};
 
 pub(super) async fn memory_timeline(
@@ -19,7 +19,10 @@ pub(super) async fn memory_timeline(
     sp.finish_and_clear();
 
     let backend = open_memory_backend(cfg, mem_path, backend_override)?;
-    let notes = backend.search_timeline(&blob, args.limit).await?;
+    let notes = backend
+        .search_timeline(&blob, args.limit)
+        .await
+        .map_err(backend_err)?;
 
     if notes.is_empty() {
         println!("No memory entries found for topic: {}", args.query);

--- a/src/cli/cmd/plan.rs
+++ b/src/cli/cmd/plan.rs
@@ -77,7 +77,7 @@ async fn plan_create(
     let mem_path = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
     let memory_context = {
         let mblob = vec_to_blob(&query_vec);
-        match open_memory_backend(cfg, &mem_path).ok() {
+        match open_memory_backend(cfg, &mem_path, None).ok() {
             Some(b) => b.search(&mblob, 5, None).await.ok().and_then(|notes| {
                 if notes.is_empty() {
                     None

--- a/src/cli/cmd/plumbing/read_memory.rs
+++ b/src/cli/cmd/plumbing/read_memory.rs
@@ -8,7 +8,7 @@ pub(super) async fn read_memory(
     mem_path: &std::path::Path,
     cfg: &Config,
 ) -> Result<()> {
-    let backend = open_memory_backend(cfg, mem_path)?;
+    let backend = open_memory_backend(cfg, mem_path, None)?;
 
     if let Some(id) = args.id {
         match backend.get(id).await? {

--- a/src/cli/cmd/status.rs
+++ b/src/cli/cmd/status.rs
@@ -34,7 +34,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
         let drift = db.drift_candidates(30, 10).unwrap_or_default();
         let usage = db.usage_last_7_days().unwrap_or_default();
         let mem_path = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
-        let memory_count = match open_memory_backend(&cfg, &mem_path).ok() {
+        let memory_count = match open_memory_backend(&cfg, &mem_path, None).ok() {
             Some(b) => b.count().await.unwrap_or(0),
             None => 0,
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,3 +35,9 @@ pub enum SearchError {
     #[error("database error: {0}")]
     Database(#[from] rusqlite::Error),
 }
+
+#[derive(Error, Debug)]
+pub enum SpelunkError {
+    #[error("backend does not support this operation: {0}")]
+    BackendUnsupported(String),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ mod cli;
 
 use clap::{CommandFactory, FromArgMatches};
 use cli::{Cli, Command};
-use spelunk::{backends, config, embeddings, indexer, llm, registry, search, storage, utils};
+use spelunk::{
+    backends, config, embeddings, error, indexer, llm, registry, search, storage, utils,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/storage/git_notes.rs
+++ b/src/storage/git_notes.rs
@@ -276,9 +276,7 @@ impl MemoryBackend for GitNotesBackend {
         _include_archived: bool,
         _as_of: Option<i64>,
     ) -> Result<Vec<Note>> {
-        Err(anyhow!(
-            "git-notes backend does not support list_by_source_ref"
-        ))
+        Err(crate::error::SpelunkError::BackendUnsupported("list_by_source_ref".into()).into())
     }
 
     async fn get(&self, id: i64) -> Result<Option<Note>> {
@@ -317,9 +315,7 @@ impl MemoryBackend for GitNotesBackend {
     // ── Unsupported ──────────────────────────────────────────────────────────
 
     async fn search_timeline(&self, _query_blob: &[u8], _limit: usize) -> Result<Vec<Note>> {
-        Err(anyhow!(
-            "git-notes backend does not support semantic search — run spelunk index first"
-        ))
+        Err(crate::error::SpelunkError::BackendUnsupported("search_timeline".into()).into())
     }
 
     async fn search(
@@ -328,9 +324,7 @@ impl MemoryBackend for GitNotesBackend {
         _limit: usize,
         _as_of: Option<i64>,
     ) -> Result<Vec<Note>> {
-        Err(anyhow!(
-            "git-notes backend does not support semantic search — run spelunk index first"
-        ))
+        Err(crate::error::SpelunkError::BackendUnsupported("search".into()).into())
     }
 
     async fn search_text(
@@ -339,9 +333,7 @@ impl MemoryBackend for GitNotesBackend {
         _limit: usize,
         _as_of: Option<i64>,
     ) -> Result<Vec<Note>> {
-        Err(anyhow!(
-            "git-notes backend does not support text search — run spelunk index first"
-        ))
+        Err(crate::error::SpelunkError::BackendUnsupported("search_text".into()).into())
     }
 
     async fn search_hybrid(
@@ -351,28 +343,26 @@ impl MemoryBackend for GitNotesBackend {
         _limit: usize,
         _as_of: Option<i64>,
     ) -> Result<Vec<Note>> {
-        Err(anyhow!(
-            "git-notes backend does not support semantic search — run spelunk index first"
-        ))
+        Err(crate::error::SpelunkError::BackendUnsupported("search_hybrid".into()).into())
     }
 
     async fn supersede(&self, _old_id: i64, _new_id: i64) -> Result<bool> {
-        Err(anyhow!("git-notes backend does not support supersede"))
+        Err(crate::error::SpelunkError::BackendUnsupported("supersede".into()).into())
     }
 
     async fn harvested_shas(&self) -> Result<HashSet<String>> {
-        Err(anyhow!("git-notes backend does not support harvested_shas"))
+        Err(crate::error::SpelunkError::BackendUnsupported("harvested_shas".into()).into())
     }
 
     async fn has_source_ref(&self, _sha: &str) -> Result<bool> {
-        Err(anyhow!("git-notes backend does not support has_source_ref"))
+        Err(crate::error::SpelunkError::BackendUnsupported("has_source_ref".into()).into())
     }
 
     async fn add_edge(&self, _from_id: i64, _to_id: i64, _kind: &str) -> Result<()> {
-        Err(anyhow!("git-notes backend does not support graph edges"))
+        Err(crate::error::SpelunkError::BackendUnsupported("add_edge".into()).into())
     }
 
     async fn get_edges(&self, _id: i64) -> Result<(Vec<MemoryEdge>, Vec<MemoryEdge>)> {
-        Err(anyhow!("git-notes backend does not support graph edges"))
+        Err(crate::error::SpelunkError::BackendUnsupported("get_edges".into()).into())
     }
 }

--- a/src/storage/git_notes.rs
+++ b/src/storage/git_notes.rs
@@ -1,0 +1,378 @@
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::process::Command;
+
+use super::backend::{MemoryBackend, NoteInput};
+use super::memory::{MemoryEdge, Note};
+
+/// Serialised form stored inside a git note blob.
+#[derive(Debug, Serialize, Deserialize)]
+struct NoteRecord {
+    id: i64,
+    kind: String,
+    title: String,
+    body: String,
+    tags: Vec<String>,
+    linked_files: Vec<String>,
+    created_at: i64,
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    valid_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    invalid_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    superseded_by: Option<i64>,
+}
+
+/// Memory backend backed by `git notes` in the `refs/notes/spelunk` namespace.
+///
+/// Each memory entry is attached to the `HEAD` commit at write time as a single
+/// JSON object.  Multiple entries accumulate across commits as the user works.
+///
+/// # Concurrency warning
+/// `add` uses `git notes add -f` (force-replace).  If two processes add a note
+/// to the same `HEAD` simultaneously the second write silently overwrites the
+/// first.  For multi-agent workflows use the sqlite backend (the default).
+/// See issue #185 for the full analysis.
+///
+/// # Unsupported methods
+/// Semantic search (`search`, `search_hybrid`, `search_timeline`, `search_text`),
+/// graph edges (`add_edge`, `get_edges`), `supersede`, `harvested_shas`, and
+/// `has_source_ref` all return `Err` with a clear message rather than silently
+/// returning empty results.
+pub struct GitNotesBackend {
+    git_root: Option<std::path::PathBuf>,
+}
+
+impl Default for GitNotesBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GitNotesBackend {
+    pub fn new() -> Self {
+        Self { git_root: None }
+    }
+
+    /// Create a backend pinned to `root` — useful for testing with a temporary repo.
+    pub fn with_root(root: std::path::PathBuf) -> Self {
+        Self {
+            git_root: Some(root),
+        }
+    }
+
+    fn git(&self) -> Command {
+        let mut cmd = Command::new("git");
+        if let Some(ref root) = self.git_root {
+            cmd.current_dir(root);
+        }
+        cmd
+    }
+
+    async fn run(&self, args: &[&str]) -> Result<String> {
+        let out = self.git().args(args).output().await?;
+        if out.status.success() {
+            Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+        } else {
+            Err(anyhow!(
+                "git {}: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ))
+        }
+    }
+
+    async fn head_sha(&self) -> Result<String> {
+        Ok(self.run(&["rev-parse", "HEAD"]).await?.trim().to_string())
+    }
+
+    /// Return (commit-sha, commit-timestamp) pairs for commits that have a
+    /// spelunk note, in reverse-chronological (newest first) order.
+    async fn noted_commits(&self) -> Result<Vec<(String, i64)>> {
+        // `git notes --ref=spelunk list` → "<note-blob-sha> <commit-sha>"
+        let list_out = self
+            .git()
+            .args(["notes", "--ref=spelunk", "list"])
+            .output()
+            .await?;
+
+        if !list_out.status.success() {
+            return Ok(vec![]);
+        }
+
+        let noted: HashSet<String> = String::from_utf8_lossy(&list_out.stdout)
+            .lines()
+            .filter_map(|l| l.split_whitespace().nth(1).map(str::to_owned))
+            .collect();
+
+        if noted.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Walk git log in reverse-chronological order to get commit timestamps.
+        let log_out = self.git().args(["log", "--format=%H %at"]).output().await?;
+
+        if !log_out.status.success() {
+            return Ok(vec![]);
+        }
+
+        let pairs = String::from_utf8_lossy(&log_out.stdout)
+            .lines()
+            .filter_map(|line| {
+                let mut parts = line.split_whitespace();
+                let sha = parts.next()?.to_owned();
+                let ts: i64 = parts.next()?.parse().ok()?;
+                noted.contains(&sha).then_some((sha, ts))
+            })
+            .collect();
+
+        Ok(pairs)
+    }
+
+    async fn read_record(&self, commit_sha: &str) -> Result<Option<NoteRecord>> {
+        let out = self
+            .git()
+            .args(["notes", "--ref=spelunk", "show", commit_sha])
+            .output()
+            .await?;
+
+        if !out.status.success() {
+            return Ok(None);
+        }
+
+        let json = String::from_utf8_lossy(&out.stdout);
+        let record: NoteRecord = serde_json::from_str(json.trim())
+            .map_err(|e| anyhow!("parsing spelunk note on {commit_sha}: {e}"))?;
+        Ok(Some(record))
+    }
+
+    async fn collect(
+        &self,
+        kind_filter: Option<&str>,
+        include_archived: bool,
+        as_of: Option<i64>,
+        limit: usize,
+    ) -> Result<Vec<Note>> {
+        let commits = self.noted_commits().await?;
+        let mut notes = Vec::new();
+
+        for (sha, _) in commits {
+            if notes.len() >= limit {
+                break;
+            }
+            if let Some(record) = self.read_record(&sha).await? {
+                if kind_filter.is_some_and(|k| record.kind != k) {
+                    continue;
+                }
+                if !include_archived && record.status == "archived" {
+                    continue;
+                }
+                if let Some(ts) = as_of {
+                    let effective = record.valid_at.unwrap_or(record.created_at);
+                    if effective > ts {
+                        continue;
+                    }
+                    if record.invalid_at.is_some_and(|ia| ia <= ts) {
+                        continue;
+                    }
+                }
+                notes.push(record_to_note(record));
+            }
+        }
+
+        Ok(notes)
+    }
+}
+
+fn record_to_note(r: NoteRecord) -> Note {
+    Note {
+        id: r.id,
+        kind: r.kind,
+        title: r.title,
+        body: r.body,
+        tags: r.tags,
+        linked_files: r.linked_files,
+        created_at: r.created_at,
+        status: r.status,
+        superseded_by: r.superseded_by,
+        source_ref: r.source_ref,
+        valid_at: r.valid_at,
+        invalid_at: r.invalid_at,
+        distance: None,
+        score: None,
+    }
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+#[async_trait]
+impl MemoryBackend for GitNotesBackend {
+    async fn add(&self, input: NoteInput) -> Result<i64> {
+        let id = now_millis();
+        let record = NoteRecord {
+            id,
+            kind: input.kind,
+            title: input.title,
+            body: input.body,
+            tags: input.tags,
+            linked_files: input.linked_files,
+            created_at: now_secs(),
+            status: "active".to_string(),
+            source_ref: input.source_ref,
+            valid_at: input.valid_at,
+            invalid_at: None,
+            superseded_by: None,
+        };
+
+        let json = serde_json::to_string(&record)?;
+        let head = self.head_sha().await?;
+
+        let status = self
+            .git()
+            .args(["notes", "--ref=spelunk", "add", "-f", "-m", &json, &head])
+            .status()
+            .await?;
+
+        if !status.success() {
+            return Err(anyhow!("git notes add failed"));
+        }
+
+        Ok(id)
+    }
+
+    async fn list(
+        &self,
+        kind_filter: Option<&str>,
+        limit: usize,
+        include_archived: bool,
+        as_of: Option<i64>,
+    ) -> Result<Vec<Note>> {
+        self.collect(kind_filter, include_archived, as_of, limit)
+            .await
+    }
+
+    async fn list_by_source_ref(
+        &self,
+        _source_ref_prefix: &str,
+        _limit: usize,
+        _include_archived: bool,
+        _as_of: Option<i64>,
+    ) -> Result<Vec<Note>> {
+        Err(anyhow!(
+            "git-notes backend does not support list_by_source_ref"
+        ))
+    }
+
+    async fn get(&self, id: i64) -> Result<Option<Note>> {
+        for (sha, _) in self.noted_commits().await? {
+            if let Some(record) = self.read_record(&sha).await?
+                && record.id == id
+            {
+                return Ok(Some(record_to_note(record)));
+            }
+        }
+        Ok(None)
+    }
+
+    async fn count(&self) -> Result<i64> {
+        Ok(self.noted_commits().await?.len() as i64)
+    }
+
+    async fn archive(&self, id: i64) -> Result<bool> {
+        for (sha, _) in self.noted_commits().await? {
+            if let Some(mut record) = self.read_record(&sha).await?
+                && record.id == id
+            {
+                record.status = "archived".to_string();
+                let json = serde_json::to_string(&record)?;
+                let status = self
+                    .git()
+                    .args(["notes", "--ref=spelunk", "add", "-f", "-m", &json, &sha])
+                    .status()
+                    .await?;
+                return Ok(status.success());
+            }
+        }
+        Ok(false)
+    }
+
+    // ── Unsupported ──────────────────────────────────────────────────────────
+
+    async fn search_timeline(&self, _query_blob: &[u8], _limit: usize) -> Result<Vec<Note>> {
+        Err(anyhow!(
+            "git-notes backend does not support semantic search — run spelunk index first"
+        ))
+    }
+
+    async fn search(
+        &self,
+        _query_blob: &[u8],
+        _limit: usize,
+        _as_of: Option<i64>,
+    ) -> Result<Vec<Note>> {
+        Err(anyhow!(
+            "git-notes backend does not support semantic search — run spelunk index first"
+        ))
+    }
+
+    async fn search_text(
+        &self,
+        _query: &str,
+        _limit: usize,
+        _as_of: Option<i64>,
+    ) -> Result<Vec<Note>> {
+        Err(anyhow!(
+            "git-notes backend does not support text search — run spelunk index first"
+        ))
+    }
+
+    async fn search_hybrid(
+        &self,
+        _query_blob: &[u8],
+        _query: &str,
+        _limit: usize,
+        _as_of: Option<i64>,
+    ) -> Result<Vec<Note>> {
+        Err(anyhow!(
+            "git-notes backend does not support semantic search — run spelunk index first"
+        ))
+    }
+
+    async fn supersede(&self, _old_id: i64, _new_id: i64) -> Result<bool> {
+        Err(anyhow!("git-notes backend does not support supersede"))
+    }
+
+    async fn harvested_shas(&self) -> Result<HashSet<String>> {
+        Err(anyhow!("git-notes backend does not support harvested_shas"))
+    }
+
+    async fn has_source_ref(&self, _sha: &str) -> Result<bool> {
+        Err(anyhow!("git-notes backend does not support has_source_ref"))
+    }
+
+    async fn add_edge(&self, _from_id: i64, _to_id: i64, _kind: &str) -> Result<()> {
+        Err(anyhow!("git-notes backend does not support graph edges"))
+    }
+
+    async fn get_edges(&self, _id: i64) -> Result<(Vec<MemoryEdge>, Vec<MemoryEdge>)> {
+        Err(anyhow!("git-notes backend does not support graph edges"))
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,5 +1,6 @@
 pub mod backend;
 pub mod db;
+pub mod git_notes;
 pub mod memory;
 pub mod remote;
 
@@ -15,6 +16,7 @@ mod stats;
 pub use backend::{LocalMemoryBackend, MemoryBackend, NoteInput};
 pub use db::Database;
 pub use files::FileRecord;
+pub use git_notes::GitNotesBackend;
 pub use graph::GraphEdge;
 pub use memory::{MemoryEdge, MemoryStore};
 pub use remote::RemoteMemoryBackend;
@@ -25,15 +27,20 @@ pub use stats::{DriftCandidate, IndexStats, StalenessReport, record_usage_at};
 use anyhow::Result;
 use std::path::Path;
 
-/// Open the appropriate memory backend based on config.
+/// Open the appropriate memory backend.
 ///
-/// - If `memory_server_url` is set in config, returns a `RemoteMemoryBackend`.
-///   `project_id` must also be set (validated by `Config::validate()`).
-/// - Otherwise, opens local SQLite at `mem_path`.
+/// Priority:
+/// 1. `backend_override = Some("git-notes")` → `GitNotesBackend`
+/// 2. `memory_server_url` set in config → `RemoteMemoryBackend`
+/// 3. Otherwise → local SQLite at `mem_path`
 pub fn open_memory_backend(
     cfg: &crate::config::Config,
     mem_path: &Path,
+    backend_override: Option<&str>,
 ) -> Result<Box<dyn MemoryBackend + Send>> {
+    if backend_override == Some("git-notes") {
+        return Ok(Box::new(GitNotesBackend::new()));
+    }
     if let Some(url) = &cfg.memory_server_url {
         let project_id = cfg.project_id.clone().expect(
             "project_id must be set when memory_server_url is configured; \

--- a/tests/integration_git_notes.rs
+++ b/tests/integration_git_notes.rs
@@ -109,19 +109,19 @@ async fn git_notes_list_without_kind_returns_all() {
     // Make a second commit so the two notes don't overwrite each other.
     std::fs::write(dir.path().join("a.txt"), "a").expect("write");
     std::process::Command::new("git")
-        .args(["add", ".", "&&"])
-        .current_dir(dir.path())
+        .args(["-C", dir.path().to_str().unwrap(), "add", "."])
         .output()
         .ok();
     std::process::Command::new("git")
         .args([
+            "-C",
+            dir.path().to_str().unwrap(),
             "commit",
             "--no-gpg-sign",
             "--allow-empty",
             "-m",
             "second commit",
         ])
-        .current_dir(dir.path())
         .output()
         .expect("second commit");
 

--- a/tests/integration_git_notes.rs
+++ b/tests/integration_git_notes.rs
@@ -1,0 +1,225 @@
+//! Integration tests for `GitNotesBackend` — concurrency and round-trip.
+//!
+//! These tests require `git` to be on PATH and are skipped if the current
+//! working directory is not inside a git repository (CI environments without
+//! git are unaffected).
+//!
+//! ## Concurrent-write safety (#185)
+//!
+//! `git notes add -f` uses replace semantics: two agents writing a note to the
+//! same HEAD commit simultaneously will silently lose one entry.  This test
+//! documents the behaviour and the chosen mitigation strategy.
+//!
+//! **Chosen strategy: Option C — document last-write-wins.**
+//! For the v1 spike, concurrent writes to the *same HEAD* are a known
+//! limitation.  The typical agent workflow produces a note per commit; agents
+//! working in separate commits (the common case) are unaffected.
+//! Users who need conflict-free concurrent writes should use the sqlite
+//! backend (the default).
+
+mod common;
+
+use serial_test::serial;
+use spelunk::storage::GitNotesBackend;
+use spelunk::storage::MemoryBackend;
+use spelunk::storage::NoteInput;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Create a temporary git repo with one initial commit.
+/// Returns the path; the repo is cleaned up when the returned `TempDir` drops.
+fn make_temp_git_repo() -> tempfile::TempDir {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let p = dir.path();
+
+    let run = |args: &[&str]| {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(p)
+            .output()
+            .expect("git command")
+    };
+
+    run(&["init", "-b", "main"]);
+    run(&["config", "user.email", "test@example.com"]);
+    run(&["config", "user.name", "Test"]);
+    // Create an initial commit so HEAD resolves.
+    std::fs::write(p.join("README.md"), "test").expect("write");
+    run(&["add", "."]);
+    run(&[
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "init",
+        "--allow-empty-message",
+    ]);
+
+    dir
+}
+
+fn note_input(kind: &str, title: &str) -> NoteInput {
+    NoteInput {
+        kind: kind.to_string(),
+        title: title.to_string(),
+        body: format!("body for {title}"),
+        tags: vec![],
+        linked_files: vec![],
+        embedding: None,
+        source_ref: None,
+        valid_at: None,
+        supersedes: None,
+    }
+}
+
+// ── basic round-trip ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial]
+async fn git_notes_add_and_list_round_trip() {
+    let dir = make_temp_git_repo();
+    let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
+
+    let id = backend
+        .add(note_input("decision", "use sqlcipher"))
+        .await
+        .expect("add");
+
+    let notes = backend
+        .list(Some("decision"), 10, false, None)
+        .await
+        .expect("list");
+
+    assert_eq!(notes.len(), 1, "expected exactly one note");
+    assert_eq!(notes[0].id, id);
+    assert_eq!(notes[0].title, "use sqlcipher");
+    assert_eq!(notes[0].kind, "decision");
+}
+
+#[tokio::test]
+#[serial]
+async fn git_notes_list_without_kind_returns_all() {
+    let dir = make_temp_git_repo();
+    let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
+
+    backend
+        .add(note_input("decision", "first"))
+        .await
+        .expect("add 1");
+
+    // Make a second commit so the two notes don't overwrite each other.
+    std::fs::write(dir.path().join("a.txt"), "a").expect("write");
+    std::process::Command::new("git")
+        .args(["add", ".", "&&"])
+        .current_dir(dir.path())
+        .output()
+        .ok();
+    std::process::Command::new("git")
+        .args([
+            "commit",
+            "--no-gpg-sign",
+            "--allow-empty",
+            "-m",
+            "second commit",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("second commit");
+
+    backend
+        .add(note_input("note", "second"))
+        .await
+        .expect("add 2");
+
+    let all = backend.list(None, 10, false, None).await.expect("list");
+    assert_eq!(all.len(), 2, "expected two notes across two commits");
+}
+
+// ── concurrent write safety (#185) ───────────────────────────────────────────
+
+/// Documents the last-write-wins behaviour when two tasks write to the same HEAD
+/// concurrently.  The test asserts the *known* outcome (one entry survives) and
+/// is annotated so maintainers understand the trade-off.
+///
+/// To protect against silent data loss, use the sqlite backend for multi-agent
+/// workflows (the default backend).
+#[tokio::test]
+#[serial]
+async fn git_notes_concurrent_same_head_last_write_wins() {
+    let dir = make_temp_git_repo();
+
+    let root = dir.path().to_path_buf();
+    let b1 = GitNotesBackend::with_root(root.clone());
+    let b2 = GitNotesBackend::with_root(root.clone());
+
+    // Two concurrent adds to the same HEAD.
+    let (r1, r2) = tokio::join!(
+        b1.add(note_input("note", "agent A")),
+        b2.add(note_input("note", "agent B")),
+    );
+    r1.expect("agent A add");
+    r2.expect("agent B add");
+
+    // At most one survives because both wrote to the same HEAD using -f.
+    let notes = GitNotesBackend::with_root(dir.path().to_path_buf())
+        .list(None, 10, false, None)
+        .await
+        .expect("list");
+
+    // KNOWN LIMITATION: only the last writer's note survives.
+    // Acceptable for the v1 spike; use sqlite backend for multi-agent workflows.
+    assert!(
+        notes.len() <= 1,
+        "expected at most one note (last-write-wins); got {}",
+        notes.len()
+    );
+}
+
+/// Archive marks an entry with status=archived and hides it from default list.
+#[tokio::test]
+#[serial]
+async fn git_notes_archive_hides_entry() {
+    let dir = make_temp_git_repo();
+    let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
+
+    let id = backend
+        .add(note_input("decision", "archive me"))
+        .await
+        .expect("add");
+
+    let archived = backend.archive(id).await.expect("archive");
+    assert!(archived);
+
+    let active = backend
+        .list(None, 10, false, None)
+        .await
+        .expect("list active");
+    assert!(
+        active.is_empty(),
+        "archived entry should not appear in default list"
+    );
+
+    let all = backend
+        .list(None, 10, true, None)
+        .await
+        .expect("list including archived");
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].status, "archived");
+}
+
+/// Unsupported methods return clear errors rather than panicking.
+#[tokio::test]
+#[serial]
+async fn git_notes_unsupported_methods_return_errors() {
+    let dir = make_temp_git_repo();
+    let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
+
+    assert!(backend.search(&[], 5, None).await.is_err());
+    assert!(backend.search_hybrid(&[], "q", 5, None).await.is_err());
+    assert!(backend.search_text("q", 5, None).await.is_err());
+    assert!(backend.search_timeline(&[], 5).await.is_err());
+    assert!(backend.harvested_shas().await.is_err());
+    assert!(backend.has_source_ref("abc123").await.is_err());
+    assert!(backend.add_edge(1, 2, "relates_to").await.is_err());
+    assert!(backend.get_edges(1).await.is_err());
+    assert!(backend.supersede(1, 2).await.is_err());
+}


### PR DESCRIPTION
## Summary

- Adds `SpelunkError::BackendUnsupported(String)` variant to `src/error.rs`
- Exposes `error` module from `main.rs` via `use spelunk::{..., error, ...}` so callers in the binary can reference it
- Updates 9 unsupported methods in `GitNotesBackend` (search variants, graph edges, `supersede`, `harvested_shas`, `has_source_ref`, `list_by_source_ref`) to return the typed error instead of bare `anyhow!()`
- Adds `backend_err()` helper in `src/cli/cmd/memory/mod.rs` that remaps `BackendUnsupported` to a user-friendly message: _"This operation requires the sqlite backend. Re-run without --backend git-notes."_
- Applies `.map_err(backend_err)?` at every call site in `search.rs`, `timeline.rs`, `graph_cmd.rs`, `supersede.rs`, `harvest.rs`, `harvest_claude.rs`

Closes #188

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)