### PR TITLE
chore: drop POST /v1/projects/{id}/plan endpoint

### DIFF
--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -131,7 +131,6 @@ pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
     }
     if state.llm.is_some() {
         capabilities.push("explore".to_string());
-        capabilities.push("plan".to_string());
     }
     Json(HealthResponse {
         status: "ok",
@@ -775,7 +774,7 @@ pub async fn index_embed(
 
 // ── Explore (SSE) ─────────────────────────────────────────────────────────────
 
-/// A single context chunk supplied by the CLI for `/explore` and `/plan`.
+/// A single context chunk supplied by the CLI for `/explore`.
 #[derive(Deserialize, ToSchema)]
 pub struct ExploreContextChunk {
     pub file: String,
@@ -904,147 +903,6 @@ pub async fn explore(
     };
 
     Ok(Sse::new(s).keep_alive(KeepAlive::default()).into_response())
-}
-
-// ── Plan ──────────────────────────────────────────────────────────────────────
-
-/// Request body for `POST /v1/projects/{project_id}/plan`.
-#[derive(Deserialize, ToSchema)]
-pub struct PlanRequest {
-    pub goal: String,
-    #[serde(default)]
-    pub context_chunks: Vec<ExploreContextChunk>,
-    /// `"steps"` (default) or `"checklist"`.
-    #[serde(default = "default_plan_style")]
-    pub style: String,
-}
-fn default_plan_style() -> String {
-    "steps".to_string()
-}
-
-/// A structured plan returned by the plan endpoint.
-#[derive(Serialize, ToSchema)]
-pub struct PlanResult {
-    pub title: String,
-    pub steps: Vec<String>,
-}
-
-/// Response body for `POST /v1/projects/{project_id}/plan`.
-#[derive(Serialize, ToSchema)]
-pub struct PlanResponse {
-    pub plan: PlanResult,
-}
-
-/// Generate a structured implementation plan via LLM over caller-supplied context.
-/// Returns 503 if no LLM is configured.
-#[utoipa::path(
-    post,
-    path = "/v1/projects/{project_id}/plan",
-    params(
-        ("project_id" = String, Path, description = "Project slug"),
-    ),
-    request_body = PlanRequest,
-    responses(
-        (status = 200, description = "Structured implementation plan", body = PlanResponse),
-        (status = 401, description = "Unauthorized", body = ErrorBody),
-        (status = 503, description = "No LLM configured", body = ErrorBody),
-    ),
-    security(("bearer_auth" = [])),
-    tag = "inference"
-)]
-pub async fn plan(
-    State(state): State<AppState>,
-    Path(_project_id): Path<String>,
-    Json(body): Json<PlanRequest>,
-) -> Result<Response, AppError> {
-    let llm = state.llm.clone().ok_or_else(|| {
-        AppError::ServiceUnavailable(
-            "This server has no LLM configured. Set SPELUNK_LLM_URL and SPELUNK_LLM_MODEL."
-                .to_string(),
-        )
-    })?;
-
-    // Build context block.
-    let context_text = if body.context_chunks.is_empty() {
-        "(no context provided)".to_string()
-    } else {
-        body.context_chunks
-            .iter()
-            .map(|c| {
-                format!(
-                    "// {}:{}-{}\n{}",
-                    c.file, c.start_line, c.end_line, c.content
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n\n---\n\n")
-    };
-
-    let style_instruction = match body.style.as_str() {
-        "checklist" => "Format each step as a markdown checkbox list item: `- [ ] step text`.",
-        _ => "Format each step as a numbered list item: `1. step text`.",
-    };
-
-    let system_prompt = "You are an expert software architect. \
-        Generate a clear, actionable implementation plan for the given goal. \
-        Return a JSON object with this exact shape: \
-        {\"title\": \"<one-line title>\", \"steps\": [\"<step 1>\", \"<step 2>\", ...]}. \
-        Return only the JSON object, no markdown fences, no extra text.";
-
-    let user_prompt = format!(
-        "<code_context>\n{context_text}\n</code_context>\n\n\
-         <goal>\n{goal}\n</goal>\n\n\
-         {style_instruction}\n\
-         Return a JSON object: {{\"title\": \"...\", \"steps\": [\"...\", ...]}}",
-        goal = body.goal
-    );
-
-    let messages = vec![
-        spelunk_core::llm::Message::system(system_prompt),
-        spelunk_core::llm::Message::user(user_prompt),
-    ];
-
-    let (tx, mut rx) = mpsc::channel::<String>(256);
-
-    tokio::spawn(async move {
-        if let Err(e) = llm.generate(&messages, 2048, tx, None).await {
-            tracing::warn!("plan LLM generate error: {e}");
-        }
-    });
-
-    // Collect all tokens into one string.
-    let mut full_response = String::new();
-    while let Some(token) = rx.recv().await {
-        full_response.push_str(&token);
-    }
-
-    // Parse the JSON plan.
-    #[derive(serde::Deserialize)]
-    struct LlmPlan {
-        title: String,
-        steps: Vec<String>,
-    }
-
-    // Strip markdown code fences if present (some models wrap output).
-    let json_str = full_response
-        .trim()
-        .trim_start_matches("```json")
-        .trim_start_matches("```")
-        .trim_end_matches("```")
-        .trim();
-
-    let llm_plan: LlmPlan = serde_json::from_str(json_str).map_err(|e| {
-        tracing::warn!("plan: failed to parse LLM response as JSON: {e}; raw: {json_str:?}");
-        AppError::Internal(anyhow::anyhow!("LLM returned malformed plan JSON: {e}"))
-    })?;
-
-    Ok(Json(PlanResponse {
-        plan: PlanResult {
-            title: llm_plan.title,
-            steps: llm_plan.steps,
-        },
-    })
-    .into_response())
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -1331,25 +1189,6 @@ mod tests {
             resp.status(),
             http::StatusCode::SERVICE_UNAVAILABLE,
             "explore without LLM must return 503"
-        );
-    }
-
-    /// POST /v1/projects/{slug}/plan with no LLM should return 503.
-    #[tokio::test]
-    async fn plan_without_llm_returns_503() {
-        let (app, _) = make_app(0.92);
-        let body = json!({"goal": "add rate limiting", "context_chunks": []});
-        let req = Request::builder()
-            .method("POST")
-            .uri("/v1/projects/proj/plan")
-            .header("content-type", "application/json")
-            .body(Body::from(serde_json::to_vec(&body).unwrap()))
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(
-            resp.status(),
-            http::StatusCode::SERVICE_UNAVAILABLE,
-            "plan without LLM must return 503"
         );
     }
 

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -31,7 +31,7 @@ pub struct AppState {
     /// a pre-computed vector. If absent, entries without a vector are stored without one
     /// (text search only).
     pub embedder: Option<Arc<dyn spelunk_core::embeddings::EmbeddingBackend>>,
-    /// Optional LLM backend for `/explore` and `/plan`.
+    /// Optional LLM backend for `/explore`.
     pub llm: Option<Arc<dyn spelunk_core::llm::LlmBackend>>,
 }
 
@@ -67,7 +67,6 @@ pub fn default_conflict_threshold() -> f32 {
         handlers::memory_stream,
         handlers::index_embed,
         handlers::explore,
-        handlers::plan,
     ),
     components(schemas(
         handlers::AddNoteRequest,
@@ -87,9 +86,6 @@ pub fn default_conflict_threshold() -> f32 {
         handlers::EmbedChunkOut,
         handlers::ExploreRequest,
         handlers::ExploreContextChunk,
-        handlers::PlanRequest,
-        handlers::PlanResponse,
-        handlers::PlanResult,
         ErrorBody,
         ErrorDetail,
         db::Project,
@@ -101,7 +97,7 @@ pub fn default_conflict_threshold() -> f32 {
         (name = "projects", description = "Project management"),
         (name = "memory", description = "Memory CRUD and semantic search"),
         (name = "index", description = "Code index / embedding"),
-        (name = "inference", description = "LLM-powered explore and plan"),
+        (name = "inference", description = "LLM-powered code exploration"),
     ),
     security(
         ("bearer_auth" = [])
@@ -183,7 +179,6 @@ pub fn router(state: AppState) -> Router {
             post(handlers::index_embed),
         )
         .route("/v1/projects/{project_id}/explore", post(handlers::explore))
-        .route("/v1/projects/{project_id}/plan", post(handlers::plan))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -52,7 +52,7 @@ struct Args {
     embedding_model: String,
 
     /// Base URL of an OpenAI-compatible chat completions server for LLM features
-    /// (`/explore`, `/plan`). Overrides `SPELUNK_LLM_URL`.
+    /// (`/explore`). Overrides `SPELUNK_LLM_URL`.
     #[arg(long, env = "SPELUNK_LLM_URL")]
     llm_url: Option<String>,
 

--- a/docs/architecture/server-api.md
+++ b/docs/architecture/server-api.md
@@ -31,7 +31,7 @@ constrained as follows; cloud implementations MUST uphold the same contract.
 | Chunk content (text) for embedding | yes | **no** | yes (eviction within session) |
 | Embedding vectors generated for the CLI | n/a (server emits) | **no** | yes (request-scoped) |
 | Search queries (text) | yes | **no** (logs may carry metadata only — never the query body in plaintext) | yes (LRU for rate limiting) |
-| `context_chunks` sent with `/explore` and `/plan` | yes | **no** | request-scoped only |
+| `context_chunks` sent with `/explore` | yes | **no** | request-scoped only |
 | Memory entries (notes) | yes | **yes** (this IS the server's persistence role) | n/a |
 | Project metadata (id, slug, stats) | yes | yes | n/a |
 | Auth principals (api keys, user ids) | yes | hash/identifier only — never the raw bearer | yes |
@@ -212,8 +212,7 @@ emit this format (currently some return plain text):
     "memory",
     "index.embed",
     "search.semantic",
-    "explore",
-    "plan"
+    "explore"
   ]
 }
 ```
@@ -337,40 +336,6 @@ Event `kind` values: `thought`, `answer`, `done`, `error`.
 
 **Response `503`:** no LLM configured on this server.
 
-### `POST /v1/projects/{project_id}/plan`
-
-Generate a structured implementation plan via LLM. Same context assembly
-pattern as explore.
-
-**Request:**
-
-```json
-{
-  "goal": "Add rate limiting to the memory push endpoint",
-  "context_chunks": [ ... ],
-  "style": "steps"
-}
-```
-
-`style`: `"steps"` (numbered list, default) or `"checklist"` (markdown
-checkbox list).
-
-**Response `200`:**
-
-```json
-{
-  "plan": {
-    "title": "Add rate limiting to memory push",
-    "steps": [
-      "Add a `RateLimiter` struct to `spelunk-server/src/middleware/`...",
-      ...
-    ]
-  }
-}
-```
-
-**Response `503`:** no LLM configured on this server.
-
 ---
 
 ## Project identity
@@ -423,7 +388,6 @@ A CI check diffs the committed file against a freshly generated one.
 | `GET` | `/v1/projects/{id}/stats` | Bearer | 1 | No change |
 | `POST` | `/v1/projects/{id}/index/embed` | Bearer | 1 | **New** |
 | `POST` | `/v1/projects/{id}/explore` | Bearer | 1 | **New** (SSE) |
-| `POST` | `/v1/projects/{id}/plan` | Bearer | 1 | **New** |
 
 ---
 
@@ -437,7 +401,6 @@ A CI check diffs the committed file against a freshly generated one.
 - [ ] `POST /v1/projects/{id}/memory/search` accepts `{"query": String}`
 - [ ] `POST /v1/projects/{id}/index/embed` implemented
 - [ ] `POST /v1/projects/{id}/explore` implemented (SSE)
-- [ ] `POST /v1/projects/{id}/plan` implemented
 - [ ] Error responses use `{"error": {"code": "...", "message": "..."}}` format
 - [ ] OpenAPI spec updated for all new/changed endpoints
 - [ ] All existing `cargo test` suites pass; `cargo fmt` + `cargo clippy` clean

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -946,73 +946,6 @@
         ]
       }
     },
-    "/v1/projects/{project_id}/plan": {
-      "post": {
-        "tags": [
-          "inference"
-        ],
-        "summary": "Generate a structured implementation plan via LLM over caller-supplied context.\nReturns 503 if no LLM is configured.",
-        "operationId": "plan",
-        "parameters": [
-          {
-            "name": "project_id",
-            "in": "path",
-            "description": "Project slug",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlanRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Structured implementation plan",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlanResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorBody"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "No LLM configured",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorBody"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearer_auth": []
-          }
-        ]
-      }
-    },
     "/v1/projects/{project_id}/stats": {
       "get": {
         "tags": [
@@ -1289,7 +1222,7 @@
       },
       "ExploreContextChunk": {
         "type": "object",
-        "description": "A single context chunk supplied by the CLI for `/explore` and `/plan`.",
+        "description": "A single context chunk supplied by the CLI for `/explore`.",
         "required": [
           "file",
           "start_line",
@@ -1381,59 +1314,6 @@
             "type": "integer",
             "description": "Maximum number of results to return (default: 20).",
             "minimum": 0
-          }
-        }
-      },
-      "PlanRequest": {
-        "type": "object",
-        "description": "Request body for `POST /v1/projects/{project_id}/plan`.",
-        "required": [
-          "goal"
-        ],
-        "properties": {
-          "context_chunks": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExploreContextChunk"
-            }
-          },
-          "goal": {
-            "type": "string"
-          },
-          "style": {
-            "type": "string",
-            "description": "`\"steps\"` (default) or `\"checklist\"`."
-          }
-        }
-      },
-      "PlanResponse": {
-        "type": "object",
-        "description": "Response body for `POST /v1/projects/{project_id}/plan`.",
-        "required": [
-          "plan"
-        ],
-        "properties": {
-          "plan": {
-            "$ref": "#/components/schemas/PlanResult"
-          }
-        }
-      },
-      "PlanResult": {
-        "type": "object",
-        "description": "A structured plan returned by the plan endpoint.",
-        "required": [
-          "title",
-          "steps"
-        ],
-        "properties": {
-          "steps": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "title": {
-            "type": "string"
           }
         }
       },
@@ -1648,7 +1528,7 @@
     },
     {
       "name": "inference",
-      "description": "LLM-powered explore and plan"
+      "description": "LLM-powered code exploration"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Removes the `POST /v1/projects/{id}/plan` endpoint from spelunk-server entirely
- Extends decision #287 ("Drop spelunk plan") to all surfaces — CLI and server alike
- Removes: `PlanRequest`, `PlanResult`, `PlanResponse` structs; `plan` handler; router registration; `ApiDoc` paths/schemas; `plan_without_llm_returns_503` integration test; all spec references in `docs/architecture/server-api.md`
- Retains `/explore`: LLM reasoning over retrieved context chunks is additive; harnesses do not replicate it

**Rationale:** Agent harnesses (Claude Code et al.) implement plan/spec generation natively. A server-side planning endpoint would duplicate that capability with no added value. This was the same rationale that drove the CLI removal in #287. Spelunk memory decision #85.

## Test plan

- [x] `cargo build -p spelunk-server` clean
- [x] `cargo test -p spelunk-server` — 12 tests pass (was 13; `plan_without_llm_returns_503` correctly removed)
- [x] `cargo fmt --check` clean (enforced by pre-commit hook)
- [x] `cargo clippy` clean (enforced by pre-commit hook)

Closes #287 (fully — server surface now also removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)