### PR TITLE
fix(#197): add contains_secret checks to harvest_entire LLM fallback path

### DIFF
--- a/src/cli/cmd/memory/harvest_entire.rs
+++ b/src/cli/cmd/memory/harvest_entire.rs
@@ -11,6 +11,7 @@ use super::{MemoryHarvestArgs, backend_err};
 use crate::{
     config::Config,
     embeddings::{EmbeddingBackend as _, vec_to_blob},
+    indexer::secrets::contains_secret,
     storage::{NoteInput, open_memory_backend},
 };
 
@@ -465,6 +466,13 @@ pub(super) async fn harvest_entire(
                     }
                 };
                 if !text.is_empty() {
+                    if contains_secret(&text) {
+                        eprintln!(
+                            "warning: skipping checkpoint {} (secret detected in prompt.txt)",
+                            cp.id
+                        );
+                        continue;
+                    }
                     checkpoint_texts.push((cp.id.clone(), text, cp.files_touched.clone()));
                 }
             }
@@ -570,6 +578,11 @@ pub(super) async fn harvest_entire(
                     .find(|(id, _, _)| *id == cp_id || id.starts_with(&cp_id))
                     .map(|(_, _, f)| f.clone())
                     .unwrap_or_default();
+
+                if contains_secret(&body) {
+                    eprintln!("warning: skipping entry '{title}' (secret detected in LLM body)");
+                    continue;
+                }
 
                 let source_ref = format!("entire:{cp_id}");
                 if backend


### PR DESCRIPTION
Follow-up to #212 addressing QA security feedback.

## Summary

- Scan `prompt.txt` content with `contains_secret()` **before** sending to the LLM — skips the checkpoint with a warning if a credential is detected (parity with `harvest_claude.rs` line ~170)
- Scan each LLM-generated `body` with `contains_secret()` **before** storage — skips the entry with a warning (parity with `harvest_claude.rs` line ~360)

The fast path (Summary structs are machine-generated) is unchanged per QA recommendation.

## Test plan

- [x] `cargo test` — all passing (no new tests needed; `contains_secret` is already exercised by the secrets module's own suite)
- [x] `cargo fmt` + `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)