### PR TITLE
feat: --detach flag for spelunk index and memory harvest (#295)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/helpers.rs
+++ b/crates/spelunk-cli/src/cli/cmd/helpers.rs
@@ -64,3 +64,22 @@ pub(crate) fn project_display_name(path: &std::path::Path) -> String {
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| path.to_string_lossy().into_owned())
 }
+
+/// Detach: re-exec this binary with the same CLI arguments but without
+/// `--detach`, with all stdio closed, so the caller (e.g. a git hook) regains
+/// its prompt immediately while spelunk continues in the background.
+pub(crate) fn spawn_detached() -> Result<()> {
+    let exe = std::env::current_exe().context("resolving current executable")?;
+    let args: Vec<String> = std::env::args()
+        .skip(1)
+        .filter(|a| a != "--detach")
+        .collect();
+    std::process::Command::new(exe)
+        .args(&args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .context("spawning detached background process")?;
+    Ok(())
+}

--- a/crates/spelunk-cli/src/cli/cmd/hooks.rs
+++ b/crates/spelunk-cli/src/cli/cmd/hooks.rs
@@ -40,16 +40,16 @@ fi
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 
-spelunk index "$PROJECT_ROOT"
-spelunk memory harvest --git-range HEAD~1..HEAD
+spelunk index "$PROJECT_ROOT" --detach
+spelunk memory harvest --git-range HEAD~1..HEAD --detach
 "#;
 
 const CI_STEP: &str = r#"# Add to your .github/workflows/ file:
 - name: Update spelunk index
   run: |
     if command -v spelunk >/dev/null 2>&1; then
-      spelunk index .
-      spelunk memory harvest --git-range HEAD~1..HEAD
+      spelunk index . --detach
+      spelunk memory harvest --git-range HEAD~1..HEAD --detach
     fi
 "#;
 

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -36,6 +36,11 @@ pub struct IndexArgs {
     /// Used by the background process spawned after a large foreground index.
     #[arg(long = "_background-phases", hide = true, default_value_t = false)]
     pub background_phases: bool,
+
+    /// Detach immediately: re-exec spelunk in the background and return.
+    /// Useful in git hooks so the hook does not block the git process.
+    #[arg(long, default_value_t = false)]
+    pub detach: bool,
 }
 
 use crate::{capability, config::Config, registry::Registry, storage::Database};
@@ -47,6 +52,11 @@ mod summaries;
 mod worktree;
 
 pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
+    if args.detach {
+        super::helpers::spawn_detached()?;
+        return Ok(());
+    }
+
     // Validate config: server_url requires project_id.
     cfg.validate()?;
 

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -101,6 +101,7 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
             no_summaries: true,
             summary_batch_size: 10,
             background_phases: false,
+            detach: false,
         };
         super::index::index(index_args, cfg).await?;
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -13,6 +13,11 @@ pub(super) async fn memory_harvest(
     cfg: &Config,
     backend_override: Option<&str>,
 ) -> Result<()> {
+    if args.detach {
+        super::super::helpers::spawn_detached()?;
+        return Ok(());
+    }
+
     match args.source.as_str() {
         "git" => memory_harvest_git(args, mem_path, cfg, backend_override).await,
         "claude-code" => {

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -218,6 +218,11 @@ pub struct MemoryHarvestArgs {
     /// Only used with --source entire.
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Detach immediately: re-exec spelunk in the background and return.
+    /// Useful in git hooks so the hook does not block the git process.
+    #[arg(long, default_value_t = false)]
+    pub detach: bool,
 }
 
 #[derive(Args, Debug)]


### PR DESCRIPTION
## Summary

- Adds `--detach` to `spelunk index` and `spelunk memory harvest`
- When `--detach` is set the binary re-execs itself without the flag with all stdio null'd, returns immediately to the caller (git hook / CI step), and continues work in the background
- `spelunk hooks install` template updated to use `--detach` on both commands so new hook installs are non-blocking by default
- Existing hooks (without `--detach`) are unaffected

## Test plan

- [ ] `cargo build && spelunk index . --detach` returns in <100 ms while indexing proceeds in the background
- [ ] `spelunk memory harvest --git-range HEAD~1..HEAD --detach` returns immediately
- [ ] `spelunk hooks install` now writes the `--detach` variant
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo test` passes

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)