### PR TITLE
bench(memory): redesign Cross-Session Handoff with verifiable tasks

### DIFF
--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -76,9 +76,47 @@ python bench/memory/decision_archaeology.py \
 
 ## Cross-Session Handoff
 
-See `bench/memory/cross_session_handoff.py`. TODO(#228): update once redesign lands.
+Measures whether spelunk memory improves completion success for a fresh
+agent picking up partially-completed work.
 
-### Current limitations
+### Three conditions
 
-The 2026-05-15 proof-of-concept (n=1, no correctness check) is a demo,
-not a benchmark. See #228 for the redesign requirements.
+| Condition | Session 1 files | Memory access | Measures |
+|-----------|----------------|---------------|----------|
+| Cold start | None | None | Intrinsic task difficulty |
+| Files present | On disk | None | Value of file state alone |
+| With memory | On disk | Full | Value of files + memory |
+
+### Task format
+
+Tasks live in `bench/memory/handoff_tasks.json`:
+
+```json
+[
+    {
+        "task": "Fix the failing test in tests/test_parser.py",
+        "repo_url": "https://github.com/user/repo.git",
+        "setup_cmd": "pip install -e '.[dev]'",
+        "verify_cmd": "python -m pytest tests/test_parser.py -x -q"
+    }
+]
+```
+
+- `task`: natural-language description
+- `repo_url`: git clone URL (repo cloned fresh per task)
+- `setup_cmd`: shell command to install dependencies
+- `verify_cmd`: shell command that exits 0 on success (binary pass/fail)
+
+Session 1 is cut off at `--session-1-turns` (default 5) with a system
+prompt instructing the agent to write a detailed handoff. Three Session 2
+clones then attempt the task under the three conditions.
+
+Usage:
+
+```bash
+python bench/memory/cross_session_handoff.py \
+    --tasks bench/memory/handoff_tasks.json \
+    --session-1-turns 5 \
+    --session-2-turns 15 \
+    --out bench/results/handoff.json
+```

--- a/bench/memory/cross_session_handoff.py
+++ b/bench/memory/cross_session_handoff.py
@@ -1,39 +1,44 @@
 #!/usr/bin/env python3
-"""Cross-session handoff benchmark — measure the value of spelunk memory.
+"""Cross-session handoff benchmark — verifiable tasks, forced cutoff, n>=10.
 
-Simulates the core agent workflow:
-  1. Session 1: Agent works on a multi-file task, stores handoff + decisions
-     via `spelunk memory add` when it reaches turn limit.
-  2. Session 2: Fresh agent (no prior conversation) attempts the same task.
-     - Without memory: baseline tools only
-     - With memory: has spelunk_memory_search to find the handoff
+Three conditions for Session 2:
+    no_memory_no_session_1 — cold start, clean repo, no prior session
+    no_memory_present      — Session 1 file changes on disk, no memory tools
+    with_memory            — full spelunk memory access
 
-Measures: turns to completion, tokens used.
+Each task has a verify_cmd that produces a binary pass/fail signal.
+Tasks are defined in bench/memory/handoff_tasks.json.
 
 Usage:
     python bench/memory/cross_session_handoff.py \\
-        --repo-path /path/to/repo \\
-        --task "Rename all occurrences of foo to bar across the codebase" \\
+        --tasks bench/memory/handoff_tasks.json \\
         --model deepseek-v4-flash \\
-        --max-turns 15 \\
-        --out bench/results/handoff-demo.json
+        --session-1-turns 5 \\
+        --session-2-turns 15 \\
+        --out bench/results/handoff.json
 
-Prerequisites:
-    - Repo must be indexed: spelunk index <repo>
-    - API key in DEEPSEEK_API_KEY or passed via --api-key
+Workflow per task:
+  1. Clone fresh repo, run setup_cmd (installs deps)
+  2. Session 1: agent runs --session-1-turns, forced cutoff, stores handoff
+  3. Session 2a: fresh clone, no memory, no S1 files
+  4. Session 2b: S1 files on disk, no memory tools
+  5. Session 2c: S1 files + spelunk memory access
+  6. Verify each session's outcome with verify_cmd
 """
 
 import argparse
 import json
 import os
+import shutil
+import statistics
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
 from dotenv import load_dotenv
 
-# Auto-load .env.local
 _root = Path(__file__).resolve().parents[2]
 _dotenv = _root / ".env.local"
 if _dotenv.exists():
@@ -41,6 +46,13 @@ if _dotenv.exists():
 
 AGENT_SCRIPT = Path(__file__).resolve().parents[1] / "agents" / "agent.py"
 REQUIREMENTS = Path(__file__).resolve().parents[1] / "requirements.txt"
+
+SESSION_1_SYSTEM_ADDON = (
+    "You have LIMITED TURNS. At the end of your turns, you MUST write a "
+    "detailed handoff summarising what you investigated, what you changed, "
+    "what is left to do, and any decisions you made. The next agent will "
+    "rely on this handoff to continue your work."
+)
 
 
 def run_agent(
@@ -51,12 +63,14 @@ def run_agent(
     api_base: str,
     api_key: str,
     max_turns: int,
-    extra_message: str = "",
+    seed: int,
+    extra_system: str = "",
 ) -> dict:
-    """Run agent.py and return the parsed JSON result."""
     issue_file = repo_path / "ISSUE.txt"
-    if not issue_file.exists():
-        issue_file.write_text(task)
+    task_text = task
+    if extra_system:
+        task_text = extra_system + "\n\n" + task
+    issue_file.write_text(task_text)
 
     cmd = [
         "uv",
@@ -83,31 +97,28 @@ def run_agent(
         "--max-turns",
         str(max_turns),
         "--seed",
-        "42",
+        str(seed),
     ]
-
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
     if result.returncode == 0:
         for line in reversed(result.stdout.strip().splitlines()):
             line = line.strip()
             if line.startswith("{"):
                 return json.loads(line)
-    return {
-        "error": True,
-        "stderr": result.stderr[:500],
-        "stdout": result.stdout[-500:],
-    }
+    return {"error": True, "stderr": result.stderr[:500]}
 
 
-def store_handoff(repo_path: Path, task: str, turns_used: int) -> None:
-    """Store a handoff memory entry via spelunk memory add."""
-    title = f"Handoff: {task[:80]}"
-    body = (
-        f"Task: {task}\n"
-        f"Session ran for {turns_used} turns before reaching limit.\n"
-        f"Repo state: partial changes may be present.\n"
-        f"Next agent should review current state and continue the work."
-    )
+def run_verify(repo_path: Path, cmd: str) -> bool:
+    try:
+        r = subprocess.run(
+            cmd, shell=True, cwd=repo_path, capture_output=True, text=True, timeout=60
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def store_handoff(repo_path: Path, task: str, turns: int) -> None:
     subprocess.run(
         [
             "spelunk",
@@ -116,9 +127,14 @@ def store_handoff(repo_path: Path, task: str, turns_used: int) -> None:
             "--kind",
             "handoff",
             "--title",
-            title,
+            f"Handoff: {task[:80]}",
             "--body",
-            body,
+            (
+                f"Task: {task}\n"
+                f"Session cut off after {turns} turns.\n"
+                f"Repo state: partial changes present.\n"
+                f"Next agent: review current state and continue."
+            ),
         ],
         cwd=repo_path,
         capture_output=True,
@@ -138,131 +154,192 @@ def get_spelunk_version() -> str:
 
 def main():
     parser = argparse.ArgumentParser(description="Cross-session handoff benchmark.")
-    parser.add_argument("--repo-path", required=True)
-    parser.add_argument("--task", required=True, help="Refactoring task description.")
+    parser.add_argument("--tasks", required=True, help="Tasks JSON file.")
     parser.add_argument("--model", default="deepseek-v4-flash")
     parser.add_argument("--api-base-url", default="https://api.deepseek.com/v1")
     parser.add_argument("--api-key", default=None)
+    parser.add_argument("--session-1-turns", type=int, default=5)
+    parser.add_argument("--session-2-turns", type=int, default=15)
+    parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(
-        "--max-turns",
-        type=int,
-        default=10,
-        help="Max turns per session (default: 10, so S1 stops early).",
+        "--workdir", default=None, help="Scratch directory (default: tmp)."
     )
-    parser.add_argument("--out", default=None, help="Output JSON path.")
+    parser.add_argument("--out", default=None)
     args = parser.parse_args()
-
-    repo_path = Path(args.repo_path).resolve()
-    if not repo_path.is_dir():
-        parser.error(f"repo-path does not exist: {repo_path}")
 
     api_key = args.api_key or os.environ.get("DEEPSEEK_API_KEY", "")
     if not api_key:
-        parser.error("No API key. Use --api-key or set DEEPSEEK_API_KEY.")
+        parser.error("No API key.")
 
-    print(f"Repo:      {repo_path}")
-    print(f"Task:      {args.task[:100]}")
-    print(f"Max turns: {args.max_turns}")
+    with open(args.tasks) as f:
+        tasks = json.load(f)
+
+    workdir = (
+        Path(args.workdir)
+        if args.workdir
+        else Path(tempfile.mkdtemp(prefix="handoff-"))
+    )
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Tasks:     {len(tasks)}")
+    print(f"S1 turns:  {args.session_1_turns}")
+    print(f"S2 turns:  {args.session_2_turns}")
+    print(f"Workdir:   {workdir}")
     print()
 
-    # ── Session 1: Agent works until turn limit, stores handoff ──────────
-    print("=== Session 1 (baseline, stores handoff) ===")
-    s1_start = time.monotonic()
-    s1 = run_agent(
-        repo_path,
-        args.task,
-        "baseline",
-        args.model,
-        args.api_base_url,
-        api_key,
-        args.max_turns,
-    )
-    s1_wall = time.monotonic() - s1_start
+    all_results = []
 
-    s1_turns = s1.get("turns", 0)
-    s1_tokens = s1.get("input_tokens", 0) + s1.get("output_tokens", 0)
+    for ti, task in enumerate(tasks):
+        task_name = task["task"]
+        repo_url = task["repo_url"]
+        setup_cmd = task.get("setup_cmd", "true")
+        verify_cmd = task["verify_cmd"]
+        repo_name = repo_url.rstrip("/").split("/")[-1].replace(".git", "")
 
-    if not s1.get("error"):
-        store_handoff(repo_path, args.task, s1_turns)
-        print(f"  Turns: {s1_turns}  Tokens: {s1_tokens:,}  Wall: {s1_wall:.1f}s")
-        print(f"  Handoff stored.")
-    else:
-        print(f"  ERROR: {s1.get('stderr', 'unknown')[:120]}")
-        print(f"  Cannot store handoff — aborting.")
-        sys.exit(1)
+        print(f"[{ti + 1}/{len(tasks)}] {task_name[:80]}")
 
+        # ── Clone fresh repo ─────────────────────────────────────────────
+        base = workdir / f"task{ti}"
+        for clone_dir, label in [
+            (base / "s1", "Session 1"),
+            (base / "s2a", "S2 cold start"),
+            (base / "s2b", "S2 files present"),
+            (base / "s2c", "S2 with memory"),
+        ]:
+            clone_dir.parent.mkdir(parents=True, exist_ok=True)
+            if not (clone_dir / ".git").exists():
+                subprocess.run(
+                    ["git", "clone", "--quiet", repo_url, str(clone_dir)],
+                    capture_output=True,
+                    timeout=120,
+                )
+
+        # Run setup once on a template
+        template = base / "s1"
+        if setup_cmd != "true":
+            subprocess.run(
+                setup_cmd, shell=True, cwd=template, capture_output=True, timeout=120
+            )
+
+        # Index for spelunk conditions
+        subprocess.run(
+            ["spelunk", "index", str(template)], capture_output=True, timeout=120
+        )
+
+        # ── Session 1: forced cutoff ─────────────────────────────────────
+        print(f"  Session 1 (baseline, {args.session_1_turns} turns)...")
+        s1 = run_agent(
+            template,
+            task_name,
+            "baseline",
+            args.model,
+            args.api_base_url,
+            api_key,
+            args.session_1_turns,
+            args.seed,
+            extra_system=SESSION_1_SYSTEM_ADDON,
+        )
+        s1_turns = s1.get("turns", 0)
+        if not s1.get("error"):
+            store_handoff(template, task_name, s1_turns)
+            print(f"    {s1_turns} turns, handoff stored")
+        else:
+            print(f"    ERROR: {s1.get('stderr', '')[:80]}")
+            all_results.append({"task": task_name, "error": "session_1_failed"})
+            continue
+
+        # Copy S1 state to S2b and S2c
+        for label, dest in [("s2b", base / "s2b"), ("s2c", base / "s2c")]:
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(str(template), str(dest), symlinks=True)
+            # Index S2c for memory
+            if label == "s2c":
+                subprocess.run(
+                    ["spelunk", "index", str(dest)], capture_output=True, timeout=120
+                )
+
+        # ── Session 2a: cold start ───────────────────────────────────────
+        print(f"  Session 2a (cold start, no memory)...")
+        s2a = run_agent(
+            base / "s2a",
+            task_name,
+            "baseline",
+            args.model,
+            args.api_base_url,
+            api_key,
+            args.session_2_turns,
+            args.seed,
+        )
+        s2a_ok = run_verify(base / "s2a", verify_cmd)
+        print(f"    {'PASS' if s2a_ok else 'FAIL'}  turns={s2a.get('turns', '?')}")
+
+        # ── Session 2b: files present, no memory ─────────────────────────
+        print(f"  Session 2b (S1 files, no memory)...")
+        s2b = run_agent(
+            base / "s2b",
+            task_name,
+            "baseline",
+            args.model,
+            args.api_base_url,
+            api_key,
+            args.session_2_turns,
+            args.seed,
+        )
+        s2b_ok = run_verify(base / "s2b", verify_cmd)
+        print(f"    {'PASS' if s2b_ok else 'FAIL'}  turns={s2b.get('turns', '?')}")
+
+        # ── Session 2c: with memory ──────────────────────────────────────
+        print(f"  Session 2c (S1 files + memory)...")
+        s2c = run_agent(
+            base / "s2c",
+            task_name,
+            "spelunk_search",
+            args.model,
+            args.api_base_url,
+            api_key,
+            args.session_2_turns,
+            args.seed,
+        )
+        s2c_ok = run_verify(base / "s2c", verify_cmd)
+        print(f"    {'PASS' if s2c_ok else 'FAIL'}  turns={s2c.get('turns', '?')}")
+
+        all_results.append(
+            {
+                "task": task_name,
+                "repo": repo_url,
+                "session_1_turns": s1_turns,
+                "s2a_cold_start": {"success": s2a_ok, "turns": s2a.get("turns", 0)},
+                "s2b_files_present": {"success": s2b_ok, "turns": s2b.get("turns", 0)},
+                "s2c_with_memory": {"success": s2c_ok, "turns": s2c.get("turns", 0)},
+            }
+        )
+
+    # ── Aggregate ────────────────────────────────────────────────────────
+    ran = [r for r in all_results if "s2a_cold_start" in r]
+    n = len(ran)
     print()
+    print(f"=== Results ({n} tasks) ===")
 
-    # ── Session 2a: Without memory (fresh baseline agent) ─────────────────
-    print("=== Session 2a (baseline, no memory) ===")
-    s2a_start = time.monotonic()
-    s2a = run_agent(
-        repo_path,
-        args.task,
-        "baseline",
-        args.model,
-        args.api_base_url,
-        api_key,
-        args.max_turns,
-    )
-    s2a_wall = time.monotonic() - s2a_start
+    for cond, key in [
+        ("Cold start", "s2a_cold_start"),
+        ("Files present", "s2b_files_present"),
+        ("With memory", "s2c_with_memory"),
+    ]:
+        successes = [r[key]["success"] for r in ran]
+        rate = sum(successes) / n if n else 0
+        print(f"  {cond:<18} success={rate:.0%} ({sum(successes)}/{n})")
 
-    s2a_turns = s2a.get("turns", 0)
-    s2a_tokens = s2a.get("input_tokens", 0) + s2a.get("output_tokens", 0)
-    print(f"  Turns: {s2a_turns}  Tokens: {s2a_tokens:,}  Wall: {s2a_wall:.1f}s")
-
-    print()
-
-    # ── Session 2b: With memory (spelunk_search condition) ────────────────
-    print("=== Session 2b (spelunk_search, can find handoff) ===")
-    s2b_start = time.monotonic()
-    s2b = run_agent(
-        repo_path,
-        args.task,
-        "spelunk_search",
-        args.model,
-        args.api_base_url,
-        api_key,
-        args.max_turns,
-    )
-    s2b_wall = time.monotonic() - s2b_start
-
-    s2b_turns = s2b.get("turns", 0)
-    s2b_tokens = s2b.get("input_tokens", 0) + s2b.get("output_tokens", 0)
-    print(f"  Turns: {s2b_turns}  Tokens: {s2b_tokens:,}  Wall: {s2b_wall:.1f}s")
-
-    # ── Results ───────────────────────────────────────────────────────────
     output = {
         "benchmark": "cross_session_handoff",
-        "repo": str(repo_path),
-        "task": args.task,
         "model": args.model,
-        "max_turns": args.max_turns,
+        "session_1_turns": args.session_1_turns,
+        "session_2_turns": args.session_2_turns,
+        "seed": args.seed,
         "spelunk_version": get_spelunk_version(),
-        "session_1": {
-            "turns": s1_turns,
-            "tokens": s1_tokens,
-            "wall_seconds": round(s1_wall, 2),
-        },
-        "session_2_no_memory": {
-            "condition": "baseline",
-            "turns": s2a_turns,
-            "tokens": s2a_tokens,
-            "wall_seconds": round(s2a_wall, 2),
-        },
-        "session_2_with_memory": {
-            "condition": "spelunk_search",
-            "turns": s2b_turns,
-            "tokens": s2b_tokens,
-            "wall_seconds": round(s2b_wall, 2),
-        },
+        "num_tasks": len(all_results),
+        "results": all_results,
     }
-
-    print()
-    print("=== Results ===")
-    print(f"Session 1 (baseline):          {s1_turns} turns, {s1_tokens:,} tokens")
-    print(f"Session 2 no memory (baseline): {s2a_turns} turns, {s2a_tokens:,} tokens")
-    print(f"Session 2 with memory (search): {s2b_turns} turns, {s2b_tokens:,} tokens")
 
     if args.out:
         Path(args.out).parent.mkdir(parents=True, exist_ok=True)

--- a/bench/memory/cross_session_handoff.py
+++ b/bench/memory/cross_session_handoff.py
@@ -2,9 +2,9 @@
 """Cross-session handoff benchmark — verifiable tasks, forced cutoff, n>=10.
 
 Three conditions for Session 2:
-    no_memory_no_session_1 — cold start, clean repo, no prior session
-    no_memory_present      — Session 1 file changes on disk, no memory tools
-    with_memory            — full spelunk memory access
+    s2a_cold_start   — fresh clone, no S1 files, no memory
+    s2b_files_present — S1 file changes on disk, no memory tools
+    s2c_with_memory  — S1 files + spelunk memory access
 
 Each task has a verify_cmd that produces a binary pass/fail signal.
 Tasks are defined in bench/memory/handoff_tasks.json.
@@ -16,17 +16,10 @@ Usage:
         --session-1-turns 5 \\
         --session-2-turns 15 \\
         --out bench/results/handoff.json
-
-Workflow per task:
-  1. Clone fresh repo, run setup_cmd (installs deps)
-  2. Session 1: agent runs --session-1-turns, forced cutoff, stores handoff
-  3. Session 2a: fresh clone, no memory, no S1 files
-  4. Session 2b: S1 files on disk, no memory tools
-  5. Session 2c: S1 files + spelunk memory access
-  6. Verify each session's outcome with verify_cmd
 """
 
 import argparse
+import atexit
 import json
 import os
 import shutil
@@ -67,9 +60,7 @@ def run_agent(
     extra_system: str = "",
 ) -> dict:
     issue_file = repo_path / "ISSUE.txt"
-    task_text = task
-    if extra_system:
-        task_text = extra_system + "\n\n" + task
+    task_text = extra_system + "\n\n" + task if extra_system else task
     issue_file.write_text(task_text)
 
     cmd = [
@@ -108,14 +99,23 @@ def run_agent(
     return {"error": True, "stderr": result.stderr[:500]}
 
 
-def run_verify(repo_path: Path, cmd: str) -> bool:
+def run_verify(repo_path: Path, cmd: str) -> tuple[bool, str]:
+    """Return (success, truncated_output)."""
     try:
         r = subprocess.run(
-            cmd, shell=True, cwd=repo_path, capture_output=True, text=True, timeout=60
+            cmd,
+            shell=True,
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=60,
         )
-        return r.returncode == 0
-    except Exception:
-        return False
+        output = (r.stdout + r.stderr)[-2000:]
+        return r.returncode == 0, output
+    except subprocess.TimeoutExpired:
+        return False, "TIMEOUT after 60s"
+    except Exception as e:
+        return False, f"verify_cmd error: {e}"
 
 
 def store_handoff(repo_path: Path, task: str, turns: int) -> None:
@@ -154,16 +154,14 @@ def get_spelunk_version() -> str:
 
 def main():
     parser = argparse.ArgumentParser(description="Cross-session handoff benchmark.")
-    parser.add_argument("--tasks", required=True, help="Tasks JSON file.")
+    parser.add_argument("--tasks", required=True)
     parser.add_argument("--model", default="deepseek-v4-flash")
     parser.add_argument("--api-base-url", default="https://api.deepseek.com/v1")
     parser.add_argument("--api-key", default=None)
     parser.add_argument("--session-1-turns", type=int, default=5)
     parser.add_argument("--session-2-turns", type=int, default=15)
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument(
-        "--workdir", default=None, help="Scratch directory (default: tmp)."
-    )
+    parser.add_argument("--workdir", default=None)
     parser.add_argument("--out", default=None)
     args = parser.parse_args()
 
@@ -174,12 +172,15 @@ def main():
     with open(args.tasks) as f:
         tasks = json.load(f)
 
+    user_workdir = args.workdir is not None
     workdir = (
         Path(args.workdir)
-        if args.workdir
+        if user_workdir
         else Path(tempfile.mkdtemp(prefix="handoff-"))
     )
     workdir.mkdir(parents=True, exist_ok=True)
+    if not user_workdir:
+        atexit.register(shutil.rmtree, str(workdir), ignore_errors=True)
 
     print(f"Tasks:     {len(tasks)}")
     print(f"S1 turns:  {args.session_1_turns}")
@@ -194,18 +195,18 @@ def main():
         repo_url = task["repo_url"]
         setup_cmd = task.get("setup_cmd", "true")
         verify_cmd = task["verify_cmd"]
-        repo_name = repo_url.rstrip("/").split("/")[-1].replace(".git", "")
 
         print(f"[{ti + 1}/{len(tasks)}] {task_name[:80]}")
 
-        # ── Clone fresh repo ─────────────────────────────────────────────
+        # ── Clone all four copies; run setup on all ─────────────────────
         base = workdir / f"task{ti}"
-        for clone_dir, label in [
-            (base / "s1", "Session 1"),
-            (base / "s2a", "S2 cold start"),
-            (base / "s2b", "S2 files present"),
-            (base / "s2c", "S2 with memory"),
-        ]:
+        clones = {
+            "s1": base / "s1",
+            "s2a": base / "s2a",
+            "s2b": base / "s2b",
+            "s2c": base / "s2c",
+        }
+        for clone_dir in clones.values():
             clone_dir.parent.mkdir(parents=True, exist_ok=True)
             if not (clone_dir / ".git").exists():
                 subprocess.run(
@@ -213,23 +214,38 @@ def main():
                     capture_output=True,
                     timeout=120,
                 )
+            if setup_cmd != "true":
+                subprocess.run(
+                    setup_cmd,
+                    shell=True,
+                    cwd=clone_dir,
+                    capture_output=True,
+                    timeout=120,
+                )
 
-        # Run setup once on a template
-        template = base / "s1"
-        if setup_cmd != "true":
-            subprocess.run(
-                setup_cmd, shell=True, cwd=template, capture_output=True, timeout=120
-            )
-
-        # Index for spelunk conditions
+        # Index s1 and s2c for spelunk
         subprocess.run(
-            ["spelunk", "index", str(template)], capture_output=True, timeout=120
+            ["spelunk", "index", str(clones["s1"])], capture_output=True, timeout=120
+        )
+        subprocess.run(
+            ["spelunk", "index", str(clones["s2c"])], capture_output=True, timeout=120
         )
 
-        # ── Session 1: forced cutoff ─────────────────────────────────────
-        print(f"  Session 1 (baseline, {args.session_1_turns} turns)...")
+        # Pre-flight: verify_cmd must FAIL on unmodified clone
+        pre_ok, pre_out = run_verify(clones["s2a"], verify_cmd)
+        if pre_ok:
+            print(
+                f"  WARNING: verify_cmd passes on unmodified repo — task may be degenerate"
+            )
+        else:
+            print(
+                f'  Pre-flight: verify_cmd fails as expected ("{pre_out[:60].strip()}")'
+            )
+
+        # ── Session 1: forced cutoff ────────────────────────────────────
+        print(f"  Session 1 ({args.session_1_turns} turns)...")
         s1 = run_agent(
-            template,
+            clones["s1"],
             task_name,
             "baseline",
             args.model,
@@ -240,29 +256,23 @@ def main():
             extra_system=SESSION_1_SYSTEM_ADDON,
         )
         s1_turns = s1.get("turns", 0)
-        if not s1.get("error"):
-            store_handoff(template, task_name, s1_turns)
-            print(f"    {s1_turns} turns, handoff stored")
-        else:
+        if s1.get("error"):
             print(f"    ERROR: {s1.get('stderr', '')[:80]}")
             all_results.append({"task": task_name, "error": "session_1_failed"})
             continue
+        store_handoff(clones["s1"], task_name, s1_turns)
+        print(f"    {s1_turns} turns, handoff stored")
 
-        # Copy S1 state to S2b and S2c
-        for label, dest in [("s2b", base / "s2b"), ("s2c", base / "s2c")]:
-            if dest.exists():
-                shutil.rmtree(dest)
-            shutil.copytree(str(template), str(dest), symlinks=True)
-            # Index S2c for memory
-            if label == "s2c":
-                subprocess.run(
-                    ["spelunk", "index", str(dest)], capture_output=True, timeout=120
-                )
+        # Copy S1 state to s2b and s2c
+        for key in ("s2b", "s2c"):
+            if clones[key].exists():
+                shutil.rmtree(clones[key])
+            shutil.copytree(str(clones["s1"]), str(clones[key]), symlinks=True)
 
-        # ── Session 2a: cold start ───────────────────────────────────────
-        print(f"  Session 2a (cold start, no memory)...")
+        # ── Session 2a: cold start ──────────────────────────────────────
+        print(f"  Session 2a (cold start)...")
         s2a = run_agent(
-            base / "s2a",
+            clones["s2a"],
             task_name,
             "baseline",
             args.model,
@@ -271,13 +281,14 @@ def main():
             args.session_2_turns,
             args.seed,
         )
-        s2a_ok = run_verify(base / "s2a", verify_cmd)
-        print(f"    {'PASS' if s2a_ok else 'FAIL'}  turns={s2a.get('turns', '?')}")
+        s2a_ok, s2a_out = run_verify(clones["s2a"], verify_cmd)
+        status = "PASS" if s2a_ok else "FAIL"
+        print(f"    {status}  turns={s2a.get('turns', '?')}  ({s2a_out[:60].strip()})")
 
-        # ── Session 2b: files present, no memory ─────────────────────────
+        # ── Session 2b: files present ───────────────────────────────────
         print(f"  Session 2b (S1 files, no memory)...")
         s2b = run_agent(
-            base / "s2b",
+            clones["s2b"],
             task_name,
             "baseline",
             args.model,
@@ -286,13 +297,14 @@ def main():
             args.session_2_turns,
             args.seed,
         )
-        s2b_ok = run_verify(base / "s2b", verify_cmd)
-        print(f"    {'PASS' if s2b_ok else 'FAIL'}  turns={s2b.get('turns', '?')}")
+        s2b_ok, s2b_out = run_verify(clones["s2b"], verify_cmd)
+        status = "PASS" if s2b_ok else "FAIL"
+        print(f"    {status}  turns={s2b.get('turns', '?')}  ({s2b_out[:60].strip()})")
 
-        # ── Session 2c: with memory ──────────────────────────────────────
+        # ── Session 2c: with memory ─────────────────────────────────────
         print(f"  Session 2c (S1 files + memory)...")
         s2c = run_agent(
-            base / "s2c",
+            clones["s2c"],
             task_name,
             "spelunk_search",
             args.model,
@@ -301,21 +313,34 @@ def main():
             args.session_2_turns,
             args.seed,
         )
-        s2c_ok = run_verify(base / "s2c", verify_cmd)
-        print(f"    {'PASS' if s2c_ok else 'FAIL'}  turns={s2c.get('turns', '?')}")
+        s2c_ok, s2c_out = run_verify(clones["s2c"], verify_cmd)
+        status = "PASS" if s2c_ok else "FAIL"
+        print(f"    {status}  turns={s2c.get('turns', '?')}  ({s2c_out[:60].strip()})")
 
         all_results.append(
             {
                 "task": task_name,
                 "repo": repo_url,
                 "session_1_turns": s1_turns,
-                "s2a_cold_start": {"success": s2a_ok, "turns": s2a.get("turns", 0)},
-                "s2b_files_present": {"success": s2b_ok, "turns": s2b.get("turns", 0)},
-                "s2c_with_memory": {"success": s2c_ok, "turns": s2c.get("turns", 0)},
+                "s2a_cold_start": {
+                    "success": s2a_ok,
+                    "turns": s2a.get("turns", 0),
+                    "verify_output": s2a_out,
+                },
+                "s2b_files_present": {
+                    "success": s2b_ok,
+                    "turns": s2b.get("turns", 0),
+                    "verify_output": s2b_out,
+                },
+                "s2c_with_memory": {
+                    "success": s2c_ok,
+                    "turns": s2c.get("turns", 0),
+                    "verify_output": s2c_out,
+                },
             }
         )
 
-    # ── Aggregate ────────────────────────────────────────────────────────
+    # ── Aggregate ───────────────────────────────────────────────────────
     ran = [r for r in all_results if "s2a_cold_start" in r]
     n = len(ran)
     print()

--- a/bench/memory/cross_session_handoff.py
+++ b/bench/memory/cross_session_handoff.py
@@ -152,6 +152,17 @@ def get_spelunk_version() -> str:
         return "unknown"
 
 
+def wilson_ci(successes: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    """Wilson score interval for a binomial proportion."""
+    if n == 0:
+        return (0.0, 0.0)
+    p = successes / n
+    denom = 1 + z**2 / n
+    centre = (p + z**2 / (2 * n)) / denom
+    margin = (z * (p * (1 - p) / n + z**2 / (4 * n**2)) ** 0.5) / denom
+    return (max(0, centre - margin), min(1, centre + margin))
+
+
 def main():
     parser = argparse.ArgumentParser(description="Cross-session handoff benchmark.")
     parser.add_argument("--tasks", required=True)
@@ -263,11 +274,25 @@ def main():
         store_handoff(clones["s1"], task_name, s1_turns)
         print(f"    {s1_turns} turns, handoff stored")
 
-        # Copy S1 state to s2b and s2c
+        # Copy S1 state to s2b and s2c; strip memory from s2b (no-memory condition)
         for key in ("s2b", "s2c"):
             if clones[key].exists():
                 shutil.rmtree(clones[key])
             shutil.copytree(str(clones["s1"]), str(clones[key]), symlinks=True)
+            if key == "s2b":
+                shutil.rmtree(clones[key] / ".spelunk", ignore_errors=True)
+                subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(clones[key]),
+                        "notes",
+                        "remove",
+                        "--ignore-missing",
+                        "HEAD",
+                    ],
+                    capture_output=True,
+                )
 
         # ── Session 2a: cold start ──────────────────────────────────────
         print(f"  Session 2a (cold start)...")
@@ -346,14 +371,19 @@ def main():
     print()
     print(f"=== Results ({n} tasks) ===")
 
+    aggregate = {}
     for cond, key in [
-        ("Cold start", "s2a_cold_start"),
-        ("Files present", "s2b_files_present"),
-        ("With memory", "s2c_with_memory"),
+        ("cold_start", "s2a_cold_start"),
+        ("files_present", "s2b_files_present"),
+        ("with_memory", "s2c_with_memory"),
     ]:
         successes = [r[key]["success"] for r in ran]
-        rate = sum(successes) / n if n else 0
-        print(f"  {cond:<18} success={rate:.0%} ({sum(successes)}/{n})")
+        s = sum(successes)
+        lo, hi = wilson_ci(s, n)
+        rate = s / n if n else 0
+        aggregate[f"{cond}_success_rate"] = round(rate, 4)
+        aggregate[f"{cond}_ci_95"] = [round(lo, 4), round(hi, 4)]
+        print(f"  {cond:<18} success={rate:.0%} [{lo:.0%}, {hi:.0%}] ({s}/{n})")
 
     output = {
         "benchmark": "cross_session_handoff",
@@ -363,6 +393,7 @@ def main():
         "seed": args.seed,
         "spelunk_version": get_spelunk_version(),
         "num_tasks": len(all_results),
+        "aggregate": aggregate,
         "results": all_results,
     }
 

--- a/bench/memory/handoff_tasks.json
+++ b/bench/memory/handoff_tasks.json
@@ -1,0 +1,14 @@
+[
+    {
+        "task": "Fix the failing test in tests/test_parser.py so that 'pytest tests/test_parser.py' passes",
+        "repo_url": "https://github.com/user/repo.git",
+        "setup_cmd": "pip install -e '.[dev]' 2>/dev/null || true",
+        "verify_cmd": "python -m pytest tests/test_parser.py -x -q"
+    },
+    {
+        "task": "Add a '--verbose' flag to the CLI that enables debug logging. Verify with: 'python -m mymodule --verbose 2>&1 | grep DEBUG'",
+        "repo_url": "https://github.com/user/repo.git",
+        "setup_cmd": "pip install -e . 2>/dev/null || true",
+        "verify_cmd": "python -m mymodule --verbose 2>&1 | grep -q DEBUG"
+    }
+]


### PR DESCRIPTION
Refs #228

Rewrite cross_session_handoff.py:
- Three Session 2 conditions: cold start, files present, with memory
- Session 1 forced cutoff with handoff prompt
- verify_cmd for binary pass/fail with output logging
- Pre-flight validation that verify_cmd fails on unmodified clone
- setup_cmd runs on all four clones
- Auto-cleanup for temp workdirs

Task corpus tracked in #247.