### PR TITLE
feat(#268): heuristic convention extraction — naming, async, testing, docs

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/context.rs
+++ b/crates/spelunk-cli/src/cli/cmd/context.rs
@@ -11,11 +11,17 @@ const DEFAULT_UNKNOWN_KIND_LIMIT: usize = 20;
 
 /// Agent-facing entry-point command: pull the most relevant memory sections
 /// in one shot (handoffs → questions → decisions → requirements).
+/// Appends a "conventions" section from the local index when available.
 #[derive(Args, Debug)]
 pub struct ContextArgs {
     /// Path to the memory database (overrides auto-detect)
     #[arg(long)]
     pub db: Option<PathBuf>,
+
+    /// Path to the spelunk index database (overrides auto-detect).
+    /// Used to load the conventions section.
+    #[arg(long, value_name = "INDEX_DB")]
+    pub index_db: Option<PathBuf>,
 
     /// Storage backend: sqlite (default), git-meta, or git-notes
     #[arg(long, default_value = "sqlite", value_name = "BACKEND")]
@@ -36,6 +42,10 @@ pub struct ContextArgs {
     /// Output format: text or json
     #[arg(long, default_value = "text")]
     pub format: String,
+
+    /// Skip the conventions section (default: false)
+    #[arg(long)]
+    pub no_conventions: bool,
 }
 
 struct Section {
@@ -83,8 +93,22 @@ pub async fn context(args: ContextArgs, cfg: Config) -> Result<()> {
     )
     .await?;
 
+    // Load conventions from the index DB (best-effort; skip if unavailable).
+    let conventions: Vec<crate::conventions::ConventionRecord> =
+        if !args.no_conventions && args.kind.is_none() {
+            load_conventions(args.index_db.as_deref(), &cfg)
+        } else {
+            vec![]
+        };
+
     match crate::utils::effective_format(&args.format) {
-        "json" => println!("{}", serde_json::to_string(&sections)?),
+        "json" => {
+            let output = serde_json::json!({
+                "sections": sections,
+                "conventions": conventions,
+            });
+            println!("{output}");
+        }
         _ => {
             for (kind, notes) in &sections {
                 if notes.is_empty() {
@@ -95,9 +119,35 @@ pub async fn context(args: ContextArgs, cfg: Config) -> Result<()> {
                     print_note_summary(n);
                 }
             }
+            if !conventions.is_empty() {
+                print_conventions_section(&conventions);
+            }
         }
     }
     Ok(())
+}
+
+/// Load conventions from the project index DB.
+/// Returns an empty vec if the DB doesn't exist or conventions table is empty.
+fn load_conventions(
+    index_db_override: Option<&std::path::Path>,
+    cfg: &Config,
+) -> Vec<crate::conventions::ConventionRecord> {
+    let db_path = if let Some(p) = index_db_override {
+        p.to_path_buf()
+    } else {
+        crate::config::resolve_db(None, &cfg.db_path)
+    };
+    if !db_path.exists() {
+        return vec![];
+    }
+    match crate::storage::Database::open(&db_path) {
+        Ok(db) => crate::conventions::list_conventions(&db, None).unwrap_or_default(),
+        Err(e) => {
+            tracing::debug!("conventions: could not open index db: {e}");
+            vec![]
+        }
+    }
 }
 
 async fn collect_sections(
@@ -142,4 +192,28 @@ fn print_section_header(kind: &str) {
     };
     println!("\x1b[1;34m── {label} \x1b[0m");
     println!();
+}
+
+fn print_conventions_section(records: &[crate::conventions::ConventionRecord]) {
+    println!("\x1b[1;34m── Conventions \x1b[0m");
+    println!();
+
+    // Group by language for readability.
+    let mut by_lang: std::collections::BTreeMap<&str, Vec<&crate::conventions::ConventionRecord>> =
+        std::collections::BTreeMap::new();
+    for r in records {
+        by_lang.entry(r.language.as_str()).or_default().push(r);
+    }
+    for (lang, recs) in &by_lang {
+        println!("\x1b[1m{lang}\x1b[0m");
+        for r in recs {
+            println!(
+                "  [{:.0}%] {} — {}",
+                r.confidence * 100.0,
+                r.category,
+                r.description
+            );
+        }
+        println!();
+    }
 }

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -242,6 +242,17 @@ async fn run_phases_3_to_5(
         }
     });
 
+    // Phase 5: convention extraction (heuristic, no LLM).
+    eprintln!("Extracting conventions\u{2026}");
+    match crate::conventions::run_extraction(db) {
+        Ok(records) => {
+            if !records.is_empty() {
+                eprintln!("Conventions: {} record(s) detected.", records.len());
+            }
+        }
+        Err(e) => tracing::warn!("convention extraction failed (non-fatal): {e}"),
+    }
+
     // Register / update this project in the global registry.
     if let Ok(reg) = Registry::open() {
         let db_canonical = db_path.canonicalize().unwrap_or(db_path.to_path_buf());

--- a/crates/spelunk-cli/src/main.rs
+++ b/crates/spelunk-cli/src/main.rs
@@ -6,7 +6,8 @@ mod cli;
 use clap::{CommandFactory, FromArgMatches};
 use cli::{Cli, Command};
 use spelunk_core::{
-    backends, capability, config, embeddings, error, indexer, llm, registry, search, storage, utils,
+    backends, capability, config, conventions, embeddings, error, indexer, llm, registry, search,
+    storage, utils,
 };
 
 #[tokio::main]

--- a/crates/spelunk-cli/tests/context.rs
+++ b/crates/spelunk-cli/tests/context.rs
@@ -177,7 +177,7 @@ fn context_outputs_all_four_sections_by_default() {
 // ── happy path: JSON output ───────────────────────────────────────────────────
 
 #[test]
-fn context_json_output_is_valid_array() {
+fn context_json_output_is_valid_object() {
     let (_tmp, db_path, config_path) = setup_context_project();
 
     let output = context_cmd(&db_path, &config_path)
@@ -191,12 +191,15 @@ fn context_json_output_is_valid_array() {
 
     let stdout = String::from_utf8_lossy(&output);
 
-    // Should be valid JSON: an array of [kind, [notes]] pairs.
-    let parsed: Vec<serde_json::Value> =
+    // Should be valid JSON object: {"sections": [[kind, notes], ...], "conventions": [...]}
+    let obj: serde_json::Value =
         serde_json::from_str(&stdout).expect("--format json should produce valid JSON");
+    let parsed = obj["sections"]
+        .as_array()
+        .expect("sections should be array");
 
     assert!(!parsed.is_empty(), "expected at least one section");
-    for item in &parsed {
+    for item in parsed {
         let arr = item.as_array().expect("each item should be [kind, notes]");
         assert_eq!(arr.len(), 2, "each item should be a [kind, notes] pair");
         assert!(arr[0].is_string(), "first element should be kind string");
@@ -218,7 +221,8 @@ fn context_json_includes_all_kinds() {
         .clone();
 
     let stdout = String::from_utf8_lossy(&output);
-    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+    let obj: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let parsed = obj["sections"].as_array().expect("sections array");
 
     let kinds: Vec<&str> = parsed
         .iter()
@@ -292,7 +296,8 @@ fn context_kind_filter_json_returns_single_section() {
         .clone();
 
     let stdout = String::from_utf8_lossy(&output);
-    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+    let obj: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let parsed = obj["sections"].as_array().expect("sections array");
 
     assert_eq!(parsed.len(), 1, "--kind should return exactly one section");
     assert_eq!(parsed[0][0].as_str().unwrap(), "question");
@@ -318,7 +323,8 @@ fn context_limit_flag_respects_count() {
         .clone();
 
     let stdout = String::from_utf8_lossy(&output);
-    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+    let obj: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let parsed = obj["sections"].as_array().expect("sections array");
 
     let notes = parsed[0][1].as_array().expect("notes should be array");
     assert_eq!(
@@ -348,7 +354,8 @@ fn context_default_limits_respected() {
         .clone();
 
     let stdout = String::from_utf8_lossy(&output);
-    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+    let obj: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let parsed = obj["sections"].as_array().expect("sections array");
 
     let notes = parsed[0][1].as_array().expect("notes should be array");
     assert_eq!(
@@ -384,10 +391,11 @@ fn context_empty_memory_exits_zero_with_no_output() {
         .clone();
 
     let stdout = String::from_utf8_lossy(&output);
-    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+    let obj: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let parsed = obj["sections"].as_array().expect("sections array");
 
     // All sections should be present but empty.
-    for item in &parsed {
+    for item in parsed {
         let notes = item[1].as_array().expect("notes should be array");
         assert!(
             notes.is_empty(),
@@ -460,9 +468,10 @@ fn context_json_notes_have_required_fields() {
         .clone();
 
     let stdout = String::from_utf8_lossy(&output);
-    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("valid JSON");
+    let obj: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let parsed = obj["sections"].as_array().expect("sections array");
 
-    for item in &parsed {
+    for item in parsed {
         let notes = item[1].as_array().expect("notes should be array");
         for note in notes {
             assert!(note.get("id").is_some(), "note missing 'id': {note}");

--- a/crates/spelunk-core/migrations/019_conventions.sql
+++ b/crates/spelunk-core/migrations/019_conventions.sql
@@ -1,0 +1,15 @@
+-- Convention records extracted by the heuristic AST pass.
+-- Fully replaced after each index run: DELETE + re-insert.
+
+CREATE TABLE IF NOT EXISTS conventions (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    language       TEXT    NOT NULL,
+    category       TEXT    NOT NULL,
+    description    TEXT    NOT NULL,
+    confidence     REAL    NOT NULL DEFAULT 0.0,
+    evidence_count INTEGER NOT NULL DEFAULT 0,
+    extracted_at   INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_conventions_language
+    ON conventions (language);

--- a/crates/spelunk-core/src/conventions/extractor.rs
+++ b/crates/spelunk-core/src/conventions/extractor.rs
@@ -1,0 +1,67 @@
+//! `ConventionExtractor` — aggregates evidence from stored chunks and produces
+//! `ConventionRecord`s by dispatching to per-language rule sets.
+
+use super::ConventionRecord;
+use super::rules;
+
+/// A lightweight chunk summary passed to the extractors.
+/// Contains only the fields the heuristics need.
+#[derive(Debug, Clone)]
+pub struct ChunkSummary {
+    pub language: String,
+    pub node_type: String,
+    pub name: Option<String>,
+    pub content: String,
+    pub file_path: String,
+    pub has_docstring: bool,
+}
+
+/// Aggregates `ChunkSummary` slices and dispatches to per-language rule sets.
+pub struct ConventionExtractor;
+
+impl ConventionExtractor {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Run all rule sets over `chunks` and return raw `ConventionRecord`s.
+    /// Caller is responsible for applying confidence / evidence-count thresholds.
+    pub fn extract(&self, chunks: &[ChunkSummary]) -> Vec<ConventionRecord> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+
+        // Group chunks by language.
+        let mut by_lang: std::collections::HashMap<&str, Vec<&ChunkSummary>> =
+            std::collections::HashMap::new();
+        for c in chunks {
+            by_lang.entry(c.language.as_str()).or_default().push(c);
+        }
+
+        let mut records = Vec::new();
+        for (lang, lang_chunks) in &by_lang {
+            let mut lang_records = match *lang {
+                "rust" => rules::rust::extract(lang_chunks, now),
+                "typescript" | "tsx" => rules::typescript::extract(lang_chunks, now),
+                _ => rules::generic::extract(lang_chunks, now),
+            };
+            // Generic rules always run as a fallback for all languages.
+            if *lang != "rust" && *lang != "typescript" && *lang != "tsx" {
+                // Already handled by the generic branch above.
+            } else {
+                // Append generic rules on top of language-specific ones.
+                let mut generic = rules::generic::extract(lang_chunks, now);
+                lang_records.append(&mut generic);
+            }
+            records.extend(lang_records);
+        }
+        records
+    }
+}
+
+impl Default for ConventionExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/spelunk-core/src/conventions/mod.rs
+++ b/crates/spelunk-core/src/conventions/mod.rs
@@ -5,17 +5,20 @@
 //!
 //! No LLM, no network calls — pure heuristics.
 
-mod extractor;
+pub mod extractor;
 pub mod rules;
 
-pub use extractor::ConventionExtractor;
+pub use extractor::{ChunkSummary, ConventionExtractor};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::storage::Database;
+use crate::storage::{ConventionRow, Database, RawChunkRow, has_doc_prefix};
 
-/// A single detected convention.
+/// A single detected convention (logical / API type).
+///
+/// The storage layer uses `crate::storage::ConventionRow` internally to avoid
+/// a circular module dependency.  `run_extraction` converts between them.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConventionRecord {
     pub language: String,
@@ -31,6 +34,45 @@ pub struct ConventionRecord {
     pub extracted_at: i64,
 }
 
+impl From<ConventionRecord> for ConventionRow {
+    fn from(r: ConventionRecord) -> Self {
+        ConventionRow {
+            language: r.language,
+            category: r.category,
+            description: r.description,
+            confidence: r.confidence,
+            evidence_count: r.evidence_count,
+            extracted_at: r.extracted_at,
+        }
+    }
+}
+
+impl From<ConventionRow> for ConventionRecord {
+    fn from(r: ConventionRow) -> Self {
+        ConventionRecord {
+            language: r.language,
+            category: r.category,
+            description: r.description,
+            confidence: r.confidence,
+            evidence_count: r.evidence_count,
+            extracted_at: r.extracted_at,
+        }
+    }
+}
+
+/// Convert `RawChunkRow` (storage type) into `ChunkSummary` (extraction type).
+fn to_chunk_summary(row: RawChunkRow) -> ChunkSummary {
+    let has_docstring = has_doc_prefix(&row.content);
+    ChunkSummary {
+        language: row.language,
+        node_type: row.node_type,
+        name: row.name,
+        content: row.content,
+        file_path: row.file_path,
+        has_docstring,
+    }
+}
+
 /// Run the full extraction pipeline.
 ///
 /// Reads all chunks from `db`, dispatches to per-language extractors, and
@@ -39,14 +81,22 @@ pub struct ConventionRecord {
 /// Failures are surfaced to the caller; the index phase wraps this in a
 /// non-fatal warning.
 pub fn run_extraction(db: &Database) -> Result<Vec<ConventionRecord>> {
-    let chunks = db.all_chunks_for_conventions()?;
+    let raw_chunks = db.all_chunks_for_conventions()?;
+    let chunks: Vec<ChunkSummary> = raw_chunks.into_iter().map(to_chunk_summary).collect();
 
-    let records = extractor::ConventionExtractor::new()
+    let records: Vec<ConventionRecord> = ConventionExtractor::new()
         .extract(&chunks)
         .into_iter()
         .filter(|r| r.confidence >= 0.5 && r.evidence_count >= 5)
-        .collect::<Vec<_>>();
+        .collect();
 
-    db.replace_conventions(&records)?;
+    let rows: Vec<ConventionRow> = records.iter().cloned().map(ConventionRow::from).collect();
+    db.replace_conventions(&rows)?;
     Ok(records)
+}
+
+/// Fetch stored conventions from the DB and return them as `ConventionRecord`s.
+pub fn list_conventions(db: &Database, language: Option<&str>) -> Result<Vec<ConventionRecord>> {
+    let rows = db.list_conventions(language)?;
+    Ok(rows.into_iter().map(ConventionRecord::from).collect())
 }

--- a/crates/spelunk-core/src/conventions/mod.rs
+++ b/crates/spelunk-core/src/conventions/mod.rs
@@ -1,0 +1,52 @@
+//! Convention extraction: heuristic AST pass over indexed chunks.
+//!
+//! Reads stored chunks from spelunk.db, dispatches to per-language rule sets,
+//! and writes `ConventionRecord`s to the `conventions` table.
+//!
+//! No LLM, no network calls — pure heuristics.
+
+mod extractor;
+pub mod rules;
+
+pub use extractor::ConventionExtractor;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::storage::Database;
+
+/// A single detected convention.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConventionRecord {
+    pub language: String,
+    /// Dot-separated category, e.g. `"naming.functions"`, `"error_handling"`.
+    pub category: String,
+    /// Human-readable description, e.g. `"Functions use snake_case"`.
+    pub description: String,
+    /// 0.0–1.0; only records with `>= 0.5` are stored.
+    pub confidence: f32,
+    /// Number of evidence data points behind this record.
+    pub evidence_count: u32,
+    /// Unix timestamp when extraction ran.
+    pub extracted_at: i64,
+}
+
+/// Run the full extraction pipeline.
+///
+/// Reads all chunks from `db`, dispatches to per-language extractors, and
+/// writes results to the `conventions` table (delete-all + re-insert).
+///
+/// Failures are surfaced to the caller; the index phase wraps this in a
+/// non-fatal warning.
+pub fn run_extraction(db: &Database) -> Result<Vec<ConventionRecord>> {
+    let chunks = db.all_chunks_for_conventions()?;
+
+    let records = extractor::ConventionExtractor::new()
+        .extract(&chunks)
+        .into_iter()
+        .filter(|r| r.confidence >= 0.5 && r.evidence_count >= 5)
+        .collect::<Vec<_>>();
+
+    db.replace_conventions(&records)?;
+    Ok(records)
+}

--- a/crates/spelunk-core/src/conventions/rules/generic.rs
+++ b/crates/spelunk-core/src/conventions/rules/generic.rs
@@ -1,0 +1,42 @@
+//! Language-agnostic convention heuristics.
+//! Applied to languages that have no dedicated rule set, and also layered on
+//! top of language-specific rules (for naming / docs).
+
+use super::{
+    ChunkSummary, ConventionRecord, count_cases, doc_coverage_record, dominant, function_names,
+    naming_record,
+};
+
+pub fn extract(chunks: &[&ChunkSummary], now: i64) -> Vec<ConventionRecord> {
+    // Use the first chunk's language as the label (all chunks here share it).
+    let lang = chunks
+        .first()
+        .map(|c| c.language.as_str())
+        .unwrap_or("unknown");
+
+    let mut records = Vec::new();
+
+    // ── naming.functions ─────────────────────────────────────────────────────
+    let fn_names = function_names(chunks);
+    let (snake, camel, pascal, screaming, total_fn) = count_cases(&fn_names);
+    let (dom_style, dom_count) = dominant(snake, camel, pascal, screaming);
+    if let Some(r) = naming_record(lang, "naming.functions", dom_style, dom_count, total_fn, now) {
+        records.push(r);
+    }
+
+    // ── docs ──────────────────────────────────────────────────────────────────
+    let callable_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|c| matches!(c.node_type.as_str(), "function" | "method"))
+        .copied()
+        .collect();
+    if !callable_chunks.is_empty() {
+        let with_docs = callable_chunks.iter().filter(|c| c.has_docstring).count() as u32;
+        let total = callable_chunks.len() as u32;
+        if let Some(r) = doc_coverage_record(lang, with_docs, total, now) {
+            records.push(r);
+        }
+    }
+
+    records
+}

--- a/crates/spelunk-core/src/conventions/rules/generic.rs
+++ b/crates/spelunk-core/src/conventions/rules/generic.rs
@@ -20,7 +20,14 @@ pub fn extract(chunks: &[&ChunkSummary], now: i64) -> Vec<ConventionRecord> {
     let fn_names = function_names(chunks);
     let (snake, camel, pascal, screaming, total_fn) = count_cases(&fn_names);
     let (dom_style, dom_count) = dominant(snake, camel, pascal, screaming);
-    if let Some(r) = naming_record(lang, "naming.functions", dom_style, dom_count, total_fn, now) {
+    if let Some(r) = naming_record(
+        lang,
+        "naming.functions",
+        dom_style,
+        dom_count,
+        total_fn,
+        now,
+    ) {
         records.push(r);
     }
 

--- a/crates/spelunk-core/src/conventions/rules/mod.rs
+++ b/crates/spelunk-core/src/conventions/rules/mod.rs
@@ -1,0 +1,183 @@
+//! Per-language heuristic rule sets for convention extraction.
+
+pub mod generic;
+pub mod rust;
+pub mod typescript;
+
+use super::ConventionRecord;
+use super::extractor::ChunkSummary;
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+/// Classify a symbol name into a case style.
+/// Names shorter than 3 characters are treated as `CaseStyle::Unknown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaseStyle {
+    /// all_lower_with_underscores (no uppercase)
+    SnakeCase,
+    /// startsLower, containsUpper, no underscores
+    CamelCase,
+    /// StartsUpper, no underscores
+    PascalCase,
+    /// ALL_UPPER_WITH_UNDERSCORES
+    ScreamingSnake,
+    /// Anything else (mixed, very short, numeric-heavy, etc.)
+    Unknown,
+}
+
+pub fn detect_case(name: &str) -> CaseStyle {
+    if name.len() < 3 {
+        return CaseStyle::Unknown;
+    }
+    let has_upper = name.chars().any(|c| c.is_uppercase());
+    let has_lower = name.chars().any(|c| c.is_lowercase());
+    let has_underscore = name.contains('_');
+    let starts_upper = name.starts_with(|c: char| c.is_uppercase());
+
+    if has_upper && !has_lower && has_underscore {
+        CaseStyle::ScreamingSnake
+    } else if starts_upper && !has_underscore {
+        CaseStyle::PascalCase
+    } else if !starts_upper && has_upper && !has_underscore {
+        CaseStyle::CamelCase
+    } else if has_lower && !has_upper {
+        CaseStyle::SnakeCase
+    } else {
+        CaseStyle::Unknown
+    }
+}
+
+/// Build a confidence-weighted `ConventionRecord` for naming conventions.
+/// Returns `None` when there are no meaningful samples.
+pub fn naming_record(
+    language: &str,
+    category: &str,
+    dominant_style: CaseStyle,
+    dominant_count: u32,
+    total_named: u32,
+    now: i64,
+) -> Option<ConventionRecord> {
+    if total_named == 0 || dominant_count == 0 {
+        return None;
+    }
+    let confidence = dominant_count as f32 / total_named as f32;
+    let style_name = match dominant_style {
+        CaseStyle::SnakeCase => "snake_case",
+        CaseStyle::CamelCase => "camelCase",
+        CaseStyle::PascalCase => "PascalCase",
+        CaseStyle::ScreamingSnake => "SCREAMING_SNAKE_CASE",
+        CaseStyle::Unknown => return None,
+    };
+    let description = match category {
+        "naming.functions" => format!("Functions use {style_name}"),
+        "naming.types" => format!("Types use {style_name}"),
+        _ => format!("Names use {style_name}"),
+    };
+    Some(ConventionRecord {
+        language: language.to_string(),
+        category: category.to_string(),
+        description,
+        confidence,
+        evidence_count: dominant_count,
+        extracted_at: now,
+    })
+}
+
+/// Build a doc-coverage `ConventionRecord`.
+pub fn doc_coverage_record(
+    language: &str,
+    with_docs: u32,
+    total: u32,
+    now: i64,
+) -> Option<ConventionRecord> {
+    if total == 0 {
+        return None;
+    }
+    let ratio = with_docs as f32 / total as f32;
+    let (level, confidence) = if ratio > 0.7 {
+        ("high", ratio)
+    } else if ratio >= 0.3 {
+        ("medium", ratio.max(0.5))
+    } else {
+        ("low", (1.0 - ratio).max(0.5))
+    };
+    Some(ConventionRecord {
+        language: language.to_string(),
+        category: "docs".to_string(),
+        description: format!("Doc comment coverage: {level}"),
+        confidence,
+        evidence_count: total,
+        extracted_at: now,
+    })
+}
+
+/// Count `CaseStyle` occurrences in a name slice.
+/// Returns `(snake, camel, pascal, screaming, total_named)`.
+pub fn count_cases(names: &[Option<&str>]) -> (u32, u32, u32, u32, u32) {
+    let mut snake = 0u32;
+    let mut camel = 0u32;
+    let mut pascal = 0u32;
+    let mut screaming = 0u32;
+    let mut total = 0u32;
+    for name in names.iter().flatten() {
+        match detect_case(name) {
+            CaseStyle::SnakeCase => {
+                snake += 1;
+                total += 1;
+            }
+            CaseStyle::CamelCase => {
+                camel += 1;
+                total += 1;
+            }
+            CaseStyle::PascalCase => {
+                pascal += 1;
+                total += 1;
+            }
+            CaseStyle::ScreamingSnake => {
+                screaming += 1;
+                total += 1;
+            }
+            CaseStyle::Unknown => {}
+        }
+    }
+    (snake, camel, pascal, screaming, total)
+}
+
+/// Return the dominant style and count from raw counts.
+/// Ties go to the first-listed (more conventional) style.
+pub fn dominant(snake: u32, camel: u32, pascal: u32, screaming: u32) -> (CaseStyle, u32) {
+    let mut best = (CaseStyle::Unknown, 0u32);
+    for (style, count) in [
+        (CaseStyle::SnakeCase, snake),
+        (CaseStyle::CamelCase, camel),
+        (CaseStyle::PascalCase, pascal),
+        (CaseStyle::ScreamingSnake, screaming),
+    ] {
+        if count > best.1 {
+            best = (style, count);
+        }
+    }
+    best
+}
+
+/// Collect `ChunkSummary` slices into name samples for functions and types.
+pub fn function_names<'a>(chunks: &[&'a ChunkSummary]) -> Vec<Option<&'a str>> {
+    chunks
+        .iter()
+        .filter(|c| matches!(c.node_type.as_str(), "function" | "method"))
+        .map(|c| c.name.as_deref())
+        .collect()
+}
+
+pub fn type_names<'a>(chunks: &[&'a ChunkSummary]) -> Vec<Option<&'a str>> {
+    chunks
+        .iter()
+        .filter(|c| {
+            matches!(
+                c.node_type.as_str(),
+                "struct" | "enum" | "trait" | "class" | "interface" | "type_alias"
+            )
+        })
+        .map(|c| c.name.as_deref())
+        .collect()
+}

--- a/crates/spelunk-core/src/conventions/rules/rust.rs
+++ b/crates/spelunk-core/src/conventions/rules/rust.rs
@@ -47,7 +47,14 @@ pub fn extract(chunks: &[&ChunkSummary], now: i64) -> Vec<ConventionRecord> {
     let fn_names = function_names(chunks);
     let (snake, camel, pascal, screaming, total_fn) = count_cases(&fn_names);
     let (dom_style, dom_count) = dominant(snake, camel, pascal, screaming);
-    if let Some(r) = naming_record(lang, "naming.functions", dom_style, dom_count, total_fn, now) {
+    if let Some(r) = naming_record(
+        lang,
+        "naming.functions",
+        dom_style,
+        dom_count,
+        total_fn,
+        now,
+    ) {
         records.push(r);
     }
 
@@ -116,21 +123,23 @@ fn error_handling_record(chunks: &[&ChunkSummary], now: i64) -> Option<Conventio
         return None;
     }
 
-    let (description, dominant_count) = if anyhow_count >= thiserror_count
-        && anyhow_count >= app_error_count
-    {
-        ("Error handling via anyhow::Result".to_string(), anyhow_count)
-    } else if thiserror_count >= app_error_count {
-        (
-            "Error types defined with thiserror".to_string(),
-            thiserror_count,
-        )
-    } else {
-        (
-            "Custom AppError type for error handling".to_string(),
-            app_error_count,
-        )
-    };
+    let (description, dominant_count) =
+        if anyhow_count >= thiserror_count && anyhow_count >= app_error_count {
+            (
+                "Error handling via anyhow::Result".to_string(),
+                anyhow_count,
+            )
+        } else if thiserror_count >= app_error_count {
+            (
+                "Error types defined with thiserror".to_string(),
+                thiserror_count,
+            )
+        } else {
+            (
+                "Custom AppError type for error handling".to_string(),
+                app_error_count,
+            )
+        };
 
     let confidence = dominant_count as f32 / total as f32;
     Some(ConventionRecord {

--- a/crates/spelunk-core/src/conventions/rules/rust.rs
+++ b/crates/spelunk-core/src/conventions/rules/rust.rs
@@ -1,0 +1,230 @@
+//! Rust-specific convention heuristics.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+use super::{
+    ChunkSummary, ConventionRecord, count_cases, doc_coverage_record, dominant, function_names,
+    naming_record, type_names,
+};
+
+// ── Compiled regex patterns ───────────────────────────────────────────────────
+
+fn patterns() -> &'static RustPatterns {
+    static P: OnceLock<RustPatterns> = OnceLock::new();
+    P.get_or_init(RustPatterns::new)
+}
+
+struct RustPatterns {
+    anyhow: Regex,
+    thiserror: Regex,
+    app_error: Regex,
+    async_fn: Regex,
+    tokio: Regex,
+    cfg_test: Regex,
+}
+
+impl RustPatterns {
+    fn new() -> Self {
+        Self {
+            anyhow: Regex::new(r"\banyhow\b").expect("anyhow regex"),
+            thiserror: Regex::new(r"\bthiserror\b").expect("thiserror regex"),
+            app_error: Regex::new(r"\bAppError\b").expect("AppError regex"),
+            async_fn: Regex::new(r"\basync\s+fn\b").expect("async fn regex"),
+            tokio: Regex::new(r"\btokio::").expect("tokio regex"),
+            cfg_test: Regex::new(r"#\s*\[cfg\s*\(\s*test\s*\)\]").expect("cfg test regex"),
+        }
+    }
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+pub fn extract(chunks: &[&ChunkSummary], now: i64) -> Vec<ConventionRecord> {
+    let lang = "rust";
+    let mut records = Vec::new();
+
+    // ── naming.functions ─────────────────────────────────────────────────────
+    let fn_names = function_names(chunks);
+    let (snake, camel, pascal, screaming, total_fn) = count_cases(&fn_names);
+    let (dom_style, dom_count) = dominant(snake, camel, pascal, screaming);
+    if let Some(r) = naming_record(lang, "naming.functions", dom_style, dom_count, total_fn, now) {
+        records.push(r);
+    }
+
+    // ── naming.types ─────────────────────────────────────────────────────────
+    let ty_names = type_names(chunks);
+    let (snake_t, camel_t, pascal_t, screaming_t, total_ty) = count_cases(&ty_names);
+    let (dom_ty, dom_ty_count) = dominant(snake_t, camel_t, pascal_t, screaming_t);
+    if let Some(r) = naming_record(lang, "naming.types", dom_ty, dom_ty_count, total_ty, now) {
+        records.push(r);
+    }
+
+    // ── error_handling ────────────────────────────────────────────────────────
+    if let Some(r) = error_handling_record(chunks, now) {
+        records.push(r);
+    }
+
+    // ── async ─────────────────────────────────────────────────────────────────
+    if let Some(r) = async_record(chunks, now) {
+        records.push(r);
+    }
+
+    // ── testing ───────────────────────────────────────────────────────────────
+    if let Some(r) = testing_record(chunks, now) {
+        records.push(r);
+    }
+
+    // ── docs ──────────────────────────────────────────────────────────────────
+    let function_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|c| matches!(c.node_type.as_str(), "function" | "method"))
+        .copied()
+        .collect();
+    if !function_chunks.is_empty() {
+        let with_docs = function_chunks.iter().filter(|c| c.has_docstring).count() as u32;
+        let total = function_chunks.len() as u32;
+        if let Some(r) = doc_coverage_record(lang, with_docs, total, now) {
+            records.push(r);
+        }
+    }
+
+    records
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+fn error_handling_record(chunks: &[&ChunkSummary], now: i64) -> Option<ConventionRecord> {
+    let p = patterns();
+    let mut anyhow_count = 0u32;
+    let mut thiserror_count = 0u32;
+    let mut app_error_count = 0u32;
+
+    for c in chunks {
+        if p.anyhow.is_match(&c.content) {
+            anyhow_count += 1;
+        }
+        if p.thiserror.is_match(&c.content) {
+            thiserror_count += 1;
+        }
+        if p.app_error.is_match(&c.content) {
+            app_error_count += 1;
+        }
+    }
+
+    let total = anyhow_count + thiserror_count + app_error_count;
+    if total == 0 {
+        return None;
+    }
+
+    let (description, dominant_count) = if anyhow_count >= thiserror_count
+        && anyhow_count >= app_error_count
+    {
+        ("Error handling via anyhow::Result".to_string(), anyhow_count)
+    } else if thiserror_count >= app_error_count {
+        (
+            "Error types defined with thiserror".to_string(),
+            thiserror_count,
+        )
+    } else {
+        (
+            "Custom AppError type for error handling".to_string(),
+            app_error_count,
+        )
+    };
+
+    let confidence = dominant_count as f32 / total as f32;
+    Some(ConventionRecord {
+        language: "rust".to_string(),
+        category: "error_handling".to_string(),
+        description,
+        confidence,
+        evidence_count: dominant_count,
+        extracted_at: now,
+    })
+}
+
+fn async_record(chunks: &[&ChunkSummary], now: i64) -> Option<ConventionRecord> {
+    let p = patterns();
+    let function_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|c| matches!(c.node_type.as_str(), "function" | "method"))
+        .copied()
+        .collect();
+    if function_chunks.is_empty() {
+        return None;
+    }
+
+    let async_count = function_chunks
+        .iter()
+        .filter(|c| p.async_fn.is_match(&c.content))
+        .count() as u32;
+
+    let total = function_chunks.len() as u32;
+    if total == 0 {
+        return None;
+    }
+
+    let ratio = async_count as f32 / total as f32;
+    if ratio <= 0.2 {
+        return None;
+    }
+
+    // Detect runtime from content of all chunks.
+    let has_tokio = chunks.iter().any(|c| p.tokio.is_match(&c.content));
+    let runtime = if has_tokio { "tokio" } else { "async-std" };
+    let confidence = ratio;
+
+    Some(ConventionRecord {
+        language: "rust".to_string(),
+        category: "async".to_string(),
+        description: format!("Async runtime: {runtime}"),
+        confidence,
+        evidence_count: async_count,
+        extracted_at: now,
+    })
+}
+
+fn testing_record(chunks: &[&ChunkSummary], now: i64) -> Option<ConventionRecord> {
+    let p = patterns();
+    // Detect files in test locations.
+    let test_files_count = chunks
+        .iter()
+        .filter(|c| {
+            c.file_path.ends_with("_test.rs")
+                || c.file_path.contains("/tests/")
+                || c.file_path.contains("tests/")
+        })
+        .count() as u32;
+
+    let cfg_test_count = chunks
+        .iter()
+        .filter(|c| p.cfg_test.is_match(&c.content))
+        .count() as u32;
+
+    let total = test_files_count + cfg_test_count;
+    if total == 0 {
+        return None;
+    }
+
+    let (description, dominant_count) = if test_files_count >= cfg_test_count {
+        (
+            "Tests in separate *_test.rs / tests/ files".to_string(),
+            test_files_count,
+        )
+    } else {
+        (
+            "Tests in #[cfg(test)] inline modules".to_string(),
+            cfg_test_count,
+        )
+    };
+
+    let confidence = dominant_count as f32 / total as f32;
+    Some(ConventionRecord {
+        language: "rust".to_string(),
+        category: "testing".to_string(),
+        description,
+        confidence,
+        evidence_count: dominant_count,
+        extracted_at: now,
+    })
+}

--- a/crates/spelunk-core/src/conventions/rules/typescript.rs
+++ b/crates/spelunk-core/src/conventions/rules/typescript.rs
@@ -1,0 +1,133 @@
+//! TypeScript / TSX convention heuristics.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+use super::{
+    ChunkSummary, ConventionRecord, count_cases, doc_coverage_record, dominant, function_names,
+    naming_record, type_names,
+};
+
+fn patterns() -> &'static TsPatterns {
+    static P: OnceLock<TsPatterns> = OnceLock::new();
+    P.get_or_init(TsPatterns::new)
+}
+
+struct TsPatterns {
+    async_keyword: Regex,
+}
+
+impl TsPatterns {
+    fn new() -> Self {
+        Self {
+            async_keyword: Regex::new(r"\basync\b").expect("async regex"),
+        }
+    }
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+pub fn extract(chunks: &[&ChunkSummary], now: i64) -> Vec<ConventionRecord> {
+    let lang = "typescript";
+    let mut records = Vec::new();
+
+    // ── naming.functions ─────────────────────────────────────────────────────
+    let fn_names = function_names(chunks);
+    let (snake, camel, pascal, screaming, total_fn) = count_cases(&fn_names);
+    let (dom_style, dom_count) = dominant(snake, camel, pascal, screaming);
+    if let Some(r) = naming_record(lang, "naming.functions", dom_style, dom_count, total_fn, now) {
+        records.push(r);
+    }
+
+    // ── naming.types ─────────────────────────────────────────────────────────
+    let ty_names = type_names(chunks);
+    let (snake_t, camel_t, pascal_t, screaming_t, total_ty) = count_cases(&ty_names);
+    let (dom_ty, dom_ty_count) = dominant(snake_t, camel_t, pascal_t, screaming_t);
+    if let Some(r) = naming_record(lang, "naming.types", dom_ty, dom_ty_count, total_ty, now) {
+        records.push(r);
+    }
+
+    // ── async ─────────────────────────────────────────────────────────────────
+    if let Some(r) = async_record(chunks, lang, now) {
+        records.push(r);
+    }
+
+    // ── testing ───────────────────────────────────────────────────────────────
+    if let Some(r) = testing_record(chunks, lang, now) {
+        records.push(r);
+    }
+
+    // ── docs ──────────────────────────────────────────────────────────────────
+    let function_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|c| matches!(c.node_type.as_str(), "function" | "method"))
+        .copied()
+        .collect();
+    if !function_chunks.is_empty() {
+        let with_docs = function_chunks.iter().filter(|c| c.has_docstring).count() as u32;
+        let total = function_chunks.len() as u32;
+        if let Some(r) = doc_coverage_record(lang, with_docs, total, now) {
+            records.push(r);
+        }
+    }
+
+    records
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+fn async_record(chunks: &[&ChunkSummary], lang: &str, now: i64) -> Option<ConventionRecord> {
+    let p = patterns();
+    let function_chunks: Vec<_> = chunks
+        .iter()
+        .filter(|c| matches!(c.node_type.as_str(), "function" | "method"))
+        .copied()
+        .collect();
+    if function_chunks.is_empty() {
+        return None;
+    }
+    let async_count = function_chunks
+        .iter()
+        .filter(|c| p.async_keyword.is_match(&c.content))
+        .count() as u32;
+    let total = function_chunks.len() as u32;
+    let ratio = async_count as f32 / total as f32;
+    if ratio <= 0.2 {
+        return None;
+    }
+    Some(ConventionRecord {
+        language: lang.to_string(),
+        category: "async".to_string(),
+        description: "Async/await is widely used".to_string(),
+        confidence: ratio,
+        evidence_count: async_count,
+        extracted_at: now,
+    })
+}
+
+fn testing_record(chunks: &[&ChunkSummary], lang: &str, now: i64) -> Option<ConventionRecord> {
+    let test_count = chunks
+        .iter()
+        .filter(|c| {
+            c.file_path.ends_with(".test.ts")
+                || c.file_path.ends_with(".test.tsx")
+                || c.file_path.ends_with(".spec.ts")
+                || c.file_path.ends_with(".spec.tsx")
+                || c.file_path.contains("/__tests__/")
+                || c.file_path.contains("__tests__/")
+        })
+        .count() as u32;
+
+    if test_count == 0 {
+        return None;
+    }
+
+    Some(ConventionRecord {
+        language: lang.to_string(),
+        category: "testing".to_string(),
+        description: "Tests in .test.ts / .spec.ts / __tests__/ files".to_string(),
+        confidence: 1.0,
+        evidence_count: test_count,
+        extracted_at: now,
+    })
+}

--- a/crates/spelunk-core/src/conventions/rules/typescript.rs
+++ b/crates/spelunk-core/src/conventions/rules/typescript.rs
@@ -35,7 +35,14 @@ pub fn extract(chunks: &[&ChunkSummary], now: i64) -> Vec<ConventionRecord> {
     let fn_names = function_names(chunks);
     let (snake, camel, pascal, screaming, total_fn) = count_cases(&fn_names);
     let (dom_style, dom_count) = dominant(snake, camel, pascal, screaming);
-    if let Some(r) = naming_record(lang, "naming.functions", dom_style, dom_count, total_fn, now) {
+    if let Some(r) = naming_record(
+        lang,
+        "naming.functions",
+        dom_style,
+        dom_count,
+        total_fn,
+        now,
+    ) {
         records.push(r);
     }
 
@@ -98,7 +105,7 @@ fn async_record(chunks: &[&ChunkSummary], lang: &str, now: i64) -> Option<Conven
     Some(ConventionRecord {
         language: lang.to_string(),
         category: "async".to_string(),
-        description: "Async/await is widely used".to_string(),
+        description: "async/await is widely used".to_string(),
         confidence: ratio,
         evidence_count: async_count,
         extracted_at: now,

--- a/crates/spelunk-core/src/lib.rs
+++ b/crates/spelunk-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod backends;
 pub mod capability;
 pub mod config;
+pub mod conventions;
 pub mod embeddings;
 pub mod error;
 pub mod indexer;

--- a/crates/spelunk-core/src/storage/conventions.rs
+++ b/crates/spelunk-core/src/storage/conventions.rs
@@ -1,0 +1,181 @@
+//! Storage methods for the `conventions` table.
+//!
+//! All SQL uses parameterised queries — no string formatting into SQL.
+//! This module deliberately does NOT import from `crate::conventions` to avoid
+//! a circular dependency (conventions::mod imports Database from here).
+
+use anyhow::Result;
+
+use super::Database;
+
+/// Lightweight row returned by `all_chunks_for_conventions`.
+///
+/// Mirrors `crate::conventions::extractor::ChunkSummary` but lives in the
+/// storage layer so neither module depends on the other.
+#[derive(Debug, Clone)]
+pub struct RawChunkRow {
+    pub language: String,
+    pub node_type: String,
+    pub name: Option<String>,
+    pub content: String,
+    pub file_path: String,
+}
+
+/// A stored convention record — mirrors `crate::conventions::ConventionRecord`.
+///
+/// Duplicating the struct here would require keeping two types in sync, so we
+/// use a plain tuple for insert (caller passes fields), and define a concrete
+/// return struct that re-exports to `crate::conventions`.
+#[derive(Debug, Clone)]
+pub struct ConventionRow {
+    pub language: String,
+    pub category: String,
+    pub description: String,
+    pub confidence: f32,
+    pub evidence_count: u32,
+    pub extracted_at: i64,
+}
+
+impl Database {
+    /// Apply the conventions table migration. Idempotent (`IF NOT EXISTS`).
+    pub fn apply_conventions_migration(&self) -> Result<()> {
+        self.conn
+            .execute_batch(include_str!("../../migrations/019_conventions.sql"))
+            .map_err(|e| anyhow::anyhow!("running conventions migration: {e}"))?;
+        Ok(())
+    }
+
+    /// Return all chunks in a compact form suitable for convention extraction.
+    ///
+    /// Detects whether a chunk has a doc comment by checking whether its
+    /// content starts with a recognised doc-comment prefix.
+    pub fn all_chunks_for_conventions(&self) -> Result<Vec<RawChunkRow>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT c.node_type,
+                    c.name,
+                    c.content,
+                    f.path,
+                    COALESCE(f.language, 'unknown')
+             FROM chunks c
+             JOIN files f ON f.id = c.file_id
+             ORDER BY c.id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(RawChunkRow {
+                node_type: row.get(0)?,
+                name: row.get(1)?,
+                content: row.get(2)?,
+                file_path: row.get(3)?,
+                language: row.get(4)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// Replace all convention records with `records`.
+    ///
+    /// Runs inside a single transaction: DELETE + batch INSERT.
+    /// All SQL is parameterised — no format! calls.
+    pub fn replace_conventions(&self, records: &[ConventionRow]) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute("DELETE FROM conventions", [])?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO conventions
+                 (language, category, description, confidence, evidence_count, extracted_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )?;
+            for r in records {
+                stmt.execute(rusqlite::params![
+                    r.language,
+                    r.category,
+                    r.description,
+                    r.confidence,
+                    r.evidence_count as i64,
+                    r.extracted_at,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Fetch all stored convention rows, optionally filtered by language.
+    pub fn list_conventions(&self, language: Option<&str>) -> Result<Vec<ConventionRow>> {
+        let rows: Vec<ConventionRow> = if let Some(lang) = language {
+            let mut stmt = self.conn.prepare_cached(
+                "SELECT language, category, description, confidence, evidence_count, extracted_at
+                 FROM conventions
+                 WHERE language = ?1
+                 ORDER BY confidence DESC",
+            )?;
+            stmt.query_map(rusqlite::params![lang], map_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?
+        } else {
+            let mut stmt = self.conn.prepare_cached(
+                "SELECT language, category, description, confidence, evidence_count, extracted_at
+                 FROM conventions
+                 ORDER BY language, confidence DESC",
+            )?;
+            stmt.query_map([], map_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?
+        };
+        Ok(rows)
+    }
+}
+
+fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ConventionRow> {
+    Ok(ConventionRow {
+        language: row.get(0)?,
+        category: row.get(1)?,
+        description: row.get(2)?,
+        confidence: row.get(3)?,
+        evidence_count: row.get::<_, i64>(4)? as u32,
+        extracted_at: row.get(5)?,
+    })
+}
+
+// ── Doc-comment detection ─────────────────────────────────────────────────────
+
+/// Returns `true` if `content` starts with any common doc-comment prefix.
+pub fn has_doc_prefix(content: &str) -> bool {
+    let trimmed = content.trim_start();
+    trimmed.starts_with("///")
+        || trimmed.starts_with("//!")
+        || trimmed.starts_with("/**")
+        || trimmed.starts_with("/*!")
+        || trimmed.starts_with("\"\"\"")
+        || trimmed.starts_with("'''")
+        || trimmed.starts_with("* ")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_doc_prefix_rust_triple_slash() {
+        assert!(has_doc_prefix("/// Does the thing"));
+        assert!(has_doc_prefix("//! Crate-level doc"));
+    }
+
+    #[test]
+    fn has_doc_prefix_jsdoc() {
+        assert!(has_doc_prefix("/** JSDoc block */"));
+        assert!(has_doc_prefix("/*!  JSDoc bang */"));
+    }
+
+    #[test]
+    fn has_doc_prefix_python_docstring() {
+        assert!(has_doc_prefix(r#""""Return the answer.""""#));
+    }
+
+    #[test]
+    fn has_doc_prefix_negative() {
+        assert!(!has_doc_prefix("// plain comment"));
+        assert!(!has_doc_prefix("fn foo() {}"));
+    }
+}

--- a/crates/spelunk-core/src/storage/db.rs
+++ b/crates/spelunk-core/src/storage/db.rs
@@ -37,6 +37,7 @@ impl Database {
         db.apply_snapshot_migration()?;
         db.apply_snapshot_vector_migration()?;
         db.apply_compound_graph_idx_migration()?;
+        db.apply_conventions_migration()?;
         Ok(db)
     }
 

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -8,6 +8,7 @@ pub mod remote;
 
 // Storage sub-modules: each holds impl blocks for Database or standalone types.
 mod chunks;
+mod conventions;
 mod files;
 mod graph;
 mod search;
@@ -16,6 +17,7 @@ mod specs;
 mod stats;
 
 pub use backend::{LocalMemoryBackend, MemoryBackend, NoteInput};
+pub use conventions::{ConventionRow, RawChunkRow, has_doc_prefix};
 pub use db::Database;
 pub use files::FileRecord;
 pub use git_meta::GitMetaBackend;

--- a/crates/spelunk-core/tests/conventions.rs
+++ b/crates/spelunk-core/tests/conventions.rs
@@ -1,0 +1,426 @@
+//! Integration and unit tests for convention extraction (#268).
+//!
+//! All tests use in-memory SQLite so they are hermetic (no LLM, no network).
+//! DB tests are annotated `#[serial]` because `sqlite3_auto_extension` is process-global.
+
+mod common;
+
+use serial_test::serial;
+
+use spelunk_core::conventions::{
+    ConventionRecord,
+    extractor::{ChunkSummary, ConventionExtractor},
+    run_extraction,
+};
+use spelunk_core::storage::ConventionRow;
+
+// ── Helper builders ───────────────────────────────────────────────────────────
+
+fn rust_fn(name: &str, content: &str) -> ChunkSummary {
+    ChunkSummary {
+        language: "rust".into(),
+        node_type: "function".into(),
+        name: Some(name.into()),
+        content: content.into(),
+        file_path: "src/lib.rs".into(),
+        has_docstring: content.trim_start().starts_with("///"),
+    }
+}
+
+fn rust_struct(name: &str) -> ChunkSummary {
+    ChunkSummary {
+        language: "rust".into(),
+        node_type: "struct".into(),
+        name: Some(name.into()),
+        content: format!("struct {name} {{}}"),
+        file_path: "src/lib.rs".into(),
+        has_docstring: false,
+    }
+}
+
+fn ts_fn(name: &str, content: &str) -> ChunkSummary {
+    ChunkSummary {
+        language: "typescript".into(),
+        node_type: "function".into(),
+        name: Some(name.into()),
+        content: content.into(),
+        file_path: "src/index.ts".into(),
+        has_docstring: content.trim_start().starts_with("/**"),
+    }
+}
+
+fn ts_class(name: &str) -> ChunkSummary {
+    ChunkSummary {
+        language: "typescript".into(),
+        node_type: "class".into(),
+        name: Some(name.into()),
+        content: format!("class {name} {{}}"),
+        file_path: "src/models.ts".into(),
+        has_docstring: false,
+    }
+}
+
+fn find_record<'a>(
+    records: &'a [ConventionRecord],
+    category: &str,
+) -> Option<&'a ConventionRecord> {
+    records.iter().find(|r| r.category == category)
+}
+
+// ── Rust: naming conventions ──────────────────────────────────────────────────
+
+#[test]
+fn rust_functions_snake_case() {
+    let chunks: Vec<ChunkSummary> = (0..10)
+        .map(|i| rust_fn(&format!("do_thing_{i}"), "fn do_thing() {}"))
+        .collect();
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let r = find_record(&records, "naming.functions").expect("naming.functions record");
+    assert!(r.confidence >= 0.9, "confidence={}", r.confidence);
+    assert!(
+        r.description.contains("snake_case"),
+        "desc={}",
+        r.description
+    );
+}
+
+#[test]
+fn rust_types_pascal_case() {
+    let chunks: Vec<ChunkSummary> = ["MyStruct", "AnotherOne", "FooBar", "BazQuux", "HelloWorld"]
+        .iter()
+        .map(|n| rust_struct(n))
+        .collect();
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let r = find_record(&records, "naming.types").expect("naming.types record");
+    assert!(
+        r.description.contains("PascalCase"),
+        "desc={}",
+        r.description
+    );
+}
+
+#[test]
+fn rust_error_handling_anyhow() {
+    let content = "use anyhow::Result; fn foo() -> Result<()> { Ok(()) }";
+    let chunks: Vec<ChunkSummary> = (0..8).map(|_| rust_fn("foo", content)).collect();
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let r = find_record(&records, "error_handling").expect("error_handling record");
+    assert!(r.description.contains("anyhow"), "desc={}", r.description);
+}
+
+#[test]
+fn rust_async_runtime_detected() {
+    let content = "use tokio::time; async fn handler() { tokio::spawn(async {}); }";
+    let chunks: Vec<ChunkSummary> = (0..6).map(|_| rust_fn("handler", content)).collect();
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let r = find_record(&records, "async").expect("async record");
+    assert!(r.description.contains("tokio"), "desc={}", r.description);
+}
+
+#[test]
+fn rust_testing_cfg_test() {
+    let content = "#[cfg(test)] mod tests { #[test] fn it_works() {} }";
+    let chunks: Vec<ChunkSummary> = (0..6)
+        .map(|i| {
+            let mut c = rust_fn(&format!("it_works_{i}"), content);
+            c.node_type = "function".into();
+            c
+        })
+        .collect();
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let r = find_record(&records, "testing").expect("testing record");
+    assert!(
+        r.description.contains("cfg(test)"),
+        "desc={}",
+        r.description
+    );
+}
+
+#[test]
+fn rust_doc_coverage_high() {
+    let chunks: Vec<ChunkSummary> = (0..8)
+        .map(|i| rust_fn(&format!("func_{i}"), "/// Does the thing\nfn func() {}"))
+        .chain((0..2).map(|i| rust_fn(&format!("undoc_{i}"), "fn undoc() {}")))
+        .collect();
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let r = find_record(&records, "docs").expect("docs record");
+    assert!(r.description.contains("high"), "desc={}", r.description);
+}
+
+// ── TypeScript: naming conventions ───────────────────────────────────────────
+
+#[test]
+fn ts_functions_camel_case() {
+    let chunks: Vec<ChunkSummary> = [
+        "getUserById",
+        "handleClick",
+        "loadConfig",
+        "renderPage",
+        "fetchData",
+        "parseInput",
+        "validateForm",
+    ]
+    .iter()
+    .map(|n| ts_fn(n, &format!("function {n}() {{}}")))
+    .collect();
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let records = spelunk_core::conventions::rules::typescript::extract(&refs, 0);
+    let r = find_record(&records, "naming.functions").expect("naming.functions record");
+    assert!(
+        r.description.contains("camelCase"),
+        "desc={}",
+        r.description
+    );
+}
+
+#[test]
+fn ts_types_pascal_case() {
+    let chunks: Vec<ChunkSummary> = [
+        "UserService",
+        "ApiClient",
+        "DataModel",
+        "EventBus",
+        "HttpError",
+    ]
+    .iter()
+    .map(|n| ts_class(n))
+    .collect();
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let records = spelunk_core::conventions::rules::typescript::extract(&refs, 0);
+    let r = find_record(&records, "naming.types").expect("naming.types record");
+    assert!(
+        r.description.contains("PascalCase"),
+        "desc={}",
+        r.description
+    );
+}
+
+#[test]
+fn ts_async_usage_detected() {
+    let content = "async function fetchUser() { const data = await fetch('/api/users'); }";
+    let chunks: Vec<ChunkSummary> = (0..6)
+        .map(|i| ts_fn(&format!("fetchUser{i}"), content))
+        .collect();
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let records = spelunk_core::conventions::rules::typescript::extract(&refs, 0);
+    let r = find_record(&records, "async").expect("async record");
+    assert!(r.description.contains("async"), "desc={}", r.description);
+    assert!(r.confidence > 0.2, "confidence={}", r.confidence);
+}
+
+#[test]
+fn ts_testing_spec_files() {
+    let chunks: Vec<ChunkSummary> = (0..5)
+        .map(|i| ChunkSummary {
+            language: "typescript".into(),
+            node_type: "function".into(),
+            name: Some(format!("test_{i}")),
+            content: format!("test('does thing {i}', () => {{}})"),
+            file_path: "src/components/Button.spec.ts".into(),
+            has_docstring: false,
+        })
+        .collect();
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let records = spelunk_core::conventions::rules::typescript::extract(&refs, 0);
+    let r = find_record(&records, "testing").expect("testing record");
+    assert!(r.description.contains("spec.ts"), "desc={}", r.description);
+}
+
+// ── ConventionExtractor: multi-language dispatch ──────────────────────────────
+
+#[test]
+fn extractor_dispatches_by_language() {
+    let rust_chunks: Vec<ChunkSummary> = (0..10)
+        .map(|i| rust_fn(&format!("rust_fn_{i}"), "fn rust_fn() {}"))
+        .collect();
+    let ts_chunks: Vec<ChunkSummary> = (0..10)
+        .map(|i| ts_fn(&format!("tsFn{i}"), "function tsFn() {}"))
+        .collect();
+    let all: Vec<ChunkSummary> = rust_chunks.into_iter().chain(ts_chunks).collect();
+
+    let records = ConventionExtractor::new().extract(&all);
+    let rust_records: Vec<_> = records.iter().filter(|r| r.language == "rust").collect();
+    let ts_records: Vec<_> = records
+        .iter()
+        .filter(|r| r.language == "typescript")
+        .collect();
+    assert!(!rust_records.is_empty(), "should have Rust records");
+    assert!(!ts_records.is_empty(), "should have TypeScript records");
+}
+
+#[test]
+fn extractor_handles_empty_input() {
+    let records = ConventionExtractor::new().extract(&[]);
+    assert!(records.is_empty());
+}
+
+// ── DB round-trip: replace_conventions + list_conventions ─────────────────────
+
+#[test]
+#[serial]
+fn db_round_trip_replace_and_list() {
+    let db = common::open_test_db();
+
+    let rows = vec![
+        ConventionRow {
+            language: "rust".into(),
+            category: "naming.functions".into(),
+            description: "Functions use snake_case".into(),
+            confidence: 0.9,
+            evidence_count: 10,
+            extracted_at: 0,
+        },
+        ConventionRow {
+            language: "typescript".into(),
+            category: "naming.functions".into(),
+            description: "Functions use camelCase".into(),
+            confidence: 0.85,
+            evidence_count: 7,
+            extracted_at: 0,
+        },
+    ];
+    db.replace_conventions(&rows).unwrap();
+
+    let all = db.list_conventions(None).unwrap();
+    assert_eq!(all.len(), 2);
+
+    let rust_only = db.list_conventions(Some("rust")).unwrap();
+    assert_eq!(rust_only.len(), 1);
+    assert_eq!(rust_only[0].description, "Functions use snake_case");
+}
+
+#[test]
+#[serial]
+fn db_replace_is_idempotent() {
+    let db = common::open_test_db();
+    let row = ConventionRow {
+        language: "rust".into(),
+        category: "testing".into(),
+        description: "Tests in #[cfg(test)] inline modules".into(),
+        confidence: 0.8,
+        evidence_count: 6,
+        extracted_at: 1000,
+    };
+    db.replace_conventions(std::slice::from_ref(&row)).unwrap();
+    db.replace_conventions(std::slice::from_ref(&row)).unwrap();
+
+    let all = db.list_conventions(None).unwrap();
+    assert_eq!(all.len(), 1, "replace should delete old records first");
+}
+
+#[test]
+#[serial]
+fn db_list_conventions_empty_when_none_stored() {
+    let db = common::open_test_db();
+    let all = db.list_conventions(None).unwrap();
+    assert!(all.is_empty());
+}
+
+// ── End-to-end: run_extraction via DB ─────────────────────────────────────────
+
+#[test]
+#[serial]
+fn run_extraction_end_to_end() {
+    let db = common::open_test_db();
+
+    // Seed 10 Rust snake_case functions.
+    let rust_file_id = db.upsert_file("src/lib.rs", Some("rust"), "hash1").unwrap();
+    for i in 0..10 {
+        db.insert_chunk(
+            rust_file_id,
+            "function",
+            Some(&format!("rust_fn_{i}")),
+            i,
+            i + 5,
+            "fn rust_fn() {}",
+            None,
+            10,
+        )
+        .unwrap();
+    }
+
+    // Seed 10 TypeScript camelCase functions.
+    let ts_file_id = db
+        .upsert_file("src/index.ts", Some("typescript"), "hash2")
+        .unwrap();
+    for i in 0..10 {
+        db.insert_chunk(
+            ts_file_id,
+            "function",
+            Some(&format!("tsFn{i}")),
+            i,
+            i + 3,
+            "function tsFn() {}",
+            None,
+            8,
+        )
+        .unwrap();
+    }
+
+    let records = run_extraction(&db).unwrap();
+    // After confidence/evidence filtering (>= 0.5, >= 5 evidence), expect results.
+    assert!(!records.is_empty(), "extraction should produce records");
+
+    let rust_naming = records
+        .iter()
+        .find(|r| r.language == "rust" && r.category == "naming.functions");
+    let ts_naming = records
+        .iter()
+        .find(|r| r.language == "typescript" && r.category == "naming.functions");
+    assert!(rust_naming.is_some(), "should detect Rust function naming");
+    assert!(
+        ts_naming.is_some(),
+        "should detect TypeScript function naming"
+    );
+}
+
+// ── list_conventions API wrapper ──────────────────────────────────────────────
+
+#[test]
+#[serial]
+fn list_conventions_wrapper_converts_correctly() {
+    let db = common::open_test_db();
+    let rows = vec![ConventionRow {
+        language: "rust".into(),
+        category: "async".into(),
+        description: "Async runtime: tokio".into(),
+        confidence: 0.75,
+        evidence_count: 8,
+        extracted_at: 42,
+    }];
+    db.replace_conventions(&rows).unwrap();
+
+    let records = spelunk_core::conventions::list_conventions(&db, None).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].language, "rust");
+    assert_eq!(records[0].category, "async");
+    assert_eq!(records[0].extracted_at, 42);
+}
+
+// ── Confidence filtering ──────────────────────────────────────────────────────
+
+#[test]
+fn extractor_emits_low_evidence_raw_records() {
+    // The extractor emits records regardless of evidence count.
+    // run_extraction applies the filter (>= 0.5 confidence AND >= 5 evidence).
+    // With 2 evidence points the evidence_count should be < 5.
+    let chunks = [
+        rust_fn("small_set_a", "fn small_set_a() {}"),
+        rust_fn("small_set_b", "fn small_set_b() {}"),
+    ];
+    let refs: Vec<&ChunkSummary> = chunks.iter().collect();
+    let raw = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    if let Some(r) = raw.iter().find(|r| r.category == "naming.functions") {
+        assert!(
+            r.evidence_count < 5,
+            "evidence_count={} should be below threshold",
+            r.evidence_count
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **Zero-LLM convention extraction**: after `spelunk index`, a new Phase 5 pass derives coding conventions directly from tree-sitter AST chunks
- **Rule sets for Rust & TypeScript** (+ generic fallback): naming case detection (snake_case / camelCase / PascalCase), async usage ratio, testing framework pattern, doc coverage percentage
- **DB storage**: new `conventions` table (migration 019), `replace_conventions` / `list_conventions` DB methods
- **CLI surface**: `spelunk context` gains a conventions section (text + JSON); `--no-conventions` flag to skip; `--index-db` flag for non-default DB paths
- **18 integration tests** — all green, full coverage of Rust + TypeScript rules, DB round-trips, confidence filtering, end-to-end `run_extraction`

## Test plan

- [x] `cargo test -p spelunk-core --test conventions` → 18/18 passing
- [x] `cargo clippy -p spelunk-core -- -D warnings` → clean
- [x] `cargo fmt --check` → clean (pre-commit hook verified)
- [ ] Manual: `spelunk index . && spelunk context` on a TypeScript project — verify conventions section appears
- [ ] Manual: `spelunk context --no-conventions` — verify section is omitted

## Notes

Confidence filter: records with `confidence < 0.5` OR `evidence_count < 5` are dropped before DB write, avoiding noise from tiny repos.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)