### PR TITLE
feat: gate spelunk explore behind Tier 2/3 (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **`spelunk explore` now requires a configured server** — the command is gated
+  behind the Tier 2/3 capability check (`server_url` must be set and reachable).
+  The previous check for `llm_model` has been removed in line with decision #47
+  (no LLM inference in the CLI without a server). Run `spelunk status` for
+  guidance if the command is unavailable.
+
+---
+
 ## [0.7.0] — 2026-05-17
 
 ### Added

--- a/crates/spelunk-cli/src/cli/cmd/explore.rs
+++ b/crates/spelunk-cli/src/cli/cmd/explore.rs
@@ -32,17 +32,14 @@ use super::helpers::open_project_db;
 use super::search::maybe_warn_stale;
 use super::ui::spinner;
 use crate::{
+    capability,
     config::Config,
     search::explore::{ExploreResult, Explorer},
 };
 
 pub async fn explore(args: ExploreArgs, cfg: Config) -> Result<()> {
-    if cfg.llm_model.is_none() {
-        anyhow::bail!(
-            "spelunk explore requires a chat model. \
-             Set `llm_model` in ~/.config/spelunk/config.toml."
-        );
-    }
+    let tier = capability::get_tier(&cfg).await;
+    capability::require_tier1("explore", tier, cfg.server_url.as_deref())?;
 
     let (db_path, _db) = open_project_db(args.db.as_deref(), &cfg.db_path)?;
     maybe_warn_stale(&db_path);


### PR DESCRIPTION
## Summary

- Replaces the `cfg.llm_model.is_none()` guard in `spelunk explore` with `capability::require_tier1("explore", tier, cfg.server_url.as_deref())?`, matching the pattern already used by `memory push` and `memory watch`
- Removes the old error message that directed users to set `llm_model`; users are now directed to `spelunk status` which already shows "set server_url to enable" for the explore row
- Adds an `[Unreleased]` CHANGELOG entry per decision #47 (no LLM inference in the CLI without a server)

## Test plan

- [x] `cargo fmt --check` passes (enforced by pre-commit hook)
- [x] `cargo clippy -p spelunk-cli -- -D warnings` passes
- [x] `cargo test -p spelunk-cli` — all 21 unit tests and all integration tests pass
- [x] `cargo audit` — checked (no new advisories introduced by this change)
- [ ] Manually verify: without `server_url` set, `spelunk explore "test"` exits with a clear tier error; with `server_url` set, it proceeds to the embedder/LLM load step

🤖 Generated with [Claude Code](https://claude.com/claude-code)