### PR TITLE
release: spelunk 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   security alerts (6 high, 1 medium) for gix-related crates were already cleared by
   previous bumps (PRs #307, #327, #334). Cargo.lock contains patched versions:
   gix 0.84.0 (>=0.83.0), gix-fs 0.21.2 (>=0.21.1), gix-pack 0.71.0 (>=0.69.0),
-  gix-transport 0.57.1 (>=0.56.0). `cargo audit` returns zero vulnerabilities;
-  one allowed warning (RUSTSEC-2024-0436 paste unmaintained, in audit.toml).
+  gix-transport 0.57.1 (>=0.56.0). `cargo audit` returns zero vulnerabilities
+  (exit 0); the unmaintained `paste` crate surfaces as a non-failing warning
+  (RUSTSEC-2024-0436), and the one advisory suppressed in audit.toml is
+  RUSTSEC-2026-0097 (rand 0.10.0 via lopdf, no patched release yet).
   Affected advisories: GHSA-fr8x-3vfx-f45h, GHSA-pg4w-g64p-qwhj, GHSA-f26g-jm89-4g65,
   GHSA-p3hw-mv63-rf9w, GHSA-f89h-2fjh-2r9q, GHSA-x494-mj8g-cj27, GHSA-9857-6mw7-fq2m.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-06-15
+
 ### Security
 
 - **gix/gitoxide Dependabot alerts verified resolved (P1-2).** All 7 open Dependabot
@@ -44,18 +46,13 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   (ADR-003)
 
 - **`spelunk memory reconcile`** — imports notes from a local `spelunk-server`
-  database (`server.db`) into the project's `memory.db` by content-hash dedup.
-  Reads `server.db` in read-only mode; never writes to it. Supports `--dry-run`
-  (report candidates without importing), `--json` (NDJSON summary), and
-  `--all-projects` (reconcile every project slug found in `server.db`). Exits
-  with code 0 when there is nothing to import. Key flag: `--source-db <path>`
-  overrides the default source path (`~/.local/state/spelunk/server.db`).
-  (#391, ADR-004 follow-up)
-
-- **`spelunk memory reconcile`** — import memory entries from a `spelunk-server` SQLite
-  database into the local project database without running the server. Flags:
-  `--source-db <path>`, `--dry-run` (preview without writing), `--all-projects`
-  (import across all server projects), `--format json` (machine-readable output).
+  database (`server.db`) into the project's `memory.db` by content-hash dedup,
+  without running the server. Reads `server.db` in read-only mode; never writes
+  to it. Flags: `--source-db <path>` (override the default source path
+  `~/.local/state/spelunk/server.db`), `--dry-run` (report candidates without
+  importing), `--all-projects` (reconcile every project slug found in
+  `server.db`), and `--format json` (machine-readable summary). Exits with code
+  0 when there is nothing to import. (#391, ADR-004 follow-up)
 
 ### Fixed
 
@@ -68,6 +65,12 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   inadvertently hidden from the top-level help output; the hide attribute has
   been removed so users can discover it alongside the other subcommands.
   ([#400](https://github.com/spelunk-cloud/spelunk/issues/400))
+
+### Dependencies
+
+- `openssl` 0.10.80 → 0.10.81 (#408)
+- `openssl-sys` 0.9.116 → 0.9.117 (#410)
+- `regex` 1.12.3 → 1.12.4 (#409)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"


### PR DESCRIPTION
Release PR for **spelunk 0.8.2**. Cuts from current `main` after today's sweep. No major change is outstanding in spelunk-oss (the only open PRs are the bench set #377 and the docs-only security specs #411/#412, both merged; the queued security code-fixes #403/#404/#405/#406 are slated for a later release).

## What's in this PR
- Version bump `0.8.1` -> `0.8.2` across all three crates (`spelunk-core`, `spelunk-cli`, `spelunk-server`) + `Cargo.lock`.
- `CHANGELOG.md` rolled: `[Unreleased]` -> `[0.8.2] — 2026-06-15`, fresh empty `[Unreleased]` added.

## 0.8.2 highlights (from the changelog)
- **Security:** `spelunk memory add` now blocks the entire write (SQLite + git-notes) on secret detection (#344); gix/gitoxide Dependabot alerts verified resolved (P1-2).
- **Added:** cross-project memory visibility for `memory search|list|context` with source-project tagging (ADR-003); `--local-only` flag; `spelunk memory reconcile` (import from a local `server.db`).
- **Fixed:** `memory watch --help` references `server_url` correctly; `explore` shows in top-level `--help` (#400).
- **Dependencies:** openssl, openssl-sys, regex bumps.

## Reviews completed (pre-PR, per request)
- **Docs Writer:** rolled the changelog, merged a duplicate `memory reconcile` bullet (flags verified against the clap args), added the `Dependencies` section (matching the 0.7.1 convention), swept docs/README for stale hardcoded versions (none).
- **QA Reviewer:** release-readiness gate. Build green; `cargo test` 365 passed / 0 failed (core+cli+server); `cargo audit` exit 0, zero vulns. Caught one changelog inaccuracy in the gix entry (it misattributed the `audit.toml` suppression) — corrected in commit `cabf8e4` (the suppressed advisory is RUSTSEC-2026-0097 / rand-via-lopdf; the `paste` advisory RUSTSEC-2024-0436 is a non-failing warning).

## Test plan
- `cargo build --release` succeeds in the release worktree.
- `cargo test -p spelunk-core -p spelunk-cli -p spelunk-server` -> 365 passed, 0 failed.
- `cargo audit` -> exit 0, zero vulnerabilities (one allowed paste warning; one suppressed advisory in audit.toml).
- Verified `0.8.2` in all three crate `Cargo.toml` + `Cargo.lock`, matching the `## [0.8.2]` changelog heading.
- `grep -rn "spelunk-v[0-9]\|spelunk_[0-9]" docs/ README.md` -> only the intentional illustrative download-URL examples in `docs/releasing.md`.

## After merge (release-engineering, owner: Johan)
Per `docs/releasing.md`, the release is tag-triggered. After merging this PR to `main`:

    git tag v0.8.2 && git push origin v0.8.2

That fires `.github/workflows/release.yml` (multi-platform binaries, `.deb`, GitHub Release with auto-notes, Homebrew formula update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)