### PR TITLE
feat: add spelunk sync as top-level alias for memory push (#286)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,7 @@ cargo run -p spelunk-cli -- status --all
 cargo run -p spelunk-cli -- graph <symbol>
 cargo run -p spelunk-cli -- chunks src/some/file.rs
 cargo run -p spelunk-cli -- languages
+cargo run -p spelunk-cli -- sync              # push local memory to server (alias for memory push)
 
 # Run the server
 cargo run -p spelunk-server -- --port 7777

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ spelunk memory add --kind decision --title "Chose sqlite-vec over pgvector" \
 spelunk memory list --kind decision --limit 10
 spelunk memory search "why did we choose this database"
 spelunk memory harvest   # auto-extract decisions from recent commits (requires llm_model)
+spelunk sync             # push local memory entries to the configured server (alias for `memory push`)
 ```
 
 Memory is stored in git notes by default — it travels with the repo. Point at `memory_server_url` to share across a team.

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -307,7 +307,7 @@ mod harvest;
 mod harvest_claude;
 mod harvest_entire;
 mod list;
-mod push;
+pub mod push;
 mod search;
 mod show;
 mod since;

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -7,7 +7,7 @@ use crate::{
     storage::{NoteInput, open_memory_backend},
 };
 
-pub(super) async fn memory_push(
+pub async fn memory_push(
     args: MemoryPushArgs,
     mem_path: &std::path::Path,
     cfg: &Config,

--- a/crates/spelunk-cli/src/cli/cmd/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/mod.rs
@@ -25,6 +25,7 @@ pub use init::init;
 pub use link::{autoclean, link, unlink};
 pub use links::links;
 pub use memory::memory;
+pub use memory::push::memory_push;
 pub use misc::{chunks, languages};
 pub use plumbing::plumbing;
 pub use search::search;

--- a/crates/spelunk-cli/src/cli/mod.rs
+++ b/crates/spelunk-cli/src/cli/mod.rs
@@ -15,6 +15,7 @@ pub use cmd::init::InitArgs;
 pub use cmd::link::{LinkArgs, UnlinkArgs};
 pub use cmd::links::LinksArgs;
 pub use cmd::memory::MemoryArgs;
+pub use cmd::memory::MemoryPushArgs as SyncArgs;
 pub use cmd::misc::ChunksArgs;
 pub use cmd::plumbing::PlumbingArgs;
 pub use cmd::search::SearchArgs;
@@ -68,4 +69,6 @@ pub enum Command {
     Links(LinksArgs),
     /// Low-level plumbing commands for agents and scripts (NDJSON output)
     Plumbing(PlumbingArgs),
+    /// Sync local memory entries to the configured server (alias for `memory push`)
+    Sync(SyncArgs),
 }

--- a/crates/spelunk-cli/src/main.rs
+++ b/crates/spelunk-cli/src/main.rs
@@ -72,5 +72,9 @@ async fn main() -> Result<()> {
             }
             Ok(())
         }
+        Command::Sync(args) => {
+            let mem_path = config::resolve_db(None, &cfg.db_path).with_file_name("memory.db");
+            cli::cmd::memory_push(args, &mem_path, &cfg, None).await
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a new `Sync(SyncArgs)` variant to the `Command` enum in `crates/spelunk-cli/src/cli/mod.rs`
- Re-exports `MemoryPushArgs as SyncArgs` so callers can use it without touching memory internals
- Dispatch in `main.rs` calls `cli::cmd::memory_push` directly — zero logic duplication
- Makes `memory::push` submodule `pub` and `memory_push` function `pub` (was `pub(super)`) to enable re-export
- Updates README quickstart and CLAUDE.md Common Commands with `spelunk sync` examples

## Test plan

- [ ] `cargo build -p spelunk-cli` compiles clean
- [ ] `cargo fmt && cargo clippy -p spelunk-cli -- -D warnings` passes with no warnings
- [ ] `cargo test -p spelunk-cli` — all 21 unit + integration tests pass
- [ ] `cargo run -p spelunk-cli -- sync --help` shows: "Sync local memory entries to the configured server (alias for \`memory push\`)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)