### PR TITLE
fix(harvest): swallow per-entry errors instead of fast-failing the run

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -254,13 +254,30 @@ async fn memory_harvest_git(
             }
             buf
         };
-        let (_, raw_json) =
-            tokio::try_join!(generate, async { Ok::<_, anyhow::Error>(collect.await) })?;
-        let raw_json = crate::utils::strip_ansi(&raw_json);
+        let llm_result =
+            tokio::try_join!(generate, async { Ok::<_, anyhow::Error>(collect.await) });
+        let raw_json = match llm_result {
+            Ok((_, raw)) => crate::utils::strip_ansi(&raw),
+            Err(e) => {
+                eprintln!(
+                    "  warning: LLM call failed for batch {batch_num} ({} commit(s)), skipping: {e:#}",
+                    batch.len()
+                );
+                continue;
+            }
+        };
 
-        let parsed: serde_json::Value = serde_json::from_str(&raw_json).with_context(|| {
-            format!("parsing LLM harvest response (batch {batch_num}):\n{raw_json}")
-        })?;
+        let parsed: serde_json::Value = match serde_json::from_str(&raw_json) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!(
+                    "  warning: could not parse LLM response for batch {batch_num} ({} commit(s)), skipping: {e}\n  Raw: {}",
+                    batch.len(),
+                    &raw_json[..raw_json.len().min(200)]
+                );
+                continue;
+            }
+        };
 
         let entries = parsed["entries"].as_array().cloned().unwrap_or_default();
 
@@ -290,23 +307,40 @@ async fn memory_harvest_git(
                 .map(|(s, _, _)| s.clone())
                 .unwrap_or(sha_short.clone());
 
-            if backend
-                .has_source_ref(&full_sha)
-                .await
-                .map_err(backend_err)?
-            {
-                println!("  [skip] already harvested {full_sha}");
-                continue;
+            match backend.has_source_ref(&full_sha).await.map_err(backend_err) {
+                Ok(true) => {
+                    println!("  [skip] already harvested {full_sha}");
+                    continue;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    eprintln!("  warning: could not check source_ref for {full_sha}: {e:#}");
+                    continue;
+                }
             }
 
             let embed_text = format!("title: {title} | text: {body}");
-            let vecs = embedder.embed(&[&embed_text]).await?;
+            let vecs = match embedder.embed(&[&embed_text]).await {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!(
+                        "  warning: embedding failed for entry '{title}' ({full_sha}), skipping: {e:#}"
+                    );
+                    continue;
+                }
+            };
             let Some(vec) = vecs.into_iter().next() else {
                 continue;
             };
             let blob = vec_to_blob(&vec);
 
-            let neighbors = backend.search(&blob, 1, None).await?;
+            let neighbors = match backend.search(&blob, 1, None).await {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!("  warning: dedup search failed for '{title}', skipping: {e:#}");
+                    continue;
+                }
+            };
             if let Some(top) = neighbors.first()
                 && top.distance.unwrap_or(1.0) < DEDUP_THRESHOLD
             {
@@ -321,7 +355,7 @@ async fn memory_harvest_git(
                 continue;
             }
 
-            let note_id = backend
+            let note_id = match backend
                 .add(NoteInput {
                     kind: kind.to_string(),
                     title: title.clone(),
@@ -333,7 +367,16 @@ async fn memory_harvest_git(
                     valid_at: None,
                     supersedes: None,
                 })
-                .await?;
+                .await
+            {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!(
+                        "  warning: failed to store entry '{title}' ({full_sha}), skipping: {e:#}"
+                    );
+                    continue;
+                }
+            };
 
             let short_sha = &full_sha[..full_sha.len().min(8)];
             println!("  + [{kind}] #{note_id}: {title}  \x1b[2m({short_sha})\x1b[0m");
@@ -597,13 +640,30 @@ async fn memory_harvest_failures(
             }
             buf
         };
-        let (_, raw_json) =
-            tokio::try_join!(generate, async { Ok::<_, anyhow::Error>(collect.await) })?;
-        let raw_json = crate::utils::strip_ansi(&raw_json);
+        let llm_result =
+            tokio::try_join!(generate, async { Ok::<_, anyhow::Error>(collect.await) });
+        let raw_json = match llm_result {
+            Ok((_, raw)) => crate::utils::strip_ansi(&raw),
+            Err(e) => {
+                eprintln!(
+                    "  warning: LLM call failed for batch {batch_num} ({} commit(s)), skipping: {e:#}",
+                    batch.len()
+                );
+                continue;
+            }
+        };
 
-        let parsed: serde_json::Value = serde_json::from_str(&raw_json).with_context(|| {
-            format!("parsing LLM failures response (batch {batch_num}):\n{raw_json}")
-        })?;
+        let parsed: serde_json::Value = match serde_json::from_str(&raw_json) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!(
+                    "  warning: could not parse LLM response for batch {batch_num} ({} commit(s)), skipping: {e}\n  Raw: {}",
+                    batch.len(),
+                    &raw_json[..raw_json.len().min(200)]
+                );
+                continue;
+            }
+        };
 
         let entries = parsed["entries"].as_array().cloned().unwrap_or_default();
         if entries.is_empty() {
@@ -631,23 +691,40 @@ async fn memory_harvest_failures(
                 .map(|(s, _, _)| s.clone())
                 .unwrap_or(sha_short.clone());
 
-            if backend
-                .has_source_ref(&full_sha)
-                .await
-                .map_err(backend_err)?
-            {
-                println!("  [skip] already harvested {full_sha}");
-                continue;
+            match backend.has_source_ref(&full_sha).await.map_err(backend_err) {
+                Ok(true) => {
+                    println!("  [skip] already harvested {full_sha}");
+                    continue;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    eprintln!("  warning: could not check source_ref for {full_sha}: {e:#}");
+                    continue;
+                }
             }
 
             let embed_text = format!("title: {title} | text: {body}");
-            let vecs = embedder.embed(&[&embed_text]).await?;
+            let vecs = match embedder.embed(&[&embed_text]).await {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!(
+                        "  warning: embedding failed for entry '{title}' ({full_sha}), skipping: {e:#}"
+                    );
+                    continue;
+                }
+            };
             let Some(vec) = vecs.into_iter().next() else {
                 continue;
             };
             let blob = vec_to_blob(&vec);
 
-            let neighbors = backend.search(&blob, 1, None).await?;
+            let neighbors = match backend.search(&blob, 1, None).await {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!("  warning: dedup search failed for '{title}', skipping: {e:#}");
+                    continue;
+                }
+            };
             if let Some(top) = neighbors.first()
                 && top.distance.unwrap_or(1.0) < DEDUP_THRESHOLD
             {
@@ -662,7 +739,7 @@ async fn memory_harvest_failures(
                 continue;
             }
 
-            let note_id = backend
+            let note_id = match backend
                 .add(NoteInput {
                     kind: "antipattern".to_string(),
                     title: title.clone(),
@@ -674,7 +751,16 @@ async fn memory_harvest_failures(
                     valid_at: None,
                     supersedes: None,
                 })
-                .await?;
+                .await
+            {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!(
+                        "  warning: failed to store entry '{title}' ({full_sha}), skipping: {e:#}"
+                    );
+                    continue;
+                }
+            };
 
             let short_sha = &full_sha[..full_sha.len().min(8)];
             println!("  + [antipattern] #{note_id}: {title}  \x1b[2m({short_sha})\x1b[0m");
@@ -682,10 +768,7 @@ async fn memory_harvest_failures(
         }
     }
 
-    println!(
-        "\nStored {stored} antipattern(s). Skipped {} near-duplicate.",
-        dedup_skipped
-    );
+    println!("\nStored {stored} antipattern(s). Skipped {dedup_skipped} near-duplicate.");
     Ok(())
 }
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
@@ -325,13 +325,30 @@ pub(super) async fn harvest_claude_code(
             }
             buf
         };
-        let (_, raw_json) =
-            tokio::try_join!(generate, async { Ok::<_, anyhow::Error>(collect.await) })?;
-        let raw_json = crate::utils::strip_ansi(&raw_json);
+        let llm_result =
+            tokio::try_join!(generate, async { Ok::<_, anyhow::Error>(collect.await) });
+        let raw_json = match llm_result {
+            Ok((_, raw)) => crate::utils::strip_ansi(&raw),
+            Err(e) => {
+                eprintln!(
+                    "  warning: LLM call failed for batch {batch_num} ({} session(s)), skipping: {e:#}",
+                    batch.len()
+                );
+                continue;
+            }
+        };
 
-        let parsed: serde_json::Value = serde_json::from_str(&raw_json).with_context(|| {
-            format!("parsing LLM harvest response (batch {batch_num}):\n{raw_json}")
-        })?;
+        let parsed: serde_json::Value = match serde_json::from_str(&raw_json) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!(
+                    "  warning: could not parse LLM response for batch {batch_num} ({} session(s)), skipping: {e}\n  Raw: {}",
+                    batch.len(),
+                    &raw_json[..raw_json.len().min(200)]
+                );
+                continue;
+            }
+        };
 
         let entries = parsed["entries"].as_array().cloned().unwrap_or_default();
 
@@ -364,23 +381,44 @@ pub(super) async fn harvest_claude_code(
 
             let source_ref = format!("claude-code:{session_id}");
 
-            if backend
+            match backend
                 .has_source_ref(&source_ref)
                 .await
-                .map_err(backend_err)?
+                .map_err(backend_err)
             {
-                println!("  [skip] already harvested session {session_id}");
-                continue;
+                Ok(true) => {
+                    println!("  [skip] already harvested session {session_id}");
+                    continue;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    eprintln!("  warning: could not check source_ref for {source_ref}: {e:#}");
+                    continue;
+                }
             }
 
             let embed_text = format!("title: {title} | text: {body}");
-            let vecs = embedder.embed(&[&embed_text]).await?;
+            let vecs = match embedder.embed(&[&embed_text]).await {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!(
+                        "  warning: embedding failed for entry '{title}' (session {session_id}), skipping: {e:#}"
+                    );
+                    continue;
+                }
+            };
             let Some(vec) = vecs.into_iter().next() else {
                 continue;
             };
             let blob = vec_to_blob(&vec);
 
-            let neighbors = backend.search(&blob, 1, None).await?;
+            let neighbors = match backend.search(&blob, 1, None).await {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!("  warning: dedup search failed for '{title}', skipping: {e:#}");
+                    continue;
+                }
+            };
             if let Some(top) = neighbors.first()
                 && top.distance.unwrap_or(1.0) < DEDUP_THRESHOLD
             {
@@ -395,7 +433,7 @@ pub(super) async fn harvest_claude_code(
                 continue;
             }
 
-            let note_id = backend
+            let note_id = match backend
                 .add(NoteInput {
                     kind: kind.to_string(),
                     title: title.clone(),
@@ -407,7 +445,16 @@ pub(super) async fn harvest_claude_code(
                     valid_at: None,
                     supersedes: None,
                 })
-                .await?;
+                .await
+            {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!(
+                        "  warning: failed to store entry '{title}' (session {session_id}), skipping: {e:#}"
+                    );
+                    continue;
+                }
+            };
 
             let short_id = &session_id[..session_id.len().min(8)];
             println!("  + [{kind}] #{note_id}: {title}  \x1b[2m({short_id}…)\x1b[0m");

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest_entire.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest_entire.rs
@@ -329,13 +329,27 @@ pub(super) async fn harvest_entire(
 
         for (kind, title, body, tags) in entries {
             let embed_text = format!("title: {title} | text: {body}");
-            let vecs = embedder.embed(&[&embed_text]).await?;
+            let vecs = match embedder.embed(&[&embed_text]).await {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!(
+                        "  warning: embedding failed for entry '{title}' ({short_id}), skipping: {e:#}"
+                    );
+                    continue;
+                }
+            };
             let Some(vec) = vecs.into_iter().next() else {
                 continue;
             };
             let blob = vec_to_blob(&vec);
 
-            let neighbors = backend.search(&blob, 1, None).await?;
+            let neighbors = match backend.search(&blob, 1, None).await {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!("  warning: dedup search failed for '{title}', skipping: {e:#}");
+                    continue;
+                }
+            };
             if let Some(top) = neighbors.first()
                 && top.distance.unwrap_or(1.0) < DEDUP_THRESHOLD
             {
@@ -350,7 +364,7 @@ pub(super) async fn harvest_entire(
                 continue;
             }
 
-            let note_id = backend
+            let note_id = match backend
                 .add(NoteInput {
                     kind: kind.clone(),
                     title: title.clone(),
@@ -362,7 +376,16 @@ pub(super) async fn harvest_entire(
                     valid_at: None,
                     supersedes: None,
                 })
-                .await?;
+                .await
+            {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!(
+                        "  warning: failed to store entry '{title}' ({short_id}), skipping: {e:#}"
+                    );
+                    continue;
+                }
+            };
 
             println!("  + [{kind}] #{note_id}: {title}  \x1b[2m({short_id})\x1b[0m");
             stored += 1;
@@ -543,13 +566,30 @@ pub(super) async fn harvest_entire(
                 }
                 buf
             };
-            let (_, raw_json) =
-                tokio::try_join!(generate, async { Ok::<_, anyhow::Error>(collect.await) })?;
-            let raw_json = crate::utils::strip_ansi(&raw_json);
+            let llm_result =
+                tokio::try_join!(generate, async { Ok::<_, anyhow::Error>(collect.await) });
+            let raw_json = match llm_result {
+                Ok((_, raw)) => crate::utils::strip_ansi(&raw),
+                Err(e) => {
+                    eprintln!(
+                        "  warning: LLM call failed for batch {batch_num} ({} checkpoint(s)), skipping: {e:#}",
+                        checkpoint_texts.len()
+                    );
+                    continue;
+                }
+            };
 
-            let parsed: serde_json::Value = serde_json::from_str(&raw_json).with_context(|| {
-                format!("parsing LLM harvest response (batch {batch_num}):\n{raw_json}")
-            })?;
+            let parsed: serde_json::Value = match serde_json::from_str(&raw_json) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!(
+                        "  warning: could not parse LLM response for batch {batch_num} ({} checkpoint(s)), skipping: {e}\n  Raw: {}",
+                        checkpoint_texts.len(),
+                        &raw_json[..raw_json.len().min(200)]
+                    );
+                    continue;
+                }
+            };
 
             let entries = parsed["entries"].as_array().cloned().unwrap_or_default();
             if entries.is_empty() {
@@ -585,23 +625,44 @@ pub(super) async fn harvest_entire(
                 }
 
                 let source_ref = format!("entire:{cp_id}");
-                if backend
+                match backend
                     .has_source_ref(&source_ref)
                     .await
-                    .map_err(backend_err)?
+                    .map_err(backend_err)
                 {
-                    println!("  [skip] already harvested {cp_id}");
-                    continue;
+                    Ok(true) => {
+                        println!("  [skip] already harvested {cp_id}");
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        eprintln!("  warning: could not check source_ref for {source_ref}: {e:#}");
+                        continue;
+                    }
                 }
 
                 let embed_text = format!("title: {title} | text: {body}");
-                let vecs = embedder.embed(&[&embed_text]).await?;
+                let vecs = match embedder.embed(&[&embed_text]).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!(
+                            "  warning: embedding failed for entry '{title}' ({cp_id}), skipping: {e:#}"
+                        );
+                        continue;
+                    }
+                };
                 let Some(vec) = vecs.into_iter().next() else {
                     continue;
                 };
                 let blob = vec_to_blob(&vec);
 
-                let neighbors = backend.search(&blob, 1, None).await?;
+                let neighbors = match backend.search(&blob, 1, None).await {
+                    Ok(n) => n,
+                    Err(e) => {
+                        eprintln!("  warning: dedup search failed for '{title}', skipping: {e:#}");
+                        continue;
+                    }
+                };
                 if let Some(top) = neighbors.first()
                     && top.distance.unwrap_or(1.0) < DEDUP_THRESHOLD
                 {
@@ -616,7 +677,7 @@ pub(super) async fn harvest_entire(
                     continue;
                 }
 
-                let note_id = backend
+                let note_id = match backend
                     .add(NoteInput {
                         kind: kind.to_string(),
                         title: title.clone(),
@@ -628,7 +689,16 @@ pub(super) async fn harvest_entire(
                         valid_at: None,
                         supersedes: None,
                     })
-                    .await?;
+                    .await
+                {
+                    Ok(id) => id,
+                    Err(e) => {
+                        eprintln!(
+                            "  warning: failed to store entry '{title}' ({cp_id}), skipping: {e:#}"
+                        );
+                        continue;
+                    }
+                };
 
                 let short_id = &cp_id[..cp_id.len().min(8)];
                 println!("  + [{kind}] #{note_id}: {title}  \x1b[2m({short_id})\x1b[0m");


### PR DESCRIPTION
## Summary
- Converts all `?`-propagated errors inside the per-entry/per-batch processing loops in `harvest.rs`, `harvest_claude.rs`, and `harvest_entire.rs` to `match`/`continue` patterns
- LLM call failures, JSON parse errors, embedding failures, dedup search failures, and storage failures now emit a `warning:` line to stderr and continue to the next entry/batch
- The rest of the harvest is no longer blocked by one oversized or malformed batch

Fixes #270.

## Test plan
- [ ] Regression test to be filed by Test Engineer (inbox entry already created)
- [ ] Manual: run `spelunk memory harvest --source claude-code --confirm` on a large session history and confirm it completes without aborting

🤖 Generated with [Claude Code](https://claude.com/claude-code)