### PR TITLE
refactor: replace git subprocess with gix status API (#215)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,13 +1808,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
 dependencies = [
  "bstr",
+ "gix-attributes 0.33.0",
  "gix-command 0.9.0",
  "gix-filter 0.30.0",
  "gix-fs 0.21.1",
  "gix-hash 0.25.0",
  "gix-imara-diff",
+ "gix-index 0.51.0",
  "gix-object 0.60.0",
  "gix-path 0.12.0",
+ "gix-pathspec 0.18.0",
  "gix-tempfile 23.0.0",
  "gix-trace",
  "gix-traverse 0.57.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ rusqlite = { version = "0.39", features = ["bundled"] }
 # Zero-infrastructure memory backend: SQLite in .git/ + refs/meta/ for push/fetch
 git-meta-lib = "0.1.10"
 # gix is a transitive dep of git-meta-lib; declared directly to call Session::open()
-gix = { version = "0.83.0", default-features = false, features = ["sha1"] }
+gix = { version = "0.83.0", default-features = false, features = ["sha1", "status"] }
 
 # Vector extension for SQLite
 sqlite-vec = "0.1"

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -88,39 +88,21 @@ pub fn format_age(created_at: i64) -> String {
     }
 }
 
-/// Collect files modified or untracked relative to HEAD using git.
+/// Collect files modified or untracked relative to HEAD using gix.
 /// Returns an empty set on any error (graceful degradation).
 pub fn worktree_modified_files() -> std::collections::HashSet<String> {
-    let mut files = std::collections::HashSet::new();
-
-    if let Ok(out) = std::process::Command::new("git")
-        .args(["diff", "--name-only", "HEAD"])
-        .output()
-    {
-        for line in String::from_utf8_lossy(&out.stdout).lines() {
-            let s = line.trim();
-            if !s.is_empty() {
-                files.insert(s.to_string());
-            }
-        }
-    }
-
-    if let Ok(out) = std::process::Command::new("git")
-        .args(["status", "--porcelain"])
-        .output()
-    {
-        for line in String::from_utf8_lossy(&out.stdout).lines() {
-            let s = line.trim();
-            if s.len() > 3 {
-                let path = s[3..].trim();
-                if !path.is_empty() {
-                    files.insert(path.to_string());
-                }
-            }
-        }
-    }
-
-    files
+    let Ok(repo) = gix::discover(".") else {
+        return std::collections::HashSet::new();
+    };
+    let Ok(platform) = repo.status(gix::progress::Discard) else {
+        return std::collections::HashSet::new();
+    };
+    let Ok(iter) = platform.into_iter(Vec::<gix::bstr::BString>::new()) else {
+        return std::collections::HashSet::new();
+    };
+    iter.filter_map(|res| res.ok())
+        .map(|item| item.location().to_string())
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Removes the `git status --porcelain` subprocess call from `worktree_modified_files()`
- Replaces it with the `gix` status API (`repo.status(Discard).into_iter()`)
- Added `"status"` feature to the `gix` dependency in `Cargo.toml` (was already a transitive dep via `git-meta-lib`)

## Why

Spawning a child process for `git status` is fragile (PATH dependency, subprocess overhead, shell injection surface). The `gix` crate is already in the dependency tree — using its native API is more reliable and avoids the subprocess entirely.

## Test plan

- [ ] `cargo test` passes
- [ ] `spelunk status` correctly reflects modified/untracked files in a repo with dirty state
- [ ] `spelunk status` returns empty set gracefully when run outside a git repo

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)