### PR TITLE
feat(#303-F3): check/status/init UX for loopback auto-discovered server

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -12,7 +12,7 @@ pub struct InitArgs {
     pub no_index: bool,
 }
 
-use crate::{config::Config, registry::Registry, storage::Database};
+use crate::{capability, config::Config, registry::Registry, storage::Database};
 
 pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
     // ── 1. Detect project root ────────────────────────────────────────────────
@@ -103,7 +103,7 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
             background_phases: false,
             detach: false,
         };
-        super::index::index(index_args, cfg).await?;
+        super::index::index(index_args, cfg.clone()).await?;
 
         // Read fresh stats from the just-created DB.
         match Database::open(&db_path) {
@@ -162,13 +162,31 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
         }
     }
 
-    // ── 7. Print success summary ──────────────────────────────────────────────
+    // ── 7. Probe for a local server (non-blocking; uses the cached tier result).
+    //      The probe runs with a 250 ms timeout so init stays fast.
+    let server_line = {
+        let tier = capability::get_tier(&cfg).await;
+        match tier {
+            capability::Tier::Server {
+                url,
+                auto_discovered: true,
+                ..
+            } => Some(format!("{}  \x1b[32m✓\x1b[0m  (auto-started)", url)),
+            capability::Tier::Server { url, .. } => Some(format!("{url}  \x1b[32m✓\x1b[0m")),
+            capability::Tier::Offline => None,
+        }
+    };
+
+    // ── 8. Print success summary ──────────────────────────────────────────────
     println!();
     println!("spelunk initialised for {}", project_name);
     println!();
     println!("  Index:   {} files, {} chunks", file_count, chunk_count);
     println!("  DB:      {}", db_path.display());
     println!("  Hook:    {}", hook_status);
+    if let Some(line) = server_line {
+        println!("  Server:  {line}");
+    }
     println!();
     println!("Next steps:");
     println!("  spelunk search \"your query\"");

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -315,8 +315,17 @@ fn print_tier_section(tier: &Tier, cfg: &Config) {
             println!("  explore         unavailable  [set server_url to enable]");
             println!("  plan            unavailable  [set server_url to enable]");
         }
-        Tier::Server { url, caps, .. } => {
-            println!("Capability tier:  \x1b[32mServer\x1b[0m  \x1b[2m({url})\x1b[0m");
+        Tier::Server {
+            url,
+            caps,
+            auto_discovered,
+        } => {
+            let url_label = if *auto_discovered {
+                format!("{url}  \x1b[2m(local, auto)\x1b[0m")
+            } else {
+                url.clone()
+            };
+            println!("Capability tier:  \x1b[32mServer\x1b[0m  \x1b[2m({url_label})\x1b[0m");
             let search_label = if caps.search_semantic {
                 "ast-grep + text + semantic"
             } else {


### PR DESCRIPTION
## Summary

- **status.rs**: `print_tier_section` now pattern-matches on `auto_discovered` in `Tier::Server` and annotates the URL with `(local, auto)` when the server was found via loopback probe. Explicit servers are shown as before.
- **init.rs**: probes the capability tier after the index step and adds a `Server: <url> ✓ (auto-started)` line to the success summary. Uses `cfg.clone()` before passing cfg to `index()` so the config remains available for the tier probe.
- **check.rs**: already covered by PR #326 — the server line now shows for auto-discovered servers via `tier.is_server()` guard.

## Test plan

- [x] 45 spelunk-cli unit tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: run `spelunk status` with a local spelunk-server running → URL annotated `(local, auto)`
- [ ] Manual: run `spelunk init` with a local server running → summary prints `Server: http://127.0.0.1:7777 ✓ (auto-started)`

Parent: #303 · Depends on: #316 (merged in #326) · Sub-issue: closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)