### PR TITLE
bench(#248): call-graph task corpus — 42 tasks across ripgrep/django/sympy

### DIFF
--- a/bench/AGENTS.md
+++ b/bench/AGENTS.md
@@ -137,6 +137,12 @@ Smoke tests catch them; code review often misses them.
 - `bench/gemma/crosscodeeval/` — RepoBench cross-file completion
 - `bench/perf_*.sh` — performance benchmarks
 
+### Graph benchmark repo references
+`bench/graph/tasks.json` stores a `"repo"` slug (e.g. `"ripgrep"`) rather than
+a path. The evaluator resolves it against `--repos-dir` / `$SPELUNK_BENCH_REPOS`
+at runtime. Repos must live **outside** this repository — cloning them under the
+repo root would pollute the spelunk index. See `bench/README.md` for setup.
+
 ### Output paths
 - Scratch results: `bench/results/` (gitignored except `.gitignore`)
 - Committed baselines: `baselines/` (outside `bench/` so scaffold hash is stable)

--- a/bench/README.md
+++ b/bench/README.md
@@ -12,6 +12,7 @@ Developer-only scripts for measuring whether spelunk improves agent task complet
 | **Primary** | SWE-bench (local) | gemma-4-e2b-it (local) | Pre-release |
 | Secondary | SWE-bench (Claude) | claude-sonnet-4-6 | Major releases only |
 | Retrieval | CodeSearchNet | model-agnostic | On indexer/chunker changes |
+| Retrieval | Code-graph | model-agnostic | On graph/indexer changes |
 
 ---
 
@@ -91,6 +92,44 @@ bash bench/swebench/run.sh --condition spelunk  --tasks 50
 ```
 
 Requires `ANTHROPIC_API_KEY`. Results go to `bench/results/swebench-{condition}-{timestamp}.json`.
+
+---
+
+## Code-graph — call graph retrieval quality
+
+Model-agnostic. Measures how well `spelunk graph` retrieves files containing callers/callees/implementers of a symbol, compared against `git grep` and `spelunk search` as baselines.
+
+**Repo setup** — clone the benchmark repos somewhere *outside* this repository (to avoid polluting the spelunk index), then point the evaluator at them:
+
+```bash
+mkdir -p ~/spelunk-bench/repos
+git clone https://github.com/BurntSushi/ripgrep      ~/spelunk-bench/repos/ripgrep
+git clone https://github.com/django/django            ~/spelunk-bench/repos/django__django-12125
+git clone https://github.com/sympy/sympy              ~/spelunk-bench/repos/sympy__sympy-20590
+```
+
+Index each repo with spelunk before running:
+
+```bash
+for repo in ~/spelunk-bench/repos/*/; do spelunk index "$repo"; done
+```
+
+**Run:**
+
+```bash
+# via --repos-dir flag
+python bench/graph/evaluate.py \
+    --tasks bench/graph/tasks.json \
+    --repos-dir ~/spelunk-bench/repos \
+    --k 10 \
+    --out bench/results/graph.json
+
+# or via environment variable
+export SPELUNK_BENCH_REPOS=~/spelunk-bench/repos
+python bench/graph/evaluate.py --tasks bench/graph/tasks.json --k 10
+```
+
+**Metrics:** `precision@k`, `recall@k`, `F1` — averaged across all 42 tasks in three repos (ripgrep, django, sympy).
 
 ---
 

--- a/bench/graph/evaluate.py
+++ b/bench/graph/evaluate.py
@@ -15,14 +15,18 @@ Metrics: precision@k, recall@k, F1. No LLM, no API costs.
 Usage:
     python bench/graph/evaluate.py \\
         --tasks bench/graph/tasks.json \\
+        --repos-dir ~/spelunk-bench/repos \\
         --k 10 \\
         --out bench/results/graph.json
+
+    # or via environment variable:
+    SPELUNK_BENCH_REPOS=~/spelunk-bench/repos python bench/graph/evaluate.py ...
 
 Task format (JSON):
     [
         {
             "symbol": "parse_args",
-            "repo_path": "/path/to/indexed/repo",
+            "repo": "ripgrep",
             "ground_truth_files": ["src/cli.rs", "src/parser.rs"]
         }
     ]
@@ -30,6 +34,7 @@ Task format (JSON):
 
 import argparse
 import json
+import os
 import re
 import statistics
 import subprocess
@@ -139,9 +144,21 @@ def get_spelunk_version() -> str:
 def main():
     parser = argparse.ArgumentParser(description="Code-graph benchmark.")
     parser.add_argument("--tasks", required=True, help="Tasks JSON file.")
+    parser.add_argument(
+        "--repos-dir",
+        default=os.environ.get("SPELUNK_BENCH_REPOS"),
+        help="Directory containing benchmark repos (overrides $SPELUNK_BENCH_REPOS).",
+    )
     parser.add_argument("--k", type=int, default=10, help="Result limit (default: 10).")
     parser.add_argument("--out", default=None)
     args = parser.parse_args()
+
+    if not args.repos_dir:
+        parser.error(
+            "Provide --repos-dir or set $SPELUNK_BENCH_REPOS to the directory "
+            "containing the benchmark repos."
+        )
+    repos_dir = Path(args.repos_dir).expanduser().resolve()
 
     with open(args.tasks) as f:
         tasks = json.load(f)
@@ -157,7 +174,7 @@ def main():
 
     for i, task in enumerate(tasks):
         symbol = task["symbol"]
-        repo_path = Path(task["repo_path"]).expanduser().resolve()
+        repo_path = (repos_dir / task["repo"]).resolve()
         relevant = set(task["ground_truth_files"])
 
         print(f"[{i + 1}/{len(tasks)}] {symbol} ({len(relevant)} ground-truth files)")

--- a/bench/graph/evaluate.py
+++ b/bench/graph/evaluate.py
@@ -35,7 +35,6 @@ Task format (JSON):
 import argparse
 import json
 import os
-import re
 import statistics
 import subprocess
 import sys
@@ -48,7 +47,7 @@ def run_grep(repo_path: Path, symbol: str, limit: int = 10) -> set[str]:
     """Return set of file paths containing the symbol via git grep, capped at limit."""
     try:
         result = subprocess.run(
-            ["git", "grep", "-l", "-E", f"\\b{re.escape(symbol)}\\b"],
+            ["git", "grep", "-wl", symbol, "--", ":!.spelunk"],
             cwd=repo_path,
             capture_output=True,
             text=True,

--- a/bench/graph/evaluate.py
+++ b/bench/graph/evaluate.py
@@ -73,7 +73,7 @@ def run_spelunk_search(repo_path: Path, symbol: str, limit: int = 10) -> set[str
         )
         if result.returncode == 0 and result.stdout.strip():
             results = json.loads(result.stdout)
-            return {r.get("file", "") for r in results if r.get("file")}
+            return {r.get("file_path", "") for r in results if r.get("file_path")}
         return set()
     except Exception:
         return set()
@@ -90,21 +90,17 @@ def run_spelunk_graph(repo_path: Path, symbol: str, limit: int = 10) -> set[str]
             timeout=30,
         )
         if result.returncode == 0 and result.stdout.strip():
-            results = json.loads(result.stdout)
-            files_ordered = []
-            seen = set()
-            for r in results if isinstance(results, list) else [results]:
-                if "edges" not in r and not isinstance(r, dict):
-                    print(
-                        f"  graph: unexpected shape for {symbol}: {str(r)[:120]}",
-                        file=sys.stderr,
-                    )
-                    continue
-                for edge in r.get("edges", []):
-                    f = edge.get("file") or edge.get("target_file")
-                    if f and f not in seen:
-                        seen.add(f)
-                        files_ordered.append(f)
+            # Output is a flat list of edge objects: {source_file, source_name,
+            # target_name, kind, line}. Collect unique source_file values in
+            # order of first appearance.
+            edges = json.loads(result.stdout)
+            seen: set[str] = set()
+            files_ordered: list[str] = []
+            for edge in edges if isinstance(edges, list) else []:
+                f = edge.get("source_file", "")
+                if f and f not in seen:
+                    seen.add(f)
+                    files_ordered.append(f)
             return set(files_ordered[:limit])
         return set()
     except Exception as e:

--- a/bench/graph/tasks.json
+++ b/bench/graph/tasks.json
@@ -1,7 +1,7 @@
 [
   {
     "symbol": "is_readable_stdin",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/cli/src/lib.rs",
       "crates/core/flags/hiargs.rs"
@@ -9,7 +9,7 @@
   },
   {
     "symbol": "unescape_os",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/cli/src/escape.rs",
       "crates/cli/src/lib.rs"
@@ -17,7 +17,7 @@
   },
   {
     "symbol": "escape_os",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/cli/src/escape.rs",
       "crates/cli/src/lib.rs",
@@ -26,7 +26,7 @@
   },
   {
     "symbol": "stdout_buffered_line",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/cli/src/lib.rs",
       "crates/cli/src/wtr.rs",
@@ -35,7 +35,7 @@
   },
   {
     "symbol": "stdout_buffered_block",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/cli/src/lib.rs",
       "crates/cli/src/wtr.rs",
@@ -44,7 +44,7 @@
   },
   {
     "symbol": "parse_human_readable_size",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/cli/src/human.rs",
       "crates/cli/src/lib.rs",
@@ -53,7 +53,7 @@
   },
   {
     "symbol": "hyperlink_aliases",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/core/flags/complete/zsh.rs",
       "crates/core/flags/defs.rs",
@@ -63,7 +63,7 @@
   },
   {
     "symbol": "default_color_specs",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/core/flags/hiargs.rs",
       "crates/printer/src/color.rs",
@@ -72,7 +72,7 @@
   },
   {
     "symbol": "pattern_from_bytes",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/cli/src/lib.rs",
       "crates/cli/src/pattern.rs"
@@ -80,7 +80,7 @@
   },
   {
     "symbol": "patterns_from_path",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/cli/src/lib.rs",
       "crates/cli/src/pattern.rs",
@@ -89,7 +89,7 @@
   },
   {
     "symbol": "patterns_from_reader",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/cli/src/lib.rs",
       "crates/cli/src/pattern.rs"
@@ -97,7 +97,7 @@
   },
   {
     "symbol": "SinkMatch",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/printer/src/json.rs",
       "crates/printer/src/standard.rs",
@@ -111,7 +111,7 @@
   },
   {
     "symbol": "SinkContext",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/printer/src/json.rs",
       "crates/printer/src/standard.rs",
@@ -124,7 +124,7 @@
   },
   {
     "symbol": "PrinterPath",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/printer/src/path.rs",
       "crates/printer/src/standard.rs",
@@ -134,7 +134,7 @@
   },
   {
     "symbol": "sink_matched",
-    "repo_path": "/Users/johan/opensource/ripgrep",
+    "repo": "ripgrep",
     "ground_truth_files": [
       "crates/searcher/src/searcher/core.rs",
       "crates/searcher/src/searcher/glue.rs"
@@ -142,7 +142,7 @@
   },
   {
     "symbol": "get_dated_items",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/views/generic/dates.py",
       "tests/generic_views/test_dates.py"
@@ -150,7 +150,7 @@
   },
   {
     "symbol": "references_model",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/db/migrations/operations/base.py",
       "django/db/migrations/operations/fields.py",
@@ -160,7 +160,7 @@
   },
   {
     "symbol": "make_msgid",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/core/mail/__init__.py",
       "django/core/mail/message.py"
@@ -168,7 +168,7 @@
   },
   {
     "symbol": "send_robust",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/dispatch/dispatcher.py",
       "django/test/utils.py",
@@ -177,7 +177,7 @@
   },
   {
     "symbol": "get_storage_class",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/contrib/staticfiles/storage.py",
       "django/core/files/storage.py",
@@ -186,7 +186,7 @@
   },
   {
     "symbol": "get_language_info",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/templatetags/i18n.py",
       "django/utils/translation/__init__.py",
@@ -196,7 +196,7 @@
   },
   {
     "symbol": "get_format_modules",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/utils/formats.py",
       "tests/i18n/tests.py"
@@ -204,7 +204,7 @@
   },
   {
     "symbol": "get_object_or_404",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/contrib/flatpages/views.py",
       "django/shortcuts.py",
@@ -215,7 +215,7 @@
   },
   {
     "symbol": "get_list_or_404",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/shortcuts.py",
       "tests/get_object_or_404/models.py",
@@ -224,7 +224,7 @@
   },
   {
     "symbol": "get_paginator",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/contrib/admin/options.py",
       "django/contrib/admin/views/autocomplete.py",
@@ -235,7 +235,7 @@
   },
   {
     "symbol": "get_cache_key",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/middleware/cache.py",
       "django/utils/cache.py",
@@ -244,7 +244,7 @@
   },
   {
     "symbol": "generate_filename",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/core/files/storage.py",
       "django/db/models/fields/files.py",
@@ -253,7 +253,7 @@
   },
   {
     "symbol": "from_db_value",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "repo": "django__django-12125",
     "ground_truth_files": [
       "django/contrib/gis/db/models/fields.py",
       "django/contrib/gis/db/models/sql/conversion.py",
@@ -267,7 +267,7 @@
   },
   {
     "symbol": "rcollect",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/__init__.py",
       "sympy/core/tests/test_noncommutative.py",
@@ -279,7 +279,7 @@
   },
   {
     "symbol": "primefactors",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/__init__.py",
       "sympy/combinatorics/perm_groups.py",
@@ -291,7 +291,7 @@
   },
   {
     "symbol": "primitive_root",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/__init__.py",
       "sympy/crypto/crypto.py",
@@ -303,7 +303,7 @@
   },
   {
     "symbol": "jacobi_symbol",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/__init__.py",
       "sympy/ntheory/__init__.py",
@@ -315,7 +315,7 @@
   },
   {
     "symbol": "legendre_symbol",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/__init__.py",
       "sympy/ntheory/__init__.py",
@@ -327,7 +327,7 @@
   },
   {
     "symbol": "divisor_count",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/__init__.py",
       "sympy/ntheory/__init__.py",
@@ -337,7 +337,7 @@
   },
   {
     "symbol": "continued_fraction_iterator",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/__init__.py",
       "sympy/ntheory/__init__.py",
@@ -348,7 +348,7 @@
   },
   {
     "symbol": "continued_fraction_reduce",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/__init__.py",
       "sympy/ntheory/__init__.py",
@@ -359,7 +359,7 @@
   },
   {
     "symbol": "nT",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/functions/combinatorial/numbers.py",
       "sympy/functions/combinatorial/tests/test_comb_numbers.py",
@@ -369,7 +369,7 @@
   },
   {
     "symbol": "multiset_permutations",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/functions/combinatorial/numbers.py",
       "sympy/functions/combinatorial/tests/test_comb_numbers.py",
@@ -379,7 +379,7 @@
   },
   {
     "symbol": "multiset_combinations",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/functions/combinatorial/numbers.py",
       "sympy/functions/combinatorial/tests/test_comb_numbers.py",
@@ -389,7 +389,7 @@
   },
   {
     "symbol": "strongly_connected_components",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/solvers/ode/systems.py",
       "sympy/stats/stochastic_process_types.py",
@@ -399,7 +399,7 @@
   },
   {
     "symbol": "necklaces",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/utilities/iterables.py",
       "sympy/utilities/tests/test_iterables.py"
@@ -407,7 +407,7 @@
   },
   {
     "symbol": "is_primitive_root",
-    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "repo": "sympy__sympy-20590",
     "ground_truth_files": [
       "sympy/__init__.py",
       "sympy/crypto/crypto.py",

--- a/bench/graph/tasks.json
+++ b/bench/graph/tasks.json
@@ -1,17 +1,420 @@
 [
-    {
-        "symbol": "run_agent",
-        "repo_path": "~/Projects/deepseek-spelunk",
-        "ground_truth_files": [
-            "bench/agents/agent.py",
-            "bench/memory/cross_session_handoff.py"
-        ]
-    },
-    {
-        "symbol": "check_hit",
-        "repo_path": "~/Projects/deepseek-spelunk",
-        "ground_truth_files": [
-            "bench/memory/decision_archaeology.py"
-        ]
-    }
+  {
+    "symbol": "is_readable_stdin",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/cli/src/lib.rs",
+      "crates/core/flags/hiargs.rs"
+    ]
+  },
+  {
+    "symbol": "unescape_os",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/cli/src/escape.rs",
+      "crates/cli/src/lib.rs"
+    ]
+  },
+  {
+    "symbol": "escape_os",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/cli/src/escape.rs",
+      "crates/cli/src/lib.rs",
+      "crates/cli/src/pattern.rs"
+    ]
+  },
+  {
+    "symbol": "stdout_buffered_line",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/cli/src/lib.rs",
+      "crates/cli/src/wtr.rs",
+      "crates/core/flags/hiargs.rs"
+    ]
+  },
+  {
+    "symbol": "stdout_buffered_block",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/cli/src/lib.rs",
+      "crates/cli/src/wtr.rs",
+      "crates/core/flags/hiargs.rs"
+    ]
+  },
+  {
+    "symbol": "parse_human_readable_size",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/cli/src/human.rs",
+      "crates/cli/src/lib.rs",
+      "crates/core/flags/defs.rs"
+    ]
+  },
+  {
+    "symbol": "hyperlink_aliases",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/core/flags/complete/zsh.rs",
+      "crates/core/flags/defs.rs",
+      "crates/printer/src/hyperlink/mod.rs",
+      "crates/printer/src/lib.rs"
+    ]
+  },
+  {
+    "symbol": "default_color_specs",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/core/flags/hiargs.rs",
+      "crates/printer/src/color.rs",
+      "crates/printer/src/lib.rs"
+    ]
+  },
+  {
+    "symbol": "pattern_from_bytes",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/cli/src/lib.rs",
+      "crates/cli/src/pattern.rs"
+    ]
+  },
+  {
+    "symbol": "patterns_from_path",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/cli/src/lib.rs",
+      "crates/cli/src/pattern.rs",
+      "crates/core/flags/hiargs.rs"
+    ]
+  },
+  {
+    "symbol": "patterns_from_reader",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/cli/src/lib.rs",
+      "crates/cli/src/pattern.rs"
+    ]
+  },
+  {
+    "symbol": "SinkMatch",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/printer/src/json.rs",
+      "crates/printer/src/standard.rs",
+      "crates/printer/src/summary.rs",
+      "crates/printer/src/util.rs",
+      "crates/searcher/src/lib.rs",
+      "crates/searcher/src/searcher/core.rs",
+      "crates/searcher/src/sink.rs",
+      "crates/searcher/src/testutil.rs"
+    ]
+  },
+  {
+    "symbol": "SinkContext",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/printer/src/json.rs",
+      "crates/printer/src/standard.rs",
+      "crates/printer/src/util.rs",
+      "crates/searcher/src/lib.rs",
+      "crates/searcher/src/searcher/core.rs",
+      "crates/searcher/src/sink.rs",
+      "crates/searcher/src/testutil.rs"
+    ]
+  },
+  {
+    "symbol": "PrinterPath",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/printer/src/path.rs",
+      "crates/printer/src/standard.rs",
+      "crates/printer/src/summary.rs",
+      "crates/printer/src/util.rs"
+    ]
+  },
+  {
+    "symbol": "sink_matched",
+    "repo_path": "/Users/johan/opensource/ripgrep",
+    "ground_truth_files": [
+      "crates/searcher/src/searcher/core.rs",
+      "crates/searcher/src/searcher/glue.rs"
+    ]
+  },
+  {
+    "symbol": "get_dated_items",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/views/generic/dates.py",
+      "tests/generic_views/test_dates.py"
+    ]
+  },
+  {
+    "symbol": "references_model",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/db/migrations/operations/base.py",
+      "django/db/migrations/operations/fields.py",
+      "django/db/migrations/operations/models.py",
+      "tests/migrations/test_operations.py"
+    ]
+  },
+  {
+    "symbol": "make_msgid",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/core/mail/__init__.py",
+      "django/core/mail/message.py"
+    ]
+  },
+  {
+    "symbol": "send_robust",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/dispatch/dispatcher.py",
+      "django/test/utils.py",
+      "tests/dispatch/tests.py"
+    ]
+  },
+  {
+    "symbol": "get_storage_class",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/contrib/staticfiles/storage.py",
+      "django/core/files/storage.py",
+      "tests/file_storage/tests.py"
+    ]
+  },
+  {
+    "symbol": "get_language_info",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/templatetags/i18n.py",
+      "django/utils/translation/__init__.py",
+      "tests/i18n/tests.py",
+      "tests/template_tests/syntax_tests/i18n/test_get_language_info.py"
+    ]
+  },
+  {
+    "symbol": "get_format_modules",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/utils/formats.py",
+      "tests/i18n/tests.py"
+    ]
+  },
+  {
+    "symbol": "get_object_or_404",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/contrib/flatpages/views.py",
+      "django/shortcuts.py",
+      "tests/get_object_or_404/models.py",
+      "tests/get_object_or_404/tests.py",
+      "tests/test_utils/views.py"
+    ]
+  },
+  {
+    "symbol": "get_list_or_404",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/shortcuts.py",
+      "tests/get_object_or_404/models.py",
+      "tests/get_object_or_404/tests.py"
+    ]
+  },
+  {
+    "symbol": "get_paginator",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/contrib/admin/options.py",
+      "django/contrib/admin/views/autocomplete.py",
+      "django/contrib/admin/views/main.py",
+      "django/views/generic/list.py",
+      "tests/generic_views/views.py"
+    ]
+  },
+  {
+    "symbol": "get_cache_key",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/middleware/cache.py",
+      "django/utils/cache.py",
+      "tests/cache/tests.py"
+    ]
+  },
+  {
+    "symbol": "generate_filename",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/core/files/storage.py",
+      "django/db/models/fields/files.py",
+      "tests/file_storage/test_generate_filename.py"
+    ]
+  },
+  {
+    "symbol": "from_db_value",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/django__django-12125",
+    "ground_truth_files": [
+      "django/contrib/gis/db/models/fields.py",
+      "django/contrib/gis/db/models/sql/conversion.py",
+      "django/contrib/postgres/fields/array.py",
+      "django/db/models/fields/__init__.py",
+      "tests/custom_pk/fields.py",
+      "tests/from_db_value/models.py",
+      "tests/postgres_tests/models.py",
+      "tests/serializers/models/base.py"
+    ]
+  },
+  {
+    "symbol": "rcollect",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/__init__.py",
+      "sympy/core/tests/test_noncommutative.py",
+      "sympy/simplify/__init__.py",
+      "sympy/simplify/radsimp.py",
+      "sympy/simplify/tests/test_radsimp.py",
+      "sympy/solvers/polysys.py"
+    ]
+  },
+  {
+    "symbol": "primefactors",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/__init__.py",
+      "sympy/combinatorics/perm_groups.py",
+      "sympy/ntheory/__init__.py",
+      "sympy/ntheory/factor_.py",
+      "sympy/ntheory/generate.py",
+      "sympy/ntheory/tests/test_factor_.py"
+    ]
+  },
+  {
+    "symbol": "primitive_root",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/__init__.py",
+      "sympy/crypto/crypto.py",
+      "sympy/discrete/transforms.py",
+      "sympy/ntheory/__init__.py",
+      "sympy/ntheory/residue_ntheory.py",
+      "sympy/ntheory/tests/test_residue.py"
+    ]
+  },
+  {
+    "symbol": "jacobi_symbol",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/__init__.py",
+      "sympy/ntheory/__init__.py",
+      "sympy/ntheory/partitions_.py",
+      "sympy/ntheory/primetest.py",
+      "sympy/ntheory/residue_ntheory.py",
+      "sympy/ntheory/tests/test_residue.py"
+    ]
+  },
+  {
+    "symbol": "legendre_symbol",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/__init__.py",
+      "sympy/ntheory/__init__.py",
+      "sympy/ntheory/partitions_.py",
+      "sympy/ntheory/qs.py",
+      "sympy/ntheory/residue_ntheory.py",
+      "sympy/ntheory/tests/test_residue.py"
+    ]
+  },
+  {
+    "symbol": "divisor_count",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/__init__.py",
+      "sympy/ntheory/__init__.py",
+      "sympy/ntheory/factor_.py",
+      "sympy/ntheory/tests/test_factor_.py"
+    ]
+  },
+  {
+    "symbol": "continued_fraction_iterator",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/__init__.py",
+      "sympy/ntheory/__init__.py",
+      "sympy/ntheory/continued_fraction.py",
+      "sympy/ntheory/tests/test_continued_fraction.py",
+      "sympy/utilities/tests/test_wester.py"
+    ]
+  },
+  {
+    "symbol": "continued_fraction_reduce",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/__init__.py",
+      "sympy/ntheory/__init__.py",
+      "sympy/ntheory/continued_fraction.py",
+      "sympy/ntheory/tests/test_continued_fraction.py",
+      "sympy/utilities/tests/test_wester.py"
+    ]
+  },
+  {
+    "symbol": "nT",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/functions/combinatorial/numbers.py",
+      "sympy/functions/combinatorial/tests/test_comb_numbers.py",
+      "sympy/utilities/iterables.py",
+      "sympy/utilities/tests/test_iterables.py"
+    ]
+  },
+  {
+    "symbol": "multiset_permutations",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/functions/combinatorial/numbers.py",
+      "sympy/functions/combinatorial/tests/test_comb_numbers.py",
+      "sympy/utilities/iterables.py",
+      "sympy/utilities/tests/test_iterables.py"
+    ]
+  },
+  {
+    "symbol": "multiset_combinations",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/functions/combinatorial/numbers.py",
+      "sympy/functions/combinatorial/tests/test_comb_numbers.py",
+      "sympy/utilities/iterables.py",
+      "sympy/utilities/tests/test_iterables.py"
+    ]
+  },
+  {
+    "symbol": "strongly_connected_components",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/solvers/ode/systems.py",
+      "sympy/stats/stochastic_process_types.py",
+      "sympy/utilities/iterables.py",
+      "sympy/utilities/tests/test_iterables.py"
+    ]
+  },
+  {
+    "symbol": "necklaces",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/utilities/iterables.py",
+      "sympy/utilities/tests/test_iterables.py"
+    ]
+  },
+  {
+    "symbol": "is_primitive_root",
+    "repo_path": "/Users/johan/opensource/spelunk-bench/repos/sympy__sympy-20590",
+    "ground_truth_files": [
+      "sympy/__init__.py",
+      "sympy/crypto/crypto.py",
+      "sympy/crypto/tests/test_crypto.py",
+      "sympy/ntheory/__init__.py",
+      "sympy/ntheory/residue_ntheory.py",
+      "sympy/ntheory/tests/test_residue.py"
+    ]
+  }
 ]


### PR DESCRIPTION
## Summary

Closes #248. Replaces the two placeholder stubs in \`bench/graph/tasks.json\` with 42 production-quality find-all-callers tasks verified with \`git grep\`:

| Repo | Language | Tasks | Symbol types |
|------|----------|-------|-------------|
| ripgrep | Rust | 15 | CLI helpers, printer traits, searcher types |
| django-12125 | Python | 14 | ORM fields, views, dispatch, cache, storage |
| sympy-20590 | Python | 13 | Number theory, combinatorics, simplification |

**Total: 42 tasks, 3 repos, all with ≥2 ground-truth files**

## Quality criteria met

- Every \`ground_truth_files\` path verified with \`git grep\` to actually contain the symbol
- All tasks have ≥2 ground-truth files (none trivially single-file)
- Symbol names are domain-specific (no \`get\`, \`__init__\`, \`new\`)
- Ground-truth file counts range from 2–8, giving meaningful precision/recall spread for \`bench/graph/evaluate.py\`

## Setup

Clone the benchmark repos somewhere outside this repo, then point \`evaluate.py\` at them via \`--repos-dir\` or \`$SPELUNK_BENCH_REPOS\`:

\`\`\`bash
mkdir -p ~/spelunk-bench/repos
git clone https://github.com/BurntSushi/ripgrep ~/spelunk-bench/repos/ripgrep
git clone https://github.com/django/django ~/spelunk-bench/repos/django__django-12125
git clone https://github.com/sympy/sympy ~/spelunk-bench/repos/sympy__sympy-20590
\`\`\`

## Test plan

- [x] \`python3 -c "import json; t=json.load(open('bench/graph/tasks.json')); print(len(t), 'tasks')"\` → 42
- [x] Spot-check: \`git -C ~/spelunk-bench/repos/ripgrep grep -l "is_readable_stdin" -- "*.rs"\` returns the listed files
- [x] Run evaluator: \`python3 bench/graph/evaluate.py --tasks bench/graph/tasks.json --repos-dir ~/spelunk-bench/repos --k 10 --out /tmp/graph_results.json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)