### PR TITLE
fix(test): isolate context tests from project .spelunk dir

### DIFF
--- a/tests/context.rs
+++ b/tests/context.rs
@@ -137,6 +137,11 @@ fn write_config_for_context(dir: &Path, db_path: &Path, api_base: &str) -> PathB
 /// the config, which matches where `setup_context_project` seeds entries.
 fn context_cmd(_db_path: &Path, config_path: &Path) -> Command {
     let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    // Run from the temp dir so find_project_db doesn't walk up and discover
+    // the real .spelunk/index.db in the project root.
+    if let Some(dir) = config_path.parent() {
+        cmd.current_dir(dir);
+    }
     cmd.arg("--config").arg(config_path).arg("context");
     cmd
 }
@@ -488,6 +493,7 @@ fn context_exits_nonzero_when_config_invalid() {
 
     Command::cargo_bin("spelunk")
         .unwrap()
+        .current_dir(&tmp)
         .arg("--config")
         .arg(&config_path)
         .arg("context")


### PR DESCRIPTION
## Summary

- `context_outputs_all_four_sections_by_default`, `context_empty_memory_exits_zero_with_no_output`, and `context_exits_nonzero_when_config_invalid` were all failing because the test binary ran with CWD = project root, causing `resolve_db` to auto-discover `.spelunk/index.db` and ignore the temp config's `db_path`
- All three tests then read from the real `.spelunk/memory.db` (which has handoffs and decisions only, no questions/requirements) instead of the seeded temp database
- Fix: set `current_dir` to the temp dir in `context_cmd` and in the one test that builds the command inline, so `find_project_db` walks up from `/var/folders/...` and finds nothing

## Root cause

`resolve_db(None, &cfg.db_path)` auto-discovers `.spelunk/index.db` by walking up from CWD. Once `.spelunk/index.db` existed in the project root (created by running `spelunk index .`), the auto-discovery overrode the temp config's explicit `db_path`, breaking test isolation.

## Test plan

- [x] `cargo test --test context` — all 15 pass
- [x] `cargo fmt --check` + `cargo clippy` — clean
- [x] `test_status_empty_project` confirmed pre-existing failure, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)