### PR TITLE
docs(#260): ADR-002 server AI endpoint contract — generic /llm/complete primitive

### DIFF
--- a/docs/adr/002-server-ai-endpoint-contract.md
+++ b/docs/adr/002-server-ai-endpoint-contract.md
@@ -1,0 +1,165 @@
+# ADR-002: Server AI Endpoint Contract — Generic Inference Primitives vs Per-Command Endpoints
+
+**Status:** Accepted
+**Date:** 2026-05-31
+**Context:** Issue #260 (strip embedding/LLM from `spelunk-cli`) is blocked. Issue #259 mandates the CLI does no inference — every embedding/LLM call routes through `spelunk-server`. The agreed API contract #261 (CLOSED, `docs/architecture/server-api.md`) covers `/index/embed`, `/memory/search`, `/explore`, `/plan` but has **no endpoint for `spelunk memory harvest`** (~2300 LoC across `harvest.rs`, `harvest_claude.rs`, `harvest_entire.rs`) and **no generic query-embed path** for `memory add`/`search`/`timeline`. The implementer proposed adding a bespoke endpoint per command. Johan posed an open question (#42): rather than one endpoint per command, would two **generic** endpoints — an "llm process" route and an "embed" route — be better, making `spelunk-server` a BFF/proxy for upstream AI integrations?
+
+This ADR answers #42 and specifies the contract that unblocks #260.
+
+---
+
+## Decision
+
+Adopt a **hybrid** surface: **generic inference primitives** for raw, CLI-orchestrated inference, plus a **small fixed set of scoped semantic routes** where the server legitimately owns the orchestration.
+
+### 1. One generic LLM primitive — `POST /v1/projects/{id}/llm/complete`
+
+A single completion endpoint that is a 1:1 lift of the existing `LlmBackend::generate` trait (`crates/spelunk-core/src/llm/mod.rs`):
+
+```
+(messages[], max_tokens, json_schema?) → streamed completion tokens
+```
+
+Every current LLM call site — `harvest.rs`, `harvest_claude.rs`, `harvest_entire.rs`, `summariser.rs`, and `explore` — already calls exactly this method. The CLI keeps **all** of harvest's prompt orchestration (commit chunking, prompt assembly, structured-output parsing, dedup). The server owns **no** harvest semantics; it borrows only raw inference.
+
+### 2. One generic embed primitive — reuse `POST /v1/projects/{id}/index/embed`
+
+No new embed route. `memory add`/`search`/`timeline` obtain query vectors by calling the existing `/index/embed` (from #261) with a synthetic `chunk_id` that the server echoes back opaquely. `/memory/search` retains its text-query form from #261 for server-side memory KNN.
+
+### 3. Keep `/explore` and `/plan` as scoped, server-owned SSE routes
+
+These already exist in #261 and stay. Their multi-turn reasoning loop and retrieval policy are genuinely server-side concerns; collapsing them into `llm/complete` would push agentic loop logic into the CLI — the opposite of what #259 wants and the opposite of the BFF intent.
+
+**Net surface:** 2 generic primitives (`llm/complete`, `index/embed`) + a fixed semantic set (`memory` CRUD/search, `explore`, `plan`). Not "N bespoke endpoints," and deliberately not literally "two endpoints total."
+
+---
+
+## Why (the case FOR generic primitives)
+
+**The trait is already generic.** `LlmBackend::generate` is `(messages, max_tokens, json_schema) → tokens`. There is no per-command shape to preserve. A bespoke `POST /v1/harvest` would force the server to own prompt-chaining that is pure CLI logic, duplicating ~2300 LoC across the network trust boundary and re-deriving it whenever a CLI command wants inference (harvest today; convention extraction, plan variants, future commands tomorrow).
+
+**Surface area & versioning.** Per-command endpoints grow O(commands); the generic primitive is O(1). A stable primitive is far cheaper to keep in OpenAPI parity with `cloud-api` (decision #28, V1-2: `server_url=https://api.spelunk.cloud` must "just work").
+
+**Where orchestration lives.** Explicit and correct: prompt/extraction orchestration stays in the CLI (it has the local index, the git history, the parsing); the server is a thin inference peer. This matches the project stance that "spelunk does not run agents — it serves them as peers" (decision #28).
+
+---
+
+## Why NOT (the case AGAINST this pick — considered, not rubber-stamped)
+
+A generic "run any prompt" endpoint is a **broader abuse, injection, and cost surface** than a scoped `/harvest` that only accepts a commit range. Anyone holding a valid key can run arbitrary prompts against the operator's metered/BYOK LLM. This is the strongest argument for per-command endpoints, and it is real. We accept the generic primitive **only with** the mitigations below; without them, per-command scoping would win.
+
+A second argument against: a bespoke `/harvest` could let the **server** improve harvest quality centrally (better prompts shipped server-side). We reject this because it contradicts #259/#260's data-ownership and "CLI owns orchestration" model, and because server-side prompt logic cannot see the CLI's local index without the CLI shipping context anyway.
+
+---
+
+## Security / threat-model impact (new trust boundary)
+
+`llm/complete` introduces a **new trust boundary**: a network-facing, free-form inference endpoint. `docs/security/THREAT-MODEL.md` must be updated. Binding requirements:
+
+1. **Auth + tier.** Tier-1 only, `Authorization: Bearer` required, same as all server-mediated routes (#259). No unauthenticated free-form inference.
+2. **Hard server-side `max_tokens` ceiling** and **per-principal rate limit** (token budget per `AuthContext.principal`). The client-supplied `max_tokens` is clamped, never trusted upward.
+3. **Cost attribution** is per-principal via `AuthContext` (#261 auth trait) — the same granularity a bespoke endpoint would give. No granularity is lost by going generic.
+4. **BYOK key never leaves the server.** The client sends prompts; the server holds the upstream provider key. Consistent with decisions #25/#26 (BYOK keys stored as HMAC-SHA256 hashes; real key resolved via Secret Manager in cloud — never passed to the client, never logged).
+5. **Prompt injection is the CLIENT's responsibility.** `llm/complete` is a *raw* primitive: the server adds **no** system prompt of its own and makes **no** trust assumptions about message content. Delimiter isolation / angle-bracket escaping of untrusted context stays in the CLI (CLAUDE.md "Prompt structure" decision; threat-model issue #137). The server must not "helpfully" wrap or re-prompt — doing so would create an injection surface it cannot reason about.
+6. **No persistence.** `llm/complete` stores nothing (same data-promise as `/explore` in `server-api.md`): messages are request-scoped, never written to the memory DB, never logged in plaintext.
+
+---
+
+## Endpoint contract — `POST /v1/projects/{project_id}/llm/complete`
+
+Run a single LLM completion over caller-supplied messages. Streaming SSE. The server performs no orchestration, adds no system prompt, and stores nothing.
+
+**Auth:** `Authorization: Bearer <token>` (Tier 1).
+**Tier-gating:** Tier 1 only. Tier 0 (no server) → the CLI emits the #259 locked-feature error; the endpoint is simply absent from the capabilities list.
+
+**Request:**
+
+```json
+{
+  "messages": [
+    { "role": "system", "content": "You extract decisions from commits." },
+    { "role": "user", "content": "<commit batch>" }
+  ],
+  "max_tokens": 2048,
+  "json_schema": {
+    "name": "harvested_decisions",
+    "schema": { "type": "object", "properties": { } }
+  }
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|:---:|---|
+| `messages` | array of `{role, content}` | yes | `role` ∈ `system`\|`user`\|`assistant`. Non-empty. Mirrors `crate::llm::Message`. |
+| `max_tokens` | integer | yes | Client request; **server clamps** to its configured ceiling. |
+| `json_schema` | object | no | OpenAI-style `response_format.json_schema`. Backends that don't support structured output ignore it (matches current trait contract). |
+
+**Response `200`:** `Content-Type: text/event-stream`, one JSON object per `data:` line:
+
+```
+data: {"kind":"token","content":"The "}
+data: {"kind":"token","content":"auth "}
+data: {"kind":"done"}
+```
+
+| `kind` | Fields | Meaning |
+|---|---|---|
+| `token` | `content: string` | One streamed completion fragment. Concatenate in order. |
+| `done` | — | Stream complete. Always terminal on success. |
+| `error` | `code: string`, `message: string` | Terminal on failure mid-stream. |
+
+**Error responses** (before the stream opens) use the standard envelope `{"error":{"code","message"}}`:
+
+| HTTP | `code` | When |
+|---|---|---|
+| 400 | `bad_request` | `messages` empty / malformed; `max_tokens` ≤ 0. |
+| 401 | `unauthorized` | Bearer token missing/invalid. |
+| 413 | `payload_too_large` | Request body exceeds the server content-length limit. |
+| 429 | `rate_limited` | Per-principal token budget / rate limit exceeded. |
+| 503 | `llm_unavailable` | No LLM configured on this server (mirrors `/explore` 503). |
+
+`503` body:
+
+```json
+{ "error": { "code": "llm_unavailable", "message": "llm.complete requires an LLM backend. Configure the chat model on the server." } }
+```
+
+**Capability probe.** `GET /v1/health` `capabilities` array gains `"llm.complete"`. The CLI uses this to gate `memory harvest` (and any other `llm/complete` consumer) in Tier 1 against older servers.
+
+---
+
+## Query embedding for memory — reuse `/index/embed`
+
+`memory add`/`search`/`timeline` need a query vector. They call the existing `POST /v1/projects/{id}/index/embed` with a single synthetic chunk:
+
+```json
+{ "chunks": [ { "chunk_id": "query:<uuid>", "content": "<query or note text>" } ] }
+```
+
+The server echoes `chunk_id` back with the vector (it is opaque to the server, per `server-api.md`). No new route, no new schema. `memory search` against the **server-side** memory DB continues to use the text-query `/memory/search` form from #261 (server embeds internally). The synthetic-chunk path is for **local** query vectors only (e.g. `memory add` dedup against the local note store).
+
+> Note for the implementer: prefix synthetic ids (`query:`) so they are trivially distinguishable from real chunk ids in logs/metrics. The server treats them identically.
+
+---
+
+## OpenAPI parity (decision #28, V1-2)
+
+`llm/complete` is added to the `utoipa::ApiDoc` source of truth in `crates/spelunk-server/src/lib.rs` and to the committed `docs/openapi.json` snapshot, with a request schema component and an SSE-event schema. `cloud-api` must add the matching route to preserve parity so `server_url=https://api.spelunk.cloud` works unchanged. A follow-up architect/cloud task is filed for the cloud side.
+
+---
+
+## Consequences
+
+- **#260 unblocks.** `ActiveLlm`/`ActiveEmbedder` leave `spelunk-cli`; the `EmbeddingBackend`/`LlmBackend` traits + `OpenAiCompat` impls + `backends.rs` + `summariser` move to `spelunk-server` (per the relocation plan in the inbox note). `vec_to_blob`/`blob_to_vec` stay in `spelunk-core` (pure). `spelunk-core` drops `reqwest`.
+- **harvest** becomes Tier-1-only, routed through `llm/complete`; Tier-0 emits the #259 locked-feature error. No `/harvest` endpoint is added.
+- **`server-api.md` is amended**, not replaced: it gains the `llm/complete` row and the synthetic-chunk query-embed note. Nothing in #261 is invalidated.
+- **THREAT-MODEL.md** gains the new `llm/complete` trust boundary and its six binding requirements.
+- **Cost/abuse risk** is accepted in exchange for a stable O(1) inference surface, gated behind auth + rate limiting + a server-side token ceiling.
+
+## Boundary test
+
+If a proposed new CLI command needs LLM inference and its prompt/orchestration can live in the CLI, it routes through `llm/complete` — do **not** add a new endpoint. Add a scoped route **only** when the multi-turn orchestration or retrieval policy must live server-side (as `/explore` and `/plan` do).
+
+---
+
+**Refs:** GH #260, #261, #259; question #42; decision #89 (this decision); decisions #25/#26 (BYOK), #28 (OpenAPI parity / serve-as-peers), #19 (server-default 0.8.0). Companion living doc: `docs/architecture/server-api.md`.

--- a/docs/architecture/server-api.md
+++ b/docs/architecture/server-api.md
@@ -338,6 +338,66 @@ Event `kind` values: `thought`, `answer`, `done`, `error`.
 
 ---
 
+### `POST /v1/projects/{project_id}/llm/complete`
+
+Run a single LLM completion over caller-supplied messages. This is the generic
+inference primitive (ADR-002): it is a 1:1 lift of the `LlmBackend::generate`
+trait. The server performs **no** orchestration, adds **no** system prompt, and
+stores **nothing**. The CLI owns all prompt assembly (this is how `spelunk
+memory harvest` runs after #260: ~2300 LoC of CLI-side orchestration calling
+this primitive for raw inference).
+
+**Request:**
+
+```json
+{
+  "messages": [
+    { "role": "system", "content": "You extract decisions from commits." },
+    { "role": "user", "content": "<commit batch>" }
+  ],
+  "max_tokens": 2048,
+  "json_schema": { "name": "harvested_decisions", "schema": { } }
+}
+```
+
+`messages[].role` ∈ `system`|`user`|`assistant`. `max_tokens` is a request; the
+server **clamps** it to its configured ceiling. `json_schema` (optional) is the
+OpenAI-style `response_format.json_schema`; backends without structured output
+ignore it.
+
+**Response `200`:** SSE stream, one JSON event per line:
+
+```
+data: {"kind":"token","content":"The "}
+
+data: {"kind":"done"}
+```
+
+`kind` ∈ `token` (`content`), `done`, `error` (`code`, `message`).
+
+**Errors:** `400` malformed messages / `max_tokens ≤ 0`; `401` auth; `413` body
+too large; `429` per-principal token budget exceeded; `503` no LLM configured:
+
+```json
+{ "error": { "code": "llm_unavailable", "message": "llm.complete requires an LLM backend. Configure the chat model on the server." } }
+```
+
+**Security (see THREAT-MODEL.md, ADR-002):** Tier-1 + Bearer only; server-side
+`max_tokens` ceiling; per-principal rate limit; BYOK key never leaves the server
+(decisions #25/#26); prompt-injection isolation is the **caller's**
+responsibility — the server adds no system prompt and makes no trust
+assumptions about message content. `capabilities` array gains `"llm.complete"`.
+
+### Query embedding for memory — reuse `/index/embed`
+
+`memory add`/`search`/`timeline` obtain **local** query vectors by calling
+`/index/embed` with a synthetic chunk (`{"chunk_id":"query:<uuid>","content":
+"..."}`); the server echoes the id back opaquely. No dedicated query-embed route
+is added. Server-side memory KNN continues to use the text-query
+`/memory/search` form above.
+
+---
+
 ## Project identity
 
 All per-project endpoints accept `project_id` as a URL path segment. The CLI
@@ -386,8 +446,9 @@ A CI check diffs the committed file against a freshly generated one.
 | `GET` | `/v1/projects/{id}/memory/stream` | Bearer | 1 | No change |
 | `GET` | `/v1/projects/{id}/memory/harvested-shas` | Bearer | 1 | No change |
 | `GET` | `/v1/projects/{id}/stats` | Bearer | 1 | No change |
-| `POST` | `/v1/projects/{id}/index/embed` | Bearer | 1 | **New** |
+| `POST` | `/v1/projects/{id}/index/embed` | Bearer | 1 | **New** (also serves memory query-embed via synthetic chunk) |
 | `POST` | `/v1/projects/{id}/explore` | Bearer | 1 | **New** (SSE) |
+| `POST` | `/v1/projects/{id}/llm/complete` | Bearer | 1 | **New** (SSE) — generic inference primitive (ADR-002) |
 
 ---
 

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -1,7 +1,7 @@
 # spelunk Threat Model
 
 **Method:** Lightweight threat modeling (STRIDE-informed)  
-**Last reviewed:** April 2026  
+**Last reviewed:** May 2026 (ADR-002: generic `llm/complete` inference endpoint)  
 **Reviewed by:** Architect  
 **Next review:** v1.0 release or after any new network-facing feature
 
@@ -149,6 +149,41 @@ reachable beyond localhost (e.g. on a LAN or cloud VM), all memory is unauthenti
 | Memory note stored via server contains injection payload, later retrieved in `spelunk ask` context | A+B | Low | Medium | No sanitisation of server-stored note bodies before inclusion in LLM context. Same XML delimiter isolation applies, but angle-bracket escaping must cover memory context too (issue #137). |
 
 **Residual risk:** Pre-flight only blocks known string patterns. Novel injection payloads in indexed content or server-stored memory could influence the LLM response.
+
+---
+
+## Generic inference endpoint — `POST /v1/projects/{id}/llm/complete` (Mode B, ADR-002)
+
+ADR-002 adds a generic LLM completion primitive to `spelunk-server` so the CLI
+can route `spelunk memory harvest` (and future inference-needing commands)
+through one stable route instead of a bespoke endpoint per command. This
+introduces a **new trust boundary**: a network-facing, free-form inference
+endpoint that runs arbitrary caller-supplied prompts against the server's
+configured (possibly BYOK, possibly metered) LLM.
+
+This is a deliberately broader surface than a scoped `/harvest` endpoint would
+be. The trade-off is accepted **only** with the controls below; they are
+binding requirements, not recommendations.
+
+| Threat | STRIDE | Likelihood | Impact | Mitigation (binding) |
+|--------|--------|-----------|--------|----------------------|
+| Authenticated caller runs arbitrary prompts to burn the operator's LLM budget | D / EoP | Medium | Medium | Tier-1 + Bearer auth required; **per-principal rate limit + token budget**; client `max_tokens` **clamped** to a server-side ceiling (never trusted upward) |
+| Caller exfiltrates or abuses a BYOK upstream key | I | Low | High | BYOK key **never leaves the server** — client sends prompts, server holds the upstream key; stored as HMAC-SHA256 hash, resolved via Secret Manager in cloud, never logged (decisions #25/#26) |
+| Prompt injection via caller-supplied `messages` | T | Medium | Medium | `llm/complete` is a **raw** primitive: the server adds **no** system prompt and makes **no** trust assumptions. Delimiter isolation / angle-bracket escaping of untrusted context is the **caller's** responsibility (issue #137). The server must NOT wrap or re-prompt content. |
+| Completion content or prompts persisted/leaked server-side | I | Low | Medium | No persistence: messages are request-scoped, never written to the memory DB, never logged in plaintext (same data-promise as `/explore`) |
+| Unconfigured server invoked | — | Low | Low | `503 llm_unavailable` when no LLM backend configured; endpoint absent from `/v1/health` `capabilities` so the CLI gates it |
+
+**Why generic over per-command (security framing):** a bespoke `/harvest` would
+narrow the input shape but would force harvest's ~2300 LoC of prompt
+orchestration across the trust boundary into the server, expanding the
+server's attack surface and duplicating CLI logic. Keeping orchestration in the
+CLI and exposing only a raw, auth-gated, rate-limited, non-persisting primitive
+is the smaller *server-side* trust surface, at the cost of a broader *input*
+surface — which the controls above contain. See ADR-002 for the full rationale.
+
+**Cost attribution** is per-principal via `AuthContext` (#261 auth trait) — the
+same granularity a bespoke endpoint would provide. No attribution granularity is
+lost by going generic.
 
 ---
 


### PR DESCRIPTION
## What

Adds **ADR-002** specifying the server AI endpoint contract that unblocks #260 (strip embedding/LLM from `spelunk-cli`), and answers Johan's open design question (memory question #42): generic inference primitives vs a bespoke endpoint per command.

Docs-only, purely additive — nothing in the closed contract #261 is invalidated.

- **New:** `docs/adr/002-server-ai-endpoint-contract.md`
- **Amended:** `docs/architecture/server-api.md` (adds the `llm/complete` row + synthetic-chunk query-embed note)
- **Amended:** `docs/security/THREAT-MODEL.md` (new free-form-inference trust boundary + 6 binding controls)

## Decision (hybrid, generic-leaning)

1. **Add one generic LLM primitive** — `POST /v1/projects/{id}/llm/complete`, a 1:1 lift of the existing `LlmBackend::generate` trait. `harvest`, `summariser`, etc. keep all prompt orchestration CLI-side; the server borrows only raw inference.
2. **Reuse** `POST /v1/index/embed` for memory query vectors (synthetic `chunk_id`) — no new embed route.
3. **Keep** `/explore` + `/plan` as scoped, server-owned SSE routes — their multi-turn loop genuinely belongs server-side (per #259); collapsing them into the primitive would push agentic logic into the CLI.

Net surface: 2 generic primitives + a fixed semantic set. Not N bespoke endpoints, and deliberately not literally "two endpoints total." Rationale (incl. the case *against*) is in the ADR.

## Security

New trust boundary documented: Tier-1 + Bearer only, server-side `max_tokens` clamp, per-principal rate limit + cost attribution, BYOK key never leaves the server (#25/#26), prompt-injection isolation stays caller-side (server adds no system prompt), zero persistence.

## Unblocks / follow-ups

- **Unblocks #260** — implementer builds `/llm/complete`, routes harvest + memory-embed through it, then strips `ActiveLlm`/`ActiveEmbedder` from the CLI dep tree.
- Follow-up: cloud-api OpenAPI parity for `/llm/complete` (decision #28, V1-2).

## Test plan

Docs-only change; no code or tests affected. Reviewer verification:
- [ ] `docs/adr/002-server-ai-endpoint-contract.md` renders and the endpoint contract (request/response/error tables) is internally consistent.
- [ ] `docs/architecture/server-api.md` amendment matches the ADR's `llm/complete` contract (no drift between the two).
- [ ] `docs/security/THREAT-MODEL.md` lists the `llm/complete` boundary with all 6 binding controls.
- [ ] Confirm nothing in the closed #261 contract is contradicted (change is additive only).

Refs: #260, #261, #259; memory decision #43 (team) / #89 (repo); ADR-002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)