### PR TITLE
ci: add job timeouts; build only rich-formats in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   check:
     name: Check & Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -36,17 +37,11 @@ jobs:
       - name: Rustfmt
         run: cargo fmt --all -- --check
 
-      - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
-
       - name: Clippy (rich-formats)
         run: cargo clippy --all-targets --features rich-formats -- -D warnings
 
-      - name: Check
-        run: cargo check --all-targets
-
-      - name: Build
-        run: cargo build --all-targets
+      - name: Check (rich-formats)
+        run: cargo check --all-targets --features rich-formats
 
       - name: Build (rich-formats)
         run: cargo build --all-targets --features rich-formats
@@ -54,6 +49,7 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -85,6 +81,7 @@ jobs:
   openapi-snapshot:
     name: OpenAPI snapshot check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,6 +10,7 @@ jobs:
   fuzz-parser:
     name: cargo-fuzz fuzz_parser
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     permissions:
       contents: write
     strategy:
@@ -96,6 +97,7 @@ jobs:
     name: Build Debian package (amd64)
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -151,6 +153,7 @@ jobs:
     name: Create GitHub Release
     needs: [build, deb]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -183,6 +186,7 @@ jobs:
     # Skip pre-release tags (rc/beta/alpha) — formula only tracks stable releases.
     if: ${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,7 @@ jobs:
   audit:
     name: cargo-audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -42,6 +43,7 @@ jobs:
   deny:
     name: cargo-deny
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

- Add `timeout-minutes: 15` to every job across `ci.yml`, `release.yml`, `security.yml`, and `fuzz.yml`, so a hung job (e.g. a stuck `cargo install` or runaway test) doesn't tie up a runner indefinitely.
- Drop the plain-feature `clippy`/`check`/`build` steps from the `Check & Lint` CI job — release binaries are always built with `--features rich-formats`, so the extra non-rich-formats build was redundant. CI now lints/checks/builds with `--features rich-formats` only.

## Test plan

- [x] `cargo build --all-targets --features rich-formats` succeeds locally (ran via pre-commit hook)
- [ ] CI passes on this PR with the trimmed `Check & Lint` job and new timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)