### PR TITLE
fix(ci): replace EmbarkStudios/cargo-deny-action with direct script

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,7 +45,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@v2
+      - name: Install Rust stable
+        run: |
+          rustup update stable
+          rustup default stable
+
+      - name: Cache cargo registry and binaries
+        uses: actions/cache@v5
         with:
-          command: check advisories licenses bans
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-deny-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-deny-
+
+      - name: Install cargo-deny
+        run: cargo-deny --version || cargo install cargo-deny --locked
+
+      - name: Run cargo deny
+        run: cargo deny check advisories licenses bans


### PR DESCRIPTION
## Summary

- Replaces `EmbarkStudios/cargo-deny-action@v2` (third-party, now blocked by updated GH Actions policy) with a direct `cargo install cargo-deny` + `cargo deny check` pattern
- Only `actions/` and `google-github-actions/` orgs are whitelisted; EmbarkStudios is not
- Mirrors the existing `cargo-audit` job pattern: Rust install → cargo cache → install binary (cached via version check) → run

## Test plan

- [ ] CI passes on this PR (`cargo-deny` job runs clean via script)
- [ ] Confirm `cargo deny check advisories licenses bans` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)