### PR TITLE
release: spelunk 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.3] — 2026-06-17
+
 ### Changed
 
 - **Server instance_id now uses UUID v7 instead of v4.** The persistent instance ID (returned by `/v1/health` and stored in the server database) is now a time-ordered UUID v7 minted by the `uuid` crate (`Uuid::now_v7`) and persisted verbatim, so the high 48 bits encode the millisecond Unix timestamp of creation and the value is stable for the life of the database. It remains a standard 36-char UUID string. (#416)
@@ -42,6 +44,10 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   and merges results with unchanged semantics, removing the prior cap on input
   list size. Internal change only; no user-facing behaviour change.
   ([#405](https://github.com/spelunk-cloud/spelunk/issues/405))
+
+### Internal
+
+- Repaired the fuzz crate after the three-crate workspace migration and suppressed an upstream tree-sitter-sequel LeakSanitizer false positive so the fuzz CI job runs clean. ([#417](https://github.com/spelunk-cloud/spelunk/pull/417), [#418](https://github.com/spelunk-cloud/spelunk/pull/418))
 
 ## [0.8.2] — 2026-06-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Patch release 0.8.3

Bumps `spelunk-core`, `spelunk-cli`, and `spelunk-server` from **0.8.2 → 0.8.3** (plus `Cargo.lock` and `fuzz/Cargo.lock`) and rolls the CHANGELOG `[Unreleased]` section into `[0.8.3]`.

### Scope
Cut from `main` as-is. There are **no new user-facing changes** since 0.8.2 — the only post-0.8.2 merges were internal fuzz/CI maintenance (#417, #418), captured under an `### Internal` changelog entry.

**Intentionally NOT included:** the three security PRs from the latest sweep — #419 (explore read_file path-boundary), #420 (SQL IN-clause parameterisation), #421 (UUIDv7 instance_id) — are still open and are not part of this release. They can land in a subsequent release once merged.

### How to trigger the release
Per `docs/releasing.md`, releases are tag-triggered:
1. Merge this PR to `main`.
2. `git tag v0.8.3 && git push origin v0.8.3` — this fires `.github/workflows/release.yml` (builds binaries, `.deb`, GitHub Release, Homebrew formula bump).

### Test plan
- `cargo metadata --offline` succeeds → `Cargo.lock` / `fuzz/Cargo.lock` consistent with the bumped manifests.
- Pre-commit hook ran `cargo fmt --check` + `cargo clippy` and compiled the full workspace clean (`spelunk-server v0.8.3`, `spelunk-cli v0.8.3`).
- Verified only the three workspace-crate `[[package]]` stanzas were bumped in the lockfiles (third-party crates coincidentally at 0.8.2 left untouched).
- No hardcoded version pins in `docs/`/`README.md` needed updating (the only matches are illustrative `v0.8.0` examples in `releasing.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)