### PR TITLE
chore: add AGENTS.md, bench/AGENTS.md, simplify PROTOCOL.md

### DIFF
--- a/.claude/skills/persona/SKILL.md
+++ b/.claude/skills/persona/SKILL.md
@@ -1,6 +1,8 @@
 # /persona — Activate a project persona
 
-Activate one of the project personas from `agent-personas/` for this session. Reads the persona's profile, processes their inbox, and runs their session startup protocol.
+Activate one of the project personas from `agent-personas/` for this session.
+Reads the persona's profile, processes their inbox, and runs session startup
+per the protocol defined in `agent-comms/PROTOCOL.md`.
 
 ## Usage
 
@@ -8,42 +10,45 @@ Activate one of the project personas from `agent-personas/` for this session. Re
 /persona <name>
 ```
 
-## Name aliases (case-insensitive)
+## Personas
 
-| Input | File | Inbox |
-|---|---|---|
-| `architect` | `agent-personas/architect.md` | `agent-comms/inbox/architect.ndjson` |
-| `implementer`, `impl` | `agent-personas/implementer.md` | `agent-comms/inbox/implementer.ndjson` |
-| `product-manager`, `pm` | `agent-personas/product-manager.md` | `agent-comms/inbox/product-manager.ndjson` |
-| `test-engineer`, `test`, `te` | `agent-personas/test-engineer.md` | `agent-comms/inbox/test-engineer.ndjson` |
-| `qa-reviewer`, `qa` | `agent-personas/qa-reviewer.md` | `agent-comms/inbox/qa-reviewer.ndjson` |
-| `docs-writer`, `docs` | `agent-personas/docs-writer.md` | `agent-comms/inbox/docs-writer.ndjson` |
+See `agent-comms/PROTOCOL.md` § Personas for the full table. Quick reference:
+
+| Input | Persona |
+|-------|---------|
+| `architect` | Architect |
+| `implementer`, `impl` | Implementer |
+| `pm` | Product Manager |
+| `test`, `te` | Test Engineer |
+| `qa` | QA Reviewer |
+| `docs` | Docs Writer |
 
 ## Steps when invoked
 
-1. **Read the persona file in full.** Internalize the role, model, behaviour rules, limitations, and session protocol.
+1. **Read the persona file** at `agent-personas/<name>.md` in full.
+   Internalize the role, model, behaviour rules, limitations, and session
+   protocol.
 
-2. **Process the inbox.** Read `agent-comms/inbox/<name>.ndjson` (one JSON object per line). For each message:
-   - Print: sender, date, priority, subject
-   - Summarize the body in 1–3 bullet points
-   - Flag `"priority":"high"` messages with **[HIGH]**
-   - If the inbox file does not exist, note that the inbox is empty.
+2. **Process the inbox and run session startup** as defined in
+   `agent-comms/PROTOCOL.md` § Inbox processing. This covers: read + flag
+   messages, spelunk check, list decisions/handoffs/questions, clear
+   consumed entries.
 
-3. **Run the session startup commands** from the persona's Session Protocol block. Report findings concisely (spelunk check output, recent decisions, open questions).
-
-4. **Announce readiness.** State:
+3. **Announce readiness.** State:
    - Active persona name and preferred model
-   - Inbox message count and any high-priority items requiring action
+   - Inbox message count and any blocking/question items requiring action
    - What the persona is ready to work on
 
-5. **Adopt the persona for the rest of the session.** Follow that persona's behaviour rules, scope, and communication patterns until the user starts a new session or invokes `/persona` again.
+4. **Adopt the persona for the rest of the session.** Follow that persona's
+   behaviour rules, scope, and communication patterns until the user starts
+   a new session or invokes `/persona` again.
 
-## Sending messages between personas
+## Sending messages
 
-To send a message from the active persona to another persona, append a JSON line to `agent-comms/inbox/<target-persona>.ndjson`. Use this schema:
+Follow the schema and routing in `agent-comms/PROTOCOL.md` § Routing.
+Append to `agent-comms/inbox/<recipient>.ndjson`.
 
-```json
-{"id":"<NNN>","from":"<sender>","to":"<recipient>","date":"<YYYY-MM-DD>","kind":"<message|question|handoff|amendment>","priority":"<high|normal|low>","subject":"...","body":"..."}
-```
-
-Increment `id` from the last entry in that file. Use `kind: "question"` when the sender is blocked and needs a reply before continuing.
+Use `"kind":"question"` when blocked and needing a reply. Use
+`"kind":"handoff"` for session handovers. Use `"kind":"amendment"` to
+correct a prior message. Send to `"founder"` for human-in-the-loop
+decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md — spelunk
+
+Operational findings and coding conventions for agents working on this codebase.
+Companion to `CLAUDE.md` (module map, design decisions, common commands).
+Benchmark-specific conventions live in `bench/AGENTS.md`.
+
+---
+
+## Branch Hygiene
+
+- **Always branch from `origin/main`**, never from stale local branches.
+  `feat/benchmarking-deepseek` was merged long ago; new work starts at `origin/main`.
+- **Verify your branch** before every commit: `git branch --show-current`.
+  Accidental commits on the wrong branch are the most frequent operational error.
+- **Rebase before push** when the target has moved: `git fetch origin main && git rebase origin/main`.
+- **Force-push with lease** after rebase: `git push --force-with-lease`.
+
+---
+
+## Dependabot Rust Fixes
+
+When a Cargo dependency bump breaks the build:
+
+1. **Check for new feature flags.** `gix-hash` >=0.23.0 requires explicit
+   `sha1` or `sha256` feature. Fix: add `features = ["sha1"]` to `gix` dep.
+2. **Check for API changes in transitive deps.** `git-meta-lib` 0.1.10 changed
+   `Session::open(gix::Repository)` to `Session::open(impl Into<PathBuf>)`.
+3. **Rebuild Cargo.lock** after conflict resolution with
+   `cargo update -p <crate>`.
+4. **Run `cargo test`** after every dependency change.
+
+---
+
+## GitHub Workflow
+
+- **One PR per issue.** Branch name: `fix/<issue>-<short-desc>`.
+- **PR description:** `Closes #N` or `Refs #N` with bullet summary of changes.
+- **Dependabot PRs:** commit fixes directly to the dependabot branch.
+  If both bumps touch the same line, fix #240 first (smaller change), then
+  rebase #241 onto the merged result.
+- **After merge:** the branch is deleted automatically. Move to the next issue.
+
+---
+
+## Agent Communications
+
+This project uses an agent communication protocol defined in
+`agent-comms/PROTOCOL.md`. Key points:
+
+- **Inbox:** `agent-comms/inbox/implementer.ndjson` — read at session start.
+- **GitHub Issues:** all work tracked as issues. Comment "Starting work on #N"
+  and "Done — PR #M" on each.
+- **spelunk memory:** store decisions, notes, and handoffs via
+  `spelunk memory add --kind <kind> --title "..." --body "..."`.

--- a/agent-comms/PROTOCOL.md
+++ b/agent-comms/PROTOCOL.md
@@ -15,27 +15,67 @@ Files live in `agent-comms/inbox/<recipient>.ndjson`.
 
 A message is one JSON object per line:
 ```json
-{"from": "implementer", "to": "architect", "re": "#42", "ts": "2026-04-16T10:00:00Z", "session_id": "sess_abc123", "body": "Spec is ambiguous: does knn emit one JSON object or one per line?", "priority": "blocking"}
+{"from": "implementer", "to": "architect", "re": "#42", "ts": "2026-04-16T10:00:00Z", "session_id": "sess_abc123", "kind": "question", "body": "Spec is ambiguous: does knn emit one JSON object or one per line?", "priority": "blocking"}
 ```
 
 Fields:
-- `from` — sender persona name (architect | implementer | test-engineer | docs-writer | qa-reviewer)
-- `to` — recipient persona name
+- `from` — sender persona name (see persona table below)
+- `to` — recipient persona name (or `founder` for human-in-the-loop)
 - `re` — GitHub issue reference e.g. `"#42"` (required)
 - `ts` — ISO-8601 timestamp
 - `session_id` — opaque session identifier; set when an agent claims a task. Prevents parallel agents from picking up the same issue and allows querying stuck sessions.
+- `kind` — message type: `"message"` (general), `"question"` (sender is blocked and needs a reply before continuing), `"handoff"` (session handover), or `"amendment"` (correction to a prior message)
 - `body` — free text, keep under 500 chars
-- `priority` — `"blocking"` | `"fyi"` | `"question"`
+- `priority` — `"blocking"` | `"fyi"`
 
-**Routing**: messages are placed directly into the recipient's inbox file.
+#### Personas
+
+| Alias | Full name | Inbox file |
+|-------|-----------|------------|
+| `architect` | Architect | `agent-comms/inbox/architect.ndjson` |
+| `implementer`, `impl` | Implementer | `agent-comms/inbox/implementer.ndjson` |
+| `pm` | Product Manager | `agent-comms/inbox/product-manager.ndjson` |
+| `test`, `te` | Test Engineer | `agent-comms/inbox/test-engineer.ndjson` |
+| `qa` | QA Reviewer | `agent-comms/inbox/qa-reviewer.ndjson` |
+| `docs` | Docs Writer | `agent-comms/inbox/docs-writer.ndjson` |
+| `founder` | Founder (human-in-the-loop) | `agent-comms/inbox/founder.ndjson` |
+
+`founder` is not a persona — it's the back-pressure point for human
+feedback and questions. Messages to `founder` are for decisions only
+the human can make, blocking issues that need unblocking, and
+context the human should be aware of.
+
+#### Routing
+
+To send a message, append a JSON line to `agent-comms/inbox/<recipient>.ndjson`:
+```json
+{"from":"<sender>","to":"<recipient>","re":"#<N>","ts":"<ISO-8601>","session_id":"<id>","kind":"<message|question|handoff|amendment>","priority":"<blocking|fyi>","body":"..."}
+```
+
 Each agent reads their own inbox at session start.
 
-**Inbox lifecycle**: agents MUST remove messages from their inbox as they
-finish processing them (rewrite the file without the consumed lines). A
-message with a `session_id` indicates an agent has claimed the referenced
-issue — other agents MUST NOT pick up that issue while the message is
-present. If a session appears stuck, the `session_id` can be used to
-query its status.
+#### Inbox processing (session startup)
+
+Every agent session MUST:
+
+1. **Read and process the inbox.** For each message:
+   - Print: sender, date, priority, kind, summary (first 80 chars of body)
+   - Flag `"priority":"blocking"` with **[BLOCKING]**
+   - Flag `"kind":"question"` with **[NEEDS REPLY]**
+
+2. **Run spelunk startup checks.** Dog-food the product:
+   ```bash
+   spelunk check                                    # verify index is fresh
+   spelunk memory list --kind decision --limit 10   # review prior decisions
+   spelunk memory list --kind handoff --limit 3     # pick up where last session left off
+   spelunk memory list --kind question              # check open questions
+   ```
+
+3. **Clear consumed messages.** After processing, remove consumed entries
+   from the inbox file (rewrite without consumed lines, or truncate).
+   A message with a `session_id` indicates an active claim — other agents
+   MUST NOT pick up that issue while the message is present. If a session
+   appears stuck, the `session_id` can be used to query its status.
 
 ### 3. spelunk memory (tertiary — decisions and context)
 ```bash
@@ -74,7 +114,9 @@ agent-comms/
   inbox/
     architect.ndjson   — messages waiting for Architect
     implementer.ndjson
+    product-manager.ndjson
     test-engineer.ndjson
-    docs-writer.ndjson
     qa-reviewer.ndjson
+    docs-writer.ndjson
+    founder.ndjson     — human-in-the-loop back-pressure
 ```

--- a/agent-comms/PROTOCOL.md
+++ b/agent-comms/PROTOCOL.md
@@ -1,0 +1,80 @@
+# Agent Communication Protocol
+
+Agents communicate via NDJSON files in this directory and via GitHub Issues + spelunk memory.
+
+## Channels
+
+### 1. GitHub Issues (primary — task tracking)
+- All work is tracked as GitHub Issues in `usercise/spelunk`
+- Every agent that starts a task comments on the issue: "Starting work on #N"
+- Every agent that completes a task comments: "Done — PR #M / ready for QA"
+- Labels signal which persona should pick up the work (see label descriptions)
+
+### 2. NDJSON Message Files (secondary — async agent-to-agent)
+Files live in `agent-comms/inbox/<recipient>.ndjson`.
+
+A message is one JSON object per line:
+```json
+{"from": "implementer", "to": "architect", "re": "#42", "ts": "2026-04-16T10:00:00Z", "session_id": "sess_abc123", "body": "Spec is ambiguous: does knn emit one JSON object or one per line?", "priority": "blocking"}
+```
+
+Fields:
+- `from` — sender persona name (architect | implementer | test-engineer | docs-writer | qa-reviewer)
+- `to` — recipient persona name
+- `re` — GitHub issue reference e.g. `"#42"` (required)
+- `ts` — ISO-8601 timestamp
+- `session_id` — opaque session identifier; set when an agent claims a task. Prevents parallel agents from picking up the same issue and allows querying stuck sessions.
+- `body` — free text, keep under 500 chars
+- `priority` — `"blocking"` | `"fyi"` | `"question"`
+
+**Routing**: messages are placed directly into the recipient's inbox file.
+Each agent reads their own inbox at session start.
+
+**Inbox lifecycle**: agents MUST remove messages from their inbox as they
+finish processing them (rewrite the file without the consumed lines). A
+message with a `session_id` indicates an agent has claimed the referenced
+issue — other agents MUST NOT pick up that issue while the message is
+present. If a session appears stuck, the `session_id` can be used to
+query its status.
+
+### 3. spelunk memory (tertiary — decisions and context)
+```bash
+spelunk memory add --kind decision --title "..." --body "why, what, what breaks"
+spelunk memory add --kind note --title "..." --body "..."
+spelunk memory add --kind handoff --title "Handoff: <summary>" --body "..."
+```
+All agents add handoff notes at the end of each session.
+
+## Plumbing Command Output Protocol
+
+All plumbing commands MUST:
+- Emit **NDJSON** to stdout (one JSON object per line)
+- Write human-readable errors to stderr only
+- Exit `0` on success
+- Exit `1` if the query returned zero results (not an error)
+- Exit `2` on any error (bad args, DB failure, embedding failure)
+
+Example plumbing output:
+```ndjson
+{"kind":"chunk","file":"src/main.rs","start_line":1,"end_line":42,"content":"...","chunk_id":"abc123"}
+{"kind":"chunk","file":"src/lib.rs","start_line":5,"end_line":30,"content":"...","chunk_id":"def456"}
+```
+
+## Exit Code Convention
+| Code | Meaning |
+|------|---------|
+| 0 | Success — results emitted |
+| 1 | No results — query valid but nothing matched |
+| 2 | Error — invalid args, missing DB, backend failure |
+
+## File Routing Convention
+```
+agent-comms/
+  PROTOCOL.md          — this file
+  inbox/
+    architect.ndjson   — messages waiting for Architect
+    implementer.ndjson
+    test-engineer.ndjson
+    docs-writer.ndjson
+    qa-reviewer.ndjson
+```

--- a/bench/AGENTS.md
+++ b/bench/AGENTS.md
@@ -1,0 +1,151 @@
+# bench/AGENTS.md — Benchmark Coding Conventions
+
+Operational findings and coding conventions for the `bench/` directory.
+Companion to `AGENTS.md` at the repo root.
+
+---
+
+## Benchmark Design Principles
+
+These emerged from the benchmarking overhaul (issues #224–#232) and the
+original review in `tmp/benchmark-fix-plan.md`:
+
+1. **Every claim needs a control.** Multi-turn-with-spelunk must be compared
+   against multi-turn-without-spelunk, not against single-shot. A lift that
+   disappears when the baseline gets the same compute budget is not spelunk's lift.
+2. **No question-from-corpus circularity.** Questions used to evaluate retrieval
+   must be authored by a party that has not seen what is in the memory store.
+3. **Correctness > activity.** "Turns used" and "tokens spent" without a
+   correctness signal are activity metrics, not quality metrics. Every agent
+   benchmark needs a verifiable success criterion.
+4. **Honest sample sizes.** No n=1 demos in a report that compares means.
+5. **The report should under-promise.** Where infrastructure is ready but
+   results aren't in, say so explicitly. Don't list empty rows in the
+   executive summary.
+
+### Scaffolding vs. Deliverable split
+
+When a PR delivers the *framework* but not the *content* (e.g. benchmark script
+is ready but task corpus is placeholder), use `Refs #N` not `Closes #N`. File a
+follow-up issue for the content-authoring half. This pattern was used for:
+
+- #226 (blind protocol) → #237 (question sets)
+- #228 (handoff redesign) → #247 (task corpus)
+- #230 (graph benchmark) → #248 (task corpus)
+- #231 (perf orchestrator) → follow-up (scale runs)
+
+---
+
+## Python Benchmark Scripts
+
+### Dependency management
+- Use `uv run --quiet --with-requirements bench/requirements.txt` for all Python
+  scripts under `bench/`. Never assume `python3` has the needed packages.
+- `bench/requirements.txt` is the single source of truth for Python deps.
+
+### Secrets
+- API keys live in `.env.local` (gitignored). Load via `python-dotenv` at
+  the top of every script that calls an API:
+  ```python
+  from dotenv import load_dotenv
+  _root = Path(__file__).resolve().parents[2]  # or parents[3] for nested scripts
+  _dotenv = _root / ".env.local"
+  if _dotenv.exists():
+      load_dotenv(_dotenv)
+  ```
+- Fall back to `DEEPSEEK_API_KEY` env var, then `--api-key` flag.
+- Record `api_key_source` in result JSON for auditability.
+
+### Reproducibility contract
+Every result JSON must include: `benchmark`, `condition`, `model`,
+`model_source`, `api_base_url`, `spelunk_version`, `seed`, `timestamp`.
+Add `scaffold_hash` for committed baselines.
+
+### Seed plumbing
+- `np.random.seed(args.seed)` for numpy.
+- `seed=args.seed` passed to `client.chat.completions.create()`.
+- Both must be present; numpy-only seeding was a bug caught in review.
+
+### Incremental writes
+For long-running benchmarks, write results incrementally (every N tasks) so a
+crash doesn't lose everything. `batch_run.py` does this; `swebench_eval.sh`
+writes the final envelope at the end.
+
+---
+
+## Shell Script Patterns
+
+### Don't shadow `PATH`
+```bash
+# WRONG — overrides the shell's command search path
+PATH="${entry#*:}"
+
+# RIGHT — use a different name
+REPO_DIR="${entry#*:}"
+```
+
+### spelunk status for aggregate counts
+```bash
+# WRONG — spelunk chunks wants a file, not a directory
+CHUNKS=$(spelunk chunks --format json "$DIR" ...)
+
+# RIGHT — spelunk status gives file_count and chunk_count
+STATS=$(cd "$DIR" && spelunk status --format json)
+FILES=$(echo "$STATS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('file_count',0))")
+CHUNKS=$(echo "$STATS" | python3 -c "import json,sys; print(json.load(sys.stdin).get('chunk_count',0))")
+```
+
+### Verify field names against actual output
+Always smoke-test spelunk commands to confirm JSON field names before
+committing. `file_count` vs `files` was a silent-zero bug caught in review.
+
+### set -euo pipefail with explicit failure handling
+```bash
+# Prefer explicit failure over || true
+if ! "$SPELUNK" index "$REPO_DIR" >/dev/null 2>&1; then
+    echo "FAILED — skipping repo" >&2
+    continue
+fi
+```
+
+---
+
+## Common Silent-Failure Patterns
+
+These bugs all produce zero/empty results without raising exceptions.
+Smoke tests catch them; code review often misses them.
+
+| Pattern | Example | Fix |
+|---------|---------|-----|
+| Field name mismatch | `r.get("files")` vs actual `file_count` | Smoke-test against real output |
+| Bare `except Exception: return []` | FTS syntax error swallowed | Log to stderr, narrow exception types |
+| FTS5 AND vs OR semantics | Multi-word query requires all tokens | OR-join with quoted tokens |
+| FTS5 special characters | `?` in query breaks parser | Strip non-alphanumeric before MATCH |
+| `git diff` misses untracked files | Agent creates new files via `write_file` | `git add -A && git diff --cached HEAD` |
+| `source_ref` vs `commit` field | Memory entries use different SHA field | Check both with prefix match |
+| Wrong harness output filename | SWE-bench version drift | Glob for file containing `"resolved"` key |
+
+---
+
+## Project-Specific Conventions
+
+### Directory layout
+- `bench/agents/` — SWE-bench agent and evaluation
+- `bench/memory/` — decision archaeology and cross-session handoff
+- `bench/graph/` — code-graph retrieval
+- `bench/codesearchnet/` — CodeSearchNet retrieval
+- `bench/gemma/crosscodeeval/` — RepoBench cross-file completion
+- `bench/perf_*.sh` — performance benchmarks
+
+### Output paths
+- Scratch results: `bench/results/` (gitignored except `.gitignore`)
+- Committed baselines: `baselines/` (outside `bench/` so scaffold hash is stable)
+- Plans and reports: `tmp/` (gitignored; use `git add -f` to commit)
+
+### Configuration priority for API scripts
+1. `--api-key` CLI flag
+2. `DEEPSEEK_API_KEY` environment variable
+3. `.env.local` auto-loaded via `python-dotenv`
+
+### Model name
+`deepseek-v4-flash` (not `deepseek-chat`).


### PR DESCRIPTION
Three changes:

- Create AGENTS.md with branch hygiene, dependabot fixes, GitHub workflow, and agent comms reference
- Create bench/AGENTS.md with benchmark design principles, Python/shell patterns, and silent-failure catalogue
- Simplify PROTOCOL.md: remove outbox, add session_id field, add inbox lifecycle rule (consume-and-clear)