### PR TITLE
fix(cli): correct stale "ca will:" to "spelunk will:" in hooks install message

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/hooks.rs
+++ b/crates/spelunk-cli/src/cli/cmd/hooks.rs
@@ -94,7 +94,7 @@ fn hooks_install(args: HooksInstallArgs) -> Result<()> {
     }
 
     println!("Installed post-commit hook at {}", hook_path.display());
-    println!("After each commit, ca will:");
+    println!("After each commit, spelunk will:");
     println!("  - Re-index the project");
     println!("  - Harvest memory from the new commit");
     println!("Teammates without spelunk installed are unaffected.");


### PR DESCRIPTION
## Summary
- The `spelunk hooks install` command printed a leftover `ca` binary name (pre-rename) in its post-install instructions: `"After each commit, ca will:"`. Changed to `"After each commit, spelunk will:"` so the printed guidance matches the actual binary name.
- Scanned the rest of the install-message block (`crates/spelunk-cli/src/cli/cmd/hooks.rs`, lines ~96-100) for other stray `ca`/binary-name leftovers — this was the only one.

Refs: IMP-4 (agent-comms/inbox/implementer.md), agent-comms/handoffs/qa-v080-test-plan.md §Fix 4

## Test plan
- `cargo check -p spelunk-cli` — compiles cleanly with the change.
- `cargo fmt -- --check` and `cargo clippy -- -D warnings` (run via the repo's pre-commit hook) — both pass with no diffs/warnings.
- Visual confirmation of the printed string: read the diff in `hooks_install()` — the only change is the literal string `"After each commit, ca will:"` → `"After each commit, spelunk will:"`; running `spelunk hooks install` now prints `Installed post-commit hook at <path>` followed by `After each commit, spelunk will:` / `  - Re-index the project` / `  - Harvest memory from the new commit` / `Teammates without spelunk installed are unaffected.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)