### PR TITLE
bench(swebench): switch default dataset to full split to fix 24/50 denominator gap

### DIFF
--- a/bench/agents/swebench_eval.sh
+++ b/bench/agents/swebench_eval.sh
@@ -13,10 +13,14 @@
 # Options:
 #   --results FILE     batch result JSON from agent run
 #   --patches-dir DIR  directory with per-task .patch files
-#   --dataset NAME     HuggingFace dataset (default: princeton-nlp/SWE-bench_Verified)
+#   --dataset NAME     HuggingFace dataset (default: princeton-nlp/SWE-bench)
 #   --split NAME       dataset split (default: test)
 #   --max-workers N    parallel eval workers (default: 4)
 #   --timeout SEC      per-instance timeout (default: 900)
+#
+# NOTE: We default to the full SWE-bench split (not SWE-bench_Verified) because all
+# 50 tasks in tasks_50.json exist in the full split, whereas only 24/50 are in
+# SWE-bench_Verified — causing a 26-task denominator gap. See issue #252.
 
 set -euo pipefail
 
@@ -24,7 +28,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 RESULTS=""
 PATCHES_DIR=""
-DATASET="princeton-nlp/SWE-bench_Verified"
+DATASET="princeton-nlp/SWE-bench"
 SPLIT="test"
 MAX_WORKERS=4
 TIMEOUT=900

--- a/bench/setup_repos.sh
+++ b/bench/setup_repos.sh
@@ -11,7 +11,9 @@
 #   --tasks-file FILE   path to tasks JSON array  (default: bench/agents/tasks_50.json)
 #   --tasks N           only set up first N tasks  (default: all)
 #   --repos-dir DIR     checkout root              (default: bench/repos)
-#   --dataset SLUG      HuggingFace dataset        (default: princeton-nlp/SWE-bench_Verified)
+#   --dataset SLUG      HuggingFace dataset        (default: princeton-nlp/SWE-bench)
+#                       NOTE: full split used (not SWE-bench_Verified) so all 50 tasks
+#                       in tasks_50.json resolve — see issue #252.
 #   --retries N         max retries per git op     (default: 3)
 #   --git-timeout SEC   timeout per git command    (default: 120)
 #   -h|--help
@@ -30,7 +32,7 @@ if [[ -d "${HOME}/opensource/spelunk-bench/repos" ]]; then
 else
     REPOS_DIR="${SCRIPT_DIR}/repos"
 fi
-DATASET="princeton-nlp/SWE-bench_Verified"
+DATASET="princeton-nlp/SWE-bench"
 MAX_RETRIES=3
 GIT_TIMEOUT=120
 


### PR DESCRIPTION
## Summary
- Changes the default `DATASET` in `bench/agents/swebench_eval.sh` and `bench/setup_repos.sh` from `princeton-nlp/SWE-bench_Verified` to `princeton-nlp/SWE-bench`
- The Verified split only contains 24 of our 50 pinned tasks; the full split contains all 50
- Both files now have inline comments referencing issue #252

Fixes #252.

## Note
End-to-end validation (confirming `tasks_evaluated == 50`) is blocked on #263 (Docker harness never invoked in the gemma local scripts — `resolved` was hardcoded to 0). Once #263 is fixed and the pipeline is wired correctly, re-run `setup_repos.sh` + the unified pipeline to confirm 50/50 coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)