### PR TITLE
bench(swebench): wire up Docker harness for resolve_rate

### DIFF
--- a/bench/agents/agent.py
+++ b/bench/agents/agent.py
@@ -516,12 +516,23 @@ def main() -> None:
     patch_path = None
     if args.save_patch:
         try:
-            diff = subprocess.run(
-                ["git", "diff"],
+            # Stage all changes (including untracked files from write_file)
+            # then diff against HEAD to capture everything.
+            subprocess.run(
+                ["git", "add", "-A"],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
                 timeout=30,
+                check=True,
+            )
+            diff = subprocess.run(
+                ["git", "diff", "--cached", "HEAD"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=True,
             ).stdout
             patch_path = Path(args.save_patch)
             patch_path.parent.mkdir(parents=True, exist_ok=True)

--- a/bench/agents/agent.py
+++ b/bench/agents/agent.py
@@ -473,6 +473,11 @@ def main() -> None:
     )
     parser.add_argument("--max-turns", type=int, default=20)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--save-patch",
+        default=None,
+        help="Save git diff to this file after agent finishes (for SWE-bench eval).",
+    )
     args = parser.parse_args()
 
     repo_path = Path(args.repo_path).resolve()
@@ -507,6 +512,23 @@ def main() -> None:
         seed=args.seed,
     )
 
+    # Save git diff for SWE-bench evaluation
+    patch_path = None
+    if args.save_patch:
+        try:
+            diff = subprocess.run(
+                ["git", "diff"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            ).stdout
+            patch_path = Path(args.save_patch)
+            patch_path.parent.mkdir(parents=True, exist_ok=True)
+            patch_path.write_text(diff)
+        except Exception as e:
+            print(f"Warning: failed to save patch: {e}", file=sys.stderr)
+
     # Reproducibility contract
     output = {
         "benchmark": "swebench-verified",
@@ -518,6 +540,7 @@ def main() -> None:
         "spelunk_version": get_spelunk_version(),
         "seed": args.seed,
         "max_turns": args.max_turns,
+        "patch_file": str(patch_path) if patch_path else None,
         **agent_result,
     }
     print(json.dumps(output))

--- a/bench/agents/batch_run.py
+++ b/bench/agents/batch_run.py
@@ -74,6 +74,8 @@ def run_task(
         str(max_turns),
         "--seed",
         str(seed),
+        "--save-patch",
+        str(SCRIPT_DIR.parent / "patches" / condition / f"{task_id}.patch"),
     ]
 
     try:

--- a/bench/agents/export_patches.py
+++ b/bench/agents/export_patches.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Export agent patches to SWE-bench prediction format.
 
-Reads a batch result JSON (from batch_run.py or swebench_run.sh) and
-extracts per-task patches, model info, and reproducibility fields into
-the format expected by the SWE-bench Docker harness.
+Reads a batch result JSON and writes a flat predictions list the
+SWE-bench harness can consume, plus a metadata sidecar.
 
 Usage:
     python bench/agents/export_patches.py \\
@@ -36,18 +35,26 @@ def main():
     patches_dir = Path(args.patches_dir)
     predictions = {}
 
+    skipped = 0
+    errored = 0
+    no_patch = 0
+
     for r in results:
         task_id = r.get("task_id", "")
-        if r.get("skipped") or r.get("error"):
+        if r.get("skipped"):
+            skipped += 1
+            continue
+        if r.get("error"):
+            errored += 1
             continue
 
         patch_file = r.get("patch_file")
         if not patch_file:
+            no_patch += 1
             continue
 
         patch_path = Path(patch_file)
         if not patch_path.exists():
-            # Try relative to patches-dir
             patch_path = patches_dir / f"{task_id}.patch"
 
         if patch_path.exists():
@@ -56,22 +63,37 @@ def main():
                 "model_name_or_path": r.get("model", "deepseek-v4-flash"),
                 "model_patch": patch_path.read_text(),
             }
+        else:
+            no_patch += 1
 
-    output = {
-        "predictions": list(predictions.values()),
-        "metadata": {
-            "model": results[0].get("model", "") if results else "",
-            "condition": results[0].get("condition", "") if results else "",
-            "spelunk_version": results[0].get("spelunk_version", ""),
-            "seed": results[0].get("seed", ""),
-        },
-    }
+    predictions_list = list(predictions.values())
 
+    # Write flat list — SWE-bench harness expects this format
     Path(args.out).parent.mkdir(parents=True, exist_ok=True)
     with open(args.out, "w") as f:
-        json.dump(output, f, indent=2)
+        json.dump(predictions_list, f, indent=2)
 
-    print(f"Exported {len(predictions)} predictions to {args.out}")
+    # Metadata sidecar
+    meta_path = Path(args.out).with_suffix(".meta.json")
+    meta_path.write_text(
+        json.dumps(
+            {
+                "model": results[0].get("model", "") if results else "",
+                "condition": results[0].get("condition", "") if results else "",
+                "spelunk_version": results[0].get("spelunk_version", ""),
+                "seed": results[0].get("seed", ""),
+                "tasks_total": len(results),
+                "tasks_with_patch": len(predictions_list),
+                "tasks_skipped": skipped,
+                "tasks_errored": errored,
+                "tasks_no_patch": no_patch,
+            },
+            indent=2,
+        )
+    )
+
+    print(f"Exported {len(predictions_list)} predictions to {args.out}")
+    print(f"  Skipped: {skipped}  Errored: {errored}  No patch: {no_patch}")
 
 
 if __name__ == "__main__":

--- a/bench/agents/export_patches.py
+++ b/bench/agents/export_patches.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Export agent patches to SWE-bench prediction format.
+
+Reads a batch result JSON (from batch_run.py or swebench_run.sh) and
+extracts per-task patches, model info, and reproducibility fields into
+the format expected by the SWE-bench Docker harness.
+
+Usage:
+    python bench/agents/export_patches.py \\
+        --results bench/results/swebench-baseline-batch.json \\
+        --patches-dir bench/patches/baseline \\
+        --out bench/predictions/baseline.json
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export agent patches to SWE-bench prediction format."
+    )
+    parser.add_argument("--results", required=True, help="Batch result JSON.")
+    parser.add_argument(
+        "--patches-dir",
+        required=True,
+        help="Directory containing per-task .patch files.",
+    )
+    parser.add_argument("--out", required=True, help="Output predictions JSON.")
+    args = parser.parse_args()
+
+    with open(args.results) as f:
+        results = json.load(f)
+
+    patches_dir = Path(args.patches_dir)
+    predictions = {}
+
+    for r in results:
+        task_id = r.get("task_id", "")
+        if r.get("skipped") or r.get("error"):
+            continue
+
+        patch_file = r.get("patch_file")
+        if not patch_file:
+            continue
+
+        patch_path = Path(patch_file)
+        if not patch_path.exists():
+            # Try relative to patches-dir
+            patch_path = patches_dir / f"{task_id}.patch"
+
+        if patch_path.exists():
+            predictions[task_id] = {
+                "instance_id": task_id,
+                "model_name_or_path": r.get("model", "deepseek-v4-flash"),
+                "model_patch": patch_path.read_text(),
+            }
+
+    output = {
+        "predictions": list(predictions.values()),
+        "metadata": {
+            "model": results[0].get("model", "") if results else "",
+            "condition": results[0].get("condition", "") if results else "",
+            "spelunk_version": results[0].get("spelunk_version", ""),
+            "seed": results[0].get("seed", ""),
+        },
+    }
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(output, f, indent=2)
+
+    print(f"Exported {len(predictions)} predictions to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/agents/swebench_eval.sh
+++ b/bench/agents/swebench_eval.sh
@@ -1,20 +1,14 @@
 #!/usr/bin/env bash
 # bench/agents/swebench_eval.sh — run SWE-bench Docker evaluation
 #
-# Converts agent patches to SWE-bench prediction format and runs the
-# official Docker harness to compute resolve_rate.
+# Converts agent patches to SWE-bench prediction format, runs the
+# official Docker harness, and merges resolve data back into the
+# result JSON with explicit denominator.
 #
 # Prerequisites:
 #   - SWE-bench harness installed: pip install swebench
 #   - Docker images pulled for the target dataset
 #   - Agent patches saved via agent.py --save-patch
-#
-# Usage:
-#   bash bench/agents/swebench_eval.sh \\
-#       --results bench/results/swebench-baseline-batch.json \\
-#       --patches-dir bench/patches/baseline \\
-#       --dataset princeton-nlp/SWE-bench_Verified \\
-#       --split test
 #
 # Options:
 #   --results FILE     batch result JSON from agent run
@@ -98,27 +92,46 @@ echo ""
 echo "--- Merging resolve data ---"
 HARNESS_DIR="swebench_eval_outputs/${RUN_ID}"
 if [[ -d "$HARNESS_DIR" ]]; then
-    python3 -c "
-import json, sys
-from pathlib import Path
-
+    # Glob for harness output file (filename varies by SWE-bench version)
+    HARNESS_FILE=$(find "$HARNESS_DIR" -maxdepth 2 -name '*.json' -exec grep -l '"resolved"' {} \; 2>/dev/null | head -1)
+    if [[ -z "$HARNESS_FILE" ]]; then
+        echo "ERROR: no harness output with 'resolved' field under ${HARNESS_DIR}" >&2
+    else
+        echo "  Found: ${HARNESS_FILE}"
+        python3 -c "
+import json
 results = json.load(open('${RESULTS}'))
-harness = json.load(open('${HARNESS_DIR}/results.json')) if Path('${HARNESS_DIR}/results.json').exists() else {}
+harness = json.load(open('${HARNESS_FILE}'))
+resolved_map = {r: True for r in harness.get('resolved', [])}
 
-resolved_map = {}
-for r in harness.get('resolved', []):
-    resolved_map[r] = True
+skipped_pre = sum(1 for r in results if r.get('skipped'))
+errored = sum(1 for r in results if r.get('error'))
+evaluated = 0
+resolved_count = 0
 
 for r in results:
-    tid = r.get('task_id','')
-    r['resolved'] = resolved_map.get(tid, False)
+    if not r.get('skipped') and not r.get('error'):
+        evaluated += 1
+        r['resolved'] = resolved_map.get(r.get('task_id', ''), False)
+        if r['resolved']:
+            resolved_count += 1
 
-tasks_evaluated = len([r for r in results if not r.get('skipped') and not r.get('error')])
-tasks_resolved = sum(1 for r in results if r.get('resolved'))
-print(f'  Evaluated: {tasks_evaluated}  Resolved: {tasks_resolved}')
-
-json.dump(results, open('${RESULTS}','w'), indent=2)
+rate = resolved_count / evaluated if evaluated else 0
+output = {
+    'aggregate': {
+        'tasks_total': len(results),
+        'tasks_evaluated': evaluated,
+        'tasks_resolved': resolved_count,
+        'tasks_skipped_pre_eval': skipped_pre,
+        'tasks_errored': errored,
+        'resolve_rate': round(rate, 4),
+    },
+    'tasks': results,
+}
+json.dump(output, open('${RESULTS}', 'w'), indent=2)
+print(f'  Evaluated: {evaluated}  Resolved: {resolved_count}  Rate: {rate:.1%}')
 "
+    fi
 fi
 
 echo ""

--- a/bench/agents/swebench_eval.sh
+++ b/bench/agents/swebench_eval.sh
@@ -100,7 +100,8 @@ if [[ -d "$HARNESS_DIR" ]]; then
         echo "  Found: ${HARNESS_FILE}"
         python3 -c "
 import json
-results = json.load(open('${RESULTS}'))
+raw = json.load(open('${RESULTS}'))
+results = raw['tasks'] if isinstance(raw, dict) and 'tasks' in raw else raw
 harness = json.load(open('${HARNESS_FILE}'))
 resolved_map = {r: True for r in harness.get('resolved', [])}
 

--- a/bench/agents/swebench_eval.sh
+++ b/bench/agents/swebench_eval.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# bench/agents/swebench_eval.sh — run SWE-bench Docker evaluation
+#
+# Converts agent patches to SWE-bench prediction format and runs the
+# official Docker harness to compute resolve_rate.
+#
+# Prerequisites:
+#   - SWE-bench harness installed: pip install swebench
+#   - Docker images pulled for the target dataset
+#   - Agent patches saved via agent.py --save-patch
+#
+# Usage:
+#   bash bench/agents/swebench_eval.sh \\
+#       --results bench/results/swebench-baseline-batch.json \\
+#       --patches-dir bench/patches/baseline \\
+#       --dataset princeton-nlp/SWE-bench_Verified \\
+#       --split test
+#
+# Options:
+#   --results FILE     batch result JSON from agent run
+#   --patches-dir DIR  directory with per-task .patch files
+#   --dataset NAME     HuggingFace dataset (default: princeton-nlp/SWE-bench_Verified)
+#   --split NAME       dataset split (default: test)
+#   --max-workers N    parallel eval workers (default: 4)
+#   --timeout SEC      per-instance timeout (default: 900)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RESULTS=""
+PATCHES_DIR=""
+DATASET="princeton-nlp/SWE-bench_Verified"
+SPLIT="test"
+MAX_WORKERS=4
+TIMEOUT=900
+
+usage() {
+    grep '^#' "$0" | grep -v '#!/' | sed 's/^# \?//'
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --results)      RESULTS="$2";      shift 2 ;;
+        --patches-dir)  PATCHES_DIR="$2";   shift 2 ;;
+        --dataset)      DATASET="$2";       shift 2 ;;
+        --split)        SPLIT="$2";         shift 2 ;;
+        --max-workers)  MAX_WORKERS="$2";   shift 2 ;;
+        --timeout)      TIMEOUT="$2";       shift 2 ;;
+        -h|--help)      usage ;;
+        *) echo "Unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$RESULTS" || -z "$PATCHES_DIR" ]]; then
+    echo "Error: --results and --patches-dir are required." >&2; usage
+fi
+
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+PREDICTIONS_FILE="${SCRIPT_DIR}/../predictions/eval-${TIMESTAMP}.json"
+mkdir -p "$(dirname "$PREDICTIONS_FILE")"
+
+echo "=== SWE-bench Evaluation ==="
+echo "Results:      ${RESULTS}"
+echo "Patches:      ${PATCHES_DIR}"
+echo "Dataset:      ${DATASET}"
+echo "Predictions:  ${PREDICTIONS_FILE}"
+echo ""
+
+# Step 1: Export patches to SWE-bench format
+echo "--- Exporting patches ---"
+python3 "${SCRIPT_DIR}/export_patches.py" \
+    --results "$RESULTS" \
+    --patches-dir "$PATCHES_DIR" \
+    --out "$PREDICTIONS_FILE"
+
+# Step 2: Run SWE-bench evaluation
+echo ""
+echo "--- Running Docker evaluation ---"
+python3 -m swebench.harness.run_evaluation \
+    --dataset_name "$DATASET" \
+    --split "$SPLIT" \
+    --predictions_path "$PREDICTIONS_FILE" \
+    --max_workers "$MAX_WORKERS" \
+    --timeout "$TIMEOUT" \
+    --run_id "spelunk-${TIMESTAMP}"
+
+echo ""
+echo "=== Done ==="
+echo "Results in: swebench_eval_outputs/spelunk-${TIMESTAMP}/"

--- a/bench/agents/swebench_eval.sh
+++ b/bench/agents/swebench_eval.sh
@@ -75,7 +75,14 @@ python3 "${SCRIPT_DIR}/export_patches.py" \
     --patches-dir "$PATCHES_DIR" \
     --out "$PREDICTIONS_FILE"
 
-# Step 2: Run SWE-bench evaluation
+# Step 2: Extract condition from metadata sidecar for run_id
+CONDITION="unknown"
+META_FILE="${PREDICTIONS_FILE%.json}.meta.json"
+if [[ -f "$META_FILE" ]]; then
+    CONDITION=$(python3 -c "import json; print(json.load(open('${META_FILE}')).get('condition','unknown'))" 2>/dev/null || echo "unknown")
+fi
+RUN_ID="spelunk-${CONDITION}-${TIMESTAMP}"
+
 echo ""
 echo "--- Running Docker evaluation ---"
 python3 -m swebench.harness.run_evaluation \
@@ -84,8 +91,36 @@ python3 -m swebench.harness.run_evaluation \
     --predictions_path "$PREDICTIONS_FILE" \
     --max_workers "$MAX_WORKERS" \
     --timeout "$TIMEOUT" \
-    --run_id "spelunk-${TIMESTAMP}"
+    --run_id "$RUN_ID"
+
+# Step 3: Merge harness results back into result JSON
+echo ""
+echo "--- Merging resolve data ---"
+HARNESS_DIR="swebench_eval_outputs/${RUN_ID}"
+if [[ -d "$HARNESS_DIR" ]]; then
+    python3 -c "
+import json, sys
+from pathlib import Path
+
+results = json.load(open('${RESULTS}'))
+harness = json.load(open('${HARNESS_DIR}/results.json')) if Path('${HARNESS_DIR}/results.json').exists() else {}
+
+resolved_map = {}
+for r in harness.get('resolved', []):
+    resolved_map[r] = True
+
+for r in results:
+    tid = r.get('task_id','')
+    r['resolved'] = resolved_map.get(tid, False)
+
+tasks_evaluated = len([r for r in results if not r.get('skipped') and not r.get('error')])
+tasks_resolved = sum(1 for r in results if r.get('resolved'))
+print(f'  Evaluated: {tasks_evaluated}  Resolved: {tasks_resolved}')
+
+json.dump(results, open('${RESULTS}','w'), indent=2)
+"
+fi
 
 echo ""
 echo "=== Done ==="
-echo "Results in: swebench_eval_outputs/spelunk-${TIMESTAMP}/"
+echo "Results in: ${HARNESS_DIR}/"


### PR DESCRIPTION
Closes #229

- agent.py: add --save-patch flag to capture git diff after agent loop
- export_patches.py: collate batch results into SWE-bench prediction format
- swebench_eval.sh: orchestrate export + Docker harness evaluation

Follows the plan in tmp/swebench-evaluation-plan.md. The 26 missing repos need cloned before running; the harness wrapper accepts --dataset and --split for flexibility.