### PR TITLE
bench(perf): add perf_scale.sh orchestrator for multi-repo scale benchmarks

### DIFF
--- a/bench/perf_scale.sh
+++ b/bench/perf_scale.sh
@@ -93,8 +93,8 @@ for entry in "${REPO_ENTRIES[@]}"; do
 
     # Count files and chunks via spelunk status
     STATS=$(cd "$REPO_DIR" && "$SPELUNK" status --format json 2>/dev/null || echo '{"files":0,"chunks":0}')
-    FILES=$(echo "$STATS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('files',0))")
-    CHUNKS=$(echo "$STATS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('chunks',0))")
+    FILES=$(echo "$STATS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('file_count',0))")
+    CHUNKS=$(echo "$STATS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('chunk_count',0))")
     echo "    ${FILES} files, ${CHUNKS} chunks"
 
     # Search latency — 2/7/16 word queries

--- a/bench/perf_scale.sh
+++ b/bench/perf_scale.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # bench/perf_scale.sh — orchestrator for scale-level performance benchmarks
 #
-# Runs indexing, search, and memory benchmarks across multiple repo sizes
-# and aggregates results into a single JSON file.
+# Runs indexing timing, search latency, and optional memory benchmarks
+# across multiple labelled repo sizes, aggregating into a single JSON.
 #
 # Usage:
 #   bash bench/perf_scale.sh --repos small:path medium:path large:path
@@ -47,59 +47,78 @@ if [[ -z "$REPOS" ]]; then
     echo "Error: --repos is required." >&2; usage
 fi
 
+if ! command -v "$SPELUNK" &>/dev/null; then
+    echo "Error: spelunk not found in PATH." >&2; exit 1
+fi
+
 TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 OUT_FILE="${OUT_FILE:-${SCRIPT_DIR}/results/perf-scale-${TIMESTAMP}.json}"
 mkdir -p "$(dirname "$OUT_FILE")"
+
+# Host info for reproducibility
+HOST_INFO="$(uname -a 2>/dev/null || echo 'unknown')"
+CPU_INFO="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2 | xargs || echo 'unknown')"
 
 echo "=== Performance Scale Benchmarks ==="
 echo "Repos:         ${REPOS}"
 echo "Search iters:  ${SEARCH_ITERS}"
 echo "Output:        ${OUT_FILE}"
+echo "Host:          ${CPU_INFO}"
 echo ""
 
-RESULTS='{"benchmark":"perf_scale","spelunk_version":"'"$("$SPELUNK" --version 2>&1 | head -1)"'","timestamp":"'"$TIMESTAMP"'","repos":{}}'
+RESULTS='{"benchmark":"perf_scale","host":"'"${HOST_INFO}"'","cpu":"'"${CPU_INFO}"'","spelunk_version":"'"$("$SPELUNK" --version 2>&1 | head -1)"'","timestamp":"'"$TIMESTAMP"'","repos":{}}'
 
 # ── Parse repos ────────────────────────────────────────────────────────────
 IFS=',' read -ra REPO_ENTRIES <<< "$REPOS"
 for entry in "${REPO_ENTRIES[@]}"; do
     NAME="${entry%%:*}"
-    PATH="${entry#*:}"
+    REPO_DIR="${entry#*:}"
 
-    if [[ ! -d "$PATH" ]]; then
-        echo "WARNING: repo '$NAME' path '$PATH' does not exist — skipping." >&2
+    if [[ ! -d "$REPO_DIR" ]]; then
+        echo "WARNING: repo '$NAME' path '$REPO_DIR' does not exist — skipping." >&2
         continue
     fi
 
-    echo "=== Repo: ${NAME} (${PATH}) ==="
+    echo "=== Repo: ${NAME} (${REPO_DIR}) ==="
 
-    # Index it
+    # Index it — timed
     echo "  Indexing..."
-    "$SPELUNK" index "$PATH" 2>&1 | tail -1 || true
+    INDEX_START=$(python3 -c "import time; print(time.monotonic())")
+    if ! "$SPELUNK" index "$REPO_DIR" >/dev/null 2>&1; then
+        echo "    FAILED — skipping repo" >&2
+        continue
+    fi
+    INDEX_ELAPSED=$(python3 -c "import time; print(round(time.monotonic() - $INDEX_START, 2))")
+    echo "    done (${INDEX_ELAPSED}s)"
 
-    # Count files and chunks
-    FILES=$(find "$PATH" -type f -not -path '*/.git/*' -not -path '*/node_modules/*' -not -name '*.pyc' 2>/dev/null | wc -l | tr -d ' ')
-    CHUNKS=$("$SPELUNK" chunks --format json "$PATH" 2>/dev/null | python3 -c "import json,sys; print(len([l for l in sys.stdin if l.strip()]))" 2>/dev/null || echo "?")
-
+    # Count files and chunks via spelunk status
+    STATS=$(cd "$REPO_DIR" && "$SPELUNK" status --format json 2>/dev/null || echo '{"files":0,"chunks":0}')
+    FILES=$(echo "$STATS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('files',0))")
+    CHUNKS=$(echo "$STATS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('chunks',0))")
     echo "    ${FILES} files, ${CHUNKS} chunks"
 
-    # Search latency
+    # Search latency — 2/7/16 word queries
     echo "  Search latency..."
     SEARCH_RESULT=$(python3 -c "
 import json, subprocess, time, statistics
-queries = ['error handling', 'parse command line', 'validate configuration input']
+queries = [
+    ('error handling', '2 words'),
+    ('how does authentication and session management work', '7 words'),
+    ('find all functions that parse command line arguments and validate user input configuration', '16 words'),
+]
 mode = 'hybrid'
 all_times = []
-for q in queries:
+for q, label in queries:
     run_times = []
     for _ in range(${SEARCH_ITERS}):
         start = time.monotonic()
         subprocess.run(['${SPELUNK}', 'search', q, '--mode', mode, '--limit', '5', '--format', 'json'],
-                       cwd='${PATH}', capture_output=True, timeout=30)
+                       cwd='${REPO_DIR}', capture_output=True, timeout=30)
         elapsed = (time.monotonic() - start) * 1000
         run_times.append(elapsed)
     run_times.sort()
     all_times.append({
-        'query': q, 'iterations': len(run_times),
+        'query': q, 'words': label, 'iterations': len(run_times),
         'p50_ms': round(run_times[len(run_times)//2], 1),
         'p95_ms': round(run_times[int(len(run_times)*0.95)], 1),
         'mean_ms': round(statistics.mean(run_times), 1),
@@ -111,9 +130,12 @@ print(json.dumps({'search': all_times}))
 import json
 r = json.loads('''$RESULTS''')
 r['repos']['${NAME}'] = {
-    'path': '${PATH}',
+    'path': '${REPO_DIR}',
     'files': ${FILES},
-    'chunks': '${CHUNKS}',
+    'chunks': ${CHUNKS},
+    'index_seconds': ${INDEX_ELAPSED},
+    'files_per_second': round(${FILES} / ${INDEX_ELAPSED}, 1) if ${INDEX_ELAPSED} > 0 else 0,
+    'chunks_per_second': round(${CHUNKS} / ${INDEX_ELAPSED}, 1) if ${INDEX_ELAPSED} > 0 else 0,
 }
 r['repos']['${NAME}'].update(${SEARCH_RESULT})
 print(json.dumps(r, indent=2))
@@ -126,7 +148,7 @@ done
 if [[ "$SKIP_MEMORY" != "true" ]]; then
     echo "=== Memory at scale (${MEMORY_COMMITS} commits) ==="
     if [[ -x "${SCRIPT_DIR}/git_meta_perf.sh" ]]; then
-        bash "${SCRIPT_DIR}/git_meta_perf.sh" "$MEMORY_COMMITS" 2>&1 | tail -5 || echo "  (memory benchmark skipped — requires spelunk build)"
+        bash "${SCRIPT_DIR}/git_meta_perf.sh" "$MEMORY_COMMITS" 2>&1 | tail -5 || echo "  (memory benchmark skipped)"
     else
         echo "  git_meta_perf.sh not found"
     fi
@@ -137,7 +159,6 @@ fi
 echo "$RESULTS" > "$OUT_FILE"
 echo "Results written to: ${OUT_FILE}"
 
-# Print summary
 python3 -c "
 import json
 with open('${OUT_FILE}') as f:
@@ -145,7 +166,7 @@ with open('${OUT_FILE}') as f:
 print()
 print('Summary:')
 for name, repo in d.get('repos', {}).items():
-    print(f'  {name}: {repo.get(\"files\",\"?\")} files, {repo.get(\"chunks\",\"?\")} chunks')
+    print(f'  {name}: {repo.get(\"files\",\"?\")} files, {repo.get(\"chunks\",\"?\")} chunks, index={repo.get(\"index_seconds\",\"?\")}s')
     for s in repo.get('search', []):
-        print(f'    search p50={s[\"p50_ms\"]}ms  p95={s[\"p95_ms\"]}ms  ({s[\"query\"][:40]})')
+        print(f'    search ({s[\"words\"]}) p50={s[\"p50_ms\"]}ms  p95={s[\"p95_ms\"]}ms')
 "

--- a/bench/perf_scale.sh
+++ b/bench/perf_scale.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# bench/perf_scale.sh — orchestrator for scale-level performance benchmarks
+#
+# Runs indexing, search, and memory benchmarks across multiple repo sizes
+# and aggregates results into a single JSON file.
+#
+# Usage:
+#   bash bench/perf_scale.sh --repos small:path medium:path large:path
+#   bash bench/perf_scale.sh --repos small:ripgrep medium:django large:linux
+#
+# Options:
+#   --repos       NAME:PATH,...   labelled repos (required)
+#   --out         FILE            output JSON (default: bench/results/perf-scale-<ts>.json)
+#   --search-iters N              iterations per search query (default: 10)
+#   --memory-commits N            commits for git_meta_perf.sh (default: 5000)
+#   --skip-memory                 skip the memory benchmark
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPELUNK="${SPELUNK:-spelunk}"
+
+REPOS=""
+OUT_FILE=""
+SEARCH_ITERS=10
+MEMORY_COMMITS=5000
+SKIP_MEMORY=false
+
+usage() {
+    grep '^#' "$0" | grep -v '#!/' | sed 's/^# \?//'
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repos)        REPOS="$2";        shift 2 ;;
+        --out)          OUT_FILE="$2";      shift 2 ;;
+        --search-iters) SEARCH_ITERS="$2";  shift 2 ;;
+        --memory-commits) MEMORY_COMMITS="$2"; shift 2 ;;
+        --skip-memory)  SKIP_MEMORY=true;   shift ;;
+        -h|--help)      usage ;;
+        *) echo "Unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$REPOS" ]]; then
+    echo "Error: --repos is required." >&2; usage
+fi
+
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_FILE="${OUT_FILE:-${SCRIPT_DIR}/results/perf-scale-${TIMESTAMP}.json}"
+mkdir -p "$(dirname "$OUT_FILE")"
+
+echo "=== Performance Scale Benchmarks ==="
+echo "Repos:         ${REPOS}"
+echo "Search iters:  ${SEARCH_ITERS}"
+echo "Output:        ${OUT_FILE}"
+echo ""
+
+RESULTS='{"benchmark":"perf_scale","spelunk_version":"'"$("$SPELUNK" --version 2>&1 | head -1)"'","timestamp":"'"$TIMESTAMP"'","repos":{}}'
+
+# ── Parse repos ────────────────────────────────────────────────────────────
+IFS=',' read -ra REPO_ENTRIES <<< "$REPOS"
+for entry in "${REPO_ENTRIES[@]}"; do
+    NAME="${entry%%:*}"
+    PATH="${entry#*:}"
+
+    if [[ ! -d "$PATH" ]]; then
+        echo "WARNING: repo '$NAME' path '$PATH' does not exist — skipping." >&2
+        continue
+    fi
+
+    echo "=== Repo: ${NAME} (${PATH}) ==="
+
+    # Index it
+    echo "  Indexing..."
+    "$SPELUNK" index "$PATH" 2>&1 | tail -1 || true
+
+    # Count files and chunks
+    FILES=$(find "$PATH" -type f -not -path '*/.git/*' -not -path '*/node_modules/*' -not -name '*.pyc' 2>/dev/null | wc -l | tr -d ' ')
+    CHUNKS=$("$SPELUNK" chunks --format json "$PATH" 2>/dev/null | python3 -c "import json,sys; print(len([l for l in sys.stdin if l.strip()]))" 2>/dev/null || echo "?")
+
+    echo "    ${FILES} files, ${CHUNKS} chunks"
+
+    # Search latency
+    echo "  Search latency..."
+    SEARCH_RESULT=$(python3 -c "
+import json, subprocess, time, statistics
+queries = ['error handling', 'parse command line', 'validate configuration input']
+mode = 'hybrid'
+all_times = []
+for q in queries:
+    run_times = []
+    for _ in range(${SEARCH_ITERS}):
+        start = time.monotonic()
+        subprocess.run(['${SPELUNK}', 'search', q, '--mode', mode, '--limit', '5', '--format', 'json'],
+                       cwd='${PATH}', capture_output=True, timeout=30)
+        elapsed = (time.monotonic() - start) * 1000
+        run_times.append(elapsed)
+    run_times.sort()
+    all_times.append({
+        'query': q, 'iterations': len(run_times),
+        'p50_ms': round(run_times[len(run_times)//2], 1),
+        'p95_ms': round(run_times[int(len(run_times)*0.95)], 1),
+        'mean_ms': round(statistics.mean(run_times), 1),
+    })
+print(json.dumps({'search': all_times}))
+" 2>/dev/null || echo '{"search":[]}')
+
+    RESULTS=$(python3 -c "
+import json
+r = json.loads('''$RESULTS''')
+r['repos']['${NAME}'] = {
+    'path': '${PATH}',
+    'files': ${FILES},
+    'chunks': '${CHUNKS}',
+}
+r['repos']['${NAME}'].update(${SEARCH_RESULT})
+print(json.dumps(r, indent=2))
+")
+    echo "    Done."
+    echo ""
+done
+
+# ── Memory benchmark ────────────────────────────────────────────────────────
+if [[ "$SKIP_MEMORY" != "true" ]]; then
+    echo "=== Memory at scale (${MEMORY_COMMITS} commits) ==="
+    if [[ -x "${SCRIPT_DIR}/git_meta_perf.sh" ]]; then
+        bash "${SCRIPT_DIR}/git_meta_perf.sh" "$MEMORY_COMMITS" 2>&1 | tail -5 || echo "  (memory benchmark skipped — requires spelunk build)"
+    else
+        echo "  git_meta_perf.sh not found"
+    fi
+    echo ""
+fi
+
+# ── Write output ────────────────────────────────────────────────────────────
+echo "$RESULTS" > "$OUT_FILE"
+echo "Results written to: ${OUT_FILE}"
+
+# Print summary
+python3 -c "
+import json
+with open('${OUT_FILE}') as f:
+    d = json.load(f)
+print()
+print('Summary:')
+for name, repo in d.get('repos', {}).items():
+    print(f'  {name}: {repo.get(\"files\",\"?\")} files, {repo.get(\"chunks\",\"?\")} chunks')
+    for s in repo.get('search', []):
+        print(f'    search p50={s[\"p50_ms\"]}ms  p95={s[\"p95_ms\"]}ms  ({s[\"query\"][:40]})')
+"


### PR DESCRIPTION
Refs #231

Create bench/perf_scale.sh orchestrator:
- Labelled repo sizes via --repos
- Indexing timed with throughput (files/sec, chunks/sec)
- Search latency across 2/7/16 word queries
- Optional memory benchmark
- Host/CPU info for reproducibility
- Aggregate JSON output

Scale execution tracked in follow-up issue.