### PR TITLE
fix(bench): switch --save-patch from denylist to allowlist

### DIFF
--- a/bench/agents/agent.py
+++ b/bench/agents/agent.py
@@ -516,21 +516,40 @@ def main() -> None:
     patch_path = None
     if args.save_patch:
         try:
-            # Stage all changes (including untracked files from write_file),
-            # but exclude tooling/runtime artifacts that aren't part of the
-            # agent's actual fix. Without these excludes, `.spelunk/index.db`
-            # (binary, written by `spelunk index`), `ISSUE.txt` (written by
-            # setup_repos.sh), `uv.lock` (created by `uv run`), and similar
-            # junk files end up in the saved patch and either fail to apply
-            # in the SWE-bench Docker container or pollute the diff,
-            # causing otherwise-correct fixes to be marked unresolved.
-            EXCLUDE_PATHSPECS = [
-                ":!.spelunk",
-                ":!ISSUE.txt",
-                ":!uv.lock",
+            # Stage only known source file extensions so that tooling/runtime
+            # artifacts never end up in the saved patch. Without this, junk
+            # like `.spelunk/index.db` (binary, written by `spelunk index`),
+            # `ISSUE.txt` (written by setup_repos.sh), `uv.lock` (created by
+            # `uv run`), and similar files end up in the saved patch and
+            # either fail to apply in the SWE-bench Docker container or
+            # pollute the diff, causing otherwise-correct fixes to be marked
+            # unresolved. A denylist approach (:!.spelunk :!ISSUE.txt
+            # :!uv.lock ...) is fragile: shell-mangled filenames such as
+            # "=2.6.0," (from a botched `pip install` output redirected into
+            # a file) slip through. An allowlist is strictly safer; anything
+            # that isn't a recognised source file is ignored.
+            SOURCE_PATHSPECS = [
+                "*.py",
+                "*.rs",
+                "*.ts",
+                "*.tsx",
+                "*.js",
+                "*.jsx",
+                "*.go",
+                "*.java",
+                "*.c",
+                "*.cpp",
+                "*.h",
+                "*.rb",
+                "*.sh",
+                "*.toml",
+                "*.json",
+                "*.yaml",
+                "*.yml",
+                "*.md",
             ]
             subprocess.run(
-                ["git", "add", "-A", "--", ".", *EXCLUDE_PATHSPECS],
+                ["git", "add", "--", *SOURCE_PATHSPECS],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
@@ -538,7 +557,7 @@ def main() -> None:
                 check=True,
             )
             diff = subprocess.run(
-                ["git", "diff", "--cached", "HEAD", "--", ".", *EXCLUDE_PATHSPECS],
+                ["git", "diff", "--cached", "HEAD", "--", *SOURCE_PATHSPECS],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
## Summary

- Replaces the fragile denylist approach (`:!.spelunk :!ISSUE.txt :!uv.lock`) with an allowlist that only stages and diffs known source file extensions.
- The denylist missed any junk file the denylist didn't anticipate — most notably shell-mangled filenames like `=2.6.0,` from a botched `pip install` output redirect. An allowlist is strictly safer: anything that isn't a recognised source type is ignored by construction.
- Both the `git add` and `git diff` commands now target the same `SOURCE_PATHSPECS` list: `*.py *.rs *.ts *.tsx *.js *.jsx *.go *.java *.c *.cpp *.h *.rb *.sh *.toml *.json *.yaml *.yml *.md`.

Fixes #263

## Test plan

- `python -m py_compile bench/agents/agent.py` — passes (syntax valid)
- Run a local agent with `--save-patch` against a task repo that has `.spelunk/`, `ISSUE.txt`, `uv.lock`, and a synthetic junk file (`=2.6.0,`); verify none appear in the saved patch
- Run a local agent against a real SWE-bench task; verify the patch contains only source changes and applies cleanly in the Docker harness