### PR TITLE
feat: add schema_version to NoteRecord for forward-compat detection

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -40,4 +40,7 @@ pub enum SearchError {
 pub enum SpelunkError {
     #[error("backend does not support this operation: {0}")]
     BackendUnsupported(String),
+
+    #[error("schema version {found} is newer than max known {max_known}; upgrade spelunk")]
+    SchemaMismatch { found: u8, max_known: u8 },
 }

--- a/src/storage/git_notes.rs
+++ b/src/storage/git_notes.rs
@@ -16,8 +16,13 @@ use super::memory::{MemoryEdge, Note};
 const GIT_NOTES_MAX_LIST: usize = 500;
 
 /// Serialised form stored inside a git note blob.
+///
+/// `schema_version` 0 = legacy (field absent in old blobs), 1 = current.
 #[derive(Debug, Serialize, Deserialize)]
 struct NoteRecord {
+    /// Absent in legacy blobs — treated as version 0 via `#[serde(default)]`.
+    #[serde(default)]
+    schema_version: u8,
     id: i64,
     kind: String,
     title: String,
@@ -156,6 +161,14 @@ impl GitNotesBackend {
         let json = String::from_utf8_lossy(&out.stdout);
         let record: NoteRecord = serde_json::from_str(json.trim())
             .map_err(|e| anyhow!("parsing spelunk note on {commit_sha}: {e}"))?;
+        if record.schema_version > 1 {
+            return Err(anyhow::Error::new(
+                crate::error::SpelunkError::SchemaMismatch {
+                    found: record.schema_version,
+                    max_known: 1,
+                },
+            ));
+        }
         Ok(Some(record))
     }
 
@@ -235,6 +248,7 @@ impl MemoryBackend for GitNotesBackend {
     async fn add(&self, input: NoteInput) -> Result<i64> {
         let id = now_millis();
         let record = NoteRecord {
+            schema_version: 1,
             id,
             kind: input.kind,
             title: input.title,


### PR DESCRIPTION
## Summary

- Adds `schema_version: u8` field to `NoteRecord` in `src/storage/git_notes.rs` with `#[serde(default)]` so legacy blobs (missing the field) deserialise as version 0
- Always sets `schema_version: 1` when writing new records in `add()`
- After deserialisation in `read_record()`, returns `Err(SpelunkError::SchemaMismatch { found, max_known: 1 })` if `schema_version > 1` — preventing silent data corruption from future struct changes
- Adds `SpelunkError::SchemaMismatch { found: u8, max_known: u8 }` variant to `src/error.rs`
- Documents the versioning scheme in a comment near `NoteRecord`: _"schema_version 0 = legacy (no field), 1 = current"_

Closes #192

## Versioning scheme

| Version | Meaning |
|---------|---------|
| 0 | Legacy blob (field absent) — deserialised via `#[serde(default)]`, treated as-is |
| 1 | Current format |
| >1 | Unknown future version — hard error, not silent default |

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)