### PR TITLE
feat: surface backend_kind() in status/check --format json

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/check.rs
+++ b/crates/spelunk-cli/src/cli/cmd/check.rs
@@ -91,6 +91,11 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                     .unwrap_or(serde_json::Value::Null),
             ),
         };
+        let mem_path = resolve_db(args.db.as_deref(), &cfg.db_path).with_file_name("memory.db");
+        let memory_backend_kind = open_memory_backend(&cfg, &mem_path, None)
+            .ok()
+            .map(|b| b.backend_kind())
+            .unwrap_or("sqlite");
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -101,6 +106,7 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                 "last_indexed_at": last_indexed,
                 "server_reachable": server_reachable,
                 "server_url": server_url_val,
+                "memory_backend": memory_backend_kind,
             }))?
         );
     } else if fresh {

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -42,6 +42,8 @@ use crate::{
 /// - `has_semantic_search` — `true` when a server with `search.semantic` is reachable
 /// - `last_indexed_at` — ISO-8601 UTC timestamp of the most recently indexed file, or `null`
 /// - `memory_entries` — count of memory entries accessible from this project
+/// - `memory_backend` — stable identifier for the active memory backend:
+///   `"sqlite"`, `"git-notes"`, or `"remote"` (see issue #308)
 ///
 /// Additional fields (`tier`, `server_url`, `capabilities`, `snapshot_count`,
 /// `drift_candidates`, `usage_7d`) are present for backward compatibility and
@@ -66,10 +68,15 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
         let drift = db.drift_candidates(30, 10).unwrap_or_default();
         let usage = db.usage_last_7_days().unwrap_or_default();
         let mem_path = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
-        let memory_count = match open_memory_backend(&cfg, &mem_path, None).ok() {
-            Some(b) => b.count().await.unwrap_or(0),
-            None => 0,
-        };
+        let (memory_count, memory_backend_kind) =
+            match open_memory_backend(&cfg, &mem_path, None).ok() {
+                Some(b) => {
+                    let kind = b.backend_kind();
+                    let count = b.count().await.unwrap_or(0);
+                    (count, kind)
+                }
+                None => (0, "sqlite"),
+            };
         let usage_map: std::collections::HashMap<&str, i64> =
             usage.iter().map(|(c, n)| (c.as_str(), *n)).collect();
 
@@ -129,6 +136,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
                 "has_semantic_search": has_semantic_search,
                 "last_indexed_at": last_indexed_at,
                 "memory_entries": memory_count,
+                "memory_backend": memory_backend_kind,
                 // ── Extensions (backward-compat, may change) ─────────────────
                 "tier": tier_str,
                 "server_url": tier_url,
@@ -231,6 +239,12 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
 
     let db = Database::open(db_path)?;
     let s = db.stats()?;
+
+    // ── Memory backend ────────────────────────────────────────────────────────
+    let mem_path_text = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
+    if let Ok(b) = open_memory_backend(&cfg, &mem_path_text, None) {
+        println!("Memory backend: {}", b.backend_kind());
+    }
 
     // ── Capability tier section ───────────────────────────────────────────────
     print_tier_section(tier, &cfg);

--- a/crates/spelunk-cli/tests/backend_kind_diagnostic.rs
+++ b/crates/spelunk-cli/tests/backend_kind_diagnostic.rs
@@ -1,0 +1,160 @@
+//! Integration tests for issue #308: `memory_backend` field in
+//! `spelunk status --format json` and `spelunk check --format json`.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Spin up a minimal indexed project in a temp directory and return
+/// `(TempDir, project_dir, config_path)`.  The index is built with no server
+/// URL and no explicit backend override, so the resolved backend is the
+/// default local SQLite store.
+fn setup_offline_project() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let temp = tempdir().unwrap();
+    let project_dir = temp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(
+        project_dir.join("lib.rs"),
+        "pub fn hello() -> &'static str { \"hello\" }",
+    )
+    .unwrap();
+
+    let db_path = temp.path().join("index.db");
+    let config_path = temp.path().join("config.toml");
+    // No server_url → offline, default backend is sqlite.
+    fs::write(
+        &config_path,
+        format!("db_path = {:?}\n", db_path.display().to_string()),
+    )
+    .unwrap();
+
+    // Build index (parse-only; no embedding server needed).
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    (temp, project_dir, config_path)
+}
+
+// ── `spelunk status --format json` ───────────────────────────────────────────
+
+/// `spelunk status --format json` must include a top-level `memory_backend`
+/// field whose value is one of the known backend identifiers (issue #308).
+#[test]
+fn status_json_includes_memory_backend_field() {
+    let (_temp, project_dir, config_path) = setup_offline_project();
+
+    let output = Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(&project_dir)
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "spelunk status --format json exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let body: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("output must be valid JSON");
+
+    // Field must be present.
+    assert!(
+        body.get("memory_backend").is_some(),
+        "expected a `memory_backend` key in status JSON, got: {}",
+        serde_json::to_string_pretty(&body).unwrap_or_default()
+    );
+
+    // Value must be a non-empty string.
+    let kind = body["memory_backend"]
+        .as_str()
+        .expect("`memory_backend` must be a string");
+    assert!(!kind.is_empty(), "`memory_backend` must not be empty");
+
+    // Value must be one of the known backend identifiers.
+    const KNOWN: &[&str] = &["sqlite", "git-meta", "git-notes", "remote"];
+    assert!(
+        KNOWN.contains(&kind),
+        "`memory_backend` must be one of {KNOWN:?}, got: {kind:?}"
+    );
+}
+
+// ── `spelunk check --format json` ────────────────────────────────────────────
+
+/// `spelunk check --format json` must include a top-level `memory_backend`
+/// field with the same semantics as in `spelunk status` (issue #308).
+#[test]
+fn check_json_includes_memory_backend_field() {
+    let (_temp, project_dir, config_path) = setup_offline_project();
+
+    let output = Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(&project_dir)
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("check")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    // `spelunk check` exits 1 when stale files exist; that is fine here because
+    // we only care about the JSON shape on stdout.
+    let body: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("output must be valid JSON");
+
+    // Field must be present.
+    assert!(
+        body.get("memory_backend").is_some(),
+        "expected a `memory_backend` key in check JSON, got: {}",
+        serde_json::to_string_pretty(&body).unwrap_or_default()
+    );
+
+    // Value must be a non-empty string in the known set.
+    let kind = body["memory_backend"]
+        .as_str()
+        .expect("`memory_backend` must be a string");
+    assert!(!kind.is_empty(), "`memory_backend` must not be empty");
+
+    const KNOWN: &[&str] = &["sqlite", "git-meta", "git-notes", "remote"];
+    assert!(
+        KNOWN.contains(&kind),
+        "`memory_backend` must be one of {KNOWN:?}, got: {kind:?}"
+    );
+}
+
+// ── `spelunk status` text output ─────────────────────────────────────────────
+
+/// `spelunk status` text output (no --format json) must mention the active
+/// memory backend so humans can see which store is in use (issue #308).
+#[test]
+fn status_text_mentions_memory_backend() {
+    let (_temp, project_dir, config_path) = setup_offline_project();
+
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .current_dir(&project_dir)
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Memory backend:"));
+}

--- a/crates/spelunk-core/src/storage/backend.rs
+++ b/crates/spelunk-core/src/storage/backend.rs
@@ -92,6 +92,11 @@ pub trait MemoryBackend: Send {
     async fn add_edge(&self, from_id: i64, to_id: i64, kind: &str) -> Result<()>;
     /// Return `(outgoing, incoming)` edges for a note.
     async fn get_edges(&self, id: i64) -> Result<(Vec<MemoryEdge>, Vec<MemoryEdge>)>;
+
+    /// Stable identifier for the concrete backend implementation, used for
+    /// diagnostics (`spelunk status`/`check --format json`). One of:
+    /// `"sqlite"`, `"git-notes"`, `"remote"`.
+    fn backend_kind(&self) -> &'static str;
 }
 
 // ── Local SQLite backend ──────────────────────────────────────────────────────
@@ -243,5 +248,9 @@ impl MemoryBackend for LocalMemoryBackend {
 
     async fn get_edges(&self, id: i64) -> Result<(Vec<MemoryEdge>, Vec<MemoryEdge>)> {
         self.store.lock().await.get_edges(id)
+    }
+
+    fn backend_kind(&self) -> &'static str {
+        "sqlite"
     }
 }

--- a/crates/spelunk-core/src/storage/git_notes.rs
+++ b/crates/spelunk-core/src/storage/git_notes.rs
@@ -418,4 +418,8 @@ impl MemoryBackend for GitNotesBackend {
     async fn get_edges(&self, _id: i64) -> Result<(Vec<MemoryEdge>, Vec<MemoryEdge>)> {
         Err(crate::error::SpelunkError::BackendUnsupported("get_edges".into()).into())
     }
+
+    fn backend_kind(&self) -> &'static str {
+        "git-notes"
+    }
 }

--- a/crates/spelunk-core/src/storage/remote.rs
+++ b/crates/spelunk-core/src/storage/remote.rs
@@ -438,6 +438,10 @@ impl MemoryBackend for RemoteMemoryBackend {
     async fn get_edges(&self, _id: i64) -> Result<(Vec<MemoryEdge>, Vec<MemoryEdge>)> {
         Ok((vec![], vec![]))
     }
+
+    fn backend_kind(&self) -> &'static str {
+        "remote"
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #308.

Surfaces `MemoryBackend::backend_kind()` in the JSON output of `spelunk status`/`spelunk check --format json`.

## Changes

- **`crates/spelunk-core/src/storage/backend.rs`**: adds `fn backend_kind(&self) -> &'static str` to the `MemoryBackend` trait; implements it on `LocalMemoryBackend` (`"sqlite"`)
- **`crates/spelunk-core/src/storage/remote.rs`**: implements `backend_kind()` on `RemoteMemoryBackend` (`"remote"`)
- **`crates/spelunk-core/src/storage/git_notes.rs`**: implements `backend_kind()` on `GitNotesBackend` (`"git-notes"`)
- **`crates/spelunk-cli/src/cli/cmd/status.rs`**: emits `"memory_backend"` in JSON output (stable schema field, documented in the docstring); emits `"Memory backend: <kind>"` in text mode
- **`crates/spelunk-cli/src/cli/cmd/check.rs`**: opens memory backend transiently in JSON path and emits `"memory_backend"` field
- **`crates/spelunk-cli/tests/backend_kind_diagnostic.rs`**: 3 integration tests asserting the field is present and holds a valid value

## Test plan

- [x] `spelunk status --format json` includes a `memory_backend` field (`status_json_includes_memory_backend_field`)
- [x] `spelunk check --format json` includes a `memory_backend` field (`check_json_includes_memory_backend_field`)
- [x] `spelunk status` text mode prints `Memory backend:` (`status_text_mentions_memory_backend`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` passes (all tests green, 0 failures)