### PR TITLE
feat(spelunk-server): SSE /memory/stream parity with cloud-api (ADR-026)

### DIFF
--- a/crates/spelunk-server/src/db.rs
+++ b/crates/spelunk-server/src/db.rs
@@ -424,6 +424,43 @@ impl ServerDb {
         Ok(notes)
     }
 
+    /// Return the highest `notes.id` for `project_id`, or `0` if the project
+    /// has no notes yet. Used to seed the SSE poll cursor for "start from
+    /// now" connections (no `Last-Event-ID` and no `?t=`, ADR-026 §2.4).
+    pub fn max_note_id(&self, project_id: i64) -> Result<i64> {
+        let max_id: Option<i64> = self.conn.query_row(
+            "SELECT MAX(id) FROM notes WHERE project_id = ?1",
+            rusqlite::params![project_id],
+            |r| r.get(0),
+        )?;
+        Ok(max_id.unwrap_or(0))
+    }
+
+    /// Return notes with `id > since_id` (exclusive), ordered ASC by `id`.
+    /// Unlike [`notes_since`], this includes archived entries — callers use
+    /// the `status` field to distinguish `memory.created` from
+    /// `memory.archived` transitions. `notes.id` is used directly as the SSE
+    /// `seq` (see ADR-026 §2.1). `limit` is capped at 500.
+    pub fn notes_since_id(
+        &self,
+        project_id: i64,
+        since_id: i64,
+        limit: i64,
+    ) -> Result<Vec<ServerNote>> {
+        let limit = limit.clamp(1, 500);
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT id, kind, title, body, tags, linked_files, created_at, status, superseded_by
+             FROM notes
+             WHERE project_id = ?1 AND id > ?2
+             ORDER BY id ASC
+             LIMIT ?3",
+        )?;
+        let notes = stmt
+            .query_map(rusqlite::params![project_id, since_id, limit], row_to_note)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(notes)
+    }
+
     pub fn delete_note(&self, project_id: i64, note_id: i64) -> Result<bool> {
         self.conn.execute(
             "DELETE FROM note_embeddings WHERE note_id = ?1",

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -6,7 +6,7 @@ use async_stream::stream;
 use axum::{
     Extension, Json,
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{
         IntoResponse, Response,
         sse::{Event, KeepAlive, Sse},
@@ -560,7 +560,63 @@ fn default_since_limit() -> i64 {
 #[derive(Deserialize, ToSchema, utoipa::IntoParams)]
 pub struct StreamQuery {
     /// Unix epoch seconds to start from (inclusive). Defaults to now.
+    /// Ignored if a `Last-Event-ID` header is present (see ADR-026 §2.4).
     pub t: Option<i64>,
+    /// Comma-separated kind filter, e.g. `kind=intent,question`. Absent or
+    /// empty means all kinds. Only applies to `memory.created` events —
+    /// `memory.archived` and `ping` always pass (ADR-015 semantics).
+    pub kind: Option<String>,
+}
+
+// ── SSE event naming / filtering (ADR-026 §2.2-2.3, §2.5) ─────────────────────
+// keep in sync with cloud-api src/sse/events.rs (`event_name`/`passes_filter`);
+// extraction into `spelunk-core::sse` deferred per ADR-026 §2.5 (decision #158).
+
+/// `event:` name for a given `ServerNote` status, per the `MemoryEvent` taxonomy
+/// reachable from SQLite (ADR-026 §2.2). OSS does not emit
+/// `memory.conflict_detected`/`memory.conflict_resolved`.
+fn event_name_for_status(status: &str) -> &'static str {
+    match status {
+        "archived" => "memory.archived",
+        _ => "memory.created",
+    }
+}
+
+/// Parse a comma-separated `?kind=` filter into a list of trimmed, non-empty
+/// kind strings. Returns `None` if the filter is absent or empty (no filter).
+fn parse_kind_filter(kind: Option<&str>) -> Option<Vec<String>> {
+    let kinds: Vec<String> = kind?
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect();
+    if kinds.is_empty() { None } else { Some(kinds) }
+}
+
+/// `memory.archived` and `ping` always pass; `memory.created` is filtered by
+/// `note.kind` against the `?kind=` allow-list (ADR-015 semantics).
+fn passes_kind_filter(note: &super::db::ServerNote, filter: Option<&[String]>) -> bool {
+    if note.status == "archived" {
+        return true;
+    }
+    match filter {
+        None => true,
+        Some(kinds) => kinds.iter().any(|k| k == &note.kind),
+    }
+}
+
+/// Parse the `Last-Event-ID` header (`seq-NNNNNNN` or bare integer) into an
+/// `id` lower bound (exclusive), per ADR-026 §2.4.
+fn parse_last_event_id(headers: &HeaderMap) -> Option<i64> {
+    let raw = headers.get("Last-Event-ID")?.to_str().ok()?;
+    let digits = raw.strip_prefix("seq-").unwrap_or(raw);
+    digits.parse::<i64>().ok()
+}
+
+/// Build the `id: seq-NNNNNNN` SSE event ID for a note, per ADR-026 §2.1.
+fn seq_id(note_id: i64) -> String {
+    format!("seq-{note_id:07}")
 }
 
 /// Return notes created after a given Unix timestamp. Archived entries are
@@ -592,12 +648,19 @@ pub async fn memory_since(
     Ok(Json(notes))
 }
 
-/// Stream new memory entries as Server-Sent Events. Each event carries a
-/// single `ServerNote` serialised as JSON. The stream polls the database once
-/// per second and stays open indefinitely — close the connection to stop it.
+/// Stream new memory entries as Server-Sent Events, per ADR-026.
 ///
-/// Pass `?t=<unix_secs>` to replay entries written after a known timestamp.
-/// Omit it to receive only entries written after the connection opens.
+/// Each event is framed with `event:` (`memory.created`, `memory.archived`,
+/// or `ping`), `id: seq-NNNNNNN` (the note's `id`), and a JSON `data:` payload.
+/// The stream polls the database once per second and stays open indefinitely
+/// — close the connection to stop it.
+///
+/// Resume: send a `Last-Event-ID: seq-NNNNNNN` header to resume from that
+/// sequence number (exclusive). Takes precedence over `?t=`. If neither is
+/// present, only entries written after the connection opens are streamed.
+///
+/// `?kind=<comma-separated>` filters `memory.created` events by note kind;
+/// `memory.archived` and `ping` are always emitted.
 #[utoipa::path(
     get,
     path = "/v1/projects/{project_id}/memory/stream",
@@ -617,6 +680,7 @@ pub async fn memory_stream(
     State(state): State<AppState>,
     Path(project_id): Path<String>,
     Query(params): Query<StreamQuery>,
+    headers: HeaderMap,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, AppError> {
     // Validate the project exists before opening the stream.
     {
@@ -624,15 +688,42 @@ pub async fn memory_stream(
         require_project(&db, &project_id)?;
     }
 
-    let start_t = params.t.unwrap_or_else(|| {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64
-    });
+    let kind_filter = parse_kind_filter(params.kind.as_deref());
+
+    // `Last-Event-ID` (resume) takes precedence over `?t=` (ADR-026 §2.4).
+    // If neither is present, start from "now" (`id` cursor seeded from the
+    // current max id below, `t` cursor seeded from the current time).
+    let last_event_id = parse_last_event_id(&headers);
 
     let s = stream! {
-        let mut last_seen = start_t;
+        // `since_id` is the exclusive `notes.id` lower bound used for both
+        // the replay batch and the poll cursor (de-dup safety, ADR-026 §2.4).
+        // `last_seen_t` seeds the legacy `created_at`-based cursor only for
+        // the very first poll when neither `Last-Event-ID` nor `?t=` is set.
+        let mut since_id: i64 = match last_event_id {
+            Some(id) => id,
+            None => {
+                let db = state.db.lock().await;
+                match db.get_project(&project_id) {
+                    Ok(Some(p)) => match params.t {
+                        // `?t=` provided with no Last-Event-ID: replay by
+                        // created_at, then switch to id-based cursoring.
+                        Some(t) => db
+                            .notes_since(p.id, t, 1)
+                            .ok()
+                            .and_then(|notes| notes.first().map(|n| n.id - 1))
+                            .unwrap_or(0),
+                        // No cursor at all: start from "now" — only stream
+                        // entries created after the connection opens.
+                        None => db.max_note_id(p.id).unwrap_or(0),
+                    },
+                    _ => 0,
+                }
+            }
+        };
+
+        let mut last_activity = std::time::Instant::now();
+
         loop {
             // Lock, query, immediately release.
             let notes = {
@@ -648,15 +739,37 @@ pub async fn memory_stream(
                     }
                 };
                 // Ignore DB errors mid-stream; keep the connection alive.
-                db.notes_since(pid, last_seen, 50).unwrap_or_default()
+                db.notes_since_id(pid, since_id, 50).unwrap_or_default()
             };
 
             for note in notes {
-                if note.created_at > last_seen {
-                    last_seen = note.created_at;
+                if note.id > since_id {
+                    since_id = note.id;
                 }
+                if !passes_kind_filter(&note, kind_filter.as_deref()) {
+                    continue;
+                }
+                let event_name = event_name_for_status(&note.status);
                 let data = serde_json::to_string(&note).unwrap_or_default();
-                yield Ok::<Event, Infallible>(Event::default().data(data));
+                last_activity = std::time::Instant::now();
+                yield Ok::<Event, Infallible>(
+                    Event::default()
+                        .event(event_name)
+                        .id(seq_id(note.id))
+                        .data(data),
+                );
+            }
+
+            // Named `ping` keepalive every 30s of no activity (ADR-026 §2.2),
+            // in addition to axum's transport-level keepalive.
+            if last_activity.elapsed() >= Duration::from_secs(30) {
+                last_activity = std::time::Instant::now();
+                let payload = serde_json::json!({ "event": "ping", "last_seq": since_id });
+                yield Ok::<Event, Infallible>(
+                    Event::default()
+                        .event("ping")
+                        .data(payload.to_string()),
+                );
             }
 
             tokio::time::sleep(Duration::from_secs(1)).await;

--- a/crates/spelunk-server/tests/integration_server.rs
+++ b/crates/spelunk-server/tests/integration_server.rs
@@ -42,6 +42,50 @@ async fn send(
     router(state).oneshot(req).await.unwrap()
 }
 
+/// Like [`send`], but allows attaching extra headers (e.g. `Last-Event-ID`).
+async fn send_with_headers(
+    state: AppState,
+    method: &str,
+    uri: &str,
+    headers: &[(&str, &str)],
+) -> axum::response::Response {
+    let mut builder = Request::builder().method(method).uri(uri);
+    for (k, v) in headers {
+        builder = builder.header(*k, *v);
+    }
+    let req = builder.body(Body::empty()).unwrap();
+    router(state).oneshot(req).await.unwrap()
+}
+
+/// Read raw SSE bytes off a streaming response body until at least
+/// `min_events` `\n\n`-terminated frames have been seen, or `timeout` elapses.
+/// The `memory_stream` handler never closes its body, so callers must bound
+/// how much they read.
+async fn read_sse_frames(
+    resp: axum::response::Response,
+    min_events: usize,
+    timeout: std::time::Duration,
+) -> String {
+    use futures_util::StreamExt;
+    let mut body = resp.into_body().into_data_stream();
+    let mut buf = String::new();
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if buf.matches("\n\n").count() >= min_events {
+            break;
+        }
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, body.next()).await {
+            Ok(Some(Ok(chunk))) => buf.push_str(&String::from_utf8_lossy(&chunk)),
+            Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
+        }
+    }
+    buf
+}
+
 // ── health ───────────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -413,4 +457,160 @@ async fn project_stats_returns_correct_counts() {
     assert_eq!(stats["count"], 1);
     assert_eq!(stats["total"], 1);
     assert_eq!(stats["embedding_dim"], 4);
+}
+
+// ── memory_stream (SSE, ADR-026) ───────────────────────────────────────────────
+
+#[tokio::test]
+#[serial]
+async fn memory_stream_replays_with_event_framing_and_kind_filter() {
+    let state = make_state();
+
+    // Seed two notes of different kinds before opening the stream so they're
+    // picked up by the initial "since 0" poll (?t= unset, no Last-Event-ID —
+    // but seeding happens before the connection opens, so use ?t=0 to force
+    // a full replay from id 0).
+    send(
+        state.clone(),
+        "POST",
+        "/v1/projects/p/memory",
+        json_body(
+            serde_json::json!({"kind":"intent","title":"intent note","embedding":[0.0_f32,0.0,0.0,0.0]}),
+        ),
+        true,
+    )
+    .await;
+    send(
+        state.clone(),
+        "POST",
+        "/v1/projects/p/memory",
+        json_body(
+            serde_json::json!({"kind":"decision","title":"decision note","embedding":[0.0_f32,0.0,0.0,0.0]}),
+        ),
+        true,
+    )
+    .await;
+
+    // ?t=0 with no Last-Event-ID: notes_since(0,1) finds the first note (id
+    // 1), so since_id = 0 and both notes replay on the first poll.
+    let resp = send(
+        state,
+        "GET",
+        "/v1/projects/p/memory/stream?t=0&kind=intent",
+        Body::empty(),
+        false,
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let raw = read_sse_frames(resp, 1, std::time::Duration::from_secs(5)).await;
+
+    // Only the `intent` note should pass the kind filter.
+    assert!(raw.contains("event: memory.created"), "raw: {raw}");
+    assert!(raw.contains("id: seq-0000001"), "raw: {raw}");
+    assert!(raw.contains("intent note"), "raw: {raw}");
+    assert!(
+        !raw.contains("decision note"),
+        "kind filter should drop the decision note: {raw}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn memory_stream_emits_archived_event() {
+    let state = make_state();
+
+    let create = send(
+        state.clone(),
+        "POST",
+        "/v1/projects/p/memory",
+        json_body(
+            serde_json::json!({"kind":"note","title":"to archive","embedding":[0.0_f32,0.0,0.0,0.0]}),
+        ),
+        true,
+    )
+    .await;
+    let bytes = axum::body::to_bytes(create.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let created: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let note_id = created["id"].as_i64().expect("note id");
+
+    send(
+        state.clone(),
+        "POST",
+        &format!("/v1/projects/p/memory/{note_id}/archive"),
+        Body::empty(),
+        false,
+    )
+    .await;
+
+    let resp = send(
+        state,
+        "GET",
+        "/v1/projects/p/memory/stream?t=0",
+        Body::empty(),
+        false,
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let raw = read_sse_frames(resp, 1, std::time::Duration::from_secs(5)).await;
+    assert!(raw.contains("event: memory.archived"), "raw: {raw}");
+    assert!(raw.contains(&format!("id: seq-{note_id:07}")), "raw: {raw}");
+}
+
+#[tokio::test]
+#[serial]
+async fn memory_stream_resumes_from_last_event_id_without_gap_or_dup() {
+    let state = make_state();
+
+    // First note exists before the client ever connects.
+    send(
+        state.clone(),
+        "POST",
+        "/v1/projects/p/memory",
+        json_body(
+            serde_json::json!({"kind":"note","title":"note one","embedding":[0.0_f32,0.0,0.0,0.0]}),
+        ),
+        true,
+    )
+    .await;
+
+    // Pretend a previous connection already consumed note 1 (`seq-0000001`)
+    // and disconnected. A second note is written after that.
+    send(
+        state.clone(),
+        "POST",
+        "/v1/projects/p/memory",
+        json_body(
+            serde_json::json!({"kind":"note","title":"note two","embedding":[0.0_f32,0.0,0.0,0.0]}),
+        ),
+        true,
+    )
+    .await;
+
+    let resp = send_with_headers(
+        state,
+        "GET",
+        "/v1/projects/p/memory/stream",
+        &[("Last-Event-ID", "seq-0000001")],
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let raw = read_sse_frames(resp, 1, std::time::Duration::from_secs(5)).await;
+
+    // Only note two (id 2) should be replayed — no gap (note one missing
+    // would be a gap; note one re-appearing would be a dup).
+    assert!(raw.contains("id: seq-0000002"), "raw: {raw}");
+    assert!(raw.contains("note two"), "raw: {raw}");
+    assert!(
+        !raw.contains("note one"),
+        "resume from seq-0000001 must not re-send note one: {raw}"
+    );
+    assert!(
+        !raw.contains("seq-0000001"),
+        "resume from seq-0000001 must not re-send id seq-0000001: {raw}"
+    );
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -702,8 +702,8 @@
         "tags": [
           "memory"
         ],
-        "summary": "Stream new memory entries as Server-Sent Events. Each event carries a\nsingle `ServerNote` serialised as JSON. The stream polls the database once\nper second and stays open indefinitely — close the connection to stop it.",
-        "description": "Pass `?t=<unix_secs>` to replay entries written after a known timestamp.\nOmit it to receive only entries written after the connection opens.",
+        "summary": "Stream new memory entries as Server-Sent Events, per ADR-026.",
+        "description": "Each event is framed with `event:` (`memory.created`, `memory.archived`,\nor `ping`), `id: seq-NNNNNNN` (the note's `id`), and a JSON `data:` payload.\nThe stream polls the database once per second and stays open indefinitely\n— close the connection to stop it.\n\nResume: send a `Last-Event-ID: seq-NNNNNNN` header to resume from that\nsequence number (exclusive). Takes precedence over `?t=`. If neither is\npresent, only entries written after the connection opens are streamed.\n\n`?kind=<comma-separated>` filters `memory.created` events by note kind;\n`memory.archived` and `ping` are always emitted.",
         "operationId": "memory_stream",
         "parameters": [
           {
@@ -718,7 +718,7 @@
           {
             "name": "t",
             "in": "query",
-            "description": "Unix epoch seconds to start from (inclusive). Defaults to now.",
+            "description": "Unix epoch seconds to start from (inclusive). Defaults to now.\nIgnored if a `Last-Event-ID` header is present (see ADR-026 §2.4).",
             "required": false,
             "schema": {
               "type": [
@@ -726,6 +726,18 @@
                 "null"
               ],
               "format": "int64"
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "description": "Comma-separated kind filter, e.g. `kind=intent,question`. Absent or\nempty means all kinds. Only applies to `memory.created` events —\n`memory.archived` and `ping` always pass (ADR-015 semantics).",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         ],
@@ -1732,13 +1744,20 @@
       "StreamQuery": {
         "type": "object",
         "properties": {
+          "kind": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Comma-separated kind filter, e.g. `kind=intent,question`. Absent or\nempty means all kinds. Only applies to `memory.created` events —\n`memory.archived` and `ping` always pass (ADR-015 semantics)."
+          },
           "t": {
             "type": [
               "integer",
               "null"
             ],
             "format": "int64",
-            "description": "Unix epoch seconds to start from (inclusive). Defaults to now."
+            "description": "Unix epoch seconds to start from (inclusive). Defaults to now.\nIgnored if a `Last-Event-ID` header is present (see ADR-026 §2.4)."
           }
         }
       },


### PR DESCRIPTION
## Summary

Implements the spelunk-oss side of ADR-026 (cloud-api PR #36): brings
`crates/spelunk-server/src/handlers.rs::memory_stream`
(`GET /v1/projects/{project_id}/memory/stream`) up to ADR-013/015
wire-contract parity with cloud-api, so `spelunk memory watch` works
correctly (filtered, resumable) against self-hosted OSS servers.

- **Kind filter**: `StreamQuery` gains `kind: Option<String>`
  (comma-separated, ADR-015 semantics). `memory.archived` and `ping`
  always pass; `memory.created` is filtered by note kind.
- **SSE event framing**: emits `event: memory.created` /
  `event: memory.archived` / `event: ping`, each with `id: seq-NNNNNNN`
  (using `notes.id` directly as `seq`, per ADR-026 §2.1 — no schema
  migration).
- **`Last-Event-ID` resume**: parses `seq-NNNNNNN` or bare-int
  `Last-Event-ID`, uses it as an exclusive `id` lower bound via the new
  `db.rs::notes_since_id(project_id, since_id, limit)`. Takes precedence
  over `?t=` per ADR-026 §2.4. `notes_since_id` stays `project_id`-scoped
  from the URL path (same structure as `notes_since`) — a `Last-Event-ID`
  from another project's stream cannot leak rows.
- **Named `ping` keepalive** every 30s of no activity, in addition to
  axum's transport-level `KeepAlive`.
- `db.rs::max_note_id(project_id)` seeds the poll cursor for "start from
  now" connections (no `Last-Event-ID`, no `?t=`).
- utoipa docs / `StreamQuery` IntoParams updated for `kind`;
  `docs/openapi.json` regenerated.

### ADR-026 §2.5 (shared `spelunk-core::sse` extraction) — deferred

Per the ADR's explicit Implementer's-call clause, I duplicated the small
`event_name_for_status` / `passes_kind_filter` / `parse_last_event_id` /
`seq_id` helpers in `handlers.rs` with a `// keep in sync with cloud-api
src/sse/events.rs` comment, rather than standing up a new
`spelunk-core::sse` module + cross-repo dependency in this PR. Flagging
for the Architect to decide whether to follow up with the decision #158
extraction separately — the duplicated surface is ~60 lines of pure
functions.

### Known limitation (documented for follow-up)

`memory.archived` is only emitted for notes whose `id > since_id` (i.e.
notes created since the client's last cursor). A note created *before*
the cursor that is archived *after* won't surface a `memory.archived`
event on this stream, because `notes` has no `archived_at`/`updated_at`
column to detect the in-place status transition without a new `id`. This
matches "no schema migration required" (ADR-026 §2.1) but is a real gap
for long-lived `--since-seq` resumes. Worth a follow-up if it becomes a
problem in practice (would need an `updated_at` column + `WHERE
updated_at > ?` query).

## Test plan

- `cargo test -p spelunk-server` — all 25 unit + 15 integration tests
  pass, including 3 new SSE integration tests:
  - `memory_stream_replays_with_event_framing_and_kind_filter` — seeds an
    `intent` and a `decision` note, connects with `?t=0&kind=intent`,
    asserts `event: memory.created` / `id: seq-0000001` framing and that
    the `decision` note is filtered out.
  - `memory_stream_emits_archived_event` — creates then archives a note,
    asserts `event: memory.archived` with the matching `id: seq-NNNNNNN`.
  - `memory_stream_resumes_from_last_event_id_without_gap_or_dup` —
    writes two notes, connects with `Last-Event-ID: seq-0000001`, asserts
    only note two replays (no gap, no dup of note one).
- `cargo fmt -p spelunk-server` and `cargo clippy -p spelunk-server
  --all-targets -- -D warnings` — clean.
- Workspace pre-commit hooks (`cargo fmt --check`, `cargo clippy`) passed
  on commit.

Refs: #375, ADR-026 (spelunk-cloud/cloud-api#36)