### PR TITLE
fix(test): update stale e2e assertions for ADR-004 inference-only routing

### DIFF
--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -725,7 +725,9 @@ async fn test_index_prints_note_when_no_server_configured() {
         .arg(&project_dir)
         .assert()
         .success()
-        .stderr(predicate::str::contains("no server_url configured"));
+        .stderr(predicate::str::contains(
+            "Skipping summaries (no server_url configured)",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two e2e assertions in `crates/spelunk-cli/tests/e2e_cli.rs` were stale after the ADR-004 implementation (PR #390):

- `test_index_prints_note_when_no_server_configured`: the index command now emits `"Skipping summaries (no server_url configured)"` rather than the old `"configure server_url"` hint. Updated to match the string in `summaries.rs:26`.
- `test_search_explicit_hybrid_no_embedder_falls_back_to_text`: under ADR-004 the loopback server is inference-only; when unreachable the CLI falls back to FTS silently. Replaced the old `"[server unreachable — using text search]"` stderr notice assertion with `is_empty()`.

No production code was modified — test file only.

## Test plan

- `cargo test -p spelunk-cli -- test_index_prints_note_when_no_server_configured` passes
- `cargo test -p spelunk-cli -- test_search_explicit_hybrid_no_embedder_falls_back_to_text` passes
- No new test failures introduced by this commit (pre-existing `harvest_upfront_check` failures are environment-related and pre-date this change)

## Security review

- No SQL string formatting
- No new chunk-storage paths
- No credentials or tokens
- No new dependencies
- Test-only change; no trust-boundary impact

Refs: ADR-004 (`docs/adr/004-unified-memory-storage.md`), PR #390 (implementation), story-testfix-20260613-1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)