### PR TITLE
feat(#308): surface memory_backend in spelunk status/check JSON output

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/check.rs
+++ b/crates/spelunk-cli/src/cli/cmd/check.rs
@@ -91,6 +91,11 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                     .unwrap_or(serde_json::Value::Null),
             ),
         };
+        let mem_path = resolve_db(args.db.as_deref(), &cfg.db_path).with_file_name("memory.db");
+        let memory_backend_kind = open_memory_backend(&cfg, &mem_path, None)
+            .ok()
+            .map(|b| b.backend_kind())
+            .unwrap_or("sqlite");
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -101,6 +106,7 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                 "last_indexed_at": last_indexed,
                 "server_reachable": server_reachable,
                 "server_url": server_url_val,
+                "memory_backend": memory_backend_kind,
             }))?
         );
     } else if fresh {

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -42,6 +42,8 @@ use crate::{
 /// - `has_semantic_search` — `true` when a server with `search.semantic` is reachable
 /// - `last_indexed_at` — ISO-8601 UTC timestamp of the most recently indexed file, or `null`
 /// - `memory_entries` — count of memory entries accessible from this project
+/// - `memory_backend` — stable identifier for the active memory backend: `"sqlite"`,
+///   `"git-meta"`, `"git-notes"`, or `"remote"` (see issue #308)
 ///
 /// Additional fields (`tier`, `server_url`, `capabilities`, `snapshot_count`,
 /// `drift_candidates`, `usage_7d`) are present for backward compatibility and
@@ -66,10 +68,15 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
         let drift = db.drift_candidates(30, 10).unwrap_or_default();
         let usage = db.usage_last_7_days().unwrap_or_default();
         let mem_path = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
-        let memory_count = match open_memory_backend(&cfg, &mem_path, None).ok() {
-            Some(b) => b.count().await.unwrap_or(0),
-            None => 0,
-        };
+        let (memory_count, memory_backend_kind) =
+            match open_memory_backend(&cfg, &mem_path, None).ok() {
+                Some(b) => {
+                    let kind = b.backend_kind();
+                    let count = b.count().await.unwrap_or(0);
+                    (count, kind)
+                }
+                None => (0, "sqlite"),
+            };
         let usage_map: std::collections::HashMap<&str, i64> =
             usage.iter().map(|(c, n)| (c.as_str(), *n)).collect();
 
@@ -129,6 +136,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
                 "has_semantic_search": has_semantic_search,
                 "last_indexed_at": last_indexed_at,
                 "memory_entries": memory_count,
+                "memory_backend": memory_backend_kind,
                 // ── Extensions (backward-compat, may change) ─────────────────
                 "tier": tier_str,
                 "server_url": tier_url,
@@ -231,6 +239,12 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
 
     let db = Database::open(db_path)?;
     let s = db.stats()?;
+
+    // ── Memory backend ────────────────────────────────────────────────────────
+    let mem_path_text = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
+    if let Ok(b) = open_memory_backend(&cfg, &mem_path_text, None) {
+        println!("Memory backend: {}", b.backend_kind());
+    }
 
     // ── Capability tier section ───────────────────────────────────────────────
     print_tier_section(tier, &cfg);

--- a/crates/spelunk-cli/tests/backend_kind_diagnostic.rs
+++ b/crates/spelunk-cli/tests/backend_kind_diagnostic.rs
@@ -1,0 +1,173 @@
+//! Integration tests for issue #308: `memory_backend` field in
+//! `spelunk status --format json` and `spelunk check --format json`.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+fn init_git_repo(dir: &std::path::Path) {
+    std::process::Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    // Commit something so HEAD exists (required for git-meta backend).
+    let f = dir.join("readme.txt");
+    fs::write(&f, "hi").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+}
+
+fn write_config(dir: &std::path::Path) -> std::path::PathBuf {
+    let db_path = dir.join("index.db");
+    let config_path = dir.join("config.toml");
+    fs::write(
+        &config_path,
+        format!("db_path = {:?}\n", db_path.display().to_string()),
+    )
+    .unwrap();
+    config_path
+}
+
+/// `spelunk status --format json` must include a `memory_backend` field with
+/// a known value (issue #308, stable schema field).
+#[test]
+fn status_json_includes_memory_backend_field() {
+    let temp = tempdir().unwrap();
+    init_git_repo(temp.path());
+    let config_path = write_config(temp.path());
+
+    // Index the repo so status can return JSON without the "no index" bail-out.
+    let mut index_cmd = Command::cargo_bin("spelunk").unwrap();
+    index_cmd
+        .current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(".")
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output).expect("status --format json must produce valid JSON");
+    let backend = json
+        .get("memory_backend")
+        .and_then(|v| v.as_str())
+        .expect("memory_backend field must be present and a string");
+
+    assert!(
+        matches!(backend, "sqlite" | "git-meta" | "git-notes" | "remote"),
+        "memory_backend must be one of the known values, got: {backend}"
+    );
+}
+
+/// `spelunk check --format json` must include a `memory_backend` field (issue #308).
+#[test]
+fn check_json_includes_memory_backend_field() {
+    let temp = tempdir().unwrap();
+    init_git_repo(temp.path());
+    let config_path = write_config(temp.path());
+
+    // Index so check can open the DB.
+    let mut index_cmd = Command::cargo_bin("spelunk").unwrap();
+    index_cmd
+        .current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(".")
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("check")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .expect("check --format json must run");
+
+    // check exits 1 when stale files exist, which is fine for this test.
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("check --format json must produce valid JSON on stdout");
+    let backend = json
+        .get("memory_backend")
+        .and_then(|v| v.as_str())
+        .expect("memory_backend field must be present and a string");
+
+    assert!(
+        matches!(backend, "sqlite" | "git-meta" | "git-notes" | "remote"),
+        "memory_backend must be one of the known values, got: {backend}"
+    );
+}
+
+/// `spelunk status` text output must mention the memory backend (issue #308).
+#[test]
+fn status_text_mentions_memory_backend() {
+    let temp = tempdir().unwrap();
+    init_git_repo(temp.path());
+    let config_path = write_config(temp.path());
+
+    // Index first.
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(".")
+        .assert()
+        .success();
+
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Memory backend:"));
+}


### PR DESCRIPTION
## Summary

Adds a stable `memory_backend` field to `spelunk status --format json` and `spelunk check --format json`, and a `Memory backend: <kind>` line to `spelunk status` text output.

- **status.rs**: calls `b.backend_kind()` alongside the existing `b.count()` call; emits `"memory_backend"` in JSON and `"Memory backend: <kind>"` in text mode
- **check.rs**: opens memory backend transiently in JSON mode and emits `"memory_backend"`
- **backend_kind_diagnostic.rs**: 3 integration tests covering all three cases

Valid values: `"sqlite"` | `"git-meta"` | `"git-notes"` | `"remote"`

This PR is stacked on `task/implementer-20260601-0748` (#283 — git-meta default backend) which adds the `backend_kind()` method to the `MemoryBackend` trait. Merge #283 first.

## Test plan
- [x] `cargo test -p spelunk-cli --test backend_kind_diagnostic` — 3 tests, all pass
- [x] `cargo clippy -p spelunk-cli -- -D warnings` — clean

Closes #308

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM7ZjFmwc5tD62eb9vgYY4)_