### PR TITLE
chore(deps): drop cargo-audit library dev-dep to clear 7 Dependabot alerts

### DIFF
--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -64,4 +64,3 @@ tempfile          = { workspace = true }
 wiremock          = { workspace = true }
 pretty_assertions = { workspace = true }
 serial_test       = { workspace = true }
-cargo-audit       = { version = "0.22", features = ["fix"] }


### PR DESCRIPTION
## Summary

- Removes `cargo-audit = { version = "0.22", features = ["fix"] }` from `[dev-dependencies]` in `crates/spelunk-core/Cargo.toml`
- This library dep was never used programmatically — CI already installs and runs `cargo audit` as a CLI binary via `.github/workflows/security.yml`
- The dep dragged in `rustsec → gix 0.78.0` which pulled in the vulnerable subtree (`gix-fs 0.19.2`, `gix-pack 0.65.0`, `gix-submodule 0.25.0`, `gix-transport 0.53.0`) flagged by Dependabot (6 high, 1 medium). No bump is available (cargo-audit 0.22.1 latest still has the same transitive dep)
- All tests pass; `cargo audit --quiet` exits 0 after the change

## Test plan

- [x] `cargo test -p spelunk-core` — all pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo audit --quiet` — exit 0, no advisories
- [ ] Verify Dependabot alerts auto-close on merge

Refs: implementer inbox 2026-06-03T08:40Z, CoS handoff #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)