### PR TITLE
feat(#260): add POST /v1/projects/{id}/llm/complete SSE inference endpoint (ADR-002)

### DIFF
--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -13,7 +13,7 @@ use axum::{
     },
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use utoipa::ToSchema;
 
 use super::{AppError, AppState, ErrorBody};
@@ -899,26 +899,48 @@ pub async fn llm_complete(
         .collect();
 
     let (tx, mut rx) = mpsc::channel::<String>(64);
+    let (err_tx, err_rx) = oneshot::channel::<anyhow::Error>();
     let json_schema = body.json_schema;
 
     // Spawn LLM generation into a background task.
+    // On error, forward the error to the SSE stream via err_tx so the client
+    // receives a {"kind":"error",...} event before the stream closes (ADR-002 §109).
     tokio::spawn(async move {
         if let Err(e) = llm.generate(&messages, max_tokens, tx, json_schema).await {
             tracing::warn!("llm/complete generate error: {e}");
+            // Best-effort send — the receiver may have gone away, which is fine.
+            let _ = err_tx.send(e);
         }
     });
 
     // Stream tokens as SSE events per ADR-002 contract:
     //   {"kind":"token","content":"..."} per token
-    //   {"kind":"done"} as the terminal event
+    //   {"kind":"error","code":"...","message":"..."} on LLM failure (terminal)
+    //   {"kind":"done"} as the terminal success event
     let s = stream! {
+        let mut err_rx = err_rx;
         while let Some(token) = rx.recv().await {
             let data = serde_json::json!({"kind": "token", "content": token}).to_string();
             yield Ok::<Event, Infallible>(Event::default().data(data));
         }
-        yield Ok::<Event, Infallible>(
-            Event::default().data(r#"{"kind":"done"}"#)
-        );
+        // After the token channel closes, check whether the background task
+        // ended with an error.  If so, emit the error event instead of done.
+        match err_rx.try_recv() {
+            Ok(e) => {
+                let data = serde_json::json!({
+                    "kind": "error",
+                    "code": "llm_error",
+                    "message": e.to_string(),
+                })
+                .to_string();
+                yield Ok::<Event, Infallible>(Event::default().data(data));
+            }
+            Err(_) => {
+                yield Ok::<Event, Infallible>(
+                    Event::default().data(r#"{"kind":"done"}"#)
+                );
+            }
+        }
     };
 
     Ok(Sse::new(s).keep_alive(KeepAlive::default()).into_response())
@@ -1341,6 +1363,65 @@ mod tests {
             resp.status(),
             http::StatusCode::SERVICE_UNAVAILABLE,
             "explore without LLM must return 503"
+        );
+    }
+
+    /// POST /v1/projects/{slug}/llm/complete with an empty `messages` array must return 400.
+    #[tokio::test]
+    async fn llm_complete_empty_messages_returns_400() {
+        let (app, _) = make_app(0.92);
+        let body = json!({"messages": [], "max_tokens": 256});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/projects/proj/llm/complete")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            http::StatusCode::BAD_REQUEST,
+            "empty messages must return 400"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        assert_eq!(
+            json["error"]["code"],
+            json!("bad_request"),
+            "error code must be bad_request; got: {json}"
+        );
+    }
+
+    /// POST /v1/projects/{slug}/llm/complete with a valid body but no LLM configured must return 503.
+    #[tokio::test]
+    async fn llm_complete_without_llm_returns_503() {
+        let (app, _) = make_app(0.92);
+        let body = json!({
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 256,
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/projects/proj/llm/complete")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            "llm/complete without LLM must return 503"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        assert_eq!(
+            json["error"]["code"],
+            json!("llm_unavailable"),
+            "error code must be llm_unavailable; got: {json}"
         );
     }
 

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -131,6 +131,7 @@ pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
     }
     if state.llm.is_some() {
         capabilities.push("explore".to_string());
+        capabilities.push("llm.complete".to_string());
     }
     Json(HealthResponse {
         status: "ok",
@@ -770,6 +771,157 @@ pub async fn index_embed(
 
     // Data promise: vectors are NOT stored on the server. We return them directly.
     Ok(Json(EmbedResponse { chunks: out_chunks }).into_response())
+}
+
+// ── LLM complete (SSE) ───────────────────────────────────────────────────────
+
+/// A single chat message in the completion request.
+#[derive(Deserialize, ToSchema)]
+pub struct LlmMessage {
+    /// Role of the message author: `system`, `user`, or `assistant`.
+    pub role: String,
+    /// Text content of the message.
+    pub content: String,
+}
+
+/// Request body for `POST /v1/projects/{project_id}/llm/complete`.
+#[derive(Deserialize, ToSchema)]
+pub struct LlmCompleteRequest {
+    /// Ordered list of chat messages. Must be non-empty.
+    pub messages: Vec<LlmMessage>,
+    /// Maximum tokens to generate. The server clamps this to its configured ceiling.
+    pub max_tokens: u32,
+    /// Optional OpenAI-style `response_format.json_schema` for structured output.
+    /// Backends that do not support structured output silently ignore this field.
+    #[serde(default)]
+    pub json_schema: Option<serde_json::Value>,
+}
+
+/// Server-side ceiling for `max_tokens` on `llm/complete` requests.
+const LLM_COMPLETE_MAX_TOKENS: u32 = 8192;
+
+/// Run a single LLM completion over caller-supplied messages. Streams tokens as SSE events.
+///
+/// The server performs **no orchestration**, adds **no system prompt**, and stores **nothing**.
+/// Prompt content is entirely the caller's responsibility.
+///
+/// Response events (one per `data:` line):
+/// - `{"kind":"token","content":"..."}` — one streamed token fragment
+/// - `{"kind":"done"}` — terminal success event
+/// - `{"kind":"error","code":"...","message":"..."}` — terminal failure event
+///
+/// Returns **400** when `messages` is empty or `max_tokens` ≤ 0.
+/// Returns **503** when no LLM backend is configured on this server.
+#[utoipa::path(
+    post,
+    path = "/v1/projects/{project_id}/llm/complete",
+    params(
+        ("project_id" = String, Path, description = "Project slug (e.g. `usercise/spelunk`)")
+    ),
+    request_body = LlmCompleteRequest,
+    responses(
+        (status = 200, description = "SSE stream: token/done/error events"),
+        (status = 400, description = "Bad request (empty messages or invalid max_tokens)", body = ErrorBody),
+        (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 503, description = "No LLM configured on this server", body = ErrorBody),
+    ),
+    security(("bearer_auth" = [])),
+    tag = "inference"
+)]
+pub async fn llm_complete(
+    State(state): State<AppState>,
+    Path(_project_id): Path<String>,
+    Json(body): Json<LlmCompleteRequest>,
+) -> Result<Response, AppError> {
+    // Validate inputs before touching the LLM backend.
+    if body.messages.is_empty() {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorBody::new("bad_request", "messages must not be empty")),
+        )
+            .into_response());
+    }
+    if body.max_tokens == 0 {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorBody::new(
+                "bad_request",
+                "max_tokens must be greater than 0",
+            )),
+        )
+            .into_response());
+    }
+
+    // Validate roles.
+    for msg in &body.messages {
+        if !matches!(msg.role.as_str(), "system" | "user" | "assistant") {
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorBody::new(
+                    "bad_request",
+                    &format!(
+                        "invalid role {:?}; must be system, user, or assistant",
+                        msg.role
+                    ),
+                )),
+            )
+                .into_response());
+        }
+    }
+
+    // 503 when no LLM is configured — use the llm_unavailable code from ADR-002.
+    let llm = match state.llm.clone() {
+        Some(l) => l,
+        None => {
+            return Ok((
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorBody::new(
+                    "llm_unavailable",
+                    "llm.complete requires an LLM backend. \
+                     Configure the chat model on the server.",
+                )),
+            )
+                .into_response());
+        }
+    };
+
+    // Clamp max_tokens to server ceiling.
+    let max_tokens = body.max_tokens.min(LLM_COMPLETE_MAX_TOKENS) as usize;
+
+    // Convert request messages to core Message type.
+    let messages: Vec<spelunk_core::llm::Message> = body
+        .messages
+        .into_iter()
+        .map(|m| spelunk_core::llm::Message {
+            role: m.role,
+            content: m.content,
+        })
+        .collect();
+
+    let (tx, mut rx) = mpsc::channel::<String>(64);
+    let json_schema = body.json_schema;
+
+    // Spawn LLM generation into a background task.
+    tokio::spawn(async move {
+        if let Err(e) = llm.generate(&messages, max_tokens, tx, json_schema).await {
+            tracing::warn!("llm/complete generate error: {e}");
+        }
+    });
+
+    // Stream tokens as SSE events per ADR-002 contract:
+    //   {"kind":"token","content":"..."} per token
+    //   {"kind":"done"} as the terminal event
+    let s = stream! {
+        while let Some(token) = rx.recv().await {
+            let data = serde_json::json!({"kind": "token", "content": token}).to_string();
+            yield Ok::<Event, Infallible>(Event::default().data(data));
+        }
+        yield Ok::<Event, Infallible>(
+            Event::default().data(r#"{"kind":"done"}"#)
+        );
+    };
+
+    Ok(Sse::new(s).keep_alive(KeepAlive::default()).into_response())
 }
 
 // ── Explore (SSE) ─────────────────────────────────────────────────────────────

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -67,6 +67,7 @@ pub fn default_conflict_threshold() -> f32 {
         handlers::memory_stream,
         handlers::index_embed,
         handlers::explore,
+        handlers::llm_complete,
     ),
     components(schemas(
         handlers::AddNoteRequest,
@@ -86,6 +87,8 @@ pub fn default_conflict_threshold() -> f32 {
         handlers::EmbedChunkOut,
         handlers::ExploreRequest,
         handlers::ExploreContextChunk,
+        handlers::LlmCompleteRequest,
+        handlers::LlmMessage,
         ErrorBody,
         ErrorDetail,
         db::Project,
@@ -179,6 +182,10 @@ pub fn router(state: AppState) -> Router {
             post(handlers::index_embed),
         )
         .route("/v1/projects/{project_id}/explore", post(handlers::explore))
+        .route(
+            "/v1/projects/{project_id}/llm/complete",
+            post(handlers::llm_complete),
+        )
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -205,6 +205,77 @@
         ]
       }
     },
+    "/v1/projects/{project_id}/llm/complete": {
+      "post": {
+        "tags": [
+          "inference"
+        ],
+        "summary": "Run a single LLM completion over caller-supplied messages. Streams tokens as SSE events.",
+        "description": "The server performs **no orchestration**, adds **no system prompt**, and stores **nothing**.\nPrompt content is entirely the caller's responsibility.\n\nResponse events (one per `data:` line):\n- `{\"kind\":\"token\",\"content\":\"...\"}` — one streamed token fragment\n- `{\"kind\":\"done\"}` — terminal success event\n- `{\"kind\":\"error\",\"code\":\"...\",\"message\":\"...\"}` — terminal failure event\n\nReturns **400** when `messages` is empty or `max_tokens` ≤ 0.\nReturns **503** when no LLM backend is configured on this server.",
+        "operationId": "llm_complete",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "Project slug (e.g. `usercise/spelunk`)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LlmCompleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "SSE stream: token/done/error events"
+          },
+          "400": {
+            "description": "Bad request (empty messages or invalid max_tokens)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "No LLM configured on this server",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/v1/projects/{project_id}/memory": {
       "get": {
         "tags": [
@@ -1314,6 +1385,50 @@
             "type": "integer",
             "description": "Maximum number of results to return (default: 20).",
             "minimum": 0
+          }
+        }
+      },
+      "LlmCompleteRequest": {
+        "type": "object",
+        "description": "Request body for `POST /v1/projects/{project_id}/llm/complete`.",
+        "required": [
+          "messages",
+          "max_tokens"
+        ],
+        "properties": {
+          "json_schema": {
+            "description": "Optional OpenAI-style `response_format.json_schema` for structured output.\nBackends that do not support structured output silently ignore this field."
+          },
+          "max_tokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum tokens to generate. The server clamps this to its configured ceiling.",
+            "minimum": 0
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LlmMessage"
+            },
+            "description": "Ordered list of chat messages. Must be non-empty."
+          }
+        }
+      },
+      "LlmMessage": {
+        "type": "object",
+        "description": "A single chat message in the completion request.",
+        "required": [
+          "role",
+          "content"
+        ],
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Text content of the message."
+          },
+          "role": {
+            "type": "string",
+            "description": "Role of the message author: `system`, `user`, or `assistant`."
           }
         }
       },


### PR DESCRIPTION
## Summary

Implements the generic LLM inference endpoint specified in ADR-002 (`docs/adr/002-server-ai-endpoint-contract.md`).

- **Route:** `POST /v1/projects/{id}/llm/complete`
- **Auth:** Tier-1 + Bearer (same as `/explore`)
- **Request:** `{ messages: [...], max_tokens: u32, json_schema?: Value }`
- **Response:** SSE stream of `{"kind":"token","content":"..."}` events + `{"kind":"done"}` terminal
- **Safety:** server clamps `max_tokens` to 8192; 503 `llm_unavailable` when no LLM configured; 400 on empty messages or invalid role
- **Health:** `"llm.complete"` added to `/v1/health` capabilities when LLM present
- **OpenAPI:** `docs/openapi.json` regenerated

Closes #261. Unblocks #260 (strip LLM from CLI dep tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)