### PR TITLE
feat: default spelunk search to ast-grep when no embedder (#284)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -27,8 +27,8 @@ pub struct SearchArgs {
     #[arg(long, default_value = "10")]
     pub graph_limit: usize,
 
-    /// Search mode: text (FTS only) or semantic/hybrid (default, uses LinearRAG)
-    #[arg(long, default_value = "hybrid")]
+    /// Search mode: auto (default), text (FTS only), semantic/hybrid (LinearRAG), or ast-grep
+    #[arg(long, default_value = "auto")]
     pub mode: String,
 
     /// Path to the SQLite database (overrides config)
@@ -59,6 +59,23 @@ use crate::{
 };
 
 pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
+    let mode = args.mode.as_str();
+    let auto_mode = mode == "auto";
+
+    // ── No-index / no-embedder fast path ─────────────────────────────────────
+    // When the user hasn't asked for a specific mode (auto) and either the
+    // index is missing or the embedder is unavailable, silently fall back to
+    // ast-grep — mirroring the `graph --live` pattern.
+    if auto_mode {
+        let db_result = resolve_project_and_deps(args.db.as_ref(), &cfg);
+        if db_result.is_err() {
+            // No index found — fall back to ast-grep silently.
+            return search_live(&args.query, &args.format, std::path::Path::new("."));
+        }
+        // Index exists but embedder may not be available. We'll check below
+        // after attempting to load it; for now, fall through to normal path.
+    }
+
     let (db_path, dep_projects) = resolve_project_and_deps(args.db.as_ref(), &cfg)?;
     crate::storage::record_usage_at(&db_path, "search");
 
@@ -91,8 +108,6 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
         None
     };
 
-    let mode = args.mode.as_str();
-
     let mut results = if mode == "text" && snapshot_id.is_none() {
         // Text mode: FTS5 only, no embedding model required.
         let sp = spinner("Searching (text)…");
@@ -102,13 +117,32 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
             .unwrap_or_default();
         sp.finish_and_clear();
         res
+    } else if mode == "ast-grep" && snapshot_id.is_none() {
+        // Explicit ast-grep mode: skip index entirely.
+        return search_live(&args.query, &args.format, std::path::Path::new("."));
     } else {
-        // semantic, hybrid, or snapshot search: need an embedding.
-        let sp = spinner("Loading model…");
+        // semantic, hybrid, auto, or snapshot search: need an embedding.
+        // Note: load_embedder only constructs an HTTP client and always succeeds.
+        // The actual network call (and potential failure) happens in embed_query_vec.
         let embedder = load_embedder(&cfg).await?;
 
-        sp.set_message("Embedding query…");
-        let query_vec = embed_query_vec(&embedder, "code retrieval", &args.query).await?;
+        let sp = spinner("Embedding query…");
+        let query_vec_result = embed_query_vec(&embedder, "code retrieval", &args.query).await;
+
+        // In auto mode, if the embedding call fails (e.g. embedder unreachable),
+        // fall back to ast-grep silently.
+        if auto_mode && query_vec_result.is_err() && snapshot_id.is_none() {
+            sp.finish_and_clear();
+            return search_live(&args.query, &args.format, std::path::Path::new("."));
+        }
+
+        let query_vec = query_vec_result.map_err(|e| {
+            anyhow::anyhow!(
+                "{e}\n\
+                 No embedder configured. Run `spelunk index` with a server_url to enable \
+                 semantic search, or use `--mode text` or `--mode ast-grep`."
+            )
+        })?;
         let query_blob = vec_to_blob(&query_vec);
 
         // Budget mode overfetches a candidate pool; limit is applied after packing.
@@ -132,11 +166,17 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
             )?
         };
         sp.finish_and_clear();
+
+        // Auto mode: stale index + empty results → fall back to ast-grep silently.
+        if auto_mode && res.is_empty() && !args.no_stale_check && index_is_stale(&db_path) {
+            return search_live(&args.query, &args.format, std::path::Path::new("."));
+        }
+
         res
     };
 
     if results.is_empty() {
-        println!("No results found. Make sure the index has embeddings (`spelunk index <path>`).");
+        println!("No results found.");
         return Ok(());
     }
 
@@ -314,6 +354,61 @@ fn annotate_specs(all: &mut [SearchResult], primary_db_path: &std::path::Path) {
             }
         }
     }
+}
+
+/// Run an ast-grep pattern search for `query` over the working tree rooted at `root`.
+///
+/// This is the zero-infra fallback: no index and no embedder required.
+/// It mirrors the `graph_live` pattern in `graph.rs`.
+pub(crate) fn search_live(query: &str, format: &str, root: &std::path::Path) -> Result<()> {
+    if std::process::Command::new("ast-grep")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        anyhow::bail!(
+            "ast-grep not found. Install with: brew install ast-grep\n\
+             (or: cargo install ast-grep --locked)\n\
+             Run `spelunk index .` to enable index-backed search."
+        );
+    }
+
+    let out = std::process::Command::new("ast-grep")
+        .args(["run", "--pattern", query, "--json"])
+        .arg(root)
+        .output()?;
+
+    if !out.status.success() && out.stdout.is_empty() {
+        println!("No results found.");
+        return Ok(());
+    }
+
+    let matches: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout).unwrap_or_default();
+
+    if matches.is_empty() {
+        println!("No results found.");
+        return Ok(());
+    }
+
+    match crate::utils::effective_format(format) {
+        "json" => println!("{}", serde_json::to_string_pretty(&matches)?),
+        "ndjson" => {
+            for m in &matches {
+                println!("{}", serde_json::to_string(m)?);
+            }
+        }
+        _ => {
+            println!("\x1b[1mResults (ast-grep live scan):\x1b[0m");
+            for m in &matches {
+                let file = m["path"].as_str().unwrap_or("?");
+                let line = m["range"]["start"]["line"].as_u64().unwrap_or(0);
+                let text = m["text"].as_str().unwrap_or("").trim();
+                println!("  \x1b[36m{file}\x1b[0m:\x1b[33m{line}\x1b[0m  {text}");
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Search a primary DB and any dep projects, merge results by distance, return top `limit`.

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -599,3 +599,143 @@ fn test_status_json_offline_tier() {
     assert!(body["server_url"].is_null());
     assert!(body["capabilities"].is_null());
 }
+
+// ── Issue #284: search falls back to ast-grep when no index / no embedder ───
+
+/// When there is no .spelunk/index.db, `spelunk search` in auto mode must
+/// succeed (via ast-grep fallback) rather than printing an opaque error.
+#[test]
+fn test_search_no_index_falls_back_to_ast_grep_or_clean_message() {
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    // Write a small Rust file so ast-grep has something to scan.
+    fs::write(
+        project_dir.join("lib.rs"),
+        "pub fn greet(name: &str) -> String { format!(\"hello {name}\") }",
+    )
+    .unwrap();
+
+    let config_path = temp.path().join("config.toml");
+    let db_path = temp.path().join("nonexistent.db"); // deliberately absent
+    fs::write(
+        &config_path,
+        format!(
+            "db_path = {:?}\napi_base_url = \"http://127.0.0.1:1234\"\nembedding_model = \"test\"\nllm_model = \"test\"\n",
+            db_path
+        ),
+    )
+    .unwrap();
+
+    // With no index, auto mode must not fail with a hard error.
+    // It either returns ast-grep results or a clean "No results found." message.
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let assert = cmd
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("search")
+        .arg("greet") // simple pattern ast-grep can match
+        .assert()
+        .success();
+
+    // Must not print the old opaque error message.
+    assert.stdout(predicate::str::contains("Make sure the index has embeddings").not());
+}
+
+/// When the index exists but there is no embedder (api_base_url points
+/// nowhere), `spelunk search` in auto mode must fall back to ast-grep and
+/// succeed, not bail out with a hard error.
+#[test]
+fn test_search_index_but_no_embedder_falls_back_to_ast_grep() {
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(
+        project_dir.join("lib.rs"),
+        "pub fn compute(x: i32) -> i32 { x * 2 }",
+    )
+    .unwrap();
+
+    let config_path = temp.path().join("config.toml");
+    let db_path = temp.path().join("index.db");
+    // Point at an unreachable endpoint so there's no embedder.
+    fs::write(
+        &config_path,
+        format!(
+            "db_path = {:?}\napi_base_url = \"http://127.0.0.1:19999\"\nembedding_model = \"test\"\nllm_model = \"test\"\n",
+            db_path
+        ),
+    )
+    .unwrap();
+
+    // Build the index (offline — no embedder needed for parse phase).
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    // Now search in auto mode: embedder is unavailable, so fallback kicks in.
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let assert = cmd
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("search")
+        .arg("compute")
+        .assert()
+        .success();
+
+    // Must not print the old opaque error message.
+    assert.stdout(predicate::str::contains("Make sure the index has embeddings").not());
+}
+
+/// Explicit `--mode hybrid` with an unreachable embedder must fail with a
+/// helpful message telling the user what to do, not the old opaque message.
+#[test]
+fn test_search_explicit_hybrid_no_embedder_shows_helpful_error() {
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("lib.rs"), "pub fn foo() {}").unwrap();
+
+    let config_path = temp.path().join("config.toml");
+    let db_path = temp.path().join("index.db");
+    fs::write(
+        &config_path,
+        format!(
+            "db_path = {:?}\napi_base_url = \"http://127.0.0.1:19999\"\nembedding_model = \"test\"\nllm_model = \"test\"\n",
+            db_path
+        ),
+    )
+    .unwrap();
+
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    // Explicit --mode hybrid must fail with a helpful error message.
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("search")
+        .arg("--mode")
+        .arg("hybrid")
+        .arg("foo")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("--mode text").or(predicate::str::contains("--mode ast-grep")),
+        );
+}


### PR DESCRIPTION
## Summary

- Changes `--mode` default from `hybrid` to `auto`; adds `ast-grep` as a valid explicit mode
- In `auto` mode: no index → silent ast-grep fallback; embedder unreachable → silent ast-grep fallback; stale index + empty results → silent ast-grep fallback (mirrors `graph --live` pattern at `graph.rs:47-74`)
- Explicit `--mode hybrid/semantic` with no embedder now shows a helpful error suggesting `--mode text` or `--mode ast-grep` instead of the opaque "make sure the index has embeddings" message
- Removes the misleading empty-results message; plain "No results found." now
- Adds `search_live()` fn (mirror of `graph_live()`) and three new e2e tests

## Test plan

- [ ] `test_search_no_index_falls_back_to_ast_grep_or_clean_message` — no `.spelunk/index.db` → exits 0
- [ ] `test_search_index_but_no_embedder_falls_back_to_ast_grep` — index present, embedder unreachable → ast-grep fallback
- [ ] `test_search_explicit_hybrid_no_embedder_shows_helpful_error` — `--mode hybrid` + no embedder → helpful error in stderr
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo test -p spelunk-cli` passes

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)