### PR TITLE
feat(server): optional server-side embedding via SPELUNK_EMBEDDING_URL (#221)

### DIFF
--- a/src/bin/spelunk_server.rs
+++ b/src/bin/spelunk_server.rs
@@ -4,7 +4,6 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
-// Pull in the spelunk library crate (same workspace).
 use spelunk::server::db::ServerDb;
 use spelunk::server::{ApiDoc, AppState, default_conflict_threshold, router};
 use utoipa::OpenApi;
@@ -39,6 +38,18 @@ struct Args {
     #[arg(long, default_value_t = default_conflict_threshold())]
     conflict_threshold: f32,
 
+    /// Base URL of an OpenAI-compatible embedding server for server-side embedding
+    /// (e.g. `http://127.0.0.1:1234`). Overrides `SPELUNK_EMBEDDING_URL`.
+    /// When set, entries posted without a pre-computed `embedding` field are embedded
+    /// by the server before storage.
+    #[arg(long, env = "SPELUNK_EMBEDDING_URL")]
+    embedding_url: Option<String>,
+
+    /// Embedding model name to pass to the embedding server (e.g.
+    /// `text-embedding-embeddinggemma-300m-qat`). Overrides `SPELUNK_EMBEDDING_MODEL`.
+    #[arg(long, env = "SPELUNK_EMBEDDING_MODEL", default_value = "")]
+    embedding_model: String,
+
     /// Print the OpenAPI spec as JSON and exit (for Postman / Newman import).
     #[arg(long)]
     print_openapi: bool,
@@ -54,7 +65,6 @@ async fn main() -> Result<()> {
         )));
     }
 
-    // Logging.
     tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .with(fmt::layer())
@@ -72,14 +82,38 @@ async fn main() -> Result<()> {
 
     if args.key.is_none() {
         tracing::warn!(
-            "No API key configured — server is running without authentication. Set --key or SPELUNK_SERVER_KEY for production use."
+            "No API key configured — server is running without authentication. \
+             Set --key or SPELUNK_SERVER_KEY for production use."
         );
     }
+
+    // Build the optional server-side embedder.
+    let embedder: Option<Arc<dyn spelunk::embeddings::EmbeddingBackend>> =
+        if let Some(base_url) = args.embedding_url {
+            let model = if args.embedding_model.is_empty() {
+                "default".to_string()
+            } else {
+                args.embedding_model.clone()
+            };
+            tracing::info!("server-side embedding enabled: {base_url} model={model}");
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(60))
+                .build()
+                .context("building HTTP client for server-side embedder")?;
+            Some(Arc::new(ServerEmbedder {
+                client,
+                base_url,
+                model,
+            }))
+        } else {
+            None
+        };
 
     let state = AppState {
         db: Arc::new(tokio::sync::Mutex::new(db)),
         api_key: args.key,
         conflict_threshold: args.conflict_threshold,
+        embedder,
     };
 
     let app = router(state);
@@ -92,4 +126,54 @@ async fn main() -> Result<()> {
     axum::serve(listener, app).await?;
 
     Ok(())
+}
+
+// ── Inline embedder for the server binary ─────────────────────────────────────
+
+struct ServerEmbedder {
+    client: reqwest::Client,
+    base_url: String,
+    model: String,
+}
+
+#[async_trait::async_trait]
+impl spelunk::embeddings::EmbeddingBackend for ServerEmbedder {
+    async fn embed(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        #[derive(serde::Serialize)]
+        struct Req<'a> {
+            model: &'a str,
+            input: &'a [&'a str],
+        }
+        #[derive(serde::Deserialize)]
+        struct Resp {
+            data: Vec<Data>,
+        }
+        #[derive(serde::Deserialize)]
+        struct Data {
+            embedding: Vec<f32>,
+        }
+
+        let resp: Resp = self
+            .client
+            .post(format!("{}/v1/embeddings", self.base_url))
+            .json(&Req {
+                model: &self.model,
+                input: texts,
+            })
+            .send()
+            .await
+            .context("calling embedding server")?
+            .error_for_status()
+            .context("embedding server returned an error")?
+            .json()
+            .await
+            .context("parsing embedding response")?;
+
+        anyhow::ensure!(!resp.data.is_empty(), "embedding server returned 0 vectors");
+        Ok(resp.data.into_iter().map(|d| d.embedding).collect())
+    }
+
+    fn dimension(&self) -> usize {
+        0 // dimension is model-dependent; not used server-side
+    }
 }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -32,7 +32,9 @@ pub struct AddNoteRequest {
     /// Source file paths this entry is linked to.
     #[serde(default)]
     pub linked_files: Vec<String>,
-    /// Pre-computed embedding vector from the client (required for semantic search).
+    /// Pre-computed embedding vector from the client. Optional — if omitted and the server has an
+    /// embedding backend configured (`SPELUNK_EMBEDDING_URL`), the server embeds the entry.
+    /// If neither is available, the entry is stored without a vector (text search only).
     pub embedding: Option<Vec<f32>>,
 }
 
@@ -135,8 +137,9 @@ pub async fn list_projects(State(state): State<AppState>) -> Result<impl IntoRes
 
 /// Add a memory entry to a project. The project is auto-created on first write.
 ///
-/// The client must supply a pre-computed `embedding` vector. All entries in
-/// a project must use the same embedding dimension — the first write fixes it.
+/// The `embedding` field is optional. If omitted and the server has `SPELUNK_EMBEDDING_URL`
+/// configured, the server embeds the entry before storage. If neither is available, the
+/// entry is stored without a vector (text search only, no KNN).
 ///
 /// Returns **201** on success. Returns **409** when the new entry is semantically
 /// close to one or more existing active entries (similarity ≥ conflict_threshold).
@@ -162,7 +165,26 @@ pub async fn add_note(
     Path(project_id): Path<String>,
     Json(body): Json<AddNoteRequest>,
 ) -> Result<Response, AppError> {
-    let embedding = body.embedding.as_deref();
+    // Server-side embedding: embed the entry when no client vector is supplied.
+    let server_embedding: Option<Vec<f32>> = if body.embedding.is_none() {
+        if let Some(embedder) = &state.embedder {
+            let text = format!("title: {} | text: {}", body.title, body.body);
+            match embedder.embed(&[text.as_str()]).await {
+                Ok(mut vecs) if !vecs.is_empty() => vecs.pop(),
+                Ok(_) => None,
+                Err(e) => {
+                    tracing::warn!("server-side embedding failed, storing without vector: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let embedding = body.embedding.as_deref().or(server_embedding.as_deref());
     let dim = embedding.map(|v| v.len()).unwrap_or(0);
 
     let db = state.db.lock().await;
@@ -621,6 +643,7 @@ mod tests {
             db: Arc::new(tokio::sync::Mutex::new(db)),
             api_key: None,
             conflict_threshold,
+            embedder: None,
         };
         (router(state), dim as i32)
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -22,6 +22,10 @@ pub struct AppState {
     /// Cosine similarity threshold above which a new entry is flagged as conflicting (0.0–1.0).
     /// Default: 0.92. Set to 1.0 to disable conflict detection.
     pub conflict_threshold: f32,
+    /// Optional server-side embedder. When set, the server embeds entries that arrive without
+    /// a pre-computed vector. If absent, entries without a vector are stored without one
+    /// (text search only).
+    pub embedder: Option<Arc<dyn crate::embeddings::EmbeddingBackend>>,
 }
 
 pub fn default_conflict_threshold() -> f32 {

--- a/tests/integration_server.rs
+++ b/tests/integration_server.rs
@@ -23,6 +23,7 @@ fn make_state() -> AppState {
         db: Arc::new(tokio::sync::Mutex::new(db)),
         api_key: None,
         conflict_threshold: spelunk::server::default_conflict_threshold(),
+        embedder: None,
     }
 }
 
@@ -258,6 +259,7 @@ async fn protected_endpoint_rejects_missing_token() {
         db: Arc::new(tokio::sync::Mutex::new(db)),
         api_key: Some("secret".into()),
         conflict_threshold: spelunk::server::default_conflict_threshold(),
+        embedder: None,
     };
     let resp = send(state, "GET", "/v1/projects", Body::empty(), false).await;
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
@@ -271,6 +273,7 @@ async fn protected_endpoint_accepts_correct_token() {
         db: Arc::new(tokio::sync::Mutex::new(db)),
         api_key: Some("secret".into()),
         conflict_threshold: spelunk::server::default_conflict_threshold(),
+        embedder: None,
     };
     let req = Request::builder()
         .method("GET")
@@ -367,6 +370,7 @@ async fn since_endpoint_returns_entries_after_timestamp() {
         db: Arc::new(tokio::sync::Mutex::new(db)),
         api_key: None,
         conflict_threshold: spelunk::server::default_conflict_threshold(),
+        embedder: None,
     };
 
     // Query with t=1500 — should return only the note at t=2000.


### PR DESCRIPTION
## Summary

- Adds `embedder: Option<Arc<dyn EmbeddingBackend>>` to `AppState`
- `spelunk-server` accepts `--embedding-url` / `SPELUNK_EMBEDDING_URL` to configure a server-side embedder
- Entries posted without an `embedding` field are embedded by the server before storage when an embedder is configured
- Entries posted with a vector bypass server-side embedding (client wins)
- If neither is available, the entry is stored without a vector (text/FTS search only — no KNN)
- `ServerEmbedder` is an inline struct in `spelunk_server.rs` implementing `EmbeddingBackend` via `reqwest` — no new crate dependencies

## Why

Teams often want to run a single embedder on the server rather than requiring every client to have a local inference server. This makes spelunk-server self-contained: clients can POST plain text entries and the server handles vectorisation.

## Test plan

- [ ] `cargo test` passes
- [ ] `spelunk-server --embedding-url http://127.0.0.1:1234` starts without error
- [ ] POST without `embedding` field → server embeds and stores (requires embedding server)
- [ ] POST with `embedding` field → vector used as-is, no server-side call
- [ ] Server without `--embedding-url` → entry stored without vector, text search still works

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)