### PR TITLE
fix: prevent self-referential .spelunk symlink in git worktrees

### DIFF
--- a/src/cli/cmd/index/worktree.rs
+++ b/src/cli/cmd/index/worktree.rs
@@ -28,14 +28,25 @@ pub(super) fn ensure_spelunk_symlink(root: &std::path::Path) {
     };
     let gitdir = std::path::PathBuf::from(gitdir_str.trim());
 
-    // Walk up two levels: worktrees/<name> → .git → main worktree root
-    let Some(main_root) = gitdir
-        .parent()
-        .and_then(|p| p.parent())
-        .and_then(|p| p.parent())
-    else {
+    // Validate expected structure: <main>/.git/worktrees/<name>
+    // parent()  → worktrees/
+    // parent()  → .git/
+    // parent()  → main worktree root
+    let Some(worktrees_dir) = gitdir.parent() else {
         return;
     };
+    if worktrees_dir.file_name() != Some(std::ffi::OsStr::new("worktrees")) {
+        return; // unexpected gitdir layout — don't guess
+    }
+    let Some(main_root) = worktrees_dir.parent().and_then(|p| p.parent()) else {
+        return;
+    };
+
+    // Guard: never create a symlink that points to itself.
+    if main_root == root {
+        return;
+    }
+
     let main_spelunk = main_root.join(".spelunk");
     if !main_spelunk.exists() {
         return; // main worktree not yet indexed — skip

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -15,6 +15,16 @@ impl Database {
     /// load the sqlite-vec extension into every new connection.
     pub fn open(path: &Path) -> Result<Self> {
         if let Some(parent) = path.parent() {
+            // If the .spelunk path exists as a broken or self-referential symlink,
+            // create_dir_all will fail with EEXIST. Detect and explain that case.
+            if parent.is_symlink() && !parent.exists() {
+                anyhow::bail!(
+                    "creating db directory {}: path exists as a broken symlink. \
+                     Remove it with `rm {}` and re-run.",
+                    parent.display(),
+                    parent.display(),
+                );
+            }
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating db directory {}", parent.display()))?;
         }


### PR DESCRIPTION
## Summary

- `ensure_spelunk_symlink` used a blind 3-level `parent()` walk to find the main worktree root from the gitdir path. If the path structure differed from the expected `…/.git/worktrees/<name>` layout, `main_root` could resolve to the same directory as `root`, producing a symlink pointing to itself — causing `spelunk init` and `spelunk index` to fail with `File exists (os error 17)` on the next run.
- `Database::open` surfaced this as an opaque OS error with no recovery hint.

## Changes

**`src/cli/cmd/index/worktree.rs`**
- Validate that the second component of the gitdir path is `worktrees/`; bail out if the structure is unexpected instead of guessing.
- Explicit guard: `if main_root == root { return; }` — never create a self-referential symlink under any circumstances.

**`src/storage/db.rs`**
- Before calling `create_dir_all`, detect if `.spelunk` is a broken/self-referential symlink and emit a clear `rm .spelunk` instruction instead of the opaque `File exists (os error 17)`.

## Test plan

- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean ✓
- [x] `cargo test --lib` — 33/33 pass ✓
- [x] `spelunk index .` in a git worktree still creates the correct symlink to the main worktree's `.spelunk`
- [x] `spelunk init` in the main repo with an existing `.spelunk` directory no longer replaces it with a symlink
- [x] Running either command with a broken `.spelunk` symlink present prints a clear error with recovery instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)