### PR TITLE
docs: align CLAUDE.md + agent-guide.md + memory.md with ADR-004; flip ADR-004 Status to Approved

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,9 @@ Full reference: `SKILL.md` and `docs/agent-guide.md`.
 
 **Built-in (zero infrastructure):** git-notes memory, full-text search, code graph (AST + call edges), tree-sitter chunking. Works immediately with no setup.
 
-**Semantic search via spelunk-server:** from v0.8.0 the default UX runs a local `spelunk-server` (auto-bound on `127.0.0.1`). The server bundles a native embedder (fastembed-rs, NomicEmbedTextV15) — no external embedding endpoint required. Semantic search, `spelunk explore`, `spelunk memory harvest`, and LLM summaries all route through the server's inference endpoints; the CLI talks to it via `server_client.rs`. Manage the daemon with `spelunk server start|stop|status|logs`.
+**Semantic search via spelunk-server:** from v0.8.0 the default UX runs a local `spelunk-server` (auto-bound on `127.0.0.1`). The server bundles a native embedder (fastembed-rs, NomicEmbedTextV15) — no external embedding endpoint required. Semantic search, `spelunk explore`, `spelunk memory harvest`, and LLM summaries all route through the server's inference endpoints; the CLI talks to it via `server_client.rs`. Manage the daemon with `spelunk server start|stop|status|logs`. This **auto-discovered loopback server is an inference backend only** — it embeds queries and runs LLM calls, but it is **never** a memory store. A project's memory always lives in its local `memory.db`; the loopback server holds no authoritative memory.
 
-**Optional: team memory server** (`server_url` pointing at a shared instance): share memory (decisions, requirements) across a team. Each developer's code stays local.
+**Optional: team memory server** (`server_url` *explicitly* set in config, pointing at a shared instance): share memory (decisions, requirements) across a team. Setting an explicit `server_url` is the **only** way memory moves off the local `memory.db` — it relocates the store of record to the shared server. Each developer's code stays local. (Note the distinction: an auto-discovered loopback server provides inference and never owns memory; an explicit team `server_url` does own memory. They must not be conflated.)
 
 You search with spelunk, then reason over the results yourself.
 
@@ -240,6 +240,8 @@ Concrete backends live in spelunk-server (not in this repo).
 
 `capability.rs` probes server availability at startup and exposes a `Tier`
 enum so commands degrade gracefully when no server is configured.
+
+**Inference vs. memory storage are separate concerns.** Reaching the server for inference (`ServerLlmClient` / `ServerEmbedClient`) does **not** mean memory is stored there. For an auto-discovered loopback server, memory CRUD (`add`, `list`, `search`, `timeline`, `context`, `harvest`, `read-memory`) resolves to the project's local `memory.db`; the server is used only to embed the query for `memory search`, with the vector KNN run locally against `memory.db`. Memory lives on a server **only** when an explicit team `server_url` is configured. See `docs/adr/004-unified-memory-storage.md`.
 
 ---
 

--- a/docs/adr/004-unified-memory-storage.md
+++ b/docs/adr/004-unified-memory-storage.md
@@ -1,6 +1,6 @@
 # ADR-004: One Way to Store Memory — Resolving the Local Storage Split-Brain
 
-**Status:** Proposed
+**Status:** Approved
 **Date:** 2026-06-11
 **Context:** Escalated by Johan on PR #386 (ADR-003) line 88: *"We've said that memory lives in the server, but it seems we've not made that the case when we have the auto-discovery server running locally. There should be one way of storing memory."* This is out of scope for ADR-003 (cross-project visibility) and is captured here as its own decision. Builds on the three-tier product architecture (decision #75), the CLI backend-selection order (decision #76), and the progressive-enhancement principle (decision #77).
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -4,9 +4,11 @@
 
 **The key mental model**: spelunk retrieves context; you reason over it. Use `spelunk graph` and `spelunk search` to find the right code, read the results, then synthesise the answer yourself. spelunk is a persistent memory store and code navigation tool, not an oracle.
 
-**What's built-in:** memory (git-notes + local SQLite), code graph, full-text and ast-grep search, and extracted conventions work with just the CLI binary — no server needed.
+**What's built-in:** memory (local SQLite `memory.db`, optionally mirrored to git-notes), code graph, full-text and ast-grep search, and extracted conventions work with just the CLI binary — no server needed. A project's memory always lives in its local `memory.db`; that is the canonical store of record for every memory command.
 
-**What's server-backed:** semantic/hybrid search (`spelunk search --mode auto|semantic|hybrid`), `spelunk explore`, and `spelunk memory harvest` go through `spelunk-server`. From v0.8.0 the server is autostarted locally on demand and bundles a native embedder (Nomic Embed Text v1.5, via fastembed-rs) — there is no external embedding server to run by default. If you force offline mode (`SPELUNK_NO_SERVER=1`), these commands fall back to text/ast-grep search or error clearly.
+**What's server-backed:** semantic/hybrid search (`spelunk search --mode auto|semantic|hybrid`), `spelunk explore`, and `spelunk memory harvest` use `spelunk-server` for **inference** (embeddings + LLM). From v0.8.0 the server is autostarted locally on demand and bundles a native embedder (Nomic Embed Text v1.5, via fastembed-rs) — there is no external embedding server to run by default. The auto-discovered loopback server is **inference-only**: it never stores memory. For `memory search` the CLI sends only the query to the loopback embedder and runs the vector search locally against `memory.db` — note text never leaves the local store. If you force offline mode (`SPELUNK_NO_SERVER=1`), these commands fall back to text/ast-grep search or error clearly, and all memory commands operate on `memory.db`.
+
+**Where does memory live?** Always `memory.db` for the active project — **unless** you have *explicitly* configured a team `server_url`, which relocates the store of record to that shared server (the team-memory tier). An auto-discovered loopback server does **not** change where memory lives.
 
 ## The core loop
 
@@ -40,7 +42,7 @@ You can also use `--format json` on individual commands.
 If your config does not have a `server_url`, `spelunk` auto-discovers a local
 `spelunk-server` running on loopback by reading
 `~/.local/state/spelunk/server.port`.  You can start, stop, and inspect that
-daemon with the `spelunk server` subcommand.
+daemon with the `spelunk server` subcommand. This auto-discovered daemon is an **inference backend only** — it serves embeddings and LLM calls. It is **not** a memory store: your project's memory stays in `memory.db` regardless of whether this server is running. (Memory moves to a server only when you *explicitly* set `server_url` to a team instance in your config.)
 
 ```bash
 # Start spelunk-server on port 7777 (idempotent — no-op if already running)

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -6,7 +6,7 @@ Memory entries are stored in a local SQLite database by default, and — with
 `store_in_git_notes` enabled (the default) — also written through to
 `refs/notes/spelunk` on `HEAD`, so they travel with the repository. No external
 database or server is required. (You can make git-notes the primary backend with
-`--backend git-notes`, or point at a shared server with `server_url`.) Entries
+`--backend git-notes`, or point at a shared server with `server_url`.) The auto-started local `spelunk-server` (loopback) is used only for *inference* (embeddings/LLM for semantic search) — it does **not** store memory. Memory lives on a server only when you *explicitly* configure a team `server_url`. Entries
 are searchable by full text at all times; semantic search (by meaning) is
 available when a server is running — the local one is autostarted on demand.
 


### PR DESCRIPTION
## Summary

- Flips ADR-004 status from Proposed to Approved (decision #144; implementation merged via PR #390)
- Updates `CLAUDE.md` to state plainly that the auto-discovered loopback server is inference-only and that `memory.db` is the canonical memory store; adds an "Inference vs. memory storage are separate concerns" paragraph to the Inference Backend section
- Updates `docs/agent-guide.md` with the same loopback-is-inference-only framing; adds explicit "Where does memory live?" callout; clarifies that `memory search` sends only the query to the loopback embedder and runs KNN locally against `memory.db`
- Updates `docs/memory.md` intro paragraph to note that the auto-started loopback server is inference-only and memory lives on a server only when an explicit team `server_url` is configured

Closes #392.

## Test plan

- Docs-only change; no code touched.
- Verified all four changed files are internally consistent: loopback = inference-only, `memory.db` = canonical store, explicit `server_url` = only path to team-memory tier.
- Verified ADR-004 approval gate: PR #390 merged (visible in main branch history); decision #144 confirms approval.
- Two pre-existing test failures from PR #390 are unrelated to this story (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)