### PR TITLE
fix: cap GitNotesBackend list at 500 entries to prevent O(n) hang

### DIFF
--- a/src/storage/git_notes.rs
+++ b/src/storage/git_notes.rs
@@ -8,6 +8,13 @@ use tokio::process::Command;
 use super::backend::{MemoryBackend, NoteInput};
 use super::memory::{MemoryEdge, Note};
 
+/// Hard cap on entries returned by `list()`.
+///
+/// Each entry requires one `git notes show` subprocess call (~13 ms).
+/// Without a guard, `list(5000)` would take ~65 seconds.
+/// Callers needing unbounded listing should use `--backend sqlite`.
+const GIT_NOTES_MAX_LIST: usize = 500;
+
 /// Serialised form stored inside a git note blob.
 #[derive(Debug, Serialize, Deserialize)]
 struct NoteRecord {
@@ -265,7 +272,16 @@ impl MemoryBackend for GitNotesBackend {
         include_archived: bool,
         as_of: Option<i64>,
     ) -> Result<Vec<Note>> {
-        self.collect(kind_filter, include_archived, as_of, limit)
+        let effective_limit = limit.min(GIT_NOTES_MAX_LIST);
+        if limit > GIT_NOTES_MAX_LIST {
+            tracing::warn!(
+                "GitNotesBackend::list: caller requested {} entries; capped at {} to prevent \
+                 O(n) subprocess hang. Use --backend sqlite for unbounded listing.",
+                limit,
+                GIT_NOTES_MAX_LIST
+            );
+        }
+        self.collect(kind_filter, include_archived, as_of, effective_limit)
             .await
     }
 


### PR DESCRIPTION
## Summary

- Adds `GIT_NOTES_MAX_LIST: usize = 500` constant to `src/storage/git_notes.rs`
- Clamps `limit` to `GIT_NOTES_MAX_LIST` in `GitNotesBackend::list()` with a `tracing::warn!` when the caller requested more

Benchmark data (measured at 100% note density):

| Notes | Unbounded list |
|-------|---------------|
| 250 | 3,342 ms |
| 500 | 6,849 ms |
| 750 | 9,533 ms |
| 5,000 (extrapolated) | ~65 seconds |

The cap makes the worst case ~6.5 seconds at 500 entries, which is acceptable for an experimental backend. Callers needing unbounded listing should use `--backend sqlite`. Option A (index file) can follow as a post-GA optimisation.

Closes #191

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)