### PR TITLE
feat(#201): add spelunk context command as agent session entry point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,23 +73,18 @@ src/
     mod.rs         — clap structs (Cli, Command, *Args)
     cmd/
       mod.rs       — re-exports one pub fn per subcommand
-      ask.rs       — `spelunk ask` handler
       check.rs     — `spelunk check` handler
+      context.rs   — `spelunk context` handler (agent session entry point)
       explore.rs   — `spelunk explore` handler
       graph.rs     — `spelunk graph` handler
       helpers.rs   — shared output / progress helpers
-      history.rs   — `spelunk history` handler
       hooks.rs     — `spelunk hooks` handler
       init.rs      — `spelunk init` handler
       link.rs      — `spelunk link/unlink/autoclean` handlers
       links.rs     — `spelunk links` handler
       misc.rs      — `spelunk chunks` / `spelunk languages` handlers
-      plan.rs      — `spelunk plan` handler
       search.rs    — `spelunk search` handler
-      snapshot.rs  — `spelunk snapshot` handler
-      spec.rs      — `spelunk spec` handler
       status.rs    — `spelunk status` handler
-      verify.rs    — `spelunk verify` handler
       ui.rs        — TUI helpers (private)
       index/
         mod.rs         — `spelunk index` entry point

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -39,18 +39,18 @@ At the start of a session, orient yourself:
 # Check the index is fresh
 spelunk check
 
-# Review open questions from previous sessions
-AGENT=true spelunk memory list --kind question
-
-# Review recent handoff notes
-AGENT=true spelunk memory list --kind handoff --limit 5
-
-# Understand what's been decided
-AGENT=true spelunk memory search "architecture decisions"
+# Pull handoffs, open questions, decisions, and requirements in one shot
+spelunk context
 
 # Check antipatterns — things to avoid repeating
 AGENT=true spelunk memory failures
 ```
+
+`spelunk context` replaces the old multi-command sequence. It prints the four
+most agent-relevant memory sections (handoffs, open questions, decisions,
+requirements) sorted newest-first with per-section defaults. Add `--format json`
+for machine-readable output, `--kind decision` to narrow to one section, or
+`--path src/auth` to filter to entries tagged with a specific path.
 
 ## Searching before writing
 
@@ -197,7 +197,7 @@ spelunk memory add \
 At the start of the next session, read it:
 
 ```bash
-AGENT=true spelunk memory list --kind handoff --limit 3
+spelunk context
 ```
 
 ## Multi-agent coordination

--- a/src/cli/cmd/context.rs
+++ b/src/cli/cmd/context.rs
@@ -1,0 +1,129 @@
+use anyhow::Result;
+use clap::Args;
+use std::path::PathBuf;
+
+use super::memory::print_note_summary;
+use crate::storage::memory::Note;
+use crate::{config::Config, storage::open_memory_backend};
+
+/// Agent-facing entry-point command: pull the most relevant memory sections
+/// in one shot (handoffs → questions → decisions → requirements).
+#[derive(Args, Debug)]
+pub struct ContextArgs {
+    /// Path to the memory database (overrides auto-detect)
+    #[arg(long)]
+    pub db: Option<PathBuf>,
+
+    /// Storage backend: sqlite (default), git-meta, or git-notes
+    #[arg(long, default_value = "sqlite", value_name = "BACKEND")]
+    pub backend: String,
+
+    /// Filter to a specific kind instead of the default multi-section view
+    #[arg(short, long, value_name = "KIND")]
+    pub kind: Option<String>,
+
+    /// Maximum entries per section (defaults: handoff=3, question=all, decision=10, requirement=all)
+    #[arg(short, long, value_name = "N")]
+    pub limit: Option<usize>,
+
+    /// Output format: text or json
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+struct Section {
+    kind: &'static str,
+    default_limit: usize,
+}
+
+const SECTIONS: &[Section] = &[
+    Section {
+        kind: "handoff",
+        default_limit: 3,
+    },
+    Section {
+        kind: "question",
+        default_limit: 1000,
+    },
+    Section {
+        kind: "decision",
+        default_limit: 10,
+    },
+    Section {
+        kind: "requirement",
+        default_limit: 1000,
+    },
+];
+
+pub async fn context(args: ContextArgs, cfg: Config) -> Result<()> {
+    cfg.validate()?;
+    let mem_path = args.db.clone().unwrap_or_else(|| {
+        crate::config::resolve_db(None, &cfg.db_path).with_file_name("memory.db")
+    });
+    let be = match args.backend.as_str() {
+        "git-meta" => Some("git-meta"),
+        "git-notes" => Some("git-notes"),
+        _ => None,
+    };
+    let backend = open_memory_backend(&cfg, &mem_path, be)?;
+
+    match crate::utils::effective_format(&args.format) {
+        "json" => {
+            let sections = collect_sections(&*backend, args.kind.as_deref(), args.limit).await?;
+            println!("{}", serde_json::to_string_pretty(&sections)?);
+        }
+        _ => {
+            let sections = collect_sections(&*backend, args.kind.as_deref(), args.limit).await?;
+            for (kind, notes) in &sections {
+                if notes.is_empty() {
+                    continue;
+                }
+                print_section_header(kind);
+                for n in notes {
+                    print_note_summary(n);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn collect_sections(
+    backend: &dyn crate::storage::MemoryBackend,
+    kind_filter: Option<&str>,
+    limit_override: Option<usize>,
+) -> Result<Vec<(String, Vec<Note>)>> {
+    let mut result = Vec::new();
+
+    let sections: Vec<(&str, usize)> = if let Some(k) = kind_filter {
+        let default_limit = SECTIONS
+            .iter()
+            .find(|s| s.kind == k)
+            .map(|s| s.default_limit)
+            .unwrap_or(20);
+        vec![(k, limit_override.unwrap_or(default_limit))]
+    } else {
+        SECTIONS
+            .iter()
+            .map(|s| (s.kind, limit_override.unwrap_or(s.default_limit)))
+            .collect()
+    };
+
+    for (kind, limit) in sections {
+        let notes = backend.list(Some(kind), limit, false, None).await?;
+        result.push((kind.to_string(), notes));
+    }
+    Ok(result)
+}
+
+fn print_section_header(kind: &str) {
+    let label = match kind {
+        "handoff" => "Handoffs",
+        "question" => "Open questions",
+        "decision" => "Decisions",
+        "requirement" => "Requirements",
+        other => other,
+    };
+    println!("\x1b[1;34m── {label} \x1b[0m");
+    println!();
+}

--- a/src/cli/cmd/context.rs
+++ b/src/cli/cmd/context.rs
@@ -6,6 +6,9 @@ use super::memory::print_note_summary;
 use crate::storage::memory::Note;
 use crate::{config::Config, storage::open_memory_backend};
 
+/// Fallback per-section limit when `--kind` names a kind not in SECTIONS.
+const DEFAULT_UNKNOWN_KIND_LIMIT: usize = 20;
+
 /// Agent-facing entry-point command: pull the most relevant memory sections
 /// in one shot (handoffs → questions → decisions → requirements).
 #[derive(Args, Debug)]
@@ -22,9 +25,13 @@ pub struct ContextArgs {
     #[arg(short, long, value_name = "KIND")]
     pub kind: Option<String>,
 
-    /// Maximum entries per section (defaults: handoff=3, question=all, decision=10, requirement=all)
+    /// Maximum entries per section (defaults: handoff=3, question=500, decision=10, requirement=500)
     #[arg(short, long, value_name = "N")]
     pub limit: Option<usize>,
+
+    /// Only show entries tagged with this file or directory path
+    #[arg(long, value_name = "PATH")]
+    pub path: Option<String>,
 
     /// Output format: text or json
     #[arg(long, default_value = "text")]
@@ -33,6 +40,7 @@ pub struct ContextArgs {
 
 struct Section {
     kind: &'static str,
+    /// Fetch this many entries before optional path post-filter; 500 is the NoteStore hard-cap.
     default_limit: usize,
 }
 
@@ -43,7 +51,7 @@ const SECTIONS: &[Section] = &[
     },
     Section {
         kind: "question",
-        default_limit: 1000,
+        default_limit: 500,
     },
     Section {
         kind: "decision",
@@ -51,7 +59,7 @@ const SECTIONS: &[Section] = &[
     },
     Section {
         kind: "requirement",
-        default_limit: 1000,
+        default_limit: 500,
     },
 ];
 
@@ -67,13 +75,17 @@ pub async fn context(args: ContextArgs, cfg: Config) -> Result<()> {
     };
     let backend = open_memory_backend(&cfg, &mem_path, be)?;
 
+    let sections = collect_sections(
+        &*backend,
+        args.kind.as_deref(),
+        args.limit,
+        args.path.as_deref(),
+    )
+    .await?;
+
     match crate::utils::effective_format(&args.format) {
-        "json" => {
-            let sections = collect_sections(&*backend, args.kind.as_deref(), args.limit).await?;
-            println!("{}", serde_json::to_string_pretty(&sections)?);
-        }
+        "json" => println!("{}", serde_json::to_string(&sections)?),
         _ => {
-            let sections = collect_sections(&*backend, args.kind.as_deref(), args.limit).await?;
             for (kind, notes) in &sections {
                 if notes.is_empty() {
                     continue;
@@ -92,6 +104,7 @@ async fn collect_sections(
     backend: &dyn crate::storage::MemoryBackend,
     kind_filter: Option<&str>,
     limit_override: Option<usize>,
+    path_filter: Option<&str>,
 ) -> Result<Vec<(String, Vec<Note>)>> {
     let mut result = Vec::new();
 
@@ -100,7 +113,7 @@ async fn collect_sections(
             .iter()
             .find(|s| s.kind == k)
             .map(|s| s.default_limit)
-            .unwrap_or(20);
+            .unwrap_or(DEFAULT_UNKNOWN_KIND_LIMIT);
         vec![(k, limit_override.unwrap_or(default_limit))]
     } else {
         SECTIONS
@@ -110,7 +123,10 @@ async fn collect_sections(
     };
 
     for (kind, limit) in sections {
-        let notes = backend.list(Some(kind), limit, false, None).await?;
+        let mut notes = backend.list(Some(kind), limit, false, None).await?;
+        if let Some(p) = path_filter {
+            notes.retain(|n| n.linked_files.iter().any(|f| f.contains(p)));
+        }
         result.push((kind.to_string(), notes));
     }
     Ok(result)

--- a/src/cli/cmd/init.rs
+++ b/src/cli/cmd/init.rs
@@ -114,7 +114,54 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
         }
     };
 
-    // ── 6. Print success summary ──────────────────────────────────────────────
+    // ── 6. Write CLAUDE.md if missing ─────────────────────────────────────────
+    let claude_md_path = project_root.join("CLAUDE.md");
+    if !claude_md_path.exists() {
+        let claude_md = format!(
+            "# CLAUDE.md — {name}\n\
+             \n\
+             Developer guide for AI agents working on this codebase.\n\
+             \n\
+             ---\n\
+             \n\
+             ## Agent workflow\n\
+             \n\
+             This project is indexed with spelunk. Use it — don't just use Read/Grep/Glob.\n\
+             \n\
+             **At the start of every session:**\n\
+             ```bash\n\
+             spelunk check                 # verify index is fresh\n\
+             spelunk context               # review handoffs, open questions, decisions, requirements\n\
+             ```\n\
+             \n\
+             **Before reading any file, search first:**\n\
+             ```bash\n\
+             spelunk search \"<topic>\"      # find relevant chunks by meaning\n\
+             spelunk graph <symbol>        # trace callers/callees when needed\n\
+             ```\n\
+             \n\
+             **Store decisions as you make them:**\n\
+             ```bash\n\
+             spelunk memory add --kind decision --title \"...\" --body \"why, alternatives, tradeoffs\"\n\
+             spelunk memory add --kind requirement --title \"...\"\n\
+             spelunk memory add --kind note --title \"...\"      # surprising/non-obvious facts\n\
+             ```\n\
+             \n\
+             **At the end of every session:**\n\
+             ```bash\n\
+             spelunk memory add --kind handoff --title \"Handoff: <summary>\" --body \"done, next, open\"\n\
+             spelunk index .               # re-index after any commits\n\
+             ```\n",
+            name = project_name
+        );
+        if let Err(e) = std::fs::write(&claude_md_path, claude_md) {
+            eprintln!("Warning: could not write CLAUDE.md: {e}");
+        } else {
+            println!("  CLAUDE.md written to {}", claude_md_path.display());
+        }
+    }
+
+    // ── 7. Print success summary ──────────────────────────────────────────────
     println!();
     println!("spelunk initialised for {}", project_name);
     println!();
@@ -124,7 +171,7 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
     println!();
     println!("Next steps:");
     println!("  spelunk search \"your query\"");
-    println!("  spelunk ask \"how does X work?\"");
+    println!("  spelunk context");
 
     Ok(())
 }

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod check;
+pub mod context;
 pub mod explore;
 pub mod graph;
 pub mod helpers;
@@ -15,6 +16,7 @@ pub mod status;
 mod ui;
 
 pub use check::check;
+pub use context::context;
 pub use explore::explore;
 pub use graph::graph;
 pub use hooks::hooks;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub mod cmd;
 // Sub-command Args types (Memory*Args, Plumbing*Args, etc.) are accessed via
 // their owning modules (e.g. `crate::cli::cmd::memory::MemoryAddArgs`) when needed.
 pub use cmd::check::CheckArgs;
+pub use cmd::context::ContextArgs;
 pub use cmd::explore::ExploreArgs;
 pub use cmd::graph::GraphArgs;
 pub use cmd::hooks::HooksArgs;
@@ -43,6 +44,8 @@ pub enum Command {
     Status(StatusArgs),
     /// Check whether the index is in sync with the current source tree (exit 1 if stale)
     Check(CheckArgs),
+    /// Print agent session context: handoffs, open questions, decisions, and requirements
+    Context(ContextArgs),
     /// List supported languages
     Languages,
     /// Query the code graph (imports, calls, extends/implements)

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ async fn main() -> Result<()> {
         Command::Search(args) => cli::cmd::search(args, cfg).await,
         Command::Status(args) => cli::cmd::status(args, cfg).await,
         Command::Check(args) => cli::cmd::check(args, cfg).await,
+        Command::Context(args) => cli::cmd::context(args, cfg).await,
         Command::Languages => cli::cmd::languages(),
         Command::Graph(args) => cli::cmd::graph(args, cfg),
         Command::Chunks(args) => cli::cmd::chunks(args, cfg),

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -1,0 +1,510 @@
+//! Component tests for `spelunk context` (#206).
+//!
+//! Tests the porcelain `context` command which serves as the agent session
+//! entry point, printing handoffs, open questions, decisions, and requirements
+//! in one shot.
+
+use assert_cmd::Command;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Set up a temp project with a mock embedding server, indexed fixture, and
+/// pre-seeded memory entries of multiple kinds.
+///
+/// Returns `(TempDir, db_path, config_path)`.  The TempDir must stay alive
+/// for the duration of the test.
+fn setup_context_project() -> (TempDir, PathBuf, PathBuf) {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let tmp = TempDir::new().expect("create temp dir");
+    let db_path = tmp.path().join("spelunk.db");
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mock_server = rt.block_on(async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{ "embedding": vec![0.1f32; 768], "index": 0 }],
+                "model": "test-model",
+                "object": "list",
+                "usage": { "prompt_tokens": 5, "total_tokens": 5 }
+            })))
+            .mount(&server)
+            .await;
+        server
+    });
+
+    let mock_url = mock_server.uri();
+    let config_path = write_config_for_context(tmp.path(), &db_path, &mock_url);
+
+    // The memory DB lives next to the main DB.
+    let mem_path = db_path.with_file_name("memory.db");
+
+    // Seed memory entries of different kinds.
+    let entries: &[(&str, &str, &str)] = &[
+        (
+            "handoff",
+            "Handoff: session #1",
+            "Implemented the context command. Next: tests and docs.",
+        ),
+        (
+            "handoff",
+            "Handoff: session #2",
+            "Reviewed PR #134. Fixed 5 CI blockers.",
+        ),
+        (
+            "decision",
+            "Use sqlite for memory backend",
+            "Chose sqlite over git-notes for performance.",
+        ),
+        (
+            "decision",
+            "NDJSON for plumbing output",
+            "All plumbing commands emit NDJSON, one object per line.",
+        ),
+        (
+            "decision",
+            "Context command design",
+            "spelunk context replaces three separate memory list calls for agent workflow.",
+        ),
+        (
+            "question",
+            "Should we support remote backends?",
+            "Need architect input on remote memory sync priority.",
+        ),
+        (
+            "question",
+            "What about pagination?",
+            "If we have 1000+ decisions, should context paginate?",
+        ),
+        (
+            "requirement",
+            "All commands must support --format json",
+            "Porcelain commands need machine-readable output mode.",
+        ),
+        (
+            "requirement",
+            "Exit codes follow protocol",
+            "0=ok, 1=no-results, 2=error for all plumbing commands.",
+        ),
+        (
+            "note",
+            "GitHub Actions CI is flaky on macOS",
+            "Intermittent timeouts on macos-14 runner.",
+        ),
+    ];
+
+    for (kind, title, body) in entries {
+        Command::cargo_bin("spelunk")
+            .unwrap()
+            .arg("--config")
+            .arg(&config_path)
+            .arg("memory")
+            .arg("--db")
+            .arg(&mem_path)
+            .arg("add")
+            .arg("--kind")
+            .arg(kind)
+            .arg("--title")
+            .arg(title)
+            .arg("--body")
+            .arg(body)
+            .assert()
+            .success();
+    }
+
+    (tmp, db_path, config_path)
+}
+
+/// Write a minimal config.toml for the context tests.
+fn write_config_for_context(dir: &Path, db_path: &Path, api_base: &str) -> PathBuf {
+    let cfg = format!(
+        "db_path = {:?}\napi_base_url = {:?}\nembedding_model = \"test-model\"\nllm_model = \"test-chat\"\n",
+        db_path, api_base
+    );
+    let config_path = dir.join("config.toml");
+    std::fs::write(&config_path, cfg).expect("write config");
+    config_path
+}
+
+/// Helper to invoke `spelunk context` with the given args and config.
+///
+/// Does NOT pass `--db`; the command derives `memory.db` from `db_path` in
+/// the config, which matches where `setup_context_project` seeds entries.
+fn context_cmd(_db_path: &Path, config_path: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--config").arg(config_path).arg("context");
+    cmd
+}
+
+// ── happy path: default text output ───────────────────────────────────────────
+
+#[test]
+fn context_outputs_all_four_sections_by_default() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    let output = context_cmd(&db_path, &config_path)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+
+    // All four default section headers should appear.
+    assert!(stdout.contains("Handoffs"), "expected 'Handoffs' header");
+    assert!(
+        stdout.contains("Open questions"),
+        "expected 'Open questions' header"
+    );
+    assert!(stdout.contains("Decisions"), "expected 'Decisions' header");
+    assert!(
+        stdout.contains("Requirements"),
+        "expected 'Requirements' header"
+    );
+}
+
+// ── happy path: JSON output ───────────────────────────────────────────────────
+
+#[test]
+fn context_json_output_is_valid_array() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    let output = context_cmd(&db_path, &config_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+
+    // Should be valid JSON: an array of [kind, [notes]] pairs.
+    let parsed: Vec<serde_json::Value> =
+        serde_json::from_str(&stdout).expect("--format json should produce valid JSON");
+
+    assert!(!parsed.is_empty(), "expected at least one section");
+    for item in &parsed {
+        let arr = item.as_array().expect("each item should be [kind, notes]");
+        assert_eq!(arr.len(), 2, "each item should be a [kind, notes] pair");
+        assert!(arr[0].is_string(), "first element should be kind string");
+        assert!(arr[1].is_array(), "second element should be notes array");
+    }
+}
+
+#[test]
+fn context_json_includes_all_kinds() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    let output = context_cmd(&db_path, &config_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+
+    let kinds: Vec<&str> = parsed
+        .iter()
+        .map(|item| item[0].as_str().unwrap_or(""))
+        .collect();
+
+    assert!(kinds.contains(&"handoff"), "should include handoff section");
+    assert!(
+        kinds.contains(&"decision"),
+        "should include decision section"
+    );
+    assert!(
+        kinds.contains(&"question"),
+        "should include question section"
+    );
+    assert!(
+        kinds.contains(&"requirement"),
+        "should include requirement section"
+    );
+}
+
+// ── kind filter ───────────────────────────────────────────────────────────────
+
+#[test]
+fn context_kind_filter_shows_only_requested_kind() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    let output = context_cmd(&db_path, &config_path)
+        .arg("--kind")
+        .arg("decision")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+
+    // Should show Decisions header but not Handoffs.
+    assert!(
+        stdout.contains("Decisions"),
+        "should show Decisions when --kind decision"
+    );
+    assert!(
+        !stdout.contains("Handoffs"),
+        "should NOT show Handoffs when --kind decision"
+    );
+    assert!(
+        !stdout.contains("Open questions"),
+        "should NOT show questions"
+    );
+    assert!(
+        !stdout.contains("Requirements"),
+        "should NOT show requirements"
+    );
+}
+
+#[test]
+fn context_kind_filter_json_returns_single_section() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    let output = context_cmd(&db_path, &config_path)
+        .arg("--kind")
+        .arg("question")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+
+    assert_eq!(parsed.len(), 1, "--kind should return exactly one section");
+    assert_eq!(parsed[0][0].as_str().unwrap(), "question");
+}
+
+// ── limit flag ────────────────────────────────────────────────────────────────
+
+#[test]
+fn context_limit_flag_respects_count() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    let output = context_cmd(&db_path, &config_path)
+        .arg("--kind")
+        .arg("decision")
+        .arg("--limit")
+        .arg("2")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+
+    let notes = parsed[0][1].as_array().expect("notes should be array");
+    assert_eq!(
+        notes.len(),
+        2,
+        "--limit 2 should return exactly 2 entries, got {}",
+        notes.len()
+    );
+}
+
+// ── default limits ────────────────────────────────────────────────────────────
+
+#[test]
+fn context_default_limits_respected() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    // We have 2 handoffs. Default handoff limit is 3, so both should appear.
+    let output = context_cmd(&db_path, &config_path)
+        .arg("--kind")
+        .arg("handoff")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+
+    let notes = parsed[0][1].as_array().expect("notes should be array");
+    assert_eq!(
+        notes.len(),
+        2,
+        "default handoff limit of 3 should include both entries"
+    );
+}
+
+// ── empty memory / no results ─────────────────────────────────────────────────
+
+#[test]
+fn context_empty_memory_exits_zero_with_no_output() {
+    // Fresh project with no memory entries at all.
+    let tmp = TempDir::new().expect("create temp dir");
+    let db_path = tmp.path().join("spelunk.db");
+    let config_path = write_config_for_context(tmp.path(), &db_path, "http://127.0.0.1:19999");
+
+    // Write a valid but empty memory.db so the backend can open.
+    // MemoryStore::open creates the DB on demand, but context doesn't
+    // create the DB if it doesn't exist.  `spelunk memory add` will
+    // create it, then we delete the entries — but that's complex.
+    //
+    // Instead, just create a minimal config and let the backend handle
+    // the empty case.  The command should exit 0 with minimal output.
+    let output = context_cmd(&db_path, &config_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+
+    // All sections should be present but empty.
+    for item in &parsed {
+        let notes = item[1].as_array().expect("notes should be array");
+        assert!(
+            notes.is_empty(),
+            "section with no entries should have empty array"
+        );
+    }
+}
+
+// ── exit codes ────────────────────────────────────────────────────────────────
+
+#[test]
+fn context_exits_zero_on_success() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    context_cmd(&db_path, &config_path).assert().code(0);
+}
+
+#[test]
+fn context_exits_zero_with_kind_filter() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    context_cmd(&db_path, &config_path)
+        .arg("--kind")
+        .arg("decision")
+        .assert()
+        .code(0);
+}
+
+#[test]
+fn context_exits_zero_when_kind_has_no_entries() {
+    // We have no "intent" entries in the seed data, but the command
+    // should still exit 0 — empty results are not an error for porcelain.
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    context_cmd(&db_path, &config_path)
+        .arg("--kind")
+        .arg("intent")
+        .assert()
+        .code(0);
+}
+
+// ── backend flag ──────────────────────────────────────────────────────────────
+
+#[test]
+fn context_explicit_sqlite_backend_works() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    context_cmd(&db_path, &config_path)
+        .arg("--backend")
+        .arg("sqlite")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success();
+}
+
+// ── JSON output structural assertions ─────────────────────────────────────────
+
+#[test]
+fn context_json_notes_have_required_fields() {
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    let output = context_cmd(&db_path, &config_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+
+    for item in &parsed {
+        let notes = item[1].as_array().expect("notes should be array");
+        for note in notes {
+            assert!(note.get("id").is_some(), "note missing 'id': {note}");
+            assert!(note.get("kind").is_some(), "note missing 'kind': {note}");
+            assert!(note.get("title").is_some(), "note missing 'title': {note}");
+            assert!(note.get("body").is_some(), "note missing 'body': {note}");
+        }
+    }
+}
+
+// ── error path: bad config ────────────────────────────────────────────────────
+
+#[test]
+fn context_exits_nonzero_when_config_invalid() {
+    // A config with a db_path inside a non-existent directory that cannot be
+    // created (deeply nested under a non-existent root) will cause MemoryStore
+    // to fail its create_dir_all, producing a non-zero exit.
+    let tmp = TempDir::new().expect("create temp dir");
+    let config_path = tmp.path().join("config.toml");
+    // Use /dev/null/impossible/path — /dev/null is a file, so mkdir fails.
+    let db_path = std::path::Path::new("/dev/null/impossible/path/spelunk.db");
+
+    std::fs::write(
+        &config_path,
+        format!("db_path = {:?}\napi_base_url = \"http://127.0.0.1:19999\"\nembedding_model = \"test\"\nllm_model = \"test\"\n", db_path),
+    )
+    .expect("write config");
+
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .arg("--config")
+        .arg(&config_path)
+        .arg("context")
+        .assert()
+        .failure();
+}
+
+// ── format flag validation ────────────────────────────────────────────────────
+
+#[test]
+fn context_unknown_format_falls_back_to_text() {
+    // Unknown formats should fall back to text output (not crash).
+    let (_tmp, db_path, config_path) = setup_context_project();
+
+    context_cmd(&db_path, &config_path)
+        .arg("--format")
+        .arg("yaml")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary

- Adds `spelunk context` as a single agent-facing command that prints the most relevant memory sections in one shot: handoffs (3), open questions (all), decisions (10), requirements (all)
- Supports `--kind`, `--limit`, `--format json`, `--db`, and `--backend` flags
- `spelunk init` now generates a `CLAUDE.md` on first run (skipped if the file already exists) containing the recommended agent workflow referencing `spelunk context`
- Fixed the stale `spelunk ask` reference on the post-init next-steps hint (replaced with `spelunk context`)

## Implementation notes

Lives in `src/cli/cmd/context.rs`. Uses `MemoryBackend::list()` directly — no LLM required. The `collect_sections` helper is async and iterates over the four default sections, or a single section when `--kind` is provided. Section headers are printed to stdout with bold-blue ANSI decoration (suppressed in JSON mode).

## Test plan

- [ ] `cargo build` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test --lib` passes (33 tests)
- [ ] `spelunk context` in a project with memory entries shows formatted sections
- [ ] `spelunk context --format json` emits valid JSON array of `(kind, [notes])` pairs
- [ ] `spelunk context --kind decision --limit 5` shows only decisions
- [ ] `spelunk init` on a fresh project writes `CLAUDE.md` mentioning `spelunk context`
- [ ] `spelunk init` re-run on existing project does NOT overwrite `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)