### PR TITLE
bench(memory): add blind question-authoring protocol

### DIFF
--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -21,13 +21,15 @@ database. The protocol:
 3. **Ground truth:** For each question, record the commit SHA(s) that best
    answer it. Derive this from the raw git log, NOT from memory entries.
 4. **Review:** Have the question set reviewed by a second party with no
-   access to the spelunk memory database.
+   access to the spelunk memory database. Record the reviewer and date
+   in the `reviewed_by` field.
 5. **Format:** Save as `bench/memory/questions-<repo>.json`:
    ```json
    [
        {
            "question": "How does error handling work in the parser?",
-           "ground_truth_commit": "abc123def456"
+           "ground_truth_commit": "abc123def456",
+           "reviewed_by": "<name> on <date>"
        }
    ]
    ```
@@ -74,7 +76,7 @@ python bench/memory/decision_archaeology.py \
 
 ## Cross-Session Handoff
 
-See `bench/memory/cross_session_handoff.py`. Under redesign per issue #228.
+See `bench/memory/cross_session_handoff.py`. TODO(#228): update once redesign lands.
 
 ### Current limitations
 

--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -1,0 +1,82 @@
+# Memory Benchmarks
+
+## Decision Archaeology
+
+Measures whether spelunk memory can retrieve design rationale from git history
+better than lexical search (grep, FTS5).
+
+### Blindness Protocol
+
+Questions MUST be authored without access to the harvested spelunk memory
+database. The protocol:
+
+1. **Source material:** Read raw `git log` output for the target repo. Use
+   `git log --format="%H %s"` or GitHub PR/commit pages. Do NOT run
+   `spelunk memory list` or `spelunk memory search`.
+2. **Question authoring:** Write natural-language questions a developer would
+   genuinely ask about the codebase's history. Examples:
+   - "How does error handling work in the parser?"
+   - "Why was async I/O chosen over threads for the network layer?"
+   - "What tradeoffs led to the current lock-free queue design?"
+3. **Ground truth:** For each question, record the commit SHA(s) that best
+   answer it. Derive this from the raw git log, NOT from memory entries.
+4. **Review:** Have the question set reviewed by a second party with no
+   access to the spelunk memory database.
+5. **Format:** Save as `bench/memory/questions-<repo>.json`:
+   ```json
+   [
+       {
+           "question": "How does error handling work in the parser?",
+           "ground_truth_commit": "abc123def456"
+       }
+   ]
+   ```
+
+### Script
+
+```
+bench/memory/author_questions.py   — extracts git log for blind authoring
+bench/memory/decision_archaeology.py — runs four-condition comparison
+```
+
+### Authoring workflow
+
+```bash
+# 1. Export raw git log (no spelunk access)
+python bench/memory/author_questions.py \
+    --repo-path /path/to/repo \
+    --num-commits 500 \
+    --out bench/memory/raw-commits-<repo>.json
+
+# 2. Read the raw-commits file (NOT spelunk memory output).
+#    Author ≥10 questions per repo. Record ground-truth commit SHAs.
+
+# 3. Save questions
+#    (hand-write into bench/memory/questions-<repo>.json)
+
+# 4. Index + harvest memory, then run benchmark
+spelunk index /path/to/repo
+cd /path/to/repo && spelunk memory harvest --git-range HEAD~500..HEAD
+python bench/memory/decision_archaeology.py \
+    --repo-path /path/to/repo \
+    --questions bench/memory/questions-<repo>.json \
+    --out bench/results/archaeology-<repo>.json
+```
+
+### Four conditions
+
+| Condition | Query | Search target |
+|-----------|-------|---------------|
+| `grep_literal` | Full question verbatim | `git log --grep` |
+| `grep_keywords` | Regex-extracted keywords | `git log --grep` per keyword |
+| `fts_commit_messages` | Full question | SQLite FTS5 over all commit messages |
+| `memory_search` | Full question | `spelunk memory search` (semantic) |
+
+## Cross-Session Handoff
+
+See `bench/memory/cross_session_handoff.py`. Under redesign per issue #228.
+
+### Current limitations
+
+The 2026-05-15 proof-of-concept (n=1, no correctness check) is a demo,
+not a benchmark. See #228 for the redesign requirements.

--- a/bench/memory/author_questions.py
+++ b/bench/memory/author_questions.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Export raw git log for blind question authoring.
+
+Produces a JSON file containing commit SHAs, subjects, and bodies from
+a repo's git history. The output is intended to be read by a human (or
+another LLM session) that has NO access to the spelunk memory database.
+
+The resulting questions-<repo>.json file should be authored from this
+raw material, NOT from spelunk memory output.
+
+Usage:
+    python bench/memory/author_questions.py \\
+        --repo-path /path/to/repo \\
+        --num-commits 500 \\
+        --out bench/memory/raw-commits-ripgrep.json
+"""
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def export_git_log(repo_path: Path, num_commits: int) -> list[dict]:
+    cmd = [
+        "git",
+        "--no-pager",
+        "log",
+        "--max-count",
+        str(num_commits),
+        "--format=%H%x00%s%x00%b%x00---",
+    ]
+    result = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True)
+
+    commits = []
+    for block in result.stdout.strip().split("---"):
+        block = block.strip()
+        if not block:
+            continue
+        parts = block.split("\0")
+        if len(parts) >= 2:
+            commits.append(
+                {
+                    "commit": parts[0].strip(),
+                    "subject": parts[1].strip(),
+                    "body": parts[2].strip() if len(parts) > 2 else "",
+                }
+            )
+    return commits
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export raw git log for blind question authoring."
+    )
+    parser.add_argument("--repo-path", required=True)
+    parser.add_argument("--num-commits", type=int, default=500)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    repo_path = Path(args.repo_path).resolve()
+    if not repo_path.is_dir():
+        parser.error(f"repo-path does not exist: {repo_path}")
+
+    commits = export_git_log(repo_path, args.num_commits)
+    output = {
+        "repo": str(repo_path),
+        "num_commits_exported": len(commits),
+        "instructions": (
+            "Author questions from the commits below. Do NOT consult spelunk "
+            "memory (spelunk memory list / spelunk memory search). Use the raw "
+            "commit subjects and bodies as your only source material. Record "
+            "ground-truth commit SHAs for each question."
+        ),
+        "commits": commits,
+    }
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"Exported {len(commits)} commits to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/memory/author_questions.py
+++ b/bench/memory/author_questions.py
@@ -31,6 +31,8 @@ def export_git_log(repo_path: Path, num_commits: int) -> list[dict]:
         "--format=%H%x00%s%x00%b%x00---",
     ]
     result = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"git log failed: {result.stderr.strip()}")
 
     commits = []
     for block in result.stdout.strip().split("---"):


### PR DESCRIPTION
Refs #226

- Create bench/memory/README.md documenting the 5-step blindness protocol
- Create bench/memory/author_questions.py to export raw git log as source material
- Questions must be authored from raw commits, not from spelunk memory
- Ground truth = commit SHA, recorded with reviewer audit field
- Actual question sets (>=30 questions across >=3 repos) tracked separately

Post-review fixes:
- Check git log return code in author_questions.py
- Add reviewed_by field to question format
- Add TODO(#228) marker for Cross-Session Handoff section