### PR TITLE
bench(memory): give grep baseline a fair query in Decision Archaeology

### DIFF
--- a/bench/memory/decision_archaeology.py
+++ b/bench/memory/decision_archaeology.py
@@ -31,6 +31,7 @@ import re
 import sqlite3
 import statistics
 import subprocess
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -49,21 +50,15 @@ def extract_keywords(question: str) -> list[str]:
     """
     keywords: list[str] = []
 
-    # Quoted strings
     quoted = re.findall(r'"([^"]+)"', question)
     keywords.extend(quoted)
-
-    # CAPITALISED acronyms
     caps = re.findall(r"\b[A-Z][A-Z_]{2,}\b", question)
     keywords.extend(caps)
-
-    # snake_case and CamelCase identifiers
     snake = re.findall(r"\b[a-z]+_[a-z_]+\b", question, re.IGNORECASE)
     keywords.extend(snake)
     camel = re.findall(r"\b[A-Z][a-z]+(?:[A-Z][a-z]+)+\b", question)
     keywords.extend(camel)
 
-    # Deduplicate, sort by length desc, take top 5
     seen = set()
     unique = []
     for kw in keywords:
@@ -136,12 +131,10 @@ def _git_log_grep(repo_path: Path, pattern: str, limit: int = 10) -> list[dict]:
 
 
 def run_grep_literal(repo_path: Path, query: str, limit: int = 10) -> list[dict]:
-    """Grep using the full question string (verbatim)."""
     return _git_log_grep(repo_path, query, limit)
 
 
 def run_grep_keywords(repo_path: Path, query: str, limit: int = 10) -> list[dict]:
-    """Extract keywords from the question, grep for each, merge results."""
     keywords = extract_keywords(query)
     all_results: list[dict] = []
     seen_commits: set[str] = set()
@@ -156,7 +149,6 @@ def run_grep_keywords(repo_path: Path, query: str, limit: int = 10) -> list[dict
 
 
 def _build_fts_index(repo_path: Path, rebuild: bool = False) -> Path:
-    """Build a SQLite FTS5 index over commit messages. Returns path to the DB."""
     db_path = repo_path / ".git" / "spelunk_fts_commits.db"
     if rebuild and db_path.exists():
         db_path.unlink()
@@ -169,7 +161,6 @@ def _build_fts_index(repo_path: Path, rebuild: bool = False) -> Path:
     )
     conn.commit()
 
-    # Stream commits via git log
     proc = subprocess.Popen(
         ["git", "--no-pager", "log", "--format=%H%x00%s%x00%b%x00---"],
         cwd=repo_path,
@@ -197,18 +188,25 @@ def _build_fts_index(repo_path: Path, rebuild: bool = False) -> Path:
     return db_path
 
 
-def run_fts_commit_messages(repo_path: Path, query: str, limit: int = 10) -> list[dict]:
+def run_fts_commit_messages(
+    repo_path: Path, query: str, limit: int = 10, rebuild_fts: bool = False
+) -> list[dict]:
     """Build FTS5 index over commit messages and query with the full question."""
     try:
-        db_path = _build_fts_index(repo_path)
+        db_path = _build_fts_index(repo_path, rebuild=rebuild_fts)
         conn = sqlite3.connect(str(db_path))
         rows = conn.execute(
-            "SELECT commit, title, body FROM commits WHERE commits MATCH ? ORDER BY rank LIMIT ?",
+            "SELECT sha, title, body FROM commits WHERE commits MATCH ? ORDER BY rank LIMIT ?",
             (query, limit),
         ).fetchall()
         conn.close()
         return [{"commit": r[0], "title": r[1], "body": r[2]} for r in rows]
-    except Exception:
+    except sqlite3.OperationalError as e:
+        # FTS query syntax errors — treat as no results
+        print(f"  FTS query failed (syntax): {e}", file=sys.stderr)
+        return []
+    except Exception as e:
+        print(f"  FTS query failed: {type(e).__name__}: {e}", file=sys.stderr)
         return []
 
 
@@ -276,7 +274,6 @@ def main() -> None:
     print(f"Questions: {len(questions)}")
     print()
 
-    # Accumulators per condition
     conditions = {
         "grep_literal": {"hits": [], "ranks": [], "wall": []},
         "grep_keywords": {"hits": [], "ranks": [], "wall": []},
@@ -314,7 +311,6 @@ def main() -> None:
             status = "HIT" if hit else "MISS"
             print(f"  {cond_name:<22} {status:4} (rank={rank or '-'}, {elapsed:.2f}s)")
 
-    # Build output
     output: dict = {
         "benchmark": "decision_archaeology",
         "repo": str(repo_path),

--- a/bench/memory/decision_archaeology.py
+++ b/bench/memory/decision_archaeology.py
@@ -188,16 +188,26 @@ def _build_fts_index(repo_path: Path, rebuild: bool = False) -> Path:
     return db_path
 
 
+def _sanitize_fts_query(query: str) -> str:
+    """Strip FTS5-special characters; return space-separated tokens."""
+    cleaned = "".join(c if c.isalnum() or c.isspace() else " " for c in query)
+    tokens = cleaned.split()
+    return " ".join(tokens) if tokens else ""
+
+
 def run_fts_commit_messages(
     repo_path: Path, query: str, limit: int = 10, rebuild_fts: bool = False
 ) -> list[dict]:
     """Build FTS5 index over commit messages and query with the full question."""
     try:
+        clean = _sanitize_fts_query(query)
+        if not clean:
+            return []
         db_path = _build_fts_index(repo_path, rebuild=rebuild_fts)
         conn = sqlite3.connect(str(db_path))
         rows = conn.execute(
             "SELECT sha, title, body FROM commits WHERE commits MATCH ? ORDER BY rank LIMIT ?",
-            (query, limit),
+            (clean, limit),
         ).fetchall()
         conn.close()
         return [{"commit": r[0], "title": r[1], "body": r[2]} for r in rows]

--- a/bench/memory/decision_archaeology.py
+++ b/bench/memory/decision_archaeology.py
@@ -1,44 +1,86 @@
 #!/usr/bin/env python3
 """Decision archaeology benchmark — measure spelunk memory retrieval vs grep.
 
-Evaluates whether `spelunk memory search` can retrieve decisions, context,
-and design rationale from git history better than raw `git log --grep`.
+Four conditions compared against the same question set:
 
-Workflow:
-  1. Index the repo:           spelunk index <repo>
-  2. Harvest memory:           spelunk memory harvest --git-range <range>
-  3. Run this benchmark:       python bench/memory/decision_archaeology.py ...
-
-For each curated question, runs both memory search and grep baseline,
-checking whether ground-truth keywords or commits appear in results.
+    grep_literal    — git log --grep with the full question string (verbatim)
+    grep_keywords   — git log --grep with regex-extracted keywords from question
+    fts_commit_msgs — SQLite FTS5 index over all commit messages, full question
+    memory_search   — spelunk memory search (semantic over harvested entries)
 
 Usage:
-    # Single repo with a questions file
     python bench/memory/decision_archaeology.py \\
         --repo-path /path/to/repo \\
         --questions bench/memory/questions-ripgrep.json \\
-        --out bench/results/archaeology-ripgrep.json
+        --out bench/results/archaeology.json
 
 Questions file format (JSON):
     [
         {
-            "question": "Why was X chosen over Y?",
-            "answer_keywords": ["X", "Y", "reason"],
+            "question": "How does error handling work in the parser?",
             "ground_truth_commit": "abc123"
         }
     ]
+
+See bench/memory/README.md for the authoring protocol.
 """
 
 import argparse
 import json
+import re
+import sqlite3
+import statistics
 import subprocess
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+# ---------------------------------------------------------------------------
+# Keyword extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_keywords(question: str) -> list[str]:
+    """Extract search keywords from a natural-language question.
+
+    Heuristic: capitalised words, underscored symbols, quoted strings,
+    and CamelCase tokens. Returns ≤5 keywords, sorted by length descending
+    (longer tokens are more specific).
+    """
+    keywords: list[str] = []
+
+    # Quoted strings
+    quoted = re.findall(r'"([^"]+)"', question)
+    keywords.extend(quoted)
+
+    # CAPITALISED acronyms
+    caps = re.findall(r"\b[A-Z][A-Z_]{2,}\b", question)
+    keywords.extend(caps)
+
+    # snake_case and CamelCase identifiers
+    snake = re.findall(r"\b[a-z]+_[a-z_]+\b", question, re.IGNORECASE)
+    keywords.extend(snake)
+    camel = re.findall(r"\b[A-Z][a-z]+(?:[A-Z][a-z]+)+\b", question)
+    keywords.extend(camel)
+
+    # Deduplicate, sort by length desc, take top 5
+    seen = set()
+    unique = []
+    for kw in keywords:
+        low = kw.lower()
+        if low not in seen and len(kw) >= 3:
+            seen.add(low)
+            unique.append(kw)
+    unique.sort(key=len, reverse=True)
+    return unique[:5] if unique else [question.split()[0]]
+
+
+# ---------------------------------------------------------------------------
+# Retrieval functions
+# ---------------------------------------------------------------------------
+
 
 def run_memory_search(repo_path: Path, query: str, limit: int = 10) -> list[dict]:
-    """Run spelunk memory search, return parsed results."""
     cmd = [
         "spelunk",
         "memory",
@@ -60,14 +102,13 @@ def run_memory_search(repo_path: Path, query: str, limit: int = 10) -> list[dict
         return []
 
 
-def run_git_log(repo_path: Path, query: str, limit: int = 10) -> list[dict]:
-    """Run git log --grep, return parsed results as pseudo-results."""
+def _git_log_grep(repo_path: Path, pattern: str, limit: int = 10) -> list[dict]:
     cmd = [
         "git",
         "--no-pager",
         "log",
         "--grep",
-        query,
+        pattern,
         "-i",
         "--max-count",
         str(limit),
@@ -94,19 +135,99 @@ def run_git_log(repo_path: Path, query: str, limit: int = 10) -> list[dict]:
         return []
 
 
-def check_hit(
-    results: list[dict], keywords: list[str], commit: str
-) -> tuple[bool, int | None]:
-    """Check if results contain any keyword or the ground-truth commit.
-    Returns (hit: bool, rank: int | None)."""
+def run_grep_literal(repo_path: Path, query: str, limit: int = 10) -> list[dict]:
+    """Grep using the full question string (verbatim)."""
+    return _git_log_grep(repo_path, query, limit)
+
+
+def run_grep_keywords(repo_path: Path, query: str, limit: int = 10) -> list[dict]:
+    """Extract keywords from the question, grep for each, merge results."""
+    keywords = extract_keywords(query)
+    all_results: list[dict] = []
+    seen_commits: set[str] = set()
+    for kw in keywords:
+        for r in _git_log_grep(repo_path, kw, limit):
+            if r["commit"] not in seen_commits:
+                seen_commits.add(r["commit"])
+                all_results.append(r)
+        if len(all_results) >= limit:
+            break
+    return all_results[:limit]
+
+
+def _build_fts_index(repo_path: Path) -> Path:
+    """Build a SQLite FTS5 index over commit messages. Returns path to the DB."""
+    db_path = repo_path / ".git" / "spelunk_fts_commits.db"
+    if db_path.exists():
+        return db_path
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS commits USING fts5(commit, title, body)"
+    )
+    conn.commit()
+
+    # Stream commits via git log
+    proc = subprocess.Popen(
+        ["git", "--no-pager", "log", "--format=%H%x00%s%x00%b%x00---"],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    batch = []
+    for line in proc.stdout:
+        line = line.strip()
+        if line == "---" or not line:
+            continue
+        parts = line.split("\0")
+        if len(parts) >= 2:
+            batch.append((parts[0], parts[1], parts[2] if len(parts) > 2 else ""))
+        if len(batch) >= 1000:
+            conn.executemany(
+                "INSERT INTO commits(commit, title, body) VALUES(?,?,?)", batch
+            )
+            batch = []
+    if batch:
+        conn.executemany(
+            "INSERT INTO commits(commit, title, body) VALUES(?,?,?)", batch
+        )
+    conn.commit()
+    proc.wait()
+    conn.close()
+    return db_path
+
+
+def run_fts_commit_messages(repo_path: Path, query: str, limit: int = 10) -> list[dict]:
+    """Build FTS5 index over commit messages and query with the full question."""
+    try:
+        db_path = _build_fts_index(repo_path)
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            "SELECT commit, title, body FROM commits WHERE commits MATCH ? ORDER BY rank LIMIT ?",
+            (query, limit),
+        ).fetchall()
+        conn.close()
+        return [{"commit": r[0], "title": r[1], "body": r[2]} for r in rows]
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Hit checking
+# ---------------------------------------------------------------------------
+
+
+def check_hit(results: list[dict], commit: str) -> tuple[bool, int | None]:
+    """Check if ground-truth commit appears in results."""
     for i, r in enumerate(results):
-        text = json.dumps(r).lower()
-        for kw in keywords:
-            if kw.lower() in text:
-                return True, i + 1
-        if commit and commit in text:
+        if commit and r.get("commit", "") == commit:
             return True, i + 1
     return False, None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def get_spelunk_version() -> str:
@@ -119,18 +240,17 @@ def get_spelunk_version() -> str:
         return "unknown"
 
 
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Decision archaeology benchmark — memory search vs grep."
-    )
+    parser = argparse.ArgumentParser(description="Decision archaeology benchmark.")
     parser.add_argument("--repo-path", required=True)
-    parser.add_argument(
-        "--questions", required=True, help="Path to questions JSON file."
-    )
-    parser.add_argument("--out", default=None, help="Output JSON path.")
-    parser.add_argument(
-        "--limit", type=int, default=10, help="Results per query (default: 10)."
-    )
+    parser.add_argument("--questions", required=True)
+    parser.add_argument("--out", default=None)
+    parser.add_argument("--limit", type=int, default=10)
     args = parser.parse_args()
 
     repo_path = Path(args.repo_path).resolve()
@@ -144,93 +264,78 @@ def main() -> None:
     print(f"Questions: {len(questions)}")
     print()
 
-    memory_hits = []
-    memory_ranks = []
-    grep_hits = []
-    grep_ranks = []
-    memory_wall = []
-    grep_wall = []
+    # Accumulators per condition
+    conditions = {
+        "grep_literal": {"hits": [], "ranks": [], "wall": []},
+        "grep_keywords": {"hits": [], "ranks": [], "wall": []},
+        "fts_commit_messages": {"hits": [], "ranks": [], "wall": []},
+        "memory_search": {"hits": [], "ranks": [], "wall": []},
+    }
 
     for i, q in enumerate(questions):
         question = q["question"]
-        keywords = q.get("answer_keywords", [])
         commit = q.get("ground_truth_commit", "")
 
         print(f"[{i + 1}/{len(questions)}] {question[:80]}...")
 
-        # Memory search
-        start = time.monotonic()
-        mem_results = run_memory_search(repo_path, question, args.limit)
-        mem_elapsed = time.monotonic() - start
-        mem_hit, mem_rank = check_hit(mem_results, keywords, commit)
-        memory_hits.append(1.0 if mem_hit else 0.0)
-        memory_ranks.append(1.0 / mem_rank if mem_rank else 0.0)
-        memory_wall.append(mem_elapsed)
+        for cond_name, cond_data in conditions.items():
+            start = time.monotonic()
+            if cond_name == "grep_literal":
+                results = run_grep_literal(repo_path, question, args.limit)
+            elif cond_name == "grep_keywords":
+                results = run_grep_keywords(repo_path, question, args.limit)
+            elif cond_name == "fts_commit_messages":
+                results = run_fts_commit_messages(repo_path, question, args.limit)
+            elif cond_name == "memory_search":
+                results = run_memory_search(repo_path, question, args.limit)
+            else:
+                results = []
+            elapsed = time.monotonic() - start
 
-        # Grep baseline
-        start = time.monotonic()
-        grep_results = run_git_log(repo_path, question, args.limit)
-        grep_elapsed = time.monotonic() - start
-        grep_hit, grep_rank = check_hit(grep_results, keywords, commit)
-        grep_hits.append(1.0 if grep_hit else 0.0)
-        grep_ranks.append(1.0 / grep_rank if grep_rank else 0.0)
-        grep_wall.append(grep_elapsed)
+            hit, rank = check_hit(results, commit)
+            cond_data["hits"].append(1.0 if hit else 0.0)
+            cond_data["ranks"].append(1.0 / rank if rank else 0.0)
+            cond_data["wall"].append(elapsed)
 
-        print(
-            f"  memory: {'HIT' if mem_hit else 'MISS'} (rank={mem_rank or '-'}, {mem_elapsed:.2f}s)"
-        )
-        print(
-            f"  grep:   {'HIT' if grep_hit else 'MISS'} (rank={grep_rank or '-'}, {grep_elapsed:.2f}s)"
-        )
+            status = "HIT" if hit else "MISS"
+            print(f"  {cond_name:<22} {status:4} (rank={rank or '-'}, {elapsed:.2f}s)")
 
-    import statistics
-
-    mem_recall = float(sum(memory_hits) / len(memory_hits)) if memory_hits else 0.0
-    mem_mrr = float(sum(memory_ranks) / len(memory_ranks)) if memory_ranks else 0.0
-    grep_recall = float(sum(grep_hits) / len(grep_hits)) if grep_hits else 0.0
-    grep_mrr = float(sum(grep_ranks) / len(grep_ranks)) if grep_ranks else 0.0
-
-    output = {
+    # Build output
+    output: dict = {
         "benchmark": "decision_archaeology",
         "repo": str(repo_path),
         "spelunk_version": get_spelunk_version(),
         "timestamp": datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
         "num_questions": len(questions),
-        "memory_search": {
-            "recall": round(mem_recall, 4),
-            "mrr": round(mem_mrr, 4),
-            "median_wall_seconds": round(
-                statistics.median(memory_wall) if memory_wall else 0, 3
-            ),
-        },
-        "grep_baseline": {
-            "recall": round(grep_recall, 4),
-            "mrr": round(grep_mrr, 4),
-            "median_wall_seconds": round(
-                statistics.median(grep_wall) if grep_wall else 0, 3
-            ),
-        },
-        "details": [
-            {
-                "question": q["question"],
-                "memory_hit": bool(h),
-                "memory_rank": r,
-                "grep_hit": bool(gh),
-                "grep_rank": gr,
-            }
-            for q, h, r, gh, gr in zip(
-                questions, memory_hits, memory_ranks, grep_hits, grep_ranks
-            )
-        ],
     }
 
+    for cond_name, cond_data in conditions.items():
+        hits = cond_data["hits"]
+        ranks = cond_data["ranks"]
+        walls = cond_data["wall"]
+        output[cond_name] = {
+            "recall": round(float(sum(hits) / len(hits)), 4) if hits else 0.0,
+            "mrr": round(float(sum(ranks) / len(ranks)), 4) if ranks else 0.0,
+            "median_wall_seconds": round(float(statistics.median(walls)), 3)
+            if walls
+            else 0.0,
+        }
+
+    output["details"] = [
+        {
+            "question": q["question"],
+            **{f"{c}_hit": bool(conditions[c]["hits"][i]) for c in conditions},
+            **{f"{c}_rank": conditions[c]["ranks"][i] for c in conditions},
+        }
+        for i, q in enumerate(questions)
+    ]
+
     print()
-    print(
-        f"Memory search: recall={mem_recall:.2%}  MRR={mem_mrr:.3f}  wall={statistics.median(memory_wall):.3f}s"
-    )
-    print(
-        f"Grep baseline: recall={grep_recall:.2%}  MRR={grep_mrr:.3f}  wall={statistics.median(grep_wall):.3f}s"
-    )
+    for cond_name in conditions:
+        r = output[cond_name]["recall"]
+        m = output[cond_name]["mrr"]
+        w = output[cond_name]["median_wall_seconds"]
+        print(f"{cond_name:<22} recall={r:.2%}  MRR={m:.3f}  wall={w:.3f}s")
 
     if args.out:
         Path(args.out).parent.mkdir(parents=True, exist_ok=True)

--- a/bench/memory/decision_archaeology.py
+++ b/bench/memory/decision_archaeology.py
@@ -188,11 +188,21 @@ def _build_fts_index(repo_path: Path, rebuild: bool = False) -> Path:
     return db_path
 
 
+FTS5_RESERVED = {"and", "or", "not", "near"}
+
+
 def _sanitize_fts_query(query: str) -> str:
-    """Strip FTS5-special characters; return space-separated tokens."""
+    """Convert natural-language query to FTS5 OR-of-quoted-tokens.
+
+    FTS5 defaults to AND semantics; OR avoids requiring every token
+    to appear in the same commit message. Tokens are quoted to protect
+    against FTS5 reserved words and special characters.
+    """
     cleaned = "".join(c if c.isalnum() or c.isspace() else " " for c in query)
-    tokens = cleaned.split()
-    return " ".join(tokens) if tokens else ""
+    tokens = [
+        t for t in cleaned.split() if len(t) >= 2 and t.lower() not in FTS5_RESERVED
+    ]
+    return " OR ".join(f'"{t}"' for t in tokens) if tokens else ""
 
 
 def run_fts_commit_messages(

--- a/bench/memory/decision_archaeology.py
+++ b/bench/memory/decision_archaeology.py
@@ -44,8 +44,8 @@ def extract_keywords(question: str) -> list[str]:
     """Extract search keywords from a natural-language question.
 
     Heuristic: capitalised words, underscored symbols, quoted strings,
-    and CamelCase tokens. Returns ≤5 keywords, sorted by length descending
-    (longer tokens are more specific).
+    and CamelCase tokens. Returns ≤5 keywords, sorted by length descending.
+    Returns empty list if no technical tokens found (caller handles honestly).
     """
     keywords: list[str] = []
 
@@ -72,7 +72,7 @@ def extract_keywords(question: str) -> list[str]:
             seen.add(low)
             unique.append(kw)
     unique.sort(key=len, reverse=True)
-    return unique[:5] if unique else [question.split()[0]]
+    return unique[:5]  # empty if no technical tokens — caller scores 0 honestly
 
 
 # ---------------------------------------------------------------------------
@@ -155,15 +155,17 @@ def run_grep_keywords(repo_path: Path, query: str, limit: int = 10) -> list[dict
     return all_results[:limit]
 
 
-def _build_fts_index(repo_path: Path) -> Path:
+def _build_fts_index(repo_path: Path, rebuild: bool = False) -> Path:
     """Build a SQLite FTS5 index over commit messages. Returns path to the DB."""
     db_path = repo_path / ".git" / "spelunk_fts_commits.db"
+    if rebuild and db_path.exists():
+        db_path.unlink()
     if db_path.exists():
         return db_path
 
     conn = sqlite3.connect(str(db_path))
     conn.execute(
-        "CREATE VIRTUAL TABLE IF NOT EXISTS commits USING fts5(commit, title, body)"
+        "CREATE VIRTUAL TABLE IF NOT EXISTS commits USING fts5(sha, title, body)"
     )
     conn.commit()
 
@@ -184,13 +186,11 @@ def _build_fts_index(repo_path: Path) -> Path:
             batch.append((parts[0], parts[1], parts[2] if len(parts) > 2 else ""))
         if len(batch) >= 1000:
             conn.executemany(
-                "INSERT INTO commits(commit, title, body) VALUES(?,?,?)", batch
+                "INSERT INTO commits(sha, title, body) VALUES(?,?,?)", batch
             )
             batch = []
     if batch:
-        conn.executemany(
-            "INSERT INTO commits(commit, title, body) VALUES(?,?,?)", batch
-        )
+        conn.executemany("INSERT INTO commits(sha, title, body) VALUES(?,?,?)", batch)
     conn.commit()
     proc.wait()
     conn.close()
@@ -218,9 +218,16 @@ def run_fts_commit_messages(repo_path: Path, query: str, limit: int = 10) -> lis
 
 
 def check_hit(results: list[dict], commit: str) -> tuple[bool, int | None]:
-    """Check if ground-truth commit appears in results."""
+    """Check if ground-truth commit appears in results.
+
+    Handles both grep/FTS results (commit field) and memory results
+    (source_ref field). Prefix-matches so short SHAs work with full SHAs.
+    """
+    if not commit:
+        return False, None
     for i, r in enumerate(results):
-        if commit and r.get("commit", "") == commit:
+        candidate = r.get("commit") or r.get("source_ref") or ""
+        if candidate.startswith(commit) or commit.startswith(candidate):
             return True, i + 1
     return False, None
 
@@ -251,6 +258,11 @@ def main() -> None:
     parser.add_argument("--questions", required=True)
     parser.add_argument("--out", default=None)
     parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument(
+        "--rebuild-fts",
+        action="store_true",
+        help="Rebuild the FTS5 commit index from scratch.",
+    )
     args = parser.parse_args()
 
     repo_path = Path(args.repo_path).resolve()
@@ -285,7 +297,9 @@ def main() -> None:
             elif cond_name == "grep_keywords":
                 results = run_grep_keywords(repo_path, question, args.limit)
             elif cond_name == "fts_commit_messages":
-                results = run_fts_commit_messages(repo_path, question, args.limit)
+                results = run_fts_commit_messages(
+                    repo_path, question, args.limit, rebuild_fts=args.rebuild_fts
+                )
             elif cond_name == "memory_search":
                 results = run_memory_search(repo_path, question, args.limit)
             else:
@@ -305,6 +319,7 @@ def main() -> None:
         "benchmark": "decision_archaeology",
         "repo": str(repo_path),
         "spelunk_version": get_spelunk_version(),
+        "fts_rebuilt": args.rebuild_fts,
         "timestamp": datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
         "num_questions": len(questions),
     }


### PR DESCRIPTION
Closes #227

Replace single rigged grep_literal condition with four:
- grep_literal: git log --grep with full question (labelled honestly)
- grep_keywords: regex-extract keywords, grep each, merge results
- fts_commit_messages: SQLite FTS5 index over all commits
- memory_search: unchanged spelunk memory search

All four run on the same question set. Output JSON includes recall, MRR, and median wall per condition. Hit checking matches ground_truth_commit SHA.