### PR TITLE
docs: clarify spelunk explore --help visibility requires LLM config

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -139,6 +139,8 @@ AGENT=true spelunk explore "where is the embedding model loaded?" --max-steps 3
 
 `explore` is slower than `search` (multiple LLM calls) — use it only when `search` alone isn't enough.
 
+Note: `spelunk explore` is hidden from `spelunk --help` until a chat model is configured on the server, since it would otherwise error on every invocation. The command works as shown above once a backend is configured — it isn't missing.
+
 ## After making changes
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -112,6 +112,10 @@ Agentic search: the server's LLM iteratively calls spelunk's own tools (search,
 graph, read) to answer an open-ended question. Requires a server with an LLM
 backend configured.
 
+> `explore` is hidden from `spelunk --help` until an LLM backend is
+> configured (it would error if run without one). The command itself works
+> as documented here once a backend is set up — see [Agent Guide](agent-guide.md).
+
 ```
 spelunk explore "<question>" [options]
 ```


### PR DESCRIPTION
## Summary
- `spelunk explore` is intentionally hidden from `spelunk --help` when no chat/LLM model is configured (`main.rs:46`, `c.hide(!llm_configured)`), but the docs didn't explain this — closes #374.
- Adds a note to `docs/commands.md` (## spelunk explore) and `docs/agent-guide.md` clarifying that the command works as documented once an LLM backend is configured, and that its absence from `--help` isn't a bug.

## Test plan
- [x] `cargo fmt --check` and `cargo clippy` pass (docs-only change, no code touched)
- [x] Manually reviewed rendered markdown in `docs/commands.md` and `docs/agent-guide.md` for correct placement/formatting