### PR TITLE
security: bind auto-spawned server to 127.0.0.1 (THREAT-MODEL req #9 / #303)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -303,6 +303,11 @@ fn find_available_port(start: u16, range: u16) -> Result<u16> {
 /// child process inherits the log file handles and runs independently; the
 /// CLI process exits after writing the PID/port state files, at which point
 /// the child is reparented to init/launchd and becomes fully detached.
+///
+/// `--host 127.0.0.1` is always passed so the auto-spawned daemon only binds
+/// the loopback interface (THREAT-MODEL req #9 / decision #88).  Without this
+/// flag spelunk-server defaults to 0.0.0.0 and would be LAN-reachable while
+/// unauthenticated.
 #[cfg(unix)]
 fn spawn_daemon_unix(
     bin: &Path,
@@ -313,6 +318,8 @@ fn spawn_daemon_unix(
     let log_file_err = log_file.try_clone().context("cloning log file handle")?;
 
     let child = std::process::Command::new(bin)
+        .arg("--host")
+        .arg("127.0.0.1")
         .arg("--port")
         .arg(port.to_string())
         .arg("--db")
@@ -327,6 +334,11 @@ fn spawn_daemon_unix(
 }
 
 /// Spawn the server on Windows with `CREATE_NEW_PROCESS_GROUP`.
+///
+/// `--host 127.0.0.1` is always passed so the auto-spawned daemon only binds
+/// the loopback interface (THREAT-MODEL req #9 / decision #88).  Without this
+/// flag spelunk-server defaults to 0.0.0.0 and would be LAN-reachable while
+/// unauthenticated.
 #[cfg(not(unix))]
 fn spawn_daemon_windows(
     bin: &Path,
@@ -338,6 +350,8 @@ fn spawn_daemon_windows(
     const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
 
     let child = std::process::Command::new(bin)
+        .arg("--host")
+        .arg("127.0.0.1")
         .arg("--port")
         .arg(port.to_string())
         .arg("--db")


### PR DESCRIPTION
## Summary

- Passes `--host 127.0.0.1` in both `spawn_daemon_unix` and `spawn_daemon_windows` so the auto-spawned `spelunk-server` only binds the loopback interface.
- Without this flag `spelunk-server` defaults to `0.0.0.0`, making it LAN-reachable while running without authentication.
- `find_available_port` already test-binds on `127.0.0.1`; the listen address now matches.

Fixes THREAT-MODEL req #9 / decision #88. Closes #303.

## Test plan

- [ ] `cargo test -p spelunk-cli -- server` passes (all 25 tests green).
- [ ] After `spelunk server start`, verify with `ss -tlnp` / `lsof -i` that `spelunk-server` is bound only to `127.0.0.1:<port>` and not `0.0.0.0`.
- [ ] Confirm that `spelunk-server` refuses connections from a remote host on the same LAN.
- [ ] `spelunk init` flow (auto-spawn path via `ensure_server_running`) also starts the server on loopback only.

Note: pre-existing test failure in `test_index_prints_note_when_no_server_configured` is unrelated to this change (string mismatch in stderr assertion, reproduced on main before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)