### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,104 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.7.0] — 2026-05-17
+
+### Added
+
+- **`spelunk context`** — new agent session entry point command that surfaces
+  index health, recent memory, and open questions in a single structured
+  output, making it easier for AI agents to orient at the start of a session.
+
+- **`spelunk memory harvest --source entire`** — mines Entire.io checkpoint
+  files (stored on the `refs/entire/checkpoints/v1` branch) for decisions,
+  notes, and requirements. The structured `Summary` in each checkpoint is used
+  directly; an LLM fallback is used only for checkpoints that lack one. Secret
+  scanning is applied on all paths so credentials are never stored.
+
+- **`GitMetaBackend`** — second memory backend backed by `git-meta-lib`, available
+  alongside the existing git-notes and server backends.
+
+- **`git-notes` memory backend** (`GitNotesBackend`) — store and retrieve memory
+  entries using git's native notes mechanism, with no server or external database
+  required. Supports optional embedding for semantic memory search. `NoteRecord`
+  now carries a `schema_version` field for forward-compatible detection of future
+  record formats.
+
+- **Benchmark suite** (`bench/`) — five benchmarks now ship with the repo to
+  measure and document retrieval quality and performance: Decision Archaeology
+  (memory recall), Cross-Session Handoff (agent continuity), SWE-bench
+  (patch resolution rate via Docker harness), Code-Graph (grep vs search vs
+  graph), and Perf-at-Scale (indexing and search latency at 50k–500k LOC).
+  A benchmarking report (`tmp/benchmarking-report.md`) summarises current
+  results.
+
+### Changed
+
+- **Removed legacy commands** — `ask`, `plan`, `spec`, `snapshot`, `history`,
+  and `verify` subcommands have been removed. The core spelunk workflow is now
+  index-free by default; docs and SKILL.md have been updated to reflect this.
+
+- **`gix::discover` replaces `git rev-parse`** — subprocess calls to
+  `git rev-parse` for repository discovery are replaced with `gix::discover`,
+  removing a shell dependency.
+
+- **Dependency updates** — `gix` bumped to 0.83.0 (fixes worktree exclude
+  handling so `.gitignore` rules are correctly respected in git worktrees);
+  `git-meta-lib` bumped to 0.1.10 with API adaptation.
+
+### Fixed
+
+- `GitNotesBackend` unsupported methods now return a typed `BackendUnsupported`
+  error instead of panicking.
+
+- `GitNotesBackend` list capped at 500 entries, preventing an O(n) hang on
+  repositories with many notes.
+
+- `spelunk index` no longer creates a self-referential `.spelunk` symlink when
+  run inside a git worktree checked out at the same path as the main repo.
+
+### Security
+
+- Server audit checklist (`docs/security/`) added as groundwork for the upcoming
+  v1.0 server release.
+
+---
+
+## [0.6.0] — 2026-04-26
+
+### Added
+
+- **LinearRAG two-stage retrieval** — a new graph-diffusion retrieval algorithm
+  combining personalised PageRank with full-text pre-filtering. Now the default
+  for `spelunk search`; multi-hop recall is +33.5 % over the previous baseline
+  at ~1.9× median latency. Compound indexes and in-memory Stage 1 propagation
+  keep latency within acceptable bounds.
+
+- **`.spelunkignore` files** — place a `.spelunkignore` file anywhere in your
+  project tree to exclude paths from indexing, using the same format as
+  `.gitignore`.
+
+- **`antipattern` memory kind + `spelunk memory failures`** — record failure
+  patterns and anti-patterns as first-class memory entries. `spelunk memory
+  failures` lists them; `spelunk memory harvest` can extract them from session
+  history.
+
+- **Expanded fuzzer coverage** — fuzzer targets now cover secrets, chunker,
+  `escape_xml`, NDJSON, and history entry parsing.
+
+### Fixed
+
+- OOM guard added to the parser; `doc_comment` nodes are skipped during AST
+  walking to avoid memory exhaustion on files with large doc blocks.
+
+- `spelunk check` was made fully async, fixing a panic caused by calling
+  `block_on` inside an existing async context.
+
+- PageRank dangling-node indices are now precomputed before power iterations,
+  improving performance on sparse graphs.
+
+---
+
 ## [0.5.0] — 2026-04-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 default-run = "spelunk"
 description = "Local context engine for AI coding agents — tree-sitter AST chunking, semantic search, code graph"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,23 +6,23 @@ Download the latest binary for your platform from the [releases page](https://gi
 
 ```bash
 # macOS (Apple Silicon) — universal binary also available
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-aarch64-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.7.0-aarch64-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # macOS (Intel)
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-x86_64-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.7.0-x86_64-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # macOS (universal — works on both Intel and Apple Silicon)
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-universal-apple-darwin.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.7.0-universal-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Linux x86_64
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-x86_64-unknown-linux-gnu.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.7.0-x86_64-unknown-linux-gnu.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Linux ARM64
-curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-aarch64-unknown-linux-gnu.tar.gz \
+curl -L https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.7.0-aarch64-unknown-linux-gnu.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Verify

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -59,8 +59,8 @@ git push origin main
 ### 2. Tag and push
 
 ```bash
-git tag v0.6.0
-git push origin v0.6.0
+git tag v0.7.0
+git push origin v0.7.0
 ```
 
 That's it. The release workflow triggers automatically on the pushed tag.
@@ -71,7 +71,7 @@ Watch progress at:
 `https://github.com/usercise/spelunk/actions/workflows/release.yml`
 
 Once all jobs pass, the release appears at:
-`https://github.com/usercise/spelunk/releases/tag/v0.6.0`
+`https://github.com/usercise/spelunk/releases/tag/v0.7.0`
 
 ## Pre-releases
 
@@ -80,8 +80,8 @@ GitHub Release as a pre-release when the tag contains `-rc`, `-beta`, or
 `-alpha`:
 
 ```bash
-git tag v0.6.0-rc.1
-git push origin v0.6.0-rc.1
+git tag v0.7.0-rc.1
+git push origin v0.7.0-rc.1
 ```
 
 ## Download URLs
@@ -96,16 +96,16 @@ Examples:
 
 ```bash
 # macOS Apple Silicon
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-aarch64-apple-darwin.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.7.0-aarch64-apple-darwin.tar.gz
 
 # macOS universal (x86_64 + Apple Silicon)
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-universal-apple-darwin.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.7.0-universal-apple-darwin.tar.gz
 
 # Linux x86_64
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-x86_64-unknown-linux-gnu.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.7.0-x86_64-unknown-linux-gnu.tar.gz
 
 # Linux ARM64
-https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.6.0-aarch64-unknown-linux-gnu.tar.gz
+https://github.com/usercise/spelunk/releases/latest/download/spelunk-v0.7.0-aarch64-unknown-linux-gnu.tar.gz
 ```
 
 ## Deleting a bad release
@@ -114,11 +114,11 @@ If a release needs to be pulled:
 
 ```bash
 # Delete the tag locally and on remote
-git tag -d v0.6.0
-git push origin :refs/tags/v0.6.0
+git tag -d v0.7.0
+git push origin :refs/tags/v0.7.0
 
 # Delete the GitHub Release (requires gh CLI)
-gh release delete v0.6.0 --yes
+gh release delete v0.7.0 --yes
 ```
 
 Then fix the issue, re-commit, and re-tag.

--- a/docs/security/V1-SERVER-AUDIT.md
+++ b/docs/security/V1-SERVER-AUDIT.md
@@ -1,0 +1,107 @@
+# v1.0 Server Security Audit Checklist
+
+**Scope:** spelunk-server (crates/spelunk-server after workspace restructure) — new attack surface not covered by the existing CLI security program.  
+**Gate:** Must be completed before v1.0 GA. Blocks the v1.0 tag.  
+**Date drafted:** 2026-05-17
+
+The CLI threat model (`THREAT-MODEL.md`) remains valid for the CLI crate. This document covers threats introduced by the HTTP server.
+
+---
+
+## 1. Injection scanning middleware
+
+| Check | Status |
+|---|---|
+| `src/security/injection.rs` is called in POST /v1/projects/{id}/memory before any DB write | ☐ |
+| No client header or query parameter can bypass the scan | ☐ |
+| 422 response returns `field` and `category` — never the raw regex | ☐ |
+| OnceLock pattern compilation verified: no per-request recompilation | ☐ |
+| All 8 default patterns have positive and negative unit tests | ☐ |
+| Audit log (`tracing::warn!`) fires on every match | ☐ |
+
+## 2. API key authentication
+
+| Check | Status |
+|---|---|
+| API key stored as BLAKE3 hash — plaintext never persisted | ☐ |
+| Key comparison uses constant-time equality (not `==` on strings) | ☐ |
+| `sk-sp-` prefix format validated before any DB lookup | ☐ |
+| Revoked/deleted keys rejected immediately (no cache window) | ☐ |
+| Key scope enforced: project-scoped key cannot write to other projects | ☐ |
+
+## 3. Multi-tenancy isolation
+
+| Check | Status |
+|---|---|
+| Every DB query includes an `org_id` filter (no bare table scans) | ☐ |
+| RLS enabled and tested: a valid key from org A cannot read org B's entries | ☐ |
+| Integration test: cross-org read attempt returns 403, not 404 or 200 | ☐ |
+
+## 4. Input validation
+
+| Check | Status |
+|---|---|
+| Title field: max 500 characters enforced at route handler | ☐ |
+| Body field: max 50 000 characters enforced at route handler | ☐ |
+| UUID path params validated (malformed UUID returns 400, not 500) | ☐ |
+| All SQL uses parameterised queries — no string concatenation | ☐ |
+
+## 5. SSE stream
+
+| Check | Status |
+|---|---|
+| SSE connections require a valid API key on connection open | ☐ |
+| Heartbeat tick re-validates key (revoked key disconnected within 60s) | ☐ |
+| SSE events scoped to org — no cross-tenant event possible | ☐ |
+| Integration test: revoke key, verify SSE connection closes within 60s | ☐ |
+
+## 6. Dependencies
+
+| Check | Status |
+|---|---|
+| `cargo audit` passes clean for spelunk-server crate | ☐ |
+| `cargo deny` passes (licenses + sources) | ☐ |
+| No yanked dependencies in Cargo.lock | ☐ |
+
+## 7. Configuration and secrets
+
+| Check | Status |
+|---|---|
+| Server refuses to start if JWT_SECRET is absent or < 32 bytes | ☐ |
+| DATABASE_URL never logged (trace level or above) | ☐ |
+| No secrets in default config files or committed .env files | ☐ |
+| `.env*` excluded from any server-side file operations | ☐ |
+
+## 8. Error responses
+
+| Check | Status |
+|---|---|
+| 5xx responses do not leak stack traces or internal paths | ☐ |
+| 422 injection responses reveal category, not pattern | ☐ |
+| 401/403 responses consistent — cannot distinguish missing key from wrong key | ☐ |
+
+---
+
+## Running the checks
+
+```bash
+# From spelunk-server crate root (after workspace restructure)
+cargo audit
+cargo deny check
+cargo clippy -p spelunk-server -- -W clippy::all -D warnings
+
+# Integration tests (require running server + postgres)
+cargo test -p spelunk-server --test integration
+
+# Cross-tenant isolation test
+cargo test -p spelunk-server cross_tenant
+
+# SSE revocation test
+cargo test -p spelunk-server sse_key_revocation
+```
+
+---
+
+## Sign-off
+
+All checks must be marked ✅ before the v1.0 tag is created. Add initials + date next to each check when complete.

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -82,7 +82,7 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
             .find(|s| s.commit_sha.starts_with(sha_prefix.as_str()))
             .ok_or_else(|| {
                 anyhow::anyhow!(
-                    "No snapshot found for '{}'. Run `spelunk snapshot list` to see available snapshots.",
+                    "No snapshot found for '{}'. Provide a full or partial commit SHA from your indexed history.",
                     sha_prefix
                 )
             })?;


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` version to 0.7.0
- Adds `## [0.7.0]` and `## [0.6.0]` CHANGELOG entries (0.6.0 was missing)
- Updates version strings in `docs/getting-started.md` and `docs/releasing.md`
- Fixes stale error message in `search.rs` referencing the removed `spelunk snapshot list` command

## Test plan

- [ ] CI passes
- [x] After merge, tag `v0.7.0` and push to trigger the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)