### PR TITLE
feat(#325): install paths — install.sh, deb packaging, service units, brew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,9 +176,72 @@ jobs:
           name: spelunk-${{ github.ref_name }}-universal-apple-darwin${{ matrix.suffix }}
           path: ${{ env.ARCHIVE }}
 
+  deb:
+    name: Build Debian package (amd64)
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download x86_64 Linux artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: spelunk-${{ github.ref_name }}-x86_64-unknown-linux-gnu
+          path: linux-amd64
+
+      - name: Extract tarball
+        run: |
+          tar -xzf linux-amd64/spelunk-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz \
+            -C linux-amd64
+
+      - name: Assemble deb layout
+        run: |
+          VERSION="${{ github.ref_name }}"
+          # Strip leading 'v' for deb version field
+          DEB_VERSION="${VERSION#v}"
+
+          mkdir -p BUILD/DEBIAN
+          mkdir -p BUILD/usr/bin
+          mkdir -p BUILD/usr/lib/systemd/user
+
+          # Binaries
+          install -m 755 linux-amd64/spelunk        BUILD/usr/bin/spelunk
+          install -m 755 linux-amd64/spelunk-server BUILD/usr/bin/spelunk-server
+
+          # systemd user unit
+          install -m 644 packaging/spelunk-server.service \
+            BUILD/usr/lib/systemd/user/spelunk-server.service
+
+          # DEBIAN/control (no leading whitespace — dpkg is strict)
+          cat > BUILD/DEBIAN/control <<EOF
+Package: spelunk
+Version: ${DEB_VERSION}
+Architecture: amd64
+Maintainer: spelunk-cloud <hello@spelunk.cloud>
+Depends: libc6 (>= 2.17)
+Description: Code intelligence for AI agents
+ spelunk provides persistent memory, a code graph, and semantic search
+ for AI coding agents. Includes the spelunk CLI and spelunk-server.
+Homepage: https://spelunk.cloud
+EOF
+
+          echo "DEB_VERSION=${DEB_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Build .deb
+        run: |
+          dpkg-deb --build BUILD "spelunk_${{ env.DEB_VERSION }}_amd64.deb"
+
+      - name: Upload deb artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: spelunk-${{ github.ref_name }}-amd64-deb
+          path: spelunk_${{ env.DEB_VERSION }}_amd64.deb
+
   release:
     name: Create GitHub Release
-    needs: [build, universal-macos]
+    needs: [build, universal-macos, deb]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -203,4 +266,5 @@ jobs:
             --title "${{ github.ref_name }}" \
             --generate-notes \
             $PRERELEASE \
-            artifacts/*.tar.gz
+            artifacts/*.tar.gz \
+            artifacts/*.deb

--- a/homebrew-tap/.github/workflows/update-formula.yml
+++ b/homebrew-tap/.github/workflows/update-formula.yml
@@ -1,0 +1,47 @@
+name: Update Formula
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version (e.g. 0.9.0)"
+        required: true
+      url:
+        description: "Download URL for the macOS x86_64 tarball"
+        required: true
+      sha256:
+        description: "SHA-256 of the tarball"
+        required: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update formula
+        env:
+          VERSION: ${{ inputs.version }}
+          URL: ${{ inputs.url }}
+          SHA256: ${{ inputs.sha256 }}
+        run: |
+          FORMULA="Formula/spelunk.rb"
+
+          sed -i "s|^  url .*|  url \"${URL}\"|" "$FORMULA"
+          sed -i "s|^  sha256 .*|  sha256 \"${SHA256}\"|" "$FORMULA"
+          sed -i "s|^  version .*|  version \"${VERSION}\"|" "$FORMULA"
+
+          echo "Updated formula to v${VERSION}"
+          cat "$FORMULA"
+
+      - name: Commit and push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/spelunk.rb
+          git commit -m "chore: update spelunk formula to v${{ inputs.version }}"
+          git push

--- a/homebrew-tap/Formula/spelunk.rb
+++ b/homebrew-tap/Formula/spelunk.rb
@@ -1,0 +1,25 @@
+class Spelunk < Formula
+  desc "Code intelligence for AI agents — persistent memory, code graph, search"
+  homepage "https://spelunk.cloud"
+  # TODO: update url and sha256 on each release
+  url "https://github.com/spelunk-cloud/spelunk/releases/download/v0.8.0/spelunk-x86_64-apple-darwin.tar.gz"
+  sha256 "TODO"
+  license "EUPL-1.2"
+  version "0.8.0"
+
+  def install
+    bin.install "spelunk"
+    bin.install "spelunk-server"
+  end
+
+  test do
+    system "#{bin}/spelunk", "--version"
+  end
+
+  def caveats
+    <<~EOS
+      Run `spelunk init` in a project directory to get started.
+      To start the local server: `spelunk server start`
+    EOS
+  end
+end

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,6 @@
 set -e
 
 REPO="spelunk-cloud/spelunk"
-BASE_URL="https://github.com/${REPO}/releases/latest/download"
 DRY_RUN=0
 
 for arg in "$@"; do
@@ -51,8 +50,18 @@ case "${OS_NAME}-${ARCH_NAME}" in
   macos-aarch64)  TARGET="aarch64-apple-darwin" ;;
 esac
 
-TARBALL="spelunk-${TARGET}.tar.gz"
-DOWNLOAD_URL="${BASE_URL}/${TARBALL}"
+# ── Resolve latest version tag ───────────────────────────────────────────────
+VERSION=$(curl -sf "https://api.github.com/repos/${REPO}/releases/latest" \
+  | grep '"tag_name"' \
+  | sed 's/.*"tag_name": *"\(.*\)".*/\1/')
+
+if [ -z "$VERSION" ]; then
+  printf 'Error: could not determine latest spelunk version\n' >&2
+  exit 1
+fi
+
+TARBALL="spelunk-${VERSION}-${TARGET}.tar.gz"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
 
 # ── Install directory ─────────────────────────────────────────────────────────
 if [ -w /usr/local/bin ]; then
@@ -71,6 +80,7 @@ printf '\n'
 printf '  spelunk installer\n'
 printf '  ─────────────────────────────────────────\n'
 printf '  OS/arch  : %s / %s\n' "$OS" "$ARCH"
+printf '  Version  : %s\n' "$VERSION"
 printf '  Target   : %s\n' "$TARGET"
 printf '  Download : %s\n' "$DOWNLOAD_URL"
 printf '  Install  : %s/spelunk\n' "$INSTALL_DIR"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+# spelunk installer — https://spelunk.cloud
+# Usage: curl -fsSL https://spelunk.cloud/install.sh | sh
+#        curl -fsSL https://spelunk.cloud/install.sh | sh -s -- --dry-run
+set -e
+
+REPO="spelunk-cloud/spelunk"
+BASE_URL="https://github.com/${REPO}/releases/latest/download"
+DRY_RUN=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    *)
+      printf 'Unknown flag: %s\n' "$arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── OS detection ──────────────────────────────────────────────────────────────
+OS="$(uname -s)"
+case "$OS" in
+  Linux)  OS_NAME="linux" ;;
+  Darwin) OS_NAME="macos" ;;
+  *)
+    printf 'Unsupported OS: %s\n' "$OS" >&2
+    printf 'spelunk supports Linux and macOS. Please install from source:\n' >&2
+    printf '  https://github.com/%s\n' "$REPO" >&2
+    exit 1
+    ;;
+esac
+
+# ── Arch detection ────────────────────────────────────────────────────────────
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)          ARCH_NAME="x86_64" ;;
+  aarch64|arm64)   ARCH_NAME="aarch64" ;;
+  *)
+    printf 'Unsupported architecture: %s\n' "$ARCH" >&2
+    printf 'spelunk supports x86_64 and aarch64/arm64.\n' >&2
+    exit 1
+    ;;
+esac
+
+# ── Map to release tarball name ───────────────────────────────────────────────
+case "${OS_NAME}-${ARCH_NAME}" in
+  linux-x86_64)   TARGET="x86_64-unknown-linux-gnu" ;;
+  linux-aarch64)  TARGET="aarch64-unknown-linux-gnu" ;;
+  macos-x86_64)   TARGET="x86_64-apple-darwin" ;;
+  macos-aarch64)  TARGET="aarch64-apple-darwin" ;;
+esac
+
+TARBALL="spelunk-${TARGET}.tar.gz"
+DOWNLOAD_URL="${BASE_URL}/${TARBALL}"
+
+# ── Install directory ─────────────────────────────────────────────────────────
+if [ -w /usr/local/bin ]; then
+  INSTALL_DIR="/usr/local/bin"
+elif [ "$(id -u)" -eq 0 ]; then
+  # Running as root but /usr/local/bin not writable? Unusual but handle it.
+  INSTALL_DIR="/usr/local/bin"
+  mkdir -p "$INSTALL_DIR"
+else
+  INSTALL_DIR="${HOME}/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+fi
+
+# ── Dry-run summary ───────────────────────────────────────────────────────────
+printf '\n'
+printf '  spelunk installer\n'
+printf '  ─────────────────────────────────────────\n'
+printf '  OS/arch  : %s / %s\n' "$OS" "$ARCH"
+printf '  Target   : %s\n' "$TARGET"
+printf '  Download : %s\n' "$DOWNLOAD_URL"
+printf '  Install  : %s/spelunk\n' "$INSTALL_DIR"
+printf '             %s/spelunk-server\n' "$INSTALL_DIR"
+printf '\n'
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '  Dry-run mode — nothing was installed.\n\n'
+  exit 0
+fi
+
+# ── Check for required tools ──────────────────────────────────────────────────
+for cmd in curl tar; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    printf 'Required tool not found: %s\n' "$cmd" >&2
+    exit 1
+  fi
+done
+
+# ── Download and extract ──────────────────────────────────────────────────────
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+printf 'Downloading %s ...\n' "$TARBALL"
+curl --fail --silent --show-error --location \
+  --output "${TMP_DIR}/${TARBALL}" \
+  "$DOWNLOAD_URL"
+
+printf 'Extracting ...\n'
+tar -xzf "${TMP_DIR}/${TARBALL}" -C "$TMP_DIR"
+
+# ── Install binaries ──────────────────────────────────────────────────────────
+for bin in spelunk spelunk-server; do
+  if [ -f "${TMP_DIR}/${bin}" ]; then
+    install -m 755 "${TMP_DIR}/${bin}" "${INSTALL_DIR}/${bin}"
+    printf 'Installed %s -> %s/%s\n' "$bin" "$INSTALL_DIR" "$bin"
+  fi
+done
+
+# ── PATH hint ─────────────────────────────────────────────────────────────────
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) : ;;  # already in PATH
+  *)
+    printf '\n'
+    printf '  Note: %s is not in your PATH.\n' "$INSTALL_DIR"
+    printf '  Add the following to your shell profile:\n'
+    printf '    export PATH="%s:$PATH"\n' "$INSTALL_DIR"
+    printf '\n'
+    ;;
+esac
+
+# ── Verify ────────────────────────────────────────────────────────────────────
+printf '\n'
+if command -v spelunk >/dev/null 2>&1; then
+  spelunk --version
+elif [ -x "${INSTALL_DIR}/spelunk" ]; then
+  "${INSTALL_DIR}/spelunk" --version
+fi
+printf '\nspelunk installed successfully. Run `spelunk init` to get started.\n\n'

--- a/packaging/spelunk-server.plist
+++ b/packaging/spelunk-server.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  macOS LaunchAgent for spelunk-server.
+
+  To install and load:
+    cp packaging/spelunk-server.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/spelunk-server.plist
+
+  To unload:
+    launchctl unload ~/Library/LaunchAgents/spelunk-server.plist
+    rm ~/Library/LaunchAgents/spelunk-server.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>cloud.spelunk.server</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/spelunk-server</string>
+        <string>--port</string>
+        <string>7777</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/spelunk-server.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/spelunk-server.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>RUST_LOG</key>
+        <string>info</string>
+    </dict>
+</dict>
+</plist>

--- a/packaging/spelunk-server.service
+++ b/packaging/spelunk-server.service
@@ -1,0 +1,27 @@
+# systemd user unit for spelunk-server
+#
+# To enable and start at login:
+#   systemctl --user enable --now spelunk-server
+#
+# To view logs:
+#   journalctl --user -u spelunk-server -f
+#
+# To stop:
+#   systemctl --user stop spelunk-server
+#
+# Install path: ~/.config/systemd/user/spelunk-server.service
+# Or system-wide: /usr/lib/systemd/user/spelunk-server.service
+
+[Unit]
+Description=spelunk-server — code intelligence server for AI agents
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/spelunk-server --port 7777
+Restart=on-failure
+RestartSec=5s
+Environment=RUST_LOG=info
+
+[Install]
+WantedBy=default.target

--- a/scripts/push-homebrew-tap.sh
+++ b/scripts/push-homebrew-tap.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Create the spelunk-cloud/homebrew-spelunk repo and push the tap formula.
+# Run this once after merging the install-paths PR.
+#
+# Prerequisites: gh CLI authenticated as a spelunk-cloud org admin.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TAP_SRC="${REPO_ROOT}/homebrew-tap"
+REMOTE="spelunk-cloud/homebrew-spelunk"
+TMP_DIR="$(mktemp -d)"
+
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Creating ${REMOTE} ..."
+gh repo create "${REMOTE}" \
+  --public \
+  --description "Homebrew tap for spelunk" \
+  --confirm 2>/dev/null || echo "(repo may already exist — continuing)"
+
+echo "Setting up local clone in ${TMP_DIR} ..."
+cp -r "${TAP_SRC}/." "${TMP_DIR}/"
+
+git -C "$TMP_DIR" init
+git -C "$TMP_DIR" checkout -b main
+git -C "$TMP_DIR" add .
+git -C "$TMP_DIR" \
+  -c user.name="spelunk-cloud" \
+  -c user.email="hello@spelunk.cloud" \
+  commit -m "chore: initial homebrew tap for spelunk v0.8.0"
+
+PUSH_URL="https://github.com/${REMOTE}.git"
+echo "Pushing to ${PUSH_URL} ..."
+git -C "$TMP_DIR" remote add origin "$PUSH_URL"
+git -C "$TMP_DIR" push -u origin main
+
+echo ""
+echo "Done. Homebrew tap is live at https://github.com/${REMOTE}"
+echo ""
+echo "Install with:"
+echo "  brew tap spelunk-cloud/spelunk"
+echo "  brew install spelunk"


### PR DESCRIPTION
Closes #325

## Summary

- **`install.sh`** — POSIX `curl | sh` installer: detects OS/arch (Linux x86_64/aarch64, macOS x86_64/arm64), maps to the correct release tarball, installs to `/usr/local/bin` (falls back to `~/.local/bin` if not writable), supports `--dry-run`, prints `spelunk --version` on success.
- **`packaging/spelunk-server.plist`** — macOS LaunchAgent (`cloud.spelunk.server`) that runs `spelunk-server --port 7777` at login, with `KeepAlive=true`, stdout/stderr to `/tmp/spelunk-server.{log,err}`.
- **`packaging/spelunk-server.service`** — Linux systemd user unit (`Type=simple`, `Restart=on-failure`, `WantedBy=default.target`).
- **`.github/workflows/release.yml`** — new `deb` job (runs after `build`, before `release`) that assembles a proper `DEBIAN/control` + binary layout and calls `dpkg-deb --build`; the `release` job now also uploads `*.deb` assets.
- **`homebrew-tap/`** — `Formula/spelunk.rb` and `.github/workflows/update-formula.yml` (workflow\_dispatch with version/url/sha256 inputs) ready to push to `spelunk-cloud/homebrew-spelunk`. Run `scripts/push-homebrew-tap.sh` once to create the tap repo and push.

## Test plan

- `bash install.sh --dry-run` prints the plan (OS, arch, target, download URL, install path) and exits 0 without touching the filesystem.
- YAML files are syntactically valid (`yamllint` / GitHub Actions linter).
- deb job: on next tag push the CI matrix will produce `spelunk_VERSION_amd64.deb`; install and verify `dpkg -l spelunk`, `spelunk --version`, `systemctl --user enable spelunk-server`.
- Homebrew tap: after running `scripts/push-homebrew-tap.sh`, `brew tap spelunk-cloud/spelunk && brew install spelunk` installs both binaries (sha256 needs updating for the actual v0.8.0 release).

## Follow-up

- Update `sha256` in `homebrew-tap/Formula/spelunk.rb` once v0.8.0 is tagged and the macOS tarball is published.
- Add an `install.sh` download link to the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)