### PR TITLE
feat(#198): GitMetaBackend — zero-infra memory via git-meta-lib 0.1.9

### DIFF
--- a/.spelunk
+++ b/.spelunk
@@ -1,0 +1,1 @@
+/Users/johan/Projects/codeanalysis/.spelunk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,54 +1376,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "git-meta-lib"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885a087e4c81a3f992eda59340ae10bf655fbc924cf09d576730c5b9778b81a0"
+dependencies = [
+ "gix 0.81.0",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "gix"
 version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3428a03ace494ae40308bd3df0b37e7eb7403e24389f27abdff30abf2b5adf17"
 dependencies = [
- "gix-actor",
- "gix-attributes",
- "gix-command",
- "gix-commitgraph",
- "gix-config",
+ "gix-actor 0.38.0",
+ "gix-attributes 0.30.1",
+ "gix-command 0.7.1",
+ "gix-commitgraph 0.32.0",
+ "gix-config 0.51.0",
  "gix-credentials",
- "gix-date",
- "gix-diff",
- "gix-discover",
- "gix-error",
+ "gix-date 0.13.0",
+ "gix-diff 0.58.0",
+ "gix-discover 0.46.0",
+ "gix-error 0.0.0",
  "gix-features",
- "gix-filter",
+ "gix-filter 0.25.0",
  "gix-fs",
  "gix-glob",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
  "gix-ignore",
- "gix-index",
+ "gix-index 0.46.0",
  "gix-lock",
- "gix-negotiate",
- "gix-object",
- "gix-odb",
- "gix-pack",
+ "gix-negotiate 0.26.0",
+ "gix-object 0.55.0",
+ "gix-odb 0.75.0",
+ "gix-pack 0.65.0",
  "gix-path",
- "gix-pathspec",
+ "gix-pathspec 0.15.1",
  "gix-prompt",
- "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-revwalk",
+ "gix-protocol 0.56.0",
+ "gix-ref 0.58.0",
+ "gix-refspec 0.36.0",
+ "gix-revision 0.40.0",
+ "gix-revwalk 0.26.0",
  "gix-sec",
- "gix-shallow",
- "gix-submodule",
+ "gix-shallow 0.8.1",
+ "gix-submodule 0.25.0",
  "gix-tempfile",
  "gix-trace",
- "gix-transport",
- "gix-traverse",
+ "gix-transport 0.53.0",
+ "gix-traverse 0.52.0",
  "gix-url",
  "gix-utils",
  "gix-validate",
- "gix-worktree",
- "gix-worktree-state",
+ "gix-worktree 0.47.0",
+ "gix-worktree-state 0.25.0",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix"
+version = "0.81.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0473c64d9ccbcfb9953a133b47c8b9a335b87ac6c52b983ee4b03d49000b0f3f"
+dependencies = [
+ "gix-actor 0.40.0",
+ "gix-archive",
+ "gix-attributes 0.31.0",
+ "gix-blame",
+ "gix-command 0.8.1",
+ "gix-commitgraph 0.35.0",
+ "gix-config 0.54.0",
+ "gix-date 0.15.3",
+ "gix-diff 0.61.0",
+ "gix-dir",
+ "gix-discover 0.49.0",
+ "gix-error 0.2.3",
+ "gix-features",
+ "gix-filter 0.28.0",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash 0.23.0",
+ "gix-hashtable 0.13.0",
+ "gix-ignore",
+ "gix-index 0.49.0",
+ "gix-lock",
+ "gix-merge",
+ "gix-negotiate 0.29.0",
+ "gix-object 0.58.0",
+ "gix-odb 0.78.0",
+ "gix-pack 0.68.0",
+ "gix-path",
+ "gix-pathspec 0.16.1",
+ "gix-protocol 0.59.0",
+ "gix-ref 0.61.0",
+ "gix-refspec 0.39.0",
+ "gix-revision 0.43.0",
+ "gix-revwalk 0.29.0",
+ "gix-sec",
+ "gix-shallow 0.10.0",
+ "gix-status",
+ "gix-submodule 0.28.0",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse 0.55.0",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree 0.50.0",
+ "gix-worktree-state 0.28.0",
+ "gix-worktree-stream",
+ "nonempty",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -1421,11 +1507,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50ce5433eaa46187349e59089eea71b0397caa71991b2fa3e124120426d7d15"
 dependencies = [
  "bstr",
- "gix-date",
+ "gix-date 0.13.0",
  "gix-utils",
  "itoa",
  "thiserror 2.0.18",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35"
+dependencies = [
+ "bstr",
+ "gix-date 0.15.3",
+ "gix-error 0.2.3",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "651c99be11aac9b303483193ae50b45eb6e094da4f5ed797019b03948f51aad6"
+dependencies = [
+ "bstr",
+ "gix-date 0.15.3",
+ "gix-error 0.2.3",
+ "gix-object 0.58.0",
+ "gix-worktree-stream",
 ]
 
 [[package]]
@@ -1437,7 +1548,24 @@ dependencies = [
  "bstr",
  "gix-glob",
  "gix-path",
- "gix-quote",
+ "gix-quote 0.6.2",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote 0.7.1",
  "gix-trace",
  "kstring",
  "smallvec",
@@ -1455,12 +1583,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-bitmap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
+dependencies = [
+ "gix-error 0.2.3",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77aaf9f7348f4da3ebfbfbbc35fa0d07155d98377856198dde6f695fd648705"
+dependencies = [
+ "gix-commitgraph 0.35.0",
+ "gix-date 0.15.3",
+ "gix-diff 0.61.0",
+ "gix-error 0.2.3",
+ "gix-hash 0.23.0",
+ "gix-object 0.58.0",
+ "gix-revwalk 0.29.0",
+ "gix-trace",
+ "gix-traverse 0.55.0",
+ "gix-worktree 0.50.0",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "gix-chunk"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e516efaac951ed21115b11d5514b120c26ccb493d0c0b9ea6cc10edf4fdf44"
 dependencies = [
- "gix-error",
+ "gix-error 0.0.0",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
+dependencies = [
+ "gix-error 0.2.3",
 ]
 
 [[package]]
@@ -1471,7 +1637,20 @@ checksum = "2962172c6f78731e2b7773bf762f7b8d1746a342a4c0a8914a612206e1295953"
 dependencies = [
  "bstr",
  "gix-path",
- "gix-quote",
+ "gix-quote 0.6.2",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4bb9fa74c44c93f7238b08255f7f9afc158bafea4b95af665fa535352cd73c"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote 0.7.1",
  "gix-trace",
  "shell-words",
 ]
@@ -1483,10 +1662,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0dda2e4d5a61d4a16a780f61f2b7e9406ad1f8da97c35c09ef501f3fdf74de0"
 dependencies = [
  "bstr",
- "gix-chunk",
- "gix-error",
- "gix-hash",
+ "gix-chunk 0.5.0",
+ "gix-error 0.0.0",
+ "gix-hash 0.22.1",
  "memmap2",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3196655fd1443f3c58a48c114aa480be3e4e87b393d7292daaa0d543862eb445"
+dependencies = [
+ "bstr",
+ "gix-chunk 0.7.1",
+ "gix-error 0.2.3",
+ "gix-hash 0.23.0",
+ "memmap2",
+ "nonempty",
 ]
 
 [[package]]
@@ -1500,7 +1693,27 @@ dependencies = [
  "gix-features",
  "gix-glob",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.58.0",
+ "gix-sec",
+ "memchr",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08939b4c4ed7a663d0e64be9e1e9bdf23a1fb4fcee1febdf449f12229542e50d"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref 0.61.0",
  "gix-sec",
  "memchr",
  "smallvec",
@@ -1529,9 +1742,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6ef04ac6b0b9cb75b02afaab4045eafb7b59be41815fbfaaa184a2280af2146"
 dependencies = [
  "bstr",
- "gix-command",
+ "gix-command 0.7.1",
  "gix-config-value",
- "gix-date",
+ "gix-date 0.13.0",
  "gix-path",
  "gix-prompt",
  "gix-sec",
@@ -1547,7 +1760,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12553b32d1da25671f31c0b084bf1e5cb6d5ef529254d04ec33cdc890bd7f687"
 dependencies = [
  "bstr",
- "gix-error",
+ "gix-error 0.0.0",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543"
+dependencies = [
+ "bstr",
+ "gix-error 0.2.3",
  "itoa",
  "jiff",
  "smallvec",
@@ -1560,8 +1786,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26bcd367b2c5dbf6bec9ce02ca59eab179fc82cf39f15ec83549ee25c255c99f"
 dependencies = [
  "bstr",
- "gix-hash",
- "gix-object",
+ "gix-hash 0.22.1",
+ "gix-object 0.55.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f3b3475e5d3877d7c30c40827cc2441936ce890efc226e5ba4afe3a7ae33f0"
+dependencies = [
+ "bstr",
+ "gix-command 0.8.1",
+ "gix-filter 0.28.0",
+ "gix-fs",
+ "gix-hash 0.23.0",
+ "gix-object 0.58.0",
+ "gix-path",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse 0.55.0",
+ "gix-worktree 0.50.0",
+ "imara-diff 0.1.8",
+ "imara-diff 0.2.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da4604a360988f0ba8efe6f90093ca5a844f4a7f8e1a3dcda501ec44e600ea9"
+dependencies = [
+ "bstr",
+ "gix-discover 0.49.0",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index 0.49.0",
+ "gix-object 0.58.0",
+ "gix-path",
+ "gix-pathspec 0.16.1",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree 0.50.0",
  "thiserror 2.0.18",
 ]
 
@@ -1575,7 +1843,22 @@ dependencies = [
  "dunce",
  "gix-fs",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.58.0",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65bd3330fe0cb9d40d875bf862fd5e8ad6fa4164ddbc4842fbeb889c3f0b2c6"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref 0.61.0",
  "gix-sec",
  "thiserror 2.0.18",
 ]
@@ -1585,6 +1868,15 @@ name = "gix-error"
 version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dffc9ca4dfa4f519a3d2cf1c038919160544923577ac60f45bcb602a24d82c6"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613"
 dependencies = [
  "bstr",
 ]
@@ -1618,13 +1910,34 @@ checksum = "7240442915cdd74e1f889566695ce0d0c23c7185b13318a1232ce646af0d18ad"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes",
- "gix-command",
- "gix-hash",
- "gix-object",
+ "gix-attributes 0.30.1",
+ "gix-command 0.7.1",
+ "gix-hash 0.22.1",
+ "gix-object 0.55.0",
  "gix-packetline",
  "gix-path",
- "gix-quote",
+ "gix-quote 0.6.2",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37598282a6566da6fb52667570c7fe0aedcb122ac886724a9e62a2180523e35"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes 0.31.0",
+ "gix-command 0.8.1",
+ "gix-hash 0.23.0",
+ "gix-object 0.58.0",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote 0.7.1",
  "gix-trace",
  "gix-utils",
  "smallvec",
@@ -1670,12 +1983,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-hash"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fb896a02d9ab96fa518475a5f30ad3952010f801a8de5840f633f4a6b985dfb"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "gix-hashtable"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f1eecdd006390cbed81f105417dbf82a6fe40842022006550f2e32484101da"
 dependencies = [
- "gix-hash",
+ "gix-hash 0.22.1",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2664216fc5e89b51e756a4a3ac676315602ce2dac07acf1da959a22038d69b33"
+dependencies = [
+ "gix-hash 0.23.0",
  "hashbrown 0.16.1",
  "parking_lot",
 ]
@@ -1703,13 +2039,41 @@ dependencies = [
  "bstr",
  "filetime",
  "fnv",
- "gix-bitmap",
+ "gix-bitmap 0.2.16",
  "gix-features",
  "gix-fs",
- "gix-hash",
+ "gix-hash 0.22.1",
  "gix-lock",
- "gix-object",
- "gix-traverse",
+ "gix-object 0.55.0",
+ "gix-traverse 0.52.0",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap 0.3.1",
+ "gix-features",
+ "gix-fs",
+ "gix-hash 0.23.0",
+ "gix-lock",
+ "gix-object 0.58.0",
+ "gix-traverse 0.55.0",
  "gix-utils",
  "gix-validate",
  "hashbrown 0.16.1",
@@ -1733,19 +2097,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-merge"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4606747466512d22c2dffc019142e1941238f543987ea51353c938cca80c500"
+dependencies = [
+ "bstr",
+ "gix-command 0.8.1",
+ "gix-diff 0.61.0",
+ "gix-filter 0.28.0",
+ "gix-fs",
+ "gix-hash 0.23.0",
+ "gix-index 0.49.0",
+ "gix-object 0.58.0",
+ "gix-path",
+ "gix-quote 0.7.1",
+ "gix-revision 0.43.0",
+ "gix-revwalk 0.29.0",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree 0.50.0",
+ "imara-diff 0.1.8",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "gix-negotiate"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00dff6d49869f16b8900da7c27b886a45cbf641b1e45aab355d012afe4266b7f"
 dependencies = [
  "bitflags",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-object",
- "gix-revwalk",
+ "gix-commitgraph 0.32.0",
+ "gix-date 0.13.0",
+ "gix-hash 0.22.1",
+ "gix-object 0.55.0",
+ "gix-revwalk 0.26.0",
  "smallvec",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph 0.35.0",
+ "gix-date 0.15.3",
+ "gix-hash 0.23.0",
+ "gix-object 0.58.0",
+ "gix-revwalk 0.29.0",
 ]
 
 [[package]]
@@ -1755,11 +2159,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3f705c977d90ace597049252ae1d7fec907edc0fa7616cc91bf5508d0f4006"
 dependencies = [
  "bstr",
- "gix-actor",
- "gix-date",
+ "gix-actor 0.38.0",
+ "gix-date 0.13.0",
  "gix-features",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
+ "gix-path",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cafb802bb688a7c1e69ef965612ff5ff859f046bfb616377e4a0ba4c01e43d47"
+dependencies = [
+ "bstr",
+ "gix-actor 0.40.0",
+ "gix-date 0.15.3",
+ "gix-features",
+ "gix-hash 0.23.0",
+ "gix-hashtable 0.13.0",
  "gix-path",
  "gix-utils",
  "gix-validate",
@@ -1778,12 +2203,32 @@ dependencies = [
  "arc-swap",
  "gix-features",
  "gix-fs",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-pack",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
+ "gix-object 0.55.0",
+ "gix-pack 0.65.0",
  "gix-path",
- "gix-quote",
+ "gix-quote 0.6.2",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24833ae9323b4f7079575fb9f961cf9c414b0afbec428a536ab8e7dd93bc002b"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash 0.23.0",
+ "gix-hashtable 0.13.0",
+ "gix-object 0.58.0",
+ "gix-pack 0.68.0",
+ "gix-path",
+ "gix-quote 0.7.1",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.18",
@@ -1796,12 +2241,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c44db57ebbbeaad9972c2a60662142660427a1f0a7529314d53fefb4fedad24"
 dependencies = [
  "clru",
- "gix-chunk",
- "gix-error",
+ "gix-chunk 0.5.0",
+ "gix-error 0.0.0",
  "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
+ "gix-object 0.55.0",
  "gix-path",
  "gix-tempfile",
  "memmap2",
@@ -1809,6 +2254,25 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "uluru",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3484119cd19859d7d7639413c27e192478fa354d3f4ff5f7e3c041e8040f0f4"
+dependencies = [
+ "clru",
+ "gix-chunk 0.7.1",
+ "gix-error 0.2.3",
+ "gix-features",
+ "gix-hash 0.23.0",
+ "gix-hashtable 0.13.0",
+ "gix-object 0.58.0",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1843,7 +2307,22 @@ checksum = "c7f4cc23f55ca7c190bf243f1a4e2139d4522022f724fb0dfc06c93f65a01ef6"
 dependencies = [
  "bitflags",
  "bstr",
- "gix-attributes",
+ "gix-attributes 0.30.1",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-attributes 0.31.0",
  "gix-config-value",
  "gix-glob",
  "gix-path",
@@ -1856,7 +2335,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4806f1ebf969cd54d178ccd975911ef1829aeccea0b27630e63c9d26c8347d7f"
 dependencies = [
- "gix-command",
+ "gix-command 0.7.1",
  "gix-config-value",
  "parking_lot",
  "rustix",
@@ -1871,20 +2350,40 @@ checksum = "54f20837b0c70b65f6ac77886be033de3b69d5879f99128b47c42665ab0a17c2"
 dependencies = [
  "bstr",
  "gix-credentials",
- "gix-date",
+ "gix-date 0.13.0",
  "gix-features",
- "gix-hash",
+ "gix-hash 0.22.1",
  "gix-lock",
- "gix-negotiate",
- "gix-object",
- "gix-ref",
- "gix-refspec",
- "gix-revwalk",
- "gix-shallow",
+ "gix-negotiate 0.26.0",
+ "gix-object 0.55.0",
+ "gix-ref 0.58.0",
+ "gix-refspec 0.36.0",
+ "gix-revwalk 0.26.0",
+ "gix-shallow 0.8.1",
  "gix-trace",
- "gix-transport",
+ "gix-transport 0.53.0",
  "gix-utils",
  "maybe-async",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f38666350736b5877c79f57ddae02bde07a4ce186d889adc391e831cddcbe76"
+dependencies = [
+ "bstr",
+ "gix-date 0.15.3",
+ "gix-features",
+ "gix-hash 0.23.0",
+ "gix-ref 0.61.0",
+ "gix-shallow 0.10.0",
+ "gix-transport 0.55.1",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
  "thiserror 2.0.18",
  "winnow 0.7.15",
 ]
@@ -1901,17 +2400,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-quote"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+dependencies = [
+ "bstr",
+ "gix-error 0.2.3",
+ "gix-utils",
+]
+
+[[package]]
 name = "gix-ref"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cf780dcd9ac99fd3fcfc8523479a0e2ffd55f5e0be63e5e3248fb7e46cff966"
 dependencies = [
- "gix-actor",
+ "gix-actor 0.38.0",
  "gix-features",
  "gix-fs",
- "gix-hash",
+ "gix-hash 0.22.1",
  "gix-lock",
- "gix-object",
+ "gix-object 0.55.0",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2159978abb99b7027c8579d15211e262ef0ef2594d5cecb3334fbcbdfe2997c"
+dependencies = [
+ "gix-actor 0.40.0",
+ "gix-features",
+ "gix-fs",
+ "gix-hash 0.23.0",
+ "gix-lock",
+ "gix-object 0.58.0",
  "gix-path",
  "gix-tempfile",
  "gix-utils",
@@ -1928,10 +2459,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60ce400a770a7952e45267803192cc2d1fe0afa08e2c08dde32e04c7908c6e61"
 dependencies = [
  "bstr",
- "gix-error",
+ "gix-error 0.0.0",
  "gix-glob",
- "gix-hash",
- "gix-revision",
+ "gix-hash 0.22.1",
+ "gix-revision 0.40.0",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc806ee13f437428f8a1ba4c72ecfaa3f20e14f5f0d4c2bc17d0b33e794aa6ac"
+dependencies = [
+ "bstr",
+ "gix-error 0.2.3",
+ "gix-glob",
+ "gix-hash 0.23.0",
+ "gix-revision 0.43.0",
  "gix-validate",
  "smallvec",
  "thiserror 2.0.18",
@@ -1945,14 +2492,33 @@ checksum = "c719cf7d669439e1fca735bd1c4de54d43c5d30e8883fd6063c4924b213d70c9"
 dependencies = [
  "bitflags",
  "bstr",
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
+ "gix-commitgraph 0.32.0",
+ "gix-date 0.13.0",
+ "gix-error 0.0.0",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
+ "gix-object 0.55.0",
+ "gix-revwalk 0.26.0",
  "gix-trace",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-commitgraph 0.35.0",
+ "gix-date 0.15.3",
+ "gix-error 0.2.3",
+ "gix-hash 0.23.0",
+ "gix-hashtable 0.13.0",
+ "gix-object 0.58.0",
+ "gix-revwalk 0.29.0",
+ "gix-trace",
+ "nonempty",
 ]
 
 [[package]]
@@ -1961,12 +2527,28 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a50b30aa0c6e6de43c723359c5809a96275a3aa92d323ef7f58b1cdd60f16"
 dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
+ "gix-commitgraph 0.32.0",
+ "gix-date 0.13.0",
+ "gix-error 0.0.0",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
+ "gix-object 0.55.0",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4b2b87772b21ca449249e86d32febadba5cba32b0fcce804ab9cefc6f2111c"
+dependencies = [
+ "gix-commitgraph 0.35.0",
+ "gix-date 0.15.3",
+ "gix-error 0.2.3",
+ "gix-hash 0.23.0",
+ "gix-hashtable 0.13.0",
+ "gix-object 0.58.0",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -1990,8 +2572,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "189386b5da5285216cc0ede89eff5a943d5261fc794241ee6ec5360b77df15ad"
 dependencies = [
  "bstr",
- "gix-hash",
+ "gix-hash 0.22.1",
  "gix-lock",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf60711c9083b2364b3fac8a352444af76b17201f3682fdebe74fa66d89a772"
+dependencies = [
+ "bstr",
+ "gix-hash 0.23.0",
+ "gix-lock",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d6c598e3fdbc352fba1c5ba7e709e69402fafbc44d9295edad2e3c4738996b"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff 0.61.0",
+ "gix-dir",
+ "gix-features",
+ "gix-filter 0.28.0",
+ "gix-fs",
+ "gix-hash 0.23.0",
+ "gix-index 0.49.0",
+ "gix-object 0.58.0",
+ "gix-path",
+ "gix-pathspec 0.16.1",
+ "gix-worktree 0.50.0",
+ "portable-atomic",
  "thiserror 2.0.18",
 ]
 
@@ -2002,10 +2620,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db1840fe723c6264ee596e5a179e1b9a2df59351f09bae9cea570a472a790bc0"
 dependencies = [
  "bstr",
- "gix-config",
+ "gix-config 0.51.0",
  "gix-path",
- "gix-pathspec",
- "gix-refspec",
+ "gix-pathspec 0.15.1",
+ "gix-refspec 0.36.0",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5c3929c5e6821f651d35e8420f72fea3cfafe9fc1e928a61e718b462c72a5"
+dependencies = [
+ "bstr",
+ "gix-config 0.54.0",
+ "gix-path",
+ "gix-pathspec 0.16.1",
+ "gix-refspec 0.39.0",
  "gix-url",
  "thiserror 2.0.18",
 ]
@@ -2016,6 +2649,7 @@ version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
 dependencies = [
+ "dashmap",
  "gix-fs",
  "libc",
  "parking_lot",
@@ -2036,14 +2670,30 @@ checksum = "de1064c7ffa5a915014a6a5b71fbc5299462ae655348bed23e083b4a735076c3"
 dependencies = [
  "base64",
  "bstr",
- "gix-command",
+ "gix-command 0.7.1",
  "gix-credentials",
  "gix-features",
  "gix-packetline",
- "gix-quote",
+ "gix-quote 0.6.2",
  "gix-sec",
  "gix-url",
  "reqwest 0.13.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-transport"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a521e39c6235ce63ed6c001e2dd79818c830b82c3b7b59247ee7b229c39ec9bb"
+dependencies = [
+ "bstr",
+ "gix-command 0.8.1",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote 0.7.1",
+ "gix-sec",
+ "gix-url",
  "thiserror 2.0.18",
 ]
 
@@ -2054,12 +2704,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37f8b53b4c56b01c43a4491c4edfe2ce66c654eb86232205172ceb1650d21c55"
 dependencies = [
  "bitflags",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
+ "gix-commitgraph 0.32.0",
+ "gix-date 0.13.0",
+ "gix-hash 0.22.1",
+ "gix-hashtable 0.12.0",
+ "gix-object 0.55.0",
+ "gix-revwalk 0.26.0",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph 0.35.0",
+ "gix-date 0.15.3",
+ "gix-hash 0.23.0",
+ "gix-hashtable 0.13.0",
+ "gix-object 0.58.0",
+ "gix-revwalk 0.29.0",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -2082,6 +2749,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
 dependencies = [
+ "bstr",
  "fastrand",
  "unicode-normalization",
 ]
@@ -2102,13 +2770,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2ad658586ec0039b03e96c664f08b7cb7a2b7cca6947a9c856c9ed59b807b1"
 dependencies = [
  "bstr",
- "gix-attributes",
+ "gix-attributes 0.30.1",
  "gix-fs",
  "gix-glob",
- "gix-hash",
+ "gix-hash 0.22.1",
  "gix-ignore",
- "gix-index",
- "gix-object",
+ "gix-index 0.46.0",
+ "gix-object 0.55.0",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6bd5830cbc43c9c00918b826467d2afad685b195cb82329cde2b2d116d2c578"
+dependencies = [
+ "bstr",
+ "gix-attributes 0.31.0",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash 0.23.0",
+ "gix-ignore",
+ "gix-index 0.49.0",
+ "gix-object 0.58.0",
  "gix-path",
  "gix-validate",
 ]
@@ -2121,14 +2807,50 @@ checksum = "9895abc7654cbd8e102d6a765d3bdfa1567fcd5d2849b8e3d3da6405d64913c9"
 dependencies = [
  "bstr",
  "gix-features",
- "gix-filter",
+ "gix-filter 0.25.0",
  "gix-fs",
- "gix-index",
- "gix-object",
+ "gix-index 0.46.0",
+ "gix-object 0.55.0",
  "gix-path",
- "gix-worktree",
+ "gix-worktree 0.47.0",
  "io-close",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644a1681f96e1be43c2a8384337d9d220e7624f50db54beda70997052aebf707"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter 0.28.0",
+ "gix-fs",
+ "gix-index 0.49.0",
+ "gix-object 0.58.0",
+ "gix-path",
+ "gix-worktree 0.50.0",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e3fb70a1f650a5cec7d5b8d10d6d6fe86daf3cf15bde08ba0c70988a2932c3"
+dependencies = [
+ "gix-attributes 0.31.0",
+ "gix-error 0.2.3",
+ "gix-features",
+ "gix-filter 0.28.0",
+ "gix-fs",
+ "gix-hash 0.23.0",
+ "gix-object 0.58.0",
+ "gix-path",
+ "gix-traverse 0.55.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2182,6 +2904,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2526,6 +3254,25 @@ dependencies = [
  "tiff",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
+dependencies = [
+ "hashbrown 0.15.5",
+ "memchr",
 ]
 
 [[package]]
@@ -2936,6 +3683,12 @@ dependencies = [
  "memchr",
  "nom",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "normalize-line-endings"
@@ -3727,7 +4480,7 @@ dependencies = [
  "cargo-lock",
  "cvss",
  "fs-err",
- "gix",
+ "gix 0.78.0",
  "home",
  "once_cell",
  "platforms",
@@ -4066,6 +4819,8 @@ dependencies = [
  "dirs",
  "docx-rs",
  "futures-util",
+ "git-meta-lib",
+ "gix 0.81.0",
  "ignore",
  "indicatif",
  "lopdf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,11 @@ dirs = "6"
 # SQLite
 rusqlite = { version = "0.39", features = ["bundled"] }
 
+# Zero-infrastructure memory backend: SQLite in .git/ + refs/meta/ for push/fetch
+git-meta-lib = "0.1.9"
+# gix is a transitive dep of git-meta-lib; declared directly to call Session::open()
+gix = { version = "0.81.0", default-features = false }
+
 # Vector extension for SQLite
 sqlite-vec = "0.1"
 

--- a/src/cli/cmd/memory/mod.rs
+++ b/src/cli/cmd/memory/mod.rs
@@ -11,7 +11,7 @@ pub struct MemoryArgs {
     #[arg(long, global = true)]
     pub db: Option<PathBuf>,
 
-    /// Storage backend: sqlite (default) or git-notes
+    /// Storage backend: sqlite (default), git-meta, or git-notes
     #[arg(long, global = true, default_value = "sqlite", value_name = "BACKEND")]
     pub backend: String,
 }
@@ -314,6 +314,7 @@ pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> 
 /// Returns `None` for the default "sqlite" to fall through to config-based dispatch.
 fn backend_override(s: &str) -> Option<&'static str> {
     match s {
+        "git-meta" => Some("git-meta"),
         "git-notes" => Some("git-notes"),
         _ => None,
     }
@@ -423,13 +424,14 @@ pub(super) use crate::utils::dates::parse_as_of;
 
 /// Convert a `BackendUnsupported` error into a user-friendly message.
 /// Pass as `.map_err(backend_err)?` at each call site that invokes an
-/// unsupported git-notes method.
+/// unsupported method on a limited backend.
 pub(super) fn backend_err(e: anyhow::Error) -> anyhow::Error {
     if e.downcast_ref::<crate::error::SpelunkError>()
         .is_some_and(|s| matches!(s, crate::error::SpelunkError::BackendUnsupported(_)))
     {
         anyhow::anyhow!(
-            "This operation requires the sqlite backend. Re-run without --backend git-notes."
+            "This operation requires the sqlite backend. \
+             Re-run without --backend git-meta or --backend git-notes."
         )
     } else {
         e

--- a/src/storage/git_meta.rs
+++ b/src/storage/git_meta.rs
@@ -82,7 +82,7 @@ fn read_records(session: &Session) -> Result<Vec<NoteRecord>> {
 
     // Return newest-first by id (id = now_millis() at insert time, so higher = newer)
     let mut records: Vec<NoteRecord> = by_id.into_values().map(|(_, r)| r).collect();
-    records.sort_by(|a, b| b.id.cmp(&a.id));
+    records.sort_by_key(|r| std::cmp::Reverse(r.id));
     Ok(records)
 }
 

--- a/src/storage/git_meta.rs
+++ b/src/storage/git_meta.rs
@@ -1,0 +1,342 @@
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use git_meta_lib::{Session, Target};
+
+use super::backend::{MemoryBackend, NoteInput};
+use super::memory::{MemoryEdge, Note};
+use super::note_record::{NoteRecord, now_millis, now_secs, record_to_note};
+
+const SPELUNK_KEY: &str = "spelunk:entries";
+
+pub struct GitMetaBackend {
+    /// If `Some`, pin session to this directory (for tests).
+    /// If `None`, use `Session::discover()` from the current directory.
+    root: Option<PathBuf>,
+}
+
+impl Default for GitMetaBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GitMetaBackend {
+    pub fn new() -> Self {
+        Self { root: None }
+    }
+
+    pub fn with_root(root: PathBuf) -> Self {
+        Self { root: Some(root) }
+    }
+}
+
+fn open_session(root: &Option<PathBuf>) -> Result<Session> {
+    match root {
+        Some(path) => {
+            let repo = gix::open(path).map_err(|e| anyhow!("git-meta: open repo: {e}"))?;
+            Session::open(repo).map_err(|e| anyhow!("git-meta: open session: {e}"))
+        }
+        None => Session::discover().map_err(|e| anyhow!("git-meta: discover session: {e}")),
+    }
+}
+
+/// Deserialize all list entries and deduplicate by id, keeping the entry with
+/// the highest `ListEntry.timestamp` for each id (handles append-only archive updates).
+fn read_records(session: &Session) -> Result<Vec<NoteRecord>> {
+    let handle = session.target(&Target::project());
+    let entries = handle
+        .list_entries(SPELUNK_KEY)
+        .map_err(|e| anyhow!("git-meta: list_entries: {e}"))?;
+
+    let mut by_id: std::collections::HashMap<i64, (i64, NoteRecord)> =
+        std::collections::HashMap::new();
+
+    for entry in entries {
+        let record: NoteRecord = serde_json::from_str(&entry.value)
+            .map_err(|e| anyhow!("git-meta: deserialize record: {e}"))?;
+
+        if record.schema_version > 1 {
+            return Err(anyhow::Error::new(
+                crate::error::SpelunkError::SchemaMismatch {
+                    found: record.schema_version,
+                    max_known: 1,
+                },
+            ));
+        }
+
+        let ts = entry.timestamp;
+        match by_id.entry(record.id) {
+            std::collections::hash_map::Entry::Vacant(v) => {
+                v.insert((ts, record));
+            }
+            std::collections::hash_map::Entry::Occupied(mut o) => {
+                if ts > o.get().0 {
+                    o.insert((ts, record));
+                }
+            }
+        }
+    }
+
+    // Return newest-first by id (id = now_millis() at insert time, so higher = newer)
+    let mut records: Vec<NoteRecord> = by_id.into_values().map(|(_, r)| r).collect();
+    records.sort_by(|a, b| b.id.cmp(&a.id));
+    Ok(records)
+}
+
+#[async_trait]
+impl MemoryBackend for GitMetaBackend {
+    async fn add(&self, input: NoteInput) -> Result<i64> {
+        let root = self.root.clone();
+        tokio::task::spawn_blocking(move || {
+            let session = open_session(&root)?;
+            let id = now_millis();
+            let record = NoteRecord {
+                schema_version: 1,
+                id,
+                kind: input.kind,
+                title: input.title,
+                body: input.body,
+                tags: input.tags,
+                linked_files: input.linked_files,
+                created_at: now_secs(),
+                status: "active".to_string(),
+                source_ref: input.source_ref,
+                valid_at: input.valid_at,
+                invalid_at: None,
+                superseded_by: None,
+            };
+            let json = serde_json::to_string(&record)?;
+            let handle = session.target(&Target::project());
+            handle
+                .list_push(SPELUNK_KEY, &json)
+                .map_err(|e| anyhow!("git-meta: list_push: {e}"))?;
+            Ok(id)
+        })
+        .await?
+    }
+
+    async fn list(
+        &self,
+        kind_filter: Option<&str>,
+        limit: usize,
+        include_archived: bool,
+        as_of: Option<i64>,
+    ) -> Result<Vec<Note>> {
+        let root = self.root.clone();
+        let kind_filter = kind_filter.map(str::to_owned);
+        tokio::task::spawn_blocking(move || {
+            let session = open_session(&root)?;
+            let records = read_records(&session)?;
+            let notes = records
+                .into_iter()
+                .filter(|r| kind_filter.as_deref().is_none_or(|k| r.kind == k))
+                .filter(|r| include_archived || r.status != "archived")
+                .filter(|r| {
+                    if let Some(ts) = as_of {
+                        let effective = r.valid_at.unwrap_or(r.created_at);
+                        if effective > ts {
+                            return false;
+                        }
+                        if r.invalid_at.is_some_and(|ia| ia <= ts) {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .take(limit)
+                .map(record_to_note)
+                .collect();
+            Ok(notes)
+        })
+        .await?
+    }
+
+    async fn get(&self, id: i64) -> Result<Option<Note>> {
+        let root = self.root.clone();
+        tokio::task::spawn_blocking(move || {
+            let session = open_session(&root)?;
+            let records = read_records(&session)?;
+            Ok(records.into_iter().find(|r| r.id == id).map(record_to_note))
+        })
+        .await?
+    }
+
+    async fn count(&self) -> Result<i64> {
+        let root = self.root.clone();
+        tokio::task::spawn_blocking(move || {
+            let session = open_session(&root)?;
+            Ok(read_records(&session)?.len() as i64)
+        })
+        .await?
+    }
+
+    async fn archive(&self, id: i64) -> Result<bool> {
+        let root = self.root.clone();
+        tokio::task::spawn_blocking(move || {
+            let session = open_session(&root)?;
+            let records = read_records(&session)?;
+            let Some(mut record) = records.into_iter().find(|r| r.id == id) else {
+                return Ok(false);
+            };
+            record.status = "archived".to_string();
+            let json = serde_json::to_string(&record)?;
+            let handle = session.target(&Target::project());
+            handle
+                .list_push(SPELUNK_KEY, &json)
+                .map_err(|e| anyhow!("git-meta: list_push (archive): {e}"))?;
+            Ok(true)
+        })
+        .await?
+    }
+
+    // ── Unsupported ──────────────────────────────────────────────────────────
+
+    async fn search_timeline(&self, _query_blob: &[u8], _limit: usize) -> Result<Vec<Note>> {
+        Err(crate::error::SpelunkError::BackendUnsupported("search_timeline".into()).into())
+    }
+
+    async fn search(
+        &self,
+        _query_blob: &[u8],
+        _limit: usize,
+        _as_of: Option<i64>,
+    ) -> Result<Vec<Note>> {
+        Err(crate::error::SpelunkError::BackendUnsupported("search".into()).into())
+    }
+
+    async fn search_text(
+        &self,
+        _query: &str,
+        _limit: usize,
+        _as_of: Option<i64>,
+    ) -> Result<Vec<Note>> {
+        Err(crate::error::SpelunkError::BackendUnsupported("search_text".into()).into())
+    }
+
+    async fn search_hybrid(
+        &self,
+        _query_blob: &[u8],
+        _query: &str,
+        _limit: usize,
+        _as_of: Option<i64>,
+    ) -> Result<Vec<Note>> {
+        Err(crate::error::SpelunkError::BackendUnsupported("search_hybrid".into()).into())
+    }
+
+    async fn list_by_source_ref(
+        &self,
+        _source_ref_prefix: &str,
+        _limit: usize,
+        _include_archived: bool,
+        _as_of: Option<i64>,
+    ) -> Result<Vec<Note>> {
+        Err(crate::error::SpelunkError::BackendUnsupported("list_by_source_ref".into()).into())
+    }
+
+    async fn supersede(&self, _old_id: i64, _new_id: i64) -> Result<bool> {
+        Err(crate::error::SpelunkError::BackendUnsupported("supersede".into()).into())
+    }
+
+    async fn harvested_shas(&self) -> Result<HashSet<String>> {
+        Err(crate::error::SpelunkError::BackendUnsupported("harvested_shas".into()).into())
+    }
+
+    async fn has_source_ref(&self, _sha: &str) -> Result<bool> {
+        Err(crate::error::SpelunkError::BackendUnsupported("has_source_ref".into()).into())
+    }
+
+    async fn add_edge(&self, _from_id: i64, _to_id: i64, _kind: &str) -> Result<()> {
+        Err(crate::error::SpelunkError::BackendUnsupported("add_edge".into()).into())
+    }
+
+    async fn get_edges(&self, _id: i64) -> Result<(Vec<MemoryEdge>, Vec<MemoryEdge>)> {
+        Err(crate::error::SpelunkError::BackendUnsupported("get_edges".into()).into())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::storage::backend::NoteInput;
+
+    fn make_temp_repo() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        let path = dir.path().to_path_buf();
+        (dir, path)
+    }
+
+    fn input(kind: &str, title: &str) -> NoteInput {
+        NoteInput {
+            kind: kind.to_string(),
+            title: title.to_string(),
+            body: "body".to_string(),
+            tags: vec![],
+            linked_files: vec![],
+            embedding: None,
+            source_ref: None,
+            valid_at: None,
+            supersedes: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_add_and_list() {
+        let (_dir, path) = make_temp_repo();
+        let backend = GitMetaBackend::with_root(path);
+        backend.add(input("decision", "alpha")).await.unwrap();
+        backend.add(input("decision", "beta")).await.unwrap();
+        backend.add(input("decision", "gamma")).await.unwrap();
+
+        let notes = backend.list(None, 100, false, None).await.unwrap();
+        assert_eq!(notes.len(), 3);
+        // newest first
+        assert_eq!(notes[0].title, "gamma");
+        assert_eq!(notes[2].title, "alpha");
+    }
+
+    #[tokio::test]
+    async fn test_list_kind_filter() {
+        let (_dir, path) = make_temp_repo();
+        let backend = GitMetaBackend::with_root(path);
+        backend.add(input("decision", "a decision")).await.unwrap();
+        backend.add(input("note", "a note")).await.unwrap();
+
+        let notes = backend.list(Some("note"), 100, false, None).await.unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].title, "a note");
+    }
+
+    #[tokio::test]
+    async fn test_archive_hides_entry() {
+        let (_dir, path) = make_temp_repo();
+        let backend = GitMetaBackend::with_root(path);
+        let id = backend.add(input("decision", "to archive")).await.unwrap();
+        assert!(backend.archive(id).await.unwrap());
+
+        let notes = backend.list(None, 100, false, None).await.unwrap();
+        assert!(notes.is_empty());
+
+        let all = backend.list(None, 100, true, None).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].status, "archived");
+    }
+}

--- a/src/storage/git_notes.rs
+++ b/src/storage/git_notes.rs
@@ -1,12 +1,11 @@
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::process::Command;
 
 use super::backend::{MemoryBackend, NoteInput};
 use super::memory::{MemoryEdge, Note};
+use super::note_record::{NoteRecord, now_millis, now_secs, record_to_note};
 
 /// Hard cap on entries returned by `list()`.
 ///
@@ -14,32 +13,6 @@ use super::memory::{MemoryEdge, Note};
 /// Without a guard, `list(5000)` would take ~65 seconds.
 /// Callers needing unbounded listing should use `--backend sqlite`.
 const GIT_NOTES_MAX_LIST: usize = 500;
-
-/// Serialised form stored inside a git note blob.
-///
-/// `schema_version` 0 = legacy (field absent in old blobs), 1 = current.
-#[derive(Debug, Serialize, Deserialize)]
-struct NoteRecord {
-    /// Absent in legacy blobs — treated as version 0 via `#[serde(default)]`.
-    #[serde(default)]
-    schema_version: u8,
-    id: i64,
-    kind: String,
-    title: String,
-    body: String,
-    tags: Vec<String>,
-    linked_files: Vec<String>,
-    created_at: i64,
-    status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    source_ref: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    valid_at: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    invalid_at: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    superseded_by: Option<i64>,
-}
 
 /// Memory backend backed by `git notes` in the `refs/notes/spelunk` namespace.
 ///
@@ -208,39 +181,6 @@ impl GitNotesBackend {
 
         Ok(notes)
     }
-}
-
-fn record_to_note(r: NoteRecord) -> Note {
-    Note {
-        id: r.id,
-        kind: r.kind,
-        title: r.title,
-        body: r.body,
-        tags: r.tags,
-        linked_files: r.linked_files,
-        created_at: r.created_at,
-        status: r.status,
-        superseded_by: r.superseded_by,
-        source_ref: r.source_ref,
-        valid_at: r.valid_at,
-        invalid_at: r.invalid_at,
-        distance: None,
-        score: None,
-    }
-}
-
-fn now_secs() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64
-}
-
-fn now_millis() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as i64
 }
 
 #[async_trait]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,7 +1,9 @@
 pub mod backend;
 pub mod db;
+pub mod git_meta;
 pub mod git_notes;
 pub mod memory;
+pub mod note_record;
 pub mod remote;
 
 // Storage sub-modules: each holds impl blocks for Database or standalone types.
@@ -16,6 +18,7 @@ mod stats;
 pub use backend::{LocalMemoryBackend, MemoryBackend, NoteInput};
 pub use db::Database;
 pub use files::FileRecord;
+pub use git_meta::GitMetaBackend;
 pub use git_notes::GitNotesBackend;
 pub use graph::GraphEdge;
 pub use memory::{MemoryEdge, MemoryStore};
@@ -30,14 +33,18 @@ use std::path::Path;
 /// Open the appropriate memory backend.
 ///
 /// Priority:
-/// 1. `backend_override = Some("git-notes")` → `GitNotesBackend`
-/// 2. `memory_server_url` set in config → `RemoteMemoryBackend`
-/// 3. Otherwise → local SQLite at `mem_path`
+/// 1. `backend_override = Some("git-meta")` → `GitMetaBackend`
+/// 2. `backend_override = Some("git-notes")` → `GitNotesBackend`
+/// 3. `memory_server_url` set in config → `RemoteMemoryBackend`
+/// 4. Otherwise → local SQLite at `mem_path`
 pub fn open_memory_backend(
     cfg: &crate::config::Config,
     mem_path: &Path,
     backend_override: Option<&str>,
 ) -> Result<Box<dyn MemoryBackend + Send>> {
+    if backend_override == Some("git-meta") {
+        return Ok(Box::new(GitMetaBackend::new()));
+    }
     if backend_override == Some("git-notes") {
         return Ok(Box::new(GitNotesBackend::new()));
     }

--- a/src/storage/note_record.rs
+++ b/src/storage/note_record.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::memory::Note;
+
+/// Serialised form stored as JSON in a memory backend (git-notes blob or git-meta list entry).
+///
+/// `schema_version` 0 = legacy (field absent in old blobs), 1 = current.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NoteRecord {
+    /// Absent in legacy blobs — treated as version 0 via `#[serde(default)]`.
+    #[serde(default)]
+    pub schema_version: u8,
+    pub id: i64,
+    pub kind: String,
+    pub title: String,
+    pub body: String,
+    pub tags: Vec<String>,
+    pub linked_files: Vec<String>,
+    pub created_at: i64,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invalid_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<i64>,
+}
+
+pub fn record_to_note(r: NoteRecord) -> Note {
+    Note {
+        id: r.id,
+        kind: r.kind,
+        title: r.title,
+        body: r.body,
+        tags: r.tags,
+        linked_files: r.linked_files,
+        created_at: r.created_at,
+        status: r.status,
+        superseded_by: r.superseded_by,
+        source_ref: r.source_ref,
+        valid_at: r.valid_at,
+        invalid_at: r.invalid_at,
+        distance: None,
+        score: None,
+    }
+}
+
+pub fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+pub fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}


### PR DESCRIPTION
## Summary

- Adds `GitMetaBackend` in `src/storage/git_meta.rs` backed by git-meta-lib 0.1.9 (SQLite WAL in `.git/git-meta.sqlite`, refs/meta/ for push/fetch)
- Extracts `NoteRecord` to `src/storage/note_record.rs` — shared by both git-notes and git-meta backends
- Wires `--backend git-meta` in `open_memory_backend()` and CLI
- 3 unit tests: add+list, kind filter, archive hides entry

Closes #198

## Supported operations
`add`, `list` (kind/archived/as_of filters), `get`, `count`, `archive`

## Unsupported (BackendUnsupported)
`search*`, `supersede`, `harvested_shas`, `has_source_ref`, `add_edge`, `get_edges`, `list_by_source_ref`

## Test plan
- [x] `cargo test --lib storage::git_meta` — 3/3 pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)