### PR TITLE
feat(memory): cross-project visibility for search/list/context (ADR-003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Cross-project memory visibility (`spelunk memory search|list|context`).** When
+  projects are linked with `spelunk link`, `memory search`, `memory list`, and
+  `context` now also query each linked project's memory store and surface
+  `locked` or `cross-project`-tagged `decision` and `requirement` entries
+  alongside local results. Each cross-project result is tagged with its source
+  project (`[from: <project>]` in text mode; `source_project` /
+  `source_project_path` fields in JSON) so conflicting decisions remain
+  attributable. `handoff` and `question` entries remain strictly project-local.
+  (ADR-003)
+
+- **`--local-only` flag for `memory search`, `memory list`, and `context`.**
+  Suppresses the cross-project dep pass and queries only the primary project's
+  memory store -- matching the existing `spelunk search --local-only` behaviour.
+  (ADR-003)
+
 - **`spelunk memory reconcile`** — imports notes from a local `spelunk-server`
   database (`server.db`) into the project's `memory.db` by content-hash dedup.
   Reads `server.db` in read-only mode; never writes to it. Supports `--dry-run`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,7 +276,13 @@ Changed files: delete old chunks + embeddings, reparse, re-embed.
 ### Multi-project registry
 `~/.config/spelunk/registry.db` tracks all indexed projects and their
 dependency links. `spelunk search` automatically queries all linked project DBs
-and merges results by distance.
+and merges results by distance. Additionally, `spelunk memory search`,
+`spelunk memory list`, and `spelunk context` surface `locked`- or
+`cross-project`-tagged `decision` and `requirement` entries from linked
+projects' memory stores (ADR-003). Each cross-project result is tagged with its
+source project so decisions remain attributable. Pass `--local-only` to any of
+these commands to query only the primary project's memory. See
+`docs/memory.md#cross-project-visibility`.
 
 ### Secret scanning
 `crates/spelunk-core/src/indexer/secrets.rs` runs before each chunk is stored. Chunks matching

--- a/crates/spelunk-cli/src/cli/cmd/context.rs
+++ b/crates/spelunk-cli/src/cli/cmd/context.rs
@@ -2,12 +2,17 @@ use anyhow::Result;
 use clap::Args;
 use std::path::PathBuf;
 
+use super::memory::cross_project::collect_dep_cross_cutting;
 use super::memory::print_note_summary;
 use crate::storage::memory::Note;
 use crate::{config::Config, storage::open_memory_backend};
 
 /// Fallback per-section limit when `--kind` names a kind not in SECTIONS.
 const DEFAULT_UNKNOWN_KIND_LIMIT: usize = 20;
+
+/// Kinds for which the cross-project dep pass runs (§3 ADR-003).
+/// `handoff` and `question` are strictly local — session/project-scoped noise.
+const DEP_PASS_KINDS: &[&str] = &["decision", "requirement"];
 
 /// Agent-facing entry-point command: pull the most relevant memory sections
 /// in one shot (handoffs → questions → decisions → requirements).
@@ -46,6 +51,10 @@ pub struct ContextArgs {
     /// Skip the conventions section (default: false)
     #[arg(long)]
     pub no_conventions: bool,
+
+    /// Query only the local project's memory, skipping linked project stores
+    #[arg(long)]
+    pub local_only: bool,
 }
 
 struct Section {
@@ -88,13 +97,50 @@ pub async fn context(args: ContextArgs, cfg: Config) -> Result<()> {
     };
     let backend = open_memory_backend(&cfg, &mem_path, be)?;
 
-    let sections = collect_sections(
+    let mut sections = collect_sections(
         &*backend,
         args.kind.as_deref(),
         args.limit,
         args.path.as_deref(),
     )
     .await?;
+
+    // Cross-project dep pass (ADR-003): for decision and requirement sections,
+    // append locked/cross-project entries from linked projects.
+    // `handoff` and `question` are always local (§3 ADR-003).
+    if !args.local_only {
+        let index_db_path = args
+            .index_db
+            .clone()
+            .unwrap_or_else(|| crate::config::resolve_db(None, &cfg.db_path));
+        let mut seen: std::collections::HashSet<(String, i64)> = Default::default();
+        // Seed seen from all local notes to avoid printing a dep note that
+        // somehow shares an ID with a local note.
+        for (_, notes) in &sections {
+            for n in notes {
+                seen.insert((String::new(), n.id));
+            }
+        }
+        let dep_notes = collect_dep_cross_cutting(&index_db_path, &mut seen).await;
+
+        // Merge dep notes into the appropriate section buckets.
+        for dep_note in dep_notes {
+            let kind = dep_note.kind.clone();
+            if !DEP_PASS_KINDS.contains(&kind.as_str()) {
+                continue;
+            }
+            // If a --kind filter is active, only include matching dep notes.
+            if let Some(ref kf) = args.kind
+                && &kind != kf
+            {
+                continue;
+            }
+            // Find the matching section bucket and append.
+            if let Some((_, notes)) = sections.iter_mut().find(|(k, _)| k == &kind) {
+                notes.push(dep_note);
+            }
+        }
+    }
 
     // Load conventions from the index DB (best-effort; skip if unavailable).
     let conventions: Vec<crate::conventions::ConventionRecord> =

--- a/crates/spelunk-cli/src/cli/cmd/memory/cross_project.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/cross_project.rs
@@ -1,0 +1,141 @@
+/// Cross-project memory dep pass — ADR-003.
+///
+/// For `spelunk memory search/list` and `spelunk context`, after querying the
+/// local backend, this module walks the registry dependency graph and surfaces
+/// `locked` or `cross-project`-tagged decisions and requirements from each
+/// linked project's `memory.db`.
+///
+/// Only `kind == "decision"` or `kind == "requirement"` entries with
+/// `status == "active"` and at least one of the tags `locked` or
+/// `cross-project` are returned — see §1 of ADR-003 for the privacy rationale.
+///
+/// Results are tagged with `source_project` / `source_project_path` so the
+/// consuming agent can tell which project a surfaced entry originated from.
+use std::path::Path;
+
+use crate::registry::{Project, Registry};
+use crate::storage::memory::Note;
+use crate::storage::{LocalMemoryBackend, MemoryBackend, MemoryStore};
+
+/// Cross-cutting kinds that are eligible for cross-project surfacing (§1 ADR-003).
+const CROSS_CUTTING_KINDS: &[&str] = &["decision", "requirement"];
+
+/// Tags that opt an entry into cross-project visibility (§1 ADR-003).
+const CROSS_PROJECT_TAGS: &[&str] = &["locked", "cross-project"];
+
+/// Resolve the dep `Project` list for the current working directory, using
+/// `index_db_path` (the primary `.spelunk/index.db`) to locate the project in
+/// the registry.
+///
+/// Returns an empty vec (not an error) when:
+/// - The registry cannot be opened.
+/// - The current project is not registered.
+/// - The project has no registered deps.
+///
+/// This matches the graceful-degradation contract in `search.rs`
+/// (`resolve_project_and_deps` / `search_all_dbs_linearrag`).
+fn resolve_dep_projects(index_db_path: &Path) -> Vec<Project> {
+    let Ok(reg) = Registry::open() else {
+        return vec![];
+    };
+    // index_db_path = <root>/.spelunk/index.db
+    // parent        = <root>/.spelunk
+    // parent.parent = <root>
+    let project_root = index_db_path
+        .parent()
+        .and_then(|p| p.parent())
+        .unwrap_or(index_db_path);
+    let Ok(Some(project)) = reg.find_project_for_path(project_root) else {
+        return vec![];
+    };
+    reg.get_deps(project.id).unwrap_or_default()
+}
+
+/// Query a single dep project's `memory.db` for cross-cutting entries and tag
+/// them with `source_project` / `source_project_path`.
+///
+/// Silently skips deps whose `memory.db` does not exist (common when a project
+/// is linked for code search but has no memory entries yet).
+/// Emits `tracing::warn!` and skips on open/query errors (corrupt DB, etc.),
+/// matching `search_all_dbs_linearrag`'s `"could not open dep DB"` pattern.
+async fn query_dep_cross_cutting(dep: &Project) -> Vec<Note> {
+    let mem_db_path = dep.db_path.with_file_name("memory.db");
+    if !mem_db_path.exists() {
+        return vec![];
+    }
+
+    let store = match MemoryStore::open(&mem_db_path) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                "cross-project memory: could not open dep DB {}: {e}",
+                mem_db_path.display()
+            );
+            return vec![];
+        }
+    };
+    let backend = LocalMemoryBackend::new(store);
+
+    let source_project = crate::cli::cmd::helpers::project_display_name(&dep.root_path);
+    let source_project_path = dep.root_path.to_string_lossy().into_owned();
+
+    let mut cross_cutting = Vec::new();
+
+    for kind in CROSS_CUTTING_KINDS {
+        // Fetch all active entries of this kind (up to the NoteStore cap of 500).
+        let notes = match backend.list(Some(kind), 500, false, None).await {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    "cross-project memory: list failed for dep {} kind={kind}: {e}",
+                    mem_db_path.display()
+                );
+                continue;
+            }
+        };
+
+        for mut note in notes {
+            if is_cross_cutting(&note.tags) {
+                note.source_project = Some(source_project.clone());
+                note.source_project_path = Some(source_project_path.clone());
+                cross_cutting.push(note);
+            }
+        }
+    }
+
+    cross_cutting
+}
+
+/// Return `true` when `tags` contains at least one of `CROSS_PROJECT_TAGS`.
+fn is_cross_cutting(tags: &[String]) -> bool {
+    tags.iter()
+        .any(|t| CROSS_PROJECT_TAGS.iter().any(|&ct| t == ct))
+}
+
+/// Collect cross-cutting notes from all dep projects of the primary project
+/// (identified by `index_db_path`).
+///
+/// `seen` is a set of `(root_path_string, id)` pairs for entries already
+/// emitted, allowing deduplication when two deps link to a shared grandparent
+/// project — per ADR-003 §3 ("dedupe by `(root_path, id)`").
+///
+/// Returns the aggregated dep notes in registry `project_deps` iteration order
+/// (same as `search_all_dbs_linearrag`), each dep's notes in their natural
+/// list order.
+pub(crate) async fn collect_dep_cross_cutting(
+    index_db_path: &Path,
+    seen: &mut std::collections::HashSet<(String, i64)>,
+) -> Vec<Note> {
+    let deps = resolve_dep_projects(index_db_path);
+    let mut result = Vec::new();
+    for dep in &deps {
+        let root_key = dep.root_path.to_string_lossy().into_owned();
+        for note in query_dep_cross_cutting(dep).await {
+            // Deduplicate by (source project root, entry id).
+            if seen.insert((root_key.clone(), note.id)) {
+                result.push(note);
+            }
+        }
+    }
+    result
+}

--- a/crates/spelunk-cli/src/cli/cmd/memory/list.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/list.rs
@@ -15,7 +15,7 @@ pub(super) async fn memory_list(
 
     let backend = open_memory_backend(cfg, mem_path, backend_override)?;
     let as_of = parse_as_of(args.as_of.as_deref())?;
-    let notes = if let Some(ref sha_prefix) = args.source_ref {
+    let mut notes = if let Some(ref sha_prefix) = args.source_ref {
         backend
             .list_by_source_ref(sha_prefix, args.limit, args.archived, as_of)
             .await?
@@ -24,6 +24,31 @@ pub(super) async fn memory_list(
             .list(args.kind.as_deref(), args.limit, args.archived, as_of)
             .await?
     };
+
+    // Cross-project dep pass (ADR-003): append locked/cross-project decisions
+    // and requirements from linked projects unless --local-only is set.
+    // The dep pass is skipped when --source-ref is given (commit-specific queries
+    // are inherently local) or when --archived is set (archived entries are
+    // project-local housekeeping noise, not cross-cutting signals).
+    if !args.local_only && args.source_ref.is_none() && !args.archived {
+        let index_db_path = crate::config::resolve_db(None, &cfg.db_path);
+        let mut seen: std::collections::HashSet<(String, i64)> = Default::default();
+        // Seed seen set from local results so local entries don't collide with
+        // same-id entries from a dep that happens to share a local path (unlikely
+        // but defensive). Local notes have no root_path key, so we use "".
+        for n in &notes {
+            seen.insert((String::new(), n.id));
+        }
+        let dep_notes =
+            super::cross_project::collect_dep_cross_cutting(&index_db_path, &mut seen).await;
+        // Filter dep notes to the requested kind (if --kind was specified).
+        let dep_notes: Vec<_> = if let Some(ref k) = args.kind {
+            dep_notes.into_iter().filter(|n| &n.kind == k).collect()
+        } else {
+            dep_notes
+        };
+        notes.extend(dep_notes);
+    }
 
     if notes.is_empty() {
         println!("No memory entries found.");

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -137,6 +137,10 @@ pub struct MemorySearchArgs {
     /// Expand results by 1 hop along relates_to edges
     #[arg(long)]
     pub expand_graph: bool,
+
+    /// Search only the local project's memory, skipping linked project stores
+    #[arg(long)]
+    pub local_only: bool,
 }
 
 #[derive(Args, Debug)]
@@ -164,6 +168,10 @@ pub struct MemoryListArgs {
     /// Return only entries valid at this point in time (ISO 8601, e.g. 2026-03-15 or 2026-03-15T10:00:00)
     #[arg(long, value_name = "DATE")]
     pub as_of: Option<String>,
+
+    /// List only local project's memory, skipping linked project stores
+    #[arg(long)]
+    pub local_only: bool,
 }
 
 #[derive(Args, Debug)]
@@ -318,6 +326,7 @@ use super::status::format_age;
 
 mod add;
 mod archive;
+pub(crate) mod cross_project;
 mod failures;
 mod graph_cmd;
 mod harvest;
@@ -380,8 +389,13 @@ pub(super) fn print_note_summary(n: &crate::storage::memory::Note) {
     } else {
         ""
     };
+    let source_badge = n
+        .source_project
+        .as_deref()
+        .map(|p| format!("  \x1b[36m[from: {p}]\x1b[0m"))
+        .unwrap_or_default();
     println!(
-        "\x1b[1m#{id}\x1b[0m  \x1b[33m[{kind}]\x1b[0m  {title}{archived}{dist_fmt}",
+        "\x1b[1m#{id}\x1b[0m  \x1b[33m[{kind}]\x1b[0m  {title}{archived}{dist_fmt}{source}",
         id = n.id,
         kind = n.kind,
         title = n.title,
@@ -391,6 +405,7 @@ pub(super) fn print_note_summary(n: &crate::storage::memory::Note) {
         } else {
             format!("\x1b[2m{dist}\x1b[0m")
         },
+        source = source_badge,
     );
     println!("     \x1b[2m{}\x1b[0m", format_age(n.created_at));
     if let Some(valid_at) = n.valid_at {

--- a/crates/spelunk-cli/src/cli/cmd/memory/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/search.rs
@@ -58,12 +58,7 @@ pub(super) async fn memory_search(
         }
     };
 
-    if notes.is_empty() {
-        println!("No memory entries found.");
-        return Ok(());
-    }
-
-    let notes = if args.expand_graph {
+    let mut notes = if args.expand_graph {
         let mut seen: std::collections::HashSet<i64> = notes.iter().map(|n| n.id).collect();
         let mut expanded = notes;
         let mut neighbours = vec![];
@@ -90,6 +85,26 @@ pub(super) async fn memory_search(
     } else {
         notes
     };
+
+    // Cross-project dep pass (ADR-003): append locked/cross-project decisions
+    // and requirements from linked projects unless --local-only is set.
+    // Dep stores are queried via text search (they have no embedder available
+    // in the CLI path), filtered post-query to the `locked`/`cross-project`
+    // tag set. Results are appended after local results per ADR-003 §6.
+    if !args.local_only {
+        let mut seen: std::collections::HashSet<(String, i64)> = Default::default();
+        for n in &notes {
+            seen.insert((String::new(), n.id));
+        }
+        let dep_notes =
+            super::cross_project::collect_dep_cross_cutting(&index_db_path, &mut seen).await;
+        notes.extend(dep_notes);
+    }
+
+    if notes.is_empty() {
+        println!("No memory entries found.");
+        return Ok(());
+    }
 
     match crate::utils::effective_format(&args.format) {
         "json" => println!("{}", serde_json::to_string_pretty(&notes)?),

--- a/crates/spelunk-cli/tests/cross_project_memory.rs
+++ b/crates/spelunk-cli/tests/cross_project_memory.rs
@@ -299,6 +299,9 @@ fn setup_linked_projects() -> (
 fn memory_cmd(home: &Path, primary_root: &Path, config: &Path, primary_mem: &Path) -> Command {
     let mut cmd = Command::cargo_bin("spelunk").unwrap();
     cmd.env("HOME", home)
+        // Unset XDG_CONFIG_HOME so dirs::config_dir() uses $HOME/.config on Linux,
+        // matching what TestRegistry::new() writes to home_dir.join(".config").
+        .env_remove("XDG_CONFIG_HOME")
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(primary_root)
         .arg("--config")
@@ -319,6 +322,7 @@ fn context_cmd(
 ) -> Command {
     let mut cmd = Command::cargo_bin("spelunk").unwrap();
     cmd.env("HOME", home)
+        .env_remove("XDG_CONFIG_HOME")
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(primary_root)
         .arg("--config")
@@ -525,6 +529,7 @@ fn untagged_dep_decision_is_not_surfaced() {
     let raw = Command::cargo_bin("spelunk")
         .unwrap()
         .env("HOME", &home)
+        .env_remove("XDG_CONFIG_HOME")
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(&primary_root)
         .arg("--config")
@@ -569,6 +574,7 @@ fn dep_note_kind_is_not_surfaced_even_if_locked() {
     let raw = Command::cargo_bin("spelunk")
         .unwrap()
         .env("HOME", &home)
+        .env_remove("XDG_CONFIG_HOME")
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(&primary_root)
         .arg("--config")
@@ -658,6 +664,7 @@ fn single_project_no_deps_works_unchanged() {
     let output = Command::cargo_bin("spelunk")
         .unwrap()
         .env("HOME", &home)
+        .env_remove("XDG_CONFIG_HOME")
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(&project_root)
         .arg("--config")
@@ -966,6 +973,7 @@ fn archived_dep_decision_is_not_surfaced() {
     let raw = Command::cargo_bin("spelunk")
         .unwrap()
         .env("HOME", &home)
+        .env_remove("XDG_CONFIG_HOME")
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(&primary_root)
         .arg("--config")
@@ -1048,6 +1056,7 @@ fn dep_question_is_never_surfaced_cross_project() {
     let raw = Command::cargo_bin("spelunk")
         .unwrap()
         .env("HOME", &home)
+        .env_remove("XDG_CONFIG_HOME")
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(&primary_root)
         .arg("--config")
@@ -1137,6 +1146,7 @@ fn multiple_deps_results_are_aggregated_not_duplicated() {
     let output = Command::cargo_bin("spelunk")
         .unwrap()
         .env("HOME", &home)
+        .env_remove("XDG_CONFIG_HOME")
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(&primary_root)
         .arg("--config")
@@ -1220,6 +1230,7 @@ fn missing_dep_memory_db_is_skipped_silently() {
     let output = Command::cargo_bin("spelunk")
         .unwrap()
         .env("HOME", &home)
+        .env_remove("XDG_CONFIG_HOME")
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(&primary_root)
         .arg("--config")

--- a/crates/spelunk-cli/tests/cross_project_memory.rs
+++ b/crates/spelunk-cli/tests/cross_project_memory.rs
@@ -1,0 +1,1356 @@
+//! Integration tests for ADR-003: cross-project memory visibility in
+//! `spelunk memory search`, `spelunk memory list`, and `spelunk context`.
+//!
+//! Coverage:
+//!   1. Multi-project search aggregation: `memory list` returns results from
+//!      both the local store AND linked project memory stores.
+//!   2. Source-project tagging: dep results carry `source_project` in JSON output.
+//!   3. Locked-decision propagation: a `locked` dep decision surfaces locally.
+//!   4. Privacy boundary: only `locked`/`cross-project`-tagged decisions/requirements
+//!      are surfaced — untagged dep decisions are NOT exposed.
+//!   5. Single-project path regression: no-deps projects behave exactly as before.
+//!   6. Context command cross-project merge for `decision`/`requirement` sections;
+//!      `handoff`/`question` sections remain strictly local.
+//!   7. `--local-only` flag suppresses the dep pass for `memory search`, `list`, `context`.
+//!   8. Archived dep entries are NOT surfaced.
+//!   9. `handoff`/`question` kinds are never surfaced cross-project.
+//!  10. Deduplication when two deps both point to the same grandparent.
+//!  11. Missing dep `memory.db` is skipped silently (no crash, no error output).
+//!  12. Security: SQL injection payload in a dep note title/body is inert.
+//!  13. MemoryStore unit assertions: source_project is None for local notes,
+//!      archived notes are excluded from list().
+
+use assert_cmd::Command;
+use rusqlite::Connection;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+// ── test-registry helpers ─────────────────────────────────────────────────────
+
+/// A self-contained test registry backed by a file inside the test's HOME dir.
+///
+/// The registry is a `registry.db`-format SQLite file.  We redirect `HOME`
+/// for every CLI invocation so tests never touch the developer's real registry.
+struct TestRegistry {
+    conn: Connection,
+}
+
+impl TestRegistry {
+    /// Create a fresh registry in the platform-appropriate location under `home_dir`.
+    ///
+    /// - macOS: `home_dir/Library/Application Support/spelunk/registry.db`
+    ///   (`dirs::config_dir()` on macOS = `home_dir()/Library/Application Support`,
+    ///   which respects the `HOME` env var via `dirs_sys::home_dir`).
+    /// - Linux/others: `home_dir/.config/spelunk/registry.db`
+    fn new(home_dir: &Path) -> Self {
+        #[cfg(target_os = "macos")]
+        let config_dir = home_dir
+            .join("Library")
+            .join("Application Support")
+            .join("spelunk");
+        #[cfg(not(target_os = "macos"))]
+        let config_dir = home_dir.join(".config").join("spelunk");
+        fs::create_dir_all(&config_dir).expect("create registry dir");
+        let db_path = config_dir.join("registry.db");
+        let conn = Connection::open(&db_path).expect("open registry db");
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA foreign_keys=ON;
+             CREATE TABLE IF NOT EXISTS projects (
+                 id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                 root_path     TEXT    NOT NULL UNIQUE,
+                 db_path       TEXT    NOT NULL,
+                 registered_at INTEGER NOT NULL DEFAULT (unixepoch())
+             );
+             CREATE TABLE IF NOT EXISTS project_deps (
+                 project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+                 dep_id     INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+                 PRIMARY KEY (project_id, dep_id)
+             );",
+        )
+        .expect("init registry schema");
+        Self { conn }
+    }
+
+    /// Register a project and return its id.
+    ///
+    /// Paths are canonicalized before insertion to resolve macOS symlinks
+    /// (`/var/folders` ↔ `/private/var/folders`) that would otherwise cause
+    /// mismatches between the registered path and the path the CLI sees when it
+    /// resolves `current_dir()`.
+    fn register(&self, root: &Path, db: &Path) -> i64 {
+        let root_c = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+        let db_c = std::fs::canonicalize(db).unwrap_or_else(|_| db.to_path_buf());
+        self.conn
+            .execute(
+                "INSERT INTO projects (root_path, db_path)
+                 VALUES (?1, ?2)
+                 ON CONFLICT(root_path) DO UPDATE SET db_path = excluded.db_path",
+                rusqlite::params![root_c.to_string_lossy(), db_c.to_string_lossy()],
+            )
+            .expect("register project");
+        self.conn
+            .query_row(
+                "SELECT id FROM projects WHERE root_path = ?1",
+                rusqlite::params![root_c.to_string_lossy()],
+                |r| r.get(0),
+            )
+            .expect("fetch project id")
+    }
+
+    /// Add a `project_id` → `dep_id` edge (project_id depends on dep_id).
+    fn add_dep(&self, project_id: i64, dep_id: i64) {
+        self.conn
+            .execute(
+                "INSERT OR IGNORE INTO project_deps (project_id, dep_id) VALUES (?1, ?2)",
+                rusqlite::params![project_id, dep_id],
+            )
+            .expect("add dep edge");
+    }
+}
+
+// ── memory-db helpers ─────────────────────────────────────────────────────────
+
+/// Register the sqlite-vec extension once per test process (required for
+/// MemoryStore::open which creates the vec0 virtual table).
+fn register_sqlite_vec_once() {
+    use std::sync::OnceLock;
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| unsafe {
+        #[allow(clippy::missing_transmute_annotations)]
+        rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+            sqlite_vec::sqlite3_vec_init as *const (),
+        )));
+    });
+}
+
+/// Open and migrate a `memory.db` at `path`, returning the raw `Connection`
+/// for direct seeding of test data.
+fn open_memory_db(path: &Path) -> Connection {
+    register_sqlite_vec_once();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create memory db parent");
+    }
+    let conn = Connection::open(path).expect("open memory db");
+    // Verbatim migrations from MemoryStore::migrate.
+    conn.execute_batch(include_str!(
+        "../../../crates/spelunk-core/migrations/004_memory.sql"
+    ))
+    .expect("004_memory migration");
+    for stmt in [
+        "ALTER TABLE notes ADD COLUMN status TEXT NOT NULL DEFAULT 'active'",
+        "ALTER TABLE notes ADD COLUMN superseded_by INTEGER REFERENCES notes(id)",
+        "ALTER TABLE notes ADD COLUMN source_ref TEXT",
+    ] {
+        match conn.execute_batch(stmt) {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => panic!("migration failed: {e}"),
+        }
+    }
+    conn.execute_batch(include_str!(
+        "../../../crates/spelunk-core/migrations/012_memory_fts.sql"
+    ))
+    .expect("012_memory_fts migration");
+    for stmt in [
+        "ALTER TABLE notes ADD COLUMN valid_at INTEGER",
+        "ALTER TABLE notes ADD COLUMN invalid_at INTEGER",
+        "CREATE INDEX IF NOT EXISTS idx_memory_invalid_at ON notes(invalid_at)",
+    ] {
+        match conn.execute_batch(stmt) {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => panic!("migration failed: {e}"),
+        }
+    }
+    conn.execute_batch(include_str!(
+        "../../../crates/spelunk-core/migrations/015_memory_edges.sql"
+    ))
+    .expect("015_memory_edges migration");
+    conn
+}
+
+/// Insert a note directly into a `memory.db`.  Returns the row id.
+fn seed_note(
+    conn: &Connection,
+    kind: &str,
+    title: &str,
+    body: &str,
+    tags: &[&str],
+    status: &str,
+) -> i64 {
+    conn.execute(
+        "INSERT INTO notes (kind, title, body, tags, status)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![kind, title, body, tags.join(","), status],
+    )
+    .expect("seed note");
+    conn.last_insert_rowid()
+}
+
+// ── project setup helpers ─────────────────────────────────────────────────────
+
+/// Write a minimal config.toml pointing `db_path` at the primary index.db.
+///
+/// `memory search` / `memory list` derive `index_db_path` from `cfg.db_path`
+/// (via `config::resolve_db`), which is then passed to `collect_dep_cross_cutting`
+/// so the registry can look up the project and its deps.
+///
+/// The `db_path` is canonicalized to match what `Registry::register` stores
+/// (both must agree on `/private/var/...` vs `/var/...` on macOS).
+fn write_config(dir: &Path, index_db: &Path) -> PathBuf {
+    let index_db_c = std::fs::canonicalize(index_db).unwrap_or_else(|_| index_db.to_path_buf());
+    let cfg = format!(
+        concat!(
+            "db_path = {:?}\n",
+            "api_base_url = \"http://127.0.0.1:1\"\n",
+            "embedding_model = \"none\"\n",
+            "llm_model = \"none\"\n",
+        ),
+        index_db_c
+    );
+    let config_path = dir.join("config.toml");
+    fs::write(&config_path, cfg).expect("write config");
+    config_path
+}
+
+/// Create `.spelunk/index.db` inside `project_root` and return the path.
+///
+/// The registry `db_path` column must point at this file.  An empty SQLite
+/// database is sufficient — the dep pass never opens the index DB itself.
+fn create_spelunk_dir(project_root: &Path) -> PathBuf {
+    let spelunk_dir = project_root.join(".spelunk");
+    fs::create_dir_all(&spelunk_dir).expect("create .spelunk dir");
+    let index_db = spelunk_dir.join("index.db");
+    let _ = Connection::open(&index_db).expect("create stub index.db");
+    index_db
+}
+
+/// Full two-project setup: "primary" depends on "dep".
+///
+/// Returns `(TempDir, home, primary_root, primary_index_db, primary_config,
+///           dep_root, dep_memory_db)`.
+///
+/// All returned paths are canonicalized so that:
+/// - CLI subprocess `current_dir` matches registry `root_path` entries.
+/// - Config `db_path` matches what `find_project_for_path` looks up.
+///
+/// On macOS, `TempDir::new()` returns `/var/folders/...` which resolves to
+/// `/private/var/folders/...`; without canonicalization the registry lookup
+/// finds the wrong path and the dep pass returns nothing.
+///
+/// The caller must keep `_tmp` alive to prevent tempdir removal.
+#[allow(clippy::type_complexity)]
+fn setup_linked_projects() -> (
+    TempDir, // keep alive
+    PathBuf, // home (use as HOME env)
+    PathBuf, // primary project root (canonical)
+    PathBuf, // primary index.db path (canonical)
+    PathBuf, // primary config.toml
+    PathBuf, // dep project root (canonical)
+    PathBuf, // dep memory.db (canonical, caller seeds this)
+) {
+    let tmp = TempDir::new().expect("create temp dir");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).expect("create home dir");
+
+    let primary_root_raw = tmp.path().join("primary");
+    fs::create_dir_all(&primary_root_raw).expect("create primary dir");
+    let primary_index_raw = create_spelunk_dir(&primary_root_raw);
+
+    let dep_root_raw = tmp.path().join("dep");
+    fs::create_dir_all(&dep_root_raw).expect("create dep dir");
+    let dep_index_raw = create_spelunk_dir(&dep_root_raw);
+
+    // Canonicalize after the directories exist so symlink resolution succeeds.
+    let primary_root = std::fs::canonicalize(&primary_root_raw).unwrap_or(primary_root_raw);
+    let primary_index = std::fs::canonicalize(&primary_index_raw).unwrap_or(primary_index_raw);
+    let dep_root = std::fs::canonicalize(&dep_root_raw).unwrap_or(dep_root_raw);
+    let dep_index = std::fs::canonicalize(&dep_index_raw).unwrap_or(dep_index_raw);
+
+    // Config db_path uses the canonical index.db path.
+    let primary_config = write_config(&primary_root, &primary_index);
+    let dep_mem = dep_index.with_file_name("memory.db");
+
+    let reg = TestRegistry::new(&home);
+    let primary_id = reg.register(&primary_root, &primary_index);
+    let dep_id = reg.register(&dep_root, &dep_index);
+    reg.add_dep(primary_id, dep_id);
+
+    (
+        tmp,
+        home,
+        primary_root,
+        primary_index,
+        primary_config,
+        dep_root,
+        dep_mem,
+    )
+}
+
+/// Build a base `spelunk memory` command for the primary project.
+///
+/// - `HOME` is set to the isolated home dir (registry isolation).
+/// - `SPELUNK_NO_SERVER=1` disables the loopback-server capability probe.
+/// - `current_dir` is `primary_root` so registry path lookup walks from there.
+/// - `--config` points to the primary config.toml (which has `db_path = <index.db>`).
+/// - `memory --db <primary_mem>` routes memory reads to the primary's memory.db.
+fn memory_cmd(home: &Path, primary_root: &Path, config: &Path, primary_mem: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.env("HOME", home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(primary_root)
+        .arg("--config")
+        .arg(config)
+        .arg("memory")
+        .arg("--db")
+        .arg(primary_mem);
+    cmd
+}
+
+/// Build a base `spelunk context` command for the primary project.
+fn context_cmd(
+    home: &Path,
+    primary_root: &Path,
+    config: &Path,
+    primary_mem: &Path,
+    primary_index: &Path,
+) -> Command {
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.env("HOME", home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(primary_root)
+        .arg("--config")
+        .arg(config)
+        .arg("context")
+        .arg("--db")
+        .arg(primary_mem)
+        .arg("--index-db")
+        .arg(primary_index)
+        .arg("--no-conventions");
+    cmd
+}
+
+// ── 1. Multi-project search aggregation ──────────────────────────────────────
+
+/// `memory list` includes a `locked` dep decision alongside local notes.
+#[test]
+fn memory_list_includes_locked_decision_from_linked_dep() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+
+    let primary_mem = primary_index.with_file_name("memory.db");
+    let primary_conn = open_memory_db(&primary_mem);
+    seed_note(
+        &primary_conn,
+        "decision",
+        "Local decision",
+        "local body",
+        &[],
+        "active",
+    );
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "SSE is Cloud-only",
+        "SSE memory stream is Cloud-only per decision #134.",
+        &["locked", "v1"],
+        "active",
+    );
+
+    let output = memory_cmd(&home, &primary_root, &primary_config, &primary_mem)
+        .args(["list", "--format", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let notes: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("valid JSON");
+    let titles: Vec<&str> = notes.iter().filter_map(|n| n["title"].as_str()).collect();
+
+    assert!(
+        titles.contains(&"Local decision"),
+        "local note must appear; got: {titles:?}"
+    );
+    assert!(
+        titles.contains(&"SSE is Cloud-only"),
+        "locked dep decision must be surfaced; got: {titles:?}"
+    );
+}
+
+// ── 2. Source-project tagging ─────────────────────────────────────────────────
+
+/// A dep note in `memory list --format json` must have `source_project` set to
+/// the dep's directory name.
+#[test]
+fn dep_note_carries_source_project_tag_in_json() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "Cross-project tagged decision",
+        "Must carry source_project in JSON.",
+        &["locked"],
+        "active",
+    );
+
+    let output = memory_cmd(&home, &primary_root, &primary_config, &primary_mem)
+        .args(["list", "--format", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let notes: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("valid JSON");
+    let dep_note = notes
+        .iter()
+        .find(|n| n["title"].as_str() == Some("Cross-project tagged decision"))
+        .expect("dep note must appear in list");
+
+    assert_eq!(
+        dep_note["source_project"].as_str(),
+        Some("dep"),
+        "source_project must be 'dep'; got: {dep_note}"
+    );
+    assert!(
+        dep_note["source_project_path"].as_str().is_some(),
+        "source_project_path must be set; got: {dep_note}"
+    );
+}
+
+/// Local notes must NOT have `source_project` in JSON output.
+#[test]
+fn local_note_has_no_source_project_field() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, _dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let primary_conn = open_memory_db(&primary_mem);
+    seed_note(
+        &primary_conn,
+        "decision",
+        "Local-only decision",
+        "body",
+        &[],
+        "active",
+    );
+
+    let output = memory_cmd(&home, &primary_root, &primary_config, &primary_mem)
+        .args(["list", "--format", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let notes: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("valid JSON");
+    let local = notes
+        .iter()
+        .find(|n| n["title"].as_str() == Some("Local-only decision"))
+        .expect("local note must appear");
+
+    assert!(
+        local.get("source_project").is_none() || local["source_project"].is_null(),
+        "local note must not have source_project; got: {local}"
+    );
+}
+
+// ── 3. Locked-decision propagation ───────────────────────────────────────────
+
+/// `memory search --mode text` appends locked dep decisions in the results.
+///
+/// Text-mode search is used (not hybrid/semantic) so no embedding server is
+/// needed.  Per ADR-003 §3, the dep pass appends ALL cross-cutting entries
+/// regardless of the FTS search query.
+#[test]
+fn memory_search_text_appends_locked_dep_decisions() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "Auth uses JWT tokens",
+        "All authentication must use signed JWT tokens.",
+        &["locked", "security"],
+        "active",
+    );
+
+    let output = memory_cmd(&home, &primary_root, &primary_config, &primary_mem)
+        .args(["search", "--mode", "text", "--format", "json", "anything"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let notes: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("valid JSON");
+    let titles: Vec<&str> = notes.iter().filter_map(|n| n["title"].as_str()).collect();
+    assert!(
+        titles.contains(&"Auth uses JWT tokens"),
+        "locked dep decision must be appended by dep pass; got: {titles:?}"
+    );
+}
+
+// ── 4. Privacy boundary ───────────────────────────────────────────────────────
+
+/// A dep decision WITHOUT `locked` or `cross-project` tag must NOT be surfaced.
+#[test]
+fn untagged_dep_decision_is_not_surfaced() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "Internal dep naming convention",
+        "We use camelCase for internal variables.",
+        &["style"], // not locked, not cross-project
+        "active",
+    );
+
+    let raw = Command::cargo_bin("spelunk")
+        .unwrap()
+        .env("HOME", &home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&primary_root)
+        .arg("--config")
+        .arg(&primary_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&primary_mem)
+        .args(["list", "--format", "json"])
+        .output()
+        .expect("run spelunk");
+
+    let text = String::from_utf8_lossy(&raw.stdout);
+    if text.trim().starts_with('[') {
+        let notes: Vec<serde_json::Value> = serde_json::from_str(text.trim()).expect("valid JSON");
+        let titles: Vec<&str> = notes.iter().filter_map(|n| n["title"].as_str()).collect();
+        assert!(
+            !titles.contains(&"Internal dep naming convention"),
+            "untagged dep decision must NOT be surfaced; got: {titles:?}"
+        );
+    }
+    // "No memory entries found." → untagged note not surfaced; test passes.
+}
+
+/// A dep `note` (kind=note) tagged `locked` must NOT cross project boundaries —
+/// only `decision` and `requirement` kinds are eligible per ADR-003 §1.
+#[test]
+fn dep_note_kind_is_not_surfaced_even_if_locked() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "note", // wrong kind — notes are always local
+        "Surprising fact: locked",
+        "A note tagged locked should remain private to its project.",
+        &["locked"],
+        "active",
+    );
+
+    let raw = Command::cargo_bin("spelunk")
+        .unwrap()
+        .env("HOME", &home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&primary_root)
+        .arg("--config")
+        .arg(&primary_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&primary_mem)
+        .args(["list", "--format", "json"])
+        .output()
+        .expect("run spelunk");
+
+    let text = String::from_utf8_lossy(&raw.stdout);
+    if text.trim().starts_with('[') {
+        let notes: Vec<serde_json::Value> = serde_json::from_str(text.trim()).expect("valid JSON");
+        let titles: Vec<&str> = notes.iter().filter_map(|n| n["title"].as_str()).collect();
+        assert!(
+            !titles.contains(&"Surprising fact: locked"),
+            "dep note (kind=note) must not cross boundary; got: {titles:?}"
+        );
+    }
+}
+
+/// A dep `requirement` tagged `cross-project` IS surfaced (not just `locked`).
+#[test]
+fn dep_requirement_with_cross_project_tag_is_surfaced() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "requirement",
+        "All APIs must be TLS 1.3",
+        "Security requirement applying to all linked projects.",
+        &["cross-project", "security"],
+        "active",
+    );
+
+    let output = memory_cmd(&home, &primary_root, &primary_config, &primary_mem)
+        .args(["list", "--format", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let notes: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("valid JSON");
+    let titles: Vec<&str> = notes.iter().filter_map(|n| n["title"].as_str()).collect();
+    assert!(
+        titles.contains(&"All APIs must be TLS 1.3"),
+        "dep requirement with cross-project tag must be surfaced; got: {titles:?}"
+    );
+}
+
+// ── 5. Single-project path regression ────────────────────────────────────────
+
+/// With no deps registered, `memory list` works exactly as before ADR-003.
+#[test]
+fn single_project_no_deps_works_unchanged() {
+    let tmp = TempDir::new().expect("create temp dir");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).expect("create home dir");
+
+    let project_root_raw = tmp.path().join("proj");
+    fs::create_dir_all(&project_root_raw).expect("create project dir");
+    let index_db_raw = create_spelunk_dir(&project_root_raw);
+    let project_root = std::fs::canonicalize(&project_root_raw).unwrap_or(project_root_raw);
+    let index_db = std::fs::canonicalize(&index_db_raw).unwrap_or(index_db_raw);
+    let config = write_config(&project_root, &index_db);
+    let mem = index_db.with_file_name("memory.db");
+
+    // Register with NO deps.
+    let reg = TestRegistry::new(&home);
+    reg.register(&project_root, &index_db);
+
+    let conn = open_memory_db(&mem);
+    seed_note(
+        &conn,
+        "decision",
+        "Local-only note",
+        "no deps anywhere",
+        &[],
+        "active",
+    );
+
+    let output = Command::cargo_bin("spelunk")
+        .unwrap()
+        .env("HOME", &home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&project_root)
+        .arg("--config")
+        .arg(&config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem)
+        .args(["list", "--format", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let notes: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("valid JSON");
+    assert_eq!(
+        notes.len(),
+        1,
+        "exactly one local note, no phantom dep notes"
+    );
+    assert_eq!(notes[0]["title"].as_str(), Some("Local-only note"));
+}
+
+// ── 6. Context command cross-project merge ────────────────────────────────────
+
+/// `spelunk context` (text mode) includes a locked dep decision and renders
+/// the `[from: dep]` badge.
+#[test]
+fn context_includes_locked_dep_decision_with_source_badge() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "SSE endpoint is Cloud-only",
+        "The /v1/memory/sse endpoint must never be in OSS.",
+        &["locked"],
+        "active",
+    );
+
+    let stdout = context_cmd(
+        &home,
+        &primary_root,
+        &primary_config,
+        &primary_mem,
+        &primary_index,
+    )
+    .assert()
+    .success()
+    .get_output()
+    .stdout
+    .clone();
+
+    let text = String::from_utf8_lossy(&stdout);
+    assert!(
+        text.contains("SSE endpoint is Cloud-only"),
+        "dep decision must appear in context; got:\n{text}"
+    );
+    assert!(
+        text.contains("[from: dep]"),
+        "source badge must appear for dep decision; got:\n{text}"
+    );
+}
+
+/// `spelunk context --format json` includes dep decision with `source_project` field.
+#[test]
+fn context_json_includes_dep_decision_with_source_project() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "Dep locked decision for context JSON",
+        "Must appear in context JSON with source_project.",
+        &["locked"],
+        "active",
+    );
+
+    let output = context_cmd(
+        &home,
+        &primary_root,
+        &primary_config,
+        &primary_mem,
+        &primary_index,
+    )
+    .args(["--format", "json"])
+    .assert()
+    .success()
+    .get_output()
+    .stdout
+    .clone();
+
+    let obj: serde_json::Value = serde_json::from_slice(&output).expect("valid JSON");
+    let sections = obj["sections"].as_array().expect("sections array");
+    let decision_section = sections
+        .iter()
+        .find(|s| s[0].as_str() == Some("decision"))
+        .expect("decision section");
+    let decision_notes = decision_section[1].as_array().expect("notes array");
+
+    let dep_note = decision_notes
+        .iter()
+        .find(|n| n["title"].as_str() == Some("Dep locked decision for context JSON"))
+        .expect("dep decision must appear in context JSON");
+
+    assert_eq!(
+        dep_note["source_project"].as_str(),
+        Some("dep"),
+        "source_project must be 'dep' in context JSON; got: {dep_note}"
+    );
+}
+
+/// `spelunk context` does NOT include dep `requirement` notes in the `decision`
+/// section, but DOES include them in the `requirement` section.
+#[test]
+fn context_dep_requirement_appears_in_requirement_section() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "requirement",
+        "Dep TLS requirement",
+        "All endpoints must use TLS.",
+        &["locked"],
+        "active",
+    );
+
+    let output = context_cmd(
+        &home,
+        &primary_root,
+        &primary_config,
+        &primary_mem,
+        &primary_index,
+    )
+    .args(["--format", "json"])
+    .assert()
+    .success()
+    .get_output()
+    .stdout
+    .clone();
+
+    let obj: serde_json::Value = serde_json::from_slice(&output).expect("valid JSON");
+    let sections = obj["sections"].as_array().expect("sections array");
+
+    // Must appear in the requirement section.
+    let req_section = sections
+        .iter()
+        .find(|s| s[0].as_str() == Some("requirement"))
+        .expect("requirement section");
+    let req_notes = req_section[1].as_array().expect("requirement notes");
+    let found_in_req = req_notes
+        .iter()
+        .any(|n| n["title"].as_str() == Some("Dep TLS requirement"));
+    assert!(
+        found_in_req,
+        "dep requirement must appear in requirement section of context"
+    );
+
+    // Must NOT appear in the decision section (it's a requirement, not a decision).
+    let dec_section = sections
+        .iter()
+        .find(|s| s[0].as_str() == Some("decision"))
+        .expect("decision section");
+    let dec_notes = dec_section[1].as_array().expect("decision notes");
+    let found_in_dec = dec_notes
+        .iter()
+        .any(|n| n["title"].as_str() == Some("Dep TLS requirement"));
+    assert!(
+        !found_in_dec,
+        "dep requirement must NOT appear in decision section"
+    );
+}
+
+// ── 7. --local-only flag ──────────────────────────────────────────────────────
+
+/// `memory list --local-only` suppresses the dep pass entirely.
+#[test]
+fn memory_list_local_only_suppresses_dep_results() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "Would appear without local-only",
+        "body",
+        &["locked"],
+        "active",
+    );
+
+    let stdout = memory_cmd(&home, &primary_root, &primary_config, &primary_mem)
+        .args(["list", "--local-only"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8_lossy(&stdout);
+    assert!(
+        !text.contains("Would appear without local-only"),
+        "--local-only must suppress dep results; got:\n{text}"
+    );
+}
+
+/// `memory search --local-only` suppresses the dep pass.
+#[test]
+fn memory_search_local_only_suppresses_dep_results() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "Search-suppressed dep decision",
+        "Normally appended by dep pass.",
+        &["locked"],
+        "active",
+    );
+
+    let stdout = memory_cmd(&home, &primary_root, &primary_config, &primary_mem)
+        .args(["search", "--mode", "text", "--local-only", "dep decision"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8_lossy(&stdout);
+    assert!(
+        !text.contains("Search-suppressed dep decision"),
+        "search --local-only must suppress dep results; got:\n{text}"
+    );
+}
+
+/// `context --local-only` suppresses the dep pass.
+#[test]
+fn context_local_only_suppresses_dep_results() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "Context-suppressed dep decision",
+        "body",
+        &["locked"],
+        "active",
+    );
+
+    let stdout = context_cmd(
+        &home,
+        &primary_root,
+        &primary_config,
+        &primary_mem,
+        &primary_index,
+    )
+    .arg("--local-only")
+    .assert()
+    .success()
+    .get_output()
+    .stdout
+    .clone();
+
+    let text = String::from_utf8_lossy(&stdout);
+    assert!(
+        !text.contains("Context-suppressed dep decision"),
+        "context --local-only must suppress dep results; got:\n{text}"
+    );
+}
+
+// ── 8. Archived dep entries are not surfaced ──────────────────────────────────
+
+/// An archived dep decision (status='archived') must NOT appear even if tagged `locked`.
+#[test]
+fn archived_dep_decision_is_not_surfaced() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "Old locked decision now archived",
+        "Superseded and archived — must not propagate.",
+        &["locked"],
+        "archived", // <-- archived
+    );
+
+    let raw = Command::cargo_bin("spelunk")
+        .unwrap()
+        .env("HOME", &home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&primary_root)
+        .arg("--config")
+        .arg(&primary_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&primary_mem)
+        .args(["list", "--format", "json"])
+        .output()
+        .expect("run spelunk");
+
+    let text = String::from_utf8_lossy(&raw.stdout);
+    if text.trim().starts_with('[') {
+        let notes: Vec<serde_json::Value> = serde_json::from_str(text.trim()).expect("valid JSON");
+        let titles: Vec<&str> = notes.iter().filter_map(|n| n["title"].as_str()).collect();
+        assert!(
+            !titles.contains(&"Old locked decision now archived"),
+            "archived dep note must not be surfaced; got: {titles:?}"
+        );
+    }
+    // "No memory entries found." → archived note was correctly suppressed.
+}
+
+// ── 9. handoff/question kinds are never cross-project ─────────────────────────
+
+/// `context` must NOT pull `handoff` entries from dep projects, even if tagged `locked`.
+#[test]
+fn context_never_pulls_dep_handoffs() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "handoff",
+        "Dep handoff: session ended",
+        "This handoff must remain local to the dep project.",
+        &["locked"], // even locked tag cannot make a handoff cross-project
+        "active",
+    );
+
+    let stdout = context_cmd(
+        &home,
+        &primary_root,
+        &primary_config,
+        &primary_mem,
+        &primary_index,
+    )
+    .assert()
+    .success()
+    .get_output()
+    .stdout
+    .clone();
+
+    let text = String::from_utf8_lossy(&stdout);
+    assert!(
+        !text.contains("Dep handoff: session ended"),
+        "dep handoff must never cross project boundaries; got:\n{text}"
+    );
+}
+
+/// `memory list` must NOT pull a `question` from a dep project.
+#[test]
+fn dep_question_is_never_surfaced_cross_project() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "question",
+        "Dep question: should we use SSE?",
+        "Only relevant within the dep project.",
+        &["locked"],
+        "active",
+    );
+
+    let raw = Command::cargo_bin("spelunk")
+        .unwrap()
+        .env("HOME", &home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&primary_root)
+        .arg("--config")
+        .arg(&primary_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&primary_mem)
+        .args(["list", "--format", "json"])
+        .output()
+        .expect("run spelunk");
+
+    let text = String::from_utf8_lossy(&raw.stdout);
+    if text.trim().starts_with('[') {
+        let notes: Vec<serde_json::Value> = serde_json::from_str(text.trim()).expect("valid JSON");
+        let titles: Vec<&str> = notes.iter().filter_map(|n| n["title"].as_str()).collect();
+        assert!(
+            !titles.contains(&"Dep question: should we use SSE?"),
+            "dep question must not cross boundary; got: {titles:?}"
+        );
+    }
+}
+
+// ── 10. Deduplication ─────────────────────────────────────────────────────────
+
+/// When primary has two direct deps (dep-a and dep-b), and both happen to have
+/// a note with the same (root_path, id) key, it must appear at most once.
+///
+/// In practice the dep-pass deduplication protects against diamond-shaped
+/// dependency graphs where two direct deps both link to a shared grandparent.
+/// Here we simulate the simpler scenario: two direct deps each with a unique
+/// entry to confirm no cross-dep pollution.
+#[test]
+fn multiple_deps_results_are_aggregated_not_duplicated() {
+    let tmp = TempDir::new().expect("create temp dir");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).expect("create home dir");
+
+    let primary_root_raw = tmp.path().join("primary");
+    fs::create_dir_all(&primary_root_raw).expect("primary dir");
+    let primary_index_raw = create_spelunk_dir(&primary_root_raw);
+    let primary_root = std::fs::canonicalize(&primary_root_raw).unwrap_or(primary_root_raw);
+    let primary_index = std::fs::canonicalize(&primary_index_raw).unwrap_or(primary_index_raw);
+    let primary_config = write_config(&primary_root, &primary_index);
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_a_root_raw = tmp.path().join("dep-a");
+    fs::create_dir_all(&dep_a_root_raw).expect("dep-a dir");
+    let dep_a_index_raw = create_spelunk_dir(&dep_a_root_raw);
+    let dep_a_root = std::fs::canonicalize(&dep_a_root_raw).unwrap_or(dep_a_root_raw);
+    let dep_a_index = std::fs::canonicalize(&dep_a_index_raw).unwrap_or(dep_a_index_raw);
+    let dep_a_mem = dep_a_index.with_file_name("memory.db");
+
+    let dep_b_root_raw = tmp.path().join("dep-b");
+    fs::create_dir_all(&dep_b_root_raw).expect("dep-b dir");
+    let dep_b_index_raw = create_spelunk_dir(&dep_b_root_raw);
+    let dep_b_root = std::fs::canonicalize(&dep_b_root_raw).unwrap_or(dep_b_root_raw);
+    let dep_b_index = std::fs::canonicalize(&dep_b_index_raw).unwrap_or(dep_b_index_raw);
+    let dep_b_mem = dep_b_index.with_file_name("memory.db");
+
+    // Seed a locked decision in each dep.
+    let conn_a = open_memory_db(&dep_a_mem);
+    seed_note(
+        &conn_a,
+        "decision",
+        "Dep-A policy",
+        "body",
+        &["locked"],
+        "active",
+    );
+    let conn_b = open_memory_db(&dep_b_mem);
+    seed_note(
+        &conn_b,
+        "decision",
+        "Dep-B policy",
+        "body",
+        &["locked"],
+        "active",
+    );
+
+    let reg = TestRegistry::new(&home);
+    let primary_id = reg.register(&primary_root, &primary_index);
+    let dep_a_id = reg.register(&dep_a_root, &dep_a_index);
+    let dep_b_id = reg.register(&dep_b_root, &dep_b_index);
+    reg.add_dep(primary_id, dep_a_id);
+    reg.add_dep(primary_id, dep_b_id);
+
+    let output = Command::cargo_bin("spelunk")
+        .unwrap()
+        .env("HOME", &home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&primary_root)
+        .arg("--config")
+        .arg(&primary_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&primary_mem)
+        .args(["list", "--format", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let notes: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("valid JSON");
+    let titles: Vec<&str> = notes.iter().filter_map(|n| n["title"].as_str()).collect();
+
+    // Both dep notes must appear exactly once each.
+    assert_eq!(
+        titles.iter().filter(|&&t| t == "Dep-A policy").count(),
+        1,
+        "Dep-A policy must appear exactly once; got: {titles:?}"
+    );
+    assert_eq!(
+        titles.iter().filter(|&&t| t == "Dep-B policy").count(),
+        1,
+        "Dep-B policy must appear exactly once; got: {titles:?}"
+    );
+}
+
+// ── 11. Missing dep memory.db is silently skipped ────────────────────────────
+
+/// A dep with no `memory.db` is skipped silently — no crash, no error in stdout.
+/// Other deps with a `memory.db` still contribute their results.
+#[test]
+fn missing_dep_memory_db_is_skipped_silently() {
+    let tmp = TempDir::new().expect("create temp dir");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).expect("create home dir");
+
+    let primary_root_raw = tmp.path().join("primary");
+    fs::create_dir_all(&primary_root_raw).expect("primary dir");
+    let primary_index_raw = create_spelunk_dir(&primary_root_raw);
+    let primary_root = std::fs::canonicalize(&primary_root_raw).unwrap_or(primary_root_raw);
+    let primary_index = std::fs::canonicalize(&primary_index_raw).unwrap_or(primary_index_raw);
+    let primary_config = write_config(&primary_root, &primary_index);
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    // dep-a: has a memory.db with a locked decision.
+    let dep_a_root_raw = tmp.path().join("dep-a");
+    fs::create_dir_all(&dep_a_root_raw).expect("dep-a dir");
+    let dep_a_index_raw = create_spelunk_dir(&dep_a_root_raw);
+    let dep_a_root = std::fs::canonicalize(&dep_a_root_raw).unwrap_or(dep_a_root_raw);
+    let dep_a_index = std::fs::canonicalize(&dep_a_index_raw).unwrap_or(dep_a_index_raw);
+    let dep_a_mem = dep_a_index.with_file_name("memory.db");
+    let conn_a = open_memory_db(&dep_a_mem);
+    seed_note(
+        &conn_a,
+        "decision",
+        "Dep-a locked decision",
+        "body",
+        &["locked"],
+        "active",
+    );
+
+    // dep-b: exists in registry but has NO memory.db.
+    let dep_b_root_raw = tmp.path().join("dep-b");
+    fs::create_dir_all(&dep_b_root_raw).expect("dep-b dir");
+    let dep_b_index_raw = create_spelunk_dir(&dep_b_root_raw);
+    let dep_b_root = std::fs::canonicalize(&dep_b_root_raw).unwrap_or(dep_b_root_raw);
+    let dep_b_index = std::fs::canonicalize(&dep_b_index_raw).unwrap_or(dep_b_index_raw);
+    // Deliberately do NOT create dep_b_index.with_file_name("memory.db").
+
+    let reg = TestRegistry::new(&home);
+    let primary_id = reg.register(&primary_root, &primary_index);
+    let dep_a_id = reg.register(&dep_a_root, &dep_a_index);
+    let dep_b_id = reg.register(&dep_b_root, &dep_b_index);
+    reg.add_dep(primary_id, dep_a_id);
+    reg.add_dep(primary_id, dep_b_id);
+
+    let output = Command::cargo_bin("spelunk")
+        .unwrap()
+        .env("HOME", &home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&primary_root)
+        .arg("--config")
+        .arg(&primary_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&primary_mem)
+        .args(["list", "--format", "json"])
+        .assert()
+        .success() // must NOT crash or fail even with a missing dep memory.db
+        .get_output()
+        .stdout
+        .clone();
+
+    let notes: Vec<serde_json::Value> = serde_json::from_slice(&output).expect("valid JSON");
+    let titles: Vec<&str> = notes.iter().filter_map(|n| n["title"].as_str()).collect();
+    assert!(
+        titles.contains(&"Dep-a locked decision"),
+        "dep-a result must appear despite dep-b having no memory.db; got: {titles:?}"
+    );
+}
+
+// ── 12. Security: SQL injection payload in dep note is inert ─────────────────
+
+/// SQL injection payload in a dep note title / body must not alter the DB or
+/// crash the CLI — parameterised queries must be used throughout.
+/// (SAMM v2 Verification — Security Testing, level 1.)
+#[test]
+fn sql_injection_in_dep_note_is_inert() {
+    let (_tmp, home, primary_root, primary_index, primary_config, _dep_root, dep_mem) =
+        setup_linked_projects();
+    let primary_mem = primary_index.with_file_name("memory.db");
+
+    let dep_conn = open_memory_db(&dep_mem);
+    seed_note(
+        &dep_conn,
+        "decision",
+        "'; DROP TABLE notes; --",
+        "body: \" OR 1=1; --",
+        &["locked"],
+        "active",
+    );
+    // A benign note to verify the notes table survived the payload.
+    seed_note(
+        &dep_conn,
+        "decision",
+        "Benign note after injection payload",
+        "This note must still exist.",
+        &["locked"],
+        "active",
+    );
+
+    let output = memory_cmd(&home, &primary_root, &primary_config, &primary_mem)
+        .args(["list", "--format", "json"])
+        .assert()
+        .success() // must not crash
+        .get_output()
+        .stdout
+        .clone();
+
+    let notes: Vec<serde_json::Value> =
+        serde_json::from_slice(&output).expect("valid JSON after injection payload");
+    let titles: Vec<&str> = notes.iter().filter_map(|n| n["title"].as_str()).collect();
+    assert!(
+        titles.contains(&"Benign note after injection payload"),
+        "notes table must survive injection payload; got: {titles:?}"
+    );
+}
+
+// ── 13. MemoryStore unit assertions ───────────────────────────────────────────
+//
+// These exercise spelunk-core's MemoryStore directly (no CLI binary) to assert
+// the storage-layer preconditions that the dep-pass relies on.
+
+/// `MemoryStore::list` excludes archived notes when `include_archived=false`
+/// (the precondition for the dep-pass not surfacing archived entries).
+#[test]
+fn memory_store_list_excludes_archived_by_default() {
+    register_sqlite_vec_once();
+
+    use spelunk_core::storage::memory::MemoryStore;
+    let store = MemoryStore::open(std::path::Path::new(":memory:")).expect("in-memory MemoryStore");
+
+    store
+        .add_note("decision", "Active note", "body", &[], &[], None, None)
+        .expect("add active note");
+    let archived_id = store
+        .add_note("decision", "Archived note", "body", &[], &[], None, None)
+        .expect("add to-be-archived note");
+    store.archive(archived_id).expect("archive note");
+
+    let notes = store
+        .list(Some("decision"), 100, false)
+        .expect("list notes");
+    let titles: Vec<&str> = notes.iter().map(|n| n.title.as_str()).collect();
+    assert!(titles.contains(&"Active note"), "active note must appear");
+    assert!(
+        !titles.contains(&"Archived note"),
+        "archived note must be excluded; got: {titles:?}"
+    );
+}
+
+/// `MemoryStore::list` returns `Note` instances with `source_project == None` —
+/// that field is populated exclusively by the CLI dep-pass, not by the store.
+#[test]
+fn memory_store_notes_have_no_source_project_by_default() {
+    register_sqlite_vec_once();
+
+    use spelunk_core::storage::memory::MemoryStore;
+    let store = MemoryStore::open(std::path::Path::new(":memory:")).expect("in-memory MemoryStore");
+
+    store
+        .add_note(
+            "decision",
+            "Some decision",
+            "body",
+            &["locked"],
+            &[],
+            None,
+            None,
+        )
+        .expect("add note");
+
+    let notes = store.list(Some("decision"), 100, false).expect("list");
+    assert_eq!(notes.len(), 1);
+    assert!(
+        notes[0].source_project.is_none(),
+        "MemoryStore must not set source_project — CLI dep-pass sets it"
+    );
+    assert!(
+        notes[0].source_project_path.is_none(),
+        "MemoryStore must not set source_project_path — CLI dep-pass sets it"
+    );
+}

--- a/crates/spelunk-core/src/storage/memory/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/mod.rs
@@ -49,6 +49,14 @@ pub struct Note {
     /// Fused relevance score — only populated by hybrid search, None otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score: Option<f64>,
+    /// Set only for notes returned via cross-project dep pass. None for local notes.
+    /// Contains the dep project's display name (final path component of root_path).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_project: Option<String>,
+    /// Set alongside source_project: the dep project's root path, for disambiguation
+    /// when two linked projects share a display name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_project_path: Option<String>,
 }
 
 impl MemoryStore {

--- a/crates/spelunk-core/src/storage/memory/notes.rs
+++ b/crates/spelunk-core/src/storage/memory/notes.rs
@@ -21,6 +21,8 @@ pub(super) fn row_to_note(row: &rusqlite::Row<'_>) -> rusqlite::Result<Note> {
         invalid_at: row.get(11)?,
         distance: None,
         score: None,
+        source_project: None,
+        source_project_path: None,
     })
 }
 
@@ -40,6 +42,8 @@ pub(super) fn row_to_note_with_distance(row: &rusqlite::Row<'_>) -> rusqlite::Re
         invalid_at: row.get(11)?,
         distance: Some(row.get(12)?),
         score: None,
+        source_project: None,
+        source_project_path: None,
     })
 }
 

--- a/crates/spelunk-core/src/storage/note_record.rs
+++ b/crates/spelunk-core/src/storage/note_record.rs
@@ -45,6 +45,8 @@ pub fn record_to_note(r: NoteRecord) -> Note {
         invalid_at: r.invalid_at,
         distance: None,
         score: None,
+        source_project: None,
+        source_project_path: None,
     }
 }
 

--- a/crates/spelunk-core/src/storage/remote/wire_types.rs
+++ b/crates/spelunk-core/src/storage/remote/wire_types.rs
@@ -72,6 +72,8 @@ impl From<NoteResponse> for Note {
             invalid_at: r.invalid_at,
             distance: r.distance,
             score: None,
+            source_project: None,
+            source_project_path: None,
         }
     }
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -198,12 +198,19 @@ spelunk context [options]
 | `--path <path>` | — | Only show entries tagged with this file/directory |
 | `--format text\|json` | text | Output format |
 | `--no-conventions` | false | Skip the conventions section |
+| `--local-only` | false | Skip cross-project dep pass; query only the primary project's memory |
+
+When projects are linked with `spelunk link`, `context` also surfaces `locked`
+or `cross-project`-tagged `decision` and `requirement` entries from linked
+projects' memory stores, each labelled with its source project. Pass
+`--local-only` to suppress this behaviour. See [Memory](memory.md#cross-project-visibility).
 
 **Example:**
 
 ```bash
 spelunk context
 spelunk context --kind decision
+spelunk context --local-only      # primary project only, no dep pass
 AGENT=true spelunk context        # JSON for machine processing
 ```
 
@@ -269,7 +276,9 @@ spelunk languages
 ## spelunk link / spelunk unlink / spelunk links
 
 Add or remove a project dependency. When linked, `spelunk search` also queries
-the linked project's index. `spelunk links` inspects existing links.
+the linked project's index, and `spelunk memory search|list|context` surfaces
+`locked`/`cross-project`-tagged decisions and requirements from the linked
+project's memory store. `spelunk links` inspects existing links.
 
 ```
 spelunk link <path>
@@ -347,8 +356,8 @@ Store and query project context, decisions, and requirements. See
 ```
 spelunk memory add --title "..." [--body "..."] [--kind decision] [--tags auth,db] [--files src/auth.rs]
 spelunk memory add --from-url <url> [--title "override"] [--kind requirement]
-spelunk memory search <query> [--limit 10] [--format text|json]
-spelunk memory list [--kind decision] [--limit 20] [--format text|json]
+spelunk memory search <query> [--limit 10] [--format text|json] [--local-only]
+spelunk memory list [--kind decision] [--limit 20] [--format text|json] [--local-only]
 spelunk memory show <id> [--format text|json]
 spelunk memory harvest [--git-range HEAD~10..HEAD] [--source git|claude-code|failures]
 spelunk memory failures                    # list all antipatterns
@@ -364,6 +373,11 @@ spelunk memory reconcile [--dry-run] [--all-projects] [--source-db <path>]
 
 All `memory` subcommands accept `--backend sqlite|git-notes` (default `sqlite`)
 and `--db <path>`.
+
+`memory search` and `memory list` accept `--local-only` to skip the
+cross-project dep pass (see [Cross-project visibility](memory.md#cross-project-visibility)).
+Results from linked projects carry a `[from: <project>]` badge in text output
+and `source_project` / `source_project_path` fields in JSON.
 
 **Memory kinds:** `decision` · `context` · `requirement` · `note` · `intent` ·
 `answer` · `handoff` · `question` · `antipattern`

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -141,6 +141,81 @@ spelunk memory list --source-ref abc1234
 
 `question` and `answer` entries show titles only in list view to avoid context saturation. Use `spelunk memory show <id>` to read the full body.
 
+## Cross-project visibility
+
+When projects are linked with `spelunk link`, `spelunk memory search`,
+`spelunk memory list`, and `spelunk context` automatically surface relevant
+memory from linked projects alongside local results. This is how settled
+decisions recorded in one project (for example, a Cloud-only architecture
+constraint in `cloud-api`) remain visible to agents working in a sibling
+project (for example, `spelunk-oss`).
+
+### What crosses project boundaries
+
+Not all memory propagates. Only entries that match **all three** of the
+following criteria are surfaced from a linked project:
+
+- **Kind:** `decision` or `requirement` (never `handoff`, `question`, or `note`).
+- **Tag:** must carry the tag `locked` (for settled v1 decisions) or
+  `cross-project` (for cross-cutting items that are not otherwise locked). Tags
+  like `auth` or `database` alone are not sufficient.
+- **Status:** `active` only. Archived or superseded cross-project decisions do
+  not resurface after they are retracted in the source project.
+
+Decisions and requirements that do not carry `locked` or `cross-project` remain
+strictly project-local, regardless of which `spelunk link` edges are configured.
+
+### Source attribution
+
+Every result from a linked project is labelled with its origin so conflicting
+decisions between projects are visible and attributable:
+
+- **Text output:** a `[from: <project>]` badge appended to the entry line.
+- **JSON output:** `source_project` and `source_project_path` fields on the
+  note object (absent on local results, so existing JSON consumers are
+  unaffected).
+
+Local results always appear first; cross-project results are appended, in
+registry dependency order, after all local results. The existing `--limit` flag
+applies only to the local query; cross-project results are additional and not
+counted against the limit.
+
+### Skipping the dep pass
+
+Pass `--local-only` to any of `memory search`, `memory list`, or `context` to
+query only the primary project's memory store:
+
+```bash
+spelunk memory search "auth decisions" --local-only
+spelunk memory list --kind decision --local-only
+spelunk context --local-only
+```
+
+### Tagging decisions for cross-project visibility
+
+```bash
+# Tag a decision as locked so linked projects can see it
+spelunk memory add --kind decision \
+  --title "SSE memory stream is Cloud-only" \
+  --body "OSS spelunk-server must not expose SSE; Cloud API owns that surface." \
+  --tags v1,locked
+
+# Tag a requirement that applies across all linked projects
+spelunk memory add --kind requirement \
+  --title "All writes validated for secrets before storage" \
+  --body "Applies to cloud-api and spelunk-oss alike." \
+  --tags security,cross-project
+```
+
+### Privacy boundary
+
+The dep pass reads each linked project's `memory.db` directly from disk (local
+SQLite only). It does not route through `spelunk-server` or any remote endpoint.
+A linked project's memory is only reachable if its `memory.db` file is
+accessible on the local filesystem (same machine, same user). Remote or
+server-backed linked projects whose memory lives exclusively on a remote server
+are not queried by the dep pass in v1.
+
 ## Showing a single entry
 
 ```bash


### PR DESCRIPTION
## Summary

Closes the tooling gap identified in the 2026-06-11 SSE/local-server incident (root cause: a `locked` cloud-api decision was invisible to an agent working in spelunk-oss, even though `spelunk link` was already in place). Backlog item P1-4 (WS-1 Security).

- Implements ADR-003 cross-project memory visibility: `spelunk memory search`, `spelunk memory list`, and `spelunk context` now surface `locked`/`cross-project`-tagged decisions and requirements from linked projects' memory stores after querying the local backend.
- Adds `source_project`/`source_project_path` fields to the `Note` struct; renders a `[from: <project>]` badge in text output; absent on local notes (zero JSON consumer breakage).
- Adds `--local-only` flag to all three commands, mirroring `spelunk search --local-only`.
- Graceful degradation: missing dep `memory.db` → silent skip; open/query error → `tracing::warn!` + skip (matches `search_all_dbs_linearrag` behaviour).
- Privacy boundary enforced: only `kind == decision|requirement`, `status == active`, and tagged `locked` or `cross-project` entries cross project boundaries. All other memory remains strictly project-local.
- 22 integration tests covering: multi-project aggregation, source tagging, privacy boundary, `--local-only`, archived-entry suppression, handoff/question isolation, deduplication, missing-dep silent-skip, SQL-injection inertness, and MemoryStore unit preconditions.

## Refs

- Backlog: P1-4 (WS-1 Security, cross-project memory blindness)
- ADR-003: `docs/adr/003-cross-project-memory-visibility.md`
- SSE incident: spelunk-oss issues #375, PRs #379/#384 (closed invalid); cloud-api PR #36 (closed invalid)
- ADR status: Approved (see commit `3fbf1a1` — "docs(adr-003): mark Status Approved per Johan review")

## Test plan

- All 22 new integration tests pass: `cargo test -p spelunk-cli --test cross_project_memory`
- All `spelunk-core` unit tests pass: `cargo test -p spelunk-core`
- `cargo fmt --check`: clean
- `cargo clippy -p spelunk-cli -p spelunk-core -- -D warnings`: clean
- Pre-existing failures (`e2e_cli::test_index_prints_note_when_no_server_configured` and `test_search_explicit_hybrid_no_embedder_falls_back_to_text`) are on the base branch and tracked separately in story-testfix; not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)