### PR TITLE
fix(fuzz): suppress upstream tree-sitter-sequel scanner leak

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,6 +34,20 @@ jobs:
       - name: Install cargo-fuzz
         run: cargo-fuzz --version 2>/dev/null || cargo +nightly install cargo-fuzz --locked
 
+      # LeakSanitizer suppressions (fuzz/lsan.suppressions) are matched against
+      # symbolized frames, so a working llvm-symbolizer must be discoverable;
+      # otherwise leak stacks stay raw and the suppression cannot match.
+      - name: Ensure leak-stack symbolization
+        run: |
+          SYM="$(command -v llvm-symbolizer || ls /usr/bin/llvm-symbolizer* /usr/lib/llvm-*/bin/llvm-symbolizer 2>/dev/null | sort -V | tail -1 || true)"
+          if [ -z "$SYM" ]; then
+            sudo apt-get update && sudo apt-get install -y llvm
+            SYM="$(ls /usr/bin/llvm-symbolizer* | sort -V | tail -1)"
+          fi
+          echo "Using symbolizer: $SYM"
+          echo "ASAN_SYMBOLIZER_PATH=$SYM" >> "$GITHUB_ENV"
+          echo "LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/fuzz/lsan.suppressions" >> "$GITHUB_ENV"
+
       - name: Run fuzzer (60 s)
         run: cargo +nightly fuzz run fuzz_parser -- -max_total_time=60
 

--- a/fuzz/lsan.suppressions
+++ b/fuzz/lsan.suppressions
@@ -1,0 +1,19 @@
+# LeakSanitizer suppressions for the fuzz targets.
+#
+# Scope: ONLY the upstream tree-sitter-sequel (SQL grammar) external scanner.
+# Leak detection stays ON for everything else, including all of our own Rust.
+#
+# tree-sitter-sequel 0.3.11 ships a hand-written C scanner (src/scanner.c) that
+# leaks the dollar-quote `start_tag` allocation on malformed PostgreSQL
+# dollar-quoted input (e.g. `4$64$$`):
+#   * deserialize() overwrites state->start_tag without freeing the old one
+#   * serialize() frees start_tag, violating the read-only serialize contract
+# 0.3.11 is the latest release, so there is no version to bump to.
+#
+# All allocations on the leak path unwind through the uniquely-named external
+# scanner entry points (tree_sitter_sql_external_scanner_{scan,deserialize,...}),
+# so this single substring suppresses the upstream leak without masking ours.
+#
+# TODO(upstream): remove once fixed in tree-sitter-sequel. Upstream project:
+# https://github.com/derekstride/tree-sitter-sql (leak in external scanner)
+leak:tree_sitter_sql_external_scanner


### PR DESCRIPTION
## What

With the build fix ([#417](https://github.com/spelunk-cloud/spelunk/pull/417)) in place, the `fuzz_parser` target now actually runs — and immediately trips **LeakSanitizer** on malformed PostgreSQL dollar-quoted input (e.g. `4$64$$`):

```
SUMMARY: AddressSanitizer: 10 byte(s) leaked in 2 allocation(s).
```

## Root cause (upstream, not our code)

The leak is in **`tree-sitter-sequel` 0.3.11**'s hand-written C external scanner (`src/scanner.c`):

- `tree_sitter_sql_external_scanner_deserialize()` overwrites `state->start_tag` **without freeing the existing allocation**.
- `tree_sitter_sql_external_scanner_serialize()` **frees `start_tag`**, violating tree-sitter's read-only serialize contract.

Our wrapper [`SourceParser::parse`](crates/spelunk-core/src/indexer/parser/mod.rs:131) is clean RAII (both `Tree` and `Parser` are dropped). 0.3.11 is the latest release, so there's no version to bump to. Upstream: https://github.com/derekstride/tree-sitter-sql

## Fix

Scope a LeakSanitizer **suppression** to the upstream scanner's uniquely-named external entry points rather than disabling leak detection wholesale — leak detection stays ON for all of our own Rust.

- Add [`fuzz/lsan.suppressions`](fuzz/lsan.suppressions): `leak:tree_sitter_sql_external_scanner` (every allocation on the leak path unwinds through `tree_sitter_sql_external_scanner_{scan,deserialize,…}`).
- Wire `LSAN_OPTIONS=suppressions=…` into the fuzz job.
- Suppressions match **symbolized** frames, and the prior run's leak stacks were raw addresses — so the job now also ensures `llvm-symbolizer` is discoverable (`ASAN_SYMBOLIZER_PATH`).

## Dependency

Logically depends on [#417](https://github.com/spelunk-cloud/spelunk/pull/417) (the fuzz crate must build before the fuzzer can run). The two PRs touch disjoint files and can merge in either order.

## Test plan

1. **End-to-end CI**: dispatched the Fuzz workflow on a throwaway branch carrying both this change and #417 — `fuzz_parser` runs the full 60 s without LSan failing on the SQL dollar-quote input. (Run link added as a comment below.)
2. `cargo +nightly fmt --check` + `cargo clippy` (full workspace) pass via the pre-commit hook.
3. Sanity that the suppression is *scoped*, not blanket: it names only `tree_sitter_sql_external_scanner`, so a leak introduced anywhere in our own code would still fail the job.