### PR TITLE
docs: reframe spelunk as index-free by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ spelunk memory add --kind note --title "..."                       # surprising/
 **At the end of every session:**
 ```bash
 spelunk memory add --kind handoff --title "Handoff: <summary>" --body "what's done, what's next, open questions"
-spelunk index .                   # re-index after any commits (hook does this, but run manually if no commit)
+spelunk index .                   # re-index if project uses semantic search (hook does this on commit)
 ```
 
 Full reference: `SKILL.md` and `docs/agent-guide.md`.
@@ -43,17 +43,15 @@ Full reference: `SKILL.md` and `docs/agent-guide.md`.
 
 ## What This Project Is
 
-`spelunk` (`spelunk`) is a Rust CLI that indexes a source tree using
-tree-sitter AST chunking, embeds every chunk via any OpenAI-compatible API
-(EmbeddingGemma 300M by default), and stores vectors in SQLite for semantic search.
+`spelunk` (`spelunk`) is a Rust CLI and context retrieval engine for AI agents.
 
-It is a **context retrieval engine** for AI agents like you. You search with
-spelunk, then reason over the results yourself.
+**Core (no server required):** git-notes memory, full-text search, code graph (AST + call edges), tree-sitter chunking.
 
-**Requirement**: Any OpenAI-compatible server (LM Studio, Ollama, vLLM, etc.)
-running at `http://127.0.0.1:1234` (configurable via `api_base_url`) with an
-**embedding model** loaded. A chat model is optional (enables `memory harvest`
-and `plan create`).
+**With inference server** (any OpenAI-compatible endpoint, default `http://127.0.0.1:1234`): semantic search via embeddings (EmbeddingGemma 300M by default), `spelunk explore`, `spelunk memory harvest`, LLM summaries, `spelunk plan create`. Chat model is also optional and enables harvest/plan.
+
+**With remote server** (`memory_server_url`): team-shared memory, `spelunk memory watch`, conflict detection.
+
+You search with spelunk, then reason over the results yourself.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,25 @@
 # spelunk
 
-**A local context engine for AI coding agents.** Grep finds strings — spelunk finds meaning.
-
-spelunk indexes your codebase using tree-sitter AST parsing and semantic embeddings, then serves that context to AI agents (or you) via fast CLI queries. Your code never leaves your machine.
+**Code intelligence for AI agents — no setup required.** Persistent memory, code graph, and search that work straight from the CLI.
 
 ```bash
-spelunk index .                                    # index the project
-spelunk search "how does authentication work"      # semantic search
+spelunk memory add --kind decision --title "Chose sqlite-vec" --body "no external process needed"
 spelunk graph validate_token                       # callers, callees, imports
+spelunk search "error handling" --mode text        # full-text search
 ```
+
+Add an embedding server for semantic search. Run `spelunk-server` to share memory across a team.
 
 ## Why spelunk?
 
-AI coding agents are only as good as the context they can see. Most context tools either upload your code to a cloud service or rely on grep, which only finds exact strings.
+AI coding agents lose context between sessions and can't trace how code connects across files. spelunk solves both.
 
-spelunk is different:
-
-- **Semantic search** — find code by what it *does*, not what it's called. Ask for "authentication" and find `validate_hmac_sha256` even though the word "authentication" appears nowhere in the file.
-- **Code graph** — trace callers, callees, and imports across file boundaries. Understand not just *where* code is, but *how it connects*.
-- **Multi-project search** — link local dependency projects and search across your entire stack in one query.
-- **100% local** — no cloud, no API keys for core features, no telemetry. The index is a SQLite file in your project directory.
-- **Any embedding model** — runs against any OpenAI-compatible embedding endpoint (LM Studio, Ollama, vLLM). Swap in a better model and get better results without waiting for a spelunk release.
-- **Agent-native** — built to be called by AI agents, not to replace them. JSON output, git hooks for auto-indexing, and a structured memory system for cross-session context.
+- **Persistent memory** — store decisions, requirements, and context in git notes. Retrieve them semantically next session, or share them via a server with your team.
+- **Code graph** — trace callers, callees, and imports across file boundaries without reading every file.
+- **Works without an LLM** — memory, code graph, and full-text search need nothing but the binary. No API keys, no local model server, no indexing step.
+- **Semantic search when you want it** — point spelunk at any OpenAI-compatible embedding endpoint (LM Studio, Ollama, vLLM) and get concept-level search across your codebase.
+- **100% local** — your code never leaves your machine. The optional server is self-hosted.
+- **Agent-native** — JSON output (`AGENT=true`), git hooks, and a structured memory system built for the agent workflow loop.
 
 ### When to use spelunk vs grep
 
@@ -30,10 +28,9 @@ spelunk is different:
 | Find an exact function name | `rg "fn validate_token"` |
 | Find code related to a concept | `spelunk search "request authentication"` |
 | See what calls a function | `spelunk graph validate_token` |
-| Search across linked projects | `spelunk search "connection pooling"` |
+| Remember why a decision was made | `spelunk memory search "why sqlite-vec"` |
 | Store a design decision for future sessions | `spelunk memory add --kind decision ...` |
-
-spelunk complements agentic search tools (grep, file reading) — it handles the queries they can't.
+| Share context across a team | `spelunk-server` + `memory_server_url` |
 
 ## Quick start
 
@@ -45,17 +42,25 @@ cargo install spelunk
 
 > Or download a binary from the [releases page](https://github.com/usercise/spelunk/releases). See [Getting Started](docs/getting-started.md) for full instructions.
 
-**2. Start an embedding model**
+**2. Use it**
 
-spelunk needs an embedding model running on any OpenAI-compatible endpoint. The easiest option is [LM Studio](https://lmstudio.ai/):
+No configuration needed. From inside any git repository:
 
 ```bash
-# Load google/embeddinggemma-300m-qat in LM Studio and start the server (port 1234)
+spelunk graph validate_token                       # trace callers and callees
+spelunk search "error handling" --mode text        # full-text search
+spelunk memory add --kind decision \
+  --title "Chose token bucket for rate limiting" \
+  --body "Simpler than sliding window; sufficient for <1k RPS"
+spelunk memory list --kind decision
 ```
 
-**3. Init, index, and search**
+**3. Add semantic search (optional)**
+
+For concept-level search, start any OpenAI-compatible embedding server — [LM Studio](https://lmstudio.ai/) is the easiest option — then index your project:
 
 ```bash
+# Load google/embeddinggemma-300m-qat in LM Studio (port 1234), then:
 spelunk init                                   # register + index in one step
 spelunk search "error handling in the HTTP layer"
 spelunk search "database migrations" --graph   # include callers/callees
@@ -63,16 +68,19 @@ spelunk search "database migrations" --graph   # include callers/callees
 
 ## Core features
 
-### Semantic search
+### Project memory
+
+Store decisions, requirements, and context that persist across sessions — in git notes, no server needed:
 
 ```bash
-spelunk search "how are errors propagated to the user"
-spelunk search "database connection pooling" --graph --format json
-spelunk search "auth middleware" --mode hybrid   # hybrid (default), semantic, or text
-spelunk search "request handling" --budget 4000  # fit results within a token budget
+spelunk memory add --kind decision --title "Chose sqlite-vec over pgvector" \
+  --body "Must run without a Postgres server. Revisit if we need filtering + ANN."
+spelunk memory list --kind decision --limit 10
+spelunk memory search "why did we choose this database"
+spelunk memory harvest   # auto-extract decisions from recent commits (requires llm_model)
 ```
 
-Tree-sitter extracts functions, structs, classes, and methods as discrete chunks — not naive line splits. Each chunk is embedded and stored in a local SQLite database with the [sqlite-vec](https://github.com/asg017/sqlite-vec) extension for fast KNN search.
+Memory is stored in git notes by default — it travels with the repo. Point at `memory_server_url` to share across a team.
 
 ### Code graph
 
@@ -81,20 +89,16 @@ spelunk graph RagPipeline                        # all edges for a symbol
 spelunk graph src/storage/db.rs --kind imports   # imports in a file
 ```
 
-spelunk extracts import, call, extends, and implements edges from the AST. Use `--graph` on search to automatically expand results with 1-hop callers and callees.
+spelunk extracts import, call, extends, and implements edges from the AST. No index or server needed.
 
-### Project memory
-
-Store decisions, requirements, and context that persist across agent sessions:
+### Search
 
 ```bash
-spelunk memory add --kind decision --title "Chose sqlite-vec over pgvector" \
-  --body "Must run without a Postgres server. Revisit if we need filtering + ANN."
-spelunk memory search "why did we choose this database"
-spelunk memory harvest   # auto-extract decisions from recent commits
+spelunk search "handleRequest" --mode text       # full-text, no server needed
+spelunk search "how are errors propagated"       # semantic (requires server + index)
+spelunk search "auth middleware" --graph         # expand with 1-hop callers/callees
+spelunk search "request handling" --budget 4000  # fit results within a token budget
 ```
-
-Memory entries are embedded and retrieved semantically — each query gets only the entries relevant to the current task, not the entire context file.
 
 ### Agentic exploration
 
@@ -103,7 +107,7 @@ spelunk explore "how does incremental indexing work?"   # LLM iterates search + 
 spelunk explore "what guards the context window?" --verbose
 ```
 
-`explore` requires `llm_model` to be set in config.
+`explore` requires `llm_model` in config.
 
 ### Multi-project search
 
@@ -114,11 +118,18 @@ spelunk search "connection pooling"   # searches both projects, merges by releva
 
 ### Agent integration
 
-Set `AGENT=true` for JSON output on every command. Install git hooks for automatic indexing:
+Set `AGENT=true` for JSON output on every command:
 
 ```bash
-spelunk hooks install   # post-commit: auto-index + auto-harvest memory
+AGENT=true spelunk memory list --kind decision
+AGENT=true spelunk graph validate_token
 AGENT=true spelunk search "auth flow" | jq '.[0].file_path'
+```
+
+Install git hooks to auto-harvest memory on every commit:
+
+```bash
+spelunk hooks install
 ```
 
 spelunk ships with a [Claude Code skill](SKILL.md) and [agent guide](docs/agent-guide.md) for integration with AI coding agents.

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,12 +8,51 @@ code and prior decisions, then reason over the results yourself.
 ## Setup
 
 - `spelunk` in PATH
-- OpenAI-compatible server at `http://127.0.0.1:1234` with an **embedding model** loaded
-  (override with `api_base_url` in `~/.config/spelunk/config.toml`)
+
+Core features (memory, full-text search, code graph) work without any inference server.
+
+**Optional — for semantic search and AI features:** an OpenAI-compatible server with an embedding model loaded (default: `http://127.0.0.1:1234`; override with `api_base_url` in `~/.config/spelunk/config.toml`). Commands that require this are marked **(requires server)** below.
 
 ---
 
-## Indexing
+## Code search
+
+```bash
+# Full-text search — no server needed
+spelunk search "<query>" --mode text
+
+# Call/import graph — no server needed
+spelunk graph <symbol-or-file>
+spelunk graph <symbol> --kind calls       # calls | imports | extends | implements
+spelunk graph <file> --format text|json|ndjson
+
+# Semantic search — (requires server + index)
+spelunk search "<query>"
+spelunk search "<query>" --limit 20
+spelunk search "<query>" --graph          # include call-graph neighbours
+spelunk search "<query>" --format text|json|ndjson
+
+# Deep search — iterative, uses LLM (requires server + llm_model in config)
+spelunk explore "<question>"
+spelunk explore "<question>" --max-steps 5
+spelunk explore "<question>" --json       # {answer, sources, steps}
+
+# Status and checks
+spelunk status --format text|json|ndjson
+spelunk check --format text|json|ndjson
+
+# Inspect what was indexed for a file
+spelunk chunks <file-path>
+spelunk chunks <file-path> --format text|json|ndjson
+```
+
+Use `search --mode text` for targeted lookups without a server. Use semantic `search` (with server) for concept-level queries. Use `explore` when the answer requires tracing across multiple files — it runs autonomously and reports back.
+
+---
+
+## Indexing (requires server)
+
+Indexing embeds chunks for semantic search. Skip this if you only need full-text search, memory, or code graph.
 
 ```bash
 spelunk index <path>           # index (subsequent runs are incremental)
@@ -25,66 +64,32 @@ Add a `.spelunkignore` file (same syntax as `.gitignore`) to exclude paths from 
 
 ---
 
-## Code search
-
-```bash
-# Semantic search — primary lookup
-spelunk search "<query>"
-spelunk search "<query>" --limit 20
-spelunk search "<query>" --graph          # include call-graph neighbours
-spelunk search "<query>" --format text|json|ndjson
-spelunk search "<query>" --mode text      # FTS only, no embedding model needed
-
-# Deep search — iterative, uses LLM (requires llm_model in config)
-spelunk explore "<question>"
-spelunk explore "<question>" --max-steps 5
-spelunk explore "<question>" --json       # {answer, sources, steps}
-
-# Call/import graph
-spelunk graph <symbol-or-file>
-spelunk graph <symbol> --kind calls       # calls | imports | extends | implements
-spelunk graph <file> --format text|json|ndjson
-
-# Status and checks
-spelunk status --format text|json|ndjson
-spelunk check --format text|json|ndjson
-
-# Inspect what was indexed for a file
-spelunk chunks <file-path>
-spelunk chunks <file-path> --format text|json|ndjson
-```
-
-Use `search` for targeted lookups. Use `explore` when the answer requires
-tracing across multiple files — it runs autonomously and reports back.
-
----
-
 ## Plumbing commands
 
 Plumbing commands emit NDJSON and are designed for scripts and pipelines.
 Exit codes: `0` = success, `1` = no results, `2` = error. See [Plumbing and Porcelain](docs/plumbing-and-porcelain.md) for full details.
 
 ```bash
-# Emit indexed chunks for a file
-spelunk plumbing cat-chunks <file>
-
-# List all indexed files (optionally filtered by prefix or staleness)
-spelunk plumbing ls-files [--prefix <p>] [--stale]
-
-# Parse a file without writing to the index
+# Parse a file and emit AST chunks (no DB, no server)
 spelunk plumbing parse-file <file>
 
-# Compute and verify file hash
+# Compute and verify file hash (no server)
 spelunk plumbing hash-file <file>
 
-# Read embedding from stdin, return nearest chunks by similarity
-echo "your query" | spelunk plumbing embed --query | spelunk plumbing knn --limit 10
-
-# Emit code graph edges (imports, calls, extends)
+# Emit code graph edges (no server)
 spelunk plumbing graph-edges --file <f> | --symbol <s>
 
-# Emit memory entries as NDJSON
+# Emit memory entries as NDJSON (no server)
 spelunk plumbing read-memory [--kind <k>] [--limit N]
+
+# Emit indexed chunks for a file (requires index)
+spelunk plumbing cat-chunks <file>
+
+# List all indexed files (requires index)
+spelunk plumbing ls-files [--prefix <p>] [--stale]
+
+# Read embedding from stdin, return nearest chunks by similarity (requires server + index)
+echo "your query" | spelunk plumbing embed --query | spelunk plumbing knn --limit 10
 ```
 
 ---
@@ -201,31 +206,32 @@ AGENT=true spelunk graph src/storage/db.rs
 
 **Start of every session:**
 ```bash
-spelunk check                              # includes active intents and overlapping work
-spelunk memory list --kind decision --limit 10
-spelunk memory list --kind handoff --limit 3
-spelunk memory list --kind intent          # see what teammates are working on
-spelunk memory list --kind question
-spelunk memory failures                    # check antipatterns — things to avoid
+AGENT=true spelunk check                              # includes active intents and overlapping work
+AGENT=true spelunk memory list --kind decision --limit 10
+AGENT=true spelunk memory list --kind handoff --limit 3
+AGENT=true spelunk memory list --kind intent          # see what teammates are working on
+AGENT=true spelunk memory list --kind question
+AGENT=true spelunk memory failures                    # check antipatterns — things to avoid
 ```
 
 **Understanding code:**
-1. `spelunk search "<topic>"` — find relevant chunks
-2. Read reported file/line ranges
-3. `spelunk graph <symbol>` — trace call chains
-4. `spelunk memory search "<topic>"` — check recorded context for *why*
+1. `AGENT=true spelunk search "<topic>" --mode text` — full-text search, no server needed
+2. `AGENT=true spelunk search "<topic>"` — semantic search (requires server + index)
+3. Read reported file/line ranges
+4. `AGENT=true spelunk graph <symbol>` — trace call chains
+5. `AGENT=true spelunk memory search "<topic>"` — check recorded context for *why*
 
 **Making changes:**
 1. Search and read before changing
 2. Store significant decisions: `spelunk memory add --kind decision …`
 3. Store constraints the human states: `spelunk memory add --kind requirement …`
-4. After committing: `spelunk index <project-root>`
+4. After committing (if indexed): `spelunk index <project-root>`
 
 **End of session:**
 ```bash
 spelunk memory add --kind handoff --title "Handoff: <summary>" \
   --body "what's done, what's next, open questions"
-spelunk index .
+spelunk index .   # only if project is indexed
 ```
 
 **Writing good memory entries:**
@@ -238,6 +244,8 @@ spelunk index .
 
 ## Tips
 
-- All commands except `spelunk index` can be run from any subdirectory — the index is found automatically.
-- After changing the embedding model, run `spelunk index <path> --force`.
-- `spelunk search` only needs the embedding model; `spelunk explore`, `spelunk memory harvest`, and LLM summaries also require `llm_model`.
+- Memory and code graph commands work from any subdirectory — no server or index needed.
+- All indexed-project commands can be run from any subdirectory — the index is found automatically.
+- `spelunk search --mode text` is always available. Semantic `spelunk search` requires an embedding server and a built index.
+- `spelunk explore`, `spelunk memory harvest`, and LLM summaries also require `llm_model` in config.
+- After changing the embedding model, run `spelunk index <path> --force` to rebuild the index.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -2,7 +2,9 @@
 
 `spelunk` is designed to work as infrastructure for AI coding agents, not just as a human developer tool. This guide covers the patterns that make agents most effective when paired with `spelunk`.
 
-**The key mental model**: spelunk retrieves context; you reason over it. Use `spelunk search` to find the right code, read the results, then synthesise the answer yourself — just as you would after reading documentation. spelunk is a fast, semantic grep with memory, not an oracle.
+**The key mental model**: spelunk retrieves context; you reason over it. Use `spelunk graph` and `spelunk search` to find the right code, read the results, then synthesise the answer yourself. spelunk is a persistent memory store and code navigation tool, not an oracle.
+
+**What needs a server:** semantic `spelunk search`, `spelunk explore`, `spelunk ask`, `spelunk plan create`, and `spelunk memory harvest` all require an inference server. Everything else — memory, code graph, full-text search — works with just the binary.
 
 ## The core loop
 
@@ -57,48 +59,49 @@ AGENT=true spelunk memory failures
 Before modifying any file, search for related code:
 
 ```bash
-# Find relevant chunks
-AGENT=true spelunk search "authentication middleware" --graph
+# Trace the call graph around a symbol (no server needed)
+AGENT=true spelunk graph validate_token
 
-# Get the raw chunks for a specific file
+# Full-text search (no server needed)
+AGENT=true spelunk search "authentication middleware" --mode text
+
+# Get the raw chunks for a specific file (requires index)
 AGENT=true spelunk chunks src/auth/middleware.rs
 
-# Understand the call graph around a symbol
-AGENT=true spelunk graph validate_token
+# Semantic search with call-graph expansion (requires server + index)
+AGENT=true spelunk search "authentication middleware" --graph
 ```
 
-The `--graph` flag on `spelunk search` adds 1-hop callers and callees to the result set, which is often exactly the context needed to understand blast radius before a change.
+The `--graph` flag adds 1-hop callers and callees to the result set — the right context for understanding blast radius before a change.
 
 ## Retrieving targeted context
 
-Use `spelunk search` with a focused query, then read the returned chunks and reason over them yourself:
+Use `spelunk graph` and `spelunk search` to find relevant code, then read and reason over the results yourself:
 
 ```bash
-# Find what touches the embedding format
-AGENT=true spelunk search "embedding format storage" --graph --format json
-
-# Trace call chains across the request lifecycle
+# Trace call chains
 AGENT=true spelunk graph handle_request
-AGENT=true spelunk search "request lifecycle middleware" --limit 20 --format json
+AGENT=true spelunk search "request lifecycle middleware" --mode text --limit 20 --format json
+
+# Semantic search (requires server + index)
+AGENT=true spelunk search "embedding format storage" --graph --format json
 ```
 
-For open-ended questions that require tracing through several files, use `spelunk explore` instead. It runs the same search/graph/read tools in an LLM-driven loop and returns a synthesised answer:
+For open-ended questions that require tracing through several files, use `spelunk explore` (requires server + `llm_model`). It runs an LLM-driven search loop and returns a synthesised answer:
 
 ```bash
-# Let spelunk drive the search loop; get a final answer + sources
 AGENT=true spelunk explore "how does incremental indexing decide which files to skip?"
-
-# Limit steps if you want a fast, shallow answer
 AGENT=true spelunk explore "where is the embedding model loaded?" --max-steps 3
 ```
 
-`explore` is slower than `search` (multiple LLM calls) — use `search` for targeted lookups and `explore` for questions that need synthesis across multiple code paths.
+`explore` is slower than `search` (multiple LLM calls) — use it only for questions that genuinely need synthesis across many code paths.
 
 ## Creating plans
 
-Before a significant change, generate a plan:
+Write a markdown checklist in `docs/plans/` manually, or generate one with `spelunk plan create` if `llm_model` is configured:
 
 ```bash
+# Requires llm_model in config
 spelunk plan create "add rate limiting to the API layer"
 # → writes docs/plans/add-rate-limiting.md with a - [ ] checklist
 
@@ -106,15 +109,16 @@ spelunk plan create "add rate limiting to the API layer"
 spelunk plan status
 ```
 
-Check off items as you complete them by editing the markdown file directly (`- [ ]` → `- [x]`). `spelunk plan status` reads the file and shows completion percentages.
+Check off items by editing the markdown file directly (`- [ ]` → `- [x]`). `spelunk plan status` reads the file and shows completion percentages.
 
 ## After making changes
 
 ```bash
-# Verify a modified file is still semantically retrievable
-spelunk verify src/auth/middleware.rs
+# Confirm call sites still match using the code graph (no server needed)
+spelunk graph validate_token --kind calls
 
-# Re-index to incorporate changes
+# If the project is indexed: verify semantic retrievability and re-index
+spelunk verify src/auth/middleware.rs
 spelunk index .
 ```
 
@@ -244,7 +248,9 @@ Exit codes across all plumbing commands:
 - **1** — no results (empty set, not an error)
 - **2** — hard error (bad flags, missing DB, I/O failure) — diagnostics on stderr
 
-### cat-chunks
+Commands marked **(requires server)** need an embedding model running on the configured endpoint.
+
+### cat-chunks *(requires index)*
 
 ```
 spelunk plumbing cat-chunks <file>
@@ -272,7 +278,7 @@ spelunk plumbing cat-chunks src/indexer/chunker.rs \
 
 ---
 
-### ls-files
+### ls-files *(requires index)*
 
 ```
 spelunk plumbing ls-files [--prefix <prefix>] [--stale] [--root <dir>]
@@ -353,7 +359,7 @@ spelunk plumbing hash-file src/config.rs
 
 ---
 
-### knn
+### knn *(requires server + index)*
 
 ```
 spelunk plumbing knn [--limit N] [--min-score F] [--lang <lang>]
@@ -383,7 +389,7 @@ Example output:
 
 ---
 
-### embed
+### embed *(requires server)*
 
 ```
 spelunk plumbing embed [--query]
@@ -470,21 +476,24 @@ spelunk plumbing read-memory --kind decision --limit 5 | jq '{id, title}'
 ## Summary: agent workflow at a glance
 
 ```bash
-# Session start
-spelunk check
+# Session start (no server needed)
 AGENT=true spelunk memory list --kind handoff --limit 3
 AGENT=true spelunk memory list --kind question
+AGENT=true spelunk memory failures
 
 # Before writing code — retrieve context, then reason yourself
-AGENT=true spelunk search "<topic>" --graph --format json
+AGENT=true spelunk graph <symbol>                             # call graph, no server
+AGENT=true spelunk search "<topic>" --mode text --format json # full-text, no server
+AGENT=true spelunk search "<topic>" --graph --format json     # semantic (requires server)
 AGENT=true spelunk memory search "<topic>" --format json
 
 # Planning
-spelunk plan create "<description>"
+# spelunk plan create "<description>"  ← requires llm_model
 
 # After changes
-spelunk index .
-spelunk verify <changed-file>
+spelunk graph <symbol> --kind calls    # confirm call sites, no server
+spelunk index .                         # only if project is indexed
+spelunk verify <changed-file>           # only if project is indexed
 
 # Session end
 spelunk memory add --title "Handoff: ..." --kind handoff

--- a/docs/example/AGENT.md
+++ b/docs/example/AGENT.md
@@ -9,29 +9,23 @@
 
 ## Context retrieval — use spelunk
 
-This project is indexed with [spelunk](https://github.com/usercise/spelunk).
-Before reading files directly, search the index — it's faster and surfaces
-semantically relevant code that grep would miss.
+This project uses [spelunk](https://github.com/usercise/spelunk) for code graph traversal, memory, and search.
 
 ```bash
-# Find code by meaning
-spelunk search "how does authentication work"
-spelunk search "database connection pooling"
-
-# Trace a symbol's callers and callees
+# Trace a symbol's callers and callees (no server needed)
 spelunk graph verify_token
 
-# Ask a natural language question (requires a local LLM)
-spelunk ask "what does the retry logic do when the upstream times out?"
+# Full-text search (no server needed)
+spelunk search "error handling" --mode text
 
-# List what's indexed
-spelunk status
-spelunk plumbing ls-files
+# Semantic search — finds code by meaning (requires embedding server + index)
+spelunk search "how does authentication work"
+
+# Ask a natural language question (requires llm_model in config)
+spelunk ask "what does the retry logic do when the upstream times out?"
 ```
 
-**Rule:** run `spelunk search "<topic>"` before opening any file you haven't
-already read this session. Only fall back to `Read`/`Grep`/`Glob` when the
-search returns nothing useful.
+**Rule:** run `spelunk graph <symbol>` and `spelunk search "<topic>" --mode text` before opening files you haven't read this session. Fall back to `Read`/`Grep`/`Glob` when these return nothing useful.
 
 ---
 
@@ -87,7 +81,7 @@ All plumbing commands emit NDJSON. Exit 0 = results, 1 = no results, 2 = error.
 
 ---
 
-## Re-indexing
+## Re-indexing (if project uses semantic search)
 
 spelunk indexes are incremental. Re-run after significant changes:
 
@@ -96,7 +90,7 @@ spelunk index .            # index the current directory
 spelunk check              # verify the index is fresh
 ```
 
-A pre-commit hook can do this automatically — see `spelunk hooks install`.
+A post-commit hook can do this automatically — see `spelunk hooks install`.
 
 ---
 
@@ -114,6 +108,6 @@ A pre-commit hook can do this automatically — see `spelunk hooks install`.
 ## What spelunk cannot do
 
 - It cannot run your tests or build the project — use shell commands for that
-- Search results are only as fresh as the last `spelunk index` run
-- `spelunk ask` requires a local LLM server at `http://127.0.0.1:1234`
-  (configurable via `~/.config/spelunk/config.toml`)
+- Semantic search results are only as fresh as the last `spelunk index` run
+- `spelunk ask` and `spelunk explore` require `llm_model` in `~/.config/spelunk/config.toml`
+- `spelunk search` (semantic) requires an embedding server and a built index; use `--mode text` for full-text search without either

--- a/docs/examples/multi-session-agent-workflow.md
+++ b/docs/examples/multi-session-agent-workflow.md
@@ -8,20 +8,21 @@ The agent receives a task: "Add rate limiting to the API."
 
 ```bash
 # Orient
-spelunk check   # index is fresh
 AGENT=true spelunk memory list --kind question  # no open questions
 AGENT=true spelunk memory list --kind handoff --limit 3  # no handoffs yet
 
 # Understand the codebase
-AGENT=true spelunk search "HTTP middleware handler" --graph --format json
-AGENT=true spelunk ask "How is the HTTP layer structured? Where would middleware be added?" --json
+AGENT=true spelunk graph Router --kind calls    # trace middleware wiring
+AGENT=true spelunk search "HTTP middleware handler" --mode text --format json
 
-# Generate a plan
-spelunk plan create "add rate limiting to the HTTP API layer"
-# → writes docs/plans/add-rate-limiting-to-the-http-api-layer.md
+# With server: richer search + AI-generated plan
+# AGENT=true spelunk search "HTTP middleware handler" --graph --format json
+# AGENT=true spelunk ask "How is the HTTP layer structured? Where would middleware be added?" --json
+# spelunk plan create "add rate limiting to the HTTP API layer"
 ```
 
-The plan checklist:
+The agent writes a plan manually (or generates one via `spelunk plan create` if a chat model is configured):
+
 ```
 - [ ] Research token bucket vs sliding window for this use case
 - [ ] Add RateLimiter struct in src/ratelimit/
@@ -49,7 +50,7 @@ The agent marks off the first item and writes a handoff:
 ```bash
 spelunk memory add \
   --title "Handoff: rate limiting, session 1 done" \
-  --body "Plan created at docs/plans/add-rate-limiting-to-the-http-api-layer.md. Decision made: token bucket per IP. Open question stored about per-endpoint config. No code written yet." \
+  --body "Plan in docs/plans/add-rate-limiting.md. Decision: token bucket per IP. Open question stored about per-endpoint config. No code written yet." \
   --kind handoff --tags ratelimit
 ```
 
@@ -72,18 +73,15 @@ spelunk memory add \
   --kind answer --tags ratelimit,api
 
 # Check existing middleware patterns
-AGENT=true spelunk search "middleware router registration" --format json
-AGENT=true spelunk chunks src/api/router.rs
+AGENT=true spelunk search "middleware router registration" --mode text --format json
+AGENT=true spelunk graph Router --kind calls   # trace how middleware is wired
 ```
 
 The agent implements `src/ratelimit/bucket.rs` and wires the middleware.
 
 ```bash
-# Re-index
+# Re-index if project uses semantic search (skippable otherwise)
 spelunk index .
-
-# Verify the new code is retrievable
-spelunk verify src/ratelimit/bucket.rs
 ```
 
 Marks off two more checklist items in the plan file, then:
@@ -105,14 +103,17 @@ AGENT=true spelunk memory list --kind handoff --limit 1
 AGENT=true spelunk memory search "rate limiting decisions" --limit 5
 
 # Find existing test patterns
-AGENT=true spelunk search "unit test tokio test mock" --format json
-AGENT=true spelunk ask "What testing patterns are used in this codebase? How are middleware components tested?"
+AGENT=true spelunk search "unit test tokio test mock" --mode text --format json
+AGENT=true spelunk graph RateLimiter --kind calls   # find what already calls into it
+
+# With server: ask for a synthesis
+# AGENT=true spelunk ask "What testing patterns are used in this codebase? How are middleware components tested?"
 ```
 
 The agent writes tests, updates docs, marks remaining checklist items complete.
 
 ```bash
-spelunk index .
+spelunk index .   # only if project is indexed
 spelunk plan status add-rate-limiting-to-the-http-api-layer
 # → [##########] 6/6 (100%)
 ```
@@ -121,9 +122,8 @@ spelunk plan status add-rate-limiting-to-the-http-api-layer
 
 ## Key patterns shown
 
-1. **Session start ritual**: check + read handoff + read open questions
+1. **Session start ritual**: read handoff + read open questions
 2. **Decision logging**: every non-obvious choice stored with rationale
 3. **Question parking**: blockers stored as questions, answered when resolved
-4. **Plan as shared state**: the checklist file tracks progress across sessions
+4. **Plan as shared state**: a plain markdown checklist tracks progress across sessions
 5. **Handoff as context transfer**: structured summary for the next session
-6. **Verify after changes**: confirm new code is semantically reachable

--- a/docs/examples/onboarding-a-new-codebase.md
+++ b/docs/examples/onboarding-a-new-codebase.md
@@ -2,55 +2,53 @@
 
 You've been handed a large project you've never seen before. Here's how to get up to speed quickly with `spelunk`.
 
-## Step 1: Index it
+> Steps marked **(requires server)** need an embedding model running. All other steps work with just the binary.
+
+## Step 1: Understand the structure
+
+Start with what's already committed — no indexing needed:
 
 ```bash
-spelunk index /path/to/project
-# Indexing 847 files… done in 2m 14s
-# 12,341 chunks stored, 12,341 embeddings
+# Check if there are any stored memory entries from previous contributors
+spelunk memory list --kind context --limit 20
+spelunk memory list --kind decision --limit 10
 ```
 
-## Step 2: Get a high-level overview
+If someone has used spelunk on this repo before, you'll find architectural context here.
+
+## Step 2: Find the key entry points
 
 ```bash
-spelunk ask "Give me a high-level overview of this codebase. What does it do and how is it structured?"
+# Trace what the main symbols call and what calls them
+spelunk graph main
+spelunk graph Application --kind calls
+
+# Full-text search for entry points
+spelunk search "main function application startup" --mode text
 ```
 
-## Step 3: Understand the entry points
+## Step 3: Understand the data layer
 
 ```bash
-spelunk ask "Where does the application start? What is the main entry point?"
-spelunk search "main function application startup"
-```
-
-## Step 4: Find the key abstractions
-
-```bash
-spelunk ask "What are the main abstractions and domain objects in this codebase?"
-spelunk search "core interfaces traits protocols" --graph
-```
-
-## Step 5: Understand the data layer
-
-```bash
-spelunk ask "How is data persisted? What database or storage layer is used?"
 spelunk graph Database --kind calls
+spelunk search "storage persistence database" --mode text
 ```
 
-## Step 6: Find the API surface
+## Step 4: Find the API surface
 
 ```bash
-spelunk search "HTTP handler route endpoint"
-spelunk ask "What external APIs or endpoints does this service expose?"
+spelunk search "HTTP handler route endpoint" --mode text
+spelunk graph Router --kind calls
 ```
 
-## Step 7: Understand error handling
+## Step 5: Understand error handling
 
 ```bash
-spelunk ask "What is the error handling strategy? How are errors propagated and surfaced to users?"
+spelunk search "error handling propagation" --mode text
+spelunk graph Error --kind extends
 ```
 
-## Step 8: Store what you've learned
+## Step 6: Store what you've learned
 
 ```bash
 spelunk memory add \
@@ -65,19 +63,24 @@ spelunk memory add \
   --tags error-handling
 ```
 
-Now future sessions (and future agents) can start from your notes rather than re-discovering the same things.
+Future sessions (and future agents) start from your notes rather than re-discovering the same things.
 
-## Step 9: Check what tests exist
+## Step 7: Check what tests exist
 
 ```bash
-spelunk search "test suite integration test unit test"
-spelunk ask "What testing strategy is used? Are there unit tests, integration tests, or end-to-end tests?"
+spelunk search "test suite integration unit" --mode text
+spelunk graph TestSuite --kind calls
 ```
 
-## Step 10: Understand the build and deploy story
+## Step 8: Semantic deep-dive (requires server)
+
+If you have an embedding server and a built index, these commands give richer results:
 
 ```bash
-spelunk ask "How is this project built and deployed? Are there Makefiles, Docker files, or CI configurations?"
+spelunk search "core interfaces abstractions domain objects" --graph
+spelunk ask "Give me a high-level overview of this codebase. What does it do and how is it structured?"
+spelunk ask "What is the error handling strategy? How are errors propagated and surfaced to users?"
+spelunk ask "How is this project built and deployed?"
 ```
 
 After this session you'll have a solid mental model and a set of memory entries that make every future session faster.

--- a/docs/examples/pre-change-impact-analysis.md
+++ b/docs/examples/pre-change-impact-analysis.md
@@ -22,46 +22,59 @@ Incoming to 'validate_token':
 ## Step 2: Understand each call site
 
 ```bash
-spelunk search "validate_token call site usage" --graph --limit 20
+# Full-text — no server needed
+spelunk search "validate_token" --mode text --limit 20
+
+# Semantic — requires server + index
+# spelunk search "validate_token call site usage" --graph --limit 20
 ```
 
-## Step 3: Ask about downstream effects
+## Step 3: Check memory for prior context
 
 ```bash
-spelunk ask "If I add a required 'scope' parameter to validate_token, what would I need to update across the codebase?" --context-chunks 30
+spelunk memory search "validate_token authentication"
+```
+
+If you have a chat model configured, you can also ask for a synthesis:
+
+```bash
+# spelunk ask "If I add a required 'scope' parameter to validate_token, what would I need to update across the codebase?" --context-chunks 30
 ```
 
 ## Step 4: Find the tests
 
 ```bash
-spelunk search "validate_token test mock"
-spelunk ask "How is validate_token tested? Are there mocks or stubs I need to update?"
+spelunk search "validate_token test" --mode text
 ```
 
 ## Step 5: Check for related documentation
 
 ```bash
-spelunk search "validate_token authentication documentation comment"
+spelunk search "validate_token" --mode text
+spelunk memory search "validate_token authentication"
 ```
 
-## Step 6: Create a plan
+## Step 6: Write a plan
+
+Create a checklist in `docs/plans/` manually, or generate one with `spelunk plan create` if you have a chat model configured:
 
 ```bash
-spelunk plan create "add scope parameter to validate_token"
-# writes docs/plans/add-scope-parameter-to-validate-token.md
+# spelunk plan create "add scope parameter to validate_token"
+# → writes docs/plans/add-scope-parameter-to-validate-token.md
 ```
 
-The generated checklist will include steps like:
+Either way, the checklist should cover:
 - `- [ ] Update validate_token signature in src/auth/token.rs`
 - `- [ ] Update call sites in middleware, routes, and interceptor`
 - `- [ ] Update test fixtures and mocks`
-- etc.
 
 ## Step 7: After the change, verify
 
 ```bash
+# Confirm all call sites are updated
+spelunk graph validate_token --kind calls
+
+# If the project is indexed, verify semantic connectivity
 spelunk index .
 spelunk verify src/auth/token.rs
 ```
-
-`spelunk verify` re-embeds the changed file and shows its nearest neighbours. If the function is still semantically close to its call sites, it's likely still well-connected in the index.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,27 +34,87 @@ spelunk --version
 
 > Building from source? See [Building](building.md).
 
-## 2. Set up an inference server
+## 2. Start using it
 
-spelunk works with any **OpenAI-compatible** inference server. The easiest options:
+No configuration needed. From inside any git repository:
+
+```bash
+# Trace callers and callees for any symbol
+spelunk graph validate_token
+
+# Full-text search
+spelunk search "error handling" --mode text
+
+# Store a decision
+spelunk memory add --kind decision \
+  --title "Chose token bucket for rate limiting" \
+  --body "Simpler than sliding window; sufficient for <1k RPS"
+
+# Read it back
+spelunk memory list --kind decision
+```
+
+Memory is stored in git notes — no server, no database, no setup.
+
+## 3. Try search and memory together
+
+```bash
+# Search memory for context on a topic
+spelunk memory search "why did we choose this"
+
+# Full-text code search
+spelunk search "handleRequest" --mode text
+
+# Trace a symbol's call graph
+spelunk graph Database --kind calls
+
+# Get JSON output (for agents)
+AGENT=true spelunk memory list --kind decision
+```
+
+## 4. Set up automatic memory harvesting
+
+Install a git post-commit hook so `spelunk` harvests memory on every commit:
+
+```bash
+spelunk hooks install
+```
+
+Other developers without `spelunk` installed are unaffected — the hook checks for the binary first.
+
+To remove:
+
+```bash
+spelunk hooks uninstall
+```
+
+---
+
+## Optional: semantic search
+
+For concept-level search (finding code by meaning rather than text), you need:
+1. An OpenAI-compatible embedding server
+2. A built index
+
+### Set up an inference server
+
+The easiest options:
 
 - **[LM Studio](https://lmstudio.ai/)** — desktop app for macOS/Windows/Linux; enable the local server (default port `1234`)
 - **[Ollama](https://ollama.com/)** — `ollama serve` (default port `11434`)
 - **vLLM / any OpenAI proxy** — point `api_base_url` at your endpoint
 
-Load two models in your server of choice:
+Recommended models:
+- **Embedding** — `google/embeddinggemma-300m-qat` (300M params, low VRAM, fast)
+- **Chat (optional)** — any instruction-tuned model; needed only for `memory harvest` and `plan create`
 
-1. **Embedding model** — recommended: `google/embeddinggemma-300m-qat` (fast, 300M params, low VRAM)
-2. **Chat model** — any instruction-tuned model; `google/gemma-3-4b-it` is a good starting point on 8 GB RAM (optional — only needed for `memory harvest` and `plan create`)
+### Configure spelunk
 
-## 3. Configuration
-
-`spelunk` looks for a config file at `~/.config/spelunk/config.toml`. If it doesn't exist, all defaults apply.
+`spelunk` looks for a config file at `~/.config/spelunk/config.toml`:
 
 ```toml
 # ~/.config/spelunk/config.toml
 
-# Base URL for your OpenAI-compatible server
 # LM Studio default:  http://127.0.0.1:1234
 # Ollama default:     http://127.0.0.1:11434
 api_base_url = "http://127.0.0.1:1234"
@@ -62,38 +122,29 @@ api_base_url = "http://127.0.0.1:1234"
 # Must match the model's API identifier on your server
 embedding_model = "text-embedding-embeddinggemma-300m-qat"
 
-# Optional: set a chat model to enable `memory harvest` and `plan create`
+# Optional: enables `memory harvest` and `plan create`
 # llm_model = "google/gemma-3n-e4b"
 
-# Embedding batch size — lower this if you run out of memory
+# Embedding batch size — lower if you run out of memory
 batch_size = 32
 
 # Default database location (default: ~/.local/share/spelunk/<project-slug>.db)
 # db_path = "/custom/path/myproject.db"
-
-# Directory (relative to project root) where `spelunk plan create` writes plan files
-# plans_dir = "docs/plans"
-
-# Directory (relative to project root) where spec markdown files are discovered
-# during `spelunk index` and where `spelunk spec link` defaults to looking
-# specs_dir = "docs/specs"
 ```
 
 You can also override the database path per-command with `--db <path>`.
 
-## 4. Initialise your project
-
-The quickest way to get started is `spelunk init`. Run it from inside your project directory:
+### Index your project
 
 ```bash
 cd /path/to/your/project
 spelunk init
 ```
 
-This single command:
+`spelunk init`:
 1. Registers the project in the global spelunk registry
-2. Walks the file tree (respecting `.gitignore`), parses every source file, embeds each chunk, and stores everything in SQLite
-3. Prints a summary with file/chunk counts, the DB path, and suggested next commands
+2. Parses every source file, embeds each chunk, and stores everything in SQLite
+3. Prints a summary with file/chunk counts and suggested next commands
 
 ```
 spelunk initialised for my-project
@@ -101,13 +152,7 @@ spelunk initialised for my-project
   Index:   142 files, 1 840 chunks
   DB:      ~/.local/share/spelunk/my-project.db
   Hook:    not installed — run `spelunk hooks install` to add
-
-Next steps:
-  spelunk search "your query"
-  spelunk ask "how does X work?"
 ```
-
-### Optional flags
 
 ```bash
 # Also install the post-commit git hook in one step
@@ -117,74 +162,47 @@ spelunk init --hook
 spelunk init --no-index
 ```
 
-Running `spelunk init` again is safe — it notices an existing index and won't re-register.
+Running `spelunk init` again is safe — it won't re-register an existing project.
 
 ### Manual indexing
-
-If you prefer to manage indexing yourself, you can skip `init` and call `spelunk index` directly:
 
 ```bash
 spelunk index /path/to/your/project
 
-# Force a full re-index (ignore change detection)
+# Force a full re-index (after changing embedding model)
 spelunk index /path/to/your/project --force
 ```
 
 On subsequent runs, only changed files are re-processed (blake3 hash comparison).
 
-## 5. Try it out
+### Semantic search
 
 ```bash
-# Semantic search — finds code by meaning
+# Finds code by meaning, not just text
 spelunk search "error handling in the HTTP layer"
 
-# Hybrid search (semantic + full-text) — the default
+# Hybrid search (semantic + full-text)
 spelunk search "authentication" --mode hybrid
-
-# Pure text search — no embedding model needed
-spelunk search "handleRequest" --mode text
-
-# Fit results within a token budget (useful for agent context windows)
-spelunk search "database layer" --budget 4000
 
 # With call-graph enrichment
 spelunk search "authentication" --graph
 
-# Return JSON instead of text
+# Fit results within a token budget
+spelunk search "database layer" --budget 4000
+
+# JSON output
 spelunk search "database migrations" --format json
 ```
 
-## 6. Check index health
+### Check index health
 
 ```bash
-# Show statistics for the current project
-spelunk status
-
-# Check whether the index is up to date (exits 1 if stale)
-spelunk check
-
-# Machine-readable output for scripts
-spelunk check --porcelain
-
-# List which files are stale
-spelunk check --porcelain --files
+spelunk status          # index statistics
+spelunk check           # verify index is up to date (exits 1 if stale)
+spelunk check --porcelain --files   # list stale files
 ```
 
-## 7. Set up automatic indexing
-
-Install a git post-commit hook so `spelunk` indexes and harvests memory on every commit (or use `spelunk init --hook` to do this at init time):
-
-```bash
-spelunk hooks install
-```
-
-This adds a hook that runs `spelunk index` and `spelunk memory harvest` after each commit. Other developers without `spelunk` installed are unaffected — the hook checks for the binary first.
-
-To remove:
-
-```bash
-spelunk hooks uninstall
-```
+---
 
 ## Next steps
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -2,7 +2,7 @@
 
 `spelunk memory` is a per-project knowledge store. Use it to capture decisions, context, requirements, questions, and handoff notes that would otherwise live only in chat history or someone's head.
 
-Memory entries are stored in a local SQLite database alongside your index and are searchable by meaning (semantic similarity), not just keywords.
+Memory entries are stored in git notes by default — they travel with the repository and require no database or server. An optional SQLite backend is available for projects that use semantic search. Entries are searchable by full text at all times; semantic search (by meaning) is available when an embedding server is configured.
 
 ## Why memory?
 
@@ -154,7 +154,7 @@ spelunk memory graph 42 --format json
 
 ## Harvesting from git history
 
-`spelunk memory harvest` reads your git log, sends commit messages to the LLM, and automatically extracts significant entries:
+`spelunk memory harvest` reads your git log, sends commit messages to the LLM, and automatically extracts significant entries. Requires `llm_model` in `~/.config/spelunk/config.toml`.
 
 ```bash
 # Default: last 10 commits


### PR DESCRIPTION
Update all user-facing docs (README, getting-started, SKILL.md, CLAUDE.md, agent-guide, memory, examples, AGENT.md template) to reflect the new architecture direction: core CLI features (memory, code graph, full-text search) work without any inference server. Semantic search, explore, plan create, and harvest are now clearly marked as requiring an optional server. AGENT=true added consistently to workflow commands in SKILL.md.

Closes #202