### PR TITLE
feat(graph): add --live flag and ast-grep fallback for symbol queries (#216)

### DIFF
--- a/src/cli/cmd/graph.rs
+++ b/src/cli/cmd/graph.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Args;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Args, Debug)]
 pub struct GraphArgs {
@@ -22,36 +22,58 @@ pub struct GraphArgs {
     /// Skip the lightweight staleness probe (suppress stale-index warning)
     #[arg(long)]
     pub no_stale_check: bool,
+
+    /// Skip the index and scan live files with ast-grep (requires ast-grep in PATH)
+    #[arg(long)]
+    pub live: bool,
 }
 
 use super::helpers::open_project_db;
-use super::search::maybe_warn_stale;
+use super::search::{index_is_stale, maybe_warn_stale};
 use crate::config::Config;
+use crate::storage::GraphEdge;
 
 pub fn graph(args: GraphArgs, cfg: Config) -> Result<()> {
-    let (db_path, db) = open_project_db(args.db.as_deref(), &cfg.db_path)?;
-
-    if !args.no_stale_check {
-        maybe_warn_stale(&db_path);
-    }
     let symbol = &args.symbol;
-
-    // Decide whether the query looks like a file path or a symbol name.
-    let mut edges = if symbol.contains('/')
+    let is_file_query = symbol.contains('/')
         || symbol.contains('\\')
         || symbol.ends_with(".rs")
         || symbol.ends_with(".py")
         || symbol.ends_with(".go")
         || symbol.ends_with(".java")
         || symbol.ends_with(".ts")
-        || symbol.ends_with(".js")
-    {
+        || symbol.ends_with(".js");
+
+    // --live forces ast-grep regardless of index state (symbol queries only).
+    if args.live && !is_file_query {
+        return graph_live(symbol, &args.format, &args.kind, Path::new("."));
+    }
+
+    let db_result = open_project_db(args.db.as_deref(), &cfg.db_path);
+
+    // No index present — fall back to ast-grep for symbol queries.
+    if db_result.is_err() && !is_file_query {
+        return graph_live(symbol, &args.format, &args.kind, Path::new("."));
+    }
+
+    let (db_path, db) = db_result?;
+
+    if !args.no_stale_check {
+        maybe_warn_stale(&db_path);
+    }
+
+    let mut edges = if is_file_query {
         db.edges_for_file(symbol)?
     } else {
         db.edges_for_symbol(symbol)?
     };
 
-    // Optional kind filter
+    // Stale index + empty results → fall back to ast-grep for symbol queries.
+    if edges.is_empty() && !is_file_query && !args.no_stale_check && index_is_stale(&db_path) {
+        eprintln!("note: index is stale — falling back to live ast-grep scan");
+        return graph_live(symbol, &args.format, &args.kind, Path::new("."));
+    }
+
     if let Some(kind) = &args.kind {
         edges.retain(|e| e.kind == *kind);
     }
@@ -74,8 +96,80 @@ pub fn graph(args: GraphArgs, cfg: Config) -> Result<()> {
     Ok(())
 }
 
-fn print_edges(edges: &[crate::storage::GraphEdge], query: &str) {
-    // Group into outgoing (source) and incoming (target) edges.
+/// Run an ast-grep caller search for `symbol` over the working tree rooted at `root`.
+fn graph_live(symbol: &str, format: &str, kind_filter: &Option<String>, root: &Path) -> Result<()> {
+    if std::process::Command::new("ast-grep")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        anyhow::bail!(
+            "ast-grep not found. Install with: brew install ast-grep\n\
+             (or: cargo install ast-grep --locked)\n\
+             Index-backed graph queries require `spelunk index .` first."
+        );
+    }
+
+    let pattern = format!("{symbol}($$$)");
+    let out = std::process::Command::new("ast-grep")
+        .args(["run", "--pattern", &pattern, "--json"])
+        .arg(root)
+        .output()?;
+
+    if !out.status.success() && out.stdout.is_empty() {
+        println!("No graph edges found for '{symbol}' (live scan).");
+        return Ok(());
+    }
+
+    let matches: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap_or_default();
+
+    let mut edges: Vec<GraphEdge> = matches
+        .into_iter()
+        .filter_map(|m| {
+            let path = m["path"].as_str()?.to_string();
+            let line = m["range"]["start"]["line"].as_u64().unwrap_or(0) as usize;
+            Some(GraphEdge {
+                source_file: path,
+                source_name: None,
+                target_name: symbol.to_string(),
+                kind: "calls".to_string(),
+                line,
+            })
+        })
+        .collect();
+
+    if let Some(k) = kind_filter {
+        edges.retain(|e| &e.kind == k);
+    }
+
+    if edges.is_empty() {
+        println!("No graph edges found for '{symbol}' (live scan).");
+        return Ok(());
+    }
+
+    match crate::utils::effective_format(format) {
+        "json" => println!("{}", serde_json::to_string_pretty(&edges)?),
+        "ndjson" => {
+            for edge in &edges {
+                println!("{}", serde_json::to_string(edge)?);
+            }
+        }
+        _ => {
+            println!("\x1b[1mIncoming to '{symbol}' (live scan — no ranking):\x1b[0m");
+            for e in &edges {
+                let loc = e.source_name.as_deref().unwrap_or(&e.source_file);
+                println!(
+                    "  \x1b[36m{}\x1b[0m  {}  \x1b[2m({}:{})\x1b[0m",
+                    e.kind, e.source_file, loc, e.line
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_edges(edges: &[GraphEdge], query: &str) {
     let outgoing: Vec<_> = edges
         .iter()
         .filter(|e| e.source_name.as_deref() == Some(query) || e.source_file == query)

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -249,6 +249,17 @@ pub(crate) fn maybe_warn_stale(db_path: &std::path::Path) {
     }
 }
 
+/// Return `true` when the index exists and the staleness probe indicates changed files.
+pub(crate) fn index_is_stale(db_path: &std::path::Path) -> bool {
+    if !db_path.exists() {
+        return false;
+    }
+    Database::open(db_path)
+        .ok()
+        .and_then(|db| db.sample_staleness_check(20).ok())
+        .is_some_and(|report| report.stale > 0)
+}
+
 /// Resolve the primary DB path and any dep projects via the registry.
 /// Falls back to `resolve_db` if the registry can't find a project.
 pub(crate) fn resolve_project_and_deps(


### PR DESCRIPTION
## Summary

- Adds `--live` flag to `spelunk graph` to force an ast-grep scan, bypassing the index
- Automatic fallback to ast-grep when: (a) no index exists, or (b) index is stale and returns zero results
- Extracts `index_is_stale()` helper from `maybe_warn_stale()` in `search.rs` so `graph.rs` can reuse the staleness probe

## Why

Without an index, `spelunk graph <symbol>` fails outright. With a stale index, it silently returns nothing. Both cases make the tool unhelpful on fresh checkouts or between re-indexes. The ast-grep fallback gives useful output in those situations with no extra setup.

## Test plan

- [ ] `cargo test` passes
- [ ] `spelunk graph <symbol> --live` works with ast-grep in PATH
- [ ] `spelunk graph <symbol> --live` gives a clear error when ast-grep is not installed
- [ ] Without `--live`, stale-index + empty results triggers automatic fallback with eprintln note
- [ ] File path queries (`spelunk graph src/foo.rs`) are unaffected by the ast-grep path

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)