### PR TITLE
security: gate git-notes write-through on secret-scan (memory add)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use super::MemoryAddArgs;
 use crate::{
     config::Config,
+    indexer::secrets::contains_secret,
     server_client::ServerInferenceClient,
     storage::{NoteInput, NoteRecord, append_to_git_notes, now_secs, open_memory_backend},
 };
@@ -90,7 +91,12 @@ pub(super) async fn memory_add(
             superseded_by: None,
         };
         // Use process CWD (None) — the CLI is always run from the project root.
-        if let Err(e) = append_to_git_notes(None, &record).await {
+        if contains_secret(&body) || contains_secret(&title) {
+            tracing::warn!(
+                "git-notes write-through skipped: note body or title matched a secret pattern. \
+                 Entry is stored in SQLite only. Set store_in_git_notes = false to suppress this check."
+            );
+        } else if let Err(e) = append_to_git_notes(None, &record).await {
             tracing::warn!("git-notes write-through failed (non-fatal): {e}");
         }
     }


### PR DESCRIPTION
## Summary
- Implements the architect spec in #344: gates the git-notes write-through path in `memory add` on the existing `contains_secret` scanner (`crates/spelunk-core/src/indexer/secrets.rs`), reusing it verbatim.
- Scans both `body` and `title`. On a match, the git-notes write is skipped, a static `tracing::warn!` fires (no credential text logged), and the command still exits 0.
- The SQLite write (`backend.add`) remains unconditional and unaffected — it happens before the gated block.
- Flips the "Memory note body contains a credential written to git notes" gap (THREAT-MODEL req #8) toward Mitigated.

## Test plan
- `cargo fmt` and `cargo clippy -p spelunk-cli -- -D warnings` pass clean (also ran via pre-commit hook on `cargo build`).
- Manual check of the new branch logic against the three acceptance-criteria scenarios in #344:
  - body matching `AKIA[0-9A-Z]{16}` with `store_in_git_notes = true` → git-notes write skipped, warn logged, SQLite row still created.
  - clean body/title with `store_in_git_notes = true` → git-notes write proceeds as before.
  - clean body but secret in title → git-notes write skipped (covered by the `|| contains_secret(&title)` addition).
- Automated tests for these scenarios are tracked as a follow-up for the Test Engineer (see linked inbox entry).

Closes #344