### PR TITLE
chore(security): verify gix/gitoxide Dependabot alerts resolved (P1-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- **gix/gitoxide Dependabot alerts verified resolved (P1-2).** All 7 open Dependabot
+  security alerts (6 high, 1 medium) for gix-related crates were already cleared by
+  previous bumps (PRs #307, #327, #334). Cargo.lock contains patched versions:
+  gix 0.84.0 (>=0.83.0), gix-fs 0.21.2 (>=0.21.1), gix-pack 0.71.0 (>=0.69.0),
+  gix-transport 0.57.1 (>=0.56.0). `cargo audit` returns zero vulnerabilities;
+  one allowed warning (RUSTSEC-2024-0436 paste unmaintained, in audit.toml).
+  Affected advisories: GHSA-fr8x-3vfx-f45h, GHSA-pg4w-g64p-qwhj, GHSA-f26g-jm89-4g65,
+  GHSA-p3hw-mv63-rf9w, GHSA-f89h-2fjh-2r9q, GHSA-x494-mj8g-cj27, GHSA-9857-6mw7-fq2m.
+
 ### Added
 
 - **`spelunk memory reconcile`** — import memory entries from a `spelunk-server` SQLite


### PR DESCRIPTION
## Summary

- Documents that all 7 open gix/gitoxide Dependabot security alerts (6 high, 1 medium) were already resolved by prior PRs (#307, #327, #334).
- Locked versions in Cargo.lock — gix 0.84.0, gix-fs 0.21.2, gix-pack 0.71.0, gix-transport 0.57.1 — exceed every advisory patched threshold.
- `cargo audit` returns zero vulnerabilities (1 allowed unmaintained warning for `paste`, documented in audit.toml).
- CHANGELOG-only change; no production code or Cargo.lock modified.

## Advisories resolved

GHSA-fr8x-3vfx-f45h, GHSA-pg4w-g64p-qwhj, GHSA-f26g-jm89-4g65, GHSA-p3hw-mv63-rf9w (gix), GHSA-f89h-2fjh-2r9q (gix-fs), GHSA-x494-mj8g-cj27 (gix-pack), GHSA-9857-6mw7-fq2m (gix-transport).

## Test plan

- `cargo audit` — zero vulnerabilities confirmed by Test Engineer.
- `cargo test` — only 2 pre-existing `harvest_upfront_check` failures unrelated to this change (same failures on main). All other tests pass.
- `cargo clippy` — clean.
- No Cargo.lock or source changes; verification only.

## Security review

- No SQL string formatting or credential exposure introduced.
- No new dependencies added.
- `cargo audit` clean; RUSTSEC ignore in audit.toml (paste unmaintained) has documented reason.
- CHANGELOG-only commit; scope is security verification, not new code.

Closes P1-2 from engineering/backlog.md.