### PR TITLE
fix(memory): make memory.db the single canonical CLI store (ADR-004)

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -177,20 +177,34 @@ impl Tier {
     /// explicitly or discovered via the loopback probe.
     ///
     /// Loopback auto-discovery sets the capability `Tier` WITHOUT populating
-    /// `cfg.server_url`. Commands that route through `from_config` /
-    /// `open_memory_backend` gate on `server_url`, so they wrongly report
+    /// `cfg.server_url`. Commands that route inference through `from_config`
+    /// gate on a server URL, so without this bridge they wrongly report
     /// "requires spelunk-server" even though `spelunk status` shows `Server`.
-    /// This bridges that gap: when the tier is `Server` but `cfg.server_url`
-    /// is unset (the auto-discovered case), fill in the discovered URL and
-    /// derive the `project_id` from `project_root` (mirroring `embed_phase`,
-    /// see spelunk#307). When `cfg.server_url` is already set, the config is
-    /// returned unchanged.
+    ///
+    /// ## ADR-004: inference vs memory storage are routed separately
+    ///
+    /// An auto-discovered loopback server is an **inference** backend only; it
+    /// is never a memory store. So when the tier is `Server` and `server_url`
+    /// is unset (the auto-discovered case), the discovered URL is written to
+    /// `inference_url` — NOT `server_url`. `ServerInferenceClient::from_config`
+    /// reads `inference_url` (falling back to `server_url`), so inference still
+    /// reaches the loopback server; `open_memory_backend` reads only
+    /// `server_url`, so memory stays on the project's local `memory.db`. This
+    /// is what removes the split-brain where `memory add` wrote `memory.db`
+    /// while `memory search` read the server's `server.db`.
+    ///
+    /// `project_id` is derived (mirroring `embed_phase`, see spelunk#307) so the
+    /// inference client can address the project on the server. When an explicit
+    /// `cfg.server_url` is already set (a team/remote server), it owns both
+    /// inference and memory and the config is returned unchanged.
     pub fn effective_config(&self, cfg: &Config, project_root: &std::path::Path) -> Config {
         let mut out = cfg.clone();
         if let Tier::Server { url, .. } = self
             && out.server_url.is_none()
         {
-            out.server_url = Some(url.clone());
+            // Auto-discovered loopback server: route inference here, but leave
+            // `server_url` unset so memory selection stays local (ADR-004).
+            out.inference_url = Some(url.clone());
             if out.project_id.is_none() {
                 out.project_id = Some(cfg.resolve_project_id(project_root));
             }
@@ -565,6 +579,74 @@ mod tests {
         assert!(auto.is_auto_discovered());
         assert!(!explicit.is_auto_discovered());
         assert!(!Tier::Offline.is_auto_discovered());
+    }
+
+    // ── effective_config (ADR-004 inference-vs-memory routing) ───────────────
+
+    #[test]
+    fn effective_config_auto_discovered_sets_inference_url_not_server_url() {
+        // An auto-discovered loopback server is inference-only: its URL must
+        // land in `inference_url` so memory selection (`open_memory_backend`,
+        // which reads only `server_url`) stays local. This is the core of the
+        // ADR-004 split-brain fix.
+        let tier = Tier::Server {
+            url: "http://127.0.0.1:7777".to_string(),
+            caps: Capabilities::all(),
+            auto_discovered: true,
+        };
+        let cfg = Config::default(); // server_url = None
+        let eff = tier.effective_config(&cfg, std::path::Path::new("/tmp/proj"));
+
+        assert_eq!(
+            eff.server_url, None,
+            "auto-discovered server must NOT populate server_url (memory stays local)"
+        );
+        assert_eq!(
+            eff.inference_url.as_deref(),
+            Some("http://127.0.0.1:7777"),
+            "auto-discovered server URL must route inference via inference_url"
+        );
+        assert!(
+            eff.project_id.is_some(),
+            "project_id should be derived so the inference client can address the project"
+        );
+        // Inference resolves to the loopback server; memory selection does not.
+        assert_eq!(eff.resolve_inference_url(), Some("http://127.0.0.1:7777"));
+    }
+
+    #[test]
+    fn effective_config_explicit_server_url_left_unchanged() {
+        // An explicitly-configured team server owns BOTH inference and memory
+        // (team-memory tier). `effective_config` must not touch it.
+        let tier = Tier::Server {
+            url: "http://team.example.com:7777".to_string(),
+            caps: Capabilities::all(),
+            auto_discovered: false,
+        };
+        let cfg = Config {
+            server_url: Some("http://team.example.com:7777".to_string()),
+            project_id: Some("team/proj".to_string()),
+            ..Default::default()
+        };
+        let eff = tier.effective_config(&cfg, std::path::Path::new("/tmp/proj"));
+
+        assert_eq!(
+            eff.server_url.as_deref(),
+            Some("http://team.example.com:7777"),
+            "explicit team server_url must be preserved (memory stays remote)"
+        );
+        assert_eq!(
+            eff.inference_url, None,
+            "explicit server_url path should not synthesise a separate inference_url"
+        );
+    }
+
+    #[test]
+    fn effective_config_offline_tier_is_noop() {
+        let cfg = Config::default();
+        let eff = Tier::Offline.effective_config(&cfg, std::path::Path::new("/tmp/proj"));
+        assert_eq!(eff.server_url, None);
+        assert_eq!(eff.inference_url, None);
     }
 
     // ── require_tier1 ────────────────────────────────────────────────────────

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 
 use super::MemoryAddArgs;
 use crate::{
+    capability,
     config::Config,
     indexer::secrets::contains_secret,
     server_client::ServerInferenceClient,
@@ -14,6 +15,17 @@ pub(super) async fn memory_add(
     cfg: &Config,
     backend_override: Option<&str>,
 ) -> Result<()> {
+    // Honor the auto-discovered server tier (ADR-004): loopback auto-discovery
+    // sets the capability tier without populating `cfg.server_url`, so without
+    // this bridge `try_embed_via_server` cannot reach the local embedder and the
+    // note is stored without a vector (invisible to semantic `memory search`).
+    // Build an effective config that routes inference to the discovered server
+    // while leaving `server_url` unset, so `open_memory_backend` still writes the
+    // note to the project's local `memory.db` (the single canonical store).
+    let project_root = mem_path.parent().unwrap_or(mem_path);
+    let tier = capability::get_tier(cfg).await;
+    let eff_cfg = tier.effective_config(cfg, project_root);
+    let cfg = &eff_cfg;
     let (title, body) = if let Some(url) = &args.from_url {
         let (fetched_title, fetched_body) = fetch_url_content(url)
             .await

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -17,19 +17,23 @@ pub(super) async fn memory_harvest(
 ) -> Result<()> {
     // Honor the auto-discovered server tier (IMP-3 / spelunk#316): loopback
     // auto-discovery sets the capability tier without populating
-    // `cfg.server_url`, so the plain `cfg.server_url.is_none()` gate below
-    // wrongly reports "requires spelunk-server" even when `spelunk status`
-    // shows the `Server` tier. Build an effective config that fills in
-    // `server_url`/`project_id` from the tier (mirrors `explore`) and use it
-    // for the remainder of this call tree, including the git/failures/
-    // claude-code sub-harvesters and `ServerInferenceClient::from_config`.
+    // `cfg.server_url`. Build an effective config that fills in the inference
+    // URL / `project_id` from the tier (mirrors `explore`) and use it for the
+    // remainder of this call tree, including the git/failures/claude-code
+    // sub-harvesters and `ServerInferenceClient::from_config`.
+    //
+    // ADR-004: harvest is an inference-driven command. It needs the server for
+    // embeddings + LLM extraction (gate on the inference URL), but its memory
+    // CRUD goes to the project's local `memory.db` via `open_memory_backend`
+    // (which reads only `server_url`). For an auto-discovered server that means
+    // local storage; for an explicit team `server_url` memory stays remote.
     let project_root = mem_path.parent().unwrap_or(mem_path);
     let tier = capability::get_tier(cfg).await;
     let eff_cfg = tier.effective_config(cfg, project_root);
     let cfg = &eff_cfg;
 
-    // Tier-0: harvest requires server (#259 locked-feature error).
-    if cfg.server_url.is_none() {
+    // Tier-0: harvest requires server inference (#259 locked-feature error).
+    if cfg.resolve_inference_url().is_none() {
         return Err(harvest_requires_server(None));
     }
 
@@ -160,7 +164,7 @@ async fn memory_harvest_git(
     });
 
     let server = ServerInferenceClient::from_config(cfg)
-        .ok_or_else(|| harvest_requires_server(cfg.server_url.as_deref()))?;
+        .ok_or_else(|| harvest_requires_server(cfg.resolve_inference_url()))?;
 
     let mut stored = 0usize;
     let mut dedup_skipped = 0usize;
@@ -544,7 +548,7 @@ async fn memory_harvest_failures(
     });
 
     let server = ServerInferenceClient::from_config(cfg)
-        .ok_or_else(|| harvest_requires_server(cfg.server_url.as_deref()))?;
+        .ok_or_else(|| harvest_requires_server(cfg.resolve_inference_url()))?;
 
     let mut stored = 0usize;
     let mut dedup_skipped = 0usize;

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
@@ -47,7 +47,7 @@ pub(super) async fn harvest_claude_code(
 ) -> Result<()> {
     // Tier-0 gate: harvest requires server inference.
     let server = ServerInferenceClient::from_config(cfg)
-        .ok_or_else(|| harvest_requires_server(cfg.server_url.as_deref()))?;
+        .ok_or_else(|| harvest_requires_server(cfg.resolve_inference_url()))?;
 
     // 1. Require explicit confirmation.
     if !args.confirm {

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -120,9 +120,17 @@ pub struct ServerInferenceClient {
 }
 
 impl ServerInferenceClient {
-    /// Build from config. Returns `None` when `server_url` is not configured.
+    /// Build from config. Returns `None` when no inference URL is available.
+    ///
+    /// Uses `Config::resolve_inference_url()` (ADR-004): an auto-discovered
+    /// loopback server sets `inference_url` while leaving `server_url` unset, so
+    /// inference reaches the server even though memory stays local. An explicit
+    /// team `server_url` is used for both.
     pub fn from_config(cfg: &Config) -> Option<Self> {
-        let base_url = cfg.server_url.as_deref()?.trim_end_matches('/').to_string();
+        let base_url = cfg
+            .resolve_inference_url()?
+            .trim_end_matches('/')
+            .to_string();
         let project_id = cfg.project_id.clone().unwrap_or_default();
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(300))

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -1064,12 +1064,21 @@ fn test_init_non_tty_prints_skip_notice() {
 
 // ── memory commands against an auto-discovered (loopback) server ─────────────
 //
-// IMP-3 / spelunk#316 / PR #349 (qa-v080-test-plan.md §Fix 3): `memory search`,
-// `memory timeline`, `memory harvest`, and `explore` used to gate directly on
-// `cfg.server_url`, so they reported "requires spelunk-server" even when a
-// server was reachable via loopback auto-discovery (no `server_url` in config).
-// The fix routes these commands through `Tier::effective_config`, which fills
-// in `server_url`/`project_id` from the discovered tier.
+// ADR-004 (unified memory storage): `.spelunk/memory.db` is the single
+// canonical store for every CLI memory read and write. An auto-discovered
+// loopback server is an INFERENCE backend only (embeddings + LLM); it is never
+// a memory store. So `memory add`, `memory search`, and `memory timeline` all
+// resolve to the same local `memory.db`, and the server is consulted only to
+// embed the query — never to fetch memory rows.
+//
+// Historical context: IMP-3 / spelunk#316 / PR #349 first taught these commands
+// to honour an auto-discovered server (so they no longer errored "requires
+// spelunk-server"), but routed BOTH inference and memory storage to the server
+// via a synthesised `server_url`. That produced the split-brain Johan flagged
+// on PR #386: a note added (to local `memory.db`) was invisible to
+// `memory search` (which read the server's `server.db`). ADR-004 fixes this by
+// routing inference via `inference_url` while leaving `server_url` unset for
+// auto-discovered servers, so `open_memory_backend` keeps memory local.
 //
 // These tests reproduce the auto-discovery path end-to-end: NO `server_url` in
 // config, `SPELUNK_NO_SERVER` unset, and a mock server reachable on loopback —
@@ -1080,16 +1089,12 @@ fn test_init_non_tty_prints_skip_notice() {
 // real default port 7777 (which may be occupied — or unoccupied — on the test
 // host) and without touching the developer's real `~/.local/state`.
 //
-// Coverage note: `memory search` and `memory timeline` share the exact
-// `effective_config` bridging path exercised here (see `memory_search` /
-// `memory_timeline` doc comments referencing IMP-3) and both are covered
-// below. `memory harvest` and `explore` route through the *same* bridging
-// code, but harvesting requires mocking `git log` plus a streaming
-// `/llm/complete` SSE extraction round-trip, and `explore` requires mocking a
-// multi-step tool-calling `Explorer` loop over `/llm/complete` SSE — both
-// disproportionately heavy relative to what's actually under test (the
-// auto-discovery → `effective_config` wiring, not the LLM pipelines
-// themselves, which have their own coverage elsewhere). Left uncovered here;
+// Coverage note: `memory harvest` and `explore` route through the same
+// `effective_config` bridging code, but harvesting requires mocking `git log`
+// plus a streaming `/llm/complete` SSE extraction round-trip, and `explore`
+// requires mocking a multi-step tool-calling `Explorer` loop over
+// `/llm/complete` SSE — both disproportionately heavy relative to what's under
+// test (the auto-discovery → inference-vs-storage split). Left uncovered here;
 // flagged honestly rather than thrashing on heavyweight SSE mocks.
 
 /// Write `<home>/.local/state/spelunk/server.port` so `capability::get_tier`'s
@@ -1111,13 +1116,18 @@ fn port_from_uri(uri: &str) -> u16 {
         .expect("uri port is numeric")
 }
 
-/// Mount the three endpoints the auto-discovery path needs on `server`:
-/// - `GET /v1/health` — capability probe (must report `memory` + `search.semantic`
-///   so `effective_config` and `require_server_client` both succeed)
-/// - `POST /v1/projects/{id}/index/embed` — query embedding (`embed_query`)
-/// - `POST /v1/projects/{id}/memory/search` — `RemoteMemoryBackend::search`
-///   (backs both `memory search` hybrid/semantic mode and `memory timeline`)
-async fn mount_auto_discovery_memory_endpoints(server: &wiremock::MockServer) {
+/// Mount the endpoints an INFERENCE-ONLY auto-discovered server needs:
+/// - `GET /v1/health` — capability probe (reports `memory` + `search.semantic`
+///   so `effective_config` and the inference client build successfully)
+/// - `POST /v1/projects/{id}/index/embed` — query/note embedding (`embed_query`
+///   / `try_embed_via_server`); returns a constant 768-dim vector so KNN over
+///   the LOCAL store is deterministic.
+///
+/// Deliberately does NOT mount `POST /v1/projects/{id}/memory/search`. Under
+/// ADR-004 an auto-discovered server is never a memory backend, so the CLI must
+/// not call it for memory rows. The `expect(0)` guard below turns any such call
+/// into a test failure, locking in the inference-vs-storage split.
+async fn mount_auto_discovery_inference_endpoints(server: &wiremock::MockServer) {
     use wiremock::matchers::{method, path, path_regex};
     use wiremock::{Mock, ResponseTemplate};
 
@@ -1137,44 +1147,31 @@ async fn mount_auto_discovery_memory_endpoints(server: &wiremock::MockServer) {
         .mount(server)
         .await;
 
+    // Guard: the server's memory endpoint must NEVER be hit by an auto-discovered
+    // server. If it is, the split-brain has regressed. `expect(0)` fails the test
+    // on any matching request when the `MockServer` is dropped.
     Mock::given(method("POST"))
         .and(path_regex(r"^/v1/projects/.+/memory/search$"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
-            {
-                "id": 1,
-                "kind": "decision",
-                "title": "Use loopback auto-discovery for local servers",
-                "body": "Probe 127.0.0.1:7777 (or the server.port file) when no server_url is configured.",
-                "tags": ["capability", "auto-discovery"],
-                "linked_files": [],
-                "created_at": 1_770_000_000_i64,
-                "status": "active",
-                "superseded_by": null,
-                "source_ref": null,
-                "valid_at": null,
-                "invalid_at": null,
-                "distance": 0.12
-            }
-        ])))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
         .mount(server)
         .await;
 }
 
-/// `memory search` (default hybrid mode) succeeds against a server that was
-/// discovered via the loopback probe — no `server_url` in config.
+/// ADR-004 round-trip: with a loopback server auto-discovered (no `server_url`
+/// in config), a note written by `memory add` is found by `memory search` — and
+/// the note's content comes from the LOCAL `memory.db`, not the server. The
+/// server is consulted ONLY to embed (it has no `/memory/search` mount, and the
+/// `expect(0)` guard fails the test if memory rows are ever requested from it).
 ///
-/// Exercises: `capability::get_tier` → loopback auto-discovery →
-/// `Tier::effective_config` (fills in `server_url`/`project_id`) →
-/// `require_server_client` + `embed_query` → `RemoteMemoryBackend::search`
-/// → `POST /v1/projects/{id}/memory/search`.
-///
-/// Before PR #349 this errored "'spelunk memory search' requires
-/// spelunk-server" despite the server being reachable (qa-v080-test-plan.md
-/// §Fix 3a).
+/// This is the exact split-brain the ADR removes: before ADR-004 the
+/// auto-discovered server synthesised a `server_url`, so `memory add` wrote
+/// `memory.db` while `memory search` read the server's `server.db` and could not
+/// see the note.
 #[tokio::test]
-async fn test_memory_search_with_auto_discovered_server() {
+async fn test_memory_add_then_search_round_trip_on_local_store_with_auto_discovered_server() {
     let mock_server = MockServer::start().await;
-    mount_auto_discovery_memory_endpoints(&mock_server).await;
+    mount_auto_discovery_inference_endpoints(&mock_server).await;
 
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
@@ -1199,7 +1196,7 @@ async fn test_memory_search_with_auto_discovered_server() {
     )
     .unwrap();
 
-    // Build a local index so `memory search` has a DB to resolve `mem_path`
+    // Build a local index so memory commands have a DB to resolve `mem_path`
     // from (offline embedding — SPELUNK_NO_SERVER keeps `index` from probing).
     Command::cargo_bin("spelunk")
         .unwrap()
@@ -1212,7 +1209,9 @@ async fn test_memory_search_with_auto_discovered_server() {
         .assert()
         .success();
 
-    // No SPELUNK_NO_SERVER here: this is the auto-discovery path under test.
+    // Add a note via the auto-discovery path. No SPELUNK_NO_SERVER, so the
+    // loopback server embeds the note (via /index/embed) while the note text +
+    // metadata are written to the LOCAL memory.db.
     Command::cargo_bin("spelunk")
         .unwrap()
         .env("HOME", &home)
@@ -1220,30 +1219,64 @@ async fn test_memory_search_with_auto_discovered_server() {
         .current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
-        .arg("memory")
-        .arg("search")
-        .arg("loopback auto-discovery")
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "decision",
+            "--title",
+            "Unified memory storage round-trip",
+            "--body",
+            "Memory lives in memory.db; the loopback server is inference-only.",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [decision]"));
+
+    // Search for it via the same auto-discovery path. The result must be the
+    // locally-stored note — proving add and search share one store. The server
+    // only embedded the query; the `/memory/search` guard ensures no memory rows
+    // were fetched from the server.
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .env("HOME", &home)
+        .env_remove("SPELUNK_NO_SERVER")
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .args(["memory", "search", "unified memory storage"])
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Use loopback auto-discovery for local servers",
+            "Unified memory storage round-trip",
         ))
-        .stdout(predicate::str::contains("#1"))
         .stdout(predicate::str::contains("[decision]"));
+
+    // Cross-check: `memory list` (which has always read memory.db) sees the same
+    // note. Before ADR-004 `search` and `list` could disagree; now they cannot.
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .env("HOME", &home)
+        .env_remove("SPELUNK_NO_SERVER")
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .args(["memory", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Unified memory storage round-trip",
+        ));
 }
 
-/// `memory timeline` succeeds against a server that was discovered via the
-/// loopback probe — no `server_url` in config.
-///
-/// Same bridging path as `memory search` (see above): `get_tier` →
-/// `effective_config` → `embed_query` → `RemoteMemoryBackend::search_timeline`
-/// → `POST /v1/projects/{id}/memory/search`. Before PR #349 this errored
-/// "'spelunk memory timeline' requires spelunk-server" (qa-v080-test-plan.md
-/// §Fix 3b).
+/// `memory timeline` against an auto-discovered loopback server returns notes
+/// from the LOCAL `memory.db` (the server only embeds the query). Companion to
+/// the add→search round-trip above; guards that `timeline` does not regress to
+/// reading the server's store.
 #[tokio::test]
-async fn test_memory_timeline_with_auto_discovered_server() {
+async fn test_memory_timeline_reads_local_store_with_auto_discovered_server() {
     let mock_server = MockServer::start().await;
-    mount_auto_discovery_memory_endpoints(&mock_server).await;
+    mount_auto_discovery_inference_endpoints(&mock_server).await;
 
     let temp = tempdir().unwrap();
     let home = temp.path().join("home");
@@ -1283,15 +1316,33 @@ async fn test_memory_timeline_with_auto_discovered_server() {
         .current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "decision",
+            "--title",
+            "Loopback server is inference-only",
+            "--body",
+            "Probe 127.0.0.1 when no server_url is configured; memory stays local.",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("spelunk")
+        .unwrap()
+        .env("HOME", &home)
+        .env_remove("SPELUNK_NO_SERVER")
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
         .arg("memory")
         .arg("timeline")
-        .arg("loopback auto-discovery")
+        .arg("loopback server")
         .assert()
         .success()
+        .stdout(predicate::str::contains("Timeline: loopback server"))
         .stdout(predicate::str::contains(
-            "Timeline: loopback auto-discovery",
-        ))
-        .stdout(predicate::str::contains(
-            "Use loopback auto-discovery for local servers",
+            "Loopback server is inference-only",
         ));
 }

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -215,6 +215,17 @@ pub struct Config {
     #[serde(default)]
     pub project_id: Option<String>,
 
+    /// URL of a server used **only** for inference (embeddings + LLM), never for
+    /// memory storage. Populated at runtime (not from config files) by
+    /// `Tier::effective_config()` when a loopback server is auto-discovered: the
+    /// auto-discovered server is an inference cache over the local `memory.db`,
+    /// not a second memory store (ADR-004). Inference clients prefer this field
+    /// and fall back to `server_url`; the memory backend selector
+    /// (`open_memory_backend`) ignores it entirely, so an auto-discovered server
+    /// never diverts memory CRUD away from the project's local `memory.db`.
+    #[serde(skip)]
+    pub inference_url: Option<String>,
+
     // ── Directory conventions ─────────────────────────────────────────────────
     /// Directory (relative to project root) where `spelunk plan create` writes plan files.
     /// Default: `docs/plans`
@@ -289,6 +300,7 @@ impl Default for Config {
             server_url: None,
             server_key: None,
             project_id: None,
+            inference_url: None,
             plans_dir: Self::default_plans_dir(),
             specs_dir: Self::default_specs_dir(),
             llm_context_length: Self::default_llm_context_length(),
@@ -386,6 +398,16 @@ impl Config {
         self.project_id
             .clone()
             .unwrap_or_else(|| derive_project_id(project_root))
+    }
+
+    /// Return the URL to use for inference (embeddings + LLM), if any.
+    ///
+    /// Prefers `inference_url` (set for an auto-discovered loopback server,
+    /// ADR-004) and falls back to `server_url` (an explicitly-configured
+    /// team/remote server, which serves both inference and memory). Memory
+    /// storage selection does **not** use this — see `open_memory_backend`.
+    pub fn resolve_inference_url(&self) -> Option<&str> {
+        self.inference_url.as_deref().or(self.server_url.as_deref())
     }
 }
 
@@ -677,6 +699,51 @@ project_id = "my-proj"
         let id = cfg.resolve_project_id(tmp.path());
         // Should be the local/ fallback since tmp dir is not a git repo.
         assert!(id.starts_with("local/"), "got {id}");
+    }
+
+    // ── resolve_inference_url (ADR-004) ──────────────────────────────────────
+
+    #[test]
+    fn resolve_inference_url_prefers_inference_url() {
+        // Auto-discovered case: inference_url set, server_url unset.
+        let cfg = Config {
+            inference_url: Some("http://127.0.0.1:7777".to_string()),
+            server_url: None,
+            ..Default::default()
+        };
+        assert_eq!(cfg.resolve_inference_url(), Some("http://127.0.0.1:7777"));
+    }
+
+    #[test]
+    fn resolve_inference_url_falls_back_to_server_url() {
+        // Explicit team server: only server_url set; it serves inference too.
+        let cfg = Config {
+            inference_url: None,
+            server_url: Some("http://team.example.com:7777".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            cfg.resolve_inference_url(),
+            Some("http://team.example.com:7777")
+        );
+    }
+
+    #[test]
+    fn resolve_inference_url_none_when_neither_set() {
+        let cfg = Config::default();
+        assert_eq!(cfg.resolve_inference_url(), None);
+    }
+
+    #[test]
+    fn resolve_inference_url_inference_url_wins_over_server_url() {
+        // Defensive: if both are somehow set, inference must use the dedicated
+        // inference_url (memory backend selection still uses server_url).
+        let cfg = Config {
+            inference_url: Some("http://127.0.0.1:7777".to_string()),
+            server_url: Some("http://team.example.com:7777".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(cfg.resolve_inference_url(), Some("http://127.0.0.1:7777"));
     }
 
     // ── env var overrides ────────────────────────────────────────────────────

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -33,10 +33,17 @@ use std::path::Path;
 
 /// Open the appropriate memory backend.
 ///
-/// Priority:
+/// Selection rule (ADR-004 — one canonical store per project):
 /// 1. `backend_override = Some("git-notes")` → `GitNotesBackend`
-/// 2. `server_url` set in config → `RemoteMemoryBackend`
-/// 3. Otherwise → local SQLite at `mem_path`
+/// 2. **Explicit** `server_url` in config (team/remote server) →
+///    `RemoteMemoryBackend` (the team-memory tier: memory lives on the shared
+///    server by the user's deliberate configuration).
+/// 3. Otherwise → local SQLite `memory.db` at `mem_path`.
+///
+/// This function intentionally keys only on `cfg.server_url`. An auto-discovered
+/// loopback server is inference-only and routes through `cfg.inference_url`
+/// instead (see `Tier::effective_config`), so it never diverts memory CRUD away
+/// from the project's local `memory.db`.
 pub fn open_memory_backend(
     cfg: &crate::config::Config,
     mem_path: &Path,


### PR DESCRIPTION
## What

Implements ADR-004: `.spelunk/memory.db` is the single canonical store for every CLI memory read and write. An auto-discovered loopback server is demoted to an **inference backend only** (embeddings + LLM); it is no longer a memory store.

Before this change, with a local server running (the default v0.8.0 UX) and no team `server_url`:
- `memory add` wrote to local `memory.db`
- `memory search` read from the server's separate store and could not see the just-added note

So `search` and `list`/`context` disagreed about what memory existed. This is the split-brain flagged on PR #386 ("there should be one way of storing memory").

## How (ADR-004 option (a) — the preferred option)

Inference routing and memory-backend selection are split into two independent signals:

- **`Config::inference_url`** (new, runtime-only `#[serde(skip)]`): where embeddings/LLM go. `Tier::effective_config` populates it for an auto-discovered loopback server while leaving `server_url` unset. `ServerInferenceClient::from_config` reads it via the new `Config::resolve_inference_url()` (which falls back to `server_url`).
- **`server_url`** (unchanged): the memory-backend selector. `open_memory_backend` keys only on it, so an auto-discovered server never diverts memory CRUD away from `memory.db`.

Net effect: `memory add`, `search`, `timeline`, `harvest`, and `explore` all resolve to the same project-local `memory.db` under the default auto-discovery UX, while still using the loopback server to embed queries / run LLM extraction. An explicitly-configured **team** `server_url` keeps owning memory (team-memory tier) and is untouched.

`memory add` now also routes its embedding through `effective_config`, so notes added under auto-discovery get an embedding (visible to semantic `memory search`) while still being written locally.

## Scope

Implements the routing items of the ADR checklist (decouple inference from storage; route every memory command through the local store; local KNN). The one-time `server.db` -> `memory.db` reconciliation/import is explicitly scoped by the ADR as a follow-up and is **not** included here. Docs (CLAUDE.md, agent-guide.md) and THREAT-MODEL.md updates are filed as follow-ups for the doc owners.

## Test plan

All commands run from the worktree. The two pre-existing failures noted at the end are environmental (a live spelunk-server on :7777 + spelunk-server on PATH) and fail identically on `origin/main`.

### New unit tests (routing decision)

```
$ cargo test -p spelunk-cli --bin spelunk capability::tests::effective_config
running 3 tests
test capability::tests::effective_config_offline_tier_is_noop ... ok
test capability::tests::effective_config_explicit_server_url_left_unchanged ... ok
test capability::tests::effective_config_auto_discovered_sets_inference_url_not_server_url ... ok
test result: ok. 3 passed; 0 failed

$ cargo test -p spelunk-core --lib config::tests::resolve_inference_url
running 4 tests
test config::tests::resolve_inference_url_none_when_neither_set ... ok
test config::tests::resolve_inference_url_falls_back_to_server_url ... ok
test config::tests::resolve_inference_url_prefers_inference_url ... ok
test config::tests::resolve_inference_url_inference_url_wins_over_server_url ... ok
test result: ok. 4 passed; 0 failed
```

### Round-trip: add -> search on ONE store under auto-discovery (the split-brain fix)

The e2e test stands up a mock loopback server (discovered via `~/.local/state/spelunk/server.port`, no `server_url` in config), runs `memory add` then `memory search`, and asserts the searched note is the locally-added one. A `wiremock` `.expect(0)` guard on `POST /v1/projects/{id}/memory/search` **fails the test if the server's memory endpoint is ever called** — proving memory rows come from the local store, not the server. It also cross-checks `memory list` sees the same note.

```
$ cargo test -p spelunk-cli --test e2e_cli auto_discovered
running 2 tests
test test_memory_timeline_reads_local_store_with_auto_discovered_server ... ok
test test_memory_add_then_search_round_trip_on_local_store_with_auto_discovered_server ... ok
test result: ok. 2 passed; 0 failed
```

### Full suite (affected crates)

```
$ cargo fmt --check          # clean (pre-commit hook)
$ cargo clippy --all-targets -- -D warnings   # clean (pre-commit hook)
$ cargo test -p spelunk-core -p spelunk-cli
spelunk-core lib:           56 passed
e2e_cli:                    23 passed, 2 failed (environmental, see below)
context / cat_chunks / ...: all passed
```

The 2 `e2e_cli` failures (`test_search_explicit_hybrid_no_embedder_falls_back_to_text`, `test_index_prints_note_when_no_server_configured`) assume **no** server is reachable; they don't isolate `HOME`/`SPELUNK_NO_SERVER`, so the auto-discovery probe finds the live dev server on :7777 and the text-fallback notice never prints. Confirmed to fail identically on `origin/main` (clean checkout, `git stash`), so they are not regressions from this PR.

Refs #388 (ADR-004).