### PR TITLE
feat(#303-F2): spelunk search Tier-0 fall-through to text mode

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -51,6 +51,7 @@ pub struct SearchArgs {
 use super::helpers::{embed_query_vec, project_display_name, require_server_client};
 use super::ui::{print_results_text, spinner};
 use crate::{
+    capability,
     config::Config,
     embeddings::vec_to_blob,
     registry::{Project, resolve_project_context},
@@ -112,6 +113,43 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
     } else {
         None
     };
+
+    // ── Tier-0 fall-through for explicit semantic/hybrid modes (#303-F2 / #323) ──
+    //
+    // When the user explicitly requests `--mode semantic` or `--mode hybrid`
+    // but no server is reachable (Tier 0), automatically switch to FTS text
+    // search and print a notice to stderr.  stdout stays clean so NDJSON
+    // consumers are unaffected.
+    //
+    // The `auto` mode already degrades gracefully via the embed_query_vec error
+    // path below — this guard handles the explicit-mode case only.
+    // Snapshot searches are skipped: they require embeddings by definition.
+    if (mode == "semantic" || mode == "hybrid") && snapshot_id.is_none() {
+        let tier = capability::get_tier(&cfg).await;
+        if !tier.is_server() {
+            eprintln!("[server unreachable — using text search]");
+            let sp = spinner("Searching (text)…");
+            let db = Database::open(&db_path)?;
+            let results = db
+                .search_text(&args.query, args.limit.min(100))
+                .unwrap_or_default();
+            sp.finish_and_clear();
+            if results.is_empty() {
+                println!("No results found.");
+                return Ok(());
+            }
+            match crate::utils::effective_format(&args.format) {
+                "json" => println!("{}", serde_json::to_string_pretty(&results)?),
+                "ndjson" => {
+                    for item in &results {
+                        println!("{}", serde_json::to_string(item)?);
+                    }
+                }
+                _ => print_results_text(&results),
+            }
+            return Ok(());
+        }
+    }
 
     let mut results = if mode == "text" && snapshot_id.is_none() {
         // Text mode: FTS5 only, no embedding model required.

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -712,10 +712,10 @@ fn test_search_index_but_no_embedder_falls_back_to_ast_grep() {
     assert.stdout(predicate::str::contains("Make sure the index has embeddings").not());
 }
 
-/// Explicit `--mode hybrid` with an unreachable embedder must fail with a
-/// helpful message telling the user what to do, not the old opaque message.
+/// Explicit `--mode hybrid` with no reachable server must fall through to FTS
+/// text search with a notice on stderr — not fail (#303-F2 / spelunk#323).
 #[test]
-fn test_search_explicit_hybrid_no_embedder_shows_helpful_error() {
+fn test_search_explicit_hybrid_no_embedder_falls_back_to_text() {
     let temp = tempdir().unwrap();
     let project_dir = temp.path().join("project");
     fs::create_dir(&project_dir).unwrap();
@@ -741,7 +741,7 @@ fn test_search_explicit_hybrid_no_embedder_shows_helpful_error() {
         .assert()
         .success();
 
-    // Explicit --mode hybrid must fail with a helpful error message.
+    // Explicit --mode hybrid with no server → succeeds with text search + notice.
     Command::cargo_bin("spelunk")
         .unwrap()
         .current_dir(&project_dir)
@@ -752,8 +752,45 @@ fn test_search_explicit_hybrid_no_embedder_shows_helpful_error() {
         .arg("hybrid")
         .arg("foo")
         .assert()
-        .failure()
-        .stderr(
-            predicate::str::contains("--mode text").or(predicate::str::contains("--mode ast-grep")),
-        );
+        .success()
+        .stderr(predicate::str::contains(
+            "[server unreachable — using text search]",
+        ));
+}
+
+/// Explicit `--mode semantic` with no reachable server must also fall through.
+#[test]
+fn test_search_explicit_semantic_no_server_falls_back_to_text() {
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("lib.rs"), "pub fn foo() {}").unwrap();
+
+    let config_path = temp.path().join("config.toml");
+    let db_path = temp.path().join("index.db");
+    fs::write(&config_path, format!("db_path = {:?}\n", db_path)).unwrap();
+
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("search")
+        .arg("--mode")
+        .arg("semantic")
+        .arg("foo")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "[server unreachable — using text search]",
+        ));
 }


### PR DESCRIPTION
## Summary

When `--mode semantic` or `--mode hybrid` is explicitly set but no `spelunk-server` is reachable (Tier 0), `spelunk search` now automatically falls through to FTS text search rather than failing with "no embedder configured".

**Before:** `spelunk search --mode hybrid foo` → exit 1 with error about embedder
**After:** `spelunk search --mode hybrid foo` → exit 0, runs FTS, prints `[server unreachable — using text search]` to stderr

Details:
- Probes `capability::get_tier(&cfg)` before attempting the embed path
- If `Tier::Offline`: prints `[server unreachable — using text search]` to **stderr** (stdout stays clean for NDJSON consumers)
- Runs `Database::search_text` and emits results via the normal output path
- `--mode auto` behavior is unchanged (already degrades to ast-grep on embed error)
- Snapshot searches (`--as-of`) are excluded — they require embeddings by design

## Test plan

- [x] Renamed existing test `test_search_explicit_hybrid_no_embedder_shows_helpful_error` → `test_search_explicit_hybrid_no_embedder_falls_back_to_text`: now asserts `.success()` + stderr contains the notice
- [x] Added `test_search_explicit_semantic_no_server_falls_back_to_text`
- [x] All 17 e2e_cli tests pass
- [x] Full workspace test suite clean (no regressions)
- [x] `cargo clippy -- -D warnings` clean

Parent: #303 · Depends on: #316 (merged) · Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)