### PR TITLE
refactor: rename ndjson → jsonl throughout the codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,7 @@ memory list/show/archive) continue to work offline without `server_url`.
   history.
 
 - **Expanded fuzzer coverage** — fuzzer targets now cover secrets, chunker,
-  `escape_xml`, NDJSON, and history entry parsing.
+  `escape_xml`, JSONL, and history entry parsing.
 
 ### Fixed
 
@@ -238,9 +238,9 @@ memory list/show/archive) continue to work offline without `server_url`.
 ### Added
 
 - **Unix plumbing/porcelain architecture** — 8 new `spelunk spelunk` plumbing
-  subcommands emit machine-readable NDJSON to stdout and use conventional exit
+  subcommands emit machine-readable JSONL to stdout and use conventional exit
   codes (0 = ok, 1 = no results, 2 = error). All porcelain commands now accept
-  `--format text|json|ndjson` for structured output in scripts and agents.
+  `--format text|json|jsonl` for structured output in scripts and agents.
   Plumbing commands: `cat-chunks`, `embed`, `graph-edges`, `hash-file`, `knn`,
   `ls-files`, `parse-file`, `read-memory`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,15 +201,15 @@ cli/
       watch.rs        — `spelunk memory watch`: SSE stream from spelunk-server
     plumbing/
       mod.rs               — PlumbingArgs/PlumbingCommand; dispatch; exit-2 on error
-      cat_chunks.rs        — emit indexed chunks for a file as NDJSON
-      embed_cmd.rs         — read stdin lines, emit embedding vectors as NDJSON
-      graph_edges.rs       — emit code graph edges as NDJSON
+      cat_chunks.rs        — emit indexed chunks for a file as JSONL
+      embed_cmd.rs         — read stdin lines, emit embedding vectors as JSONL
+      graph_edges.rs       — emit code graph edges as JSONL
       hash_file.rs         — blake3 hash a file; check index currency
-      knn.rs               — KNN vector search, NDJSON output
-      ls_files.rs          — list indexed files as NDJSON; exit 1 if no results
-      parse_file.rs        — parse a file and emit chunks as NDJSON (no DB write)
-      read_conventions.rs  — emit stored convention records as NDJSON
-      read_memory.rs       — emit memory entries as NDJSON
+      knn.rs               — KNN vector search, JSONL output
+      ls_files.rs          — list indexed files as JSONL; exit 1 if no results
+      parse_file.rs        — parse a file and emit chunks as JSONL (no DB write)
+      read_conventions.rs  — emit stored convention records as JSONL
+      read_memory.rs       — emit memory entries as JSONL
 ```
 
 ### spelunk-server (`crates/spelunk-server/src/`)

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,13 +24,13 @@ spelunk search "<query>" --mode text
 # Call/import graph — no server needed
 spelunk graph <symbol-or-file>
 spelunk graph <symbol> --kind calls       # calls | imports | extends | implements
-spelunk graph <file> --format text|json|ndjson
+spelunk graph <file> --format text|json|jsonl
 
 # Semantic search — (requires server + index)
 spelunk search "<query>"
 spelunk search "<query>" --limit 20
 spelunk search "<query>" --graph          # include call-graph neighbours
-spelunk search "<query>" --format text|json|ndjson
+spelunk search "<query>" --format text|json|jsonl
 
 # Deep search — iterative, uses LLM (requires server with an LLM backend)
 spelunk explore "<question>"
@@ -38,12 +38,12 @@ spelunk explore "<question>" --max-steps 5
 spelunk explore "<question>" --format json   # {answer, sources, steps}
 
 # Status and checks
-spelunk status --format text|json|ndjson
-spelunk check --format text|json|ndjson
+spelunk status --format text|json|jsonl
+spelunk check --format text|json|jsonl
 
 # Inspect what was indexed for a file
 spelunk chunks <file-path>
-spelunk chunks <file-path> --format text|json|ndjson
+spelunk chunks <file-path> --format text|json|jsonl
 ```
 
 Use `search --mode text` for targeted lookups without a server. Use semantic `search` (with server) for concept-level queries. Use `explore` when the answer requires tracing across multiple files — it runs autonomously and reports back.
@@ -81,7 +81,7 @@ State lives under `~/.local/state/spelunk/` (`server.pid`, `server.port`, `serve
 
 ## Plumbing commands
 
-Plumbing commands emit NDJSON and are designed for scripts and pipelines.
+Plumbing commands emit JSONL and are designed for scripts and pipelines.
 Exit codes: `0` = success, `1` = no results, `2` = error. See [Plumbing and Porcelain](docs/plumbing-and-porcelain.md) for full details.
 
 ```bash
@@ -94,7 +94,7 @@ spelunk plumbing hash-file <file>
 # Emit code graph edges (no server)
 spelunk plumbing graph-edges --file <f> | --symbol <s>
 
-# Emit memory entries as NDJSON (no server)
+# Emit memory entries as JSONL (no server)
 spelunk plumbing read-memory [--kind <k>] [--limit N]
 
 # Emit indexed chunks for a file (requires index)

--- a/bench/setup_repos.sh
+++ b/bench/setup_repos.sh
@@ -147,13 +147,13 @@ echo ""
 # Fetch metadata
 # ---------------------------------------------------------------------------
 echo "Fetching task metadata from HuggingFace..."
-METADATA_NDJSON="$(fetch_metadata)"
-if [[ -z "$METADATA_NDJSON" ]]; then
+METADATA_JSONL="$(fetch_metadata)"
+if [[ -z "$METADATA_JSONL" ]]; then
     echo "ERROR: Failed to fetch dataset metadata after retries." >&2
     exit 1
 fi
 
-TOTAL="$(echo "$METADATA_NDJSON" | grep -c . || true)"
+TOTAL="$(echo "$METADATA_JSONL" | grep -c . || true)"
 echo "Fetched metadata for ${TOTAL} tasks."
 echo ""
 
@@ -242,7 +242,7 @@ while IFS= read -r line; do
     echo "  Done: checked out ${BASE_COMMIT:0:12}"
     SUCCESS=$((SUCCESS + 1))
 
-done <<< "$METADATA_NDJSON"
+done <<< "$METADATA_JSONL"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/crates/spelunk-cli/src/cli/cmd/graph.rs
+++ b/crates/spelunk-cli/src/cli/cmd/graph.rs
@@ -11,7 +11,7 @@ pub struct GraphArgs {
     #[arg(long)]
     pub kind: Option<String>,
 
-    /// Output format: text, json, or ndjson
+    /// Output format: text, json, or jsonl
     #[arg(long, default_value = "text")]
     pub format: String,
 
@@ -85,7 +85,7 @@ pub fn graph(args: GraphArgs, cfg: Config) -> Result<()> {
 
     match crate::utils::effective_format(&args.format) {
         "json" => println!("{}", serde_json::to_string_pretty(&edges)?),
-        "ndjson" => {
+        "jsonl" => {
             for edge in &edges {
                 println!("{}", serde_json::to_string(edge)?);
             }
@@ -149,7 +149,7 @@ fn graph_live(symbol: &str, format: &str, kind_filter: &Option<String>, root: &P
 
     match crate::utils::effective_format(format) {
         "json" => println!("{}", serde_json::to_string_pretty(&edges)?),
-        "ndjson" => {
+        "jsonl" => {
             for edge in &edges {
                 println!("{}", serde_json::to_string(edge)?);
             }

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -248,7 +248,7 @@ pub struct MemorySinceArgs {
     #[arg(short, long, default_value_t = 100)]
     pub limit: usize,
 
-    /// Output format: text, json, or ndjson
+    /// Output format: text, json, or jsonl
     #[arg(long, default_value = "text")]
     pub format: String,
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/since.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/since.rs
@@ -74,7 +74,7 @@ pub(super) async fn memory_since(
 
     match crate::utils::effective_format(&args.format) {
         "json" => println!("{}", serde_json::to_string_pretty(&filtered)?),
-        "ndjson" => {
+        "jsonl" => {
             for n in &filtered {
                 println!("{}", serde_json::to_string(n)?);
             }
@@ -98,7 +98,7 @@ fn print_notes(notes: &[NoteResponse], format: &str) {
             "{}",
             serde_json::to_string_pretty(notes).unwrap_or_default()
         ),
-        "ndjson" => {
+        "jsonl" => {
             for n in notes {
                 println!("{}", serde_json::to_string(n).unwrap_or_default());
             }

--- a/crates/spelunk-cli/src/cli/cmd/plumbing/embed_cmd.rs
+++ b/crates/spelunk-cli/src/cli/cmd/plumbing/embed_cmd.rs
@@ -16,9 +16,7 @@ struct EmbedOutput {
 
 pub(super) async fn embed_cmd(cfg: &Config, query_mode: bool) -> Result<()> {
     if std::io::stdin().is_terminal() {
-        eprintln!(
-            "spelunk plumbing embed: reads lines from stdin, emits NDJSON embedding per line"
-        );
+        eprintln!("spelunk plumbing embed: reads lines from stdin, emits JSONL embedding per line");
         std::process::exit(2);
     }
 

--- a/crates/spelunk-cli/src/cli/cmd/plumbing/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/plumbing/mod.rs
@@ -13,21 +13,21 @@ pub struct PlumbingArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum PlumbingCommand {
-    /// Emit indexed chunks for a file as NDJSON
+    /// Emit indexed chunks for a file as JSONL
     CatChunks(PlumbingCatChunksArgs),
-    /// List all indexed files as NDJSON
+    /// List all indexed files as JSONL
     LsFiles(PlumbingLsFilesArgs),
-    /// Parse a file and emit chunks as NDJSON (without storing)
+    /// Parse a file and emit chunks as JSONL (without storing)
     ParseFile(PlumbingParseFileArgs),
     /// Compute blake3 hash of a file and check index currency
     HashFile(PlumbingHashFileArgs),
-    /// KNN vector search returning NDJSON results
+    /// KNN vector search returning JSONL results
     Knn(PlumbingKnnArgs),
-    /// Read lines from stdin and emit embedding vectors as NDJSON
+    /// Read lines from stdin and emit embedding vectors as JSONL
     Embed(PlumbingEmbedArgs),
-    /// Emit code graph edges as NDJSON
+    /// Emit code graph edges as JSONL
     GraphEdges(PlumbingGraphEdgesArgs),
-    /// Emit memory entries as NDJSON
+    /// Emit memory entries as JSONL
     ReadMemory(PlumbingReadMemoryArgs),
 }
 

--- a/crates/spelunk-cli/src/cli/cmd/plumbing/read_conventions.rs
+++ b/crates/spelunk-cli/src/cli/cmd/plumbing/read_conventions.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use super::PlumbingReadConventionsArgs;
 use crate::storage::Database;
 
-/// Emit stored convention records as NDJSON.
+/// Emit stored convention records as JSONL.
 ///
 /// Exit codes:
 /// - 0: at least one row emitted

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -15,7 +15,7 @@ pub struct SearchArgs {
     #[arg(long, conflicts_with = "limit")]
     pub budget: Option<usize>,
 
-    /// Output format: text, json, or ndjson
+    /// Output format: text, json, or jsonl
     #[arg(long, default_value = "text")]
     pub format: String,
 
@@ -126,7 +126,7 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
     //
     // When the user explicitly requests `--mode semantic` or `--mode hybrid`
     // but no server is reachable (Tier 0), automatically switch to FTS text
-    // search and print a notice to stderr.  stdout stays clean so NDJSON
+    // search and print a notice to stderr.  stdout stays clean so JSONL
     // consumers are unaffected.
     //
     // The `auto` mode already degrades gracefully via the embed_query_vec error
@@ -146,7 +146,7 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
         }
         match crate::utils::effective_format(&args.format) {
             "json" => println!("{}", serde_json::to_string_pretty(&results)?),
-            "ndjson" => {
+            "jsonl" => {
                 for item in &results {
                     println!("{}", serde_json::to_string(item)?);
                 }
@@ -327,7 +327,7 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
                 };
                 println!("{}", serde_json::to_string_pretty(&resp)?);
             }
-            "ndjson" => {
+            "jsonl" => {
                 for item in &packed {
                     println!("{}", serde_json::to_string(item)?);
                 }
@@ -342,7 +342,7 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
 
     match crate::utils::effective_format(&args.format) {
         "json" => println!("{}", serde_json::to_string_pretty(&results)?),
-        "ndjson" => {
+        "jsonl" => {
             for item in &results {
                 println!("{}", serde_json::to_string(item)?);
             }
@@ -576,7 +576,7 @@ pub(crate) fn search_live(
 
     match crate::utils::effective_format(format) {
         "json" => println!("{}", serde_json::to_string_pretty(&results)?),
-        "ndjson" => {
+        "jsonl" => {
             for item in &results {
                 println!("{}", serde_json::to_string(item)?);
             }

--- a/crates/spelunk-cli/src/cli/mod.rs
+++ b/crates/spelunk-cli/src/cli/mod.rs
@@ -68,7 +68,7 @@ pub enum Command {
     Explore(ExploreArgs),
     /// Manage and inspect cross-project links
     Links(LinksArgs),
-    /// Low-level plumbing commands for agents and scripts (NDJSON output)
+    /// Low-level plumbing commands for agents and scripts (JSONL output)
     Plumbing(PlumbingArgs),
     /// Sync local memory entries to the configured server (alias for `memory push`)
     Sync(SyncArgs),

--- a/crates/spelunk-cli/tests/cat_chunks.rs
+++ b/crates/spelunk-cli/tests/cat_chunks.rs
@@ -1,7 +1,7 @@
 //! Component tests for `spelunk plumbing cat-chunks`.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_ndjson, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 // ── happy path ────────────────────────────────────────────────────────────────
 
 #[test]
-fn cat_chunks_emits_ndjson_for_indexed_file() {
+fn cat_chunks_emits_jsonl_for_indexed_file() {
     let (_tmp, db_path, config_path) = index_fixture_project();
 
     // Use path suffix matching — the DB stores absolute paths.
@@ -23,7 +23,7 @@ fn cat_chunks_emits_ndjson_for_indexed_file() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     assert!(!rows.is_empty(), "expected at least one chunk for lib.rs");
 
     for row in &rows {
@@ -57,7 +57,7 @@ fn cat_chunks_output_includes_function_name() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     let names: Vec<&str> = rows.iter().filter_map(|r| r["name"].as_str()).collect();
     assert!(
         names.contains(&"greet"),

--- a/crates/spelunk-cli/tests/context.rs
+++ b/crates/spelunk-cli/tests/context.rs
@@ -63,8 +63,8 @@ fn setup_context_project() -> (TempDir, PathBuf, PathBuf) {
         ),
         (
             "decision",
-            "NDJSON for plumbing output",
-            "All plumbing commands emit NDJSON, one object per line.",
+            "JSONL for plumbing output",
+            "All plumbing commands emit JSONL, one object per line.",
         ),
         (
             "decision",

--- a/crates/spelunk-cli/tests/embed.rs
+++ b/crates/spelunk-cli/tests/embed.rs
@@ -66,7 +66,7 @@ async fn embed_exits_0_with_empty_piped_stdin() {
 // ── happy path: single line → one JSON embedding ──────────────────────────────
 
 #[tokio::test]
-async fn embed_document_mode_produces_ndjson_vector() {
+async fn embed_document_mode_produces_jsonl_vector() {
     let mock = MockServer::start().await;
 
     // Health probe.
@@ -102,7 +102,7 @@ async fn embed_document_mode_produces_ndjson_vector() {
         .stdout
         .clone();
 
-    let rows = plumbing_helpers::parse_ndjson(&output);
+    let rows = plumbing_helpers::parse_jsonl(&output);
     assert_eq!(rows.len(), 1, "one stdin line → one embedding");
 
     let row = &rows[0];
@@ -121,7 +121,7 @@ async fn embed_document_mode_produces_ndjson_vector() {
 }
 
 #[tokio::test]
-async fn embed_query_mode_produces_ndjson_vector() {
+async fn embed_query_mode_produces_jsonl_vector() {
     let mock = MockServer::start().await;
 
     Mock::given(method("GET"))
@@ -156,7 +156,7 @@ async fn embed_query_mode_produces_ndjson_vector() {
         .stdout
         .clone();
 
-    let rows = plumbing_helpers::parse_ndjson(&output);
+    let rows = plumbing_helpers::parse_jsonl(&output);
     assert_eq!(rows.len(), 1);
     assert!(rows[0].get("vector").is_some(), "missing 'vector'");
 }
@@ -196,7 +196,7 @@ async fn embed_multiple_lines_produce_multiple_vectors() {
         .stdout
         .clone();
 
-    let rows = plumbing_helpers::parse_ndjson(&output);
+    let rows = plumbing_helpers::parse_jsonl(&output);
     assert_eq!(rows.len(), 3, "three stdin lines → three embeddings");
 }
 

--- a/crates/spelunk-cli/tests/graph_edges.rs
+++ b/crates/spelunk-cli/tests/graph_edges.rs
@@ -1,7 +1,7 @@
 //! Component tests for `spelunk plumbing graph-edges`.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_ndjson, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 // ── happy path: file filter ───────────────────────────────────────────────────
 
 #[test]
-fn graph_edges_file_filter_returns_valid_ndjson_or_exit1() {
+fn graph_edges_file_filter_returns_valid_jsonl_or_exit1() {
     let (_tmp, db_path, config_path) = index_fixture_project();
 
     // utils.rs has no imports — may have no outgoing edges.
@@ -21,9 +21,9 @@ fn graph_edges_file_filter_returns_valid_ndjson_or_exit1() {
         .output()
         .unwrap();
 
-    // Either exit 1 (no edges) or exit 0 with valid NDJSON.
+    // Either exit 1 (no edges) or exit 0 with valid JSONL.
     if result.status.success() {
-        let rows = parse_ndjson(&result.stdout);
+        let rows = parse_jsonl(&result.stdout);
         for row in &rows {
             assert!(
                 row.get("source_file").is_some(),
@@ -42,7 +42,7 @@ fn graph_edges_file_filter_returns_valid_ndjson_or_exit1() {
 }
 
 #[test]
-fn graph_edges_main_file_returns_valid_ndjson_or_exit1() {
+fn graph_edges_main_file_returns_valid_jsonl_or_exit1() {
     let (_tmp, db_path, config_path) = index_fixture_project();
 
     // main.rs uses `greet` from lib — there should be at least a call edge.
@@ -54,7 +54,7 @@ fn graph_edges_main_file_returns_valid_ndjson_or_exit1() {
         .unwrap();
 
     if result.status.success() {
-        let rows = parse_ndjson(&result.stdout);
+        let rows = parse_jsonl(&result.stdout);
         assert!(!rows.is_empty(), "expected edges for main.rs");
         for row in &rows {
             assert!(
@@ -75,7 +75,7 @@ fn graph_edges_main_file_returns_valid_ndjson_or_exit1() {
 // ── symbol filter ─────────────────────────────────────────────────────────────
 
 #[test]
-fn graph_edges_symbol_filter_returns_valid_ndjson_or_exit1() {
+fn graph_edges_symbol_filter_returns_valid_jsonl_or_exit1() {
     let (_tmp, db_path, config_path) = index_fixture_project();
 
     let result = spelunk_cmd(&db_path, &config_path)
@@ -86,7 +86,7 @@ fn graph_edges_symbol_filter_returns_valid_ndjson_or_exit1() {
         .unwrap();
 
     if result.status.success() {
-        let rows = parse_ndjson(&result.stdout);
+        let rows = parse_jsonl(&result.stdout);
         for row in &rows {
             assert!(
                 row.get("source_file").is_some(),

--- a/crates/spelunk-cli/tests/hash_file.rs
+++ b/crates/spelunk-cli/tests/hash_file.rs
@@ -5,7 +5,7 @@
 //! (e.g. `src/lib.rs`), so the path argument must match what was indexed.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_ndjson, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -15,7 +15,7 @@ use tempfile::TempDir;
 // ── happy path: file is indexed ───────────────────────────────────────────────
 
 #[test]
-fn hash_file_emits_valid_ndjson() {
+fn hash_file_emits_valid_jsonl() {
     let (_tmp, db_path, config_path) = index_fixture_project();
 
     // We use the absolute path; the command should hash it and emit JSON.
@@ -33,7 +33,7 @@ fn hash_file_emits_valid_ndjson() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     assert_eq!(rows.len(), 1, "hash-file should emit exactly one JSON line");
 
     let row = &rows[0];
@@ -76,7 +76,7 @@ fn hash_file_is_current_for_relative_indexed_path() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     assert_eq!(rows.len(), 1);
 
     // The file hash should match what we computed.
@@ -117,7 +117,7 @@ fn hash_file_reports_null_indexed_hash_for_unknown_file() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     assert_eq!(rows.len(), 1);
 
     let row = &rows[0];

--- a/crates/spelunk-cli/tests/integration_compose.rs
+++ b/crates/spelunk-cli/tests/integration_compose.rs
@@ -8,22 +8,22 @@
 //! non-deterministic; tests assert structure and non-emptiness only.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_ndjson, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
 
 use assert_cmd::Command;
 use std::path::Path;
 
-// ── Test 1: search --format ndjson vs embed | knn ────────────────────────────
+// ── Test 1: search --format jsonl vs embed | knn ────────────────────────────
 //
-// Both pipelines should return valid NDJSON with `chunk_id` fields.
+// Both pipelines should return valid JSONL with `chunk_id` fields.
 // Ordering is non-deterministic (all mock embeddings are identical), so we
 // only assert structural validity and non-emptiness.
 
 #[test]
-fn porcelain_search_ndjson_returns_valid_chunk_ids() {
+fn porcelain_search_jsonl_returns_valid_chunk_ids() {
     let (_tmp, db_path, config_path) = index_fixture_project();
 
-    // `spelunk search "test" --db <db> --format ndjson --no-stale-check`
+    // `spelunk search "test" --db <db> --format jsonl --no-stale-check`
     let output = Command::cargo_bin("spelunk")
         .unwrap()
         .arg("--config")
@@ -33,7 +33,7 @@ fn porcelain_search_ndjson_returns_valid_chunk_ids() {
         .arg("--db")
         .arg(&db_path)
         .arg("--format")
-        .arg("ndjson")
+        .arg("jsonl")
         .arg("--no-stale-check")
         .arg("--mode")
         .arg("text") // text mode: no embedding call needed
@@ -43,10 +43,10 @@ fn porcelain_search_ndjson_returns_valid_chunk_ids() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     assert!(
         !rows.is_empty(),
-        "spelunk search --format ndjson should return at least one result"
+        "spelunk search --format jsonl should return at least one result"
     );
     for row in &rows {
         assert!(
@@ -94,7 +94,7 @@ fn plumbing_knn_returns_valid_chunk_ids() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&knn_output);
+    let rows = parse_jsonl(&knn_output);
     assert!(
         !rows.is_empty(),
         "plumbing embed | knn should return at least one result"
@@ -151,7 +151,7 @@ fn status_json_file_count_matches_ls_files_count() {
         .as_u64()
         .expect("status JSON must have 'file_count'");
 
-    // `spelunk plumbing ls-files` — counts NDJSON lines.
+    // `spelunk plumbing ls-files` — counts JSONL lines.
     let ls_output = spelunk_cmd(&db_path, &config_path)
         .arg("ls-files")
         .assert()
@@ -160,7 +160,7 @@ fn status_json_file_count_matches_ls_files_count() {
         .stdout
         .clone();
 
-    let ls_rows = parse_ndjson(&ls_output);
+    let ls_rows = parse_jsonl(&ls_output);
     let ls_count = ls_rows.len() as u64;
 
     assert_eq!(
@@ -197,7 +197,7 @@ fn parse_file_content_appears_in_cat_chunks() {
         .stdout
         .clone();
 
-    let parse_rows = parse_ndjson(&parse_output);
+    let parse_rows = parse_jsonl(&parse_output);
     assert!(
         !parse_rows.is_empty(),
         "parse-file should produce at least one chunk for lib.rs"
@@ -213,7 +213,7 @@ fn parse_file_content_appears_in_cat_chunks() {
         .stdout
         .clone();
 
-    let cat_rows = parse_ndjson(&cat_output);
+    let cat_rows = parse_jsonl(&cat_output);
     assert!(
         !cat_rows.is_empty(),
         "cat-chunks should return at least one indexed chunk for lib.rs"

--- a/crates/spelunk-cli/tests/knn.rs
+++ b/crates/spelunk-cli/tests/knn.rs
@@ -8,7 +8,7 @@
 //! Error-path tests (bad JSON on stdin, missing DB) run without a server.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_ndjson, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -94,8 +94,8 @@ fn knn_exits_1_or_error_for_wrong_dimension_vector() {
 
 #[test]
 #[ignore] // requires embedding server at 127.0.0.1:1234 AND an indexed project with real embeddings
-fn knn_returns_ndjson_results_for_valid_vector() {
-    // Run manually: cargo test knn_returns_ndjson -- --ignored
+fn knn_returns_jsonl_results_for_valid_vector() {
+    // Run manually: cargo test knn_returns_jsonl -- --ignored
     // Expected: a spelunk.db in the current directory with 768-dim embeddings.
 
     let tmp = TempDir::new().unwrap();
@@ -134,7 +134,7 @@ fn knn_returns_ndjson_results_for_valid_vector() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     for row in &rows {
         assert!(row.get("chunk_id").is_some(), "missing 'chunk_id': {row}");
         assert!(row.get("file_path").is_some(), "missing 'file_path': {row}");
@@ -184,7 +184,7 @@ fn knn_lang_filter_restricts_to_language() {
         .unwrap();
 
     if output.status.success() {
-        let rows = parse_ndjson(&output.stdout);
+        let rows = parse_jsonl(&output.stdout);
         for row in &rows {
             assert_eq!(
                 row["language"].as_str().unwrap_or(""),
@@ -235,7 +235,7 @@ fn knn_min_score_filter_respects_threshold() {
         .unwrap();
 
     if output.status.success() {
-        let rows = parse_ndjson(&output.stdout);
+        let rows = parse_jsonl(&output.stdout);
         for row in &rows {
             let score = row["score"].as_f64().unwrap_or(0.0);
             assert!(score >= 0.99, "score {score} below --min-score 0.99");

--- a/crates/spelunk-cli/tests/ls_files.rs
+++ b/crates/spelunk-cli/tests/ls_files.rs
@@ -1,7 +1,7 @@
 //! Component tests for `spelunk plumbing ls-files`.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_ndjson, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 // ── happy path ────────────────────────────────────────────────────────────────
 
 #[test]
-fn ls_files_emits_ndjson_for_indexed_project() {
+fn ls_files_emits_jsonl_for_indexed_project() {
     let (_tmp, db_path, config_path) = index_fixture_project();
 
     let output = spelunk_cmd(&db_path, &config_path)
@@ -21,7 +21,7 @@ fn ls_files_emits_ndjson_for_indexed_project() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     assert!(!rows.is_empty(), "expected at least one file entry");
 
     for row in &rows {
@@ -65,7 +65,7 @@ fn ls_files_stale_flag_returns_subset_or_empty() {
         .arg("ls-files")
         .output()
         .unwrap();
-    let all_rows = parse_ndjson(&all_output.stdout);
+    let all_rows = parse_jsonl(&all_output.stdout);
     let all_count = all_rows.len();
 
     // With --stale: only stale files returned (may be 0..all_count).
@@ -74,7 +74,7 @@ fn ls_files_stale_flag_returns_subset_or_empty() {
         .arg("--stale")
         .output()
         .unwrap();
-    let stale_rows = parse_ndjson(&stale_output.stdout);
+    let stale_rows = parse_jsonl(&stale_output.stdout);
 
     // Stale subset must not exceed total count.
     assert!(

--- a/crates/spelunk-cli/tests/parse_file.rs
+++ b/crates/spelunk-cli/tests/parse_file.rs
@@ -1,10 +1,10 @@
 //! Component tests for `spelunk plumbing parse-file`.
 //!
 //! `parse-file` does not require an indexed DB — it just parses a file
-//! on disk and emits NDJSON chunks.
+//! on disk and emits JSONL chunks.
 
 mod plumbing_helpers;
-use plumbing_helpers::parse_ndjson;
+use plumbing_helpers::parse_jsonl;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -33,7 +33,7 @@ fn dummy_config(tmp: &TempDir) -> std::path::PathBuf {
 // ── happy path ────────────────────────────────────────────────────────────────
 
 #[test]
-fn parse_file_emits_ndjson_for_rust_file() {
+fn parse_file_emits_jsonl_for_rust_file() {
     let tmp = TempDir::new().unwrap();
     let config = dummy_config(&tmp);
 
@@ -50,7 +50,7 @@ fn parse_file_emits_ndjson_for_rust_file() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     assert!(!rows.is_empty(), "expected at least one parsed chunk");
 
     // Every row must have the required fields.
@@ -89,7 +89,7 @@ fn parse_file_finds_function_and_struct_chunks() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
 
     // lib.rs has functions AND a struct; both should appear.
     let kinds: Vec<&str> = rows.iter().filter_map(|r| r["kind"].as_str()).collect();

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -187,7 +187,7 @@ pub fn fixture_path() -> std::path::PathBuf {
 
 /// Parse every line of `stdout` as JSON; return the parsed values.
 /// Panics if any line is not valid JSON.
-pub fn parse_ndjson(stdout: &[u8]) -> Vec<serde_json::Value> {
+pub fn parse_jsonl(stdout: &[u8]) -> Vec<serde_json::Value> {
     let text = std::str::from_utf8(stdout).expect("stdout is utf-8");
     text.lines()
         .filter(|l| !l.is_empty())

--- a/crates/spelunk-cli/tests/read_memory.rs
+++ b/crates/spelunk-cli/tests/read_memory.rs
@@ -1,7 +1,7 @@
 //! Component tests for `spelunk plumbing read-memory`.
 
 mod plumbing_helpers;
-use plumbing_helpers::{parse_ndjson, spelunk_cmd, write_config};
+use plumbing_helpers::{parse_jsonl, spelunk_cmd, write_config};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -82,7 +82,7 @@ fn indexed_project_with_memory_note() -> (tempfile::TempDir, std::path::PathBuf,
 // ── happy path: list all ──────────────────────────────────────────────────────
 
 #[test]
-fn read_memory_emits_ndjson_when_notes_exist() {
+fn read_memory_emits_jsonl_when_notes_exist() {
     let (_tmp, db_path, config_path) = indexed_project_with_memory_note();
 
     let output = spelunk_cmd(&db_path, &config_path)
@@ -93,7 +93,7 @@ fn read_memory_emits_ndjson_when_notes_exist() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     assert!(!rows.is_empty(), "expected at least one memory note");
 
     for row in &rows {
@@ -120,7 +120,7 @@ fn read_memory_kind_filter_returns_matching_notes() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&output);
+    let rows = parse_jsonl(&output);
     assert!(!rows.is_empty(), "expected at least one 'note' kind entry");
     for row in &rows {
         assert_eq!(
@@ -146,7 +146,7 @@ fn read_memory_by_id_returns_single_note() {
         .stdout
         .clone();
 
-    let rows = parse_ndjson(&list_output);
+    let rows = parse_jsonl(&list_output);
     let first_id = rows[0]["id"].as_i64().expect("id should be integer");
 
     let output = spelunk_cmd(&db_path, &config_path)
@@ -159,7 +159,7 @@ fn read_memory_by_id_returns_single_note() {
         .stdout
         .clone();
 
-    let detail_rows = parse_ndjson(&output);
+    let detail_rows = parse_jsonl(&output);
     assert_eq!(detail_rows.len(), 1, "expected exactly one note for --id");
     assert_eq!(detail_rows[0]["id"].as_i64(), Some(first_id));
 }

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -275,7 +275,7 @@ spelunk hooks install --ci
 
 ## Plumbing Commands
 
-Plumbing commands emit NDJSON to stdout and follow a strict exit-code convention, making them safe to use in scripts and pipelines. See [Plumbing and Porcelain](plumbing-and-porcelain.md) for a full explanation of the design philosophy.
+Plumbing commands emit JSONL to stdout and follow a strict exit-code convention, making them safe to use in scripts and pipelines. See [Plumbing and Porcelain](plumbing-and-porcelain.md) for a full explanation of the design philosophy.
 
 Exit codes across all plumbing commands:
 - **0** — success, results emitted
@@ -290,7 +290,7 @@ Commands marked **(requires server)** need an embedding model running on the con
 spelunk plumbing cat-chunks <file>
 ```
 
-Emit all indexed chunks for a given file as NDJSON.
+Emit all indexed chunks for a given file as JSONL.
 
 | Flag | Description |
 |------|-------------|
@@ -318,7 +318,7 @@ spelunk plumbing cat-chunks src/indexer/chunker.rs \
 spelunk plumbing ls-files [--prefix <prefix>] [--stale] [--root <dir>]
 ```
 
-List every indexed file as NDJSON. With `--stale`, only files whose on-disk blake3 hash differs from the stored hash are emitted.
+List every indexed file as JSONL. With `--stale`, only files whose on-disk blake3 hash differs from the stored hash are emitted.
 
 | Flag | Description |
 |------|-------------|
@@ -346,7 +346,7 @@ spelunk plumbing ls-files --stale --root .
 spelunk plumbing parse-file <file>
 ```
 
-Parse a file with tree-sitter and emit chunks as NDJSON without writing anything to the index. Useful for previewing how spelunk will chunk a file.
+Parse a file with tree-sitter and emit chunks as JSONL without writing anything to the index. Useful for previewing how spelunk will chunk a file.
 
 | Flag | Description |
 |------|-------------|
@@ -429,7 +429,7 @@ Example output:
 spelunk plumbing embed [--query]
 ```
 
-Read lines from stdin and emit one NDJSON embedding vector per line. Each output object contains the model name, vector dimensionality, and the float vector.
+Read lines from stdin and emit one JSONL embedding vector per line. Each output object contains the model name, vector dimensionality, and the float vector.
 
 | Flag | Description |
 |------|-------------|
@@ -487,7 +487,7 @@ spelunk plumbing graph-edges --symbol validate_token
 spelunk plumbing read-memory [--kind <kind>] [--id <n>] [--limit N]
 ```
 
-Emit memory entries as NDJSON. Use `--kind` to filter by entry type or `--id` to fetch a single entry.
+Emit memory entries as JSONL. Use `--kind` to filter by entry type or `--id` to fetch a single entry.
 
 | Flag | Description |
 |------|-------------|

--- a/docs/architecture/plumbing-commands.md
+++ b/docs/architecture/plumbing-commands.md
@@ -8,7 +8,7 @@ human-readable wrappers built on top of them.
 
 ## Design Principles
 
-1. **NDJSON on stdout** — every plumbing command writes one JSON object per
+1. **JSONL on stdout** — every plumbing command writes one JSON object per
    line to stdout. Consumers `jq`-filter or stream-parse without buffering.
 2. **Exit codes are semantic**
    - `0` — success, ≥1 result returned
@@ -19,7 +19,7 @@ human-readable wrappers built on top of them.
 4. **Composable** — plumbing commands read from stdin or file-path arguments;
    they do not open editors, prompt for input, or write to the DB unless
    that is their explicit job.
-5. **`--format` is absent** — plumbing commands always emit NDJSON; the flag
+5. **`--format` is absent** — plumbing commands always emit JSONL; the flag
    is a porcelain concern.
 
 ---
@@ -221,5 +221,5 @@ spelunk plumbing read-memory --kind decision \
 1. Add the args struct in `src/cli/args.rs` under `PlumbingCommand`.
 2. Add the handler in `src/cli/cmd/plumbing/<name>.rs`.
 3. Wire it in `src/cli/cmd/plumbing/mod.rs` and `src/cli/mod.rs`.
-4. Output NDJSON, exit 0/1/2, never write to stdout except JSON objects.
+4. Output JSONL, exit 0/1/2, never write to stdout except JSON objects.
 5. Add an entry to this document.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -81,7 +81,7 @@ spelunk search <query> [options]
 |------|---------|-------------|
 | `-l, --limit <n>` | 10 | Number of results (max 100); mutually exclusive with `--budget` |
 | `--budget <n>` | — | Return best chunks fitting within this token budget |
-| `--format text\|json\|ndjson` | text | Output format |
+| `--format text\|json\|jsonl` | text | Output format |
 | `-g, --graph` | false | Enrich results with 1-hop call-graph neighbours |
 | `--graph-limit <n>` | 10 | Max graph-expanded results to add (with `--graph`) |
 | `--mode <mode>` | auto | `auto`, `text` (FTS only), `semantic`/`hybrid` (LinearRAG), or `ast-grep` |
@@ -220,7 +220,7 @@ spelunk graph <symbol> [options]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--kind <type>` | all | Filter: `imports`, `calls`, `extends`, `implements` |
-| `--format text\|json\|ndjson` | text | Output format |
+| `--format text\|json\|jsonl` | text | Output format |
 | `-d, --db <path>` | auto | Override database path |
 | `--no-stale-check` | false | Suppress the stale-index warning |
 | `--live` | false | Skip the index and scan live files with ast-grep (requires `ast-grep` in PATH) |
@@ -246,7 +246,7 @@ spelunk chunks <path> [options]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--format text\|json\|ndjson` | text | Output format |
+| `--format text\|json\|jsonl` | text | Output format |
 | `-d, --db <path>` | auto | Override database path |
 
 ```bash
@@ -388,7 +388,7 @@ spelunk sync
 
 ## spelunk plumbing
 
-Low-level commands for agents and scripts. All emit NDJSON and exit non-zero on
+Low-level commands for agents and scripts. All emit JSONL and exit non-zero on
 error (exit 1 for "no results", exit 2 for errors). See
 [plumbing-and-porcelain.md](plumbing-and-porcelain.md).
 
@@ -400,7 +400,7 @@ spelunk plumbing hash-file <file>      # blake3 hash + index currency
 spelunk plumbing knn <query>           # KNN vector search
 spelunk plumbing embed                 # read stdin lines, emit vectors
 spelunk plumbing graph-edges           # code graph edges
-spelunk plumbing read-memory           # memory entries as NDJSON
+spelunk plumbing read-memory           # memory entries as JSONL
 ```
 
 ---

--- a/docs/example/AGENT.md
+++ b/docs/example/AGENT.md
@@ -60,7 +60,7 @@ spelunk memory add --kind requirement \
 spelunk exposes machine-readable plumbing commands for use in scripts:
 
 ```bash
-# Stream all indexed chunks for a file as NDJSON
+# Stream all indexed chunks for a file as JSONL
 spelunk plumbing cat-chunks src/auth.rs
 
 # Parse a file and emit AST chunks without writing to the DB
@@ -77,7 +77,7 @@ spelunk plumbing hash-file src/auth.rs
 spelunk plumbing graph-edges --symbol verify_token
 ```
 
-All plumbing commands emit NDJSON. Exit 0 = results, 1 = no results, 2 = error.
+All plumbing commands emit JSONL. Exit 0 = results, 1 = no results, 2 = error.
 
 ---
 

--- a/docs/plumbing-and-porcelain.md
+++ b/docs/plumbing-and-porcelain.md
@@ -2,17 +2,17 @@
 
 ## What is plumbing vs porcelain?
 
-Git popularised the distinction: *porcelain* commands are polished, human-friendly interfaces (coloured output, progress bars, readable prose), while *plumbing* commands are low-level, composable building blocks designed for scripts and pipelines. spelunk follows the same pattern. Porcelain commands like `spelunk search` and `spelunk memory list` format output for reading in a terminal; plumbing commands under `spelunk plumbing` emit raw NDJSON to stdout and are designed to be piped into other processes.
+Git popularised the distinction: *porcelain* commands are polished, human-friendly interfaces (coloured output, progress bars, readable prose), while *plumbing* commands are low-level, composable building blocks designed for scripts and pipelines. spelunk follows the same pattern. Porcelain commands like `spelunk search` and `spelunk memory list` format output for reading in a terminal; plumbing commands under `spelunk plumbing` emit raw JSONL to stdout and are designed to be piped into other processes.
 
 ## When to use plumbing
 
 Use plumbing commands when you are:
 
-- **Writing agent scripts** — parse NDJSON directly rather than scraping human-readable text.
+- **Writing agent scripts** — parse JSONL directly rather than scraping human-readable text.
 - **Composing pipelines** — chain plumbing commands with `jq`, `xargs`, or other plumbing commands.
 - **Running in CI** — exit codes are unambiguous (see table below); no ANSI codes pollute logs.
 - **Building reproducible queries** — the same plumbing invocation always produces the same schema, regardless of terminal width or colour settings.
-- **Integrating spelunk output into another tool** — NDJSON is trivially parsed in any language.
+- **Integrating spelunk output into another tool** — JSONL is trivially parsed in any language.
 
 ## When to use porcelain
 
@@ -34,7 +34,7 @@ Scripts should distinguish `1` (empty) from `2` (broken) rather than treating an
 
 ## Output format
 
-All plumbing commands write **one JSON object per line** (NDJSON) to **stdout**. Errors and warnings go to **stderr** only — stdout is always machine-parseable. There are no progress bars, no ANSI escape codes, and no trailing commas or array wrappers.
+All plumbing commands write **one JSON object per line** (JSONL) to **stdout**. Errors and warnings go to **stderr** only — stdout is always machine-parseable. There are no progress bars, no ANSI escape codes, and no trailing commas or array wrappers.
 
 Example: reading five results from `knn` into a shell array:
 
@@ -76,14 +76,14 @@ spelunk plumbing ls-files --stale --root . \
 
 | Command | Synopsis | Description |
 |---------|----------|-------------|
-| `cat-chunks` | `spelunk plumbing cat-chunks <file>` | Emit all indexed chunks for a file as NDJSON. Exits `1` if the file has no indexed chunks. |
-| `ls-files` | `spelunk plumbing ls-files [--prefix <p>] [--stale] [--root <dir>]` | List every indexed file as NDJSON. `--stale` restricts output to files whose on-disk hash differs from the stored hash. Exits `1` if no files match. |
-| `parse-file` | `spelunk plumbing parse-file <file>` | Parse a file using tree-sitter and emit chunks as NDJSON without writing to the index. |
+| `cat-chunks` | `spelunk plumbing cat-chunks <file>` | Emit all indexed chunks for a file as JSONL. Exits `1` if the file has no indexed chunks. |
+| `ls-files` | `spelunk plumbing ls-files [--prefix <p>] [--stale] [--root <dir>]` | List every indexed file as JSONL. `--stale` restricts output to files whose on-disk hash differs from the stored hash. Exits `1` if no files match. |
+| `parse-file` | `spelunk plumbing parse-file <file>` | Parse a file using tree-sitter and emit chunks as JSONL without writing to the index. |
 | `hash-file` | `spelunk plumbing hash-file <file>` | Compute the blake3 hash of a file and compare it to the stored hash, reporting whether the index is current for that file. |
 | `knn` | `spelunk plumbing knn [--limit N] [--min-score F] [--lang <lang>]` | Read a JSON embedding object from stdin and return the *N* nearest indexed chunks by cosine similarity. Exits `1` if no results pass the filters. |
-| `embed` | `spelunk plumbing embed [--query]` | Read lines from stdin and emit one NDJSON embedding vector per line. Pass `--query` to apply the query retrieval prefix (use this before piping into `knn`). |
-| `graph-edges` | `spelunk plumbing graph-edges --file <f> \| --symbol <s>` | Emit code graph edges (imports, calls, extends) for a file or symbol as NDJSON. At least one of `--file` or `--symbol` is required. Exits `1` if no edges found. |
-| `read-memory` | `spelunk plumbing read-memory [--kind <k>] [--id <n>] [--limit N]` | Emit memory entries as NDJSON. Filter by kind (`decision`, `question`, `note`, etc.) or fetch a single entry by id. |
+| `embed` | `spelunk plumbing embed [--query]` | Read lines from stdin and emit one JSONL embedding vector per line. Pass `--query` to apply the query retrieval prefix (use this before piping into `knn`). |
+| `graph-edges` | `spelunk plumbing graph-edges --file <f> \| --symbol <s>` | Emit code graph edges (imports, calls, extends) for a file or symbol as JSONL. At least one of `--file` or `--symbol` is required. Exits `1` if no edges found. |
+| `read-memory` | `spelunk plumbing read-memory [--kind <k>] [--id <n>] [--limit N]` | Emit memory entries as JSONL. Filter by kind (`decision`, `question`, `note`, etc.) or fetch a single entry by id. |
 
 ---
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -45,8 +45,8 @@ test = false
 doc = false
 
 [[bin]]
-name = "fuzz_ndjson_parse"
-path = "fuzz_targets/fuzz_ndjson_parse.rs"
+name = "fuzz_jsonl_parse"
+path = "fuzz_targets/fuzz_jsonl_parse.rs"
 test = false
 doc = false
 

--- a/fuzz/fuzz_targets/fuzz_jsonl_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_jsonl_parse.rs
@@ -2,13 +2,13 @@
 
 use libfuzzer_sys::fuzz_target;
 
-/// Fuzz NDJSON parsing used throughout the `spelunk spelunk` plumbing layer.
+/// Fuzz JSONL parsing used throughout the `spelunk spelunk` plumbing layer.
 ///
 /// Run with:
-///   cargo +nightly fuzz run fuzz_ndjson_parse -- -max_total_time=600
+///   cargo +nightly fuzz run fuzz_jsonl_parse -- -max_total_time=600
 ///
 /// Goal: confirm `serde_json` doesn't panic on malformed or adversarial input
-/// when lines are fed one at a time as NDJSON.
+/// when lines are fed one at a time as JSONL.
 fuzz_target!(|data: &[u8]| {
     let Ok(s) = std::str::from_utf8(data) else { return };
     for line in s.lines() {

--- a/fuzz/run.sh
+++ b/fuzz/run.sh
@@ -6,6 +6,6 @@ JOBS=4
 cargo +nightly fuzz run fuzz_chunker -- -max_total_time=$MAX_TIME -jobs=$JOBS
 cargo +nightly fuzz run fuzz_cli_history_entry -- -max_total_time=$MAX_TIME -jobs=$JOBS
 cargo +nightly fuzz run fuzz_escape_xml -- -max_total_time=$MAX_TIME -jobs=$JOBS
-cargo +nightly fuzz run fuzz_ndjson_parse -- -max_total_time=$MAX_TIME -jobs=$JOBS
+cargo +nightly fuzz run fuzz_jsonl_parse -- -max_total_time=$MAX_TIME -jobs=$JOBS
 cargo +nightly fuzz run fuzz_parser -- -max_total_time=$MAX_TIME -jobs=$JOBS
 cargo +nightly fuzz run fuzz_secret_scanner -- -max_total_time=$MAX_TIME -jobs=$JOBS


### PR DESCRIPTION
## Summary

Renames all project-owned `ndjson`/`NDJSON` references to `jsonl`/`JSONL` as requested in #348. JSONL (JSON Lines) is the more widely recognised standard name for this format; `ndjson` was a project-specific alias.

**What changed:**
- `--format ndjson` CLI flag value → `--format jsonl` (search, graph, memory commands)
- Test helper `parse_ndjson` → `parse_jsonl`; all test function names using `ndjson` updated
- Fuzz target file renamed `fuzz_ndjson_parse.rs` → `fuzz_jsonl_parse.rs`; `fuzz/Cargo.toml` and `fuzz/run.sh` updated
- All docs, CHANGELOG, SKILL.md, CLAUDE.md: terminology updated throughout
- `bench/setup_repos.sh`: `METADATA_NDJSON` variable renamed to `METADATA_JSONL`

**What was intentionally left unchanged:**
- `bench/linearrag/labels.json` and `bench/linearrag/results.json` — these are benchmark snapshot files containing historical test-run data, not source code

Closes #348.

## Test plan

- [x] `cargo fmt --all` — clean (pre-commit hook confirmed)
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings, exit 0
- [x] `cargo test --all` — 37 tests passed, 0 failed
- [x] Manually verify `spelunk search "foo" --format jsonl` emits one JSON object per line

🤖 Generated with [Claude Code](https://claude.com/claude-code)