### PR TITLE
fix(worktree): replace .spelunk symlink with runtime root resolution (#266)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -50,15 +50,15 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     // Compile secret-scanning regexes once before the hot loop.
     crate::indexer::secrets::init();
 
-    // If running inside a git worktree, symlink .spelunk to the main worktree's
-    // .spelunk so all worktrees share one index (SQLite WAL handles concurrent access).
-    worktree::ensure_spelunk_symlink(&args.path);
+    // If running inside a git linked worktree, resolve to the main worktree root
+    // so all worktrees share one index without creating any symlink.
+    let project_root = worktree::resolve_main_worktree_root(&args.path);
 
-    // Default DB lives inside the indexed directory, scoping the index to the project.
+    // Default DB lives inside the project root, scoping the index to the project.
     let db_path = args
         .db
         .clone()
-        .unwrap_or_else(|| args.path.join(".spelunk").join("index.db"));
+        .unwrap_or_else(|| project_root.join(".spelunk").join("index.db"));
     let db = match Database::open(&db_path) {
         Ok(db) => db,
         Err(e) => {

--- a/crates/spelunk-cli/src/cli/cmd/index/worktree.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/worktree.rs
@@ -1,65 +1,9 @@
-/// If `root` is a git worktree (`.git` is a file, not a directory), ensure that
-/// `.spelunk` is a symlink pointing at the main worktree's `.spelunk` folder so
-/// all worktrees share one index.  SQLite WAL mode handles concurrent access from
-/// multiple processes safely.
+/// If `root` is a git linked worktree, returns the main worktree root.
+/// Otherwise returns `root` itself.
 ///
-/// No-ops if the symlink (or a real `.spelunk` dir) already exists, or if the main
-/// worktree hasn't been indexed yet (its `.spelunk` folder doesn't exist).
-pub(super) fn ensure_spelunk_symlink(root: &std::path::Path) {
-    let spelunk = root.join(".spelunk");
-    // Already present (real dir or existing symlink) — nothing to do.
-    if spelunk.exists() || spelunk.is_symlink() {
-        return;
-    }
-
-    // A git worktree has a `.git` *file* (not a directory) containing a pointer
-    // to the worktrees entry inside the main repo's .git directory.
-    let git = root.join(".git");
-    if !git.is_file() {
-        return;
-    }
-
-    let Ok(content) = std::fs::read_to_string(&git) else {
-        return;
-    };
-    // Content is: "gitdir: /abs/path/to/main/.git/worktrees/<name>\n"
-    let Some(gitdir_str) = content.strip_prefix("gitdir:") else {
-        return;
-    };
-    let gitdir = std::path::PathBuf::from(gitdir_str.trim());
-
-    // Validate expected structure: <main>/.git/worktrees/<name>
-    // parent()  → worktrees/
-    // parent()  → .git/
-    // parent()  → main worktree root
-    let Some(worktrees_dir) = gitdir.parent() else {
-        return;
-    };
-    if worktrees_dir.file_name() != Some(std::ffi::OsStr::new("worktrees")) {
-        return; // unexpected gitdir layout — don't guess
-    }
-    let Some(main_root) = worktrees_dir.parent().and_then(|p| p.parent()) else {
-        return;
-    };
-
-    // Guard: never create a symlink that points to itself.
-    if main_root == root {
-        return;
-    }
-
-    let main_spelunk = main_root.join(".spelunk");
-    if !main_spelunk.exists() {
-        return; // main worktree not yet indexed — skip
-    }
-
-    #[cfg(unix)]
-    {
-        match std::os::unix::fs::symlink(&main_spelunk, &spelunk) {
-            Ok(()) => eprintln!(
-                "Created .spelunk symlink → {} (shared worktree index)",
-                main_spelunk.display()
-            ),
-            Err(e) => tracing::warn!("could not create .spelunk symlink in worktree: {e}"),
-        }
-    }
+/// No file is created or modified. Callers should use the returned path when
+/// constructing the default `.spelunk/index.db` path so that all worktrees
+/// share one index without needing a symlink.
+pub(super) fn resolve_main_worktree_root(root: &std::path::Path) -> std::path::PathBuf {
+    spelunk_core::utils::resolve_main_worktree_root(root)
 }

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -17,8 +17,12 @@ fn spelunk_config_dir() -> PathBuf {
 
 /// Walk up from `start` looking for `.spelunk/index.db`.
 /// Returns the first match found, or `None` if the filesystem root is reached.
+///
+/// If `start` is inside a git linked worktree, the walk begins from the main
+/// worktree root so that linked worktrees share the same index without a symlink.
 pub fn find_project_db(start: &Path) -> Option<PathBuf> {
-    let mut dir = start.to_path_buf();
+    let resolved = crate::utils::resolve_main_worktree_root(start);
+    let mut dir = resolved;
     loop {
         let candidate = dir.join(".spelunk").join("index.db");
         if candidate.exists() {

--- a/crates/spelunk-core/src/registry.rs
+++ b/crates/spelunk-core/src/registry.rs
@@ -103,9 +103,16 @@ impl Registry {
     /// Find the closest ancestor of `start` that is a registered project root.
     /// If none found in the registry, falls back to filesystem walk looking for
     /// `.spelunk/index.db` and auto-registers what it finds.
+    ///
+    /// If `start` is inside a git linked worktree, the walk begins from the
+    /// main worktree root so commands run inside a worktree find the shared DB.
     pub fn find_project_for_path(&self, start: &Path) -> Result<Option<Project>> {
+        // If start is inside a git linked worktree, resolve to the main
+        // worktree root so the shared index is found without a symlink.
+        let search_root = crate::utils::resolve_main_worktree_root(start);
+
         // 1. Registry walk-up (most specific first)
-        let mut dir = start.to_path_buf();
+        let mut dir = search_root.clone();
         loop {
             let dir_str = dir.to_string_lossy().to_string();
             let maybe: Option<(i64, String, String, i64)> = self
@@ -133,7 +140,7 @@ impl Registry {
         }
 
         // 2. Filesystem fallback — look for .spelunk/index.db and auto-register.
-        let mut dir = start.to_path_buf();
+        let mut dir = search_root;
         loop {
             let candidate = dir.join(".spelunk").join("index.db");
             if candidate.exists() {

--- a/crates/spelunk-core/src/storage/db.rs
+++ b/crates/spelunk-core/src/storage/db.rs
@@ -15,16 +15,6 @@ impl Database {
     /// load the sqlite-vec extension into every new connection.
     pub fn open(path: &Path) -> Result<Self> {
         if let Some(parent) = path.parent() {
-            // If the .spelunk path exists as a broken or self-referential symlink,
-            // create_dir_all will fail with EEXIST. Detect and explain that case.
-            if parent.is_symlink() && !parent.exists() {
-                anyhow::bail!(
-                    "creating db directory {}: path exists as a broken symlink. \
-                     Remove it with `rm {}` and re-run.",
-                    parent.display(),
-                    parent.display(),
-                );
-            }
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating db directory {}", parent.display()))?;
         }

--- a/crates/spelunk-core/src/utils/mod.rs
+++ b/crates/spelunk-core/src/utils/mod.rs
@@ -1,5 +1,60 @@
 pub mod dates;
 
+/// If `root` (or any ancestor) is a git linked worktree, returns the main
+/// worktree root. Otherwise returns `root` itself.
+///
+/// Tries gix first (no subprocess), then falls back to reading the `.git` file
+/// at `root` directly. The fallback covers the case where `root` is exactly the
+/// worktree root even when gix cannot fully open the repository.
+pub fn resolve_main_worktree_root(root: &std::path::Path) -> std::path::PathBuf {
+    // ── gix path ─────────────────────────────────────────────────────────────
+    // gix::discover walks up from root, so it works whether root is the
+    // worktree root itself or a subdirectory inside it.
+    if let Ok(repo) = gix::discover(root) {
+        let git_dir = repo.git_dir();
+        // A linked worktree has git_dir at: <main>/.git/worktrees/<name>
+        // Parent of git_dir is the "worktrees" directory.
+        if let Some(parent) = git_dir.parent()
+            && parent.file_name() == Some(std::ffi::OsStr::new("worktrees"))
+        {
+            // parent.parent() == <main>/.git ; its parent == <main>
+            if let Some(main_root) = parent.parent().and_then(|p| p.parent())
+                && main_root != root
+            {
+                return main_root.to_path_buf();
+            }
+        }
+        return root.to_path_buf();
+    }
+
+    // ── fallback: parse .git file at root directly ────────────────────────
+    let git = root.join(".git");
+    if !git.is_file() {
+        return root.to_path_buf();
+    }
+    let Ok(content) = std::fs::read_to_string(&git) else {
+        return root.to_path_buf();
+    };
+    // Format: "gitdir: /abs/path/to/main/.git/worktrees/<name>\n"
+    let Some(gitdir_str) = content.strip_prefix("gitdir:") else {
+        return root.to_path_buf();
+    };
+    let gitdir = std::path::PathBuf::from(gitdir_str.trim());
+    let Some(worktrees_dir) = gitdir.parent() else {
+        return root.to_path_buf();
+    };
+    if worktrees_dir.file_name() != Some(std::ffi::OsStr::new("worktrees")) {
+        return root.to_path_buf();
+    }
+    let Some(main_root) = worktrees_dir.parent().and_then(|p| p.parent()) else {
+        return root.to_path_buf();
+    };
+    if main_root == root {
+        return root.to_path_buf();
+    }
+    main_root.to_path_buf()
+}
+
 /// Returns true when the process is running in agent mode (`AGENT=true`).
 ///
 /// In agent mode all output defaults to structured JSON and progress spinners
@@ -108,6 +163,51 @@ pub fn worktree_modified_files() -> std::collections::HashSet<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── resolve_main_worktree_root ────────────────────────────────────────────
+
+    #[test]
+    fn resolve_main_worktree_root_linked_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let main_root = tmp.path().join("main");
+        let wt_root = tmp.path().join("feat-branch");
+        std::fs::create_dir_all(&main_root).unwrap();
+        std::fs::create_dir_all(&wt_root).unwrap();
+
+        // Simulate: main_root/.git/worktrees/feat-branch (the gitdir entry)
+        let gitdir_entry = main_root.join(".git").join("worktrees").join("feat-branch");
+        std::fs::create_dir_all(&gitdir_entry).unwrap();
+
+        // wt_root/.git is a file pointing to the worktrees entry
+        std::fs::write(
+            wt_root.join(".git"),
+            format!("gitdir: {}\n", gitdir_entry.display()),
+        )
+        .unwrap();
+
+        let resolved = resolve_main_worktree_root(&wt_root);
+        assert_eq!(resolved, main_root);
+    }
+
+    #[test]
+    fn resolve_main_worktree_root_normal_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().join("myrepo");
+        // Normal repo: .git is a directory, not a file
+        std::fs::create_dir_all(repo_root.join(".git")).unwrap();
+
+        let resolved = resolve_main_worktree_root(&repo_root);
+        assert_eq!(resolved, repo_root);
+    }
+
+    #[test]
+    fn resolve_main_worktree_root_no_git() {
+        let tmp = tempfile::tempdir().unwrap();
+        let resolved = resolve_main_worktree_root(tmp.path());
+        assert_eq!(resolved, tmp.path());
+    }
+
+    // ── strip_ansi ────────────────────────────────────────────────────────────
 
     #[test]
     fn strips_csi_colour() {


### PR DESCRIPTION
## Summary

- Replaces the side-effecting `ensure_spelunk_symlink()` with a pure `resolve_main_worktree_root()` in `spelunk-core::utils` — no file is ever written to a linked worktree directory
- Updates `spelunk index`, `find_project_db()` (config), and `find_project_for_path()` (registry) to call the resolver, so all commands find the shared DB without a symlink
- Removes the broken-symlink guard from `Database::open()` since the symlink approach is gone

Fixes #266.

## Test plan

- [x] 3 new unit tests: linked worktree (fallback path via fake `.git` file), normal repo, no-git
- [x] All existing `spelunk-core` tests pass (33/33)
- [x] All existing `spelunk-cli` tests pass except `test_status_empty_project` which was already failing on `main` before this PR (pre-existing)
- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean
- [x] `cargo audit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)