### PR TITLE
feat(capability): implement compatibility tier model (#259)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/check.rs
+++ b/crates/spelunk-cli/src/cli/cmd/check.rs
@@ -22,6 +22,7 @@ pub struct CheckArgs {
 }
 
 use crate::{
+    capability,
     config::{Config, resolve_db},
     storage::{Database, open_memory_backend},
     utils::{format_age, worktree_modified_files},
@@ -97,6 +98,33 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
             println!("  {p}");
         }
         println!("\nRun `spelunk index .` to update.");
+    }
+
+    // Show server status line (text mode only, when server_url is configured).
+    if (effective == "text" || effective == "porcelain") && cfg.server_url.is_some() {
+        let tier = capability::get_tier(&cfg).await;
+        match tier {
+            capability::Tier::Server { url, caps } => {
+                let features: Vec<&str> = [
+                    caps.search_semantic.then_some("semantic search"),
+                    caps.explore.then_some("explore"),
+                    caps.plan.then_some("plan"),
+                ]
+                .into_iter()
+                .flatten()
+                .collect();
+                let feature_str = if features.is_empty() {
+                    "memory sync".to_string()
+                } else {
+                    features.join(", ")
+                };
+                println!("Server:  {url}  \x1b[32m✓\x1b[0m  ({feature_str} available)");
+            }
+            capability::Tier::Offline => {
+                let url = cfg.server_url.as_deref().unwrap_or("?");
+                println!("Server:  {url}  \x1b[31m✗\x1b[0m  unreachable — offline mode");
+            }
+        }
     }
 
     // Show active intent entries (text mode only; silently skip if memory unavailable).

--- a/crates/spelunk-cli/src/cli/cmd/check.rs
+++ b/crates/spelunk-cli/src/cli/cmd/check.rs
@@ -80,6 +80,17 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
             }
         }
     } else if effective == "json" {
+        let tier = capability::get_tier(&cfg).await;
+        let (server_reachable, server_url_val) = match tier {
+            capability::Tier::Server { url, .. } => (true, serde_json::Value::String(url.clone())),
+            capability::Tier::Offline => (
+                false,
+                cfg.server_url
+                    .as_deref()
+                    .map(|u| serde_json::Value::String(u.to_string()))
+                    .unwrap_or(serde_json::Value::Null),
+            ),
+        };
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -88,6 +99,8 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                 "stale_files": stale.len(),
                 "stale": stale,
                 "last_indexed_at": last_indexed,
+                "server_reachable": server_reachable,
+                "server_url": server_url_val,
             }))?
         );
     } else if fresh {

--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -1,86 +1,114 @@
 use anyhow::{Context, Result};
-use futures_util::StreamExt as _;
 use indicatif::{MultiProgress, ProgressBar};
+use serde::{Deserialize, Serialize};
 
 use super::super::ui::{is_tty, progress_style};
-use super::IndexArgs;
-use crate::{
-    config::Config,
-    embeddings::{EmbeddingBackend as _, vec_to_blob},
-    storage::Database,
-};
+use crate::{capability::Tier, config::Config, embeddings::vec_to_blob, storage::Database};
 
-/// Embed all pending chunks and write their vectors to the DB.
+/// Maximum chunks per request — enforced by the server (returns 413 if exceeded).
+const MAX_BATCH: usize = 256;
+
+#[derive(Serialize)]
+struct EmbedRequest {
+    chunks: Vec<ReqChunk>,
+}
+
+#[derive(Serialize)]
+struct ReqChunk {
+    chunk_id: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct EmbedResponse {
+    chunks: Vec<RespChunk>,
+}
+
+#[derive(Deserialize)]
+struct RespChunk {
+    chunk_id: String,
+    vector: Vec<f32>,
+}
+
+/// Send pending chunks to `spelunk-server` for embedding and write the returned
+/// vectors into the local DB.
 ///
-/// Returns the number of chunks embedded.
+/// Returns the number of chunks successfully embedded.
+///
+/// Requires `Tier::Server`; returns `Ok(0)` immediately for `Tier::Offline`.
 pub(super) async fn run_embed_phase(
     chunk_ids_and_texts: Vec<(i64, String)>,
     db: &Database,
     cfg: &Config,
-    args: &IndexArgs,
+    tier: &Tier,
     mp: &MultiProgress,
 ) -> Result<u64> {
-    eprintln!("Embedding via: {}", cfg.embedding_model);
+    let (server_url, server_key) = match tier {
+        Tier::Server { url, .. } => (url.clone(), cfg.server_key.clone()),
+        Tier::Offline => return Ok(0),
+    };
 
-    let embedder = crate::backends::ActiveEmbedder::load(cfg)
-        .await
-        .with_context(|| format!("loading embedding model '{}'", cfg.embedding_model))?;
+    let project_id = cfg
+        .project_id
+        .as_deref()
+        .context("project_id is required when server_url is set")?;
 
-    let batch_size = args.batch_size.max(1);
-    let total_chunks = chunk_ids_and_texts.len() as u64;
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .context("building HTTP client for embed phase")?;
 
-    let embed_bar = if is_tty() && !crate::utils::is_agent_mode() {
-        let bar = mp.add(ProgressBar::new(total_chunks));
-        bar.set_style(progress_style("Embedding"));
-        bar
+    let total = chunk_ids_and_texts.len() as u64;
+    let bar = if is_tty() && !crate::utils::is_agent_mode() {
+        let b = mp.add(ProgressBar::new(total));
+        b.set_style(progress_style("Embedding"));
+        b
     } else {
         ProgressBar::hidden()
     };
 
-    let concurrency = batch_size;
+    let mut embedded = 0u64;
 
-    let results: Vec<(i64, Vec<f32>)> = futures_util::stream::iter(
-        chunk_ids_and_texts
+    for batch in chunk_ids_and_texts.chunks(MAX_BATCH) {
+        let req_chunks: Vec<ReqChunk> = batch
             .iter()
-            .map(|(chunk_id, text)| (*chunk_id, text.clone())),
-    )
-    .map(|(chunk_id, text)| {
-        let embedder = &embedder;
-        let embed_bar = &embed_bar;
-        async move {
-            // Simple exponential-backoff retry for transient 429 / server errors.
-            let mut delay_ms = 100u64;
-            let mut last_err: anyhow::Error = anyhow::anyhow!("unreachable");
-            for attempt in 0..3u32 {
-                match embedder.embed(&[text.as_str()]).await {
-                    Ok(mut vecs) => {
-                        embed_bar.inc(1);
-                        return Ok::<(i64, Vec<f32>), anyhow::Error>((chunk_id, vecs.remove(0)));
-                    }
-                    Err(e) => {
-                        last_err = e;
-                        if attempt < 2 {
-                            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                            delay_ms *= 2;
-                        }
-                    }
-                }
-            }
-            Err(last_err.context("generating embedding (3 attempts failed)"))
-        }
-    })
-    .buffer_unordered(concurrency)
-    .collect::<Vec<_>>()
-    .await
-    .into_iter()
-    .collect::<Result<Vec<_>>>()?;
+            .map(|(id, text)| ReqChunk {
+                chunk_id: id.to_string(),
+                content: text.clone(),
+            })
+            .collect();
 
-    // Write embeddings serially — rusqlite connections are not Send.
-    for (chunk_id, embedding) in results {
-        let blob = vec_to_blob(&embedding);
-        db.insert_embedding(chunk_id, &blob)?;
+        let url = format!(
+            "{}/v1/projects/{}/index/embed",
+            server_url.trim_end_matches('/'),
+            project_id,
+        );
+
+        let mut req = client.post(&url).json(&EmbedRequest { chunks: req_chunks });
+        if let Some(k) = &server_key {
+            req = req.bearer_auth(k);
+        }
+
+        let resp: EmbedResponse = req
+            .send()
+            .await
+            .with_context(|| format!("calling {url}"))?
+            .error_for_status()
+            .context("server returned an error for index/embed")?
+            .json()
+            .await
+            .context("parsing index/embed response")?;
+
+        for item in &resp.chunks {
+            if let Ok(row_id) = item.chunk_id.parse::<i64>() {
+                let blob = vec_to_blob(&item.vector);
+                db.insert_embedding(row_id, &blob)?;
+                embedded += 1;
+                bar.inc(1);
+            }
+        }
     }
 
-    embed_bar.finish_with_message(format!("{total_chunks} chunks embedded"));
-    Ok(total_chunks)
+    bar.finish_with_message(format!("{embedded} chunks embedded"));
+    Ok(embedded)
 }

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -38,7 +38,7 @@ pub struct IndexArgs {
     pub background_phases: bool,
 }
 
-use crate::{config::Config, registry::Registry, storage::Database};
+use crate::{capability, config::Config, registry::Registry, storage::Database};
 
 mod embed_phase;
 mod mentions;
@@ -47,6 +47,9 @@ mod summaries;
 mod worktree;
 
 pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
+    // Validate config: server_url requires project_id.
+    cfg.validate()?;
+
     // Compile secret-scanning regexes once before the hot loop.
     crate::indexer::secrets::init();
 
@@ -122,17 +125,33 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         eprintln!("Removed {} stale file(s) from index.", result.removed);
     }
 
+    // ── Phase 2: embed chunks (Tier 1 only) ─────────────────────────────────
+    let tier = capability::get_tier(&cfg).await;
+
     if result.chunk_ids_and_texts.is_empty() {
         let stats = db.stats()?;
         println!(
-            "Index: {} files, {} chunks, {} embeddings (nothing new to embed)",
+            "Index: {} files, {} chunks, {} embeddings (nothing new to process)",
             stats.file_count, stats.chunk_count, stats.embedding_count
         );
         return Ok(());
     }
 
-    // ── Phase 2: embed chunks ────────────────────────────────────────────────
-    embed_phase::run_embed_phase(result.chunk_ids_and_texts, &db, &cfg, &args, &mp).await?;
+    if tier.is_server() {
+        embed_phase::run_embed_phase(result.chunk_ids_and_texts, &db, &cfg, tier, &mp).await?;
+    } else if cfg.server_url.is_some() {
+        eprintln!(
+            "Warning: spelunk-server at {} is unreachable — skipping embedding phase.",
+            cfg.server_url.as_deref().unwrap_or("?")
+        );
+        eprintln!(
+            "Chunks are indexed for text/ast-grep search. Re-run `spelunk index` when the server is back to add embeddings."
+        );
+    } else {
+        eprintln!(
+            "Note: configure server_url in ~/.config/spelunk/config.toml to enable semantic search."
+        );
+    }
 
     let stats = db.stats()?;
     println!(

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 
 use super::MemoryPushArgs;
 use crate::{
+    capability,
     config::Config,
     storage::{NoteInput, open_memory_backend},
 };
@@ -12,12 +13,8 @@ pub(super) async fn memory_push(
     cfg: &Config,
     backend_override: Option<&str>,
 ) -> Result<()> {
-    if cfg.server_url.is_none() {
-        anyhow::bail!(
-            "'spelunk memory push' requires spelunk-server.\n\
-             Set server_url in ~/.config/spelunk/config.toml to enable this feature."
-        );
-    }
+    let tier = capability::get_tier(cfg).await;
+    capability::require_tier1("memory push", tier, cfg.server_url.as_deref())?;
 
     let src_path = args.source.as_deref().unwrap_or(mem_path);
     let local = crate::storage::MemoryStore::open(src_path)

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -12,10 +12,10 @@ pub(super) async fn memory_push(
     cfg: &Config,
     backend_override: Option<&str>,
 ) -> Result<()> {
-    if cfg.memory_server_url.is_none() {
+    if cfg.server_url.is_none() {
         anyhow::bail!(
-            "memory_server_url is not configured.\n\
-             Set it in .spelunk/config.toml or via SPELUNK_SERVER_URL."
+            "'spelunk memory push' requires spelunk-server.\n\
+             Set server_url in ~/.config/spelunk/config.toml to enable this feature."
         );
     }
 
@@ -33,7 +33,7 @@ pub(super) async fn memory_push(
     println!(
         "Pushing {} entries to {}…",
         notes.len(),
-        cfg.memory_server_url.as_deref().unwrap_or("?")
+        cfg.server_url.as_deref().unwrap_or("?")
     );
     let mut pushed = 0usize;
     let mut skipped = 0usize;

--- a/crates/spelunk-cli/src/cli/cmd/memory/since.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/since.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 
 use super::MemorySinceArgs;
-use crate::config::Config;
+use crate::{capability, config::Config};
 
 /// Wire type that matches the server's `ServerNote` JSON schema.
 #[derive(Debug, serde::Serialize, Deserialize)]
@@ -27,9 +27,11 @@ pub(super) async fn memory_since(
     backend_override: Option<&str>,
 ) -> Result<()> {
     // ── Remote path ───────────────────────────────────────────────────────────
-    if let (Some(base_url), Some(project_id)) =
-        (cfg.server_url.as_deref(), cfg.project_id.as_deref())
+    let tier = capability::get_tier(cfg).await;
+    if let (capability::Tier::Server { url: base_url, .. }, Some(project_id)) =
+        (tier, cfg.project_id.as_deref())
     {
+        let base_url = base_url.as_str();
         let limit = args.limit.min(500);
         let url = format!(
             "{}/v1/projects/{}/memory/since",

--- a/crates/spelunk-cli/src/cli/cmd/memory/since.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/since.rs
@@ -28,7 +28,7 @@ pub(super) async fn memory_since(
 ) -> Result<()> {
     // ── Remote path ───────────────────────────────────────────────────────────
     if let (Some(base_url), Some(project_id)) =
-        (cfg.memory_server_url.as_deref(), cfg.project_id.as_deref())
+        (cfg.server_url.as_deref(), cfg.project_id.as_deref())
     {
         let limit = args.limit.min(500);
         let url = format!(
@@ -40,7 +40,7 @@ pub(super) async fn memory_since(
         let mut req = client
             .get(&url)
             .query(&[("t", args.since.to_string()), ("limit", limit.to_string())]);
-        if let Some(key) = cfg.memory_server_key.as_deref() {
+        if let Some(key) = cfg.server_key.as_deref() {
             req = req.header("Authorization", format!("Bearer {key}"));
         }
         let notes: Vec<NoteResponse> = req

--- a/crates/spelunk-cli/src/cli/cmd/memory/watch.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/watch.rs
@@ -1,15 +1,12 @@
 use anyhow::{Context, Result};
 
 use super::MemoryWatchArgs;
-use crate::config::Config;
+use crate::{capability, config::Config};
 
 pub(super) async fn memory_watch(args: MemoryWatchArgs, cfg: &Config) -> Result<()> {
-    let base_url = cfg.server_url.as_deref().ok_or_else(|| {
-        anyhow::anyhow!(
-            "'spelunk memory watch' requires spelunk-server.\n\
-             Set server_url in ~/.config/spelunk/config.toml to enable this feature."
-        )
-    })?;
+    let tier = capability::get_tier(cfg).await;
+    capability::require_tier1("memory watch", tier, cfg.server_url.as_deref())?;
+    let base_url = cfg.server_url.as_deref().expect("require_tier1 passed");
     let project_id = cfg.project_id.as_deref().ok_or_else(|| {
         anyhow::anyhow!(
             "`project_id` is not configured. \

--- a/crates/spelunk-cli/src/cli/cmd/memory/watch.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/watch.rs
@@ -4,10 +4,10 @@ use super::MemoryWatchArgs;
 use crate::config::Config;
 
 pub(super) async fn memory_watch(args: MemoryWatchArgs, cfg: &Config) -> Result<()> {
-    let base_url = cfg.memory_server_url.as_deref().ok_or_else(|| {
+    let base_url = cfg.server_url.as_deref().ok_or_else(|| {
         anyhow::anyhow!(
-            "`memory_server_url` is not configured. \
-             Set it in `.spelunk/config.toml` or via `SPELUNK_SERVER_URL`."
+            "'spelunk memory watch' requires spelunk-server.\n\
+             Set server_url in ~/.config/spelunk/config.toml to enable this feature."
         )
     })?;
     let project_id = cfg.project_id.as_deref().ok_or_else(|| {
@@ -27,7 +27,7 @@ pub(super) async fn memory_watch(args: MemoryWatchArgs, cfg: &Config) -> Result<
 
     let client = reqwest::Client::new();
     let mut req = client.get(&url);
-    if let Some(key) = cfg.memory_server_key.as_deref() {
+    if let Some(key) = cfg.server_key.as_deref() {
         req = req.header("Authorization", format!("Bearer {key}"));
     }
 

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -18,6 +18,7 @@ pub struct StatusArgs {
 
 use super::search::resolve_project_and_deps;
 use crate::{
+    capability::{self, Tier},
     config::{Config, resolve_db},
     registry::Registry,
     storage::{Database, open_memory_backend},
@@ -28,6 +29,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
 
     // JSON mode: current project stats only
     if fmt == "json" {
+        let tier = capability::get_tier(&cfg).await;
         let (db_path, _) = resolve_project_and_deps(None, &cfg)?;
         let db = Database::open(&db_path)?;
         let stats = db.stats()?;
@@ -40,9 +42,20 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
         };
         let usage_map: std::collections::HashMap<&str, i64> =
             usage.iter().map(|(c, n)| (c.as_str(), *n)).collect();
+        let (tier_str, tier_url, caps_json) = match tier {
+            Tier::Offline => ("offline", serde_json::Value::Null, serde_json::Value::Null),
+            Tier::Server { url, caps } => (
+                "server",
+                serde_json::Value::String(url.clone()),
+                serde_json::to_value(caps).unwrap_or(serde_json::Value::Null),
+            ),
+        };
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
+                "tier": tier_str,
+                "server_url": tier_url,
+                "capabilities": caps_json,
                 "file_count": stats.file_count,
                 "chunk_count": stats.chunk_count,
                 "embedding_count": stats.embedding_count,
@@ -132,6 +145,8 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
     }
 
     // Current project only
+    let tier = capability::get_tier(&cfg).await;
+
     let reg = Registry::open().ok();
     let project = reg.as_ref().and_then(|r| {
         std::env::current_dir()
@@ -152,6 +167,9 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
 
     let db = Database::open(&db_path)?;
     let s = db.stats()?;
+
+    // ── Capability tier section ───────────────────────────────────────────────
+    print_tier_section(tier, &cfg);
 
     if let Some(p) = &project {
         println!("Project: \x1b[1m{}\x1b[0m", p.root_path.display());
@@ -220,6 +238,51 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn print_tier_section(tier: &Tier, cfg: &Config) {
+    match tier {
+        Tier::Offline => {
+            let server_hint = if cfg.server_url.is_some() {
+                "  [unreachable]"
+            } else {
+                "  [set server_url to enable semantic search]"
+            };
+            println!("Capability tier:  \x1b[33mOffline\x1b[0m");
+            println!("  search          ast-grep + text{server_hint}");
+            println!("  memory          git-notes (local)");
+            println!("  explore         unavailable  [set server_url to enable]");
+            println!("  plan            unavailable  [set server_url to enable]");
+        }
+        Tier::Server { url, caps } => {
+            println!("Capability tier:  \x1b[32mServer\x1b[0m  \x1b[2m({url})\x1b[0m");
+            let search_label = if caps.search_semantic {
+                "ast-grep + text + semantic"
+            } else {
+                "ast-grep + text"
+            };
+            println!("  search          {search_label}");
+            let mem_label = if caps.memory_push {
+                "git-notes + server sync"
+            } else {
+                "git-notes (local)"
+            };
+            println!("  memory          {mem_label}");
+            let explore_label = if caps.explore {
+                "available"
+            } else {
+                "unavailable"
+            };
+            println!("  explore         {explore_label}");
+            let plan_label = if caps.plan {
+                "available"
+            } else {
+                "unavailable"
+            };
+            println!("  plan            {plan_label}");
+        }
+    }
+    println!();
 }
 
 pub(crate) fn format_age(unix_ts: i64) -> String {

--- a/crates/spelunk-cli/src/main.rs
+++ b/crates/spelunk-cli/src/main.rs
@@ -6,7 +6,7 @@ mod cli;
 use clap::{CommandFactory, FromArgMatches};
 use cli::{Cli, Command};
 use spelunk_core::{
-    backends, config, embeddings, error, indexer, llm, registry, search, storage, utils,
+    backends, capability, config, embeddings, error, indexer, llm, registry, search, storage, utils,
 };
 
 #[tokio::main]

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -42,7 +42,16 @@ fn test_languages_output() {
 fn test_status_empty_project() {
     let temp = tempdir().unwrap();
     let config_path = temp.path().join("config.toml");
-    fs::write(&config_path, "llm_model = \"test-model\"\n").unwrap();
+    // Pin db_path to a non-existent temp path so the test is machine-independent.
+    let db_path = temp.path().join("nonexistent.db");
+    fs::write(
+        &config_path,
+        format!(
+            "llm_model = \"test-model\"\ndb_path = {:?}\n",
+            db_path.display().to_string()
+        ),
+    )
+    .unwrap();
 
     let mut cmd = Command::cargo_bin("spelunk").unwrap();
     cmd.current_dir(temp.path())

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -3,6 +3,9 @@ use predicates::prelude::*;
 use std::fs;
 use tempfile::tempdir;
 
+mod plumbing_helpers;
+use plumbing_helpers::{FIXTURE_PROJECT_ID, IndexEmbedResponder, write_config_with_server};
+
 #[test]
 fn test_help_output() {
     let mut cmd = Command::cargo_bin("spelunk").unwrap();
@@ -65,7 +68,7 @@ fn test_status_empty_project() {
         ));
 }
 
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
@@ -134,4 +137,332 @@ async fn test_index_and_status() {
         .success()
         .stdout(predicate::str::contains("main.rs"))
         .stdout(predicate::str::contains("fn main()"));
+}
+
+// ── Capability tier E2E tests ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_status_shows_offline_tier() {
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("main.rs"), "fn main() {}").unwrap();
+
+    let config_path = temp.path().join("config.toml");
+    let db_path = temp.path().join("index.db");
+    fs::write(
+        &config_path,
+        format!(
+            "db_path = {:?}\napi_base_url = \"http://127.0.0.1:1234\"\nembedding_model = \"test\"\nllm_model = \"test\"\n",
+            db_path
+        ),
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Capability tier:"))
+        .stdout(predicate::str::contains("Offline"))
+        .stdout(predicate::str::contains("ast-grep + text"))
+        .stdout(predicate::str::contains("git-notes (local)"))
+        .stdout(predicate::str::contains("set server_url to enable"));
+}
+
+#[tokio::test]
+async fn test_status_shows_server_tier() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "version": "test",
+            "capabilities": ["memory", "index.embed", "search.semantic", "explore", "plan"]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+        .respond_with(IndexEmbedResponder)
+        .mount(&mock_server)
+        .await;
+
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("main.rs"), "fn main() {}").unwrap();
+
+    let db_path = temp.path().join("index.db");
+    let config_path = write_config_with_server(
+        temp.path(),
+        &db_path,
+        &mock_server.uri(),
+        &mock_server.uri(),
+    );
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Capability tier:"))
+        .stdout(predicate::str::contains("Server"))
+        .stdout(predicate::str::contains("semantic"))
+        .stdout(predicate::str::contains("server sync"));
+}
+
+#[tokio::test]
+async fn test_status_json_includes_tier_fields() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "version": "test",
+            "capabilities": ["memory", "index.embed", "search.semantic", "plan"]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+        .respond_with(IndexEmbedResponder)
+        .mount(&mock_server)
+        .await;
+
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(
+        project_dir.join("lib.rs"),
+        "pub fn add(a: i32, b: i32) -> i32 { a + b }",
+    )
+    .unwrap();
+
+    let db_path = temp.path().join("index.db");
+    let config_path = write_config_with_server(
+        temp.path(),
+        &db_path,
+        &mock_server.uri(),
+        &mock_server.uri(),
+    );
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let body: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    assert_eq!(body["tier"], "server");
+    assert!(body["server_url"].is_string());
+    assert!(body["capabilities"].is_object());
+    assert!(body["capabilities"]["search_semantic"].as_bool().unwrap());
+    assert!(body["capabilities"]["index_embed"].as_bool().unwrap());
+    assert!(body["capabilities"]["plan"].as_bool().unwrap());
+    assert!(!body["capabilities"]["explore"].as_bool().unwrap());
+}
+
+#[tokio::test]
+async fn test_check_reports_server_reachable() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "version": "test",
+            "capabilities": ["memory", "search.semantic", "explore"]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+        .respond_with(IndexEmbedResponder)
+        .mount(&mock_server)
+        .await;
+
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("main.rs"), "fn main() {}").unwrap();
+
+    let db_path = temp.path().join("index.db");
+    let config_path = write_config_with_server(
+        temp.path(),
+        &db_path,
+        &mock_server.uri(),
+        &mock_server.uri(),
+    );
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("check")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Server:"))
+        .stdout(predicate::str::contains("semantic search"))
+        .stdout(predicate::str::contains("explore"));
+}
+
+#[tokio::test]
+async fn test_check_reports_server_unreachable() {
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("main.rs"), "fn main() {}").unwrap();
+
+    let db_path = temp.path().join("index.db");
+    let config_path = temp.path().join("config.toml");
+    let bad_url = "http://127.0.0.1:19999";
+    fs::write(
+        &config_path,
+        format!(
+            "db_path = {:?}\napi_base_url = {:?}\nembedding_model = \"test\"\nllm_model = \"test\"\nserver_url = {:?}\nproject_id = {:?}\n",
+            db_path, bad_url, bad_url, FIXTURE_PROJECT_ID
+        ),
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("check")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Server:"))
+        .stdout(predicate::str::contains("unreachable"));
+}
+
+#[tokio::test]
+async fn test_index_prints_note_when_no_server_configured() {
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("main.rs"), "fn main() {}").unwrap();
+
+    let config_path = temp.path().join("config.toml");
+    let db_path = temp.path().join("index.db");
+    fs::write(
+        &config_path,
+        format!(
+            "db_path = {:?}\napi_base_url = \"http://127.0.0.1:1234\"\nembedding_model = \"test\"\nllm_model = \"test\"\n",
+            db_path
+        ),
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("configure server_url"));
+}
+
+#[test]
+fn test_status_json_offline_tier() {
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("lib.rs"), "pub fn answer() -> i32 { 42 }").unwrap();
+
+    let config_path = temp.path().join("config.toml");
+    let db_path = temp.path().join("index.db");
+    fs::write(
+        &config_path,
+        format!(
+            "db_path = {:?}\napi_base_url = \"http://127.0.0.1:1234\"\nembedding_model = \"test\"\nllm_model = \"test\"\n",
+            db_path
+        ),
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let body: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    assert_eq!(body["tier"], "offline");
+    assert!(body["server_url"].is_null());
+    assert!(body["capabilities"].is_null());
 }

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -12,6 +12,9 @@ use tempfile::TempDir;
 /// Path (relative to the workspace root) of the synthetic fixture project.
 pub const FIXTURE_DIR: &str = "tests/fixtures/simple-project";
 
+/// Project ID used by the fixture mock server.
+pub const FIXTURE_PROJECT_ID: &str = "test-org/test-project";
+
 /// Build a `spelunk plumbing --db <db>` Command pre-configured to use the
 /// given DB and config file.  Callers add the specific plumbing subcommand
 /// args (e.g. `cmd.arg("cat-chunks").arg("src/lib.rs")`).
@@ -41,7 +44,73 @@ pub fn write_config(dir: &Path, db_path: &Path, api_base: &str) -> PathBuf {
     config_path
 }
 
-/// Run `spelunk index <fixture_dir>` backed by a mock embedding server.
+/// Like `write_config` but also configures `server_url` + `project_id` for
+/// Tier 1 operation (server-based embedding during `spelunk index`).
+pub fn write_config_with_server(
+    dir: &Path,
+    db_path: &Path,
+    api_base: &str,
+    server_url: &str,
+) -> PathBuf {
+    let cfg = format!(
+        concat!(
+            "db_path = {:?}\n",
+            "api_base_url = {:?}\n",
+            "embedding_model = \"test-model\"\n",
+            "llm_model = \"test-chat\"\n",
+            "server_url = {:?}\n",
+            "project_id = {:?}\n",
+        ),
+        db_path, api_base, server_url, FIXTURE_PROJECT_ID,
+    );
+    let config_path = dir.join("config.toml");
+    std::fs::write(&config_path, cfg).expect("write config");
+    config_path
+}
+
+/// Dynamic responder for `POST /v1/projects/{id}/index/embed`.
+///
+/// Parses the request body `{"chunks":[{"chunk_id":"…","content":"…"}]}` and
+/// returns `{"chunks":[{"chunk_id":"…","vector":[0.1,…,0.1]}]}` for each
+/// chunk so the CLI can store the (fake) vectors in the local DB.
+struct IndexEmbedResponder;
+
+impl wiremock::Respond for IndexEmbedResponder {
+    fn respond(&self, request: &wiremock::Request) -> wiremock::ResponseTemplate {
+        #[derive(serde::Deserialize)]
+        struct ReqBody {
+            chunks: Vec<ReqChunk>,
+        }
+        #[derive(serde::Deserialize)]
+        struct ReqChunk {
+            chunk_id: String,
+        }
+
+        let body: ReqBody =
+            serde_json::from_slice(&request.body).unwrap_or(ReqBody { chunks: vec![] });
+
+        let resp_chunks: Vec<serde_json::Value> = body
+            .chunks
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "chunk_id": c.chunk_id,
+                    "vector": vec![0.1f32; 768],
+                })
+            })
+            .collect();
+
+        wiremock::ResponseTemplate::new(200)
+            .set_body_json(serde_json::json!({ "chunks": resp_chunks }))
+    }
+}
+
+/// Run `spelunk index <fixture_dir>` backed by a mock spelunk-server.
+///
+/// The mock server handles:
+/// - `GET /v1/health` — Tier 1 capability probe
+/// - `POST /v1/embeddings` — legacy endpoint used by `spelunk plumbing embed`
+/// - `POST /v1/projects/{id}/index/embed` — new Tier 1 index embedding
 ///
 /// Returns `(TempDir, db_path, config_path)`.  The `TempDir` must be kept
 /// alive for the duration of the test.
@@ -49,29 +118,48 @@ pub fn index_fixture_project() -> (TempDir, PathBuf, PathBuf) {
     let tmp = TempDir::new().expect("create temp dir");
     let db_path = tmp.path().join("spelunk.db");
 
-    // Spin up a wiremock server that echoes back a 768-dim embedding.
-    // The server must stay alive past the index call, so we keep it in scope.
     let rt = tokio::runtime::Runtime::new().unwrap();
     let _mock_server = rt.block_on(async {
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{method, path, path_regex};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
+
+        // Health probe — returns full Tier 1 capability set.
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "ok",
+                "version": "test",
+                "capabilities": ["memory", "index.embed", "search.semantic", "explore", "plan"],
+            })))
+            .mount(&server)
+            .await;
+
+        // Legacy /v1/embeddings — used by `spelunk plumbing embed --query`.
         Mock::given(method("POST"))
             .and(path("/v1/embeddings"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "data": [{ "embedding": vec![0.1f32; 768], "index": 0 }],
                 "model": "test-model",
                 "object": "list",
-                "usage": { "prompt_tokens": 5, "total_tokens": 5 }
+                "usage": { "prompt_tokens": 5, "total_tokens": 5 },
             })))
             .mount(&server)
             .await;
+
+        // New Tier 1 index/embed — echoes back chunk_ids with constant vectors.
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+            .respond_with(IndexEmbedResponder)
+            .mount(&server)
+            .await;
+
         server
     });
 
     let mock_url = _mock_server.uri();
-    let config_path = write_config(tmp.path(), &db_path, &mock_url);
+    let config_path = write_config_with_server(tmp.path(), &db_path, &mock_url, &mock_url);
 
     // Resolve the fixture directory relative to the workspace root.
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join(FIXTURE_DIR);

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -73,7 +73,7 @@ pub fn write_config_with_server(
 /// Parses the request body `{"chunks":[{"chunk_id":"…","content":"…"}]}` and
 /// returns `{"chunks":[{"chunk_id":"…","vector":[0.1,…,0.1]}]}` for each
 /// chunk so the CLI can store the (fake) vectors in the local DB.
-struct IndexEmbedResponder;
+pub struct IndexEmbedResponder;
 
 impl wiremock::Respond for IndexEmbedResponder {
     fn respond(&self, request: &wiremock::Request) -> wiremock::ResponseTemplate {

--- a/crates/spelunk-core/src/capability.rs
+++ b/crates/spelunk-core/src/capability.rs
@@ -1,0 +1,195 @@
+//! Capability tier detection for the spelunk CLI.
+//!
+//! Tier 0 (Offline): no server_url configured, or server unreachable.
+//! Tier 1 (Server):  server_url set and GET /v1/health succeeds.
+//!
+//! The probe runs lazily on the first call that needs Tier 1 and its result
+//! is cached for the process lifetime.
+
+use serde::Serialize;
+use tokio::sync::OnceCell;
+
+use crate::config::Config;
+
+static TIER: OnceCell<Tier> = OnceCell::const_new();
+
+/// Feature availability for a server-connected tier.
+#[derive(Debug, Clone, Serialize)]
+pub struct Capabilities {
+    pub search_semantic: bool,
+    pub index_embed: bool,
+    pub memory_push: bool,
+    pub memory_pull: bool,
+    pub memory_search: bool,
+    pub memory_harvest: bool,
+    pub explore: bool,
+    pub plan: bool,
+}
+
+impl Capabilities {
+    fn from_server_caps(caps: &[&str]) -> Self {
+        let has = |c: &str| caps.contains(&c);
+        let memory = has("memory");
+        Self {
+            search_semantic: has("search.semantic"),
+            index_embed: has("index.embed"),
+            memory_push: memory,
+            memory_pull: memory,
+            memory_search: memory,
+            memory_harvest: memory,
+            explore: has("explore"),
+            plan: has("plan"),
+        }
+    }
+
+    /// Conservative set assumed when talking to a legacy server that returns
+    /// plain-text health ("ok") instead of JSON.
+    fn legacy_memory_only() -> Self {
+        Self {
+            search_semantic: false,
+            index_embed: false,
+            memory_push: true,
+            memory_pull: true,
+            memory_search: true,
+            memory_harvest: false,
+            explore: false,
+            plan: false,
+        }
+    }
+
+    /// Full set for a fully-featured server.
+    pub fn all() -> Self {
+        Self {
+            search_semantic: true,
+            index_embed: true,
+            memory_push: true,
+            memory_pull: true,
+            memory_search: true,
+            memory_harvest: true,
+            explore: true,
+            plan: true,
+        }
+    }
+}
+
+/// CLI capability tier for this process.
+#[derive(Debug, Clone)]
+pub enum Tier {
+    /// No server configured, or server unreachable. Offline features only.
+    Offline,
+    /// Server reachable. All `caps`-listed features are available.
+    Server { url: String, caps: Capabilities },
+}
+
+impl Tier {
+    pub fn is_server(&self) -> bool {
+        matches!(self, Tier::Server { .. })
+    }
+
+    pub fn server_url(&self) -> Option<&str> {
+        match self {
+            Tier::Server { url, .. } => Some(url),
+            Tier::Offline => None,
+        }
+    }
+
+    pub fn caps(&self) -> Option<&Capabilities> {
+        match self {
+            Tier::Server { caps, .. } => Some(caps),
+            Tier::Offline => None,
+        }
+    }
+}
+
+/// Return the cached capability tier for this process.
+///
+/// On the first call, probes the server (if `server_url` is set) with a 2-second
+/// timeout. Subsequent calls return immediately from the cache.
+pub async fn get_tier(cfg: &Config) -> &'static Tier {
+    let url = cfg.server_url.clone();
+    let key = cfg.server_key.clone();
+    TIER.get_or_init(|| async move { probe(url.as_deref(), key.as_deref()).await })
+        .await
+}
+
+async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
+    let Some(url) = url else {
+        return Tier::Offline;
+    };
+
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("could not build HTTP client for server probe: {e}");
+            return Tier::Offline;
+        }
+    };
+
+    let mut req = client.get(format!("{}/v1/health", url.trim_end_matches('/')));
+    if let Some(k) = key {
+        req = req.bearer_auth(k);
+    }
+
+    match req.send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let caps = parse_capabilities(resp).await;
+            Tier::Server {
+                url: url.to_string(),
+                caps,
+            }
+        }
+        Ok(resp) => {
+            tracing::warn!(
+                "spelunk-server at {url} returned {} — running in offline mode",
+                resp.status()
+            );
+            Tier::Offline
+        }
+        Err(e) => {
+            tracing::warn!("spelunk-server at {url} unreachable — running in offline mode: {e}");
+            Tier::Offline
+        }
+    }
+}
+
+async fn parse_capabilities(resp: reqwest::Response) -> Capabilities {
+    #[derive(serde::Deserialize)]
+    struct HealthBody {
+        #[serde(default)]
+        capabilities: Vec<String>,
+    }
+
+    match resp.json::<HealthBody>().await {
+        Ok(body) => {
+            let cap_strs: Vec<&str> = body.capabilities.iter().map(String::as_str).collect();
+            Capabilities::from_server_caps(&cap_strs)
+        }
+        Err(_) => {
+            // Legacy server returns plain-text "ok" — conservative fallback.
+            Capabilities::legacy_memory_only()
+        }
+    }
+}
+
+/// Return `Ok(())` if the tier is `Server`, otherwise return an `anyhow::Error`
+/// with the standard locked-feature message format.
+///
+/// Callers append `?` to propagate the error:
+/// ```ignore
+/// require_tier1("explore", tier, cfg.server_url.as_deref())?;
+/// ```
+pub fn require_tier1(feature: &str, tier: &Tier, server_url: Option<&str>) -> anyhow::Result<()> {
+    if tier.is_server() {
+        return Ok(());
+    }
+    let tried = server_url
+        .map(|u| format!("\n       (Tried: {u} — connection refused)"))
+        .unwrap_or_default();
+    anyhow::bail!(
+        "'spelunk {feature}' requires spelunk-server.\n\
+         Set server_url in ~/.config/spelunk/config.toml to enable this feature.{tried}"
+    )
+}

--- a/crates/spelunk-core/src/capability.rs
+++ b/crates/spelunk-core/src/capability.rs
@@ -193,3 +193,203 @@ pub fn require_tier1(feature: &str, tier: &Tier, server_url: Option<&str>) -> an
          Set server_url in ~/.config/spelunk/config.toml to enable this feature.{tried}"
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Capabilities::from_server_caps ──────────────────────────────────────
+
+    #[test]
+    fn from_server_caps_empty_returns_all_false() {
+        let caps = Capabilities::from_server_caps(&[]);
+        assert!(!caps.search_semantic);
+        assert!(!caps.index_embed);
+        assert!(!caps.memory_push);
+        assert!(!caps.memory_pull);
+        assert!(!caps.memory_search);
+        assert!(!caps.memory_harvest);
+        assert!(!caps.explore);
+        assert!(!caps.plan);
+    }
+
+    #[test]
+    fn from_server_caps_full_set() {
+        let caps = Capabilities::from_server_caps(&[
+            "search.semantic",
+            "index.embed",
+            "memory",
+            "explore",
+            "plan",
+        ]);
+        assert!(caps.search_semantic);
+        assert!(caps.index_embed);
+        assert!(caps.memory_push);
+        assert!(caps.memory_pull);
+        assert!(caps.memory_search);
+        assert!(caps.memory_harvest);
+        assert!(caps.explore);
+        assert!(caps.plan);
+    }
+
+    #[test]
+    fn from_server_caps_memory_only() {
+        let caps = Capabilities::from_server_caps(&["memory"]);
+        assert!(!caps.search_semantic);
+        assert!(!caps.index_embed);
+        assert!(!caps.explore);
+        assert!(!caps.plan);
+        assert!(caps.memory_push);
+        assert!(caps.memory_pull);
+        assert!(caps.memory_search);
+        assert!(caps.memory_harvest);
+    }
+
+    #[test]
+    fn from_server_caps_partial_set() {
+        let caps = Capabilities::from_server_caps(&["search.semantic", "plan"]);
+        assert!(caps.search_semantic);
+        assert!(!caps.index_embed);
+        assert!(!caps.explore);
+        assert!(caps.plan);
+        assert!(!caps.memory_push);
+        assert!(!caps.memory_pull);
+        assert!(!caps.memory_search);
+        assert!(!caps.memory_harvest);
+    }
+
+    #[test]
+    fn from_server_caps_unknown_capability_is_ignored() {
+        let caps = Capabilities::from_server_caps(&["search.semantic", "unknown.future", "memory"]);
+        assert!(caps.search_semantic);
+        assert!(!caps.index_embed);
+        assert!(caps.memory_push);
+        // Unknown capability should not affect any flag.
+    }
+
+    // ── Capabilities::legacy_memory_only ─────────────────────────────────────
+
+    #[test]
+    fn legacy_memory_only_values() {
+        let caps = Capabilities::legacy_memory_only();
+        assert!(!caps.search_semantic);
+        assert!(!caps.index_embed);
+        assert!(!caps.explore);
+        assert!(!caps.plan);
+        assert!(caps.memory_push);
+        assert!(caps.memory_pull);
+        assert!(caps.memory_search);
+        assert!(!caps.memory_harvest);
+    }
+
+    // ── Capabilities::all ────────────────────────────────────────────────────
+
+    #[test]
+    fn all_values_are_true() {
+        let caps = Capabilities::all();
+        assert!(caps.search_semantic);
+        assert!(caps.index_embed);
+        assert!(caps.memory_push);
+        assert!(caps.memory_pull);
+        assert!(caps.memory_search);
+        assert!(caps.memory_harvest);
+        assert!(caps.explore);
+        assert!(caps.plan);
+    }
+
+    // ── Tier ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn tier_server_is_server_true() {
+        let tier = Tier::Server {
+            url: "http://example.com".to_string(),
+            caps: Capabilities::all(),
+        };
+        assert!(tier.is_server());
+    }
+
+    #[test]
+    fn tier_offline_is_server_false() {
+        let tier = Tier::Offline;
+        assert!(!tier.is_server());
+    }
+
+    #[test]
+    fn tier_server_returns_url() {
+        let tier = Tier::Server {
+            url: "http://spelunk.internal:7777".to_string(),
+            caps: Capabilities::all(),
+        };
+        assert_eq!(tier.server_url(), Some("http://spelunk.internal:7777"));
+    }
+
+    #[test]
+    fn tier_offline_returns_none_url() {
+        let tier = Tier::Offline;
+        assert_eq!(tier.server_url(), None);
+    }
+
+    #[test]
+    fn tier_server_returns_caps() {
+        let caps = Capabilities::all();
+        let tier = Tier::Server {
+            url: "http://example.com".to_string(),
+            caps: caps.clone(),
+        };
+        assert!(tier.caps().is_some());
+    }
+
+    #[test]
+    fn tier_offline_returns_none_caps() {
+        let tier = Tier::Offline;
+        assert!(tier.caps().is_none());
+    }
+
+    // ── require_tier1 ────────────────────────────────────────────────────────
+
+    #[test]
+    fn require_tier1_ok_for_server() {
+        let tier = Tier::Server {
+            url: "http://example.com".to_string(),
+            caps: Capabilities::all(),
+        };
+        assert!(require_tier1("explore", &tier, Some("http://example.com")).is_ok());
+    }
+
+    #[test]
+    fn require_tier1_err_for_offline_no_url() {
+        let tier = Tier::Offline;
+        let err = require_tier1("explore", &tier, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'spelunk explore'"));
+        assert!(msg.contains("requires spelunk-server"));
+        assert!(msg.contains("server_url"));
+    }
+
+    #[test]
+    fn require_tier1_err_for_offline_with_url_includes_tried() {
+        let tier = Tier::Offline;
+        let err = require_tier1("plan", &tier, Some("http://bad:7777")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'spelunk plan'"));
+        assert!(msg.contains("requires spelunk-server"));
+        assert!(msg.contains("http://bad:7777"));
+        assert!(msg.contains("connection refused"));
+    }
+
+    #[test]
+    fn require_tier1_uses_feature_name_in_message() {
+        let tier = Tier::Offline;
+        let err = require_tier1("memory push", &tier, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'spelunk memory push'"));
+    }
+
+    #[test]
+    fn require_tier1_no_tried_line_when_url_not_set() {
+        let tier = Tier::Offline;
+        let err = require_tier1("explore", &tier, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(!msg.contains("Tried:"));
+    }
+}

--- a/crates/spelunk-core/src/capability.rs
+++ b/crates/spelunk-core/src/capability.rs
@@ -105,6 +105,11 @@ impl Tier {
 ///
 /// On the first call, probes the server (if `server_url` is set) with a 2-second
 /// timeout. Subsequent calls return immediately from the cache.
+///
+/// **Per-process cache**: the result is stored in a `static OnceCell` and is fixed
+/// for the lifetime of the process. This is correct for CLI invocations (one process
+/// = one config), but unsuitable for long-running daemons that may use multiple
+/// configs — they would always see the tier determined by the first call.
 pub async fn get_tier(cfg: &Config) -> &'static Tier {
     let url = cfg.server_url.clone();
     let key = cfg.server_key.clone();

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -2,6 +2,9 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+#[cfg(test)]
+use tempfile::TempDir;
+
 /// Returns `~/.config/spelunk/`.
 ///
 /// On all platforms we use `~/.config` rather than the OS-native config dir
@@ -268,5 +271,295 @@ impl Config {
             );
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unset all spelunk-related env vars to prevent cross-test contamination.
+    fn clear_spelunk_env() {
+        unsafe {
+            std::env::remove_var("SPELUNK_SERVER_URL");
+            std::env::remove_var("SPELUNK_MEMORY_SERVER_URL");
+            std::env::remove_var("SPELUNK_SERVER_KEY");
+            std::env::remove_var("SPELUNK_PROJECT_ID");
+        }
+    }
+
+    // ── serde alias: memory_server_url → server_url ─────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn memory_server_url_alias_loads_as_server_url() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+memory_server_url = "http://old.example.com:7777"
+project_id = "my-proj"
+"#,
+        )
+        .unwrap();
+
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(
+            cfg.server_url,
+            Some("http://old.example.com:7777".to_string())
+        );
+        assert_eq!(cfg.project_id, Some("my-proj".to_string()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn memory_server_key_alias_loads_as_server_key() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+memory_server_key = "secret-token"
+project_id = "my-proj"
+"#,
+        )
+        .unwrap();
+
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.server_key, Some("secret-token".to_string()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn loads_without_any_server_config() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "").unwrap();
+
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.server_url, None);
+        assert_eq!(cfg.server_key, None);
+        assert_eq!(cfg.project_id, None);
+    }
+
+    // ── validate() cross-field constraints ───────────────────────────────────
+
+    #[test]
+    fn validate_fails_when_server_url_set_without_project_id() {
+        let mut cfg = Config::default();
+        cfg.server_url = Some("http://example.com".to_string());
+        let result = cfg.validate();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("server_url"));
+        assert!(msg.contains("project_id"));
+    }
+
+    #[test]
+    fn validate_passes_when_both_server_url_and_project_id_set() {
+        let mut cfg = Config::default();
+        cfg.server_url = Some("http://example.com".to_string());
+        cfg.project_id = Some("my-proj".to_string());
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_passes_when_neither_server_url_nor_project_id_set() {
+        let cfg = Config::default();
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_passes_when_only_project_id_set() {
+        let mut cfg = Config::default();
+        cfg.project_id = Some("my-proj".to_string());
+        assert!(cfg.validate().is_ok());
+    }
+
+    // ── env var overrides ────────────────────────────────────────────────────
+    //
+    // Env var tests are #[serial] because they mutate process-global state.
+
+    #[test]
+    #[serial_test::serial]
+    fn env_spelunk_server_url_overrides_config() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"server_url = "http://config.example.com:7777"
+"#,
+        )
+        .unwrap();
+
+        unsafe {
+            std::env::set_var("SPELUNK_SERVER_URL", "http://env.example.com:7777");
+        }
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(
+            cfg.server_url,
+            Some("http://env.example.com:7777".to_string())
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_spelunk_server_key_overrides_config() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"server_key = "config-token"
+"#,
+        )
+        .unwrap();
+
+        unsafe {
+            std::env::set_var("SPELUNK_SERVER_KEY", "env-token");
+        }
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.server_key, Some("env-token".to_string()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_spelunk_project_id_overrides_config() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"project_id = "config-proj"
+"#,
+        )
+        .unwrap();
+
+        unsafe {
+            std::env::set_var("SPELUNK_PROJECT_ID", "env-proj");
+        }
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.project_id, Some("env-proj".to_string()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_memory_server_url_deprecated_fallback() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "").unwrap();
+
+        // Only set the deprecated var; SPELUNK_SERVER_URL must be absent.
+        unsafe {
+            std::env::set_var("SPELUNK_MEMORY_SERVER_URL", "http://old.example.com:7777");
+        }
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(
+            cfg.server_url,
+            Some("http://old.example.com:7777".to_string())
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn env_spelunk_server_url_precedence_over_memory_fallback() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "").unwrap();
+
+        unsafe {
+            std::env::set_var("SPELUNK_SERVER_URL", "http://new.example.com:7777");
+            std::env::set_var("SPELUNK_MEMORY_SERVER_URL", "http://old.example.com:7777");
+        }
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(
+            cfg.server_url,
+            Some("http://new.example.com:7777".to_string())
+        );
+    }
+
+    // ── .spelunk/config.toml project-level merge ─────────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn project_level_config_merges_server_url() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let proj_dir = tmp.path().join("project");
+        let spelunk_dir = proj_dir.join(".spelunk");
+        std::fs::create_dir_all(&spelunk_dir).unwrap();
+        std::fs::write(
+            spelunk_dir.join("config.toml"),
+            r#"server_url = "http://proj.example.com:7777"
+project_id = "team/proj"
+"#,
+        )
+        .unwrap();
+
+        let global_config = tmp.path().join("global.toml");
+        std::fs::write(&global_config, "").unwrap();
+
+        let original_cwd = std::env::current_dir().ok();
+        unsafe {
+            std::env::set_current_dir(&proj_dir).unwrap();
+        }
+
+        let cfg = Config::load(Some(&global_config)).unwrap();
+        assert_eq!(
+            cfg.server_url,
+            Some("http://proj.example.com:7777".to_string())
+        );
+        assert_eq!(cfg.project_id, Some("team/proj".to_string()));
+
+        if let Some(d) = original_cwd {
+            unsafe {
+                std::env::set_current_dir(d).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn project_level_config_accepts_memory_server_url_alias() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let proj_dir = tmp.path().join("project");
+        let spelunk_dir = proj_dir.join(".spelunk");
+        std::fs::create_dir_all(&spelunk_dir).unwrap();
+        std::fs::write(
+            spelunk_dir.join("config.toml"),
+            r#"memory_server_url = "http://old.example.com:7777"
+project_id = "team/old"
+"#,
+        )
+        .unwrap();
+
+        let global_config = tmp.path().join("global.toml");
+        std::fs::write(&global_config, "").unwrap();
+
+        let original_cwd = std::env::current_dir().ok();
+        unsafe {
+            std::env::set_current_dir(&proj_dir).unwrap();
+        }
+
+        let cfg = Config::load(Some(&global_config)).unwrap();
+        assert_eq!(
+            cfg.server_url,
+            Some("http://old.example.com:7777".to_string())
+        );
+        assert_eq!(cfg.project_id, Some("team/old".to_string()));
+
+        if let Some(d) = original_cwd {
+            unsafe {
+                std::env::set_current_dir(d).unwrap();
+            }
+        }
     }
 }

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -49,9 +49,14 @@ fn find_project_config(start: &Path) -> Option<PathBuf> {
 /// Only contains fields safe to share with the team (no secrets).
 #[derive(Debug, Default, Deserialize)]
 struct ProjectConfig {
-    memory_server_url: Option<String>,
+    /// Canonical server URL (preferred).
+    server_url: Option<String>,
     /// Shared API key — acceptable if the server is behind a VPN/firewall.
     /// For secrets, prefer `SPELUNK_SERVER_KEY` env var instead.
+    server_key: Option<String>,
+    /// Deprecated alias for server_url.
+    memory_server_url: Option<String>,
+    /// Deprecated alias for server_key.
     memory_server_key: Option<String>,
     project_id: Option<String>,
 }
@@ -103,21 +108,24 @@ pub struct Config {
     #[serde(default = "Config::default_api_base_url", alias = "lmstudio_base_url")]
     pub api_base_url: String,
 
-    // ── Shared memory server (optional) ──────────────────────────────────────
+    // ── spelunk-server (optional) ─────────────────────────────────────────────
     /// URL of the spelunk-server instance, e.g. `http://spelunk.internal:7777`.
+    /// When set, the CLI operates in Tier 1 (server-connected) mode, enabling
+    /// semantic search, embedding, explore, and plan features.
     /// Set in `.spelunk/config.toml` (project-level) or via `SPELUNK_SERVER_URL`.
-    /// If unset, memory is stored locally in memory.db.
-    #[serde(default)]
-    pub memory_server_url: Option<String>,
+    /// The old `memory_server_url` TOML key is accepted as a backward-compat alias.
+    #[serde(default, alias = "memory_server_url")]
+    pub server_url: Option<String>,
 
     /// Bearer token for spelunk-server auth.
     /// Set in `~/.config/spelunk/config.toml` (personal) or via `SPELUNK_SERVER_KEY`.
     /// Do NOT commit this to `.spelunk/config.toml`.
-    #[serde(default)]
-    pub memory_server_key: Option<String>,
+    /// The old `memory_server_key` TOML key is accepted as a backward-compat alias.
+    #[serde(default, alias = "memory_server_key")]
+    pub server_key: Option<String>,
 
-    /// Project slug for the shared memory server (e.g. `my-awesome-app`).
-    /// Required when `memory_server_url` is set.
+    /// Project slug for the spelunk-server (e.g. `acme/my-app`).
+    /// Required when `server_url` is set.
     /// Set in `.spelunk/config.toml` (project-level) or via `SPELUNK_PROJECT_ID`.
     #[serde(default)]
     pub project_id: Option<String>,
@@ -178,8 +186,8 @@ impl Default for Config {
             llm_model: None,
             batch_size: Self::default_batch_size(),
             api_base_url: Self::default_api_base_url(),
-            memory_server_url: None,
-            memory_server_key: None,
+            server_url: None,
+            server_key: None,
             project_id: None,
             plans_dir: Self::default_plans_dir(),
             specs_dir: Self::default_specs_dir(),
@@ -218,11 +226,13 @@ impl Config {
                 .with_context(|| format!("reading project config at {}", proj_path.display()))?;
             let proj: ProjectConfig =
                 toml::from_str(&raw).context("parsing .spelunk/config.toml")?;
-            if let Some(v) = proj.memory_server_url {
-                cfg.memory_server_url = Some(v);
+
+            // Prefer new name; fall back to deprecated alias.
+            if let Some(v) = proj.server_url.or(proj.memory_server_url) {
+                cfg.server_url = Some(v);
             }
-            if let Some(v) = proj.memory_server_key {
-                cfg.memory_server_key = Some(v);
+            if let Some(v) = proj.server_key.or(proj.memory_server_key) {
+                cfg.server_key = Some(v);
             }
             if let Some(v) = proj.project_id {
                 cfg.project_id = Some(v);
@@ -231,10 +241,15 @@ impl Config {
 
         // ── 3. Environment variable overrides ────────────────────────────────
         if let Ok(v) = std::env::var("SPELUNK_SERVER_URL") {
-            cfg.memory_server_url = Some(v);
+            cfg.server_url = Some(v);
+        } else if let Ok(v) = std::env::var("SPELUNK_MEMORY_SERVER_URL") {
+            tracing::warn!(
+                "SPELUNK_MEMORY_SERVER_URL is deprecated; use SPELUNK_SERVER_URL instead"
+            );
+            cfg.server_url = Some(v);
         }
         if let Ok(v) = std::env::var("SPELUNK_SERVER_KEY") {
-            cfg.memory_server_key = Some(v);
+            cfg.server_key = Some(v);
         }
         if let Ok(v) = std::env::var("SPELUNK_PROJECT_ID") {
             cfg.project_id = Some(v);
@@ -245,9 +260,9 @@ impl Config {
 
     /// Validate cross-field constraints. Call after `load()`.
     pub fn validate(&self) -> Result<()> {
-        if self.memory_server_url.is_some() && self.project_id.is_none() {
+        if self.server_url.is_some() && self.project_id.is_none() {
             anyhow::bail!(
-                "memory_server_url is set but project_id is missing.\n\
+                "server_url is set but project_id is missing.\n\
                  Add `project_id = \"my-project\"` to .spelunk/config.toml \
                  or set SPELUNK_PROJECT_ID."
             );

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -350,8 +350,10 @@ project_id = "my-proj"
 
     #[test]
     fn validate_fails_when_server_url_set_without_project_id() {
-        let mut cfg = Config::default();
-        cfg.server_url = Some("http://example.com".to_string());
+        let cfg = Config {
+            server_url: Some("http://example.com".to_string()),
+            ..Default::default()
+        };
         let result = cfg.validate();
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -361,9 +363,11 @@ project_id = "my-proj"
 
     #[test]
     fn validate_passes_when_both_server_url_and_project_id_set() {
-        let mut cfg = Config::default();
-        cfg.server_url = Some("http://example.com".to_string());
-        cfg.project_id = Some("my-proj".to_string());
+        let cfg = Config {
+            server_url: Some("http://example.com".to_string()),
+            project_id: Some("my-proj".to_string()),
+            ..Default::default()
+        };
         assert!(cfg.validate().is_ok());
     }
 
@@ -375,8 +379,10 @@ project_id = "my-proj"
 
     #[test]
     fn validate_passes_when_only_project_id_set() {
-        let mut cfg = Config::default();
-        cfg.project_id = Some("my-proj".to_string());
+        let cfg = Config {
+            project_id: Some("my-proj".to_string()),
+            ..Default::default()
+        };
         assert!(cfg.validate().is_ok());
     }
 
@@ -507,9 +513,7 @@ project_id = "team/proj"
         std::fs::write(&global_config, "").unwrap();
 
         let original_cwd = std::env::current_dir().ok();
-        unsafe {
-            std::env::set_current_dir(&proj_dir).unwrap();
-        }
+        std::env::set_current_dir(&proj_dir).unwrap();
 
         let cfg = Config::load(Some(&global_config)).unwrap();
         assert_eq!(
@@ -519,9 +523,7 @@ project_id = "team/proj"
         assert_eq!(cfg.project_id, Some("team/proj".to_string()));
 
         if let Some(d) = original_cwd {
-            unsafe {
-                std::env::set_current_dir(d).unwrap();
-            }
+            std::env::set_current_dir(d).unwrap();
         }
     }
 
@@ -545,9 +547,7 @@ project_id = "team/old"
         std::fs::write(&global_config, "").unwrap();
 
         let original_cwd = std::env::current_dir().ok();
-        unsafe {
-            std::env::set_current_dir(&proj_dir).unwrap();
-        }
+        std::env::set_current_dir(&proj_dir).unwrap();
 
         let cfg = Config::load(Some(&global_config)).unwrap();
         assert_eq!(
@@ -557,9 +557,7 @@ project_id = "team/old"
         assert_eq!(cfg.project_id, Some("team/old".to_string()));
 
         if let Some(d) = original_cwd {
-            unsafe {
-                std::env::set_current_dir(d).unwrap();
-            }
+            std::env::set_current_dir(d).unwrap();
         }
     }
 }

--- a/crates/spelunk-core/src/lib.rs
+++ b/crates/spelunk-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backends;
+pub mod capability;
 pub mod config;
 pub mod embeddings;
 pub mod error;

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 /// Priority:
 /// 1. `backend_override = Some("git-meta")` → `GitMetaBackend`
 /// 2. `backend_override = Some("git-notes")` → `GitNotesBackend`
-/// 3. `memory_server_url` set in config → `RemoteMemoryBackend`
+/// 3. `server_url` set in config → `RemoteMemoryBackend`
 /// 4. Otherwise → local SQLite at `mem_path`
 pub fn open_memory_backend(
     cfg: &crate::config::Config,
@@ -48,9 +48,9 @@ pub fn open_memory_backend(
     if backend_override == Some("git-notes") {
         return Ok(Box::new(GitNotesBackend::new()));
     }
-    if let Some(url) = &cfg.memory_server_url {
+    if let Some(url) = &cfg.server_url {
         let project_id = cfg.project_id.clone().expect(
-            "project_id must be set when memory_server_url is configured; \
+            "project_id must be set when server_url is configured; \
              call Config::validate() before open_memory_backend()",
         );
         let client = reqwest::Client::builder()
@@ -60,7 +60,7 @@ pub fn open_memory_backend(
             client,
             base_url: url.clone(),
             project_id,
-            api_key: cfg.memory_server_key.clone(),
+            api_key: cfg.server_key.clone(),
         }))
     } else {
         Ok(Box::new(LocalMemoryBackend::new(MemoryStore::open(


### PR DESCRIPTION
## Summary

- Introduces a two-tier capability model: **Tier 0 (Offline)** for parse/search with no server, **Tier 1 (Server)** when spelunk-server is reachable via `GET /v1/health` (2s timeout, cached per-process via `tokio::sync::OnceCell`)
- `spelunk index` Phase 2 embedding now POSTs to `POST /v1/projects/{id}/index/embed`; skips gracefully in Tier 0
- `spelunk status` prints a capability tier block before index stats; JSON output includes `tier`/`server_url`/`capabilities`
- `spelunk check` reports server reachability alongside index freshness
- Config gains `server_url`/`server_key` with serde aliases for backward compat with existing `memory_server_url`/`memory_server_key` TOML configs

## Files changed

- **new**: `crates/spelunk-core/src/capability.rs` — `Tier`, `Capabilities`, `get_tier()`, `require_tier1()`
- `crates/spelunk-core/src/config.rs` — `server_url`/`server_key` fields; `project_id` field
- `crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs` — rewritten for server-based batched embedding
- `crates/spelunk-cli/src/cli/cmd/status.rs` — tier section + JSON tier fields
- `crates/spelunk-cli/src/cli/cmd/check.rs` — server reachability report
- `crates/spelunk-cli/src/cli/cmd/memory/push|watch|since.rs` — `server_url`/`server_key`
- `crates/spelunk-cli/tests/plumbing_helpers.rs` — Tier 1 mock (health + index/embed) so KNN plumbing tests get embeddings

## Test plan

- [ ] `cargo test --all` passes
- [ ] `spelunk status` shows `Capability tier: Offline` when no `server_url` set
- [ ] `spelunk status` shows `Capability tier: Server` with feature list when server is reachable
- [ ] `spelunk index` skips embed phase with a note when no `server_url`; embeds via server when Tier 1
- [ ] Existing TOML configs using `memory_server_url` still load correctly (serde alias)
- [ ] `spelunk check` reports server reachability

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)