### PR TITLE
feat(#303-C): native embedder via fastembed-rs (embed-native feature flag)

### DIFF
--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/main.rs"
 name = "spelunk_server"
 path = "src/lib.rs"
 
+[features]
+default       = ["embed-native"]
+embed-native  = ["dep:fastembed"]
+
 [dependencies]
 spelunk-core = { path = "../spelunk-core" }
 anyhow       = { workspace = true }
@@ -34,6 +38,8 @@ futures-util  = "0.3"
 utoipa       = { version = "5", features = ["axum_extras"] }
 clap         = { version = "4", features = ["derive", "env"] }
 regex        = { version = "1", default-features = false, features = ["std"] }
+dirs         = "6"
+fastembed    = { version = "5", optional = true }
 
 [dev-dependencies]
 tempfile          = { workspace = true }

--- a/crates/spelunk-server/src/embedder_native.rs
+++ b/crates/spelunk-server/src/embedder_native.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+
+/// Embedding dimension produced by [`DEFAULT_MODEL`].
+pub const DIM: usize = 768;
+
+/// The bundled model: Nomic Embed Text v1.5 (768-dim, Apache-2.0).
+///
+/// 768 dimensions matches the server default (`--embedding-dim 768`).
+/// EmbeddingGemma 300M uses the same dimension and query prefix convention
+/// (`task: code retrieval | query: …`); this model is a drop-in replacement
+/// until a native EmbeddingGemma ONNX is available in fastembed's model list.
+const DEFAULT_MODEL: EmbeddingModel = EmbeddingModel::NomicEmbedTextV15;
+
+pub struct NativeEmbedder {
+    // Mutex because embed() takes &mut self.
+    model: Arc<Mutex<TextEmbedding>>,
+}
+
+impl NativeEmbedder {
+    /// Load (or download) the native embedding model.
+    ///
+    /// On first call, fastembed downloads the ONNX weights (~150 MB) into
+    /// `~/.local/share/spelunk/models/` and caches them for subsequent runs.
+    /// A progress bar is printed to stderr during the download.
+    pub fn load() -> Result<Self> {
+        let cache_dir = model_cache_dir()?;
+        std::fs::create_dir_all(&cache_dir)
+            .with_context(|| format!("creating model cache dir {}", cache_dir.display()))?;
+
+        tracing::info!(
+            "loading native embedding model (cache: {})",
+            cache_dir.display()
+        );
+
+        let model = TextEmbedding::try_new(
+            InitOptions::new(DEFAULT_MODEL)
+                .with_cache_dir(cache_dir)
+                .with_show_download_progress(true),
+        )
+        .context("initialising native embedding model")?;
+
+        Ok(Self {
+            model: Arc::new(Mutex::new(model)),
+        })
+    }
+}
+
+fn model_cache_dir() -> Result<PathBuf> {
+    dirs::data_local_dir()
+        .map(|d| d.join("spelunk").join("models"))
+        .ok_or_else(|| anyhow::anyhow!("could not determine local data directory"))
+}
+
+#[async_trait::async_trait]
+impl spelunk_core::embeddings::EmbeddingBackend for NativeEmbedder {
+    async fn embed(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        let model = Arc::clone(&self.model);
+        let owned: Vec<String> = texts.iter().map(|s| s.to_string()).collect();
+
+        tokio::task::spawn_blocking(move || {
+            let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
+            let mut m = model
+                .lock()
+                .map_err(|_| anyhow::anyhow!("native embedder lock poisoned"))?;
+            m.embed(refs, None)
+                .context("native embedding model inference failed")
+        })
+        .await
+        .context("spawn_blocking panicked in native embedder")?
+    }
+
+    fn dimension(&self) -> usize {
+        DIM
+    }
+}

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -10,6 +10,9 @@ use spelunk_server::rate_limiter::RateLimiter;
 use spelunk_server::{ApiDoc, AppState, default_conflict_threshold, router};
 use utoipa::OpenApi;
 
+#[cfg(feature = "embed-native")]
+mod embedder_native;
+
 #[derive(Parser, Debug)]
 #[command(name = "spelunk-server", about = "Shared memory server for spelunk")]
 struct Args {
@@ -110,26 +113,52 @@ async fn main() -> Result<()> {
         Arc::new(ApiKeyAuth::new(args.key.clone()));
 
     // Build the optional server-side embedder.
-    let embedder: Option<Arc<dyn spelunk_core::embeddings::EmbeddingBackend>> =
-        if let Some(base_url) = args.embedding_url {
-            let model = if args.embedding_model.is_empty() {
-                "default".to_string()
-            } else {
-                args.embedding_model.clone()
-            };
-            tracing::info!("server-side embedding enabled: {base_url} model={model}");
-            let client = reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(60))
-                .build()
-                .context("building HTTP client for server-side embedder")?;
-            Some(Arc::new(ServerEmbedder {
-                client,
-                base_url,
-                model,
-            }))
+    let embedder: Option<Arc<dyn spelunk_core::embeddings::EmbeddingBackend>> = if let Some(
+        base_url,
+    ) =
+        args.embedding_url
+    {
+        let model = if args.embedding_model.is_empty() {
+            "default".to_string()
         } else {
-            None
+            args.embedding_model.clone()
         };
+        tracing::info!("server-side embedding enabled: {base_url} model={model}");
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .context("building HTTP client for server-side embedder")?;
+        Some(Arc::new(ServerEmbedder {
+            client,
+            base_url,
+            model,
+        }))
+    } else {
+        // No --embedding-url: try the bundled native embedder (embed-native feature).
+        #[cfg(feature = "embed-native")]
+        {
+            match embedder_native::NativeEmbedder::load() {
+                Ok(native) => {
+                    tracing::info!(
+                        "native embedding model loaded (dim={})",
+                        embedder_native::DIM
+                    );
+                    Some(Arc::new(native) as Arc<dyn spelunk_core::embeddings::EmbeddingBackend>)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "native embedding model failed to load: {e}; \
+                             running without embedder (set --embedding-url to override)"
+                    );
+                    None
+                }
+            }
+        }
+        #[cfg(not(feature = "embed-native"))]
+        {
+            None
+        }
+    };
 
     // Build the optional LLM backend.
     let llm: Option<Arc<dyn spelunk_core::llm::LlmBackend>> = if let Some(base_url) = args.llm_url {

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,10 @@ ignore = [
     # RUSTSEC-2026-0097: affects rand 0.10.0 via lopdf 0.40.0 (optional rich-formats feature).
     # lopdf is at the latest release with no patched version available.
     { id = "RUSTSEC-2026-0097", reason = "no fix available; lopdf 0.40.0 is the latest release" },
+    # RUSTSEC-2024-0436: paste 1.0.15 is unmaintained; pulled in transitively via
+    # fastembed → tokenizers → macro_rules_attribute. No patched version available
+    # and the crate is only used in proc-macro context (compile-time only, no runtime risk).
+    { id = "RUSTSEC-2024-0436", reason = "compile-time only transitive dep via fastembed; no runtime risk, no fix available" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -95,6 +99,7 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
+    "NCSA",
     "Unicode-3.0",
     "Unlicense",
     "Zlib",


### PR DESCRIPTION
## Summary

- Adds `embed-native` feature flag (default on) to `spelunk-server` that gates a bundled `fastembed = "5"` dependency
- New `crates/spelunk-server/src/embedder_native.rs`:
  - Uses `fastembed::TextEmbedding` with `EmbeddingModel::NomicEmbedTextV15` (768-dim, Apache-2.0; same dimension as the `--embedding-dim 768` server default)
  - Model weights downloaded on first startup to `~/.local/share/spelunk/models/` and cached for subsequent runs
  - `with_show_download_progress(true)` — fastembed prints its built-in progress bar to stderr during the one-time download (~150 MB)
  - `embed()` dispatches to `tokio::task::spawn_blocking` (fastembed is synchronous); `Mutex<TextEmbedding>` because `embed()` takes `&mut self`
- `main.rs` embedder priority: `--embedding-url` (unchanged) → native backend → no embedder (graceful degradation with `tracing::warn!`)
- `#[cfg(not(feature = "embed-native"))]` branch returns `None` cleanly

## Definition of done

- [x] `embed-native` feature wired in `spelunk-server/Cargo.toml`
- [x] `embedder_native.rs` implements `EmbeddingBackend` trait via fastembed 5.x
- [x] On server start, native embedder loads (or downloads) the model
- [x] `--embedding-url` overrides native backend
- [x] Progress bar shown during model download (fastembed built-in)
- [x] `spelunk-server` passes `cargo build` with and without `--no-default-features`
- [x] All 37 server tests pass
- [x] `cargo clippy -- -D warnings` clean (both feature configurations)
- [x] `cargo fmt --check` clean

## Test plan

1. `cargo test -p spelunk-server` — all 37 tests pass
2. `cargo build -p spelunk-server` — succeeds (with `embed-native`)
3. `cargo build -p spelunk-server --no-default-features` — succeeds (without `embed-native`)
4. Manual: `spelunk-server --port 7777` — on first run, downloads NomicEmbedTextV15; subsequent runs use cache

**Note on model choice:** NomicEmbedTextV15 is used instead of EmbeddingGemma 300M because EmbeddingGemma is not yet in fastembed's built-in model enum. Both produce 768-dim vectors and use the same `task: code retrieval | query: …` prefix convention. A follow-up can add EmbeddingGemma via `InitOptionsUserDefined` once fastembed includes it or provides a stable ONNX HuggingFace repo ID.

Parent: #303 · Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)