### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,59 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased] — 0.8.0-dev
+## [0.8.1] — 2026-06-10
+
+### Fixed
+
+- **`spelunk search` honors auto-discovered loopback server.** Explicit
+  `--mode semantic`/`--mode hybrid` no longer error with "requires
+  spelunk-server", and `--mode auto` no longer silently falls back to
+  ast-grep, when no `server_url` is configured but a local `spelunk-server`
+  was auto-discovered via the loopback probe (the default v0.8.0 UX).
+
+- **Native embedder: fixed memory spike, CPU saturation, and index timeout.**
+  Indexing large projects no longer triggers a ~20 GB memory spike, ~750%
+  CPU usage across 31 threads, or HTTP timeouts during the embed phase.
+  Adds a new `--embed-threads` CLI arg (default 4, env
+  `SPELUNK_EMBED_THREADS`). Verified: 124-file / 1330-chunk index completes
+  in 7m30s with stable ~3.5 GB memory and ~350-400% CPU.
+
+- **Native embedder: reduced CoreML activation footprint and added compiled-model
+  cache** for hardware EP builds (`embed-coreml` / `embed-xnnpack` /
+  `embed-directml`), cutting peak memory from ~4 GB to ~1 GB and avoiding
+  CoreML recompilation on every server start. These hardware EP features
+  remain experimental and are not recommended over the default CPU EP — see
+  `docs/server.md`.
+
+### Security
+
+- **Auto-spawned `spelunk-server` now binds to `127.0.0.1` only.** Previously
+  the server started by `spelunk init` / `ensure_server_running` defaulted to
+  `0.0.0.0`, making the unauthenticated local server LAN-reachable.
+  (THREAT-MODEL req #9, decision #88)
+
+### Added
+
+- **`spelunk status`/`check --format json`** now include a `memory_backend`
+  field (`"sqlite"`, `"remote"`, or `"git-notes"`); `spelunk status` text mode
+  shows a "Memory backend: <kind>" line. (#308)
+
+### Changed
+
+- **NDJSON terminology renamed to JSONL** throughout the CLI, docs, and tests.
+  The `--format` flag value `ndjson` is now `jsonl` for `search`, `graph`, and
+  `memory` commands. (#348)
+
+- **Internal refactor:** `storage::remote` and `storage::git_notes` split into
+  module directories to stay under the 400-line file limit. No public API
+  changes.
+
+- **Homebrew tap moved to a separate repo** (`spelunk-cloud/homebrew-spelunk`);
+  the release workflow now publishes the formula there directly.
+
+---
+
+## [0.8.0] — 2026-06-08
 
 ### Breaking changes — migration required
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps `spelunk-cli`, `spelunk-core`, and `spelunk-server` from 0.8.0 to 0.8.1, and adds a CHANGELOG entry covering changes merged since the v0.8.0 tag (2026-06-08):

- fix(search): honor effective config for auto-discovered loopback server
- fix(embedder): fix memory spike, CPU saturation, and index timeout
- fix(embedder): reduce CoreML activation footprint and cache compiled model
- security: bind auto-spawned server to 127.0.0.1 (THREAT-MODEL req #9)
- feat: surface `backend_kind()` in `status`/`check --format json` (#308)
- refactor: rename ndjson → jsonl throughout the codebase (#348)
- refactor(storage): split `remote.rs` and `git_notes.rs` into module directories
- build(release): publish Homebrew formula to a separate tap repo

Also retitles the existing `[Unreleased] — 0.8.0-dev` CHANGELOG section to `[0.8.0] — 2026-06-08`, since that content describes what actually shipped in the v0.8.0 tag and was never finalized in the changelog.

## Test plan

- [x] `cargo build` succeeds with all three crates at 0.8.1 (ran via pre-commit hook)
- [x] `Cargo.lock` regenerated via `cargo update -p spelunk-cli -p spelunk-core -p spelunk-server`
- [ ] Merge, then tag `v0.8.1` to trigger the release workflow (per `docs/releasing.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)