### PR TITLE
feat(#261): spelunk-server HTTP API — AuthProvider, embed, explore, plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4999,6 +4999,7 @@ dependencies = [
  "async-trait",
  "axum",
  "clap",
+ "futures-util",
  "pretty_assertions",
  "regex",
  "reqwest 0.12.28",

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -28,8 +28,9 @@ sqlite-vec   = { workspace = true }
 reqwest      = { workspace = true }
 axum         = { version = "0.8", features = ["macros"] }
 tower-http   = { version = "0.6", features = ["auth"] }
-async-stream = "0.3"
-tokio-stream = "0.1"
+async-stream  = "0.3"
+tokio-stream  = "0.1"
+futures-util  = "0.3"
 utoipa       = { version = "5", features = ["axum_extras"] }
 clap         = { version = "4", features = ["derive", "env"] }
 regex        = { version = "1", default-features = false, features = ["std"] }

--- a/crates/spelunk-server/src/auth.rs
+++ b/crates/spelunk-server/src/auth.rs
@@ -1,0 +1,73 @@
+use axum::http::HeaderMap;
+
+/// Determines whether an incoming request is authorised and returns the
+/// caller's identity. Implement this for each auth strategy.
+#[async_trait::async_trait]
+pub trait AuthProvider: Send + Sync + 'static {
+    async fn authenticate(&self, headers: &HeaderMap) -> Result<AuthContext, AuthError>;
+}
+
+/// Outcome of a successful authentication check.
+#[derive(Clone)]
+pub struct AuthContext {
+    pub principal: Principal,
+}
+
+/// Caller identity. Extensible for alternative auth strategies.
+#[derive(Clone)]
+pub enum Principal {
+    /// Default: bearer token matched the configured key.
+    ApiKey(String),
+    /// Future: authenticated user identity (e.g. OAuth2).
+    User { id: String },
+}
+
+/// Authentication failed. Always maps to HTTP 401.
+#[derive(Debug)]
+pub struct AuthError(pub String);
+
+// ── ApiKeyAuth ─────────────────────────────────────────────────────────────────
+
+/// OSS API-key auth provider. Checks for a `Authorization: Bearer <key>` header.
+/// When no key is configured the server accepts all requests (safe on loopback).
+pub struct ApiKeyAuth {
+    /// `None` → accept all requests (no key configured; safe on a local loopback).
+    key: Option<String>,
+}
+
+impl ApiKeyAuth {
+    /// Construct from an explicit key value.
+    pub fn new(key: Option<String>) -> Self {
+        Self { key }
+    }
+
+    /// Construct from the `SPELUNK_SERVER_KEY` environment variable.
+    pub fn from_env() -> Self {
+        Self {
+            key: std::env::var("SPELUNK_SERVER_KEY").ok(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AuthProvider for ApiKeyAuth {
+    async fn authenticate(&self, headers: &HeaderMap) -> Result<AuthContext, AuthError> {
+        match &self.key {
+            None => Ok(AuthContext {
+                principal: Principal::ApiKey(String::new()),
+            }),
+            Some(expected) => {
+                let provided = headers
+                    .get("Authorization")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|v| v.strip_prefix("Bearer "));
+                match provided {
+                    Some(t) if t == expected => Ok(AuthContext {
+                        principal: Principal::ApiKey(t.to_owned()),
+                    }),
+                    _ => Err(AuthError("Unauthorized".into())),
+                }
+            }
+        }
+    }
+}

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -13,9 +13,10 @@ use axum::{
     },
 };
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
 use utoipa::ToSchema;
 
-use super::{AppError, AppState};
+use super::{AppError, AppState, ErrorBody};
 
 // ── Request / Response types ──────────────────────────────────────────────────
 
@@ -75,8 +76,8 @@ fn default_limit() -> usize {
 
 #[derive(Deserialize, ToSchema)]
 pub struct SearchRequest {
-    /// Query embedding vector (must match project's embedding dimension).
-    pub embedding: Vec<f32>,
+    /// Text query — the server encodes this using its configured embedder.
+    pub query: String,
     /// Maximum number of results to return (default: 20).
     #[serde(default = "default_limit")]
     pub limit: usize,
@@ -101,17 +102,42 @@ pub struct SupersedeRequest {
 
 // ── Health ────────────────────────────────────────────────────────────────────
 
+/// Server capabilities reported in the health response.
+#[derive(Serialize, ToSchema)]
+pub struct HealthResponse {
+    /// Always `"ok"`.
+    pub status: &'static str,
+    /// Server version string.
+    pub version: &'static str,
+    /// List of feature capabilities supported by this server instance.
+    pub capabilities: Vec<String>,
+}
+
 /// Server liveness check. No authentication required.
+/// Returns server version and capabilities list.
 #[utoipa::path(
     get,
     path = "/v1/health",
     responses(
-        (status = 200, description = "Server is up", body = str, example = "ok")
+        (status = 200, description = "Server is up", body = HealthResponse)
     ),
     tag = "health"
 )]
-pub async fn health() -> &'static str {
-    "ok"
+pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
+    let mut capabilities = vec!["memory".to_string()];
+    if state.embedder.is_some() {
+        capabilities.push("index.embed".to_string());
+        capabilities.push("search.semantic".to_string());
+    }
+    if state.llm.is_some() {
+        capabilities.push("explore".to_string());
+        capabilities.push("plan".to_string());
+    }
+    Json(HealthResponse {
+        status: "ok",
+        version: env!("CARGO_PKG_VERSION"),
+        capabilities,
+    })
 }
 
 // ── Projects ──────────────────────────────────────────────────────────────────
@@ -154,8 +180,8 @@ pub async fn list_projects(State(state): State<AppState>) -> Result<impl IntoRes
     request_body = AddNoteRequest,
     responses(
         (status = 201, description = "Note created", body = AddNoteResponse),
-        (status = 400, description = "Embedding dimension mismatch"),
-        (status = 401, description = "Unauthorized"),
+        (status = 400, description = "Embedding dimension mismatch", body = ErrorBody),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
         (status = 409, description = "Note stored but conflicts with existing entries", body = AddNoteResponse),
         (status = 422, description = "Entry rejected — prompt injection detected"),
     ),
@@ -280,8 +306,8 @@ pub async fn add_note(
     ),
     responses(
         (status = 200, description = "List of notes", body = Vec<super::db::ServerNote>),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Project not found"),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 404, description = "Project not found", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -312,8 +338,8 @@ pub async fn list_notes(
     ),
     responses(
         (status = 200, description = "Note found", body = super::db::ServerNote),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Note not found"),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 404, description = "Note not found", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -330,7 +356,8 @@ pub async fn get_note(
     }
 }
 
-/// Semantic search over memory entries using a pre-computed query embedding.
+/// Semantic search over memory entries. The server encodes the text query using its
+/// configured embedder. Returns 400 if no embedder is configured.
 #[utoipa::path(
     post,
     path = "/v1/projects/{project_id}/memory/search",
@@ -340,8 +367,9 @@ pub async fn get_note(
     request_body = SearchRequest,
     responses(
         (status = 200, description = "Nearest neighbours", body = Vec<super::db::ServerNote>),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Project not found"),
+        (status = 400, description = "No embedder configured", body = ErrorBody),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 404, description = "Project not found", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -351,9 +379,25 @@ pub async fn search_notes(
     Path(project_id): Path<String>,
     Json(body): Json<SearchRequest>,
 ) -> Result<impl IntoResponse, AppError> {
+    let embedder = state.embedder.as_ref().ok_or_else(|| {
+        AppError::BadRequest(
+            "This server has no embedder configured. Semantic memory search is unavailable."
+                .to_string(),
+        )
+    })?;
+
+    let query_vecs = embedder
+        .embed(&[body.query.as_str()])
+        .await
+        .map_err(AppError::Internal)?;
+    let query_vec = query_vecs
+        .into_iter()
+        .next()
+        .ok_or_else(|| AppError::BadRequest("Embedder returned no vectors".to_string()))?;
+
     let db = state.db.lock().await;
     let project = require_project(&db, &project_id)?;
-    let notes = db.search_notes(project.id, &body.embedding, body.limit)?;
+    let notes = db.search_notes(project.id, &query_vec, body.limit)?;
     Ok(Json(notes))
 }
 
@@ -367,8 +411,8 @@ pub async fn search_notes(
     ),
     responses(
         (status = 200, description = "Deletion result", body = BoolResponse),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Note not found"),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 404, description = "Note not found", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -394,8 +438,8 @@ pub async fn delete_note(
     ),
     responses(
         (status = 200, description = "Archive result", body = BoolResponse),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Note not found"),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 404, description = "Note not found", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -422,8 +466,8 @@ pub async fn archive_note(
     request_body = SupersedeRequest,
     responses(
         (status = 200, description = "Supersede result", body = BoolResponse),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Note not found"),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 404, description = "Note not found", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -448,8 +492,8 @@ pub async fn supersede_note(
     ),
     responses(
         (status = 200, description = "Project stats", body = super::db::ProjectStats),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Project not found"),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 404, description = "Project not found", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -476,8 +520,8 @@ pub async fn project_stats(
     ),
     responses(
         (status = 200, description = "List of harvested git SHAs", body = Vec<String>),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Project not found"),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 404, description = "Project not found", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -523,9 +567,9 @@ pub struct StreamQuery {
     ),
     responses(
         (status = 200, description = "Notes newer than `t`", body = Vec<super::db::ServerNote>),
-        (status = 400, description = "Missing or invalid `t` parameter"),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Project not found"),
+        (status = 400, description = "Missing or invalid `t` parameter", body = ErrorBody),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 404, description = "Project not found", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -556,8 +600,8 @@ pub async fn memory_since(
     ),
     responses(
         (status = 200, description = "SSE stream of new memory entries"),
-        (status = 401, description = "Unauthorized"),
-        (status = 404, description = "Project not found"),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 404, description = "Project not found", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -615,6 +659,394 @@ pub async fn memory_stream(
     Ok(Sse::new(s).keep_alive(KeepAlive::default()))
 }
 
+// ── Index / embed ─────────────────────────────────────────────────────────────
+
+/// A single chunk to embed.
+#[derive(Deserialize, ToSchema)]
+pub struct EmbedChunkIn {
+    /// Opaque CLI-assigned identifier (e.g. blake3 hash of file + offset). Echoed back verbatim.
+    pub chunk_id: String,
+    /// Raw text content to embed.
+    pub content: String,
+}
+
+/// Embedding result for a single chunk.
+#[derive(Serialize, ToSchema)]
+pub struct EmbedChunkOut {
+    /// The same `chunk_id` that was sent in the request.
+    pub chunk_id: String,
+    /// Embedding vector produced by the server.
+    pub vector: Vec<f32>,
+}
+
+/// Request body for `POST /v1/projects/{project_id}/index/embed`.
+#[derive(Deserialize, ToSchema)]
+pub struct EmbedRequest {
+    /// Chunks to embed. Maximum 256 per request.
+    pub chunks: Vec<EmbedChunkIn>,
+}
+
+/// Response body for `POST /v1/projects/{project_id}/index/embed`.
+#[derive(Serialize, ToSchema)]
+pub struct EmbedResponse {
+    pub chunks: Vec<EmbedChunkOut>,
+}
+
+/// Generate embeddings for code chunks. The server encodes each chunk and returns the
+/// vectors. **The server does not store the vectors** — the CLI is the only persistent
+/// store for index data.
+///
+/// Returns 400 if no embedder is configured.
+/// Returns 413 if the batch exceeds 256 chunks.
+#[utoipa::path(
+    post,
+    path = "/v1/projects/{project_id}/index/embed",
+    params(
+        ("project_id" = String, Path, description = "Project slug"),
+    ),
+    request_body = EmbedRequest,
+    responses(
+        (status = 200, description = "Embedding vectors (not stored server-side)", body = EmbedResponse),
+        (status = 400, description = "No embedder configured", body = ErrorBody),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 413, description = "Batch exceeds 256 chunks", body = ErrorBody),
+    ),
+    security(("bearer_auth" = [])),
+    tag = "index"
+)]
+pub async fn index_embed(
+    State(state): State<AppState>,
+    Path(_project_id): Path<String>,
+    Json(body): Json<EmbedRequest>,
+) -> Result<Response, AppError> {
+    const MAX_BATCH: usize = 256;
+
+    // Check batch size first so clients get a 413 even when no embedder is configured.
+    if body.chunks.len() > MAX_BATCH {
+        return Ok((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(ErrorBody::new(
+                "bad_request",
+                &format!(
+                    "Batch size {} exceeds maximum of {MAX_BATCH} chunks per request.",
+                    body.chunks.len()
+                ),
+            )),
+        )
+            .into_response());
+    }
+
+    let embedder = state.embedder.as_ref().ok_or_else(|| {
+        AppError::BadRequest(
+            "index.embed requires an embedder. Configure SPELUNK_EMBEDDING_URL on the server."
+                .to_string(),
+        )
+    })?;
+
+    if body.chunks.is_empty() {
+        return Ok(Json(EmbedResponse { chunks: vec![] }).into_response());
+    }
+
+    // Collect texts, preserving order for reassembly.
+    let texts: Vec<&str> = body.chunks.iter().map(|c| c.content.as_str()).collect();
+    let vectors = embedder.embed(&texts).await.map_err(AppError::Internal)?;
+
+    if vectors.len() != body.chunks.len() {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "Embedder returned {} vectors for {} chunks",
+            vectors.len(),
+            body.chunks.len()
+        )));
+    }
+
+    let out_chunks: Vec<EmbedChunkOut> = body
+        .chunks
+        .into_iter()
+        .zip(vectors)
+        .map(|(c, v)| EmbedChunkOut {
+            chunk_id: c.chunk_id,
+            vector: v,
+        })
+        .collect();
+
+    // Data promise: vectors are NOT stored on the server. We return them directly.
+    Ok(Json(EmbedResponse { chunks: out_chunks }).into_response())
+}
+
+// ── Explore (SSE) ─────────────────────────────────────────────────────────────
+
+/// A single context chunk supplied by the CLI for `/explore` and `/plan`.
+#[derive(Deserialize, ToSchema)]
+pub struct ExploreContextChunk {
+    pub file: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub content: String,
+}
+
+/// Request body for `POST /v1/projects/{project_id}/explore`.
+#[derive(Deserialize, ToSchema)]
+pub struct ExploreRequest {
+    pub question: String,
+    #[serde(default)]
+    pub context_chunks: Vec<ExploreContextChunk>,
+    #[serde(default = "default_max_turns")]
+    pub max_turns: usize,
+}
+fn default_max_turns() -> usize {
+    5
+}
+
+/// Run an LLM reasoning loop over caller-supplied context chunks.
+/// The CLI retrieves relevant chunks from its local index and sends them alongside
+/// the question. **The server does not store context chunks.**
+///
+/// Returns an SSE stream with events: `thought`, `answer`, `done`, `error`.
+/// Returns 503 if no LLM is configured.
+#[utoipa::path(
+    post,
+    path = "/v1/projects/{project_id}/explore",
+    params(
+        ("project_id" = String, Path, description = "Project slug"),
+    ),
+    request_body = ExploreRequest,
+    responses(
+        (status = 200, description = "SSE stream: thought/answer/done/error events"),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 503, description = "No LLM configured", body = ErrorBody),
+    ),
+    security(("bearer_auth" = [])),
+    tag = "inference"
+)]
+pub async fn explore(
+    State(state): State<AppState>,
+    Path(_project_id): Path<String>,
+    Json(body): Json<ExploreRequest>,
+) -> Result<Response, AppError> {
+    let llm = state.llm.clone().ok_or_else(|| {
+        AppError::ServiceUnavailable(
+            "This server has no LLM configured. Set SPELUNK_LLM_URL and SPELUNK_LLM_MODEL."
+                .to_string(),
+        )
+    })?;
+
+    // Build context block from provided chunks.
+    let context_text = if body.context_chunks.is_empty() {
+        "(no context provided)".to_string()
+    } else {
+        body.context_chunks
+            .iter()
+            .map(|c| {
+                format!(
+                    "// {}:{}-{}\n{}",
+                    c.file, c.start_line, c.end_line, c.content
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n---\n\n")
+    };
+
+    let system_prompt = "You are a code-exploration assistant. \
+        Analyse the supplied code context and answer the user's question step by step. \
+        Emit your intermediate reasoning as thoughts, then a final answer. \
+        Format: emit lines like JSON objects with 'kind' and 'content' fields.";
+
+    let user_prompt = format!(
+        "<code_context>\n{context_text}\n</code_context>\n\n\
+         <question>\n{question}\n</question>\n\n\
+         Respond with a series of JSON objects (one per line), each with \
+         {{\"kind\": \"thought\", \"content\": \"...\"}} or \
+         {{\"kind\": \"answer\", \"content\": \"...\"}}. \
+         End with {{\"kind\": \"done\"}}.",
+        question = body.question
+    );
+
+    let messages = vec![
+        spelunk_core::llm::Message::system(system_prompt),
+        spelunk_core::llm::Message::user(user_prompt),
+    ];
+
+    let (tx, mut rx) = mpsc::channel::<String>(64);
+    let max_tokens = 2048 * body.max_turns.min(10);
+
+    // Spawn LLM generation into a background task.
+    tokio::spawn(async move {
+        if let Err(e) = llm.generate(&messages, max_tokens, tx, None).await {
+            tracing::warn!("explore LLM generate error: {e}");
+        }
+    });
+
+    // Stream tokens as SSE events. We buffer tokens into lines and emit each
+    // complete JSON object as a separate SSE event.
+    let s = stream! {
+        let mut buffer = String::new();
+        while let Some(token) = rx.recv().await {
+            buffer.push_str(&token);
+            // Emit complete lines as SSE events.
+            while let Some(newline_pos) = buffer.find('\n') {
+                let line = buffer[..newline_pos].trim().to_string();
+                buffer.drain(..newline_pos + 1);
+                if line.is_empty() {
+                    continue;
+                }
+                yield Ok::<Event, Infallible>(Event::default().data(line));
+            }
+        }
+        // Flush remaining buffer content.
+        let remaining = buffer.trim().to_string();
+        if !remaining.is_empty() {
+            yield Ok::<Event, Infallible>(Event::default().data(remaining));
+        }
+        // Terminal event.
+        yield Ok::<Event, Infallible>(
+            Event::default().data(r#"{"kind":"done"}"#)
+        );
+    };
+
+    Ok(Sse::new(s).keep_alive(KeepAlive::default()).into_response())
+}
+
+// ── Plan ──────────────────────────────────────────────────────────────────────
+
+/// Request body for `POST /v1/projects/{project_id}/plan`.
+#[derive(Deserialize, ToSchema)]
+pub struct PlanRequest {
+    pub goal: String,
+    #[serde(default)]
+    pub context_chunks: Vec<ExploreContextChunk>,
+    /// `"steps"` (default) or `"checklist"`.
+    #[serde(default = "default_plan_style")]
+    pub style: String,
+}
+fn default_plan_style() -> String {
+    "steps".to_string()
+}
+
+/// A structured plan returned by the plan endpoint.
+#[derive(Serialize, ToSchema)]
+pub struct PlanResult {
+    pub title: String,
+    pub steps: Vec<String>,
+}
+
+/// Response body for `POST /v1/projects/{project_id}/plan`.
+#[derive(Serialize, ToSchema)]
+pub struct PlanResponse {
+    pub plan: PlanResult,
+}
+
+/// Generate a structured implementation plan via LLM over caller-supplied context.
+/// Returns 503 if no LLM is configured.
+#[utoipa::path(
+    post,
+    path = "/v1/projects/{project_id}/plan",
+    params(
+        ("project_id" = String, Path, description = "Project slug"),
+    ),
+    request_body = PlanRequest,
+    responses(
+        (status = 200, description = "Structured implementation plan", body = PlanResponse),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 503, description = "No LLM configured", body = ErrorBody),
+    ),
+    security(("bearer_auth" = [])),
+    tag = "inference"
+)]
+pub async fn plan(
+    State(state): State<AppState>,
+    Path(_project_id): Path<String>,
+    Json(body): Json<PlanRequest>,
+) -> Result<Response, AppError> {
+    let llm = state.llm.clone().ok_or_else(|| {
+        AppError::ServiceUnavailable(
+            "This server has no LLM configured. Set SPELUNK_LLM_URL and SPELUNK_LLM_MODEL."
+                .to_string(),
+        )
+    })?;
+
+    // Build context block.
+    let context_text = if body.context_chunks.is_empty() {
+        "(no context provided)".to_string()
+    } else {
+        body.context_chunks
+            .iter()
+            .map(|c| {
+                format!(
+                    "// {}:{}-{}\n{}",
+                    c.file, c.start_line, c.end_line, c.content
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n---\n\n")
+    };
+
+    let style_instruction = match body.style.as_str() {
+        "checklist" => "Format each step as a markdown checkbox list item: `- [ ] step text`.",
+        _ => "Format each step as a numbered list item: `1. step text`.",
+    };
+
+    let system_prompt = "You are an expert software architect. \
+        Generate a clear, actionable implementation plan for the given goal. \
+        Return a JSON object with this exact shape: \
+        {\"title\": \"<one-line title>\", \"steps\": [\"<step 1>\", \"<step 2>\", ...]}. \
+        Return only the JSON object, no markdown fences, no extra text.";
+
+    let user_prompt = format!(
+        "<code_context>\n{context_text}\n</code_context>\n\n\
+         <goal>\n{goal}\n</goal>\n\n\
+         {style_instruction}\n\
+         Return a JSON object: {{\"title\": \"...\", \"steps\": [\"...\", ...]}}",
+        goal = body.goal
+    );
+
+    let messages = vec![
+        spelunk_core::llm::Message::system(system_prompt),
+        spelunk_core::llm::Message::user(user_prompt),
+    ];
+
+    let (tx, mut rx) = mpsc::channel::<String>(256);
+
+    tokio::spawn(async move {
+        if let Err(e) = llm.generate(&messages, 2048, tx, None).await {
+            tracing::warn!("plan LLM generate error: {e}");
+        }
+    });
+
+    // Collect all tokens into one string.
+    let mut full_response = String::new();
+    while let Some(token) = rx.recv().await {
+        full_response.push_str(&token);
+    }
+
+    // Parse the JSON plan.
+    #[derive(serde::Deserialize)]
+    struct LlmPlan {
+        title: String,
+        steps: Vec<String>,
+    }
+
+    // Strip markdown code fences if present (some models wrap output).
+    let json_str = full_response
+        .trim()
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+
+    let llm_plan: LlmPlan = serde_json::from_str(json_str).map_err(|e| {
+        tracing::warn!("plan: failed to parse LLM response as JSON: {e}; raw: {json_str:?}");
+        AppError::Internal(anyhow::anyhow!("LLM returned malformed plan JSON: {e}"))
+    })?;
+
+    Ok(Json(PlanResponse {
+        plan: PlanResult {
+            title: llm_plan.title,
+            steps: llm_plan.steps,
+        },
+    })
+    .into_response())
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn require_project(db: &super::db::ServerDb, slug: &str) -> Result<super::db::Project, AppError> {
@@ -634,6 +1066,7 @@ mod tests {
     use serde_json::{Value, json};
     use tower::ServiceExt; // for `oneshot`
 
+    use super::super::auth::ApiKeyAuth;
     use super::super::db::ServerDb;
     use super::super::{AppState, router};
 
@@ -658,9 +1091,10 @@ mod tests {
             .expect("failed to open in-memory server db");
         let state = AppState {
             db: Arc::new(tokio::sync::Mutex::new(db)),
-            api_key: None,
+            auth: Arc::new(ApiKeyAuth::new(None)),
             conflict_threshold,
             embedder: None,
+            llm: None,
         };
         (router(state), dim as i32)
     }
@@ -794,6 +1228,150 @@ mod tests {
             status2,
             http::StatusCode::CREATED,
             "threshold=1.0 must disable conflict detection; body: {body2}"
+        );
+    }
+
+    /// GET /v1/health should return JSON with `status`, `version`, and `capabilities`.
+    #[tokio::test]
+    async fn health_returns_json_with_capabilities() {
+        let (app, _) = make_app(0.92);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/v1/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).expect("health must return JSON");
+        assert_eq!(json["status"], json!("ok"), "status must be 'ok'");
+        assert!(json["version"].is_string(), "version must be a string");
+        assert!(
+            json["capabilities"].is_array(),
+            "capabilities must be an array"
+        );
+        let caps = json["capabilities"].as_array().unwrap();
+        assert!(
+            caps.iter().any(|c| c == "memory"),
+            "capabilities must include 'memory'"
+        );
+    }
+
+    /// POST /v1/projects/{slug}/memory/search with no embedder should return 400.
+    #[tokio::test]
+    async fn search_without_embedder_returns_400() {
+        let (app, _) = make_app(0.92);
+        // First create the project.
+        let _ = post_note(
+            app.clone(),
+            "search-proj",
+            "seed note",
+            vec![1.0, 0.0, 0.0, 0.0],
+        )
+        .await;
+
+        let body = json!({"query": "test query", "limit": 5});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/projects/search-proj/memory/search")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            http::StatusCode::BAD_REQUEST,
+            "search without embedder must return 400"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        assert_eq!(
+            json["error"]["code"],
+            json!("bad_request"),
+            "error code must be bad_request"
+        );
+    }
+
+    /// POST /v1/projects/{slug}/index/embed with no embedder should return 400.
+    #[tokio::test]
+    async fn embed_without_embedder_returns_400() {
+        let (app, _) = make_app(0.92);
+        let body = json!({"chunks": [{"chunk_id": "abc", "content": "fn foo() {}"}]});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/projects/proj/index/embed")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            http::StatusCode::BAD_REQUEST,
+            "embed without embedder must return 400"
+        );
+    }
+
+    /// POST /v1/projects/{slug}/explore with no LLM should return 503.
+    #[tokio::test]
+    async fn explore_without_llm_returns_503() {
+        let (app, _) = make_app(0.92);
+        let body = json!({"question": "what does foo do?", "context_chunks": []});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/projects/proj/explore")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            "explore without LLM must return 503"
+        );
+    }
+
+    /// POST /v1/projects/{slug}/plan with no LLM should return 503.
+    #[tokio::test]
+    async fn plan_without_llm_returns_503() {
+        let (app, _) = make_app(0.92);
+        let body = json!({"goal": "add rate limiting", "context_chunks": []});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/projects/proj/plan")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            "plan without LLM must return 503"
+        );
+    }
+
+    /// POST /v1/projects/{slug}/index/embed with >256 chunks should return 413.
+    #[tokio::test]
+    async fn embed_batch_too_large_returns_413() {
+        let (app, _) = make_app(0.92);
+        let chunks: Vec<Value> = (0..=256)
+            .map(|i| json!({"chunk_id": format!("c{i}"), "content": "fn foo() {}"}))
+            .collect();
+        let body = json!({"chunks": chunks});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/projects/proj/index/embed")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            http::StatusCode::PAYLOAD_TOO_LARGE,
+            "batch >256 must return 413"
         );
     }
 }

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod db;
 pub mod handlers;
 pub mod security;
@@ -12,14 +13,17 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{delete, get, post},
 };
-use utoipa::OpenApi;
+use serde::Serialize;
+use utoipa::{OpenApi, ToSchema};
 
+use auth::{AuthError, AuthProvider};
 use db::ServerDb;
 
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<tokio::sync::Mutex<ServerDb>>,
-    pub api_key: Option<String>,
+    /// Auth strategy — replaces the old `api_key: Option<String>` field.
+    pub auth: Arc<dyn AuthProvider>,
     /// Cosine similarity threshold above which a new entry is flagged as conflicting (0.0–1.0).
     /// Default: 0.92. Set to 1.0 to disable conflict detection.
     pub conflict_threshold: f32,
@@ -27,6 +31,8 @@ pub struct AppState {
     /// a pre-computed vector. If absent, entries without a vector are stored without one
     /// (text search only).
     pub embedder: Option<Arc<dyn spelunk_core::embeddings::EmbeddingBackend>>,
+    /// Optional LLM backend for `/explore` and `/plan`.
+    pub llm: Option<Arc<dyn spelunk_core::llm::LlmBackend>>,
 }
 
 pub fn default_conflict_threshold() -> f32 {
@@ -41,8 +47,7 @@ pub fn default_conflict_threshold() -> f32 {
         title = "spelunk-server",
         version = "0.1.0",
         description = "Shared memory server for spelunk. Stores decisions, requirements, \
-                        and context for a team and serves them over HTTP. Clients embed \
-                        locally and send pre-computed vectors; the server stores and searches them.",
+                        and context for a team and serves them over HTTP.",
         contact(name = "spelunk", url = "https://github.com/spelunk-cloud/spelunk"),
         license(name = "MIT"),
     ),
@@ -60,6 +65,9 @@ pub fn default_conflict_threshold() -> f32 {
         handlers::harvested_shas,
         handlers::memory_since,
         handlers::memory_stream,
+        handlers::index_embed,
+        handlers::explore,
+        handlers::plan,
     ),
     components(schemas(
         handlers::AddNoteRequest,
@@ -72,6 +80,18 @@ pub fn default_conflict_threshold() -> f32 {
         handlers::SupersedeRequest,
         handlers::SinceQuery,
         handlers::StreamQuery,
+        handlers::HealthResponse,
+        handlers::EmbedRequest,
+        handlers::EmbedChunkIn,
+        handlers::EmbedResponse,
+        handlers::EmbedChunkOut,
+        handlers::ExploreRequest,
+        handlers::ExploreContextChunk,
+        handlers::PlanRequest,
+        handlers::PlanResponse,
+        handlers::PlanResult,
+        ErrorBody,
+        ErrorDetail,
         db::Project,
         db::ServerNote,
         db::ProjectStats,
@@ -80,6 +100,8 @@ pub fn default_conflict_threshold() -> f32 {
         (name = "health", description = "Liveness"),
         (name = "projects", description = "Project management"),
         (name = "memory", description = "Memory CRUD and semantic search"),
+        (name = "index", description = "Code index / embedding"),
+        (name = "inference", description = "LLM-powered explore and plan"),
     ),
     security(
         ("bearer_auth" = [])
@@ -156,6 +178,12 @@ pub fn router(state: AppState) -> Router {
             "/v1/projects/{project_id}/stats",
             get(handlers::project_stats),
         )
+        .route(
+            "/v1/projects/{project_id}/index/embed",
+            post(handlers::index_embed),
+        )
+        .route("/v1/projects/{project_id}/explore", post(handlers::explore))
+        .route("/v1/projects/{project_id}/plan", post(handlers::plan))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,
@@ -178,44 +206,94 @@ async fn openapi_spec() -> impl IntoResponse {
 
 // ── Auth middleware ───────────────────────────────────────────────────────────
 
-/// Bearer token auth middleware. Pass-through if no API key is configured.
-async fn auth_middleware(State(state): State<AppState>, request: Request, next: Next) -> Response {
-    if let Some(expected_key) = &state.api_key {
-        let auth = request
-            .headers()
-            .get("Authorization")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.strip_prefix("Bearer "));
-
-        match auth {
-            Some(token) if token == expected_key => next.run(request).await,
-            _ => (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
+/// Trait-driven auth middleware. Delegates to `AppState.auth`.
+async fn auth_middleware(
+    State(state): State<AppState>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    match state.auth.authenticate(request.headers()).await {
+        Ok(ctx) => {
+            request.extensions_mut().insert(ctx);
+            next.run(request).await
         }
-    } else {
-        next.run(request).await
+        Err(AuthError(msg)) => (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorBody::new("unauthorized", &msg)),
+        )
+            .into_response(),
+    }
+}
+
+// ── Shared error body ─────────────────────────────────────────────────────────
+
+/// Consistent JSON error body: `{"error": {"code": "...", "message": "..."}}`.
+#[derive(Serialize, ToSchema)]
+pub struct ErrorBody {
+    pub error: ErrorDetail,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct ErrorDetail {
+    pub code: String,
+    pub message: String,
+}
+
+impl ErrorBody {
+    pub fn new(code: &str, message: &str) -> Self {
+        Self {
+            error: ErrorDetail {
+                code: code.to_string(),
+                message: message.to_string(),
+            },
+        }
     }
 }
 
 // ── Error type ────────────────────────────────────────────────────────────────
 
-/// Map anyhow errors to HTTP responses.
+/// Map anyhow errors to HTTP responses using the standard error body format.
 pub enum AppError {
     NotFound,
+    BadRequest(String),
+    ServiceUnavailable(String),
     Internal(anyhow::Error),
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         match self {
-            AppError::NotFound => (StatusCode::NOT_FOUND, "Not found").into_response(),
+            AppError::NotFound => (
+                StatusCode::NOT_FOUND,
+                Json(ErrorBody::new("not_found", "Not found")),
+            )
+                .into_response(),
+            AppError::BadRequest(msg) => (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorBody::new("bad_request", &msg)),
+            )
+                .into_response(),
+            AppError::ServiceUnavailable(msg) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorBody::new("service_unavailable", &msg)),
+            )
+                .into_response(),
             AppError::Internal(e) => {
                 let msg = e.to_string();
                 // Surface dimension-mismatch and other user-facing errors as 400.
                 if msg.contains("mismatch") || msg.contains("required") {
-                    (StatusCode::BAD_REQUEST, msg).into_response()
+                    (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorBody::new("bad_request", &msg)),
+                    )
+                        .into_response()
                 } else {
                     tracing::error!("internal error: {e:#}");
-                    (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response()
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorBody::new("internal_error", "Internal server error")),
+                    )
+                        .into_response()
                 }
             }
         }
@@ -225,5 +303,31 @@ impl IntoResponse for AppError {
 impl<E: Into<anyhow::Error>> From<E> for AppError {
     fn from(e: E) -> Self {
         AppError::Internal(e.into())
+    }
+}
+
+// ── OpenAPI snapshot test ─────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod openapi_tests {
+    use utoipa::OpenApi;
+
+    /// Write the generated OpenAPI spec to `docs/openapi.json` so it can be
+    /// committed as the reference snapshot.  Run with:
+    ///   cargo test -p spelunk-server write_openapi_snapshot -- --nocapture
+    #[test]
+    fn write_openapi_snapshot() {
+        let spec = super::ApiDoc::openapi()
+            .to_pretty_json()
+            .expect("serialise openapi");
+        // Resolve path relative to the workspace root (two levels up from src/).
+        let out = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("workspace root")
+            .join("docs/openapi.json");
+        std::fs::create_dir_all(out.parent().unwrap()).ok();
+        std::fs::write(&out, &spec).expect("write docs/openapi.json");
+        println!("Written: {}", out.display());
     }
 }

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+use spelunk_server::auth::ApiKeyAuth;
 use spelunk_server::db::ServerDb;
 use spelunk_server::{ApiDoc, AppState, default_conflict_threshold, router};
 use utoipa::OpenApi;
@@ -50,6 +51,15 @@ struct Args {
     #[arg(long, env = "SPELUNK_EMBEDDING_MODEL", default_value = "")]
     embedding_model: String,
 
+    /// Base URL of an OpenAI-compatible chat completions server for LLM features
+    /// (`/explore`, `/plan`). Overrides `SPELUNK_LLM_URL`.
+    #[arg(long, env = "SPELUNK_LLM_URL")]
+    llm_url: Option<String>,
+
+    /// LLM model name (e.g. `google/gemma-3n-e4b`). Overrides `SPELUNK_LLM_MODEL`.
+    #[arg(long, env = "SPELUNK_LLM_MODEL", default_value = "")]
+    llm_model: String,
+
     /// Print the OpenAPI spec as JSON and exit (for Postman / Newman import).
     #[arg(long)]
     print_openapi: bool,
@@ -87,6 +97,10 @@ async fn main() -> Result<()> {
         );
     }
 
+    // Build the auth provider from the configured key.
+    let auth: Arc<dyn spelunk_server::auth::AuthProvider> =
+        Arc::new(ApiKeyAuth::new(args.key.clone()));
+
     // Build the optional server-side embedder.
     let embedder: Option<Arc<dyn spelunk_core::embeddings::EmbeddingBackend>> =
         if let Some(base_url) = args.embedding_url {
@@ -109,11 +123,33 @@ async fn main() -> Result<()> {
             None
         };
 
+    // Build the optional LLM backend.
+    let llm: Option<Arc<dyn spelunk_core::llm::LlmBackend>> = if let Some(base_url) = args.llm_url {
+        let model = if args.llm_model.is_empty() {
+            "default".to_string()
+        } else {
+            args.llm_model.clone()
+        };
+        tracing::info!("server-side LLM enabled: {base_url} model={model}");
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(300))
+            .build()
+            .context("building HTTP client for server-side LLM")?;
+        Some(Arc::new(ServerLlm {
+            client,
+            base_url,
+            model,
+        }))
+    } else {
+        None
+    };
+
     let state = AppState {
         db: Arc::new(tokio::sync::Mutex::new(db)),
-        api_key: args.key,
+        auth,
         conflict_threshold: args.conflict_threshold,
         embedder,
+        llm,
     };
 
     let app = router(state);
@@ -175,5 +211,121 @@ impl spelunk_core::embeddings::EmbeddingBackend for ServerEmbedder {
 
     fn dimension(&self) -> usize {
         0 // dimension is model-dependent; not used server-side
+    }
+}
+
+// ── Inline LLM for the server binary ─────────────────────────────────────────
+
+struct ServerLlm {
+    client: reqwest::Client,
+    base_url: String,
+    model: String,
+}
+
+#[async_trait::async_trait]
+impl spelunk_core::llm::LlmBackend for ServerLlm {
+    async fn generate(
+        &self,
+        messages: &[spelunk_core::llm::Message],
+        max_tokens: usize,
+        tx: tokio::sync::mpsc::Sender<spelunk_core::llm::Token>,
+        json_schema: Option<serde_json::Value>,
+    ) -> anyhow::Result<()> {
+        use futures_util::StreamExt;
+
+        #[derive(serde::Serialize)]
+        struct ChatReq<'a> {
+            model: &'a str,
+            messages: Vec<ChatMsg<'a>>,
+            stream: bool,
+            max_tokens: usize,
+            temperature: f32,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            response_format: Option<serde_json::Value>,
+        }
+        #[derive(serde::Serialize)]
+        struct ChatMsg<'a> {
+            role: &'a str,
+            content: &'a str,
+        }
+        #[derive(serde::Deserialize)]
+        struct StreamChunk {
+            choices: Vec<StreamChoice>,
+        }
+        #[derive(serde::Deserialize)]
+        struct StreamChoice {
+            delta: Delta,
+        }
+        #[derive(serde::Deserialize)]
+        struct Delta {
+            content: Option<String>,
+        }
+
+        let chat_messages: Vec<ChatMsg> = messages
+            .iter()
+            .map(|m| ChatMsg {
+                role: &m.role,
+                content: &m.content,
+            })
+            .collect();
+
+        let response_format =
+            json_schema.map(|s| serde_json::json!({ "type": "json_schema", "json_schema": s }));
+
+        let req = ChatReq {
+            model: &self.model,
+            messages: chat_messages,
+            stream: true,
+            max_tokens,
+            temperature: 0.7,
+            response_format,
+        };
+
+        let mut stream = self
+            .client
+            .post(format!("{}/v1/chat/completions", self.base_url))
+            .json(&req)
+            .send()
+            .await
+            .context("calling LLM server")?
+            .error_for_status()
+            .context("LLM server returned an error")?
+            .bytes_stream();
+
+        let mut buffer = String::new();
+        while let Some(chunk) = stream.next().await {
+            let bytes = chunk.context("reading SSE byte chunk")?;
+            buffer.push_str(&String::from_utf8_lossy(&bytes));
+
+            while let Some(pos) = buffer.find("\n\n") {
+                let event = buffer[..pos].to_string();
+                buffer.drain(..pos + 2);
+
+                for line in event.lines() {
+                    let data = match line.strip_prefix("data: ") {
+                        Some(d) => d,
+                        None => continue,
+                    };
+                    if data == "[DONE]" {
+                        return Ok(());
+                    }
+                    if data.is_empty() {
+                        continue;
+                    }
+                    if let Ok(chunk) = serde_json::from_str::<StreamChunk>(data) {
+                        for choice in chunk.choices {
+                            if let Some(content) = choice.delta.content
+                                && !content.is_empty()
+                                && tx.send(content).await.is_err()
+                            {
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/spelunk-server/tests/integration_server.rs
+++ b/crates/spelunk-server/tests/integration_server.rs
@@ -11,6 +11,7 @@ use axum::{
     http::{Request, StatusCode},
 };
 use serial_test::serial;
+use spelunk_server::auth::ApiKeyAuth;
 use spelunk_server::{AppState, router};
 use std::sync::Arc;
 use tower::ServiceExt; // for `.oneshot()`
@@ -21,9 +22,10 @@ fn make_state() -> AppState {
     let db = common::open_test_server_db(4);
     AppState {
         db: Arc::new(tokio::sync::Mutex::new(db)),
-        api_key: None,
+        auth: Arc::new(ApiKeyAuth::new(None)),
         conflict_threshold: spelunk_server::default_conflict_threshold(),
         embedder: None,
+        llm: None,
     }
 }
 
@@ -257,9 +259,10 @@ async fn protected_endpoint_rejects_missing_token() {
     let db = common::open_test_server_db(4);
     let state = AppState {
         db: Arc::new(tokio::sync::Mutex::new(db)),
-        api_key: Some("secret".into()),
+        auth: Arc::new(ApiKeyAuth::new(Some("secret".into()))),
         conflict_threshold: spelunk_server::default_conflict_threshold(),
         embedder: None,
+        llm: None,
     };
     let resp = send(state, "GET", "/v1/projects", Body::empty(), false).await;
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
@@ -271,9 +274,10 @@ async fn protected_endpoint_accepts_correct_token() {
     let db = common::open_test_server_db(4);
     let state = AppState {
         db: Arc::new(tokio::sync::Mutex::new(db)),
-        api_key: Some("secret".into()),
+        auth: Arc::new(ApiKeyAuth::new(Some("secret".into()))),
         conflict_threshold: spelunk_server::default_conflict_threshold(),
         embedder: None,
+        llm: None,
     };
     let req = Request::builder()
         .method("GET")
@@ -287,29 +291,28 @@ async fn protected_endpoint_accepts_correct_token() {
 
 // ── search ────────────────────────────────────────────────────────────────────
 
+/// memory/search now accepts `{"query": String}` and requires an embedder.
+/// Without an embedder, the endpoint must return 400.
 #[tokio::test]
 #[serial]
-async fn search_returns_closest_note() {
-    let state = make_state();
+async fn search_without_embedder_returns_400() {
+    let state = make_state(); // no embedder configured
 
-    // Add two notes with distinct embeddings.
-    for (title, emb) in [
-        ("alpha", [1.0_f32, 0.0, 0.0, 0.0]),
-        ("beta", [0.0_f32, 1.0, 0.0, 0.0]),
-    ] {
-        send(
-            state.clone(),
-            "POST",
-            "/v1/projects/s/memory",
-            json_body(serde_json::json!({"kind":"note","title":title,"embedding":emb})),
-            true,
-        )
-        .await;
-    }
+    // Create the project first.
+    send(
+        state.clone(),
+        "POST",
+        "/v1/projects/s/memory",
+        json_body(
+            serde_json::json!({"kind":"note","title":"alpha","embedding":[1.0_f32,0.0,0.0,0.0]}),
+        ),
+        true,
+    )
+    .await;
 
-    // Query near alpha.
+    // Query with text query — must return 400 (no embedder).
     let search_payload = serde_json::json!({
-        "embedding": [1.0_f32, 0.0, 0.0, 0.0],
+        "query": "how does authentication work",
         "limit": 2,
     });
     let resp = send(
@@ -320,13 +323,16 @@ async fn search_returns_closest_note() {
         true,
     )
     .await;
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "search without embedder must return 400"
+    );
     let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await
         .unwrap();
-    let notes: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-    assert!(!notes.as_array().unwrap().is_empty());
-    assert_eq!(notes[0]["title"], "alpha");
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["error"]["code"], "bad_request");
 }
 
 // ── /memory/since ─────────────────────────────────────────────────────────────
@@ -368,9 +374,10 @@ async fn since_endpoint_returns_entries_after_timestamp() {
 
     let state = AppState {
         db: Arc::new(tokio::sync::Mutex::new(db)),
-        api_key: None,
+        auth: Arc::new(ApiKeyAuth::new(None)),
         conflict_threshold: spelunk_server::default_conflict_threshold(),
         embedder: None,
+        llm: None,
     };
 
     // Query with t=1500 — should return only the note at t=2000.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "spelunk-server",
-    "description": "Shared memory server for spelunk. Stores decisions, requirements, and context for a team and serves them over HTTP. Clients embed locally and send pre-computed vectors; the server stores and searches them.",
+    "description": "Shared memory server for spelunk. Stores decisions, requirements, and context for a team and serves them over HTTP.",
     "contact": {
       "name": "spelunk",
       "url": "https://github.com/spelunk-cloud/spelunk"
@@ -18,17 +18,16 @@
         "tags": [
           "health"
         ],
-        "summary": "Server liveness check. No authentication required.",
+        "summary": "Server liveness check. No authentication required.\nReturns server version and capabilities list.",
         "operationId": "health",
         "responses": {
           "200": {
             "description": "Server is up",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
-                },
-                "example": "ok"
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
               }
             }
           }
@@ -67,6 +66,145 @@
         ]
       }
     },
+    "/v1/projects/{project_id}/explore": {
+      "post": {
+        "tags": [
+          "inference"
+        ],
+        "summary": "Run an LLM reasoning loop over caller-supplied context chunks.\nThe CLI retrieves relevant chunks from its local index and sends them alongside\nthe question. **The server does not store context chunks.**",
+        "description": "Returns an SSE stream with events: `thought`, `answer`, `done`, `error`.\nReturns 503 if no LLM is configured.",
+        "operationId": "explore",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "Project slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExploreRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "SSE stream: thought/answer/done/error events"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "No LLM configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/projects/{project_id}/index/embed": {
+      "post": {
+        "tags": [
+          "index"
+        ],
+        "summary": "Generate embeddings for code chunks. The server encodes each chunk and returns the\nvectors. **The server does not store the vectors** — the CLI is the only persistent\nstore for index data.",
+        "description": "Returns 400 if no embedder is configured.\nReturns 413 if the batch exceeds 256 chunks.",
+        "operationId": "index_embed",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "Project slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmbedRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Embedding vectors (not stored server-side)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmbedResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No embedder configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Batch exceeds 256 chunks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/v1/projects/{project_id}/memory": {
       "get": {
         "tags": [
@@ -87,7 +225,7 @@
           {
             "name": "kind",
             "in": "query",
-            "description": "Filter by kind (`decision`, `requirement`, `note`, `question`, `handoff`).",
+            "description": "Filter by kind (`decision`, `requirement`, `note`, `question`, `handoff`, `intent`).",
             "required": false,
             "schema": {
               "type": [
@@ -131,10 +269,24 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Project not found"
+            "description": "Project not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -148,7 +300,7 @@
           "memory"
         ],
         "summary": "Add a memory entry to a project. The project is auto-created on first write.",
-        "description": "The client must supply a pre-computed `embedding` vector. All entries in\na project must use the same embedding dimension — the first write fixes it.",
+        "description": "The `embedding` field is optional. If omitted and the server has `SPELUNK_EMBEDDING_URL`\nconfigured, the server embeds the entry before storage. If neither is available, the\nentry is stored without a vector (text search only, no KNN).\n\nReturns **201** on success. Returns **409** when the new entry is semantically\nclose to one or more existing active entries (similarity ≥ conflict_threshold).\nThe entry is still stored in both cases; the 409 is informational.\nReturns **422** when the entry contains prompt-injection patterns.",
         "operationId": "add_note",
         "parameters": [
           {
@@ -183,10 +335,37 @@
             }
           },
           "400": {
-            "description": "Embedding dimension mismatch"
+            "description": "Embedding dimension mismatch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Note stored but conflicts with existing entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddNoteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Entry rejected — prompt injection detected"
           }
         },
         "security": [
@@ -230,10 +409,24 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Project not found"
+            "description": "Project not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -248,7 +441,7 @@
         "tags": [
           "memory"
         ],
-        "summary": "Semantic search over memory entries using a pre-computed query embedding.",
+        "summary": "Semantic search over memory entries. The server encodes the text query using its\nconfigured embedder. Returns 400 if no embedder is configured.",
         "operationId": "search_notes",
         "parameters": [
           {
@@ -285,11 +478,189 @@
               }
             }
           },
+          "400": {
+            "description": "No embedder configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Project not found"
+            "description": "Project not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/projects/{project_id}/memory/since": {
+      "get": {
+        "tags": [
+          "memory"
+        ],
+        "summary": "Return notes created after a given Unix timestamp. Archived entries are\nexcluded. Results are ordered `created_at ASC`.",
+        "operationId": "memory_since",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "Project slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "t",
+            "in": "query",
+            "description": "Unix epoch seconds (exclusive lower bound).",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results (default: 100, max: 500).",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notes newer than `t`",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ServerNote"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid `t` parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Project not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/projects/{project_id}/memory/stream": {
+      "get": {
+        "tags": [
+          "memory"
+        ],
+        "summary": "Stream new memory entries as Server-Sent Events. Each event carries a\nsingle `ServerNote` serialised as JSON. The stream polls the database once\nper second and stays open indefinitely — close the connection to stop it.",
+        "description": "Pass `?t=<unix_secs>` to replay entries written after a known timestamp.\nOmit it to receive only entries written after the connection opens.",
+        "operationId": "memory_stream",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "Project slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "t",
+            "in": "query",
+            "description": "Unix epoch seconds to start from (inclusive). Defaults to now.",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE stream of new memory entries"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Project not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -339,10 +710,24 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Note not found"
+            "description": "Note not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -390,10 +775,24 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Note not found"
+            "description": "Note not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -443,10 +842,24 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Note not found"
+            "description": "Note not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -506,10 +919,91 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Note not found"
+            "description": "Note not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/projects/{project_id}/plan": {
+      "post": {
+        "tags": [
+          "inference"
+        ],
+        "summary": "Generate a structured implementation plan via LLM over caller-supplied context.\nReturns 503 if no LLM is configured.",
+        "operationId": "plan",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "Project slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Structured implementation plan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "No LLM configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -549,10 +1043,24 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Project not found"
+            "description": "Project not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -584,11 +1092,11 @@
               "type": "number",
               "format": "float"
             },
-            "description": "Pre-computed embedding vector from the client (required for semantic search)."
+            "description": "Pre-computed embedding vector from the client. Optional — if omitted and the server has an\nembedding backend configured (`SPELUNK_EMBEDDING_URL`), the server embeds the entry.\nIf neither is available, the entry is stored without a vector (text search only)."
           },
           "kind": {
             "type": "string",
-            "description": "Kind of memory entry: `decision`, `requirement`, `note`, `question`, `handoff`."
+            "description": "Kind of memory entry: `decision`, `requirement`, `note`, `question`, `handoff`, `intent`."
           },
           "linked_files": {
             "type": "array",
@@ -612,13 +1120,25 @@
       "AddNoteResponse": {
         "type": "object",
         "required": [
+          "stored",
           "id"
         ],
         "properties": {
+          "conflicts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConflictEntry"
+            },
+            "description": "Conflicting entries (only present on 409)."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
             "description": "ID of the created note."
+          },
+          "stored": {
+            "type": "boolean",
+            "description": "Whether the note was stored (always true for 201/409)."
           }
         }
       },
@@ -634,6 +1154,29 @@
           }
         }
       },
+      "ConflictEntry": {
+        "type": "object",
+        "description": "A single conflicting memory entry returned in a 409 response.",
+        "required": [
+          "id",
+          "title",
+          "similarity"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "similarity": {
+            "type": "number",
+            "format": "float",
+            "description": "Cosine similarity to the new entry (0.0–1.0)."
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
       "CountResponse": {
         "type": "object",
         "required": [
@@ -643,6 +1186,180 @@
           "count": {
             "type": "integer",
             "format": "int64"
+          }
+        }
+      },
+      "EmbedChunkIn": {
+        "type": "object",
+        "description": "A single chunk to embed.",
+        "required": [
+          "chunk_id",
+          "content"
+        ],
+        "properties": {
+          "chunk_id": {
+            "type": "string",
+            "description": "Opaque CLI-assigned identifier (e.g. blake3 hash of file + offset). Echoed back verbatim."
+          },
+          "content": {
+            "type": "string",
+            "description": "Raw text content to embed."
+          }
+        }
+      },
+      "EmbedChunkOut": {
+        "type": "object",
+        "description": "Embedding result for a single chunk.",
+        "required": [
+          "chunk_id",
+          "vector"
+        ],
+        "properties": {
+          "chunk_id": {
+            "type": "string",
+            "description": "The same `chunk_id` that was sent in the request."
+          },
+          "vector": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float"
+            },
+            "description": "Embedding vector produced by the server."
+          }
+        }
+      },
+      "EmbedRequest": {
+        "type": "object",
+        "description": "Request body for `POST /v1/projects/{project_id}/index/embed`.",
+        "required": [
+          "chunks"
+        ],
+        "properties": {
+          "chunks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EmbedChunkIn"
+            },
+            "description": "Chunks to embed. Maximum 256 per request."
+          }
+        }
+      },
+      "EmbedResponse": {
+        "type": "object",
+        "description": "Response body for `POST /v1/projects/{project_id}/index/embed`.",
+        "required": [
+          "chunks"
+        ],
+        "properties": {
+          "chunks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EmbedChunkOut"
+            }
+          }
+        }
+      },
+      "ErrorBody": {
+        "type": "object",
+        "description": "Consistent JSON error body: `{\"error\": {\"code\": \"...\", \"message\": \"...\"}}`.",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ErrorDetail"
+          }
+        }
+      },
+      "ErrorDetail": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "ExploreContextChunk": {
+        "type": "object",
+        "description": "A single context chunk supplied by the CLI for `/explore` and `/plan`.",
+        "required": [
+          "file",
+          "start_line",
+          "end_line",
+          "content"
+        ],
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "end_line": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "file": {
+            "type": "string"
+          },
+          "start_line": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "ExploreRequest": {
+        "type": "object",
+        "description": "Request body for `POST /v1/projects/{project_id}/explore`.",
+        "required": [
+          "question"
+        ],
+        "properties": {
+          "context_chunks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExploreContextChunk"
+            }
+          },
+          "max_turns": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "question": {
+            "type": "string"
+          }
+        }
+      },
+      "HealthResponse": {
+        "type": "object",
+        "description": "Server capabilities reported in the health response.",
+        "required": [
+          "status",
+          "version",
+          "capabilities"
+        ],
+        "properties": {
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of feature capabilities supported by this server instance."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always `\"ok\"`."
+          },
+          "version": {
+            "type": "string",
+            "description": "Server version string."
           }
         }
       },
@@ -658,12 +1375,65 @@
               "string",
               "null"
             ],
-            "description": "Filter by kind (`decision`, `requirement`, `note`, `question`, `handoff`)."
+            "description": "Filter by kind (`decision`, `requirement`, `note`, `question`, `handoff`, `intent`)."
           },
           "limit": {
             "type": "integer",
             "description": "Maximum number of results to return (default: 20).",
             "minimum": 0
+          }
+        }
+      },
+      "PlanRequest": {
+        "type": "object",
+        "description": "Request body for `POST /v1/projects/{project_id}/plan`.",
+        "required": [
+          "goal"
+        ],
+        "properties": {
+          "context_chunks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExploreContextChunk"
+            }
+          },
+          "goal": {
+            "type": "string"
+          },
+          "style": {
+            "type": "string",
+            "description": "`\"steps\"` (default) or `\"checklist\"`."
+          }
+        }
+      },
+      "PlanResponse": {
+        "type": "object",
+        "description": "Response body for `POST /v1/projects/{project_id}/plan`.",
+        "required": [
+          "plan"
+        ],
+        "properties": {
+          "plan": {
+            "$ref": "#/components/schemas/PlanResult"
+          }
+        }
+      },
+      "PlanResult": {
+        "type": "object",
+        "description": "A structured plan returned by the plan endpoint.",
+        "required": [
+          "title",
+          "steps"
+        ],
+        "properties": {
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "title": {
+            "type": "string"
           }
         }
       },
@@ -721,21 +1491,17 @@
       "SearchRequest": {
         "type": "object",
         "required": [
-          "embedding"
+          "query"
         ],
         "properties": {
-          "embedding": {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "format": "float"
-            },
-            "description": "Query embedding vector (must match project's embedding dimension)."
-          },
           "limit": {
             "type": "integer",
             "description": "Maximum number of results to return (default: 20).",
             "minimum": 0
+          },
+          "query": {
+            "type": "string",
+            "description": "Text query — the server encodes this using its configured embedder."
           }
         }
       },
@@ -774,7 +1540,7 @@
           },
           "kind": {
             "type": "string",
-            "description": "Kind: `decision`, `requirement`, `note`, `question`, or `handoff`."
+            "description": "Kind: `decision`, `requirement`, `note`, `question`, `handoff`, or `intent`."
           },
           "linked_files": {
             "type": "array",
@@ -801,6 +1567,37 @@
           },
           "title": {
             "type": "string"
+          }
+        }
+      },
+      "SinceQuery": {
+        "type": "object",
+        "required": [
+          "t"
+        ],
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum number of results (default: 100, max: 500)."
+          },
+          "t": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix epoch seconds (exclusive lower bound)."
+          }
+        }
+      },
+      "StreamQuery": {
+        "type": "object",
+        "properties": {
+          "t": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Unix epoch seconds to start from (inclusive). Defaults to now."
           }
         }
       },
@@ -844,6 +1641,14 @@
     {
       "name": "memory",
       "description": "Memory CRUD and semantic search"
+    },
+    {
+      "name": "index",
+      "description": "Code index / embedding"
+    },
+    {
+      "name": "inference",
+      "description": "LLM-powered explore and plan"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Implements the full server API contract from `docs/architecture/server-api.md` (PR #275).

### Auth refactor
- New `AuthProvider` trait in `src/auth.rs` — async, `Send + Sync + 'static`
- `ApiKeyAuth` struct implements it (same behaviour as old inline `auth_middleware`)
- `AppState.api_key: Option<String>` → `AppState.auth: Arc<dyn AuthProvider>`
- Cloud can swap in OAuth2/JWT without forking by implementing `AuthProvider`

### Endpoint changes
| Endpoint | Change |
|---|---|
| `GET /v1/health` | **Breaking:** returns `{status, version, capabilities[]}` JSON (was plain text `"ok"`) |
| `POST /v1/projects/{id}/memory/search` | **Breaking:** accepts `{query: String}` — server embeds internally; 400 if no embedder |
| `POST /v1/projects/{id}/index/embed` | **New** — batch embed up to 256 chunks; vectors returned, NOT stored (data promise) |
| `POST /v1/projects/{id}/explore` | **New** — SSE LLM reasoning over caller-supplied context; 503 if no LLM |
| `POST /v1/projects/{id}/plan` | **New** — structured plan JSON from LLM; 503 if no LLM |

All error responses: `{"error": {"code": "...", "message": "..."}}`

### OpenAPI
`docs/openapi.json` regenerated — all 16 endpoints present with full schema components.

## Test plan
- [x] `cargo test -p spelunk-server` → 36/36 passing (24 unit + 12 integration)
- [x] `cargo clippy -- -D warnings` → clean
- [x] `cargo fmt --check` → clean (pre-commit hook verified)
- [ ] Manual: `curl http://localhost:7777/v1/health` → JSON with `capabilities`
- [ ] Manual: `curl -X POST .../memory/search -d '{"query":"auth flow","limit":5}'`

## Unblocks
- #260 CLI dep refactor (can now strip reqwest from spelunk-cli)
- cloud-api #1 GCP deployment

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)