### PR TITLE
fix(storage): parameterise SQL IN-clauses with bind-limit chunking (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- **Storage SQL `IN (...)` queries are now fully parameterised and bind-limit
+  chunked.** The four list-based query methods (`chunks_by_ids`,
+  `graph_neighbor_chunks`, `mention_edges_for_chunks`, `chunks_mentioning_symbols`)
+  previously assembled their `IN (...)` placeholder list at runtime with `format!`.
+  No caller value was ever interpolated into the SQL text, so there was no active
+  injection vector, but the hand-built placeholder construction was a latent
+  hazard. A shared `placeholders(n)` helper now emits the placeholder list and all
+  values are bound positionally via rusqlite params, so no caller-supplied id,
+  name, or symbol can reach the SQL string. Each method also chunks its input at
+  the SQLite bind-parameter limit (halved for the two-clause `graph_neighbor_chunks`)
+  and merges results with unchanged semantics, removing the prior cap on input
+  list size. Internal change only; no user-facing behaviour change.
+  ([#405](https://github.com/spelunk-cloud/spelunk/issues/405))
+
 ## [0.8.2] — 2026-06-15
 
 ### Security

--- a/crates/spelunk-core/src/storage/chunks.rs
+++ b/crates/spelunk-core/src/storage/chunks.rs
@@ -218,3 +218,86 @@ impl Database {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Database;
+    use std::sync::OnceLock;
+
+    /// Register the sqlite-vec extension exactly once per test process.
+    fn register_sqlite_vec() {
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            #[allow(clippy::missing_transmute_annotations)]
+            unsafe {
+                rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                    sqlite_vec::sqlite3_vec_init as *const (),
+                )));
+            }
+        });
+    }
+
+    fn open_db() -> Database {
+        register_sqlite_vec();
+        Database::open(std::path::Path::new(":memory:")).expect("failed to open in-memory Database")
+    }
+
+    /// Insert two chunks and return their ids.
+    fn seed_two_chunks(db: &Database) -> (i64, i64) {
+        let file_id = db
+            .upsert_file("src/lib.rs", Some("rust"), "deadbeef")
+            .expect("upsert file");
+        let a = db
+            .insert_chunk(file_id, "function", Some("a"), 1, 5, "fn a() {}", None, 4)
+            .expect("insert a");
+        let b = db
+            .insert_chunk(file_id, "function", Some("b"), 6, 9, "fn b() {}", None, 4)
+            .expect("insert b");
+        (a, b)
+    }
+
+    #[test]
+    fn chunks_by_ids_empty_input_early_return() {
+        let db = open_db();
+        seed_two_chunks(&db);
+        assert!(
+            db.chunks_by_ids(&[]).expect("empty ok").is_empty(),
+            "chunks_by_ids must early-return [] on empty input"
+        );
+    }
+
+    /// Chunking across SQLITE_MAX_BIND (issue #405 §3): an input list longer
+    /// than the bind budget must run multiple statements without a prepare/bind
+    /// error and concatenate the result vecs, matching the single-statement
+    /// result for the real ids.
+    #[test]
+    fn chunks_by_ids_chunks_and_concatenates() {
+        use super::super::sql::SQLITE_MAX_BIND;
+
+        let db = open_db();
+        let (a, b) = seed_two_chunks(&db);
+
+        // Baseline: both real ids in one statement.
+        let single = db.chunks_by_ids(&[a, b]).expect("single-chunk query");
+        let mut single_ids: Vec<i64> = single.iter().map(|r| r.chunk_id).collect();
+        single_ids.sort();
+        assert_eq!(single_ids, vec![a, b], "baseline returns both chunks");
+
+        // Drive with > SQLITE_MAX_BIND ids: the two real ids plus filler that
+        // matches no row. This straddles the chunk boundary.
+        let mut ids: Vec<i64> = vec![a, b];
+        ids.extend((0..(SQLITE_MAX_BIND as i64 + 5)).map(|n| 1_000_000 + n));
+        assert!(ids.len() > SQLITE_MAX_BIND, "must exceed the bind budget");
+
+        let merged = db
+            .chunks_by_ids(&ids)
+            .expect("multi-chunk query must not hit a prepare/bind limit");
+
+        let mut merged_ids: Vec<i64> = merged.iter().map(|r| r.chunk_id).collect();
+        merged_ids.sort();
+        assert_eq!(
+            merged_ids, single_ids,
+            "concatenated chunked result must equal the single-statement result"
+        );
+    }
+}

--- a/crates/spelunk-core/src/storage/chunks.rs
+++ b/crates/spelunk-core/src/storage/chunks.rs
@@ -68,44 +68,45 @@ impl Database {
         if ids.is_empty() {
             return Ok(vec![]);
         }
-        let placeholders = ids
-            .iter()
-            .enumerate()
-            .map(|(i, _)| format!("?{}", i + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let sql = format!(
-            "SELECT c.id, 0.0, c.node_type, c.name,
-                    CAST(c.start_line AS INTEGER), CAST(c.end_line AS INTEGER),
-                    c.content, f.path, f.language, c.token_count
-             FROM chunks c
-             JOIN files f ON f.id = c.file_id
-             WHERE c.id IN ({placeholders})"
-        );
-        let mut stmt = self.conn.prepare(&sql)?;
-        let params: Vec<&dyn rusqlite::ToSql> =
-            ids.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
-        let rows = stmt.query_map(params.as_slice(), |row| {
-            Ok(crate::search::SearchResult {
-                chunk_id: row.get(0)?,
-                distance: row.get(1)?,
-                node_type: row.get(2)?,
-                name: row.get(3)?,
-                start_line: row.get::<_, i64>(4)? as usize,
-                end_line: row.get::<_, i64>(5)? as usize,
-                content: row.get(6)?,
-                file_path: row.get(7)?,
-                language: row.get(8)?,
-                from_graph: false,
-                governing_specs: vec![],
-                token_count: row.get::<_, i64>(9)? as usize,
-                project_name: None,
-                project_path: None,
-                summary: None,
-            })
-        })?;
-        rows.collect::<rusqlite::Result<Vec<_>>>()
-            .map_err(Into::into)
+        let mut out = Vec::new();
+        for chunk in ids.chunks(super::sql::SQLITE_MAX_BIND) {
+            let ph = super::sql::placeholders(chunk.len());
+            let sql = format!(
+                "SELECT c.id, 0.0, c.node_type, c.name,
+                        CAST(c.start_line AS INTEGER), CAST(c.end_line AS INTEGER),
+                        c.content, f.path, f.language, c.token_count
+                 FROM chunks c
+                 JOIN files f ON f.id = c.file_id
+                 WHERE c.id IN ({ph})"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let params: Vec<&dyn rusqlite::ToSql> =
+                chunk.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
+            debug_assert_eq!(params.len(), chunk.len());
+            let rows = stmt.query_map(params.as_slice(), |row| {
+                Ok(crate::search::SearchResult {
+                    chunk_id: row.get(0)?,
+                    distance: row.get(1)?,
+                    node_type: row.get(2)?,
+                    name: row.get(3)?,
+                    start_line: row.get::<_, i64>(4)? as usize,
+                    end_line: row.get::<_, i64>(5)? as usize,
+                    content: row.get(6)?,
+                    file_path: row.get(7)?,
+                    language: row.get(8)?,
+                    from_graph: false,
+                    governing_specs: vec![],
+                    token_count: row.get::<_, i64>(9)? as usize,
+                    project_name: None,
+                    project_path: None,
+                    summary: None,
+                })
+            })?;
+            for row in rows {
+                out.push(row?);
+            }
+        }
+        Ok(out)
     }
 
     /// Return all chunks for a file path (exact match or LIKE suffix).

--- a/crates/spelunk-core/src/storage/graph.rs
+++ b/crates/spelunk-core/src/storage/graph.rs
@@ -255,6 +255,55 @@ mod tests {
         Database::open(std::path::Path::new(":memory:")).expect("failed to open in-memory Database")
     }
 
+    /// Insert one named chunk in `src/lib.rs` and return its chunk id.
+    fn insert_named_chunk(db: &Database, file_id: i64, name: &str) -> i64 {
+        db.insert_chunk(
+            file_id,
+            "function",
+            Some(name),
+            1,
+            5,
+            &format!("fn {name}() {{}}"),
+            None,
+            4,
+        )
+        .expect("insert chunk")
+    }
+
+    /// Build a small, fully-known graph dataset:
+    ///   chunks: caller (fn), callee (fn)
+    ///   edges:  caller --calls--> callee   (structural)
+    ///           caller --mentions--> mentioned_sym
+    ///           caller --calls--> real_target
+    /// Returns (file_id, caller_id, callee_id).
+    fn seed_graph(db: &Database) -> (i64, i64, i64) {
+        let file_id = db
+            .upsert_file("src/lib.rs", Some("rust"), "deadbeef")
+            .expect("upsert file");
+        let caller_id = insert_named_chunk(db, file_id, "caller");
+        let callee_id = insert_named_chunk(db, file_id, "callee");
+        db.replace_edges(
+            "src/lib.rs",
+            &[crate::indexer::graph::Edge {
+                source_file: "src/lib.rs".to_string(),
+                source_name: Some("caller".to_string()),
+                target_name: "callee".to_string(),
+                kind: crate::indexer::graph::EdgeKind::Calls,
+                line: 2,
+            }],
+        )
+        .expect("replace edges");
+        db.append_mention_edges(
+            "src/lib.rs",
+            &[
+                (Some("caller"), "mentioned_sym"),
+                (Some("caller"), "callee"),
+            ],
+        )
+        .expect("append mention edges");
+        (file_id, caller_id, callee_id)
+    }
+
     /// A symbol containing SQL metacharacters must be treated as a literal bind
     /// value: the query runs without error and returns no rows for it (there is
     /// no edge with that target_name), proving the bytes never reach the SQL
@@ -298,6 +347,213 @@ mod tests {
             map.get("real_target").map(|v| v.len()),
             Some(1),
             "legitimate symbol must still resolve to its chunk"
+        );
+    }
+
+    /// Strengthened literal-binding check: a battery of SQL-metacharacter
+    /// payloads must each be treated as an opaque value (issue #405 priority
+    /// variant). None may error, none may match an edge, and a structurally
+    /// dangerous payload (`UNION SELECT`, comment terminators, stacked
+    /// statements) must not leak extra rows or drop the legitimate result.
+    #[test]
+    fn chunks_mentioning_symbols_binds_injection_payloads_as_literals() {
+        let db = open_db();
+        seed_graph(&db);
+
+        let payloads = [
+            "') OR 1=1 --",
+            "'; DROP TABLE chunks; --",
+            "real_target') UNION SELECT id, id FROM chunks --",
+            "\" OR \"\"=\"",
+            "real_target' OR '1'='1",
+            "%_\\",           // LIKE metacharacters (irrelevant here, must stay literal)
+            "real_target\0x", // embedded NUL byte
+        ];
+
+        let mut query: Vec<&str> = payloads.to_vec();
+        query.push("mentioned_sym"); // a genuinely-present target
+
+        let map = db
+            .chunks_mentioning_symbols(&query)
+            .expect("injection payloads must bind as literals, never error");
+
+        // The one real symbol resolves to exactly the caller chunk.
+        assert_eq!(
+            map.get("mentioned_sym").map(|v| v.len()),
+            Some(1),
+            "legitimate symbol must resolve despite injection neighbours"
+        );
+        // No payload is interpreted as SQL: none matches an edge, so none keys
+        // the map. (A successful injection would either error above or surface
+        // unexpected keys / extra chunk ids.)
+        for p in payloads {
+            assert!(
+                !map.contains_key(p),
+                "payload {p:?} must be treated as a literal value, not SQL"
+            );
+        }
+        // The whole result set is exactly the single legitimate mapping.
+        assert_eq!(map.len(), 1, "no payload may widen the result set");
+    }
+
+    // -------------------------------------------------------------------------
+    // chunking across SQLITE_MAX_BIND (issue #405 §3)
+    //
+    // Chunking is keyed purely off input-slice length vs `SQLITE_MAX_BIND`, so
+    // driving each function with an input list longer than the boundary forces
+    // the multi-statement path. Only a few elements correspond to real DB rows;
+    // the rest are non-matching filler. We assert (a) no prepare/bind error,
+    // (b) the result equals the known single-statement result, and (c) that we
+    // genuinely crossed >1 chunk.
+    // -------------------------------------------------------------------------
+
+    use super::super::sql::SQLITE_MAX_BIND;
+
+    #[test]
+    fn graph_neighbor_chunks_chunks_and_merges_distinct() {
+        let db = open_db();
+        let (_file_id, _caller_id, callee_id) = seed_graph(&db);
+
+        // graph_neighbor_chunks binds its slice twice, so the per-chunk budget
+        // is SQLITE_MAX_BIND / 2. To force >1 chunk we need an input longer than
+        // that half-budget. "caller" is the real query name (caller --calls-->
+        // callee, so the neighbour chunk is `callee`).
+        let chunk_budget = SQLITE_MAX_BIND / 2;
+        let mut names: Vec<&str> = vec!["caller"]; // matches; pulls in `callee`
+        names.resize(chunk_budget + 5, "no_such_symbol_xyz"); // filler past the boundary
+        assert!(
+            names.len() > chunk_budget,
+            "input must exceed the halved per-chunk budget to exercise chunking"
+        );
+
+        let neighbours = db
+            .graph_neighbor_chunks(&names)
+            .expect("multi-chunk query must not hit a prepare/bind limit");
+
+        // Compare against the single-statement result for the same logical query.
+        let single = db
+            .graph_neighbor_chunks(&["caller"])
+            .expect("single-chunk query");
+        assert_eq!(
+            single,
+            vec![callee_id],
+            "single-statement baseline: caller's calls-neighbour is callee"
+        );
+        assert_eq!(
+            neighbours, single,
+            "chunked result must equal the single-statement result"
+        );
+
+        // DISTINCT across chunks: callee must appear exactly once even though the
+        // matching name `caller` could in principle recur across chunk boundaries.
+        assert_eq!(
+            neighbours.iter().filter(|&&id| id == callee_id).count(),
+            1,
+            "DISTINCT semantics must be preserved across chunk merges"
+        );
+    }
+
+    #[test]
+    fn mention_edges_for_chunks_chunks_and_merges_per_key() {
+        let db = open_db();
+        let (_file_id, caller_id, _callee_id) = seed_graph(&db);
+
+        // caller mentions: "mentioned_sym" and "callee" (mentions edges) plus the
+        // structural calls edge to "callee" — kind IN ('mentions','calls').
+        let single = db
+            .mention_edges_for_chunks(&[caller_id])
+            .expect("single-chunk query");
+        let mut expected: Vec<String> = single.get(&caller_id).cloned().unwrap_or_default();
+        expected.sort();
+        assert!(
+            !expected.is_empty(),
+            "baseline: caller must mention at least one symbol"
+        );
+
+        // Drive with > SQLITE_MAX_BIND ids: the real id plus non-existent filler.
+        let mut ids: Vec<i64> = vec![caller_id];
+        // Use clearly-non-existent ids well outside the real rowid range.
+        ids.extend((0..(SQLITE_MAX_BIND as i64 + 5)).map(|n| 1_000_000 + n));
+        assert!(ids.len() > SQLITE_MAX_BIND, "must exceed bind budget");
+
+        let merged = db
+            .mention_edges_for_chunks(&ids)
+            .expect("multi-chunk query must not hit a prepare/bind limit");
+
+        let mut got: Vec<String> = merged.get(&caller_id).cloned().unwrap_or_default();
+        got.sort();
+        assert_eq!(
+            got, expected,
+            "per-key Vec must match the single-statement result after merge"
+        );
+        // No phantom keys from the filler ids.
+        assert_eq!(
+            merged.keys().copied().collect::<Vec<_>>(),
+            vec![caller_id],
+            "filler ids must not introduce spurious map keys"
+        );
+    }
+
+    #[test]
+    fn chunks_mentioning_symbols_chunks_and_merges_per_key() {
+        let db = open_db();
+        let (_file_id, caller_id, _callee_id) = seed_graph(&db);
+
+        // Baseline single-statement result for the real symbol.
+        let single = db
+            .chunks_mentioning_symbols(&["mentioned_sym"])
+            .expect("single-chunk query");
+        assert_eq!(
+            single.get("mentioned_sym"),
+            Some(&vec![caller_id]),
+            "baseline: mentioned_sym is mentioned by the caller chunk"
+        );
+
+        // Drive with > SQLITE_MAX_BIND symbols: the real one plus filler.
+        let mut syms: Vec<&str> = vec!["mentioned_sym"];
+        syms.resize(SQLITE_MAX_BIND + 5, "no_such_symbol_xyz");
+        assert!(syms.len() > SQLITE_MAX_BIND, "must exceed bind budget");
+
+        let merged = db
+            .chunks_mentioning_symbols(&syms)
+            .expect("multi-chunk query must not hit a prepare/bind limit");
+
+        assert_eq!(
+            merged.get("mentioned_sym"),
+            Some(&vec![caller_id]),
+            "per-key Vec must match the single-statement result after merge"
+        );
+        assert_eq!(
+            merged.len(),
+            1,
+            "filler symbols must not introduce spurious map keys"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // empty-input early-return (issue #405 §2.2 step 1)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn graph_functions_empty_input_early_return() {
+        let db = open_db();
+        seed_graph(&db);
+
+        assert!(
+            db.graph_neighbor_chunks(&[]).expect("empty ok").is_empty(),
+            "graph_neighbor_chunks must early-return [] on empty input"
+        );
+        assert!(
+            db.mention_edges_for_chunks(&[])
+                .expect("empty ok")
+                .is_empty(),
+            "mention_edges_for_chunks must early-return empty map"
+        );
+        assert!(
+            db.chunks_mentioning_symbols(&[])
+                .expect("empty ok")
+                .is_empty(),
+            "chunks_mentioning_symbols must early-return empty map"
         );
     }
 }

--- a/crates/spelunk-core/src/storage/graph.rs
+++ b/crates/spelunk-core/src/storage/graph.rs
@@ -82,29 +82,42 @@ impl Database {
         if names.is_empty() {
             return Ok(vec![]);
         }
-        let placeholders = names
-            .iter()
-            .enumerate()
-            .map(|(i, _)| format!("?{}", i + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let sql = format!(
-            "SELECT DISTINCT c.id
-             FROM chunks c
-             WHERE c.name IN (
-                 SELECT target_name FROM graph_edges
-                 WHERE source_name IN ({placeholders}) AND kind = 'calls'
-                 UNION
-                 SELECT source_name FROM graph_edges
-                 WHERE target_name IN ({placeholders}) AND kind = 'calls'
-             )"
-        );
-        let mut stmt = self.conn.prepare(&sql)?;
-        let params: Vec<&dyn rusqlite::ToSql> =
-            names.iter().map(|n| n as &dyn rusqlite::ToSql).collect();
-        let rows = stmt.query_map(params.as_slice(), |r| r.get::<_, i64>(0))?;
-        rows.collect::<rusqlite::Result<Vec<_>>>()
-            .map_err(Into::into)
+        // The names slice is bound twice per statement (once per IN clause), so
+        // the effective per-chunk budget is half the bind limit.
+        let chunk_size = super::sql::SQLITE_MAX_BIND / 2;
+        let mut out = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for chunk in names.chunks(chunk_size) {
+            let ph = super::sql::placeholders(chunk.len());
+            let sql = format!(
+                "SELECT DISTINCT c.id
+                 FROM chunks c
+                 WHERE c.name IN (
+                     SELECT target_name FROM graph_edges
+                     WHERE source_name IN ({ph}) AND kind = 'calls'
+                     UNION
+                     SELECT source_name FROM graph_edges
+                     WHERE target_name IN ({ph}) AND kind = 'calls'
+                 )"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            // Bind the names slice twice: once for each IN clause.
+            let params: Vec<&dyn rusqlite::ToSql> = chunk
+                .iter()
+                .chain(chunk.iter())
+                .map(|n| n as &dyn rusqlite::ToSql)
+                .collect();
+            debug_assert_eq!(params.len(), chunk.len() * 2);
+            let rows = stmt.query_map(params.as_slice(), |r| r.get::<_, i64>(0))?;
+            for row in rows {
+                let id = row?;
+                // Preserve the single-statement DISTINCT semantics across chunks.
+                if seen.insert(id) {
+                    out.push(id);
+                }
+            }
+        }
+        Ok(out)
     }
 
     /// Return all (source_name, target_name) pairs from graph_edges where
@@ -146,38 +159,34 @@ impl Database {
         if chunk_ids.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
-        let placeholders = chunk_ids
-            .iter()
-            .enumerate()
-            .map(|(i, _)| format!("?{}", i + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-        // CTE + INDEXED BY forces SQLite to start from chunk IDs rather than
-        // scanning all 'mentions' edges — critical with 25k+ mention edges.
-        let sql = format!(
-            "WITH chunk_info AS MATERIALIZED (
-                 SELECT c.id, c.name, f.path
-                 FROM chunks c JOIN files f ON f.id = c.file_id
-                 WHERE c.id IN ({placeholders})
-             )
-             SELECT ci.id, ge.target_name
-             FROM chunk_info ci
-             JOIN graph_edges ge INDEXED BY graph_edges_source_name_kind
-                  ON ge.source_name = ci.name AND ge.source_file = ci.path
-                  AND ge.kind IN ('mentions', 'calls')"
-        );
-        let mut stmt = self.conn.prepare(&sql)?;
-        let params: Vec<&dyn rusqlite::ToSql> = chunk_ids
-            .iter()
-            .map(|id| id as &dyn rusqlite::ToSql)
-            .collect();
-        let rows = stmt.query_map(params.as_slice(), |r| {
-            Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
-        })?;
         let mut map: std::collections::HashMap<i64, Vec<String>> = std::collections::HashMap::new();
-        for row in rows {
-            let (chunk_id, symbol) = row?;
-            map.entry(chunk_id).or_default().push(symbol);
+        for chunk in chunk_ids.chunks(super::sql::SQLITE_MAX_BIND) {
+            let ph = super::sql::placeholders(chunk.len());
+            // CTE + INDEXED BY forces SQLite to start from chunk IDs rather than
+            // scanning all 'mentions' edges — critical with 25k+ mention edges.
+            let sql = format!(
+                "WITH chunk_info AS MATERIALIZED (
+                     SELECT c.id, c.name, f.path
+                     FROM chunks c JOIN files f ON f.id = c.file_id
+                     WHERE c.id IN ({ph})
+                 )
+                 SELECT ci.id, ge.target_name
+                 FROM chunk_info ci
+                 JOIN graph_edges ge INDEXED BY graph_edges_source_name_kind
+                      ON ge.source_name = ci.name AND ge.source_file = ci.path
+                      AND ge.kind IN ('mentions', 'calls')"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let params: Vec<&dyn rusqlite::ToSql> =
+                chunk.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
+            debug_assert_eq!(params.len(), chunk.len());
+            let rows = stmt.query_map(params.as_slice(), |r| {
+                Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+            })?;
+            for row in rows {
+                let (chunk_id, symbol) = row?;
+                map.entry(chunk_id).or_default().push(symbol);
+            }
         }
         Ok(map)
     }
@@ -190,31 +199,105 @@ impl Database {
         if symbols.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
-        let placeholders = symbols
-            .iter()
-            .enumerate()
-            .map(|(i, _)| format!("?{}", i + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let sql = format!(
-            "SELECT ge.target_name, c.id
-             FROM graph_edges ge INDEXED BY graph_edges_target_name_kind
-             JOIN chunks c ON c.name = ge.source_name
-             JOIN files f ON f.id = c.file_id AND f.path = ge.source_file
-             WHERE ge.target_name IN ({placeholders})
-               AND ge.kind IN ('mentions', 'calls')"
-        );
-        let mut stmt = self.conn.prepare(&sql)?;
-        let params: Vec<&dyn rusqlite::ToSql> =
-            symbols.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
-        let rows = stmt.query_map(params.as_slice(), |r| {
-            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
-        })?;
         let mut map: std::collections::HashMap<String, Vec<i64>> = std::collections::HashMap::new();
-        for row in rows {
-            let (symbol, chunk_id) = row?;
-            map.entry(symbol).or_default().push(chunk_id);
+        for chunk in symbols.chunks(super::sql::SQLITE_MAX_BIND) {
+            let ph = super::sql::placeholders(chunk.len());
+            // Symbol values are user-file-derived (AST-extracted). They flow
+            // strictly through bind parameters — the only thing interpolated
+            // into the SQL text is the placeholder string `ph`, which contains
+            // no caller data.
+            let sql = format!(
+                "SELECT ge.target_name, c.id
+                 FROM graph_edges ge INDEXED BY graph_edges_target_name_kind
+                 JOIN chunks c ON c.name = ge.source_name
+                 JOIN files f ON f.id = c.file_id AND f.path = ge.source_file
+                 WHERE ge.target_name IN ({ph})
+                   AND ge.kind IN ('mentions', 'calls')"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let params: Vec<&dyn rusqlite::ToSql> =
+                chunk.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+            debug_assert_eq!(params.len(), chunk.len());
+            let rows = stmt.query_map(params.as_slice(), |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
+            })?;
+            for row in rows {
+                let (symbol, chunk_id) = row?;
+                map.entry(symbol).or_default().push(chunk_id);
+            }
         }
         Ok(map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Database;
+    use std::sync::OnceLock;
+
+    /// Register the sqlite-vec extension exactly once per test process.
+    /// `Database::open` creates a `vec0` virtual table, which requires the
+    /// extension to be loaded before any connection is opened.
+    fn register_sqlite_vec() {
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            #[allow(clippy::missing_transmute_annotations)]
+            unsafe {
+                rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                    sqlite_vec::sqlite3_vec_init as *const (),
+                )));
+            }
+        });
+    }
+
+    fn open_db() -> Database {
+        register_sqlite_vec();
+        Database::open(std::path::Path::new(":memory:")).expect("failed to open in-memory Database")
+    }
+
+    /// A symbol containing SQL metacharacters must be treated as a literal bind
+    /// value: the query runs without error and returns no rows for it (there is
+    /// no edge with that target_name), proving the bytes never reach the SQL
+    /// text as code.
+    #[test]
+    fn chunks_mentioning_symbols_treats_metacharacters_as_literal() {
+        let db = open_db();
+
+        // Seed a real edge so the table is non-empty and a successful query
+        // could in principle return rows — the injection string still must not.
+        let file_id = db
+            .upsert_file("src/lib.rs", Some("rust"), "deadbeef")
+            .expect("upsert file");
+        db.insert_chunk(
+            file_id,
+            "function",
+            Some("caller"),
+            1,
+            5,
+            "fn caller() {}",
+            None,
+            4,
+        )
+        .expect("insert chunk");
+        db.append_mention_edges("src/lib.rs", &[(Some("caller"), "real_target")])
+            .expect("append edges");
+
+        let malicious = "') OR 1=1 --";
+        let map = db
+            .chunks_mentioning_symbols(&[malicious, "real_target"])
+            .expect("query must not error on a SQL-metacharacter symbol");
+
+        // The injection attempt is a literal value with no matching edge.
+        assert!(
+            !map.contains_key(malicious),
+            "metacharacter symbol must not match any edge (was treated as SQL?)"
+        );
+        // The legitimate symbol still resolves, proving the query is intact and
+        // the malicious value did not widen or break the result set.
+        assert_eq!(
+            map.get("real_target").map(|v| v.len()),
+            Some(1),
+            "legitimate symbol must still resolve to its chunk"
+        );
     }
 }

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -13,6 +13,7 @@ mod graph;
 mod search;
 mod snapshots;
 mod specs;
+mod sql;
 mod stats;
 
 pub use backend::{LocalMemoryBackend, MemoryBackend, NoteInput};

--- a/crates/spelunk-core/src/storage/sql.rs
+++ b/crates/spelunk-core/src/storage/sql.rs
@@ -1,0 +1,47 @@
+//! Storage-internal SQL helpers.
+
+/// Maximum number of bound parameters to place in a single statement.
+///
+/// SQLite caps bound parameters per statement at `SQLITE_LIMIT_VARIABLE_NUMBER`
+/// (default 999 on older builds, 32766 on SQLite >= 3.32). Callers chunk their
+/// input lists at this size and run one statement per chunk so that a large
+/// input slice never exceeds the limit at prepare/bind time. For a statement
+/// that binds the same slice twice, halve this budget.
+pub(crate) const SQLITE_MAX_BIND: usize = 30_000;
+
+/// Build a comma-separated list of `n` anonymous bind placeholders: `?,?,?`.
+///
+/// Returns an empty string for `n == 0` (callers must early-return on empty
+/// input rather than emit an empty `IN ()` clause).
+///
+/// Anonymous `?` placeholders are used (rather than numbered `?N`) so that a
+/// query needing the same value set in two clauses can simply bind the value
+/// slice twice — no `?N` bookkeeping.
+pub(crate) fn placeholders(n: usize) -> String {
+    if n == 0 {
+        return String::new();
+    }
+    let mut s = "?,".repeat(n);
+    s.pop(); // drop trailing comma
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::placeholders;
+
+    #[test]
+    fn zero_is_empty() {
+        assert_eq!(placeholders(0), "");
+    }
+
+    #[test]
+    fn one_placeholder() {
+        assert_eq!(placeholders(1), "?");
+    }
+
+    #[test]
+    fn three_placeholders() {
+        assert_eq!(placeholders(3), "?,?,?");
+    }
+}


### PR DESCRIPTION
## What changed

The four list-based storage query methods previously built their `IN (...)` placeholder list at runtime with `format!("?{}", i+1)`:

- `chunks_by_ids` (`storage/chunks.rs`)
- `graph_neighbor_chunks`, `mention_edges_for_chunks`, `chunks_mentioning_symbols` (`storage/graph.rs`)

This PR replaces that hand-built construction with a single shared `pub(crate) fn placeholders(n)` helper in a new `storage/sql.rs`, alongside a `SQLITE_MAX_BIND` constant. The only thing interpolated into any SQL string is now the placeholder token list (`?,?,?`); all caller values (ids, names, symbols) flow strictly through rusqlite bind params.

Each method also chunks its input at `SQLITE_MAX_BIND` (halved for `graph_neighbor_chunks`, which binds its slice twice — once per `IN` clause) and merges results with unchanged semantics:
- vec-returning methods concatenate; `graph_neighbor_chunks` preserves `DISTINCT` via a cross-chunk `seen` set
- map-returning methods extend per-key `Vec`s
- `debug_assert_eq!` count guards on every bind site catch future placeholder/param drift in tests/CI

The query SQL bodies are byte-identical to the originals apart from the placeholder substitution and chunking wrappers, so existing callers (`search.rs`, `rag.rs`, `explore.rs`) are unaffected. This also removes the prior implicit cap on input-list size (lists over the bind limit previously failed at prepare/bind time).

## Security rationale

No active SQL-injection vector existed — values already went through bind params. But `chunks_mentioning_symbols` feeds **user-file-derived (AST-extracted)** symbol names into a `format!`-built statement, so the construction was injection-adjacent: one refactor moving a symbol into the SQL text would have turned it into real injection. Removing all runtime placeholder construction eliminates that latent hazard. Internal change only; no user-facing behaviour change.

## Test coverage

- `storage::sql::tests` — `placeholders(n)` for n = 0, 1, 3
- `chunks_mentioning_symbols_treats_metacharacters_as_literal` and `..._binds_injection_payloads_as_literals` — battery of payloads (`') OR 1=1 --`, `'; DROP TABLE chunks; --`, `UNION SELECT`, embedded NUL, etc.) each proven to bind as an opaque literal: no error, no edge match, the legitimate symbol still resolves, result set never widened
- chunking tests for all four functions drive an input list longer than `SQLITE_MAX_BIND` (halved budget for `graph_neighbor_chunks`) and assert the merged result equals the single-statement baseline, plus DISTINCT / per-key merge correctness and no spurious keys
- empty-input early-return tests for all four

## Test plan

- `cargo build` — clean (workspace, 8.3s)
- `cargo test -p spelunk-core` — 89 storage-suite tests + all others pass, 0 failures; the 9 new/relevant tests confirmed green by name
- `cargo test` (full workspace) — all suites pass, 0 failures
- `cargo clippy -p spelunk-core --all-targets` — clean, no warnings
- `grep -n 'format!("?' storage/{chunks,graph}.rs` — no matches; remaining `format!` calls interpolate only the placeholder string `{ph}` (and a pre-existing escaped LIKE pattern)

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)