### PR TITLE
feat(#303-B2): spelunk init auto-spawn integration (TTY-gated)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -162,18 +162,32 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
         }
     }
 
-    // ── 7. Probe for a local server (non-blocking; uses the cached tier result).
-    //      The probe runs with a 250 ms timeout so init stays fast.
-    let server_line = {
-        let tier = capability::get_tier(&cfg).await;
-        match tier {
-            capability::Tier::Server {
-                url,
-                auto_discovered: true,
-                ..
-            } => Some(format!("{}  \x1b[32m✓\x1b[0m  (auto-started)", url)),
-            capability::Tier::Server { url, .. } => Some(format!("{url}  \x1b[32m✓\x1b[0m")),
-            capability::Tier::Offline => None,
+    // ── 7. Auto-spawn server (TTY only) or probe for a running server ─────────
+    //
+    // Interactive (stdin is a TTY): attempt to start the server so semantic
+    // search works immediately. Non-interactive (CI / hook): probe only —
+    // never auto-spawn; print a skip notice if offline.
+    let server_line: Option<String> = {
+        use std::io::IsTerminal;
+        if std::io::stdin().is_terminal() {
+            match super::server::ensure_server_running(7777).await {
+                Ok((port, true)) => Some(format!(
+                    "http://127.0.0.1:{port}  \x1b[32m✓\x1b[0m  (auto-started)"
+                )),
+                Ok((port, false)) => Some(format!("http://127.0.0.1:{port}  \x1b[32m✓\x1b[0m")),
+                Err(e) => {
+                    tracing::debug!("server auto-start skipped: {e}");
+                    None
+                }
+            }
+        } else {
+            let tier = capability::get_tier(&cfg).await;
+            match tier {
+                capability::Tier::Server { url, .. } => Some(format!("{url}  \x1b[32m✓\x1b[0m")),
+                capability::Tier::Offline => {
+                    Some("[server not running — semantic search skipped]".to_string())
+                }
+            }
         }
     };
 

--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -132,6 +132,56 @@ pub async fn server(args: ServerArgs) -> Result<()> {
     }
 }
 
+// ── Public bootstrap API ──────────────────────────────────────────────────────
+
+/// Ensure a local spelunk-server is running.
+///
+/// Returns `(port, freshly_started)`. Idempotent: if the server is already
+/// healthy, returns immediately with `freshly_started = false`.
+///
+/// Called by `spelunk init` to auto-spawn the server when running interactively.
+pub async fn ensure_server_running(start_port: u16) -> Result<(u16, bool)> {
+    let state_dir = spelunk_state_dir()?;
+    std::fs::create_dir_all(&state_dir)
+        .with_context(|| format!("creating state dir {}", state_dir.display()))?;
+
+    // Already running and healthy?
+    if let Some(pid) = read_pid(&state_dir)
+        && pid_is_alive(pid)
+        && let Some(port) = read_port(&state_dir)
+        && probe_health(port).await.is_some()
+    {
+        return Ok((port, false));
+    }
+
+    let bin = which_spelunk_server()?;
+    let db = state_dir.join("server.db");
+    const PORT_RANGE: u16 = 11;
+    let port = find_available_port(start_port, PORT_RANGE)?;
+
+    let log_file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path(&state_dir))
+        .with_context(|| format!("opening {}", log_path(&state_dir).display()))?;
+
+    #[cfg(unix)]
+    let child = spawn_daemon_unix(&bin, &db, port, log_file)?;
+    #[cfg(not(unix))]
+    let child = spawn_daemon_windows(&bin, &db, port, log_file)?;
+
+    let pid = child.id();
+    std::fs::write(pid_path(&state_dir), format!("{pid}\n")).context("writing server.pid")?;
+    std::fs::write(port_path(&state_dir), format!("{port}\n")).context("writing server.port")?;
+
+    let ready = wait_for_health(port, Duration::from_secs(5)).await;
+    if !ready {
+        tracing::warn!("spelunk-server started (pid={pid}) but did not respond within 5 s");
+    }
+
+    Ok((port, true))
+}
+
 // ── start ─────────────────────────────────────────────────────────────────────
 
 async fn cmd_start(args: ServerStartArgs) -> Result<()> {

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -878,3 +878,45 @@ fn test_server_start_binary_not_found() {
         .failure()
         .stderr(predicate::str::contains("spelunk-server binary not found"));
 }
+
+/// `spelunk init` in non-TTY mode (piped stdin) prints the server skip notice
+/// when no server is reachable. This covers the CI/hook path from issue #318.
+#[test]
+fn test_init_non_tty_prints_skip_notice() {
+    let tmp = tempdir().unwrap();
+    // Initialise a git repo so spelunk init finds a project root.
+    std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(tmp.path())
+        .status()
+        .expect("git init");
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(tmp.path())
+        .status()
+        .expect("git config email");
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(tmp.path())
+        .status()
+        .expect("git config name");
+
+    let config_path = tmp.path().join("config.toml");
+    fs::write(&config_path, "").unwrap();
+
+    // stdin is piped (not a TTY) when launched via assert_cmd, so
+    // is_terminal() returns false — the non-interactive branch runs.
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(tmp.path())
+        .env("HOME", tmp.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&config_path)
+        .args(["init", "--no-index"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "server not running — semantic search skipped",
+        ));
+}


### PR DESCRIPTION
## Summary

- Adds `pub async fn ensure_server_running(start_port: u16) -> Result<(u16, bool)>` to `server.rs`: idempotent bootstrap that starts a local `spelunk-server` and returns `(port, freshly_started)`. Reuses the same spawn/health-poll logic as `spelunk server start`.
- `spelunk init` step 7 now detects `std::io::stdin().is_terminal()`:
  - **TTY** (interactive): calls `ensure_server_running(7777)` and prints `Server: http://127.0.0.1:<port> ✓ (auto-started)` or `✓` if already running. Server binary not found → skip gracefully (init still succeeds).
  - **Non-TTY** (CI / hook): probes only, never auto-spawns; prints `[server not running — semantic search skipped]` when offline.

## Definition of done

- [x] TTY detection with `std::io::IsTerminal`
- [x] `spelunk init` prints server URL when auto-started
- [x] `spelunk init` prints skip notice in non-TTY mode
- [x] Integration test using `assert_cmd` with piped stdin (`test_init_non_tty_prints_skip_notice`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] All 22 e2e CLI tests pass

## Test plan

1. `cargo test -p spelunk-cli` — all tests pass including the new `test_init_non_tty_prints_skip_notice`
2. Manual: run `spelunk init` in a terminal (TTY) in a git repo — should see `Server: http://127.0.0.1:7777 ✓ (auto-started)` in the summary when `spelunk-server` is in PATH

Parent: #303 · Closes #318 · Depends on #317 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)