### PR TITLE
fix(bench): SWE-bench eval merge path/field + agent.py patch contamination

### DIFF
--- a/bench/agents/agent.py
+++ b/bench/agents/agent.py
@@ -516,10 +516,21 @@ def main() -> None:
     patch_path = None
     if args.save_patch:
         try:
-            # Stage all changes (including untracked files from write_file)
-            # then diff against HEAD to capture everything.
+            # Stage all changes (including untracked files from write_file),
+            # but exclude tooling/runtime artifacts that aren't part of the
+            # agent's actual fix. Without these excludes, `.spelunk/index.db`
+            # (binary, written by `spelunk index`), `ISSUE.txt` (written by
+            # setup_repos.sh), `uv.lock` (created by `uv run`), and similar
+            # junk files end up in the saved patch and either fail to apply
+            # in the SWE-bench Docker container or pollute the diff,
+            # causing otherwise-correct fixes to be marked unresolved.
+            EXCLUDE_PATHSPECS = [
+                ":!.spelunk",
+                ":!ISSUE.txt",
+                ":!uv.lock",
+            ]
             subprocess.run(
-                ["git", "add", "-A"],
+                ["git", "add", "-A", "--", ".", *EXCLUDE_PATHSPECS],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
@@ -527,7 +538,7 @@ def main() -> None:
                 check=True,
             )
             diff = subprocess.run(
-                ["git", "diff", "--cached", "HEAD"],
+                ["git", "diff", "--cached", "HEAD", "--", ".", *EXCLUDE_PATHSPECS],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,

--- a/bench/agents/swebench_eval.sh
+++ b/bench/agents/swebench_eval.sh
@@ -94,20 +94,22 @@ python3 -m swebench.harness.run_evaluation \
 # Step 3: Merge harness results back into result JSON
 echo ""
 echo "--- Merging resolve data ---"
-HARNESS_DIR="swebench_eval_outputs/${RUN_ID}"
-if [[ -d "$HARNESS_DIR" ]]; then
-    # Glob for harness output file (filename varies by SWE-bench version)
-    HARNESS_FILE=$(find "$HARNESS_DIR" -maxdepth 2 -name '*.json' -exec grep -l '"resolved"' {} \; 2>/dev/null | head -1)
-    if [[ -z "$HARNESS_FILE" ]]; then
-        echo "ERROR: no harness output with 'resolved' field under ${HARNESS_DIR}" >&2
-    else
-        echo "  Found: ${HARNESS_FILE}"
-        python3 -c "
+# make_run_report() (swebench.harness.reporting) writes its summary report to
+# "<model_name>.<run_id>.json" in the current working directory — NOT under
+# swebench_eval_outputs/. Per-instance logs/test_output.txt live under
+# logs/run_evaluation/${RUN_ID}/<model>/<instance>/, but the aggregate
+# resolved/unresolved/error sets only exist in the top-level report file.
+HARNESS_FILE=$(find . -maxdepth 1 -name "*.${RUN_ID}.json" 2>/dev/null | head -1)
+if [[ -z "$HARNESS_FILE" ]]; then
+    echo "ERROR: no harness report file matching '*.${RUN_ID}.json' found in $(pwd)" >&2
+else
+    echo "  Found: ${HARNESS_FILE}"
+    python3 -c "
 import json
 raw = json.load(open('${RESULTS}'))
 results = raw['tasks'] if isinstance(raw, dict) and 'tasks' in raw else raw
 harness = json.load(open('${HARNESS_FILE}'))
-resolved_map = {r: True for r in harness.get('resolved', [])}
+resolved_map = {r: True for r in harness.get('resolved_ids', [])}
 
 skipped_pre = sum(1 for r in results if r.get('skipped'))
 errored = sum(1 for r in results if r.get('error'))
@@ -136,9 +138,8 @@ output = {
 json.dump(output, open('${RESULTS}', 'w'), indent=2)
 print(f'  Evaluated: {evaluated}  Resolved: {resolved_count}  Rate: {rate:.1%}')
 "
-    fi
 fi
 
 echo ""
 echo "=== Done ==="
-echo "Results in: ${HARNESS_DIR}/"
+echo "Per-instance logs in: logs/run_evaluation/${RUN_ID}/"


### PR DESCRIPTION
## Summary
- `swebench_eval.sh`: the merge step looked for harness output under `swebench_eval_outputs/<run_id>/` and read a `resolved` field — neither exists. `swebench.harness.reporting.make_run_report()` actually writes `<model_name>.<run_id>.json` to the CWD with a `resolved_ids` list. Fixed the discovery glob and field name so resolve data actually merges back into the result JSON.
- `agent.py` `--save-patch`: `git add -A` was staging everything, including `.spelunk/index.db` (binary), `ISSUE.txt`, and `uv.lock`. These tooling/runtime artifacts polluted saved patches and could break `git apply` in the SWE-bench Docker harness, masking otherwise-correct agent fixes as unresolved. Both the `git add` and `git diff --cached` now exclude these via pathspec.

## Test plan
- `bash -n bench/agents/swebench_eval.sh` and `python3 -m py_compile bench/agents/agent.py` — both pass.
- Replayed the corrected merge-step Python against a synthetic harness report shaped like the actual gold-patch smoke test from #263 (`resolved_ids: [django__django-11099, django__django-11133]`, one error instance) — output correctly shows `tasks_evaluated: 2, tasks_resolved: 2, resolve_rate: 1.0`, matching the harness's actual 2/2 resolve.
- Replayed the `agent.py` patch-staging logic against a synthetic repo with `.spelunk/index.db`, `ISSUE.txt`, and `uv.lock` noise alongside a real source change — confirmed only the real source change appears in the staged diff.
- `cargo fmt` / `cargo clippy -- -D warnings` ran clean via pre-commit hooks (no Rust files touched).

Refs #263