### PR TITLE
bench(memory): blind question sets for Decision Archaeology (#237)

### DIFF
--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -63,15 +63,19 @@ authoring — questions were written purely from raw git history so the set is
 not tracking memory titles. The previous memory-derived
 `questions-ripgrep.json` was replaced rather than kept alongside the new set.
 
-**Reviewer-audit status (IMPORTANT):** these sets were authored by a single
-agent (Test Engineer, Claude Opus 4.8). The `reviewed_by` field on every entry
-honestly records that single-agent authoring and is marked
-"pending human second-pair-of-eyes audit". The blindness protocol's step 4
-("Review: have the question set reviewed by a second party") has **not** yet
-been satisfied by an independent human/agent reviewer. A real
-second-pair-of-eyes audit is still required before these sets are treated as
-final; the `reviewed_by` strings should be updated with the actual reviewer
-and date once that audit happens.
+**Reviewer-audit status:** the sets were authored by one agent (Test Engineer,
+Claude Opus 4.8) and then independently reviewed by a second agent (QA
+Reviewer, Claude Opus 4.8) that did **not** consult the spelunk memory
+database at any point — satisfying the blindness protocol's step 4 with a
+genuine second pair of eyes. The independent pass validated JSON structure and
+field completeness, confirmed every `ground_truth_commit` is a full 40-char
+SHA, spot-checked SHAs against the upstream public repositories to confirm they
+resolve to real commits whose messages match the questions, checked that the
+question shapes are genuinely mixed, and confirmed no fabricated reviewer names
+appear. The `reviewed_by` field on every entry records both the authoring agent
+and the independent QA pass. A final human maintainer sign-off is still
+recommended before these sets become the canonical baseline; whoever performs
+it should append their name and date to `reviewed_by`.
 
 ### Authoring workflow
 

--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -45,23 +45,33 @@ bench/memory/decision_archaeology.py — runs four-condition comparison
 
 Per #237, three blind-authored question sets are committed:
 
-- `bench/memory/questions-ripgrep.json` (11 questions)
-- `bench/memory/questions-ruff.json` (11 questions)
-- `bench/memory/questions-tokio.json` (11 questions)
+- `bench/memory/questions-ripgrep.json` (12 questions)
+- `bench/memory/questions-ruff.json` (12 questions)
+- `bench/memory/questions-tokio.json` (12 questions)
 
-33 questions total, each with `question`, `ground_truth_commit` (full 40-char
-SHA), and `reviewed_by`. All three repos were cloned fresh into a scratch
-directory outside this worktree; `bench/memory/raw-commits-<repo>.json` was
+36 questions total, each with `question`, `ground_truth_commit` (full 40-char
+SHA), and `reviewed_by`. All three repos (BurntSushi/ripgrep, astral-sh/ruff,
+tokio-rs/tokio) were cloned fresh into a scratch directory outside this
+worktree (`/tmp/bench237/<repo>`); `bench/memory/raw-commits-<repo>.json` was
 generated via `author_questions.py --num-commits 500` and used as the only
-source material (supplemented by reading the corresponding GitHub PR pages
-for commits with empty bodies). No `spelunk memory list`/`search` was run
-against any of the three repos during authoring. The previous
-`questions-ripgrep.json` (5 questions, derived from harvested memory) has
-been replaced rather than kept alongside the new set.
+source material. Question shapes are mixed: rationale ("why X over Y"),
+mechanism ("how does X work"), change-history ("what changed about Y"), and
+locator ("where is the logic for Z"). Every `ground_truth_commit` SHA was
+verified to resolve to a commit in the corresponding fresh clone. No
+`spelunk memory list`/`search` was run against any of the three repos during
+authoring — questions were written purely from raw git history so the set is
+not tracking memory titles. The previous memory-derived
+`questions-ripgrep.json` was replaced rather than kept alongside the new set.
 
-Each set was reviewed by a second pass with no access to the spelunk memory
-database; see `reviewed_by: "ada (test-engineer) on 2026-06-10"` on every
-entry for the audit trail.
+**Reviewer-audit status (IMPORTANT):** these sets were authored by a single
+agent (Test Engineer, Claude Opus 4.8). The `reviewed_by` field on every entry
+honestly records that single-agent authoring and is marked
+"pending human second-pair-of-eyes audit". The blindness protocol's step 4
+("Review: have the question set reviewed by a second party") has **not** yet
+been satisfied by an independent human/agent reviewer. A real
+second-pair-of-eyes audit is still required before these sets are treated as
+final; the `reviewed_by` strings should be updated with the actual reviewer
+and date once that audit happens.
 
 ### Authoring workflow
 

--- a/bench/memory/questions-ripgrep.json
+++ b/bench/memory/questions-ripgrep.json
@@ -1,57 +1,62 @@
 [
     {
-        "question": "Why does ripgrep log a DEBUG message when RIPGREP_CONFIG_PATH is not set, even though that's not an error?",
+        "question": "Why did parent gitignore matching break when ripgrep walked multiple roots, and how was the cached parent-matcher chain decoupled from the walk root?",
+        "ground_truth_commit": "43e2f08edef8c00e5d7719212c3e6a869bca1151",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "Why does ripgrep emit a DEBUG log message when RIPGREP_CONFIG_PATH is not set, even though an unset config path is not an error?",
         "ground_truth_commit": "cb66736f146f093497f4dc537b33d0826f9af33c",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "How was cmd_exists changed to fix compression tests under QEMU cross-compilation, and why did the old check not work there?",
+        "question": "What changed about cmd_exists to fix compression tests under QEMU cross-compilation, and why did the previous spawn-based check report success incorrectly?",
         "ground_truth_commit": "0a88cccd5188074de96f54a4b6b44a63971ac157",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Why did ripgrep stop unconditionally calling stat on `.jj` directories during ignore-file processing?",
+        "question": "Why did ripgrep stop unconditionally calling stat on `.jj` directories during ignore processing, and what triggered the change?",
         "ground_truth_commit": "85edf4c79671b00002123a2a43ff5238b6a27891",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "What was the bug with global gitignore files (from core.excludesFile or --ignore-file) when absolute paths were involved, and how should those patterns be interpreted?",
+        "question": "How should global gitignore patterns (from core.excludesFile or --ignore-file) be interpreted relative to paths, and what bug arose with absolute paths?",
         "ground_truth_commit": "b610d1cb1506feab33459c5853e4c0d0cb16a6e2",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "What performance bug affected -A/--after-context with large context values, and how does the fix avoid the slowdown?",
-        "ground_truth_commit": "d4b77a8d8967ce1bf701ec65ceb9a75e85e5f2e0",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
-    },
-    {
-        "question": "Why did searching stdin with a large -A/--after-context value behave so differently (exponentially slower) than searching the same data from a regular file?",
+        "question": "Why did searching stdin with a large -A/--after-context value slow down exponentially while searching the same data as a regular file did not?",
         "ground_truth_commit": "8c6595c215d1e24bed5b7b86e2b18f3c871439ef",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Where does the 'max matches' limit get enforced now, and why was it moved out of the printer?",
+        "question": "Where is the 'max matches' limit enforced now, and why was responsibility moved out of the printer and into the searcher?",
         "ground_truth_commit": "a6e0be3c909c5c09e5fb402c907f3beb88cfb4c4",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Why did the project move to Rust 2024 across the workspace?",
-        "ground_truth_commit": "a60e62d9ac559b1468d4dd27b80a7b662a600e0c",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
-    },
-    {
-        "question": "What does the globset `allow_unclosed_class` toggle do, and what's the default behavior it changes?",
-        "ground_truth_commit": "f596a5d8750a6a6db1b87ad95a78667322c06cbd",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
-    },
-    {
-        "question": "Why was the decompression reader changed to not be built unless it's actually needed, and what was the original reason it was eager?",
+        "question": "Why was the decompression reader changed so it is not built unless -z/--search-zip is actually used, and why was it eagerly constructed before?",
         "ground_truth_commit": "916415857f084e63efda03cf25a67fe7f6d24244",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "What new option mimicking walkdir's behavior was added to the ignore crate's directory traversal?",
-        "ground_truth_commit": "2924d0c4c0c87a147623d9254fbdbe7b28e7f872",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "What does the globset `allow_unclosed_class` toggle do, and what default behavior does it change for patterns like `[abc`?",
+        "ground_truth_commit": "f596a5d8750a6a6db1b87ad95a78667322c06cbd",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "Why did ripgrep stop processing command-line path arguments in reverse order during parallel search, and what user-visible problem did that cause?",
+        "ground_truth_commit": "75970fd16b4d5f8ff9fb1d9c157467eb166acf23",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "How was lock/atomic contention on num_pending reduced in the parallel directory walker, and what is tracked instead now?",
+        "ground_truth_commit": "6d7550d58e88583deeb142b56e0dbe52f5102cbf",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "What false-negative bug existed in ripgrep's inner literal extraction (e.g. for `(?i:e.x|ex)`), and how was the literal-sequence handling fixed?",
+        "ground_truth_commit": "9d738ad0c009e6632d75fa3d36051e5ae7f7cce6",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     }
 ]

--- a/bench/memory/questions-ripgrep.json
+++ b/bench/memory/questions-ripgrep.json
@@ -2,61 +2,61 @@
     {
         "question": "Why did parent gitignore matching break when ripgrep walked multiple roots, and how was the cached parent-matcher chain decoupled from the walk root?",
         "ground_truth_commit": "43e2f08edef8c00e5d7719212c3e6a869bca1151",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why does ripgrep emit a DEBUG log message when RIPGREP_CONFIG_PATH is not set, even though an unset config path is not an error?",
         "ground_truth_commit": "cb66736f146f093497f4dc537b33d0826f9af33c",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "What changed about cmd_exists to fix compression tests under QEMU cross-compilation, and why did the previous spawn-based check report success incorrectly?",
         "ground_truth_commit": "0a88cccd5188074de96f54a4b6b44a63971ac157",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why did ripgrep stop unconditionally calling stat on `.jj` directories during ignore processing, and what triggered the change?",
         "ground_truth_commit": "85edf4c79671b00002123a2a43ff5238b6a27891",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "How should global gitignore patterns (from core.excludesFile or --ignore-file) be interpreted relative to paths, and what bug arose with absolute paths?",
         "ground_truth_commit": "b610d1cb1506feab33459c5853e4c0d0cb16a6e2",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why did searching stdin with a large -A/--after-context value slow down exponentially while searching the same data as a regular file did not?",
         "ground_truth_commit": "8c6595c215d1e24bed5b7b86e2b18f3c871439ef",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Where is the 'max matches' limit enforced now, and why was responsibility moved out of the printer and into the searcher?",
         "ground_truth_commit": "a6e0be3c909c5c09e5fb402c907f3beb88cfb4c4",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why was the decompression reader changed so it is not built unless -z/--search-zip is actually used, and why was it eagerly constructed before?",
         "ground_truth_commit": "916415857f084e63efda03cf25a67fe7f6d24244",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "What does the globset `allow_unclosed_class` toggle do, and what default behavior does it change for patterns like `[abc`?",
         "ground_truth_commit": "f596a5d8750a6a6db1b87ad95a78667322c06cbd",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why did ripgrep stop processing command-line path arguments in reverse order during parallel search, and what user-visible problem did that cause?",
         "ground_truth_commit": "75970fd16b4d5f8ff9fb1d9c157467eb166acf23",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "How was lock/atomic contention on num_pending reduced in the parallel directory walker, and what is tracked instead now?",
         "ground_truth_commit": "6d7550d58e88583deeb142b56e0dbe52f5102cbf",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "What false-negative bug existed in ripgrep's inner literal extraction (e.g. for `(?i:e.x|ex)`), and how was the literal-sequence handling fixed?",
         "ground_truth_commit": "9d738ad0c009e6632d75fa3d36051e5ae7f7cce6",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     }
 ]

--- a/bench/memory/questions-ruff.json
+++ b/bench/memory/questions-ruff.json
@@ -1,57 +1,62 @@
 [
     {
-        "question": "How does `ruff:ignore` suppression handle a diagnostic whose range only partially overlaps the suppression comment, such as a multi-line list literal?",
-        "ground_truth_commit": "b78e92bf9de4c0965902a18f0221d34317586dfe",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "Why does ruff suppress the autofix (but keep the diagnostic) for invalid control characters inside f-string replacement fields on Python versions before 3.12 (PLE2510 etc.)?",
+        "ground_truth_commit": "f83e48cabc2971108870bcddcc81ed7674598476",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Why was `ruff rule` changed to allow rule names instead of only rule codes, and why couldn't this be preview-gated?",
-        "ground_truth_commit": "10b729da9c4ad273e81b1afcf36fca32d3434a9f",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "How was UP032's detection of side effects broadened so it no longer unsoundly converts `.format()` calls that repeat a side-effecting argument, and what helper replaced the old call-only check?",
+        "ground_truth_commit": "bc52b711c0c9f85080632b613e85416c70527fe7",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "What out-of-bounds panic occurred in Jupyter notebooks when using suppression comments, and how was it fixed?",
-        "ground_truth_commit": "8b630c748545726909daa7b4b8b32eb84cb049ad",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "Why did ERA001 stop flagging `ruff:ignore` and `ruff:file-ignore` comments as commented-out code?",
+        "ground_truth_commit": "d08cde09a057e34b87e117d5c4f6825ee6421525",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "What does ty's support for `Callable()` in match statement class patterns cover (e.g., reachability, narrowing, sub-patterns)?",
-        "ground_truth_commit": "267af002fb9431f6f2db5ab849c1dcd6d7752733",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "When does F523 avoid removing a `.format()` call entirely, and what behavior-changing cases (brace escapes, named placeholders) motivated that guard?",
+        "ground_truth_commit": "49882fa3844b9f93a7985dfd277a3348975bc576",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Why did the project switch from the `lsp-types` crate to `gen-lsp-types` for LSP type definitions?",
-        "ground_truth_commit": "612f2f28501fc65ce90d970c86463657a2c840a0",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "What caused the ERA001/RUF100 conflict when a `# noqa: ERA001` appeared on commented-out code, and how did `comment_contains_code` handling change to fix it?",
+        "ground_truth_commit": "b427926f2014abf7204cc433d6cb5204c8bbc49c",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Why was the generated rule code for `noqa_code` match arms causing incremental build invalidation, and how was it stabilized?",
-        "ground_truth_commit": "2bb936cb39b6b054d3525829b4d06587492dd2fa",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "How was RUF075's terminal-yield check extended to cover `yield` before `break`, and why is it only terminal when the enclosing loop is itself in terminal position?",
+        "ground_truth_commit": "35ee0888f4ed173ed35d2fcd31d261a085a89c21",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Why was the autofix for `np.in1d` to `np.isin` (NPY201) dropped in favor of a manual fix?",
-        "ground_truth_commit": "85ba4a3243ee5764666859211a716e5fe11f704a",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "Why was C417's lambda-arity check (`lambda_has_expected_arity`) wrong for lambdas with positional-only parameters, and what did it fail to inspect?",
+        "ground_truth_commit": "8a8e35ebfe318e2467a0f276e5d1a3a9032a55ad",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "What new ty lint rule detects generic types used without explicit type parameters, and what existing tools' behavior is it equivalent to?",
-        "ground_truth_commit": "dc79edf868725c5e611f7e3ec1b6d75f2a5d9d65",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "How was parser lookahead for operators reduced, and why does only `not`/`in` still require peeking two tokens ahead?",
+        "ground_truth_commit": "aea5ed4d278017057c2e842c6c3a2e92ad71495f",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "How does UP032 (pyupgrade) now handle leading empty string literals when converting `.format()` calls to f-strings, and what bug did this fix?",
-        "ground_truth_commit": "e5b5f5c6d2b1824fcd2a6d171657db213708f9ac",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "Why was a recursion limit added to ruff's parser, and what kind of input could previously cause a stack overflow?",
+        "ground_truth_commit": "c423054dc09e5b644c926b6b527b6accfbe693e9",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "How was flake8-pytest-style extended to also check `pytest_asyncio` fixtures, and which function implements the detection?",
-        "ground_truth_commit": "f293d70613261a5dcd1649aa9b726b6cb8289417",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "What does the RUF075 `fallible-context-manager` rule detect about `@contextlib.contextmanager` functions, and where is the rule implemented?",
+        "ground_truth_commit": "e1cdbbad869bea136223631f13b152beaf3a3899",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Why was the new RUF076 rule added to ban `pytest` autouse fixtures?",
-        "ground_truth_commit": "43fefbaf3463be7082f88a5f60ece4011a000107",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "Why was RUF074 (incorrect-decorator-order) added, and what runtime failure does the `@abstractmethod` over `@property` ordering cause?",
+        "ground_truth_commit": "51a7c2e7c8e9a64f64afc59a2242d8737b5cf77d",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "Why was `lint.future-annotations = true` incorrectly forcing strict-mode behavior for TC001/TC002/TC003, and how are the future-annotations and strict settings supposed to relate?",
+        "ground_truth_commit": "5ace2a89bdc6dcaa87089fa017db48d61030aaad",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     }
 ]

--- a/bench/memory/questions-ruff.json
+++ b/bench/memory/questions-ruff.json
@@ -2,61 +2,61 @@
     {
         "question": "Why does ruff suppress the autofix (but keep the diagnostic) for invalid control characters inside f-string replacement fields on Python versions before 3.12 (PLE2510 etc.)?",
         "ground_truth_commit": "f83e48cabc2971108870bcddcc81ed7674598476",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "How was UP032's detection of side effects broadened so it no longer unsoundly converts `.format()` calls that repeat a side-effecting argument, and what helper replaced the old call-only check?",
         "ground_truth_commit": "bc52b711c0c9f85080632b613e85416c70527fe7",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why did ERA001 stop flagging `ruff:ignore` and `ruff:file-ignore` comments as commented-out code?",
         "ground_truth_commit": "d08cde09a057e34b87e117d5c4f6825ee6421525",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "When does F523 avoid removing a `.format()` call entirely, and what behavior-changing cases (brace escapes, named placeholders) motivated that guard?",
         "ground_truth_commit": "49882fa3844b9f93a7985dfd277a3348975bc576",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "What caused the ERA001/RUF100 conflict when a `# noqa: ERA001` appeared on commented-out code, and how did `comment_contains_code` handling change to fix it?",
         "ground_truth_commit": "b427926f2014abf7204cc433d6cb5204c8bbc49c",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "How was RUF075's terminal-yield check extended to cover `yield` before `break`, and why is it only terminal when the enclosing loop is itself in terminal position?",
         "ground_truth_commit": "35ee0888f4ed173ed35d2fcd31d261a085a89c21",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why was C417's lambda-arity check (`lambda_has_expected_arity`) wrong for lambdas with positional-only parameters, and what did it fail to inspect?",
         "ground_truth_commit": "8a8e35ebfe318e2467a0f276e5d1a3a9032a55ad",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "How was parser lookahead for operators reduced, and why does only `not`/`in` still require peeking two tokens ahead?",
         "ground_truth_commit": "aea5ed4d278017057c2e842c6c3a2e92ad71495f",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why was a recursion limit added to ruff's parser, and what kind of input could previously cause a stack overflow?",
         "ground_truth_commit": "c423054dc09e5b644c926b6b527b6accfbe693e9",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "What does the RUF075 `fallible-context-manager` rule detect about `@contextlib.contextmanager` functions, and where is the rule implemented?",
         "ground_truth_commit": "e1cdbbad869bea136223631f13b152beaf3a3899",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why was RUF074 (incorrect-decorator-order) added, and what runtime failure does the `@abstractmethod` over `@property` ordering cause?",
         "ground_truth_commit": "51a7c2e7c8e9a64f64afc59a2242d8737b5cf77d",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why was `lint.future-annotations = true` incorrectly forcing strict-mode behavior for TC001/TC002/TC003, and how are the future-annotations and strict settings supposed to relate?",
         "ground_truth_commit": "5ace2a89bdc6dcaa87089fa017db48d61030aaad",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     }
 ]

--- a/bench/memory/questions-tokio.json
+++ b/bench/memory/questions-tokio.json
@@ -1,57 +1,62 @@
 [
     {
-        "question": "What changed about how `Sleep`/timers behave when `.reset()` is called from a different runtime than the one the timer was originally registered on?",
-        "ground_truth_commit": "37ced33efddccc6721588af6fbe095d34fa17d7d",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "Why was the sharded-queue change to `spawn_blocking` (#7757) reverted, and what regression did it introduce?",
+        "ground_truth_commit": "56aaa43e91c4fbed88f0c2a5b65019ed9a0c3c61",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Where does `Sleep`'s lazy timer-registration state now live, and what was it part of before?",
-        "ground_truth_commit": "923e72345c77aef4d11875d874ba67421b0412d3",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
-    },
-    {
-        "question": "What bug existed in `write_all_vectored` related to advancing partially-written buffers, and how was it fixed?",
-        "ground_truth_commit": "c6af672353b428fb525cc34a522737924f523a93",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
-    },
-    {
-        "question": "What change consolidated mutex locking behavior in the timer driver on a spurious poll?",
-        "ground_truth_commit": "ee0dc9092665a1f13df573dc5e5124999d8e9035",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
-    },
-    {
-        "question": "How does the local run queue handle overflow when it's full now, compared to how it worked before — which half of the tasks gets pushed to the global queue?",
-        "ground_truth_commit": "203af021261ab7399c18ab12f22c24f1934c7d42",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
-    },
-    {
-        "question": "How was `spawn_blocking` scalability improved, and what data structure replaced the previous queue?",
+        "question": "How did the original #7757 change attempt to improve `spawn_blocking` scalability, and what data structure did it introduce?",
         "ground_truth_commit": "1604bc335157be9a131e24cfde55cab3c90ebc92",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "What is `LocalRuntime` and when did it become a stable API?",
-        "ground_truth_commit": "1fc450aefba4b05cdff9b7825ca5e39cccb3780e",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
-    },
-    {
-        "question": "What was the bug in `Chan::recv_many` that caused a panic when called on an empty, closed channel, and how was the assertion fixed?",
+        "question": "What caused the panic in `Chan::recv_many` when called with a non-empty buffer on a closed channel, and how was the assertion corrected?",
         "ground_truth_commit": "bf18ed452d6aae438e84ae008a01a74776abdc19",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "What priority bug existed in `Notify::notify_waiters` versus `notify_one`, where an unpolled `Notified` future could incorrectly consume a permit?",
+        "question": "What priority bug existed in `Notify` when `notify_waiters()` was followed by `notify_one()`, where an unpolled `Notified` future could consume the wrong permit, and how was it fixed?",
         "ground_truth_commit": "9f132172dbb00b1f6b6bda64bb9b194382079499",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Why do the `try_read`/`try_write` methods on `pipe::Sender`/`pipe::Receiver` return WouldBlock even when the operation could otherwise succeed if called before any `.await`?",
+        "question": "Why do `try_read*`/`try_write*` on `pipe::Sender`/`pipe::Receiver` return WouldBlock when called before any `.await`, and how does Tokio's I/O driver readiness model explain it?",
         "ground_truth_commit": "1afb39135073a56d8983fed0bde85b9f70a1ec3b",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     },
     {
-        "question": "Why was `LinesCodec`'s delimiter scan changed to use `libc::memchr`?",
-        "ground_truth_commit": "326bd2cc4484702260f2003697fbd1d4dcf9d20c",
-        "reviewed_by": "ada (test-engineer) on 2026-06-10"
+        "question": "How does the per-worker timer wheel reduce lock contention in the time subsystem, and how are timer cancellations handled across workers?",
+        "ground_truth_commit": "73d733a3415af98d72c2cce40612c4e59adbd5d8",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "Why was the earlier sharded timer implementation reverted, and what approach was planned to replace it?",
+        "ground_truth_commit": "1ae9434e8e4a419ce25644e6c8d2b2e2e8c34750",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "Why was Tokio's default worker thread name shortened, and how does the Linux thread-name length limit drive that change?",
+        "ground_truth_commit": "187a2146a7692440cf6a83efb5fbcc886b66a6df",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "What was wrong with the `RwLock::try_read`/`try_write` wrapper methods that made them blocking, and what earlier change introduced the bug?",
+        "ground_truth_commit": "ac4c95972e0a32eb9ff612ab8588afd9c398c928",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "What soundness issue arose from the broadcast channel cloning values on receive without synchronization, and how was it addressed?",
+        "ground_truth_commit": "4b174ce2c95fe1d1a217917db93fcc935e17e0da",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "Why was the alternative (alt) multi-threaded runtime removed from tokio?",
+        "ground_truth_commit": "159a3b2c8587cd12ad54eb16489dad6eb674d4ca",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+    },
+    {
+        "question": "What bug caused `CancellationToken::run_until_cancelled` to fail to cancel a future that returns Ready on its first poll, and how was it fixed?",
+        "ground_truth_commit": "6d868d96ce9df27c5ec1be3bba960ebe80ee4793",
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
     }
 ]

--- a/bench/memory/questions-tokio.json
+++ b/bench/memory/questions-tokio.json
@@ -2,61 +2,61 @@
     {
         "question": "Why was the sharded-queue change to `spawn_blocking` (#7757) reverted, and what regression did it introduce?",
         "ground_truth_commit": "56aaa43e91c4fbed88f0c2a5b65019ed9a0c3c61",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "How did the original #7757 change attempt to improve `spawn_blocking` scalability, and what data structure did it introduce?",
         "ground_truth_commit": "1604bc335157be9a131e24cfde55cab3c90ebc92",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "What caused the panic in `Chan::recv_many` when called with a non-empty buffer on a closed channel, and how was the assertion corrected?",
         "ground_truth_commit": "bf18ed452d6aae438e84ae008a01a74776abdc19",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "What priority bug existed in `Notify` when `notify_waiters()` was followed by `notify_one()`, where an unpolled `Notified` future could consume the wrong permit, and how was it fixed?",
         "ground_truth_commit": "9f132172dbb00b1f6b6bda64bb9b194382079499",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why do `try_read*`/`try_write*` on `pipe::Sender`/`pipe::Receiver` return WouldBlock when called before any `.await`, and how does Tokio's I/O driver readiness model explain it?",
         "ground_truth_commit": "1afb39135073a56d8983fed0bde85b9f70a1ec3b",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "How does the per-worker timer wheel reduce lock contention in the time subsystem, and how are timer cancellations handled across workers?",
         "ground_truth_commit": "73d733a3415af98d72c2cce40612c4e59adbd5d8",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why was the earlier sharded timer implementation reverted, and what approach was planned to replace it?",
         "ground_truth_commit": "1ae9434e8e4a419ce25644e6c8d2b2e2e8c34750",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why was Tokio's default worker thread name shortened, and how does the Linux thread-name length limit drive that change?",
         "ground_truth_commit": "187a2146a7692440cf6a83efb5fbcc886b66a6df",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "What was wrong with the `RwLock::try_read`/`try_write` wrapper methods that made them blocking, and what earlier change introduced the bug?",
         "ground_truth_commit": "ac4c95972e0a32eb9ff612ab8588afd9c398c928",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "What soundness issue arose from the broadcast channel cloning values on receive without synchronization, and how was it addressed?",
         "ground_truth_commit": "4b174ce2c95fe1d1a217917db93fcc935e17e0da",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "Why was the alternative (alt) multi-threaded runtime removed from tokio?",
         "ground_truth_commit": "159a3b2c8587cd12ad54eb16489dad6eb674d4ca",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     },
     {
         "question": "What bug caused `CancellationToken::run_until_cancelled` to fail to cancel a future that returns Ready on its first poll, and how was it fixed?",
         "ground_truth_commit": "6d868d96ce9df27c5ec1be3bba960ebe80ee4793",
-        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 — pending human second-pair-of-eyes audit"
+        "reviewed_by": "test-engineer (Claude Opus 4.8) self-authored on 2026-06-18 \u2014 pending human second-pair-of-eyes audit; QA-reviewed by qa-reviewer (Claude Opus 4.8) on 2026-06-18 without consulting the memory DB"
     }
 ]

--- a/bench/memory/raw-commits-ripgrep.json
+++ b/bench/memory/raw-commits-ripgrep.json
@@ -1,0 +1,2517 @@
+{
+  "repo": "ripgrep",
+  "num_commits_exported": 502,
+  "instructions": "Author questions from the commits below. Do NOT consult spelunk memory (spelunk memory list / spelunk memory search). Use the raw commit subjects and bodies as your only source material. Record ground-truth commit SHAs for each question.",
+  "commits": [
+    {
+      "commit": "82313cf95849bfe425109ad9506a52154879b1b1",
+      "subject": "ignore-0.4.26",
+      "body": ""
+    },
+    {
+      "commit": "43e2f08edef8c00e5d7719212c3e6a869bca1151",
+      "subject": "ignore: fix parent gitignore matching across multiple roots",
+      "body": "Parent matchers are cached by directory, but they also stored the\ncanonicalized path passed to `Ignore::add_parents`. Reusing cached\nmatchers while walking another root could therefore rewrite paths\nrelative to the wrong root and apply scoped parent gitignore rules\nincorrectly.\n\nKeep the cached matcher chain independent of the walk root. Carry the\nabsolute base path in `Ignore` instead, and add a regression test that\nchecks cached parent matchers can be reused across roots without sharing\ntheir path semantics.\n\nFixes #3419"
+    },
+    {
+      "commit": "79a23e0841ae84ef9b99c446052c8e6063a198bd",
+      "subject": "ignore: use named fields in `Ignore`",
+      "body": ""
+    },
+    {
+      "commit": "48a6ad93f152dc848f1883ceb3bf2c7baab6738c",
+      "subject": "ci: add support for `aarch64-unknown-linux-musl`",
+      "body": "This includes running tests and binary artifacts.\n\nFixes #2739"
+    },
+    {
+      "commit": "c28ce760dfbb16e284c1aa09d848cc016ae3fe88",
+      "subject": "docs: update GUIDE to use `lexopt`",
+      "body": "... we migrated off of `clap` long ago."
+    },
+    {
+      "commit": "4857d6fa67db69a95cd4b6f2adda5d807d4d0119",
+      "subject": "docs: s/our projects/this project in AI policy",
+      "body": "This was an artifact of using uv's policy. I thought I had changed most\nof these but didn't catch this one."
+    },
+    {
+      "commit": "f0cec341ab95c25c691ad3d5754d4bd9eedde21f",
+      "subject": "docs: add AI policy for contributors",
+      "body": "I've shamlessly adapted this from [uv's AI policy].\n\n[uv's AI policy]: https://github.com/astral-sh/.github/blob/c5187e200db51bfe11d56e13053d29bd3793fdd8/AI_POLICY.md"
+    },
+    {
+      "commit": "4519153e5e461527f4bca45b042fff45c4ec6fb9",
+      "subject": "doc: clarify half-boundary syntax for the `-w/--word-regexp` flag",
+      "body": "In regex 1.10.0, the \\b{start-half} and \\b{end-half} assertions were\nintroduced to improve how the -w/--word-regexp flag handles patterns\ncontaining non-word characters. While ripgrep's CLI help text was\nupdated to mention this syntax during the lexopt transition (082245d),\nit omitted the rationale, potentially leaving users puzzled by this\ncasual mention of a highly specific, non-standard regex feature.\n\nFurthermore, GUIDE.md was still outdated, incorrectly claiming\nthat -w wraps patterns in standard \\b boundaries,\nfurther compounding the inconsistency and potential for confusion.\n\nThis commit updates GUIDE.md to reflect the actual underlying regex\nemployed by ripgrep when the -w/--word-regexp flag is used.\nIt also adds a brief explanation to both the guide and the manpage\nacknowledging the non-standard nature of these half-boundary markers,\nand explaining what they're meant for.\n\nPR #3279"
+    },
+    {
+      "commit": "cb66736f146f093497f4dc537b33d0826f9af33c",
+      "subject": "core: bleat a DEBUG message when RIPGREP_CONFIG_PATH is not set",
+      "body": "It seems to be common that folks either don't understand how to set\nenvironment variables in a way that propagates to subprocesses, or just\nforget to include `export` and think ripgrep is somehow broken.\n\nWhile `RIPGREP_CONFIG_PATH` not being set is not an error, it still\nseems useful to log a debug message when it isn't. This should hopefully\nprovide a clue that, no, ripgrep isn't broken. It just doesn't see the\nenvironment variable.\n\nRef #3277"
+    },
+    {
+      "commit": "9b84e154c8e404f4c40f6f4e4c674ea02e77324a",
+      "subject": "ignore/types: add `container` type that covers both `Dockerfile` and `Containerfile`",
+      "body": "PR #3271"
+    },
+    {
+      "commit": "0a88cccd5188074de96f54a4b6b44a63971ac157",
+      "subject": "Fix compression tests in QEMU cross-compilation environments (#3248)",
+      "body": "* tests: fix cmd_exists for QEMU environments\n\nQEMU user-mode has a bug where posix_spawn returns success even when\nthe command doesn't exist. The child exits with 127, but the parent\nthinks it succeeded.\n\nChange cmd_exists to check if the command actually ran successfully\n(exit code 0), not just if spawn returned Ok.\n\nThis fixes compression tests on riscv64 and other QEMU-emulated\narchitectures.\n\nRef https://github.com/rust-lang/rust/issues/90825\n\n* tests: remove riscv64 skip for compression tests\n\nRemove the cfg guards that disabled lz4, brotli, and zstd tests on\nriscv64. These now work with the QEMU fix."
+    },
+    {
+      "commit": "cd1f981beafaeb9b61537e47e91314cea125400b",
+      "subject": "fix: derive `Default` when possible",
+      "body": "Ref https://rust-lang.github.io/rust-clippy/master/index.html#/derivable_impls"
+    },
+    {
+      "commit": "57c190d56eedac90c061a238b63dbfed434fee50",
+      "subject": "ignore-0.4.25",
+      "body": ""
+    },
+    {
+      "commit": "85edf4c79671b00002123a2a43ff5238b6a27891",
+      "subject": "ignore: only stat `.jj` if we actually care",
+      "body": "I was comparing the work being done by fd and find and noticed (with\n`strace -f -c -S` calls) that fd was doing a ton of failed `statx`\ncalls. Upon closer inspection it was stating `.jj` even though I\nwas passing `--no-ignore`. Eventually I turned up this check in\n`Ignore::add_child_path` that was doing stat on `.jj` regardless of\nwhether the options request it.\n\nWith this patch it'll only stat `.jj` if that's relevant to the query.\n\nPR #3212"
+    },
+    {
+      "commit": "36b7597693c994ffaf023b95d2e18aeeda7d9286",
+      "subject": "changelog: start next section",
+      "body": ""
+    },
+    {
+      "commit": "a132e56b8cf8dcb922c2a0e2165cece2895acec9",
+      "subject": "pkg/brew: update tap",
+      "body": ""
+    },
+    {
+      "commit": "af60c2de9d85e7f3d81c78601669468cf02dabab",
+      "subject": "15.1.0",
+      "body": ""
+    },
+    {
+      "commit": "a63671efb069bbef88a4426b08d45508af716514",
+      "subject": "deps: bump to grep 0.4.1",
+      "body": ""
+    },
+    {
+      "commit": "2ea06d69aaff19d53a0260f271a30cc28a39f1de",
+      "subject": "grep-0.4.1",
+      "body": ""
+    },
+    {
+      "commit": "85006b08d63efd7c7f2cc43a3b8e90d95b80a9aa",
+      "subject": "deps: bump to grep-printer 0.3.1",
+      "body": ""
+    },
+    {
+      "commit": "423afb851372ce62a9edab70356ebe6461e82a50",
+      "subject": "grep-printer-0.3.1",
+      "body": ""
+    },
+    {
+      "commit": "4694800be58daa9e2ca9534f674b63254eb02b3b",
+      "subject": "deps: bump to grep-searcher 0.1.16",
+      "body": ""
+    },
+    {
+      "commit": "86e0ab12eff635bd924e3f92bd01be3545eac7b5",
+      "subject": "grep-searcher-0.1.16",
+      "body": ""
+    },
+    {
+      "commit": "7189950799adf91a22bc29fdfcd99c287a091cb4",
+      "subject": "deps: bump to globset 0.4.18",
+      "body": ""
+    },
+    {
+      "commit": "0b0e013f5ac6ae1dbfdf97f6f6aaa27d7c9bc317",
+      "subject": "globset-0.4.18",
+      "body": ""
+    },
+    {
+      "commit": "cac9870a0264014ab7015bf07e154c06a668a72c",
+      "subject": "doc: update date in man page template",
+      "body": ""
+    },
+    {
+      "commit": "bee13375ed7c4360714175c2ec1e50ed8a8a8fc9",
+      "subject": "deps: update everything",
+      "body": ""
+    },
+    {
+      "commit": "f5be160839edb2d8dd68f54904a8927f8ab13178",
+      "subject": "changelog: 15.1.0",
+      "body": ""
+    },
+    {
+      "commit": "24e88dc15b58b6fcc16d217158994871e756a6ca",
+      "subject": "ignore/types: add `ssa` type",
+      "body": "This PR adds support for [.ssa](https://en.wikipedia.org/wiki/Static_single-assignment_form) files as read by [qbe](https://c9x.me/compile/):\n\nSee: https://c9x.me/compile/doc/il.html#Input-Files"
+    },
+    {
+      "commit": "5748f81bb107ce65f32cff330fe90dc639af262c",
+      "subject": "printer: use `doc_cfg` instead of `doc_auto_cfg`",
+      "body": "Fixes #3202"
+    },
+    {
+      "commit": "d47663b1b4548e4fa02d6e4b575718d0f5f5e7d6",
+      "subject": "searcher: fix regression with `--line-buffered` flag",
+      "body": "In my fix for #3184, I actually had two fixes. One was a tweak to how we\nread data and the other was a tweak to how we determined how much of the\nbuffer we needed to keep around. It turns out that fixing #3184 only\nrequired the latter fix, found in commit\nd4b77a8d8967ce1bf701ec65ceb9a75e85e5f2e0. The former fix also helped the\nspecific case of #3184, but it ended up regressing `--line-buffered`.\n\nSpecifically, previous to 8c6595c215d1e24bed5b7b86e2b18f3c871439ef (the\nfirst fix), we would do one `read` syscall. This call might not fill our\ncaller provided buffer. And in particular, `stdin` seemed to fill fewer\nbytes than reading from a file. So the \"fix\" was to put `read` in a loop\nand keep calling it until the caller provided buffer was full or until\nthe stream was exhausted. This helped alleviate #3184 by amortizing\n`read` syscalls better.\n\nBut of course, in retrospect, this change is clearly contrary to how\n`--line-buffered` works. We specifically do _not_ want to wait around\nuntil the buffer is full. We want to read what we can, search it and\nmove on.\n\nSo this reverts the first fix but leaves the second, which still\nkeeps #3184 fixed and also fixes #3194 (the regression).\n\nThis reverts commit 8c6595c215d1e24bed5b7b86e2b18f3c871439ef.\n\nFixes #3194"
+    },
+    {
+      "commit": "38d630261aded3a8e535fe85761e68af35bc462d",
+      "subject": "printer: add Cursor hyperlink alias",
+      "body": "This is similar to the other aliases used by\nVS Code forks.\n\nPR #3192"
+    },
+    {
+      "commit": "b3dc4b09988b4fe7d8ff69ad576623d57f7c3b75",
+      "subject": "globset: improve debug log",
+      "body": "This shows the regex that the glob was compiled to."
+    },
+    {
+      "commit": "f09b55b8e760de8192d17b7f89512c71035e1abd",
+      "subject": "changelog: start next section",
+      "body": ""
+    },
+    {
+      "commit": "0551c6b931be9df3b982362f144f36140d8cea2d",
+      "subject": "pkg/brew: update tap",
+      "body": ""
+    },
+    {
+      "commit": "3a612f88b805e14aef45bfa43e25a54abc6297fc",
+      "subject": "15.0.0",
+      "body": ""
+    },
+    {
+      "commit": "ca2e34f37c5fa3021d0c14a67a7f0590166ade4f",
+      "subject": "grep-0.4.0",
+      "body": ""
+    },
+    {
+      "commit": "a6092beee4a16055e32f42d4024a9bb68402f781",
+      "subject": "deps: bump to grep-printer 0.3.0",
+      "body": ""
+    },
+    {
+      "commit": "a0d61a063f5ff7c1d1b131882d92999c923c3420",
+      "subject": "grep-printer-0.3.0",
+      "body": ""
+    },
+    {
+      "commit": "c22fc0f13ce1cbe3bd40b659628aea21874938a2",
+      "subject": "deps: bump to grep-searcher 0.1.15",
+      "body": ""
+    },
+    {
+      "commit": "087f82273db91830245ba246306899f9fbbd86ec",
+      "subject": "grep-searcher-0.1.15",
+      "body": ""
+    },
+    {
+      "commit": "a3a30896be61285e713901ffbf0aa30f356f8304",
+      "subject": "deps: bump to grep-pcre2 0.1.9",
+      "body": ""
+    },
+    {
+      "commit": "7397ab7d97a9e07be60b3dde7c6f5ba58cc61ea8",
+      "subject": "grep-pcre2-0.1.9",
+      "body": ""
+    },
+    {
+      "commit": "cf1dab0d5aa15b4bf5b85660bbdcb3d257595ada",
+      "subject": "deps: bump to grep-regex 0.1.14",
+      "body": ""
+    },
+    {
+      "commit": "e523c6bf32079f5e51798dd797162a3cb2cf9beb",
+      "subject": "grep-regex-0.1.14",
+      "body": ""
+    },
+    {
+      "commit": "720376ead65b8a98469b5e3030bd009eee90f23f",
+      "subject": "deps: bump to grep-matcher 0.1.8",
+      "body": ""
+    },
+    {
+      "commit": "a5ba50ceaf01908fed077eb914a84bd02e016a70",
+      "subject": "grep-matcher-0.1.8",
+      "body": ""
+    },
+    {
+      "commit": "a766f79710f9182f78bd80e47d152cdc0f9b8c99",
+      "subject": "deps: bump to grep-cli 0.1.12",
+      "body": ""
+    },
+    {
+      "commit": "4aafe45760adfe6505a9852e14cad4a15f79b7c9",
+      "subject": "grep-cli-0.1.12",
+      "body": ""
+    },
+    {
+      "commit": "c03e49b8c55f5184824580d7c26c2d37c6b648d6",
+      "subject": "deps: bump to ignore 0.4.24",
+      "body": ""
+    },
+    {
+      "commit": "70ae7354e1b6328ed7eb2e6ff93fd28ecd5441c9",
+      "subject": "ignore-0.4.24",
+      "body": ""
+    },
+    {
+      "commit": "19c2a6e0d9bc685a767f6ab049e0a6aa6cdbfbe8",
+      "subject": "deps: bump to globset 0.4.17",
+      "body": ""
+    },
+    {
+      "commit": "064b36b115228bbe2ca72fc7932777096bcb2602",
+      "subject": "globset-0.4.17",
+      "body": ""
+    },
+    {
+      "commit": "365384a5c11760675768622b8c6e03e1e34ec81f",
+      "subject": "doc: move CHANGELOG update before dependency updates",
+      "body": "It seems better to write this first. Especially so it gets included into\ncrate publishes."
+    },
+    {
+      "commit": "72a5291b4e46371dd482b5577e77eb9cc5202967",
+      "subject": "doc: update date in man page template",
+      "body": ""
+    },
+    {
+      "commit": "62e676843af3ba046b027e5407f06e35343c808c",
+      "subject": "deps: update everything",
+      "body": ""
+    },
+    {
+      "commit": "3780168c132be6707cb2a5a4acbdbd7da5f576ce",
+      "subject": "changelog: 15.0.0",
+      "body": ""
+    },
+    {
+      "commit": "4c953731c4ea06ecce1a6f1e0229f1dc18a967ff",
+      "subject": "release: finally switch to LTO for release binaries",
+      "body": "There seems to be a modest improvement on some workloads:\n\n```\n$ time rg -co '\\w+' sixteenth.txt\n158520346\n\nreal    8.457\nuser    8.426\nsys     0.020\nmaxmem  779 MB\nfaults  0\n\n$ time rg-lto -co '\\w+' sixteenth.txt\n158520346\n\nreal    8.200\nuser    8.178\nsys     0.012\nmaxmem  778 MB\nfaults  0\n```\n\nI've somewhat reversed course on my previous thoughts here. The\nimprovement isn't much, but the hit to compile times in CI isn't\nterrible. Mostly I'm doing this out of \"good sense,\" and I think it's\ngenerally unlikely to make it more difficult for me to diagnose\nperformance problems. (Since I still use the default `release` profile\nlocally, since it's about an order of magnitude quicker to compile.)\n\nRef #325, Ref #413, Ref #1187, Ref #1255"
+    },
+    {
+      "commit": "79d393a302f1b6c0de6bf4ed893c0481d551f45a",
+      "subject": "release: remove riscv64 and powerpc64 artifacts",
+      "body": "Their CI workflows broke for different reasons.\n\nI perceive these as niche platforms that aren't worth blocking\na release on. And not worth my time investigating CI problems."
+    },
+    {
+      "commit": "85eaf9583353dd429dfe1faf76ad397ccf3ab5f4",
+      "subject": "ci: testing release",
+      "body": ""
+    },
+    {
+      "commit": "63209ae0b95d31f28d14be5125fba3f61f5835e6",
+      "subject": "printer: fix `--stats` for `--json`",
+      "body": "Somehow, the JSON printer seems to have never emitted correct summary\nstatistics. And I believe #3178 is the first time anyone has ever\nreported it. I believe this bug has persisted for years. That's\nsurprising.\n\nAnyway, the problem here was that we were bailing out of `finish()` on\nthe sink if we weren't supposed to print anything. But we bailed out\nbefore we tallied our summary statistics. Obviously we shouldn't do\nthat.\n\nFixes #3178"
+    },
+    {
+      "commit": "b610d1cb1506feab33459c5853e4c0d0cb16a6e2",
+      "subject": "ignore: fix global gitignore bug that arises with absolute paths",
+      "body": "The `ignore` crate currently handles two different kinds of \"global\"\ngitignore files: gitignores from `~/.gitconfig`'s `core.excludesFile`\nand gitignores passed in via `WalkBuilder::add_ignore` (corresponding to\nripgrep's `--ignore-file` flag).\n\nIn contrast to any other kind of gitignore file, these gitignore files\nshould have their patterns interpreted relative to the current working\ndirectory. (Arguably there are other choices we could make here, e.g.,\nbased on the paths given. But the `ignore` infrastructure can't handle\nthat, and it's not clearly correct to me.) Normally, a gitignore file\nhas its patterns interpreted relative to where the gitignore file is.\nThis relative interpretation matters for patterns like `/foo`, which are\nanchored to _some_ directory.\n\nPreviously, we would generally get the global gitignores correct because\nit's most common to use ripgrep without providing a path. Thus, it\nsearches the current working directory. In this case, no stripping of\nthe paths is needed in order for the gitignore patterns to be applied\ndirectly.\n\nBut if one provides an absolute path (or something else) to ripgrep to\nsearch, the paths aren't stripped correctly. Indeed, in the core, I had\njust given up and not provided a \"root\" path to these global gitignores.\nSo it had no hope of getting this correct.\n\nWe fix this assigning the CWD to the `Gitignore` values created from\nglobal gitignore files. This was a painful thing to do because we'd\nideally:\n\n1. Call `std::env::current_dir()` at most once for each traversal.\n2. Provide a way to avoid the library calling `std::env::current_dir()`\n   at all. (Since this is global process state and folks might want to\n   set it to different values for $reasons.)\n\nThe `ignore` crate's internals are a total mess. But I think I've\naddressed the above 2 points in a semver compatible manner.\n\nFixes #3179"
+    },
+    {
+      "commit": "9ec08522bee566c8fbf03c340acd7a1ff1789a9f",
+      "subject": "ignore/types: add lowercase R extensions",
+      "body": "PR #3186"
+    },
+    {
+      "commit": "d4b77a8d8967ce1bf701ec65ceb9a75e85e5f2e0",
+      "subject": "searcher: fix a performance bug with `-A/--after-context`",
+      "body": "Previously (with the previous commit):\n\n```\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -A999) | wc -l\n\nreal    2.321\nuser    0.674\nsys     0.735\nmaxmem  30 MB\nfaults  0\n1000\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -A9999) | wc -l\n\nreal    2.513\nuser    0.823\nsys     0.686\nmaxmem  30 MB\nfaults  0\n10000\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -A99999) | wc -l\n\nreal    5.067\nuser    3.254\nsys     0.676\nmaxmem  30 MB\nfaults  0\n100000\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -A999999) | wc -l\n\nreal    6.658\nuser    4.841\nsys     0.778\nmaxmem  51 MB\nfaults  0\n1000000\n```\n\nNow with this commit:\n\n```\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -A999) | wc -l\n\nreal    1.845\nuser    0.328\nsys     0.757\nmaxmem  30 MB\nfaults  0\n1000\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -A9999) | wc -l\n\nreal    1.917\nuser    0.334\nsys     0.771\nmaxmem  30 MB\nfaults  0\n10000\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -A99999) | wc -l\n\nreal    1.972\nuser    0.319\nsys     0.812\nmaxmem  30 MB\nfaults  0\n100000\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -A999999) | wc -l\n\nreal    2.005\nuser    0.333\nsys     0.855\nmaxmem  30 MB\nfaults  0\n1000000\n```\n\nAnd compare to GNU grep:\n\n```\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -A999) | wc -l\n\nreal    1.488\nuser    0.143\nsys     0.866\nmaxmem  30 MB\nfaults  0\n1000\n\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -A9999) | wc -l\n\nreal    1.697\nuser    0.170\nsys     0.986\nmaxmem  30 MB\nfaults  1\n10000\n\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -A99999) | wc -l\n\nreal    1.515\nuser    0.166\nsys     0.856\nmaxmem  29 MB\nfaults  0\n100000\n\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -A999999) | wc -l\n\nreal    1.490\nuser    0.174\nsys     0.851\nmaxmem  30 MB\nfaults  0\n1000000\n```\n\nInterestingly, GNU grep is still a bit faster. But both commands remain\nroughly invariant in search time as `-A` is increased.\n\nThere is definitely something \"odd\" about searching `stdin`, where it\nseems substantially slower. We can also observe with GNU grep:\n\n```\n$ (time grep ZQZQZQZQZQ -A999999 bigger.txt) | wc -l\n\nreal    0.692\nuser    0.184\nsys     0.506\nmaxmem  30 MB\nfaults  0\n1000000\n\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -A999999) | wc -l\n\nreal    1.700\nuser    0.201\nsys     0.954\nmaxmem  30 MB\nfaults  0\n1000000\n\n$ (time rg ZQZQZQZQZQ -A999999 bigger.txt) | wc -l\n\nreal    0.640\nuser    0.428\nsys     0.209\nmaxmem  7734 MB\nfaults  0\n1000000\n\n$ (time rg ZQZQZQZQZQ --no-mmap -A999999 bigger.txt) | wc -l\n\nreal    0.866\nuser    0.282\nsys     0.581\nmaxmem  30 MB\nfaults  0\n1000000\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -A999999) | wc -l\n\nreal    1.991\nuser    0.338\nsys     0.819\nmaxmem  30 MB\nfaults  0\n1000000\n```\n\nI wonder if this is related to my discovery in the previous commit where\n`read` calls on `stdin` seem to never return anything more than ~64K. Oh\nwell, I'm satisfied at this point, especially given that GNU grep seems\nto do a lot worse than ripgrep with bigger values of\n`-B/--before-context`:\n\n```\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -B9) | wc -l\n\nreal    1.568\nuser    0.170\nsys     0.885\nmaxmem  30 MB\nfaults  0\n1\n\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -B99) | wc -l\n\nreal    1.734\nuser    0.338\nsys     0.879\nmaxmem  30 MB\nfaults  0\n1\n\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -B999) | wc -l\n\nreal    2.349\nuser    1.723\nsys     0.620\nmaxmem  30 MB\nfaults  0\n1\n\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -B9999) | wc -l\n\nreal    16.459\nuser    15.848\nsys     0.586\nmaxmem  30 MB\nfaults  0\n1\n\n$ time grep ZQZQZQZQZQ -B99999 bigger.txt\nZQZQZQZQZQ\n\nreal    1:45.06\nuser    1:44.12\nsys     0.772\nmaxmem  30 MB\nfaults  0\n```\n\nThe above pattern occurs regardless of whether you put `bigger.txt` on\nstdin or whether you search it directly.\n\nAnd now ripgrep:\n\n```\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -B9) | wc -l\n\nreal    1.965\nuser    0.326\nsys     0.814\nmaxmem  29 MB\nfaults  0\n1\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -B99) | wc -l\n\nreal    1.941\nuser    0.423\nsys     0.813\nmaxmem  29 MB\nfaults  0\n1\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -B999) | wc -l\n\nreal    2.372\nuser    0.759\nsys     0.703\nmaxmem  30 MB\nfaults  0\n1\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -B9999) | wc -l\n\nreal    2.638\nuser    0.895\nsys     0.665\nmaxmem  29 MB\nfaults  0\n1\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ -B99999) | wc -l\n\nreal    5.172\nuser    3.282\nsys     0.748\nmaxmem  29 MB\nfaults  0\n1\n```\n\nNOTE: To get `bigger.txt`:\n\n```\n$ curl -LO 'https://burntsushi.net/stuff/opensubtitles/2018/en/sixteenth.txt.gz'\n$ gzip -d sixteenth.txt.gz\n$ (echo ZQZQZQZQZQ && for ((i=0;i<10;i++)); do cat sixteenth.txt; done) > bigger.txt\n```"
+    },
+    {
+      "commit": "8c6595c215d1e24bed5b7b86e2b18f3c871439ef",
+      "subject": "searcher: fix performance bug with `-A/--after-context` when searching `stdin`",
+      "body": "This was a crazy subtle bug where ripgrep could slow down exponentially\nas increasingly larger values of `-A/--after-context` were used. But,\ninterestingly, this would only occur when searching `stdin` and _not_\nwhen searching the same data as a regular file.\n\nThis confounded me because ripgrep, pretty early on, erases the\ndifference between searching a single file and `stdin`. So it wasn't\nlike there were different code paths. And I mistakenly assumed that they\nwould otherwise behave the same as they are just treated as streams.\n\nBut... it turns out that running `read` on a `stdin` versus a regular\nfile seems to behave differently. At least on my Linux system, with\n`stdin`, `read` never seems to fill the buffer with more than 64K. But\nwith a regular file, `read` pretty reliably fills the caller's buffer\nwith as much space as declared.\n\nOf course, it is expected that `read` doesn't *have* to fill up the\ncaller's buffer, and ripgrep is generally fine with that. But when\n`-A/--after-context` is used with a very large value"
+    },
+    {
+      "commit": "then more heap memory needs\nto be allocated to correctly handle all cases. This can result in\npassing buffers bigger than 64K to `read`.\n\nWhile we *correctly* handle `read` calls that don't fill the buffer,\nit turns out that if we don't fill the buffer, then we get into a\npathological case where we aren't processing as many bytes as we could.\nThat is, because of the `-A/--after-context` causing us to keep a lot of\nbytes around while we roll the buffer and because reading from `stdin`\ngives us fewer bytes than normal, we weren't amortizing our `read` calls\nas well as we should have been. Indeed, our buffer capacity increases\nspecifically take this amortization into account, but we weren't taking\nadvantage of it.\n\nWe fix this by putting `read` into an inner loop that ensures our\nbuffer gets filled up. This fixes the performance bug:\n\n```\n$ (time rg ZQZQZQZQZQ bigger.txt --no-mmap -A9999) | wc -l\n\nreal    1.330\nuser    0.767\nsys     0.559\nmaxmem  29 MB\nfaults  0\n10000\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ --no-mmap -A9999) | wc -l\n\nreal    2.355\nuser    0.860\nsys     0.613\nmaxmem  29 MB\nfaults  0\n10000\n\n$ (time rg ZQZQZQZQZQ bigger.txt --no-mmap -A99999) | wc -l\n\nreal    3.636\nuser    3.091\nsys     0.537\nmaxmem  29 MB\nfaults  0\n100000\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ --no-mmap -A99999) | wc -l\n\nreal    4.918\nuser    3.236\nsys     0.710\nmaxmem  29 MB\nfaults  0\n100000\n\n$ (time rg ZQZQZQZQZQ bigger.txt --no-mmap -A999999) | wc -l\n\nreal    5.430\nuser    4.666\nsys     0.750\nmaxmem  51 MB\nfaults  0\n1000000\n\n$ cat bigger.txt | (time rg ZQZQZQZQZQ --no-mmap -A999999) | wc -l\n\nreal    6.894\nuser    4.907\nsys     0.850\nmaxmem  51 MB\nfaults  0\n1000000\n```\n\nFor comparison, here is GNU grep:\n\n```\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -A9999) | wc -l\n\nreal    1.466\nuser    0.159\nsys     0.839\nmaxmem  29 MB\nfaults  0\n10000\n\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -A99999) | wc -l\n\nreal    1.663\nuser    0.166\nsys     0.941\nmaxmem  29 MB\nfaults  0\n100000\n\n$ cat bigger.txt | (time grep ZQZQZQZQZQ -A999999) | wc -l\n\nreal    1.631\nuser    0.204\nsys     0.910\nmaxmem  29 MB\nfaults  0\n1000000\n```\n\nGNU grep is still notably faster. We'll fix that in the next commit.\n\nFixes #3184",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "de2567a4c76fa671005538d6cd841abc44932b9a",
+      "subject": "printer: fix panic in replacements in look-around corner case",
+      "body": "The abstraction boundary fuck up is the gift that keeps on giving. It\nturns out that the invariant that the match would never exceed the range\ngiven is not always true. So we kludge around it.\n\nAlso, update the CHANGELOG to include the fix for #2111.\n\nFixes #3180"
+    },
+    {
+      "commit": "916415857f084e63efda03cf25a67fe7f6d24244",
+      "subject": "core: don't build decompression reader unless we intend to use it",
+      "body": "Building it can consume resources. In particular, on Windows, the\nvarious binaries are eagerly resolved.\n\nI think this originally wasn't done. The eager resolution was added\nlater for security purposes. But the \"eager\" part isn't actually\nnecessary.\n\nIt would probably be better to change the decompression reader to do\nlazy resolution only when the binary is needed. But this will at least\navoid doing anything when the `-z/--search-zip` flag isn't used. But\nwhen it is, ripgrep will still eagerly resolve all possible binaries.\n\nFixes #2111"
+    },
+    {
+      "commit": "5c42c8c48f4163ba7c0662cb70dbf61f9d670d9a",
+      "subject": "test: add regression test for fixed bug",
+      "body": "It turns out that #2094 was fixed in my `--max-count` refactor a few\ncommits back. This commit adds a regression test for it.\n\nCloses #2094"
+    },
+    {
+      "commit": "f0faa91c68c0d2f8c4b93a5e8546b4d3554f637e",
+      "subject": "doc: clarify `--ignore-file` precedence",
+      "body": "Fixes #2777"
+    },
+    {
+      "commit": "a5d9e03c687c14618d9224e0cbea3061860ba8de",
+      "subject": "test: attempt to fix flaky time-reliant test",
+      "body": "Fixes #2794"
+    },
+    {
+      "commit": "924ba101eed70e4e096ba639382c73dec90c2c86",
+      "subject": "test: fix `Command::current_dir` API",
+      "body": "Every single call site wants to pass a path relative to the directory\nthe command was created for. So just make it do that automatically,\nsimilar to `Dir::create` and friends."
+    },
+    {
+      "commit": "293ef80eaf0641bcfa0206e1fc142017296bac8c",
+      "subject": "test: add another regression test for gitignore matching bug",
+      "body": "I believe this was also fixed by #2933.\n\nCloses #2770"
+    },
+    {
+      "commit": "fa80aab6b0f854f7a88e7d982d27aec0a9402002",
+      "subject": "test: add regression test for fixed gitignore bug",
+      "body": "I believe this was actually fixed by #2933.\n\nCloses #3067"
+    },
+    {
+      "commit": "7c2161d68755e2c47db26717f6757f5099d500e4",
+      "subject": "release: add binaries for `riscv64gc-unknown-linux-gnu` target",
+      "body": "Note that we skip lz4/brotli/zstd tests on RISC-V.\n\nThe CI runs RISC-V tests using cross/QEMU emulation. The decompression\ntools (lz4, brotli, zstd) are x86_64 binaries on the host that cannot\nexecute in the RISC-V QEMU environment.\n\nSkip these three tests at compile-time on RISC-V to avoid test failures.\nThe -z/--search-zip functionality itself works correctly on real RISC-V\nhardware where native decompression tools are available.\n\nPR #3165"
+    },
+    {
+      "commit": "096f79ab9824753cedd989da92076be12f0904ea",
+      "subject": "deps: update everything",
+      "body": "This includes an update to `regex 1.12.1`, which fixes a couple of\noutstanding bugs in ripgrep.\n\nFixes #2750, Fixes #3135"
+    },
+    {
+      "commit": "0407e104f611d623547897ca99d172673b31779f",
+      "subject": "ignore: fix problem with searching whitelisted hidden files",
+      "body": "... specifically, when the whitelist comes from a _parent_ gitignore\nfile.\n\nOur handling of parent gitignores is pretty ham-fisted and has been a\nsource of some unfortunate bugs. The problem is that we need to strip\nthe parent path from the path we're searching in order to correctly\napply the globs. But getting this stripping correct seems to be a subtle\naffair.\n\nFixes #3173"
+    },
+    {
+      "commit": "bb88a1ac45c70bef97e0d6ccd6e91595610de860",
+      "subject": "deps: semver compatible updated to dependencies",
+      "body": ""
+    },
+    {
+      "commit": "2924d0c4c0c87a147623d9254fbdbe7b28e7f872",
+      "subject": "ignore: add `min_depth` option",
+      "body": "This mimics the eponymous option in `walkdir`.\n\nCloses #3158, PR #3162"
+    },
+    {
+      "commit": "9d8016d10c94a5af2768eb6dd0440386a7d317a0",
+      "subject": "printer: finish removal of `max_matches`",
+      "body": "This finishes what I started in commit\na6e0be3c909c5c09e5fb402c907f3beb88cfb4c4.\nSpecifically, the `max_matches` configuration has been moved to the\n`grep-searcher` crate and *removed* from the `grep-printer` crate. The\ncommit message has the details for why we're doing this, but the short\nstory is to fix #3076.\n\nNote that this is a breaking change for `grep-printer`, so this will\nrequire a semver incompatible release."
+    },
+    {
+      "commit": "9802945e6342ec284633924cb7d8d3ce67204995",
+      "subject": "doc: update the CentOS, RHEL and Rocky Linux installation instructions",
+      "body": "I've split the previously singular \"CentOS/RHEL/Rocky\" section into 3\nsections. They each benefit from having their own steps.\n\nI've also copied steps from [EPEL Getting Started] documentation,\nincluding steps that don't seem to be required because it seems to be\nbest practice (although I do not understand it). Notably, this is not\nrequired for CentOS Stream:\n\n```\ndnf config-manager --set-enabled crb\n```\n\nAnd this is not required for Red Hat:\n\n```\nsubscription-manager repos --enable codeready-builder-for-rhel-10-$(arch)-rpms\n```\n\nAnd neither are available on Rocky Linux 10. Hence, all 3 have slightly\ndifferent instructions.\n\nIt has been suggested (see [here][suggest1] and [here][suggest2]) that\nthe installation instructions should just link to the [EPEL Getting\nStarted] documentation and just contain this step:\n\n```\nsudo dnf install ripgrep\n```\n\nHowever, this is not sufficient to actually install ripgrep from a\nbase installation of these Linux distributions. I tested this via the\n`dokken/centos-stream-10:sha-d1e294f`, `rockylinux/rockylinux:10` and\n`redhat/ubi10` Docker images on DockerHub.\n\nWhile this does mean ripgrep's installation instructions can become out\nof sync from upstream, this is *always* a risk regardless of platform.\nThe instructions are provided on a best effort basis and generally\nshould work on the latest release of said platform. If the instructions\nresult in unhelpful errors (like `dnf install ripgrep` does if you\ndon't enable EPEL), then that isn't being maximally helpful to users.\nI'd rather attempt to give the entire set of instructions and risk\nbeing out of sync.\n\nAlso, since the installation instructions include URLs with version\nnumbers in them, I made the section names include version numbers as\nwell.\n\nNote: I found using the `dokken/centos-stream-10:sha-d1e294f` Docker\nimage to be somewhat odd, as I could not find any official CentOS\nDocker images. [This][DockerHub-CentOS] is still the first hit on\nGoogle, but all of its tags have been deleted and the image is\ndeprecated. I was profoundly confused by this given that the [EPEL\nGetting Started] documentation *specifically* cites CentOS 10. In fact,\nit is citing CentOS *Stream* 10, which is something wholly distinct\nfrom CentOS. What an absolute **clusterfuck**. If I had just read this\nparagraph on Wikipedia from the beginning, I would have saved myself a\nlot of confusion:\n\n> In December 2020, Red Hat unilaterally terminated CentOS development in favor\n> of CentOS Stream 9, a distribution positioned upstream of RHEL. In March\n> 2021, CloudLinux (makers of CloudLinux OS) released a RHEL derivative called\n> AlmaLinux. Later in May 2021, one of the CentOS founders (Gregory Kurtzer)\n> created the competing Rocky Linux project as a successor to the original\n> mission of CentOS.\n\nRef #2981, Ref #2924\n\n[EPEL Getting Started]: https://docs.fedoraproject.org/en-US/epel/getting-started/\n[suggest1]: https://github.com/BurntSushi/ripgrep/pull/2981#issuecomment-3204114293\n[suggest2]: https://github.com/BurntSushi/ripgrep/issues/2924#issuecomment-3326357254\n[DockerHub-CentOS]: https://hub.docker.com/_/centos"
+    },
+    {
+      "commit": "fdea9723cac34b6e93e259c2366c94e8319de0ca",
+      "subject": "doc: clarify a case where -m/--max-count is not strictly respected",
+      "body": "In #2843, it's requested that these trailing contextual lines should be\ndisplayed as non-matching because they exceed the limit. While\nreasonable, I think that:\n\n1. This would be a weird complication to the implementation.\n2. This would overall be less intuitive and more complex. Today, there\n   is never a case where ripgrep emits a matching line in a way where\n   the match isn't highlighted.\n\nCloses #2843"
+    },
+    {
+      "commit": "c45ec16360870bba60505489fb745ad245075a86",
+      "subject": "doc: clarify `--multiline --count`",
+      "body": "Specifically, it is only equivalent to `--count-matches` when the\npattern(s) given can match over multiple lines.\n\nWe could have instead made `--multiline --count` always equivalent to\n`--multiline --count-matches`, but this seems plausibly less useful.\nIndeed, I think it's generally a good thing that users can enable\n`-U/--multiline` but still use patterns that only match a single line.\nChanging how that behaves would I think be more surprising.\n\nEither way we slice this, it's unfortunately pretty subtle.\n\nFixes #2852"
+    },
+    {
+      "commit": "e42432cc5dc32820d025e28287bba70a3751f8ca",
+      "subject": "ignore: clarify `WalkBuilder::filter_entry`",
+      "body": "Fixes #2913"
+    },
+    {
+      "commit": "6e77339f30bd4eeaa3980a3256f57e81ec579302",
+      "subject": "cli: tweak docs for `resolve_binary`",
+      "body": "Fixes #2928"
+    },
+    {
+      "commit": "1b07c6616a5b06bd6c00f2a7d3418b9096f601f9",
+      "subject": "cli: document that `-c/--count` can be inconsistent with `-l/--files-with-matches`",
+      "body": "This is unfortunate, but is a known bug that I don't think can be fixed\nwithout either making `-l/--files-with-matches` much slower or changing\nwhat \"binary filtering\" means by default.\n\nIn this PR, we document this inconsistency since users may find it quite\nsurprising. The actual work-around is to disable binary filtering with\nthe `--binary` flag.\n\nWe add a test confirming this behavior.\n\nCloses #3131"
+    },
+    {
+      "commit": "c1fc6a5eb8c971fc43041d3df34cf8bd49f31032",
+      "subject": "release: build aarch64 artifacts for macos on GitHub Actions",
+      "body": "GitHub now supports this natively, so there's no need for me to do it\nany more.\n\nFixes #3155"
+    },
+    {
+      "commit": "8b5d3d1c1e3b0e32f22aa634d000b314f6d4d465",
+      "subject": "printer: hack in a fix for `-l/--files-with-matches` when using `--pcre2 --multiline` with look-around",
+      "body": "The underlying issue here is #2528, which was introduced by commit\nefd9cfb2fc1f0233de9eda4c03416d32ef2c3ce8 which fixed another bug.\n\nFor the specific case of \"did a file match,\" we can always assume the\nmatch count is at least 1 here. But this doesn't fix the underlying\nproblem.\n\nFixes #3139"
+    },
+    {
+      "commit": "491bf3f6d5bc1a621754440e291960f460a9c003",
+      "subject": "deps: update everything else",
+      "body": ""
+    },
+    {
+      "commit": "81bed78654f57f344e6ef79b81751c09ea60c74e",
+      "subject": "deps: update to PCRE2 10.46",
+      "body": "This is for completely static builds of ripgrep."
+    },
+    {
+      "commit": "1b6177bc5c53c3007c61bba4100a98d5d2a856ae",
+      "subject": "cargo: set MSRV to 1.85",
+      "body": "I believe the current stable version of Debian packages 1.85 rustc. So\nif the next release of ripgrep uses a higher MSRV, then I think Debian\nwon't be able to package it.\n\nIt also turned out that I wasn't using anything from beyond Rust 1.85\nanyway.\n\nIt's likely that I could make use of let-chains in various places, but I\ndon't think it's worth combing through the code to switch to them at\nthis point."
+    },
+    {
+      "commit": "a7b7d81d66b6e2e4311d5dd0683022c2978650f1",
+      "subject": "lint: fix a few Clippy errors",
+      "body": "PR #3151"
+    },
+    {
+      "commit": "bb8172fe9baa450ede7ff84677ab45048675fd02",
+      "subject": "style: apply rustfmt",
+      "body": "Maybe 2024 changes?\n\nNote that we now set `edition = \"2024\"` explicitly in `rustfmt.toml`.\nWithout this, it seems like it's possible in some cases for rustfmt to\nrun under an older edition's style. Not sure how though."
+    },
+    {
+      "commit": "64174b8e68b59e560ad459f3c11cc9c4f00964bd",
+      "subject": "printer: preserve line terminator when using `--crlf` and `--replace`",
+      "body": "Ref #3097, Closes #3100"
+    },
+    {
+      "commit": "f596a5d8750a6a6db1b87ad95a78667322c06cbd",
+      "subject": "globset: add `allow_unclosed_class` toggle",
+      "body": "When enabled, patterns like `[abc`, `[]`, `[!]` are treated as if the\nopening `[` is just a literal. This is in contrast the default behavior,\nwhich prioritizes better error messages, of returning a parse error.\n\nFixes #3127, Closes #3145"
+    },
+    {
+      "commit": "556623684e99fade287f265c5f513321487dd35a",
+      "subject": "ignore/types: add GDScript files (*.gd) for the Godot Engine",
+      "body": "Closes #3142"
+    },
+    {
+      "commit": "a6e0be3c909c5c09e5fb402c907f3beb88cfb4c4",
+      "subject": "searcher: move \"max matches\" from printer to searcher",
+      "body": "This is a bit of a brutal change, but I believe is necessary in order to\nfix a bug in how we handle the \"max matches\" limit in multi-line mode\nwhile simultaneously handling context lines correctly.\n\nThe main problem here is that \"max matches\" refers to the shorter of\n\"one match per line\" or \"a single match.\" In typical grep, matches\n*can't* span multiple lines, so there's never a difference. But in\nmulti-line mode, they can. So match counts necessarily must be handled\ndifferently for multi-line mode.\n\nThe printer was previously responsible for this. But for $reasons, the\nprinter is fundamentally not in charge of how matches are found and\nreported.\n\nSee my comments in #3094 for even more context.\n\nThis is a breaking change for `grep-printer`.\n\nFixes #3076, Closes #3094"
+    },
+    {
+      "commit": "a60e62d9ac559b1468d4dd27b80a7b662a600e0c",
+      "subject": "rust: move to Rust 2024",
+      "body": "I'd like to use let chains.\n\nProbably this isn't necessary to do for every crate, but I don't feel\nlike maintaining a mismash."
+    },
+    {
+      "commit": "3f565b58cc85a655b552ddcfad1e31b60bdc374f",
+      "subject": "ignore/types: add Qt types for resource files and ui declaration",
+      "body": "qrc[1] are the resource files for data related to user interfaces, and\nui[2] is the extension that the Qt Designer generates, for Widget based\nprojects.\n\nNote that the initial PR used `ui` as a name for `*.ui`, but this seems\noverly general. Instead, we use `qui` here instead.\n\nCloses #3141\n\n[1]: https://doc.qt.io/qt-6/resources.html\n[2]: https://doc.qt.io/qt-6/uic.html"
+    },
+    {
+      "commit": "74959a14cbcce19e2471b0d281ea5cdbd248527d",
+      "subject": "man: escape all hyphens in flag names",
+      "body": "Apparently, if we don't do this, some roff renderers with use a special\nUnicode hyphen. That in turn makes searching a man page not work as one\nwould expect.\n\nFixes #3140"
+    },
+    {
+      "commit": "78383de9b29a67c64bc21047caf57559f7061e26",
+      "subject": "complete/zsh: improve --hyperlink-format completion",
+      "body": "Also don't re-define helper functions if they exist.\n\nCloses #3102"
+    },
+    {
+      "commit": "519c1bd5cfd569bed29f1b3114a872329883983a",
+      "subject": "complete: improvements for the `--hyperlink-format` flag",
+      "body": "The goal is to make the completion for `rg --hyperlink-format v<TAB>`\nwork in the fish shell.\n\nThese are not exhaustive (the user can also specify custom formats).\nThis is somewhat unfortunate, but is probably better than not doing\nanything at all.\n\nThe `grep+` value necessitated a change to a test.\n\nCloses #3096"
+    },
+    {
+      "commit": "66aa4a63bb52468aa789cfa00c0643111ff03239",
+      "subject": "printer: deduplicate hyperlink alias names",
+      "body": "This exports a new `HyperlinkAlias` type in the `grep-printer` crate.\nThis includes a \"display priority\" with each alias and a function for\ngetting all supported aliases from the crate.\n\nThis should hopefully make it possible for downstream users of this\ncrate to include a list of supported aliases in the documentation.\n\nCloses #3103"
+    },
+    {
+      "commit": "fdfda9ae73bded4e1c2fc0103439a5a357c1f271",
+      "subject": "doc: actually fix deb download link",
+      "body": "Amazingly, there were about a dozen PRs fixing this same thing, and I\nhappened to choose the one that didn't actually fix the URL completely.\n\nApparently some users found this \"interesting\":\nhttps://github.com/BurntSushi/ripgrep/pull/3065#issuecomment-3204275122"
+    },
+    {
+      "commit": "c03731005020a4fef8016e46c1ba9fdab8d7df4c",
+      "subject": "doc: update installation instructions for RHEL/CentOS/Rocky Linux 9",
+      "body": "Closes #2924, Closes #2981, Closes #3124"
+    },
+    {
+      "commit": "99fe884536e18bcd9f3c57ce598791d5baa975b1",
+      "subject": "colors: add `highlight` type support for matching lines",
+      "body": "This lets users highlight non-matching text in matching lines.\n\nCloses #3024, Closes #3107"
+    },
+    {
+      "commit": "126bbeab8c1cbbc1d6cb36b4c2d560574233856d",
+      "subject": "printer: fix handling of `has_match` for summary printer",
+      "body": "Previously, `Quiet` mode in the summary printer always acted like\n\"print matching paths,\" except without the printing. This happened even\nif we wanted to \"print non-matching paths.\" Since this only afflicted\nquiet mode, this had the effect of flipping the exit status when\n`--files-without-match --quiet` was used.\n\nFixes #3108, Ref #3118"
+    },
+    {
+      "commit": "859d54270ec19f8ffc98343d9af886c10728d680",
+      "subject": "globset: make `GlobSet::new` public",
+      "body": "For users of globset who already have a `Vec<Glob>` (or similar),\nthe current API requires them to iterate over their `Vec<Glob>`,\ncalling `GlobSetBuilder::add` for each `Glob`, thus constructing a new\n`Vec<Glob>` internal to the GlobSetBuilder. This makes the consuming\ncode unnecessarily verbose. (There is unlikely to be any meaningful\nperformance impact of this, however, since the cost of allocating a new\n`Vec` is likely marginal compared to the cost of glob compilation.)\n\nInstead of taking a `&[Glob]`, we accept an iterator of anything that\ncan be borrowed as a `&Glob`. This required some light refactoring of\nthe constructor, but nothing onerous.\n\nCloses #3066"
+    },
+    {
+      "commit": "33b44812c0a01f4f2a316bac04d4a7477cf41444",
+      "subject": "globset: make `GlobSet::empty` const",
+      "body": "Closes #3098"
+    },
+    {
+      "commit": "c007d8914510e799c72a72b99980554cb673414a",
+      "subject": "doc: clarify that `.git` is covered by `--hidden` and not `--ignore-vcs`",
+      "body": "Fixes #3121, Closes #3122"
+    },
+    {
+      "commit": "60aa9f17276409257ad612fccefba13c26ed0d74",
+      "subject": "tests: increase sleep duration for sort file metadata tests on Windows AArch64",
+      "body": "Use `cfg!` to assign a 1000ms delay only on Windows Aarch64 targets.\n\nThis was done because it has been observed to be necessary on this\nplatform. The conditional logic is used because 1s is quite long to\nwait on every other more sensible platform.\n\nCloses #3071, Closes #3072"
+    },
+    {
+      "commit": "56d03a1e2f8f12a2a5fe8fcc3b1a4c5039291c9a",
+      "subject": "ignore/types: include missing files for the tf type",
+      "body": "Existing matches were too restrictives, so we simplify those to every\ntype of tfvars file we can encounter.\n\nCloses #3117"
+    },
+    {
+      "commit": "e166f271dff589ec39d21235ef38f792545be37d",
+      "subject": "ignore/types: add gleam",
+      "body": "[Gleam] is a general-purpose, concurrent, functional high-level\nprogramming language that compiles to Erlang or JavaScript source code.\n\nCloses #3105\n\n[Gleam]: https://gleam.run/"
+    },
+    {
+      "commit": "83d94672ae09a5deb6d4d795b105b3b18d34508a",
+      "subject": "ignore/types: add LLVM to default types",
+      "body": "This PR adds llvm to the list of default types, matching files with\nextension ll which is used widely for the textual form of LLVM's\nIntermediate Representation.\n\nRef: https://llvm.org/docs/LangRef.html\n\nCloses #3079"
+    },
+    {
+      "commit": "6887122e5bcef8d4b7a2c70ea04ef9d87d80faff",
+      "subject": "ignore/types: add ColdFusion and BoxLang",
+      "body": "Closes #3090"
+    },
+    {
+      "commit": "06210b382a4628258680cfdda07d5ed73a88b046",
+      "subject": "ignore/types: add `.env` to `sh` file type",
+      "body": "`.env` or \"dotenv\" is used quite often in cross-compilation/embedded\ndevelopment environments to load environment variables, define shell\nfunctions or even to execute shell commands. Just like `.zshenv` in\nthis list, I think `.env` should also be added here.\n\nCloses #3063"
+    },
+    {
+      "commit": "00e501b529fc709806a413a88c2f32487e7958cb",
+      "subject": "build: emit warning if git is missing during build",
+      "body": "Closes #3057"
+    },
+    {
+      "commit": "2ebd768d404952b5412997555b84b6ca2e20f8b8",
+      "subject": "doc: remove CentOS/RHEL installation instructions",
+      "body": "These distros, or their Docker images, appear FUBAR. The UX is so poor\nthat I cannot verify the correct installation instructions. So I'm\nremoving them.\n\nRef https://github.com/BurntSushi/ripgrep/pull/2981#issuecomment-3202063173\n\nCloses #2981, Closes #3124"
+    },
+    {
+      "commit": "4df1298127695ed1e76937f16de1a0135677ccf5",
+      "subject": "globset: fix bug where trailing `.` in file name was incorrectly handled",
+      "body": "I'm not sure why I did this, but I think I was trying to imitate the\ncontract of [`std::path::Path::file_name`]:\n\n> Returns None if the path terminates in `..`.\n\nBut the status quo clearly did not implement this. And as a result, if\nyou have a glob that ends in a `.`, it was instead treated as the empty\nstring (which only matches the empty string).\n\nWe fix this by implementing the semantic from the standard library\ncorrectly.\n\nFixes #2990\n\n[`std::path::Path::file_name`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.file_name"
+    },
+    {
+      "commit": "ba23ced8178496263af013117b70c09ce39c18e5",
+      "subject": "ignore/types: add scdoc",
+      "body": "Ref https://sr.ht/~sircmpwn/scdoc/\n\nCloses #3007"
+    },
+    {
+      "commit": "28cce895ffb8b34f3378b96b5a6b7aafe01694da",
+      "subject": "doc: fix nixpkgs link",
+      "body": "Closes #3006"
+    },
+    {
+      "commit": "7339bdf4b5f18ec9555e1a5bb69ef388b681ef79",
+      "subject": "test: check binary file detection when using memory maps",
+      "body": "This resolves a TODO comment I wrote a while back.\n\nMemory maps behave a little differently in terms of detecting binary\ndata, so the tests have somewhat different results than the tests that\ndisable memory maps.\n\nCloses #3002"
+    },
+    {
+      "commit": "79f5a5a66e68aa50ef9f63ded777e640d345df5e",
+      "subject": "globset: add `Candidate::from_bytes` constructor",
+      "body": "This is already technically possible to do on Unix by going through\n`OsStr` and `&[u8]` conversions. This just makes it easier to do in all\ncircumstances and is reasonable to intentionally support.\n\nCloses #2954, Closes #2955"
+    },
+    {
+      "commit": "4ab1862dc04783b6615807d4b4511388c6b30364",
+      "subject": "stats: fix case where \"bytes searched\" could be wrong",
+      "body": "Specifically, if the search was instructed to quit early, we might not\nhave correctly marked the number of bytes consumed.\n\nI don't think this bug occurs when memory maps are used to read the\nhaystack.\n\nCloses #2944"
+    },
+    {
+      "commit": "6244e635a1a5aa4d401826b1e970d59a3f6cbf7c",
+      "subject": "ignore/types: add Kconfig",
+      "body": "Kconfig files are used to represent the configuration database of\nKbuild build system. Kbuild is developed as part of the Linux kernel.\nThere are numerous other users including OpenWrt and U-Boot.\n\nRef: https://docs.kernel.org/kbuild/index.html\n\nCloses #2942"
+    },
+    {
+      "commit": "5e2d32fe7f3b7dcf768ffc1264dabe83e00ccaec",
+      "subject": "printer: slightly simplify code",
+      "body": "I'm not sure why it was written with `map` previously. It almost looks\nlike I was trying to make it deref, but apparently that isn't needed.\n\nCloses #2941"
+    },
+    {
+      "commit": "75e17fcabe14dd9a773e4e8dc5b2fc837f238a90",
+      "subject": "ignore/types: add `*.dtso` to `devicetree` type",
+      "body": "`dtso` files became recognized as devicetree a\ncouple of years ago with the following commit:\nhttps://github.com/torvalds/linux/commit/363547d2191cbc32ca954ba75d72908712398ff2\n\nCloses #2938"
+    },
+    {
+      "commit": "99b7957122454185dc5ea9e99bb1b56c8966f1a2",
+      "subject": "ignore/doc: explain that `require_git(false)` will ascend above git roots",
+      "body": "This should hopefully help avoid confusion about #2812 as encountered\nin https://github.com/sourcefrog/cargo-mutants/issues/450.\n\nCloses #2937"
+    },
+    {
+      "commit": "ab4665a164476bc42454b60a79aad7497ecb2592",
+      "subject": "globset: remove `__Nonexhaustive` work-around",
+      "body": "This existed before the `#[non_exhaustive]` attribute was a thing. Since\nit was not part of the API of the crate, it is not a semver incompatible\nchange."
+    },
+    {
+      "commit": "5f5da483079c61966ea34565387867609d4e22f2",
+      "subject": "globset: support nested alternates",
+      "body": "For example, `**/{node_modules/**/*/{ts,js},crates/**/*.{rs,toml}`.\n\nI originally didn't add this I think for implementation simplicity, but\nit turns out that it really isn't much work to do. There might have also\nbeen some odd behavior in the regex engine for dealing with empty\nalternates, but that has all been long fixed.\n\nCloses #3048, Closes #3112"
+    },
+    {
+      "commit": "b0c6d4c34afed68cfdc9dde98046716b1e773651",
+      "subject": "ignore/types: add `*.svelte.ts` to Svelte file type glob",
+      "body": "I was somewhat unsure about adding this, since `.svelte.ts` seems\nprimarily like a TypeScript file and it could be surprising to show up\nin a search for Svelte files. In particular, ripgrep doesn't know how to\nonly search the Svelte stuff inside of a `.svelte.ts` file, so you could\nend up with lots of false positives.\n\nHowever, I was swayed[1] by the argument that the extension does\nactually include `svelte` in it, so maybe this is fine. Please open an\nissue if this change ends up being too annoying for most users.\n\nCloses #2874, Closes #2909\n\n[1]: https://github.com/BurntSushi/ripgrep/issues/2874#issuecomment-3126892931"
+    },
+    {
+      "commit": "d199058e77cbea419f072015373ab1beb0e508ee",
+      "subject": "cli: make `rg -vf file` behave sensibly",
+      "body": "Previously, when `file` is empty (literally empty, as in, zero byte),\n`rg -f file` and `rg -vf file` would behave identically. This is odd\nand also doesn't match how GNU grep behaves. It's also not logically\ncorrect. An empty file means _zero_ patterns which is an empty set. An\nempty set matches nothing. Inverting the empty set should result in\nmatching everything.\n\nThis was because of an errant optimization that lets ripgrep quit early\nif it can statically detect that no matches are possible.\n\nMoreover, there was *also* a bug in how we constructed the PCRE2 pattern\nwhen there are zero patterns. PCRE2 doesn't have a concept of sets of\npatterns (unlike the `regex` crate), so we need to fake it with an empty\ncharacter class.\n\nFixes #1332, Fixes #3001, Closes #3041"
+    },
+    {
+      "commit": "bb0cbae3121f19e5319b28519b4c287dd49cb941",
+      "subject": "ci: add aarch64 Windows",
+      "body": "This also adds a new release artifact for aarch64 Windows.\n\nCloses #2943, Closes #3038"
+    },
+    {
+      "commit": "8fca3cdca63c9e1305e88a27cee206d73fd9a71e",
+      "subject": "doc: fix typo in FAQ",
+      "body": "Closes #3027"
+    },
+    {
+      "commit": "6f39f830cb9bc7b31c330d2c019c216477374371",
+      "subject": "globset: compact Debug impl for `GlobSetBuilder` and `Glob`",
+      "body": "Ideally we'd have a compact impl for `GlobSet` too, but that's a lot\nmore work. In particular, the constituent types don't all store the\noriginal pattern string, so that would need to be added.\n\nCloses #3026"
+    },
+    {
+      "commit": "e83828fc8c30d5d5e0672641d8ffc64bb58081d8",
+      "subject": "ignore/types: add `*.rake` extension to list of Ruby file types",
+      "body": "This PR adds the .rake extension to the Ruby type. It's a pretty common\nfile extension in Rails apps\u2014in my experience, the Rakefile is often\npretty empty and only sets some stuff up while most of the code lives\nin various .rake files.\n\nSee: https://ruby.github.io/rake/doc/rakefile_rdoc.html#label-Multiple+Rake+Files\n\nCloses #2921"
+    },
+    {
+      "commit": "72a130323813d0486861403a8aaf9b778276e6e5",
+      "subject": "ignore/types: add typst",
+      "body": "Closes #2914"
+    },
+    {
+      "commit": "861f6d374fa3d599dca86111e9b513772ca3de1a",
+      "subject": "style: simplify string formatting",
+      "body": "Most of this code was written before this was supported by Rust.\n\nCloses #2912"
+    },
+    {
+      "commit": "624bbf7dcee8d69949a447b4e4393e23d3e25b38",
+      "subject": "globset: add matches_all method",
+      "body": "This returns true if all globs in the set match the supplied file.\n\nFixes #2869, Closes #2900"
+    },
+    {
+      "commit": "53279db4143f4307c2b1b27f2cd32a43b0496205",
+      "subject": "deps: switch to tikv-jemallocator",
+      "body": "It is now a recommended crate for jemalloc and it contains an\n[important fix for compilation on riscv64gc-unknown-linux-musl][fix],\nI bumped into this when I was trying to\n[build ripgrep on OpenWrt][openwrt].\n\nCloses #2889\n\n[fix]: https://github.com/tikv/jemallocator/pull/67\n[openwrt]: https://github.com/openwrt/packages/pull/24961"
+    },
+    {
+      "commit": "292bc54e64e55b69fec806bf3ee6481958e2946f",
+      "subject": "printer: support `-r/--replace` with `--json`",
+      "body": "This adds a `replacement` field to each submatch object in the JSON\noutput. In effect, this extends the `-r/--replace` flag so that it works\nwith `--json`.\n\nThis adds a new field instead of replacing the match text (which is how\nthe standard printer works) for maximum flexibility. This way, consumers\nof the JSON output can access the original match text (and always rely\non it corresponding to the original match text) while also getting the\nreplacement text without needing to do the replacement themselves.\n\nCloses #1872, Closes #2883"
+    },
+    {
+      "commit": "5be67c1244f494414629f71be859e0e1552dd6fd",
+      "subject": "ignore/types: include msbuild solution filters",
+      "body": "Closes #2871"
+    },
+    {
+      "commit": "119407d0a918ca54da1e0a5e8806dbb8cd7e2be0",
+      "subject": "printer: use std::path::absolute on Windows",
+      "body": "This specifically avoids touching the file system, which can lead to\nfairly dramatic speed-ups in large repositories with lots of matches.\n\nCloses #2865"
+    },
+    {
+      "commit": "d869038cf610f10a8b7aca24284719e65a477e1a",
+      "subject": "ignore: improve multithreading heuristic",
+      "body": "This copies the one found in ripgrep.\n\nSee also:\nhttps://github.com/BurntSushi/ripgrep/blob/71d71d2d98964653cdfcfa315802f518664759d7/crates/core/flags/hiargs.rs#L172\n\nCloses #2854, Closes #2856"
+    },
+    {
+      "commit": "75970fd16b4d5f8ff9fb1d9c157467eb166acf23",
+      "subject": "ignore: don't process command line arguments in reverse order",
+      "body": "When searching in parallel with many more arguments than threads, the\nfirst arguments are searched last -- unlike in the -j1 case.\n\nThis is unexpected for users who know about the parallel nature of rg\nand think they can give the scheduler a hint by positioning larger\ninput files (L1, L2, ..) before smaller ones (\u2588, \u2588\u2588). Instead, this can\nresult in sub-optimal thread usage and thus longer runtime (simplified\nexample with 2 threads):\n\n T1:  \u2588 \u2588\u2588 \u2588 \u2588 \u2588 \u2588 \u2588\u2588 \u2588 \u2588 \u2588 \u2588 \u2588 \u2588\u2588 \u2560\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550L1\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2563\n T2:  \u2588 \u2588 \u2588\u2588 \u2588 \u2588 \u2588\u2588 \u2588 \u2588 \u2588 \u2588\u2588 \u2588 \u2588 \u2560\u2550\u2550\u2550\u2550\u2550L2\u2550\u2550\u2550\u2550\u2563\n\n                                       \u250f\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2513\nThis is caused by assigning work to    \u2503 T1 \u2503 T2 \u2503 T3 \u2503 T4 \u2503\n per-thread stacks in a round-robin    \u2521\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2529\n              manner, starting here  \u2192 \u2502 L1 \u2502 L2 \u2502 L3 \u2502 L4 \u2502 \u21b5\n                                       \u251c\u2500\u2500\u2500\u2500\u251c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2524\n                                       \u2502 s5 \u2502 s6 \u2502 s7 \u2502 s8 \u2502 \u21b5\n                                       \u251c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2524\n                                       \u2577 .. \u2577 .. \u2577 .. \u2577 .. \u2577\n                                       \u251c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2524\n                                       \u2502 st \u2502 su \u2502 sv \u2502 sw \u2502 \u21b5\n                                       \u251c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2518\n                                       \u2502 sx \u2502 sy \u2502 sz \u2502\n                                       \u2514\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2518\n   and then processing them bottom-up:   \u21a5    \u21a5    \u21a5    \u21a5\n\n                                       \u2577 .. \u2577 .. \u2577 .. \u2577 .. \u2577\nThis patch reverses the input order    \u251c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2524\nso the two reversals cancel each other \u2502 s7 \u2502 s6 \u2502 s5 \u2502 L4 \u2502 \u21b5\nout. Now at least the first N          \u251c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2518\narguments, N=number-of-threads, are    \u2502 L3 \u2502 L2 \u2502 L1 \u2502\nprocessed before any others (then      \u2514\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2518\nwork-stealing may happen):\n\n T1:  \u2560\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550L1\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2563 \u2588 \u2588\u2588 \u2588 \u2588 \u2588 \u2588 \u2588 \u2588 \u2588\u2588\n T2:  \u2560\u2550\u2550\u2550\u2550\u2550L2\u2550\u2550\u2550\u2550\u2563 \u2588 \u2588 \u2588\u2588 \u2588 \u2588 \u2588\u2588 \u2588 \u2588 \u2588 \u2588\u2588 \u2588 \u2588 \u2588\u2588 \u2588 \u2588 \u2588\n\n(With some more shuffling T1 could always be assigned L1 etc., but\nthat would mostly be for optics).\n\nCloses #2849"
+    },
+    {
+      "commit": "380809f1e250035808170db2e9a2cbd09395f450",
+      "subject": "ignore/types: add Makefile.*",
+      "body": "The *BSD build systems make use of \"Makefile.inc\" a lot. Make the\n\"make\" type recognize this file by default. And more generally,\n`Makefile.*` seems to be a convention, so just generalize it.\n\nCloses #2846"
+    },
+    {
+      "commit": "94ea38da3029347006ad0dcae4886c76b04d8d88",
+      "subject": "ignore: support `.jj` as well as `.git`",
+      "body": "This makes it so the presence of `.jj` will cause ripgrep to treat it\nas a VCS directory, just as if `.git` were present. This is useful for\nripgrep's default behavior when working with jj repositories that don't\nhave a `.git` but do have `.gitignore`. Namely, ripgrep requires the\npresence of a VCS repository in order to respect `.gitignore`.\n\nWe don't handle clone-specific exclude rules for jj repositories without\n`.git` though. It seems it isn't 100% set yet where we can find\nthose[1].\n\nCloses #2842\n\n[1]: https://github.com/BurntSushi/ripgrep/pull/2842#discussion_r2020076722"
+    },
+    {
+      "commit": "da672f87e853d239b2f562d70c0b34d3afea6dfc",
+      "subject": "color: add italic to style attributes",
+      "body": "Closes #2841"
+    },
+    {
+      "commit": "edafb612d2b93b0dc28531abf155bdd7e3bcfe63",
+      "subject": "core: add \"total\" to --stats output",
+      "body": "This makes it a little clearer. Apologies to anyone who is regex\nmatching on this output.\n\nCloses #2797"
+    },
+    {
+      "commit": "483628469a2580e4eab0edfbe7a7f3f8b1951848",
+      "subject": "ignore/gitignore: skip BOM at start of ignore file",
+      "body": "This matches Git's behavior.\n\nFixes #2177, Closes #2782"
+    },
+    {
+      "commit": "c93fc793a08f3a97e02457d5132b4cc346768014",
+      "subject": "searcher: add more tests for `replace_bytes`",
+      "body": "... and add a comment explaining an optimization.\n\nCloses #2729"
+    },
+    {
+      "commit": "7c004f224eb2c7b7a04ac246b456f0e4d6d36c9d",
+      "subject": "ignore/types: detect `WORKSPACE.bzlmod` for bazel file type",
+      "body": "This file came alongside MODULE.bazel and I should have added it here\npreviously.\n\nCloses #2726"
+    },
+    {
+      "commit": "52115ab633cf04a60a43f2d3727cec729cda5c13",
+      "subject": "globset: add opt-in `Arbitrary` trait implementations",
+      "body": "This feature is mandatory when using `Glob` in fuzz testing.\n\nCloses #2720"
+    },
+    {
+      "commit": "bfe2def12183f66689f23f52d85100fbc4b42d1a",
+      "subject": "tests: add test for filtering hidden files",
+      "body": "Note that this isn't a regression test. In particular, this didn't fail\nwith ripgrep 14.1.1. I couldn't figure out how to turn what the OP gave\nme into a failing test.\n\nWith #829 fixed, if the OP can provide a better regression test, it\nmight make sense to re-investigate this.\n\nCloses #2711"
+    },
+    {
+      "commit": "14f4957b3d605f14ad58bc67e54197a3084fef5a",
+      "subject": "ignore: fix filtering searching subdir or .ignore in parent dir",
+      "body": "The previous code deleted too many parts of the path when constructing\nthe absolute path, resulting in a shortened final path. This patch\ncreates the correct absolute path by only removing the necessary parts.\n\nFixes #829, Fixes #2731, Fixes #2747, Fixes #2778, Fixes #2836, Fixes #2933, Fixes #3144\nCloses #2933"
+    },
+    {
+      "commit": "f722268814e878b133d926143f3019c164ef4bc1",
+      "subject": "complete/fish: Take RIPGREP_CONFIG_PATH into account",
+      "body": "The fish completions now also pay attention to the configuration file\nto determine whether to suggest negation options and not just to the\ncurrent command line.\n\nThis doesn't cover all edge cases. For example the config file is\ncached, and so changes may not take effect until the next shell\nsession. But the cases it doesn't cover are hopefully very rare.\n\nCloses #2708"
+    },
+    {
+      "commit": "90a680ab45a7eaaffcccb22c4946771d6b424f02",
+      "subject": "impl: switch most atomic ops to `Relaxed` ordering",
+      "body": "These all seem pretty straight-forward. Compared with #2706, I dropped\nthe changes to the atomic orderings used in `ignore` because I haven't\nhad time to think through that carefully. But the ops in this PR seem\nfine.\n\nCloses #2706"
+    },
+    {
+      "commit": "119a58a400ea948c2d2b0cd4ec58361e74478641",
+      "subject": "msrv: bump to Rust 1.88",
+      "body": "This is to prep for the next release. I don't know if the requirement\nwill actually be for Rust 1.88, but it is intended to support the latest\nversion of stable Rust."
+    },
+    {
+      "commit": "3b7fd442a6f3aa73f650e763d7cbb902c03d700e",
+      "subject": "deps: update everything",
+      "body": "It looks like a new dependency on `getrandom` was added (which brings in\na few more dependencies itself) because of `jobserver`. Thankfully,\n`jobserver` is only used when ripgrep's `pcre2` feature is enabled, so\nthis still keeps the default set of dependencies very small."
+    },
+    {
+      "commit": "cbc598f245f3c157a872b69102653e2e349b6d92",
+      "subject": "doc: update version number in dpkg installation",
+      "body": "PR #3058"
+    },
+    {
+      "commit": "6dfaec03e830892e787686917509c17860456db1",
+      "subject": "deps: bump crossbeam-channel from 0.5.13 to 0.5.15",
+      "body": "Bumps [crossbeam-channel](https://github.com/crossbeam-rs/crossbeam) from 0.5.13 to 0.5.15.\n- [Release notes](https://github.com/crossbeam-rs/crossbeam/releases)\n- [Changelog](https://github.com/crossbeam-rs/crossbeam/blob/master/CHANGELOG.md)\n- [Commits](https://github.com/crossbeam-rs/crossbeam/compare/crossbeam-channel-0.5.13...crossbeam-channel-0.5.15)"
+    },
+    {
+      "commit": "updated-dependencies:\n- dependency-name: crossbeam-channel\n  dependency-version: 0.5.15\n  dependency-type: direct:production\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "5fbc4fee64131b5cd14675be71e43768a9763553",
+      "subject": "ignore/types: fix Seed7 file extension",
+      "body": "PR #3023"
+    },
+    {
+      "commit": "004370bd1619183b54dbaa41719728edfe892ac6",
+      "subject": "ignore/types: add support for Seed7 files",
+      "body": "For more info on the Seed7 programming Language see:\n\n- on Wikipedia: https://en.wikipedia.org/wiki/Seed7\n- Seed7 home:   https://seed7.sourceforge.net/\n- Seed7 repo:   https://github.com/ThomasMertes/seed7\n\nPR #3022"
+    },
+    {
+      "commit": "de4baa10024f2cb62d438596274b9b710e01c59b",
+      "subject": "globset-0.4.16",
+      "body": ""
+    },
+    {
+      "commit": "163ac157d371e97a8ceb2c88f884e50698cefe5b",
+      "subject": "globset: escape `{` and `}` in `escape`",
+      "body": "This appears to be an oversight from when `escape` was\nimplemented in #2061."
+    },
+    {
+      "commit": "e2362d4d5185d02fa857bf381e7bd52e66fafc73",
+      "subject": "searcher: add log message noting detected encoding",
+      "body": "This helps improve diagnostics. Otherwise it can be easy to miss that\nripgrep is doing transcoding.\n\nFixes #2979"
+    },
+    {
+      "commit": "d6b59feff890f038acde7d5e151995d8aec1e107",
+      "subject": "github: update WASI compilation job",
+      "body": "Ref https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html\n\nPR #2970"
+    },
+    {
+      "commit": "94305125ef33b86151b6cd2ce2b33d641f6b6ac3",
+      "subject": "zsh: support sourcing zsh completion dynamically",
+      "body": "Previously, you needed to save the completion script to a file and\nthen source it. Now, you can dynamically source completions in zsh by\nrunning\n\n    $ source <(rg --generate complete-zsh)\n\nBefore this commit, you would get an error after step 1.\nAfter this commit, it should work as expected.\n\nWe also improve the FAQ item for zsh completions.\n\nFixes #2956"
+    },
+    {
+      "commit": "79cbe89deb1151e703f4d91b19af9cdcc128b765",
+      "subject": "doc: tweak wording for stdin detection",
+      "body": "This makes it slightly more precise to cover weird cases like trying to\npass a directory on stdin.\n\nCloses #2906"
+    },
+    {
+      "commit": "bf63fe8f258afc09bae6caa48f0ae35eaf115005",
+      "subject": "regex: add as_match method to Captures trait",
+      "body": "Ref https://github.com/rust-lang/regex/issues/1146\n\nPR #2898"
+    },
+    {
+      "commit": "8bd595029656370927f846406ca4ce4ffe0b3e91",
+      "subject": "changelog: add next section",
+      "body": ""
+    },
+    {
+      "commit": "6e0539ab91a467153fa403c3d93204e4594af0b3",
+      "subject": "pkg/brew: update tap",
+      "body": ""
+    },
+    {
+      "commit": "4649aa9700619f94cf9c66876e9549d83420e16c",
+      "subject": "14.1.1",
+      "body": ""
+    },
+    {
+      "commit": "c009652e775be6b0f8682f72e059b79592fbc9c8",
+      "subject": "changelog: 14.1.1",
+      "body": ""
+    },
+    {
+      "commit": "b9f7a9ba2bede566a6a981c6a7a004836a8c4138",
+      "subject": "deps: bump grep to 0.3.2",
+      "body": ""
+    },
+    {
+      "commit": "a1960877cf699c77419b1965bcfa4de98767946f",
+      "subject": "grep-0.3.2",
+      "body": ""
+    },
+    {
+      "commit": "bb0925af9159d552af0bdbdafeea7d4271d575b9",
+      "subject": "deps: bump grep-printer to 0.2.2",
+      "body": ""
+    },
+    {
+      "commit": "be117dbafa6f7a550a4e5f1ba71bcc96b0a8c4e1",
+      "subject": "grep-printer-0.2.2",
+      "body": ""
+    },
+    {
+      "commit": "06dc13ad2d7543fb241743c44036db464ee3ff38",
+      "subject": "deps: bump grep-searcher to 0.1.14",
+      "body": ""
+    },
+    {
+      "commit": "c6c2e69b8f7b7289789c483da8b04dbd529f3c91",
+      "subject": "grep-searcher-0.1.14",
+      "body": ""
+    },
+    {
+      "commit": "e67c868dddb75cad2a961d364bdf8a74514a2731",
+      "subject": "deps: bump grep-pcre2 to 0.1.8",
+      "body": ""
+    },
+    {
+      "commit": "d33f2e2f70c4c7c4e262badb45d4c88ebbdcdbc5",
+      "subject": "grep-pcre2-0.1.8",
+      "body": ""
+    },
+    {
+      "commit": "082edafffaa4961ab5e6a17dcc58878549eb6b7a",
+      "subject": "deps: bump grep-regex to 0.1.13",
+      "body": ""
+    },
+    {
+      "commit": "7c8dc332b3a59b4902d3eec76fd98b676071eb0b",
+      "subject": "grep-regex-0.1.13",
+      "body": ""
+    },
+    {
+      "commit": "ea961915b5e4c709886168b033ba43c0fad664ce",
+      "subject": "deps: bump grep-cli to 0.1.11",
+      "body": ""
+    },
+    {
+      "commit": "7943bdfe82182de1bf6d05cbd9cd87d2c32a3130",
+      "subject": "grep-cli-0.1.11",
+      "body": ""
+    },
+    {
+      "commit": "312a7884fc6ad9e4dd07542a77bf8e94503440ad",
+      "subject": "deps: bump ignore to 0.4.23",
+      "body": ""
+    },
+    {
+      "commit": "ac02f54c892cc22cf32344600360a911537b2a27",
+      "subject": "ignore-0.4.23",
+      "body": ""
+    },
+    {
+      "commit": "24b337b9405b59724beb927de9e41d4ec329713f",
+      "subject": "deps: bump globset to 0.4.15",
+      "body": ""
+    },
+    {
+      "commit": "a5083f99ce1d777d0ce223c30f5789fb7d47783a",
+      "subject": "globset-0.4.15",
+      "body": ""
+    },
+    {
+      "commit": "f89cdba5dfdce734a9300a487f9c595013838cb7",
+      "subject": "doc: update date in man page template",
+      "body": ""
+    },
+    {
+      "commit": "f7b677d13620f11327669f768b3c6cabb4c8f2d7",
+      "subject": "deps: update everything",
+      "body": ""
+    },
+    {
+      "commit": "3f68a8f3d70d402643cae09fd6b9858385e30743",
+      "subject": "changelog: 14.1.1",
+      "body": ""
+    },
+    {
+      "commit": "9d738ad0c009e6632d75fa3d36051e5ae7f7cce6",
+      "subject": "regex: fix inner literal extraction that resulted in false negatives",
+      "body": "In some rare cases, it was possible for ripgrep's inner literal detector\nto extract a set of literals that could produce a false negative. #2884\ngives an example: `(?i:e.x|ex)`. In this case, the set extracted can be\ndiscovered by running `rg '(?i:e.x|ex) --trace`:\n\n    Seq[E(\"EX\"), E(\"Ex\"), E(\"eX\"), E(\"ex\")]\n\nThis extraction leads to building a multi-substring matcher for `EX`,\n`Ex`, `eX` and `ex`. Searching the haystack `e-x` produces no match,\nand thus, ripgrep shows no matches. But the regex `(?i:e.x|ex)` matches\n`e-x`.\n\nThe issue at play here was that when two extracted literal sequences\nwere unioned, we were correctly unioning their \"prefix\" attribute.\nAnd this in turn leads to those literal sequences being combined\nincorrectly via cross product. This case in particular triggers it\nbecause two different optimizations combine to produce an incorrect\nresult. Firslty, the regex has a common prefix extracted and is\nrewritten as `(?i:e(?:.x|x))`. Secondly, the `x` in the first branch of\nthe alternation has its `prefix` attribute set to `false` (correctly),\nwhich means it can't be cross producted with another concatenation. But\nin this case, it is unioned with the `x` from the second branch, and\nthis results in the union result having `prefix` set to `true`. This\nin turn pops up and lets it get cross producted with the `e` prefix,\nproducing an incorrect literal sequence.\n\nWe fix this by changing the implementation of `union` to return\n`prefix` set to `true` only when *both* literal sequences being unioned\nhave `prefix` set to `true`.\n\nDoing this exposed a second bug that was present, but was purely\ncosmetic: the extracted literals in this case, after the fix, are\n`X` and `x`. They were considered \"exact\" (i.e., lead to a match),\nbut of course they are not. Observing an `X` or an `x` does not mean\nthere is a match. This was fixed by making `choose` always return\nan inexact literal sequence. This is perhaps too conservative in\naggregate in some cases, but always correct. The idea here is that if\none is choosing between two concatenations, then it is likely the case\nthat the sequence returned should be considered inexact. The issue\nis that this can lead to avoiding cross products in some cases that\nwould otherwise be correct. This is bad because it means extracting\nshorter literals in some cases. (In general, the longer the literal the\nbetter.) But we prioritize correctness for now and fix it. You can see\na few tests where this shortens some extracted literals.\n\nFixes #2884"
+    },
+    {
+      "commit": "6c5108ed17987531644518fac8c1659b0b202611",
+      "subject": "github: add FUNDING",
+      "body": ""
+    },
+    {
+      "commit": "e0f1000df67f82ab0e735bad40e9b45b2d774ef0",
+      "subject": "deps: update everything",
+      "body": "This removes `once_cell` (a dependency of `cc`) but adds `shlex` (also a\ndependency of `cc`). AFAIK, ripgrep does not utilize anything in `cc`\nthat requires `shlex`, which is pretty unfortunate that we have to spend\ntime compiling it. (We use `cc` only when the `pcre2` feature is\nenabled.)"
+    },
+    {
+      "commit": "ea99421ec896fcc9a9cd5367d42a80f89316822f",
+      "subject": "doc: fix transcription bug in ugrep benchmark command",
+      "body": "I re-ran the benchmark and the timing remains nearly\nunchanged, so that part was correct.\n\nPR #2876"
+    },
+    {
+      "commit": "af8c386d5e10eaa4b8cb687c4f5b05893a7ae0ce",
+      "subject": "doc: fix typo in --heading flag help",
+      "body": "PR #2864"
+    },
+    {
+      "commit": "71d71d2d98964653cdfcfa315802f518664759d7",
+      "subject": "doc: refer to correct flag name for --engine=auto",
+      "body": "PR #2850"
+    },
+    {
+      "commit": "c9ebcbd8abe48c8336fb4826df7e9b6fb179de03",
+      "subject": "globset: optimize character escaping",
+      "body": "Rewrites the char_to_escaped_literal and bytes_to_escaped_literal\nfunctions in a way that minimizes heap allocations. After this, the\nresulting string is the only allocation remaining.\n\nI believe when this code was originally written, the routines available\nto avoid heap allocations didn't exist.\n\nI'm skeptical that this matters in the grand scheme of things, but I\nthink this is still worth doing for \"good sense\" reasons.\n\nPR #2833"
+    },
+    {
+      "commit": "dec0dc319653364d7a2c23dd78e65c8b0532f270",
+      "subject": "doc: update link for debian installation",
+      "body": "PR #2829"
+    },
+    {
+      "commit": "2f0a269f0751bf58a061d23febe340a9f5ffbb67",
+      "subject": "github: use an obviously old version of ripgrep in issue template",
+      "body": "This should hopefully avoid confusion where the use of the version\nnumber in the issue template isn't mistaken for the implication that the\nversion must therefore be recent.\n\nRef #2824"
+    },
+    {
+      "commit": "0a0893a76506518e766033d03f5b6d7c7a7a8525",
+      "subject": "ignore: add debug log message when opening gitignore file",
+      "body": "I'm not sure why it took me this long to add this debug message, but\nit's quite useful in determining where ignore rules are coming from."
+    },
+    {
+      "commit": "35160a1cdb4c7e2c370e8a7fad6508ff922a33c2",
+      "subject": "doc: add Flox as an installation method",
+      "body": "Ref https://flox.dev/docs/\n\nPR #2817"
+    },
+    {
+      "commit": "f1d23c06e30606b2428a4e32da8f0b5069e81280",
+      "subject": "cli: add more logging for stdin heuristic detection",
+      "body": "Stdin heuristic detection is complicated and opaque enough that it's\nworth having easy access to the complete story that leads ripgrep to\ndecide whether to search stdin or not.\n\nRef #2806"
+    },
+    {
+      "commit": "22b677900f7ee74dcc0ec6791805120976d86168",
+      "subject": "doc: fix some typos",
+      "body": "PR #2754"
+    },
+    {
+      "commit": "bb6f0f551972720792bd5bbd15035991a63dc472",
+      "subject": "doc: fix typo in --vimgrep help message",
+      "body": "PR #2802"
+    },
+    {
+      "commit": "b6ef99ee554346a0870245c92112aad3838c8edd",
+      "subject": "doc: remove unused man page template",
+      "body": "This seems to be causing confusion. And since we don't use it as of\nripgrep 14, let's just remove it.\n\nMan page generation is now done by ripgrep itself. That is:\n\n    rg --generate man > rg.1\n\nCloses #2801"
+    },
+    {
+      "commit": "bb8601b2bafb5e68181cbbb84e6ffa4f7a72bf16",
+      "subject": "printer: make compilation on non-unix, non-windows platforms work",
+      "body": "Some of the new hyperlink work caused ripgrep to stop compiling\non non-{Unix,Windows} platforms. The most popular of which is WASI.\n\nThis commit makes non-{Unix,Windows} compile again. And we add a\nvery basic WASI test in CI to catch regressions.\n\nMore work is needed to make tests on non-{Unix,Windows} platforms\nwork. And of course, this commit specifically takes the path of disabling\nhyperlink support for non-{Unix,Windows} platforms."
+    },
+    {
+      "commit": "02b47b7469ac8fc9e7dcb390415644f33e500b72",
+      "subject": "deps: update everything",
+      "body": "Notably, this removes winapi in favor of windows-sys, as a result of\nwinapi-util switching over to windows-sys[1].\n\nAnnoyingly, when PCRE2 is enabled, this brings in a dependency on\n`once_cell`[2]. I had worked to remove it from my dependencies and now\nit's back. Gah. I suppose I could disable the `parallel` feature of\n`cc`, but that doesn't seem like a good trade-off.\n\n[1]: https://github.com/BurntSushi/winapi-util/pull/13\n[2]: https://github.com/rust-lang/cc-rs/pull/1037"
+    },
+    {
+      "commit": "d922b7ac114c24d6800ae5f79d2967481f380c83",
+      "subject": "doc: fix typo",
+      "body": "PR #2776"
+    },
+    {
+      "commit": "2acf25c6897f45c9e7332712cca63d4eb576533c",
+      "subject": "ignore/types: add WGSL to the default file types",
+      "body": "[WGSL][1] is a shading language for WebGPU. As defined in [Appendix\nA][2], the file extension is `.wgsl`.\n\nPR #2774 \n\n[1]: https://www.w3.org/TR/WGSL/\n[2]: https://www.w3.org/TR/WGSL/#text-wgsl-media-type"
+    },
+    {
+      "commit": "80007698d3ae6c1def8ee784c6287ce1376de5c4",
+      "subject": "ignore/types: add Vue",
+      "body": "PR #2772"
+    },
+    {
+      "commit": "3ad0e83471588d8802d5747d0cc9accec76f7ccf",
+      "subject": "ignore/walk: correct build_parallel() documentation",
+      "body": "The returned closure should return `WalkState`, not `()`.\n\nCloses #2767"
+    },
+    {
+      "commit": "eca13f08a2a0ece89a423565891e48a90a8aedef",
+      "subject": "deps: bump everything else",
+      "body": ""
+    },
+    {
+      "commit": "4f99f82b1958f75d64cdb7c931190e39d67a3b17",
+      "subject": "deps: bump pcre2 and pcre2-sys",
+      "body": "This moves to PCRE2 10.43."
+    },
+    {
+      "commit": "327d74f1616e135a6eb09a0c3016f8f45cfc0cfc",
+      "subject": "doc: add link to unofficial playground",
+      "body": "PR #2760"
+    },
+    {
+      "commit": "9da0995df4cde892b899687c20b717c69b4ea0d1",
+      "subject": "ignore/types: add 'svelte' to the default file types",
+      "body": "Ref: https://svelte.dev/\n\nPR #2759"
+    },
+    {
+      "commit": "e9abbc1a02de29dbe60e1b625d540c58759b23a6",
+      "subject": "cargo: nuke 'simd-accel' from orbit",
+      "body": "This feature causes nothing but problems and is frequently broken. The\nonly optimization it was enabling were SIMD optimizations for\ntranscoding. In particular, for UTF-16 transcoding. This is performed by\nthe [`encoding_rs`](https://github.com/hsivonen/encoding_rs) crate,\nwhich specifically uses unstable portable SIMD APIs instead of the\nstable non-portable SIMD APIs.\n\nSIMD optimizations that apply to search have long been making use of\nstable APIs, and are automatically enabled when your target supports\nthem. This is, IMO, the correct user experience and one that\n`encoding_rs` refuses to support. I'm done dealing with it, so\ntranscoding will only use scalar code until the SIMD optimizations in\n`encoding_rs` work on stable. (This doesn't mean that `encoding_rs` has\nto change. This could also be fixed by stabilizing `std::simd`.)\n\nFixes #2748"
+    },
+    {
+      "commit": "9bd30e8e48b139c3f5ebe8587abff6fff7add45b",
+      "subject": "deps: update everything",
+      "body": ""
+    },
+    {
+      "commit": "59212d08d3ef122adc781dfa09343df7848febf8",
+      "subject": "style: fix new lints",
+      "body": "The Rust compiler seems to have gotten smarter at finding unused or\nredundant imports."
+    },
+    {
+      "commit": "6ebebb2aaa9991694aed10b944cf2e8196811e1c",
+      "subject": "doc: fix typo in comments",
+      "body": "PR #2741"
+    },
+    {
+      "commit": "e92e2ef8137a4333fee141f842e9a59b5da7b645",
+      "subject": "cli: remove stray `dbg!`",
+      "body": "Whoops, forgot to review my commits before pushing."
+    },
+    {
+      "commit": "4a30819302810a8772bd205970d41fe9b4e97333",
+      "subject": "cli: tweak how \"is one file\" predicate works",
+      "body": "In effect, we switch from `path.is_file()` to `!path.is_dir()`. In cases\nwhere process substitution is used, for example, the path can actually\nhave type \"fifo\" instead of \"file.\" Even if it's a fifo, we want to\ntreat it as-if it were a file. The real key here is that we basically\nalways want to consider a lone argument as a file so long as we know it\nisn't a directory. Because a directory is the only thing that will\ncauses us to (potentially) search more than one thing.\n\nFixes #2736"
+    },
+    {
+      "commit": "9b42af96f0143a395b9379b6c761b5625367a3b9",
+      "subject": "doc: fix typo in --hidden docs",
+      "body": "PR #2718"
+    },
+    {
+      "commit": "648a65f1976cc3b7eb66425024649d71d5befe1e",
+      "subject": "doc: add missing date in changelog",
+      "body": "PR #2704"
+    },
+    {
+      "commit": "bdf01f46a620cb15ef817809320cba124d42b99e",
+      "subject": "changelog: start next section",
+      "body": ""
+    },
+    {
+      "commit": "1c775f3a82a374851c7a3366ab1c690164fe9c88",
+      "subject": "pkg/brew: update tap",
+      "body": ""
+    },
+    {
+      "commit": "e50df40a1967708b9781486b1c017e48040bceb0",
+      "subject": "14.1.0",
+      "body": ""
+    },
+    {
+      "commit": "1fa76d2a42f05509a01c3e50a9424d16cfa8726d",
+      "subject": "changelog: add 14.1.0 blurb",
+      "body": ""
+    },
+    {
+      "commit": "44aa5a417d396ec75613c876e0eb5e4ba2f03b1d",
+      "subject": "deps: bump ignore to 0.4.22",
+      "body": ""
+    },
+    {
+      "commit": "2c3897585d3a6d0709954bc389bed3d957878048",
+      "subject": "ignore-0.4.22",
+      "body": ""
+    },
+    {
+      "commit": "6e9141a9ca39a7ffbb25bf0817d21895e486aacc",
+      "subject": "deps: update everything",
+      "body": ""
+    },
+    {
+      "commit": "c8e4a84519ede79b330f9a9e2b072110d5bd0c8c",
+      "subject": "cli: prefix all non-fatal error messages with 'rg: '",
+      "body": "Fixes #2694"
+    },
+    {
+      "commit": "f02a50a69da131269fe0d8460e08b1fceea04ca9",
+      "subject": "changelog: various updates",
+      "body": ""
+    },
+    {
+      "commit": "b9c774937fc285e6668be9823c4bf231a61fc4a8",
+      "subject": "ignore: fix reference cycle for compiled matchers",
+      "body": "It looks like there is a reference cycle caused by the compiled\nmatchers (compiled HashMap holds ref to Ignore and Ignore holds ref\nto HashMap). Using weak refs fixes issue #2690 in my test project.\nAlso confirmed via before and after when profiling the code, see the\nattached screenshots in #2692.\n\nFixes #2690"
+    },
+    {
+      "commit": "67dd809a8097923a721305ce0632a9fb9f19cb57",
+      "subject": "ignore: add some 'allow(dead_code)' annotations",
+      "body": "I don't usually like doing this and would prefer to just delete unused\ncode, but I don't have the context required to understand why this code\nis unused. A refresh of this crate is on the (distant) horizon, so I'll\njust leave these here for now to squash the warnings."
+    },
+    {
+      "commit": "e0a85678e112759f56f9e07d04a29f2eed6eb348",
+      "subject": "complete/fish: improve shell completions for fish",
+      "body": "- Stop using `-n __fish_use_subcommand`. This had the effect of\nignoring options if a positional argument has already been given, but\nthat's not how ripgrep works.\n\n- Only suggest negation options if the option they're negating is\npassed (e.g., only complete `--no-pcre2` if `--pcre2` is present). The\nzsh completions already do this.\n\n- Take into account whether an option takes an argument. If an option\nis not a switch then it won't suggest further options until the\nargument is given, e.g. `-C<tab>` won't suggest options but `-i<tab>`\nwill.\n\n- Suggest correct arguments for options. We already completed a fixed\nset of choices where available, but now we go further:\n\n  - Filenames are only suggested for options that take filenames.\n\n  - `--pre` and `--hostname-bin` suggest binaries from `$PATH`.\n\n  - `-t`/`--type`/&c use `--type-list` for suggestions, like in zsh,\n  with a preview of the glob patterns.\n\n  - `--encoding` uses a hardcoded list extracted from the zsh\n  completions. This has been refactored into a separate file, and the\n  range globs (`{1..5}`) replaced by comma globs (`{1,2,3,4,5}`) since\n  those work in both shells. I verified that this produces the same\n  list as before in zsh, and the same list in fish (albeit in a\n  different order).\n\nPR #2684"
+    },
+    {
+      "commit": "23af5fb043f8e625294e210446090f17dbd7e3bf",
+      "subject": "doc: update MSRV in README",
+      "body": "PR #2673"
+    },
+    {
+      "commit": "5dec4b8e3755bcc0be27fb43bd20880d6da1c42b",
+      "subject": "ci: drop custom Cross images",
+      "body": "It looks like these aren't needed any more? I'm not sure why to be\nhonest. I suspect it's because we no longer need asciidoc(tor)? to\ngenerate man pages. And I believe tests that require things like `zstd`\nare automatically if `zstd` isn't installed."
+    },
+    {
+      "commit": "827082a33ae7d86846a103ef14fb9ff297587049",
+      "subject": "ci: add more ARM build configurations to CI and release workflows",
+      "body": "... it turns out that rustembedded/cross:armv7-unknown-linux-musleabi\ndoesn't exist. And looking more closely, it looks like the Cross project\nhas decided to shake things up and publish images to ghcr instead. So we\nmigrate everything over to that."
+    },
+    {
+      "commit": "6c2a550e1ed190351707dbcb28d5085a89ac0710",
+      "subject": "deps: update everything",
+      "body": "This drops a dependency on memoffset due to a crossbeam-epoch update.\nw00t."
+    },
+    {
+      "commit": "8e8fc9c5039663bf0145d7ae292c4214da957d4f",
+      "subject": "deps: bump pcre2-sys to 0.2.8",
+      "body": "This release contains some extra logic to disable the JIT on musleabi\ntargets."
+    },
+    {
+      "commit": "2057023dc5eb2b2ab28d03d2b902f3b57ce93165",
+      "subject": "readme: update benchmarks",
+      "body": "We add a few more too."
+    },
+    {
+      "commit": "3f2fe0afee0d1a1eeb3235904cfef4f35c4644dc",
+      "subject": "deps: update everything",
+      "body": "This also drops a dependency on scopeguard, courtesy of crossbeam-epoch\ndropping it. Not sure why they did, but fine by me."
+    },
+    {
+      "commit": "56c7ad175ac1326e8d36a880061ca3b0e67ad5ea",
+      "subject": "ignore/types: add Lean",
+      "body": "Ref: https://lean-lang.org/\n\nPR #2678"
+    },
+    {
+      "commit": "5b7a30846faba930616b2dce3d2344090330420d",
+      "subject": "doc: fix Guix install instructions",
+      "body": "`guix install` should not be run using `sudo`, as per\n<https://packages.guix.gnu.org/packages/ripgrep/>.\n\nPR #2669"
+    },
+    {
+      "commit": "2a4dba3fbfef944c562bcdfa7485fa0f70d4f86f",
+      "subject": "ignore/types: add meson.options",
+      "body": "Starting with meson 1.1, there is a preference for using meson.options\ninstead of meson_options.txt.  Add the new filename to the meson set.\n\nPR #2666"
+    },
+    {
+      "commit": "84d65865e6febc784b8b0296dd4681d761fa5a67",
+      "subject": "doc: add Void Linux installation instructions",
+      "body": "PR #2665"
+    },
+    {
+      "commit": "d9aaa118737d498e4be63c6ea7e80e654e2e80da",
+      "subject": "pkg/brew: update tap",
+      "body": ""
+    },
+    {
+      "commit": "67ad9917ad40d23df054b87a38532b06f85205dd",
+      "subject": "14.0.3",
+      "body": ""
+    },
+    {
+      "commit": "daa157b5f99c064eac7cd4593e4ec07bb8fd9bef",
+      "subject": "core: actually implement --sortr=path",
+      "body": "This is an embarrassing oversight. A `todo!()` actually made its way\ninto a release! Oof.\n\nThis was working in ripgrep 13, but I had redone some aspects of sorting\nand this just got left undone.\n\nFixes #2664"
+    },
+    {
+      "commit": "ca5e294ad6b64b03c1d2fb4d9ed8c32b73e656ae",
+      "subject": "pkg/brew: update tap",
+      "body": ""
+    },
+    {
+      "commit": "6c7947b819733820c9a01e5a5452731c2f0c69fc",
+      "subject": "14.0.2",
+      "body": ""
+    },
+    {
+      "commit": "9acb4a540508ca06b1bbb1bfbd6ef01f5bd3228d",
+      "subject": "deps: bump grep to 0.3.1",
+      "body": ""
+    },
+    {
+      "commit": "0096c74c1195956e893535f1f2919068daef1c2c",
+      "subject": "grep-0.3.1",
+      "body": ""
+    },
+    {
+      "commit": "8c48355b03ee514f4962d2c038a1be9704125c75",
+      "subject": "deps: bump grep-printer to 0.2.1",
+      "body": ""
+    },
+    {
+      "commit": "f9b86de96322baea54711894ff917c0c4ec440fd",
+      "subject": "grep-printer-0.2.1",
+      "body": ""
+    },
+    {
+      "commit": "d23b74975ab02dde74f0e9799fccc53013fe61c7",
+      "subject": "deps: bump grep-searcher to 0.1.13",
+      "body": ""
+    },
+    {
+      "commit": "a5cbdb3dfe938a0fbe6f8e46f85f73eed0b2cd5e",
+      "subject": "grep-searcher-0.1.13",
+      "body": ""
+    },
+    {
+      "commit": "b6bac8484e5466d332640c4022951061bb865329",
+      "subject": "cargo: add release-lto profile",
+      "body": "The idea is to build ripgrep with as much optimization as possible.\n\nThis makes compilation times absolutely obscene. They jump from <10\nseconds to 30+ seconds on my i9-12900K. I don't even want to know how\nlong CI would take with these.\n\nI tried some ad hoc benchmarks and could not notice any meaningful\nimprovement with the LTO binary versus the normal release profile.\nBecause of that, I still don't think it's worth bloating the release\ncycle times.\n\nRef #1225"
+    },
+    {
+      "commit": "805fa32d184f9b163e7355dd335abc96440f0d2b",
+      "subject": "searcher: work around NUL line terminator bug",
+      "body": "As the FIXME comment says, ripgrep is not yet using the new line\nterminator option in regex-automata exposed for exactly this purpose.\nBecause of that, line anchors like `(?m:^)` and `(?m:$)` will only match\n`\\n` as a line terminator. This means that when --null-data is used in\ncombination with --line-regexp, the anchors inserted by --line-regexp\nwill not match correctly. This is only a big deal in the \"fast\" path,\nwhich requires the regex engine to deal with line terminators itself\ncorrectly. The slow path strips line terminators regardless of what they\nare, and so the line anchors can match (begin/end of haystack).\n\nFixes #2658"
+    },
+    {
+      "commit": "2d518dd1f96147690c1eadf58023cec3eb0e108a",
+      "subject": "release: tweak how sha256sum is invoked",
+      "body": "The output would ideally just have the basename of the file and not a\nmeaningless relative path.\n\nFixes #2654"
+    },
+    {
+      "commit": "8575d261790fe393d1768d12b3336cbb4cf0a9fc",
+      "subject": "complete/fish: Fix syntax for negated options",
+      "body": "And also, negated options don't take arguments.\n\nSpecifically, the fish completion generator currently forgets to add\n`-l` to negation options, leading to a list of these errors:\n\n    complete: too many arguments\n\n    ~/.config/fish/completions/rg.fish (line 146):\n    complete -c rg -n '__fish_use_subcommand'  no-sort-files -d '(DEPRECATED) Sort results by file path.'\n    ^\n    from sourcing file ~/.config/fish/completions/rg.fish\n\n    (Type 'help complete' for related documentation)\n\nTo reproduce, run `fish -c 'rg --generate=complete-fish | source'`.\n\nIt also potentially suggests a list of choices for negation options,\neven though those never take arguments. That case doesn't occur with\nany of the current options but it's an easy fix.\n\nFixes #2659, Closes #2655"
+    },
+    {
+      "commit": "2e81a7adfeeb9a213786b8331b244f97e7b66657",
+      "subject": "doc: fix typo that was preventing interpolation",
+      "body": "Closes #2662"
+    },
+    {
+      "commit": "cd5440fb6230f72ab598916c1c5ab96686541d47",
+      "subject": "changelog: fix wording",
+      "body": "Ref: https://news.ycombinator.com/item?id=38425790"
+    },
+    {
+      "commit": "2ee690e87a59968eb67f3a5ede56bf99a895db02",
+      "subject": "pkg/brew: update tap",
+      "body": ""
+    },
+    {
+      "commit": "59f86a45d3ca5b5d4dc7eae7cdfd8d1472d7b55d",
+      "subject": "14.0.1",
+      "body": ""
+    },
+    {
+      "commit": "2d31af38a2b764c446b2f949cb308a7310b251c0",
+      "subject": "cargo: include pkg/windows in crate package",
+      "body": "Fixes #2653"
+    },
+    {
+      "commit": "0da1176e7d053d76105ef2d71551178292b16b49",
+      "subject": "pkg/brew: update tap",
+      "body": ""
+    },
+    {
+      "commit": "eeffcd50b71e84a6345c83d8a4c574d3543462ab",
+      "subject": "doc: add step to run 'cargo package'",
+      "body": ""
+    },
+    {
+      "commit": "625743d7c833023c7a196b26650cba4dba6cdb48",
+      "subject": "grep-0.3.0",
+      "body": ""
+    },
+    {
+      "commit": "3d0171040a684533b8ba41cdfc030870d753eb4f",
+      "subject": "grep-printer-0.2.0",
+      "body": ""
+    },
+    {
+      "commit": "93429d0f85bf86ad5947b10f57e3ad864c60867a",
+      "subject": "14.0.0",
+      "body": ""
+    },
+    {
+      "commit": "9c4b0baf1019ba3b21bc2ba03f7ef7af2c925470",
+      "subject": "deps: bump grep to 0.2.13",
+      "body": ""
+    },
+    {
+      "commit": "179487aaed881a2f6a808a73ed7c11996da81d60",
+      "subject": "grep-0.2.13",
+      "body": ""
+    },
+    {
+      "commit": "b407d62b6370af1e9265d93e81d3972e411a29d4",
+      "subject": "deps: bump grep-searcher to 0.1.12",
+      "body": ""
+    },
+    {
+      "commit": "9bd1e737bcd19471d8837bec9c34143fdfa61fb2",
+      "subject": "grep-searcher-0.1.12",
+      "body": ""
+    },
+    {
+      "commit": "c12231c6219cf86724c885c8d204b77996d76fe3",
+      "subject": "deps: bump grep-pcre2 to 0.1.7",
+      "body": ""
+    },
+    {
+      "commit": "b0df573834ce5e421b9c362ff4437342e02d61e5",
+      "subject": "grep-pcre2-0.1.7",
+      "body": ""
+    },
+    {
+      "commit": "85b2ceecd1830ad35472e5e3fcdab1d29dd56a0a",
+      "subject": "deps: bump grep-regex to 0.1.12",
+      "body": ""
+    },
+    {
+      "commit": "fee7ac79f11e05640c5609a825ed6d1359cae472",
+      "subject": "grep-regex-0.1.12",
+      "body": ""
+    },
+    {
+      "commit": "54d5540c10e485346150ad63e6a1fe8ad705e2f4",
+      "subject": "deps: bump grep-matcher to 0.1.7",
+      "body": ""
+    },
+    {
+      "commit": "d0251c77fe96412310110aeb9383f20436a9f97e",
+      "subject": "grep-matcher-0.1.7",
+      "body": ""
+    },
+    {
+      "commit": "6aa5993d4b0a0a84c45d2de885407b588f84faa5",
+      "subject": "deps: bump grep-cli to 0.1.10",
+      "body": ""
+    },
+    {
+      "commit": "6f78d211bf2f2622fb7fbb4fb5af044e36a167da",
+      "subject": "grep-cli-0.1.10",
+      "body": ""
+    },
+    {
+      "commit": "51aa33983032e40c45c9077a375c698dac375aaf",
+      "subject": "deps: bump ignore to 0.4.21",
+      "body": ""
+    },
+    {
+      "commit": "381c521d02e26f86d69fbbec6e697a4609bea056",
+      "subject": "ignore-0.4.21",
+      "body": ""
+    },
+    {
+      "commit": "57495db10eb36f7c4d012eb27cf8674de384d57c",
+      "subject": "deps: bump globset to 0.4.14",
+      "body": ""
+    },
+    {
+      "commit": "47e37175ca96e33a0ca62ef77050e3f78a8e0f04",
+      "subject": "globset-0.4.14",
+      "body": ""
+    },
+    {
+      "commit": "8697946718f9a483aa1496a988d3e7e2c54ef56a",
+      "subject": "release/doc: set date in man page",
+      "body": ""
+    },
+    {
+      "commit": "8058859701f49abf0b70f506a736bf932272888b",
+      "subject": "changelog: add link for reporting perf improvements/regressions",
+      "body": ""
+    },
+    {
+      "commit": "e9ff90c8ffc9308cb1a5acb37e1adf8299124ed8",
+      "subject": "changelog: updates for the 14.0.0 release",
+      "body": ""
+    },
+    {
+      "commit": "bf9f74ea5b065d5603fa8b9039e5ca5040459d97",
+      "subject": "doc: progress",
+      "body": ""
+    },
+    {
+      "commit": "9b5091b895106a2458eadbda1e19329a346e8eff",
+      "subject": "deps: bump to memmap2 0.9.0",
+      "body": ""
+    },
+    {
+      "commit": "a4f165e3abb0b9de2971be6c4c9493f1769408ba",
+      "subject": "deps: bump everything",
+      "body": ""
+    },
+    {
+      "commit": "d1def67000194585e1bdafa8571ef6fcec64d63e",
+      "subject": "deps: bump pcre2 to 0.2.6",
+      "body": ""
+    },
+    {
+      "commit": "56af4d4a7444bfc15bfb3d6cd0202f4fb3076e90",
+      "subject": "cli: add simple flag suggestions",
+      "body": "We look for similar flag names via Jaccard index on ngrams. In my\nexperience this tends to work better than Levenshtein or other edit\ndistance based metrics. Principally because it allows for out-of-order\nsuggestions. For example, --case-smart will result in a suggestion for\n--smart-case, even though the edit distance between them is pretty big.\n\nThis is something Clap did for us. I initially thought it wasn't\nnecessary to add this back in, but I realized it wouldn't be much work\nand might actually be helpful to folks."
+    },
+    {
+      "commit": "b0f664540889f26f8f53b699dbc870de288ec428",
+      "subject": "ci: remove local deb build-and-publish script",
+      "body": "I moved this to GitHub Actions. w00t."
+    },
+    {
+      "commit": "3dbe371fe448c1e99a568c249d7e875aad59d6a5",
+      "subject": "ci: add Debian release build",
+      "body": "Previously, we were running 'cargo deb' locally. But the release process\nis a little simpler now thanks to GitHub Actions and the 'gh' tool, so I\nfelt comfortable putting the 'deb' generation in CI.\n\nNow the only real manual part of release asset creation is the M2\nrelease, but that should hopefully be automated once GitHub makes Apple\nsilicon runners available for free."
+    },
+    {
+      "commit": "30d06b3b4c39500fc99ffdc27aa6c476eaf18f3d",
+      "subject": "changelog: note that --no-ignore --ignore-vcs works as expected",
+      "body": "This fix fell out of the move off of Clap.\n\nCloses #1376"
+    },
+    {
+      "commit": "6a055d922cb0899efe48d76defad3ff56ab7395d",
+      "subject": "doc: clarify errors for -z/--search-zip",
+      "body": "Fixes #1622"
+    },
+    {
+      "commit": "e0075232291bd4043202844719e755f5980a4cc8",
+      "subject": "doc: note the precedence of -t/--type",
+      "body": "Fixes #1635"
+    },
+    {
+      "commit": "88353c80da5cb9b08112fb5faa512ac511cefd52",
+      "subject": "doc: be more explicit about ripgrep's behavior when printing to a tty",
+      "body": "Fixes #1709"
+    },
+    {
+      "commit": "cd3bcce42d1443a342cd113f904a3767ce835441",
+      "subject": "changelog: mention M2 binaries for releases",
+      "body": "Fixes #1737"
+    },
+    {
+      "commit": "1ea3552f2d85f2a0b369042af7269645971bd2fc",
+      "subject": "changelog: mention perf improvement for inner literals",
+      "body": "Fixes #1746"
+    },
+    {
+      "commit": "9ed7565fcb47d02e76398d41f24ba0817f6b9c2f",
+      "subject": "cli: error when searching for NUL",
+      "body": "Basically, unless the -a/--text flag is given, it is generally always an\nerror to search for an explicit NUL byte because the binary detection\nwill prevent it from matching.\n\nFixes #1838"
+    },
+    {
+      "commit": "7bb9f35d2d0b02952e20c082b17be856788e5f44",
+      "subject": "doc: clarify that --pre can accept any kind of path",
+      "body": "Fixes #2046"
+    },
+    {
+      "commit": "b138d5740a0e723a84014ce41614a30c44866baa",
+      "subject": "log: add message about number of threads used",
+      "body": "Closes #2122"
+    },
+    {
+      "commit": "3f0c8c29004c9e18cc6330d35b81aa6bf0982ffc",
+      "subject": "doc: improve -r/--replace docs",
+      "body": "It looks like this was done a while ago, but it didn't get added to the\nCHANGELOG or connected with the corresponding issue.\n\nFixes #2201"
+    },
+    {
+      "commit": "0e6e9417f1b16bde7ad4db009611f3923f1412e5",
+      "subject": "log: add message when a binary file is skipped",
+      "body": "The way we do this is a little hokey but I believe it is correct.\n\nFixes #2246"
+    },
+    {
+      "commit": "fded2a5fe1273ccef1d0ee36e00e052fca247d44",
+      "subject": "doc: add cargo-binstall instructions",
+      "body": "Closes #2298"
+    },
+    {
+      "commit": "e14eeb288fa4bce14fb0075a6a57da10c0446ffc",
+      "subject": "doc: mention that --stats is always implied by --json",
+      "body": "Fixes #2337"
+    },
+    {
+      "commit": "1cbcefddc9cfe1a9acbcc71adef7d9c0591fcb1d",
+      "subject": "doc: add more warnings about --vimgrep",
+      "body": "The --vimgrep flag has some severe footguns when using a pattern that\nmatches very frequently. We had already written some docs to warn about\nthat, but now we also include a suggestion to avoid exorbitant heap\nusage.\n\nCloses #2505"
+    },
+    {
+      "commit": "4fec9ffca82fb02824d889876c802b1ec54bf403",
+      "subject": "doc: make the opening line a bit more descriptive",
+      "body": "This mimics what was written in the man page.\n\nCloses #2401"
+    },
+    {
+      "commit": "00225a035baa62fbbbcb8373d0ad5e45472f56bc",
+      "subject": "doc: improve --sort=path",
+      "body": "This clarifies that the paths are not sorted in a fully lexicographic\norder, but that / is treated specially.\n\nFixes #2418"
+    },
+    {
+      "commit": "286de9564e511f01f13756c207e9b26ec781591d",
+      "subject": "cli: rejigger --version to include PCRE2 info",
+      "body": "This adds info about whether PCRE2 is available or not to the output of\n--version. Essentially, --version now subsumes --pcre2-version, although\nwe do retain the former because it (usefully) emits an exit code based\non whether PCRE2 is available or not.\n\nCloses #2645"
+    },
+    {
+      "commit": "038524a580072e9346ee9f782679618e380f4f2e",
+      "subject": "printer: trim before applying max column windowing",
+      "body": "Previously, we were applying the -M/--max-columns flag *before* triming\nprefix ASCII whitespace. But this doesn't make a whole lot of sense. We\nshould be trimming first, but the result of trimming is ultimately what\nwe'll be printing and that's what -M/--max-columns should be applied to.\n\nFixes #2458"
+    },
+    {
+      "commit": "8f9557d183d91aca8f72ce8c8401bcfb221e76c6",
+      "subject": "changelog: mention shell completion generation feature",
+      "body": "Closes #2425"
+    },
+    {
+      "commit": "58e7d2ea6375860fa09a043d6a1ba20518dfb462",
+      "subject": "doc: add docs about .ignore/.rgignore in parent directories",
+      "body": "Closes #2479"
+    },
+    {
+      "commit": "b7df9f8caa842b4904aa086b52485e63758621e6",
+      "subject": "changelog: mention --field-match-separator bug fix",
+      "body": "This was probably fixed in the migration off of Clap.\n\nCloses #2519"
+    },
+    {
+      "commit": "ebb986e767655f8c9c05a7a7e99b09236a6e8be5",
+      "subject": "logging: show heuristic information and decision",
+      "body": "When one does not provide any paths to ripgrep to search, it has to\nguess between searching stdin and the current working directory. It is\npossible for this guess to be wrong, and having the heuristics and the\nchoice in the debug logs is useful for diagnosing this.\n\nThe failure mode here is still pretty bad because you need to know to\nreach for the `--debug` flag in the first place. Namely, the typical\nfailure mode is that ripgrep tries to search stdin while the intent is\nfor it to search the current working directory, and thus likely blocking\nforever waiting for data on stdin.\n\n(Arguably this is a problem with the process architecture that invokes\nripgrep. It shouldn't give ripgrep an open stdin handle that isn't\nclosed.)\n\nCloses #2524"
+    },
+    {
+      "commit": "a2907db2de20fd33b0bf02d9bd1375da06218865",
+      "subject": "faq: update donation section to mention sponsorships",
+      "body": ""
+    },
+    {
+      "commit": "470ad1d0720f0eec83f69c44669fbdddbfee2bfa",
+      "subject": "faq: rewrite the section on shell completions",
+      "body": ""
+    },
+    {
+      "commit": "6d7550d58e88583deeb142b56e0dbe52f5102cbf",
+      "subject": "ignore: Avoid contention on num_pending",
+      "body": "Previously, every worker would increment the shared num_pending count on\nevery new work item, and decrement it after finishing them, leading to\nlots of contention.  Now, we only track the number of workers actively\nrunning, so there is no contention except when workers go to sleep or\nwake up.\n\nCloses #2642"
+    },
+    {
+      "commit": "af55fc2b38cc5d31e24f3392ec2d03ab5f6428c4",
+      "subject": "cli: make -d a short flag for --max-depth",
+      "body": "Interestingly, ripgrep now only has two available ASCII letter short\nflags remaining: -k and -y.\n\nCloses #2643, Closes #2644"
+    },
+    {
+      "commit": "3d2f49f6fe70a61fa501c3ed95d208ef10d3b94d",
+      "subject": "changelog: --pretty now behaves more sensibly",
+      "body": "This actually just kind of fell out of the migration off of Clap as a\nresult of treating `-p/--pretty` more rigorously as an alias for\n`--line-number --heading --color always`.\n\nFixes #2381, Closes #2637"
+    },
+    {
+      "commit": "50b247243800d3ad683fb0a0839ed0364d0a6f55",
+      "subject": "ci: strip release binaries on macOS",
+      "body": "We were purportedly doing this already, but actually weren't because of\nconfusion in the `if` condition.\n\nCloses #2636"
+    },
+    {
+      "commit": "ae2a09915fe9d3b4308a2b6e5710b583d22f165d",
+      "subject": "printer: drop dependency on `base64` crate",
+      "body": "Instead, we just roll our own. A slow version of this is pretty simple\nto do, and that's what we write here. The `base64` crate supports a lot\nmore functionality and is quite fast, but we care about neither of those\nthings for this particular aspect of ripgrep. (base64 is only used for\nnon-UTF-8 data or file paths, which are both quite rare.)"
+    },
+    {
+      "commit": "9c84575229131239f92149cd5790ddb553d7eea8",
+      "subject": "printer: drop dependency on serde_derive",
+      "body": "As suggested by @epage[1].\n\nAd hoc timings on my i7-12900K:\n\n    before cargo build: 4.91s\n    before cargo build release: 8.05s\n    after cargo build: 4.69s\n    after cargo build release: 7.83s\n\n... pretty underwhelming if you ask me. Ah well. And on my M2 mac mini:\n\n    before cargo build: 6.18s\n    before cargo build release: 14.50s\n    after cargo build: 5.52s\n    after cargo build release: 13.44s\n\nStill kind of underwhelming, but definitely better. It shaves a full\nsecond off of compile times in release mode. I went back to my\ni7-12900K, but passed `-j1` to `cargo build` to force single threaded\nmode:\n\n    before cargo build: 19.44s\n    before cargo build release: 50.64s\n    after cargo build: 16.76s\n    after cargo build release: 48.00s\n\nWhich seems pretty consistent with the modest improvements above.\n\nLooking at `cargo build --timings`, the beefiest chunk of time is spent\nin compiling `regex-automata`, by far. This is fine because it's core\nfunctionality. I wish a fast general purpose regex engine with its\ninternals exposed as a separately versioned library didn't require so\nmuch code... Blech.\n\n[1]: https://old.reddit.com/r/rust/comments/17rd8ww/faster_compilation_with_the_parallel_frontend_in/k8igjlg/"
+    },
+    {
+      "commit": "cddb5f57f8fa3413a6210bdd3a8f687b7dac69b2",
+      "subject": "printer: rejigger how we use serde_derive",
+      "body": "The idea is that by bringing derives in via serde's optional feature, it\nwas inhibiting compilation speed[1]. We try to fix that by depending on\n`serde_derive` as a distinct dependency.\n\nIt does seem to improve overall compilation time, but only by about 0.5\nseconds. With that said, my machine has a lot of cores, so it's possible\nthis will help more on less powerful CPUs.\n\n[1]: https://old.reddit.com/r/rust/comments/17rd8ww/faster_compilation_with_the_parallel_frontend_in/k8igjlg/"
+    },
+    {
+      "commit": "5dc424d3027be8fac4831a55f31b5a91bd0e5312",
+      "subject": "doc: scrub mentions of asciidoc/asciidoctor",
+      "body": "This optional dependency is now finally dropped. So ends a long journey\nof trying to generate man pages in a lightweight and dependable way. The\nonly thing I could figure out how to make work reliably was to just\nlearn how to write roff myself. Yay."
+    },
+    {
+      "commit": "040d8f2171b854f25544929b50ee7b059c22bef7",
+      "subject": "ci: improve docs for manual build-and-publish scripts",
+      "body": ""
+    },
+    {
+      "commit": "c81caa673b743bdac04db75c32957200bf549695",
+      "subject": "core: fix file separator bug",
+      "body": "I introduced a regression in the migration off of the clap by having\nboth the buffer writer and the printer be responsible for printing file\nseparators in multi-threaded search. The buffer writer owns that\nresponsibility in multi-threaded search."
+    },
+    {
+      "commit": "082245dadb3854238e62b91aa95a46018cf16ef1",
+      "subject": "cli: replace clap with lexopt and supporting code",
+      "body": "ripgrep began it's life with docopt for argument parsing. Then it moved\nto Clap and stayed there for a number of years. Clap has served ripgrep\nwell, and it probably could continue to serve ripgrep well, but I ended\nup deciding to move off of it.\n\nWhy?\n\nThe first time I had the thought of moving off of Clap was during the\n2->3->4 transition. I thought the 3.x and 4.x releases were great, but\nfor me, it ended up moving a little too quickly. Since the release of\n4.x was telegraphed around when 3.x came out, I decided to just hold off\nand wait to migrate to 4.x instead of doing a 3.x migration followed\nshortly by another 4.x migration. Of course, I just never ended up doing\nthe migration at all. I never got around to it and there just wasn't a\ncompelling reason for me to upgrade. While I never investigated it, I\nsaw an upgrade as a non-trivial amount of work in part because I didn't\nencapsulate the usage of Clap enough.\n\nThe above is just what got me started thinking about it. It wasn't\nenough to get me to move off of it on its own. What ended up pushing me\nover the edge was a combination of factors:\n\n* As mentioned above, I didn't want to run on the migration treadmill.\nThis has proven to not be much of an issue, but at the time of the\n2->3->4 releases, I didn't know how long Clap 4.x would be out before a\n5.x would come out.\n* The release of lexopt[1] caught my eye. IMO, that crate demonstrates\nexactly how something new can arrive on the scene and just thoroughly\nsolve a problem minimalistically. It has the docs, the reasoning, the\nsimple API, the tests and good judgment. It gets all the weird corner\ncases right that Clap also gets right (and is part of why I was\noriginally attracted to Clap).\n* I have an overall desire to reduce the size of my dependency tree. In\npart because a smaller dependency tree tends to correlate with better\ncompile times, but also in part because it reduces my reliance and trust\non others. It lets me be the \"master\" of ripgrep's destiny by reducing\nthe amount of behavior that is the result of someone else's decision\n(whether good or bad).\n* I perceived that Clap solves a more general problem than what I\nactually need solved. Despite the vast number of flags that ripgrep has,\nits requirements are actually pretty simple. We just need simple\nswitches and flags that support one value. No multi-value flags. No\nsub-commands. And probably a lot of other functionality that Clap has\nthat makes it so flexible for so many different use cases. (I'm being\nhand wavy on the last point.)\n\nWith all that said, perhaps most importantly, the future of ripgrep\npossibly demands a more flexible CLI argument parser. In today's world,\nI would really like, for example, flags like `--type` and `--type-not`\nto be able to accumulate their repeated values into a single sequence\nwhile respecting the order they appear on the CLI. For example, prior\nto this migration, `rg regex-automata -Tlock -ttoml` would not return\nresults in `Cargo.lock` in this repository because the `-Tlock` always\ntook priority even though `-ttoml` appeared after it. But with this\nmigration, `-ttoml` now correctly overrides `-Tlock`. We would like to\ndo similar things for `-g/--glob` and `--iglob` and potentially even\nnow introduce a `-G/--glob-not` flag instead of requiring users to use\n`!` to negate a glob. (Which I had done originally to work-around this\nproblem.) And some day, I'd like to add some kind of boolean matching to\nripgrep perhaps similar to how `git grep` does it. (Although I haven't\nthought too carefully on a design yet.) In order to do that, I perceive\nit would be difficult to implement correctly in Clap.\n\nI believe that this last point is possible to implement correctly in\nClap 2.x, although it is awkward to do so. I have not looked closely\nenough at the Clap 4.x API to know whether it's still possible there. In\nany case, these were enough reasons to move off of Clap and own more of\nthe argument parsing process myself.\n\nThis did require a few things:\n\n* I had to write my own logic for how arguments are combined into one\nsingle state object. Of course, I wanted this. This was part of the\nupside. But it's still code I didn't have to write for Clap.\n* I had to write my own shell completion generator.\n* I had to write my own `-h/--help` output generator.\n* I also had to write my own man page generator. Well, I had to do this\nwith Clap 2.x too, although my understanding is that Clap 4.x supports\nthis. With that said, without having tried it, my guess is that I\nprobably wouldn't have liked the output it generated because I\nultimately had to write most of the roff by hand myself to get the man\npage I wanted. (This also had the benefit of dropping the build\ndependency on asciidoc/asciidoctor.)\n\nWhile this is definitely a fair bit of extra work, it overall only cost\nme a couple days. IMO, that's a good trade off given that this code is\nunlikely to change again in any substantial way. And it should also\nallow for more flexible semantics going forward.\n\nFixes #884, Fixes #1648, Fixes #1701, Fixes #1814, Fixes #1966\n\n[1]: https://docs.rs/lexopt/0.3.0/lexopt/index.html"
+    },
+    {
+      "commit": "c33f6237199cd3ae6f884f5fe0f6ccf57f805a28",
+      "subject": "cargo: explicitly configure musl to be statically linked",
+      "body": "It looks like the musl target will, at some point, default to be\ndynamically linked. This config knob should make it so that it's always\nstatically linked.\n\nRef https://github.com/rust-lang/compiler-team/issues/422\nRef https://github.com/rust-lang/compiler-team/issues/422#issuecomment-812135847"
+    },
+    {
+      "commit": "824778c009165d5b56f97aad1b824a2bca039c08",
+      "subject": "globset: add GlobSet::builder",
+      "body": "This avoids needing to import and call GlobSetBuilder::new explicitly.\n\nCloses #2635"
+    },
+    {
+      "commit": "922bad2b92a564ac442368e9e2522f11d61f593f",
+      "subject": "ignore: improve 'excludesFile' parsing",
+      "body": "This permits the value to be surrounded in double quotes. It's still not\nperfect, but probably better than it was. Getting this to be more\ncorrect will likely require writing (or using) a real parser, which I'm\nnot particularly incliend to do at present.\n\nFixes #2392, Closes #2629"
+    },
+    {
+      "commit": "538ba956dc00b4317d0f40dc6324c31e9e1c40a9",
+      "subject": "deps: bump regex and regex-automata",
+      "body": ""
+    },
+    {
+      "commit": "443c057042f42f3a9ee5a9be07f49862aa8052b9",
+      "subject": "deps: bump regex, regex-automata and regex-syntax",
+      "body": ""
+    },
+    {
+      "commit": "5b88515faf67b1a9e5541a2130a6bebf3bd21c89",
+      "subject": "build: a bit of clean-up",
+      "body": "This does just a smidge of polishing in the build script source code."
+    },
+    {
+      "commit": "92c81b122548ab42586314ea535bb46ea41f1b10",
+      "subject": "core: switch to anyhow",
+      "body": "This commit adds `anyhow` as a dependency and switches over to it from\nBox<dyn Error>.\n\nIt actually looks like I've kept all of my errors rather shallow, such\nthat we don't get a huge benefit from anyhow at present. But now that\nanyhow is in use, I expect to use its \"context\" feature more going\nforward."
+    },
+    {
+      "commit": "53679e4c43e472b2f51d9568455caa10ad399fc4",
+      "subject": "ignore: simplify the work-stealing strategy",
+      "body": "There's no particular reason for this change. I happened to be looking\nat the code again and realized that stealing from your left neighbour\nor your right neighbour shouldn't make a difference (and indeed perf is\nthe same in my benchmarks).\n\nCloses #2624"
+    },
+    {
+      "commit": "8b766a2522f419ac33552b2f82ec2ad79646c601",
+      "subject": "ripgrep: disable hyperlinks by default",
+      "body": "As a result of discussion in #2611, it seems prudent to disable\nhyperlinks by default. Ideally they would be enabled, but it looks like\nsome environments may barf on them. Since this is the first release with\nhyperlink support, it makes sense to me at least to make users opt into\nthem. This does not preclude enabling them by default in future\nreleases."
+    },
+    {
+      "commit": "c21302b4096f9ce1af095fbe8b14828a90ecfecb",
+      "subject": "regex: tweak inner literal heuristic",
+      "body": "Previously, we had logic to skip our own inner literal optimization if\nthe regex itself was already (likely) accelerated. It turns out that the\npresence of a Unicode word boundary can defeat acceleration to a point.\nIt's likely enough that even if the underlying regex is accelerated, it\nwould be prudent to do our own inner literal optimization if the pattern\nhas a Unicode word boundary.\n\nNormally a Unicode word boundary doesn't defeat literal optimizations,\nsince even the slower engines can make use of *prefix* literal\noptimizations. But a regex can be accelerated via its own inner or\nsuffix literal optimizations, and those require the use of a DFA (or\nlazy DFA). Since DFAs crap out on haystacks that contain a non-ASCII\nUnicode scalar value when the regex contains a Unicode word boundary, it\nfollows that an \"accelerated\" can still wind up being quite slow.\n\n(An \"accelerated\" regex can also slow down because of restrictions on\navoiding quadratic behavior, but I believe this happens less frequently\nand is not as severe as the slow down as a result of Unicode word\nboundaries. Namely, avoiding quadratic behavior just means giving up on\nthe inner literal optimization for a single search. In which case, the\nregex engine can still fall back to a normal forward DFA. That will\ndefinitely be slower than an inner literal optimization done by ripgrep,\nbut not quite as dramatic as it would be when DFAs can't be used at\nall.)"
+    },
+    {
+      "commit": "8a5b81716af38234c98f684096b4c5e36ce80763",
+      "subject": "deps: update dependencies",
+      "body": "Specifically, regex-syntax 0.8.1 has this fix:\nhttps://github.com/rust-lang/regex/commit/f082244720d02fea04185c654e3d0dc95e39309d"
+    },
+    {
+      "commit": "7099e174acbcbd940f57e4ab4913fee4040c826e",
+      "subject": "cargo: remove dependency patches",
+      "body": "I'm too lazy to fixup old commits."
+    },
+    {
+      "commit": "dd810779d40911f8481175c06e4ff6d3165201c7",
+      "subject": "changelog: add another note about -w/--word-regexp bugs",
+      "body": "This was fixed a few commits ago when we updated to regex-automata 0.4\n(regex 1.10).\n\nFixes #2623"
+    },
+    {
+      "commit": "5011f6e9f1da44ffd923d612e75e70411d63a0ea",
+      "subject": "changelog: add perf bug fix for \\b",
+      "body": "Like the previous CHANGELOG entry, this marks a bug that was fixed\nlikely with the introduction of regex 1.9:\n\n    $ hyperfine \"rg-13.0.0 -ic '\\bfoo\\b \\bbar\\b' git-3a06386e.txt\" \"rg -ic '\\bfoo\\b \\bbar\\b' git-3a06386e.txt\"\n    Benchmark 1: rg-13.0.0 -ic '\\bfoo\\b \\bbar\\b' git-3a06386e.txt\n      Time (mean \u00b1 \u03c3):      1.034 s \u00b1  0.011 s    [User: 1.030 s, System: 0.004 s]\n      Range (min \u2026 max):    1.021 s \u2026  1.053 s    10 runs\n\n    Benchmark 2: rg -ic '\\bfoo\\b \\bbar\\b' git-3a06386e.txt\n      Time (mean \u00b1 \u03c3):       6.3 ms \u00b1   0.3 ms    [User: 4.6 ms, System: 1.6 ms]\n      Range (min \u2026 max):     5.6 ms \u2026   7.3 ms    343 runs\n\n    Summary\n      'rg -ic '\\bfoo\\b \\bbar\\b' git-3a06386e.txt' ran\n      164.95 \u00b1 7.70 times faster than 'rg-13.0.0 -ic '\\bfoo\\b \\bbar\\b' git-3a06386e.txt'\n\nThis was not fixed by making \\b itself faster, but rather, by improving\ninner literal extraction. In particular, if the regex doesn't have any\nliterals extracted, then search time can still be quite slow:\n\n    $ time rg-13.0.0 -ic '\\b[a-z]{3}\\b\\s\\b[a-z]{3}\\b' git-3a06386e.txt\n    57538\n\n    real    0.427\n    user    0.423\n    sys     0.003\n    maxmem  46 MB\n    faults  0\n    $ time rg -ic '\\b[a-z]{3}\\b\\s\\b[a-z]{3}\\b' git-3a06386e.txt\n    57538\n\n    real    0.337\n    user    0.333\n    sys     0.003\n    maxmem  46 MB\n    faults  0\n\nBut then again, so is grep, because grep doesn't benefit from any\nliteral optimizations either:\n\n    $ time grep -E -ic '\\b[a-z]{3}\\b\\s\\b[a-z]{3}\\b' git-3a06386e.txt\n    62396\n\n    real    1.316\n    user    1.292\n    sys     0.007\n    maxmem  13 MB\n    faults  7\n\nThe count mismatch should probably be investigated.\n\nFixes #1760"
+    },
+    {
+      "commit": "a2799ccb41078c75a0a0420299a80ca4b1361632",
+      "subject": "changelog: add bug fix for \\b",
+      "body": "This was probably fixed in a past commit where I bumped the regex engine\nto 1.9 (or perhaps more precisely, regex-automata 0.3). But I didn't\ntrack it as fixed at the time.\n\nFixes #1275"
+    },
+    {
+      "commit": "a13b5e0196324d123ca065db9bf0aa626d993feb",
+      "subject": "deps: update various crates",
+      "body": ""
+    },
+    {
+      "commit": "9626f167573527858f9736a3054882de87d6cd79",
+      "subject": "progress",
+      "body": ""
+    },
+    {
+      "commit": "f7ff34fdf9d2853f9763aceb28f5dcb014728045",
+      "subject": "searcher: simplify 'replace_bytes' routine",
+      "body": "I did this in the course of trying to optimize it. I don't believe I\nmade it any faster, but the refactoring led to code that I think is\nmore readable."
+    },
+    {
+      "commit": "b9de003f8125b7257e70dd72183ad6250facd3da",
+      "subject": "matcher: add a bunch of inline annotations",
+      "body": "Many of these functions should be inlineable, but I'm not 100% sure\nthat they can be inlined without these annotations. We don't want to\nforce things, but we do try and nudge the compiler in the right\ndirection."
+    },
+    {
+      "commit": "1659fb9b43efaf717152d7e5296a578984bbde50",
+      "subject": "printer: hand-roll decimal formatting",
+      "body": "It seems like a trifle, but if the match frequency is high enough, the\nallocation+formatting of line numbers (and columns and byte offsets)\nstarts to matter. We squash that part of the profile in this commit by\ndoing our own decimal formatting. I speculate that we get a speed-up\nfrom this by avoiding the formatting machinery and also a possible\nallocation.\n\nAn alternative would be to use the `itoa` crate, and it is indeed\nmarginally faster in ad hoc benchmarks, but I'm satisfied enough with\nthis solution."
+    },
+    {
+      "commit": "dd1bc5b89873295d4e81f7a93624963e99586c17",
+      "subject": "printer: sprinkle in a few #[inline] annotations",
+      "body": "These seem to help when ripgrep emits a lot of output, especially when\nthe --column flag is used."
+    },
+    {
+      "commit": "c9bfbe1e3d350bb93356167df9c4085abdbc2316",
+      "subject": "deps: bump regex and regex-automata",
+      "body": "This brings in a fix for a bug I found during ad hoc benchmarking:\nhttps://github.com/rust-lang/regex/commit/aa4e4c7120b0090ce0624e3c42a2ed06dd8b918a"
+    },
+    {
+      "commit": "88524a2b5232c951f9d4c0a169a046a7354251bd",
+      "subject": "core: dedup patterns",
+      "body": "ripgrep does not, and likely never will, report which pattern matched.\nBecause of that, we can dedup the patterns via just their concrete\nsyntax without any fuss.\n\nThis is somewhat of a pathological case because you don't expect the end\nuser to pass duplicate patterns in general. But if the end user\ngenerated a list of, say, names and did not dedup them, then ripgrep\ncould end up spending a lot of extra time on those duplicates if there\nare many of them. By deduping them explicitly in the application, we\nessentially remove their extra cost completely."
+    },
+    {
+      "commit": "9c6732bd2670d5f04fa5f19744aae12c3fb38572",
+      "subject": "printer: remove 'subl' alias",
+      "body": "It was apparently using a format specific to a particular plugin. I did\nknow that, but apparently the plugin is not ubiquitous or de facto\nstandard[1]. Thus, including it I think just leads to more confusion. We\ndefinitely do not want to be in the business of bundling aliases for\nevery conceivable plugin to different editors, so just drop it. We\nexpose the ability to write your own format for exactly this sort of\nreason.\n\n[1]: https://github.com/BurntSushi/ripgrep/discussions/2611#discussioncomment-7138302"
+    },
+    {
+      "commit": "392bb0944a7a2d0bc8d9e33a6c628a14fc8acc37",
+      "subject": "core: polish the core of ripgrep",
+      "body": "This I believe finishes are quest to do mechanical updates to ripgrep's\nstyle, bringing it in line with my current practice (loosely speaking)."
+    },
+    {
+      "commit": "90b849912f74a41faa9f0b4f0aa3a829a44fd4b5",
+      "subject": "deps: bump what we can",
+      "body": ""
+    },
+    {
+      "commit": "6d17b3ed6810a46fd89925c4f96cd88883224083",
+      "subject": "deps: drop thread_local, lazy_static and once_cell",
+      "body": "This is largely made possible by the addition of std::sync::OnceLock to\nthe standard library, and the memory pool available in regex-automata."
+    },
+    {
+      "commit": "f16ea0812db1e7218d98ce0a131b6b7aec510c3a",
+      "subject": "ignore: polish",
+      "body": "Like previous commits, we do a bit of polishing and bring the style up\nto my current practice."
+    },
+    {
+      "commit": "be9e308999b94aba4be0406dafbd8aa6201e326a",
+      "subject": "globset: use a Pool from regex-automata",
+      "body": "In the time before, we just used a RegexSet from the regex crate. That\nallocated unconditionally, so there was nothing we could do and it\ndidn't expose any APIs to reuse that memory. But now that we're using\nthe lower level regex-automata, we can reuse a PatternSet.\n\nIdeally we would just provide a way for the caller to build a PatternSet\n(perhaps via an opaque type) so that we don't have to shuffle data into\na PatternSet and then back into the caller's `Vec<usize>`. But this at\nleast avoids allocating for every search."
+    },
+    {
+      "commit": "d53b7310ee1424a292228f7e8986fa9306f22a7f",
+      "subject": "searcher: polish",
+      "body": "This updates some dependencies and brings code style in line with my\ncurrent practice."
+    },
+    {
+      "commit": "e30bbb8cff1fc59c9e7671c0aca1e8c664bde7df",
+      "subject": "grep: update to the 2021 edition",
+      "body": ""
+    },
+    {
+      "commit": "7f456404010005142a6493fb48bd9fd06aca2731",
+      "subject": "globset: polishing",
+      "body": "This brings the code in line with my current style. It also inlines the\ndozen or so lines of code for FNV hashing instead of bringing in a\nmicro-crate for it. Finally, it drops the dependency on regex in favor\nof using regex-syntax and regex-automata directly."
+    },
+    {
+      "commit": "0951820f63a1e38d755b2905e389e09c9b569040",
+      "subject": "core: doc and logging touchups",
+      "body": ""
+    },
+    {
+      "commit": "c3e85f2b44a05da44cea164adf14c3c39d769132",
+      "subject": "printer: fix a few issues in the hyperlink docs",
+      "body": "Closes #2612"
+    },
+    {
+      "commit": "3ad7a0d95e04d16e49f94b83a22f8942a234068f",
+      "subject": "crates: remove hard-coded links",
+      "body": "And use rustdoc's native intra-crate links. So much nicer."
+    },
+    {
+      "commit": "82d3183a04e2fac6e270c99a05229b8e1232584d",
+      "subject": "regex: some minor polish",
+      "body": "I think I already did a clean-up of this crate when I moved it to regex\n1.9, so the polish here is very minor."
+    },
+    {
+      "commit": "798f8981eb4fbbf8d06cbb2ad4722a1acf0ee841",
+      "subject": "pcre2: small polishing",
+      "body": ""
+    },
+    {
+      "commit": "96f01b92a082cc3497e8c8bc3a63257afd07ea3a",
+      "subject": "matcher: polish the grep-matcher crate",
+      "body": "Not much here. Just updating to reflect my current style and bringing\nthe crate to the 2021 edition."
+    },
+    {
+      "commit": "abfa65c2c1cd2140934ef93c438540557afc4a2c",
+      "subject": "ignore/types: add *.sarif for SARIF format files",
+      "body": "[SARIF] is a format for reporting static analysis results. It is [used\nby GitHub CodeQL][GH] for example.\n\nHere are some samples from Microsoft's VSCode extension:\n\nhttps://github.com/microsoft/sarif-vscode-extension/tree/main/samples\n\nThe SARIF format is built on top of JSON.\n\n[SARIF]: https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html\n[GH]: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning\n\nPR #2620"
+    },
+    {
+      "commit": "f608d4d9b3ab210b7e6964ca7d1d7dc9c077329e",
+      "subject": "hyperlink: rejigger how hyperlinks work",
+      "body": "This essentially takes the work done in #2483 and does a bit of a\nfacelift. A brief summary:\n\n* We reduce the hyperlink API we expose to just the format, a\n  configuration and an environment.\n* We move buffer management into a hyperlink-specific interpolator.\n* We expand the documentation on --hyperlink-format.\n* We rewrite the hyperlink format parser to be a simple state machine\n  with support for escaping '{{' and '}}'.\n* We remove the 'gethostname' dependency and instead insist on the\n  caller to provide the hostname. (So grep-printer doesn't get it\n  itself, but the application will.) Similarly for the WSL prefix.\n* Probably some other things.\n\nOverall, the general structure of #2483 was kept. The biggest change is\nprobably requiring the caller to pass in things like a hostname instead\nof having the crate do it. I did this for a couple reasons:\n\n1. I feel uncomfortable with code deep inside the printing logic\n   reaching out into the environment to assume responsibility for\n   retrieving the hostname. This feels more like an application-level\n   responsibility. Arguably, path canonicalization falls into this same\n   bucket, but it is more difficult to rip that out. (And we can do it\n   in the future in a backwards compatible fashion I think.)\n2. I wanted to permit end users to tell ripgrep about their system's\n   hostname in their own way, e.g., by running a custom executable. I\n   want this because I know at least for my own use cases, I sometimes\n   log into systems using an SSH hostname that is distinct from the\n   system's actual hostname (usually because the system is shared in\n   some way or changing its hostname is not allowed/practical).\n\nI think that's about it.\n\nCloses #665, Closes #2483"
+    },
+    {
+      "commit": "23e21133ba6a8ca2c4d040092ad1bc22f14e8861",
+      "subject": "printer: move PathPrinter into grep-printer",
+      "body": "I originally did not put PathPrinter into grep-printer because I\nconsidered it somewhat extraneous to what a \"grep\" program does, and\nalso that its implementation was rather simple. But now with hyperlink\nsupport, its implementation has grown a smidge more complicated. And\nmore importantly, its existence required exposing a lot more of the\nhyperlink guts. Without it, we can keep things like HyperlinkPath and\nHyperlinkSpan completely private.\n\nWe can now also keep `PrinterPath` completely private as well. And this\nis a breaking change."
+    },
+    {
+      "commit": "09905560ffc32206988c92c6a37c1c927c86e3cb",
+      "subject": "printer: clean-up",
+      "body": "Like a previous commit did for the grep-cli crate, this does some\npolishing to the grep-printer crate. We aren't able to achieve as much\nas we did with grep-cli, but we at least eliminate all rust-analyzer\nlints and group imports in the way I've been doing recently.\n\nNext we'll start doing some more invasive changes."
+    },
+    {
+      "commit": "25a7145c79492e8dc89b6ece9c5214c37d60d23d",
+      "subject": "cli: add new 'hostname' function",
+      "body": "This will enable us to query for the current system's hostname in both\nUnix and Windows environments.\n\nWe could have pulled in the 'gethostname' crate for this, but:\n\n1. I'm not a huge fan of micro-crates.\n2. The 'gethostname' crate panics if an error occurs. (Which, to be\nfair, an error should never occur, but it seems plausible on borked\nsystems? ripgrep runs in a lot of places, so I'd rather not take the\nchance of a panic bringing down ripgrep for an optional convenience\nfeature.)\n3. The 'gethostname' crate uses the 'windows-targets' crate from\nMicrosoft. This is arguably the \"right\" thing to do, but ripgrep\ndoesn't use them yet and they appear high-churn.\n\nSo I just added a safe wrapper to do this to winapi-util[1] and then\ninlined the Unix version here. This brings in no extra dependencies and\nthe routine is fallible so that callers can recover from potentially\nstrange failures.\n\n[1]: https://github.com/BurntSushi/winapi-util/pull/14"
+    },
+    {
+      "commit": "19a08bee8a99e8c725b9781568013a9f686605a3",
+      "subject": "cli: clean-up crate",
+      "body": "This does a variety of polishing.\n\n1. Deprecate the tty methods in favor of std's IsTerminal trait.\n2. Trim down un-needed dependencies.\n3. Use bstr to implement escaping.\n4. Various aesthetic polishing.\n\nI'm doing this as prep work before adding more to this crate. And as\npart of a general effort toward reducing ripgrep's dependencies."
+    },
+    {
+      "commit": "1a50324013708e3c73bfa986d273af2f8e8e3360",
+      "subject": "printer: add hyperlinks",
+      "body": "This commit represents the initial work to get hyperlinks working and\nwas submitted as part of PR #2483. Subsequent commits largely retain the\nfunctionality and structure of the hyperlink support added here, but\nrejigger some things around."
+    },
+    {
+      "commit": "86ef6833085428c21ef1fb7f2de8e5e7f54f1f72",
+      "subject": "deps: update everything",
+      "body": "Notably, this includes termcolor 1.3, which comes with hyperlink\nsupport."
+    },
+    {
+      "commit": "d938e955af7a39ac0245b1ce84924f7f4a2141ac",
+      "subject": "ignore: use work-stealing stack instead of Arc<Mutex<Vec<_>>>",
+      "body": "This represents yet another iteration on how `ignore` enqueues and\ndistributes work in parallel. The original implementation used a\nmulti-producer/multi-consumer thread safe queue from crossbeam. At some\npoint, I migrated to a simple `Arc<Mutex<Vec<_>>>` and treated it as a\nstack so that we did depth first traversal. This helped with memory\nusage in very wide directories.\n\nBut it turns out that a naive stack-behind-a-mutex can be quite a bit\nslower than something that's a little smarter, such as a work-stealing\nstack used in this commit. My hypothesis for why this helps is that\nwithout the stealing component, work distribution can get stuck in\nsub-optimal configurations that depend on which directory entries get\nassigned to a particular worker. It's likely that this can result in\nsome workers getting \"more\" work than others, just by chance, and thus\nremain idle. But the work-stealing approach heads that off.\n\nThis does re-introduce a dependency on parts of crossbeam which is kind\nof a bummer, but it's carrying its weight for now.\n\nCloses #1823, Closes #2591\nRef https://github.com/sharkdp/fd/issues/28"
+    },
+    {
+      "commit": "cad1f5fae2e4b48d8942add9dc4c950a170b5d2e",
+      "subject": "ignore: fix filtering when searching subdirectories",
+      "body": "When searching subdirectories the path was not correctly built and\nincluded duplicate parts. This fix will remove the duplicate part if\npossible.\n\nFixes #1757, Closes #2295"
+    },
+    {
+      "commit": "2198bd92faacef6e4a102fb96f1640a17a7c3ed2",
+      "subject": "github: convert bug-report issue template to issue form",
+      "body": "Trying this to see how well it works.\n\nPR #2560"
+    },
+    {
+      "commit": "a4387ed491b5f85b6817310c3fa0f3d20960fdcc",
+      "subject": "deps: bump to aho-corasick 1.1.0",
+      "body": "This brings in aarch64 SIMD support for Teddy[1]. In effect, it means\nsearches that are multiple (but a small number of) literals extracted\nwill likely get much faster on aarch64 (i.e., Apple silicon). For\nexample, from the PR, on my M2 mac mini:\n\n    $ time rg-before-teddy-aarch64 -i -c 'Sherlock Holmes' OpenSubtitles2018.half.en\n    3055\n\n    real    8.196\n    user    7.726\n    sys     0.469\n    maxmem  5728 MB\n    faults  17\n\n    $ time rg-after-teddy-aarch64 -i -c 'Sherlock Holmes' OpenSubtitles2018.half.en\n    3055\n\n    real    1.127\n    user    0.701\n    sys     0.425\n    maxmem  4880 MB\n    faults  13\n\nw00t.\n\n[1]: https://github.com/BurntSushi/aho-corasick/pull/129"
+    },
+    {
+      "commit": "d2a409f89f1eb8e3ad3990aeb1fff944289534f2",
+      "subject": "deps: bump to memchr 2.6.3",
+      "body": "This brings in a fix for line counting when SIMD isn't available[1].\n\n[1]: https://github.com/BurntSushi/memchr/pull/137"
+    },
+    {
+      "commit": "6cdb99ea61d585cc32716d181517d71b4df769b5",
+      "subject": "deps: drop bytecount in favor of memchr_iter(..).count()",
+      "body": "As of the memchr 2.6 release, its Iterator::count method is specialized\nto only count the number of occurrences instead of finding the offset of\neach occurrence. This replaces ripgrep's use of the bytecount crate.\nWhile micro-benchmarks suggest that memchr's method has better\nthroughput than bytecount, it turned out to be an illusion. Namely, on a\n~13GB haystack prior to this change:\n\n    $ time rg-bytecount 'You killed my friend, my best friend, my lifelong friend!' OpenSubtitles2018.raw.en --line-number\n    441450441:- You killed my friend, my best friend, my lifelong friend!\n\n    real    1.473\n    user    1.186\n    sys     0.286\n    maxmem  12512 MB\n    faults  0\n\nAnd then after:\n\n    $ time rg 'You killed my friend, my best friend, my lifelong friend!' OpenSubtitles2018.raw.en --line-number\n    441450441:- You killed my friend, my best friend, my lifelong friend!\n\n    real    1.532\n    user    1.280\n    sys     0.250\n    maxmem  12512 MB\n    faults  0\n\nBut perf is just about in the same ballpark. That's good enough for me\nat the moment in order to drop the extra dependency.\n\nI did this because the marginal cost of adding the Iterator::count()\nspecialization to memchr was extremely small."
+    },
+    {
+      "commit": "551ad3bada9f759beacf9c418ff82f78414e641a",
+      "subject": "deps: update bstr",
+      "body": ""
+    },
+    {
+      "commit": "8856f72df5525958927ada364a056e0a425d15e7",
+      "subject": "deps: update the regex family of crates",
+      "body": ""
+    },
+    {
+      "commit": "d596f6ebd035560ee5706f7c0299c4692f112e54",
+      "subject": "ignore/types: add *.vsh to V type",
+      "body": "PR #2604"
+    },
+    {
+      "commit": "6cd947963420360d8e4fe7f9eff93f4636d037a1",
+      "subject": "ignore: implement FusedIterator for Walk",
+      "body": "PR #2567"
+    },
+    {
+      "commit": "3bfa125b2ea8175947360322f1429a0205be6c76",
+      "subject": "ci: replace mips with powerpc64, aarch64 and s390x",
+      "body": "We drop our MIPS target because it no longer works.[1] We were\npreviously using it as a means of testing ripgrep in a big endian\nenvironment. So to achieve that without MIPS, we test on powerpc64 and\ns390x. (No particular reason to do both, but why not.)\n\nWe also add aarch64 as a proxy for at least ensuring everything works\nfor the same architecture as Apple silicon. It's not a guarantee that\neverything works, but it seems better than nothing until we can actually\ntest Apple silicon in CI.\n\n[1]: https://github.com/rust-lang/regex/commit/c788378d6fe407f4774df98a78436cea5d98525b"
+    },
+    {
+      "commit": "51765f2f4cbd6c561df35cf1d7d8637cf73006fa",
+      "subject": "ignore: apply rustfmt",
+      "body": "I believe this happened because rustfmt now knows how to format `let ...\nelse` constructs."
+    },
+    {
+      "commit": "67abd49678948b2d33e3a9a40f0b37a9c7dfb6c5",
+      "subject": "deps: bump everything else",
+      "body": ""
+    },
+    {
+      "commit": "a7fe2967725b1b122318c7cc61cc2bd6a37e3fa2",
+      "subject": "deps: bump regex, regex-automata and regex-syntax",
+      "body": ""
+    },
+    {
+      "commit": "f75991538b3445b79be795009b23c865351b1771",
+      "subject": "deps: bump memchr to 2.6.0",
+      "body": "This in particular brings in a PR[1] that provides huge speedups on\naarch64 (e.g., Apple silicon).\n\n[1]: https://github.com/BurntSushi/memchr/pull/129"
+    },
+    {
+      "commit": "962d47e6a1208cf2187cd34c2a7f6cf32e2a4903",
+      "subject": "ignore/types: add Prolog file types",
+      "body": "This improves the Prolog file type rules.\n\n* `.pl` is the most common extension in the wild, though `.pro` is\n   preferred in places where file extension may clash with Perl[1].\n* `.P` is used for compatibility with XSB Prolog dialect[2].\n\nPR #2590\n\n[1]: https://www.swi-prolog.org/pldoc/man?section=fileext\n[2]: https://www.swi-prolog.org/pldoc/man?section=xsb-source"
+    },
+    {
+      "commit": "19b6a45abba8cb0ba8a5b7fffedb49501619f90a",
+      "subject": "ignore/types: tweak Gradle file types",
+      "body": "This PR extends Gradle file types with the following:\n\n - Kotlin DSL buildscripts (`*.gradle.kts`)\n - Gradle Java properties (`gradle.properties`)\n - wrapper files (`gradle-wrapper.*`)\n - wrapper scripts (`gradlew`, `gradlew.bat`)\n\nPR #2587"
+    },
+    {
+      "commit": "c51790b56d6d06cfed888c759e381a86f7dc5095",
+      "subject": "deps: update everything",
+      "body": ""
+    },
+    {
+      "commit": "2af3734e0c0d729479d697cc0ba40fa00ef92358",
+      "subject": "deps: update aho-corasick",
+      "body": "This brings in [1,2], which improves memory usage substantially when\nAho-Corasick is used.\n\n[1]: https://github.com/BurntSushi/aho-corasick/pull/120\n[2]: https://github.com/BurntSushi/aho-corasick/pull/121"
+    },
+    {
+      "commit": "61733f6378b62fa2dc2e7f3eff2f2e7182069ca9",
+      "subject": "globset-0.4.13",
+      "body": ""
+    },
+    {
+      "commit": "7227e94ce5f661355a1547a1838284bb7ad5b815",
+      "subject": "globset: use non-capture groups in regex transform",
+      "body": "We currently implement globs by converting them to regexes, and in doing\nso, sometimes use grouping. In all but one case, we used non-capturing\ngroups. But for alternations, we used capturing groups, which was likely\njust an oversight. We don't make use of capture groups at all, and while\nthey usually don't have any overhead, they lead to weird cases like this\none: https://github.com/rust-lang/regex/issues/1059\n\nThat particular issue is also a bug in the regex crate itself, which is\nfixed in https://github.com/rust-lang/regex/pull/1062. Note though that\nthe bug fix in the regex crate is required. Even with this patch to\nglobset, memory usage is reduced (by about half in rust-lang/regex#1059)\nbut is not returned to where it was prior to the regex 1.9 release."
+    },
+    {
+      "commit": "341a19e0d05bc6f0cabeb2dc756b37cfc047f8f0",
+      "subject": "regex: fix fast path for -w/--word-regexp flag (#2576)",
+      "body": "It turns out our fast path for -w/--word-regexp wasn't quite correct in\nsome cases. Namely, we use `(?m:^|\\W)(<original-regex>)(?m:\\W|$)` as the\nimplementation of -w/--word-regexp since `\\b(<original-regex>)\\b` has\nsome unintuitive results in certain cases, specifically when\n<original-regex> matches non-word characters at match boundaries.\n\nThe problem is that using this formulation means that you need to\nextract the capture group around <original-regex> to find the \"real\"\nmatch, since the surrounding (^|\\W) and (\\W|$) aren't part of the match.\nThis is fine, but the capture group engine is usually slow, so we have a\nfast path where we try to deduce the correct match boundary after an\ninitial match (before running capture groups). The problem is that doing\nthis is rather tricky because it's hard to know, in general, whether the\n`^` or the `\\W` matched.\n\nThis still doesn't seem quite right overall, but we at least fix one\nmore case.\n\nFixes #2574"
+    },
+    {
+      "commit": "fed4fea217abbc502f2e823465de903c8f2b623d",
+      "subject": "ignore/types: add csproj",
+      "body": "Supports the .NET C# Project file extension.\n\nPR #2575"
+    },
+    {
+      "commit": "053a1669bb10482f0e09fd4faf9e80b1b5d1200a",
+      "subject": "globset-0.4.12",
+      "body": ""
+    },
+    {
+      "commit": "31d3f16254ec3f0c993d05be8f62dc81fc663406",
+      "subject": "api: impl Deserialize for GlobSet",
+      "body": "PR #2569"
+    },
+    {
+      "commit": "304a60e8e9d4b2a42dc3dfb1ba4cef6d7bf92515",
+      "subject": "grep-cli-0.1.9",
+      "body": ""
+    },
+    {
+      "commit": "1d35859861fa4710cee94cf0e0b2e114b152b946",
+      "subject": "globset-0.4.11",
+      "body": ""
+    },
+    {
+      "commit": "601e122e9fc94b3523d53e46eb734f54cfcc3134",
+      "subject": "ignore/types: add Windows Command Prompt files",
+      "body": "This PR adds `*.bat` and `*.cmd` file types.\n\nIn doing so, it makes a distinction between batch files (old standard\nfrom the MS-DOS era) and command scripts (new flavor - can operate on\nbatch files, although `*.cmd` is preferred for various reasons, the\nmain one being batch files will set `ERRORLEVEL` following inconsistent\nMS-DOS style rules[1]).\n\nPR #2556\n\n[1]: https://groups.google.com/g/microsoft.public.win2000.cmdprompt.admin/c/XHeUq8oe2wk/m/LIEViGNmkK0J#i106"
+    },
+    {
+      "commit": "efb2e8ce1e1277fbfa37329b6663c8cf86d6951a",
+      "subject": "ci/release: use latest OS versions",
+      "body": ""
+    },
+    {
+      "commit": "8d464e5c78510502cd1cf1d205c82df5de183825",
+      "subject": "ci/release: add sha256 sums to release artifacts",
+      "body": "Fixes #1924, Closes #2168"
+    },
+    {
+      "commit": "d67809d6c4bcd30d0864b23d415f79221f871797",
+      "subject": "github: remove dependabot configuration",
+      "body": "This does not seem to have worked at all. For example, there were\nActions being used that were clearly deprecated/archived[1]. But\nDependabot didn't make a peep. So just get rid of it to avoid the false\nsense that someone is checking our dependencies for us.\n\n[1]: https://github.com/BurntSushi/ripgrep/pull/2360"
+    },
+    {
+      "commit": "6abb962f0d655a186972462d88d2de4e5caf4a33",
+      "subject": "cli: fix non-path sorting behavior",
+      "body": "Previously, sorting worked by sorting the parents and then sorting the\nchildren within each parent. This was done during traversal, but it only\nworks when sorting parents preserves the overall order. This generally\nonly works for '--sort path' in ascending order.\n\nThis commit fixes the rest of the sorting behavior by collecting all of\nthe paths to search and then sorting them before searching. We only\ncollect all of the paths when sorting was requested.\n\nFixes #2243, Closes #2361"
+    },
+    {
+      "commit": "6d95c130d5fb56a8641092a4808f33640bfa935c",
+      "subject": "cli: add --stop-on-nonmatch flag",
+      "body": "This causes ripgrep to stop searching an individual file after it has\nfound a non-matching line. But this only occurs after it has found a\nmatching line.\n\nFixes #1790, Closes #1930"
+    },
+    {
+      "commit": "4782ebd5e0773465ba2c32a328250253c2b55779",
+      "subject": "core: lock stdout before printing an error message to stderr",
+      "body": "Adds a new eprintln_locked macro which locks STDOUT before logging\nto STDERR. This patch also replaces instances of eprintln with\neprintln_locked to avoid interleaving lines.\n\nFixes #1941, Closes #1968"
+    },
+    {
+      "commit": "4993d29a16b26b016b498765cc5636e73b479367",
+      "subject": "globset: add 'escape' routine",
+      "body": "Fixes #2060, Closes #2061"
+    },
+    {
+      "commit": "23adbd6795d4b0a7fbbb606d58fa82e3df0dabc2",
+      "subject": "cli: force binary existance check",
+      "body": "Previously, we were only doing a binary existence check on Windows. And\nin fact, the main point there wasn't binary existence, but ensuring we\ndidn't accidentally resolve a binary name relative to the CWD, which\ncould result in executing a program one didn't mean to run.\n\nHowever, it is useful to be able to check whether a binary exists on any\nplatform when associating a glob with a binary. If the binary doesn't\nexist, then the association can fail eagerly and let some other glob\napply.\n\nCloses #1946"
+    },
+    {
+      "commit": "9df8ab42b1ebdb11562b6413e25e63f6d410a4a5",
+      "subject": "cargo: reduce the size of the .crate file published to crates.io",
+      "body": "None of this stuff is needed for the main ripgrep crate.\n\nCloses #1940"
+    },
+    {
+      "commit": "cb7501ff111d32f636138cfc8975289fc5001f50",
+      "subject": "doc: clarify the comment on `Worker.work_done`",
+      "body": "We call `work_done` only once the work has been actually performed\n(otherwise `num_pending` could go to 0 before the actual work is done).\n\nCloses #2039"
+    },
+    {
+      "commit": "3b66f37a31d4fcc2aedc0737692c820d26452be4",
+      "subject": "doc: improve -r/--replace flag syntax docs",
+      "body": "Fixes #2108, Closes #2123"
+    },
+    {
+      "commit": "3eccb7c363d23d3b5e936721ed3e4358fe0acc7c",
+      "subject": "readme: add 'yum-utils' to RHEL/Centos instructions",
+      "body": "Closes #2103"
+    },
+    {
+      "commit": "f30a30867e2ad79ca7b556e5c0dbbe8c58a89267",
+      "subject": "ignore/types: name aliases for file types",
+      "body": "We also make py/python, md/markdown and ts/typescript aliases of one\nanother.\n\nNote that this only introduces aliases at the point where default types\nare defined. This just makes them a bit easier to read/write, and also\nmakes it easier to expose more names that describe the same thing.\n\nFixes #1857, Closes #1895"
+    },
+    {
+      "commit": "7313dca47286f5c71bf720172656cf2c14d8f756",
+      "subject": "ignore/types: add 'typescript' alias for 'ts'",
+      "body": "Closes #2009"
+    },
+    {
+      "commit": "99bf2b01dc261bccc6912ad733fc5f353ac411d5",
+      "subject": "ignore/types: add Ada filetypes, including gprbuild and alire",
+      "body": "*.adb and *.ads are the usual extensions for Ada source code,\nand *.gpr indicates a GPRbuild project file used for Ada, and\nthese days often being combined with alire for package dependency\nresolution. Alire stores a bunch of files named alire.toml in\ndifferent directories in your (gitignored) cache/dependencies/...\n\nCloses #2013"
+    },
+    {
+      "commit": "ee1360cc07beacbd89cc75affc855e74d76831df",
+      "subject": "ignore/types: add raku extensions to ignore types",
+      "body": "Closes #2117"
+    },
+    {
+      "commit": "db6bb21a629d5b1ec1bfe89c693b280497c9eedc",
+      "subject": "windows: attempt to enable long path support for MSVC targets",
+      "body": "See the README and comments in the build.rs. Basically, this embeds an\nXML file that I guess is a way of setting configuration knobs on\nWindows. One of those knobs is enabling long path support. You still\nneed to enable it in your registry (lol), but this will handle the other\nhalf of it.\n\nFixes #364, Closes #2049"
+    },
+    {
+      "commit": "da7c81fb960a2f5d0e3e3abd4bb86d7bb223ea57",
+      "subject": "ignore/types: add MDX format to Markdown types",
+      "body": "Ref https://mdxjs.com/\n\nCloses #2142"
+    },
+    {
+      "commit": "a4e3d56de1fcf8c5d8e7c304585733c6f9853886",
+      "subject": "ignore/types: add DITA (Darwin Information Typing Architecture)",
+      "body": "Closes #2148"
+    },
+    {
+      "commit": "7c83b90f95663d4215b4709f00fd0975277f0755",
+      "subject": "doc: fix typo",
+      "body": "Closes #2153"
+    },
+    {
+      "commit": "97b5b7769c717078515eb2f461a9ed2b3befaf6c",
+      "subject": "doc: fix some typos",
+      "body": "Closes #2195"
+    },
+    {
+      "commit": "2708f9e81d790b42783fbe6ee4f2dd6b5d091eb7",
+      "subject": "complete: add extra-verbose support to _rg_types",
+      "body": "When the extra-verbose style is set for the types tag, completed types\nare displayed along with the patterns they correspond to. This can be\nenabled by e.g. adding the following to .zshrc:\n\n  zstyle ':completion:*:rg:*:types' extra-verbose true\n\nThis change also makes _rg_types use the actual rg specified on the\ncommand line to look up types, and it fixes a mangled complete-all\nstyle check\n\nFixes #2195"
+    },
+    {
+      "commit": "f3241fd657c83284f0ec17854e41cab9fe3ce446",
+      "subject": "cli: '--no-ignore-dot' should also '.rgignore'",
+      "body": "Fixes #2198, Closes #2202"
+    },
+    {
+      "commit": "cfe357188d2fbd621b7d5f7f4139f19f0c88ca09",
+      "subject": "ignore/types: fix formatting",
+      "body": ""
+    },
+    {
+      "commit": "792451e3315e86fc66b1fd4eaeddf8433b6b32ac",
+      "subject": "ignore/types: added V type",
+      "body": "V (http://vlang.io) uses '.v' files.\n\nCloses #2302"
+    },
+    {
+      "commit": "7dafd58a323e3162bf2518ac9bef329a97d16818",
+      "subject": "readme: use 'sudo' more consistently",
+      "body": "I definitely wonder whether I should just drop 'sudo' from the install\ninstructions and just rely on the user to \"know\" to do it. But some\ncommands legitimately do not require 'sudo', so there are actual\ndifferences. Overall, this feels clearer to me but reasonable people can\ndisagree."
+    },
+    {
+      "commit": "b92550b67baf99d08b291101af5ba19667f81f34",
+      "subject": "readme: add install command for ALT Linux",
+      "body": "Closes #2330"
+    },
+    {
+      "commit": "383d3b336b02263a06f0488898c98aff85a083cb",
+      "subject": "doc: add '--hidden' to example configuration",
+      "body": "This increases visibility of the fact that hidden files are skipped by\ndefault.\n\nCloses #2356"
+    },
+    {
+      "commit": "fc7e634395f144491e6d2dc08cb5059adbb4b1fc",
+      "subject": "ci/release: Use GITHUB_REF_NAME instead of GITHUB_REF",
+      "body": "This is a nice quality of life improvement.\n\nCloses #2358"
+    },
+    {
+      "commit": "c9584b035b19244e370a50fd872a3ae2039e2931",
+      "subject": "ci/release: use GitHub CLI",
+      "body": "The old actions I was using are apparently archived because they make\nuse of deprecated features (like `set-output`). Sigh.\n\nCloses #2360"
+    },
+    {
+      "commit": "f34fd5c4b68480f5969b94709f54d493e79b3257",
+      "subject": "globset: introduce option to keep empty alternates",
+      "body": "Add a method GlobBuilder::empty_alternates and supporting mechanisms.\n\nRef #1368\nCloses #2369"
+    },
+    {
+      "commit": "d51c6c005aaac90329f61baa20821fafc96b841a",
+      "subject": "globset: permit deserializing Glob from String",
+      "body": "Closes #2386, Closes #2388"
+    },
+    {
+      "commit": "ea058813196dcdf53a51b0a689da0f4170b6ed75",
+      "subject": "readme: fix awkward grammar",
+      "body": "Closes #2402"
+    },
+    {
+      "commit": "1d4e3df19c0ce77c58ade35fbb30c216b48e2fba",
+      "subject": "readme: add winget installation section",
+      "body": "Closes #2409"
+    },
+    {
+      "commit": "0f6181d309d42061ed5be528503b93560c805f3c",
+      "subject": "ignore/types: add USD to the default file types",
+      "body": "Closes #2432"
+    },
+    {
+      "commit": "e902e2fef40b926bdf093c6a3939be8cc6f3778a",
+      "subject": "ignore/types: add Gentoo eclass type",
+      "body": "Eclasses are \"ebuild libraries\" and generally if you're filtering\nfor/filtering out an ebuild/eclass, you don't want the other either.\n\nFollowup to 4dfea016b915bb1e88679361de83a91e60447835\n\nCloses #2437"
+    },
+    {
+      "commit": "07cbfee2259d7194585a76773b45ed57f51e9fc3",
+      "subject": "ignore/types: improve Elixir globs",
+      "body": "Closes #2450"
+    },
+    {
+      "commit": "d6758445109ae0f52fc3dd09ccb88a95263217cb",
+      "subject": "core: don't let context flags override eachother",
+      "body": "This matches the behavior of GNU grep which does not ignore\nbefore-context and after-context completely if the context flag is also\nprovided.\n\nNote that this change wasn't done just to match GNU grep. In this case,\nGNU grep has the more sensible behavior.\n\nFixes #2288, Closes #2451"
+    },
+    {
+      "commit": "54e609d65725ac6683714d365b65d3cf7832dd97",
+      "subject": "doc: add another example for the config file",
+      "body": "Closes #2453"
+    },
+    {
+      "commit": "43bbcca06f0aab493b5f8c85ea2f7caf4fa3f7c4",
+      "subject": "doc: note '-n' and '-N' override each other",
+      "body": "Closes #2460"
+    },
+    {
+      "commit": "ad9bfdd98189ebeab3df945771a1a88e9b37c19a",
+      "subject": "ignore/gitignore: expose `gitconfig_excludes_path`",
+      "body": "I have reservations about this, but it looks useful and doesn't seem\nterribly onerous to support. The `ignore` crate will really always need\nto have some kind of logic supporting this in some form I think.\n\nCloses #2482"
+    },
+    {
+      "commit": "36194c27427a6df76963da472b13c36f47410824",
+      "subject": "test: test that regex inline flags work as intended",
+      "body": "This was originally fixed by using non-capturing groups when joining\npatterns in crates/core/args.rs, but before that landed, it ended up\ngetting fixed via a refactor in the course of migrating to regex 1.9.\nNamely, it's now fixed by pushing pattern joining down into the regex\nlayer, so that patterns can be joined in the most effective way\npossible.\n\nStill, #2488 contains a useful test, so we bring that in here. The\ntest actually failed for `rg -e ')('`, since it expected the command to\nfail with a syntax error. But my refactor actually causes this command\nto succeed. And indeed, #2488 worked around this by special casing a\nsingle pattern. That work-around fixes it for the single pattern case,\nbut doesn't fix it for the -w or -X or multi-pattern case. So for now,\nwe're content to leave well enough alone. The only real way to fix this\nfor real is to parse each regexp individual and verify that each is\nvalid on its own. It's not clear that doing so is worth it.\n\nFixes #2480, Closes #2488"
+    },
+    {
+      "commit": "0c1cbd99f36e4b97cbb915e9c5a7c0c091522105",
+      "subject": "ignore: tweak regex crate features",
+      "body": "This removes most of the Unicode features as they aren't currently\nused. We can always add them back later if necessary.\n\nWe can avoid the unicode-perl feature by changing `\\s` to `[[:space:]]`,\nwhich uses the ASCII-only definition of `\\s`. Since we don't expect\nnon-ASCII whitespace in git config files, this seems okay.\n\nCloses #2502"
+    },
+    {
+      "commit": "96cfc0ed133d4e4614c49463e8cae65afa65c55c",
+      "subject": "ignore/types: add 'graphql' type",
+      "body": "GraphQL file extensions: .graphql and .graphqls (schema)\n\nWe could also add `.gql`, but perhaps it's less correct to do so. We'll\nstart conservatively here, and we can always add `.gql` later.\n\nCloses #2439, Closes #2508"
+    },
+    {
+      "commit": "da8ecddce926bcf616f62c947058fe5487fd2a3b",
+      "subject": "cli: make resolve_binary take COM executables into account",
+      "body": "When `resolve_binary()` attempts to resolve a path to a program on\nWindows while searching for a program in `PATH` without an extension,\n`ripgrep` will assume the extension of the file to be `.exe` as it's\nthe *de facto* standard, which will work most (99.99%) of the time...\n\n...unless the binary is a COM executable (we're on Windows, duh).\n\nCloses #2523"
+    },
+    {
+      "commit": "545a7dc7598a20e8ef82076177164b7e3ccb15e4",
+      "subject": "ignore/types: add cml to the default types list",
+      "body": "It's used in Fuchsia to mean \"component manifest language.\"[1]\n\n[1]: https://fuchsia.dev/reference/cml?hl=en\n\nCloses #2529"
+    },
+    {
+      "commit": "16f783832e3860ffb5f96f03348dc2e31fb0204a",
+      "subject": "doc: update rust-version in Cargo.toml",
+      "body": "The MSRV got bumped a little bit ago, so this is just catchup.\n\nCloses #2539"
+    },
+    {
+      "commit": "f4d07b9cbdcf7d52e63f35fe76279e99a17492ef",
+      "subject": "grep-cli-0.1.8",
+      "body": ""
+    },
+    {
+      "commit": "0b6eccf4d34277ea254d32babae6420d5c7360c8",
+      "subject": "ci: try to fix CI",
+      "body": ""
+    },
+    {
+      "commit": "3ac4541e9fb83ba4fc67dbbd26082d0523e87743",
+      "subject": "regex: remove old inner literal extractor",
+      "body": "(It had already been removed from the crate.)"
+    },
+    {
+      "commit": "7b72e982f290983bf83ad0470eda784e6eab5735",
+      "subject": "deps: update everything",
+      "body": ""
+    },
+    {
+      "commit": "a68db3ac02fbfa2154cb2c8029c39e89d24c2792",
+      "subject": "deps: drop temporary patch and move to bstr 1.6",
+      "body": "Now that regex 1.9 is out, we can depend on it from crates.io."
+    },
+    {
+      "commit": "b12905daca8a1659e039af4e09affbc82e2de8af",
+      "subject": "deps: update everything",
+      "body": ""
+    },
+    {
+      "commit": "ca740d9ace9065103036c101ca973b79e59ae85a",
+      "subject": "regex: add new inner literal extractor",
+      "body": "This is mostly a copy of the prefix literal extractor in regex-syntax,\nbut with a tweaked notion of Seq that keeps track of whether it's a\nprefix of an expression or not. If it isn't, then we can't cross it as a\nsuffix to another Seq.\n\nThis new extractor should be a lot more robust than the old one. We\nactually will keep going through the regex to try and find the \"best\"\nliterals to search for (according to some heuristic)."
+    },
+    {
+      "commit": "e80c102dee181a623b802e610fe17548fa877c6f",
+      "subject": "regex: tweak formatting of regex-automata version spec",
+      "body": "This makes it easier to enable the `logging` feature for regex-automata.\n\nI wish I could just enable it unconditionally, but it winds up producing\na lot of output because ripgrep uses regexes for things other than the\nprimary search (like every glob). Sigh."
+    },
+    {
+      "commit": "8ac66a9e0461b0c50a5f69508f0740d893426d3d",
+      "subject": "regex: refactor matcher construction",
+      "body": "This does a little bit of refactoring so that we can pass both a\nConfiguredHIR and a Regex to the inner literal extraction routine.\n\nOne downside of this approach is that a regex object hangs on to a\nConfiguredHIR. But the extra memory usage is probably negligible. A\nbenefit though is that converting the HIR to its concrete syntax is now\nlazy and only happens when logging is enabled."
+    },
+    {
+      "commit": "04dde9a4eb5bbf6856e0a4ad16a6a9e3f1dd38ab",
+      "subject": "regex: tweak DFA settings",
+      "body": "This increases the limits a bit for when the regex engine will build and\nuse a fully compiled DFA. They can faster in some circumstances. For\nexample, '(?-u)^\\w{30,}$' gets a nice speed boost from state\nacceleration.\n\nWe are also able to remove `regex` proper as a dependency. Wow."
+    },
+    {
+      "commit": "81341702af83ce3a3f087d581565c14ba0df4de4",
+      "subject": "regex: push more pattern handling to matcher construction",
+      "body": "Previously, ripgrep core was responsible for escaping regex patterns and\nimplementing the --line-regexp flag. This commit moves that\nresponsibility down into the matchers such that ripgrep just needs to\nhand the patterns it gets off to the matcher builder. The builder will\nthen take care of escaping and all that.\n\nThis was done to make pattern construction completely owned by the\nmatcher builders. With the arrival regex-automata, this means we can\nmove to the HIR very quickly and then never move back to the concrete\nsyntax. We can then build our regex directly from the HIR. This overall\ncan save quite a bit of time, especially when searching for large\ndictionaries.\n\nWe still aren't quite as fast as GNU grep when searching something on\nthe scale of /usr/share/dict/words, but we are basically within spitting\ndistance. Prior to this, we were about an order of magnitude slower.\n\nThis architecture in particular lets us write a pretty simple fast path\nthat avoids AST parsing and HIR translation entirely: the case where one\nis just searching for a literal. In that case, we can hand construct the\nHIR directly."
+    },
+    {
+      "commit": "d34c5c88a7fb621af48e993e8f25bca4cbdb1597",
+      "subject": "globset: fix build error in tests",
+      "body": "I guess we haven't been testing with the Serde feature enabled? Weird."
+    },
+    {
+      "commit": "4b8aa91ae5b17bd988ed05ab5c7c387de9247b13",
+      "subject": "deps: update to pcre2 0.2.4",
+      "body": "0.2.4 updates to PCRE2 10.42 and has a few other nice changes. For\nexample, when `utf` is enabled, the crate will always set the\nPCRE2_MATCH_INVALID_UTF option. That means we no longer need to do\ntranscoding or UTF-8 validity checks.\n\nBecause of this, we actually get to remove one of the two uses of\n`unsafe` in ripgrep's `main` program.\n\n(This also updates a couple other dependencies for convenience.)"
+    },
+    {
+      "commit": "a775b493fd0d8dc23bdf43bbffe6d4c9f449e2ee",
+      "subject": "regex: small cleanups",
+      "body": "Just some small polishing. We also get rid of thread_local in favor of\nusing regex-automata, mostly just in the name of reducing dependencies.\n(We should eventually be able to drop thread_local completely.)"
+    },
+    {
+      "commit": "a6dbff502f1e0ce3401ea0b2a7a8a33bd12f5053",
+      "subject": "regex: s/locations/captures",
+      "body": "Now that we use regex-automata, we no longer use any type with\n\"locations\" in it. Instead, that's mostly legacy from the top-level\nregex crate."
+    },
+    {
+      "commit": "51480d57a67c229d624e5d1edb4aa3782e883696",
+      "subject": "regex: simplify AST analysis a bit",
+      "body": "The verbatim literal stuff hasn't been used for a while and I don't\nforesee it being used. If it's really needed, it would probably better\nto just implement it by looking at the pattern string itself, which\navoids parsing it into an AST altogether."
+    },
+    {
+      "commit": "d9bd261be8c52a280f767e5165de5dba6152830c",
+      "subject": "regex: some small cleanup in 'strip.rs'",
+      "body": "We also utilize bstr's methods to get rid of some helpers we had written\nby hand."
+    },
+    {
+      "commit": "9d62eb997a19efbf5e96d28870f8edad9bde1b9b",
+      "subject": "BREAKING: regex: finally remove CRLF hack",
+      "body": "Now that Rust's regex crate finally supports a CRLF mode, we can remove\nthis giant hack in ripgrep to enable it. (And assuredly did not work in\nall cases.)\n\nThe way this works in the regex engine is actually subtly different than\nwhat ripgrep previously did. Namely, --crlf would previously treat\neither \\r\\n or \\n as a line terminator. But now it treats \\r\\n, \\n and\n\\r as line terminators. In effect, it is implemented by treating \\r and\n\\n as line terminators, but ^ and $ will never match at a position\nbetween a \\r and a \\n.\n\nSo basically this means that $ will end up matching in more cases than\nit might be intended too, but I don't expect this to be a big problem in\npractice.\n\nNote that passing --crlf to ripgrep and enabling CRLF mode in the regex\nvia the `R` inline flag (e.g., `(?R:$)`) are subtly different. The `R`\nflag just controls the regex engine, but --crlf instructs all of ripgrep\nto use \\r\\n as a line terminator. There are likely some inconsistencies\nor corner cases that are wrong as a result of this cognitive dissonance,\nbut we choose to leave well enough alone for now.\n\nFixing this for real will probably require re-thinking how line\nterminators are handled in ripgrep. For example, one \"problem\" with how\nthey're handled now is that ripgrep will re-insert its own line\nterminators when printing output instead of copying the input. This is\nmaybe not so great and perhaps unexpected. (ripgrep probably can't get\naway with not inserting any line terminators. Users probably expect\nfiles that don't end with a line terminator whose last line matches to\nhave a line terminator inserted.)"
+    },
+    {
+      "commit": "e028ea37928930c80e5c3172d1df306b85a86758",
+      "subject": "regex: migrate grep-regex to regex-automata",
+      "body": "We just do a \"basic\" dumb migration. We don't try to improve anything\nhere."
+    },
+    {
+      "commit": "1035f6b1ff502eb5b1a5fc49a79f45971c772d47",
+      "subject": "deps: initial migration steps to regex 1.9",
+      "body": "This leaves the grep-regex crate in tatters. Pretty much the entire\nthing needs to be re-worked. The upshot is that it should result in some\nbig simplifications. I hope.\n\nThe idea here is to drop down and actually use regex-automata 0.3\ninstead of the regex crate itself."
+    },
+    {
+      "commit": "a7f1276021df2217dead1481b2c2b38595ed8fb3",
+      "subject": "readme: update Debian instructions",
+      "body": "We probably don't need to mention Buster specifically nor Debian\nunstable since ripgrep has been in Debian for a while now.\n\nBut we can't just get rid of the `deb` file either, because Debian might\npackage a very old version.\n\nFixes #2531"
+    },
+    {
+      "commit": "4fcb1b2202b97c5a21894672232700225223a138",
+      "subject": "cli: replace atty with std::io::IsTerminal",
+      "body": "The `atty` crate is unmaintained[1] and `std::io::IsTerminal` was\nstabilized in Rust 1.70.\n\n[1]: https://rustsec.org/advisories/RUSTSEC-2021-0145.html\n\nPR #2526"
+    },
+    {
+      "commit": "949092fd22689905fce358cdd1b2b676709feefe",
+      "subject": "ignore/types: add 'mdwn' to Markdown",
+      "body": "PR #2520"
+    },
+    {
+      "commit": "4a7e7094ad1f0c07bb38277eb1f61645adb855e2",
+      "subject": "deps: update everything else",
+      "body": ""
+    },
+    {
+      "commit": "fc0d9b90a9dbc1ba8d93a3f58da4ddbac0c40a7f",
+      "subject": "deps: bump regex to 1.8.3",
+      "body": "This brings in an update from the regex crate that fixes a matching bug\nfor particular kinds of alternations of literals.\n\nFixes #2518"
+    },
+    {
+      "commit": "335aa4937aed8f9c1bf3f5722e8fc4d671d46dcb",
+      "subject": "ignore/types: add *.pyi for Python",
+      "body": "https://peps.python.org/pep-0484/#stub-files\n\nPR #2517"
+    },
+    {
+      "commit": "803c44784509d31a8abb4297acda19bd680f667a",
+      "subject": "searcher: re-enable mmap on 32-bit architectures",
+      "body": "memmap2 v0.3.0 introduced a regression when trying to map files larger than 4GB\non 32-bit architectures[1] which was subsequently fixed in v0.3.1[2].\n\nThis commit bumps locked version of the memmap2 dependency to the current v0.5.0\nand reverts fdfc418be55ff91e0c2efad6a3e27db054cb5534 to re-enable mmap on 32-bit\narchitectures as a different approach to fixing [3].\n\nThis was tested to report matches from the end of a 5GB file using MinGW and Wine.\n\nRef #1911, PR #2000 \n\n[1] https://github.com/RazrFalcon/memmap2-rs/commit/5e271224c8411c89b42060294f9393cfc7b12a2a\n[2] https://github.com/RazrFalcon/memmap2-rs/commit/9aa838aed99a4879d8357ff295a0ca1c98ba1ae5\n[3] https://github.com/BurntSushi/ripgrep/issues/1911"
+    },
+    {
+      "commit": "c5415adbe8b1640ba097b420599dd33c7b5f2eaf",
+      "subject": "deps: update everything",
+      "body": "This does unfortunately bring in both regex-syntax 0.6 and 0.7, but\nwe'll fix that once regex 1.9 is out."
+    },
+    {
+      "commit": "251376597f808d78c11b86a4405b869e34d24658",
+      "subject": "deps: update minimum version of grep crate",
+      "body": "Ref #2516"
+    },
+    {
+      "commit": "e593f5b7ee314005f51be9124e4ee52d06eaa17a",
+      "subject": "grep-0.2.12",
+      "body": ""
+    },
+    {
+      "commit": "6b19be24776db74dd2df0bdbd5f199a8cd9964ce",
+      "subject": "crates/grep: remove 'deny(missing_docs)'",
+      "body": "This crate is only a shim over a bunch of other crates. I'm not sure\nthat there's anything to add to each of the `pub extern` items. So\ninstead of just writing fluff, I removed the lint.\n\nFixes #2516"
+    },
+    {
+      "commit": "041544853c86dde91c49983e5ddd0aa799bd2831",
+      "subject": "doc: fix --quiet docs",
+      "body": "The wording was previously inverted, which had the opposite\nmeaning as was intended.\n\nFixes #1962"
+    },
+    {
+      "commit": "a7ae9e4043533ba1b6e2f63b989b84f27d961b37",
+      "subject": "ignore/types: add support for docker-compose files",
+      "body": "Default file is docker-compose.yml and the documentation\nmentions overrides in the form of docker-compose.*.yml.\n\nPR #2469"
+    },
+    {
+      "commit": "595e7845b87c1b9e6cfd4f1c23b3910dca3e15f0",
+      "subject": "readme: add a link to delta's support for ripgrep",
+      "body": "Ref: https://github.com/BurntSushi/ripgrep/issues/86#issuecomment-1469717706"
+    },
+    {
+      "commit": "44fb9fce2c1ee1a86c450702ea3ca2952bf6c5a7",
+      "subject": "ignore/types: add *.sln for msbuild",
+      "body": ".sln is the extension for Visual Studio Project Soltion files, one of\nthe file types accepted as inputs by MSBuild.\n\nPR #2415"
+    },
+    {
+      "commit": "339c46a6edb336a42d54b0b41cbb29491a6a8573",
+      "subject": "ignore/types: enhance terraform default filter",
+      "body": "The default filter for terraform only checks for *.tf files, but there\nare quite few other terraform filetypes.\n\nThe explanation for all of them can be found below (including link to\ndocumentation from Hashicorp at time of writing)\n\n- *.tf.json & *.tfvars.json is to capture the files written in\n  JSON-based variant of the Terraform language\n    - https://developer.hashicorp.com/terraform/language/files\n- *.tfvars is used to supply variables\n    - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/variables#6-auto-tfvars-variable-files\n- .terraform.lock.hcl is used as a Dependency lock file\n    - https://developer.hashicorp.com/terraform/language/files/dependency-lock\n- terraform.rc & .terraformrc, *.tfrc\n    - https://developer.hashicorp.com/terraform/cli/config/config-file\n\nPR #2412"
+    },
+    {
+      "commit": "fe97c0a152cabc1bc07ec36b4b1e27cd230c3014",
+      "subject": "ignore-0.4.20",
+      "body": ""
+    },
+    {
+      "commit": "826f3fad5b2d08c4af26d387a2d2256f90743ae3",
+      "subject": "ignore/api: add Clone and Debug impls for OverrideBuilder",
+      "body": "PR #2397"
+    },
+    {
+      "commit": "bc5504932764d8d4735bf955f6f7e04a95f151b8",
+      "subject": "readme: update MSRV in README",
+      "body": "... this was apparently long outdated, wow."
+    },
+    {
+      "commit": "d58e9353fc82c03f434cfd9fc823f14930119736",
+      "subject": "deps: update to grep 0.2.11",
+      "body": ""
+    },
+    {
+      "commit": "ca60fef4dbb090523d3e59c69a74394aead962ae",
+      "subject": "grep-0.2.11",
+      "body": ""
+    },
+    {
+      "commit": "a25307d6c838b9770175dceb0c67b752ecbb2190",
+      "subject": "deps: update to grep-printer 0.1.7",
+      "body": ""
+    },
+    {
+      "commit": "b80947a8b3bac4fe99b3d7cb1622f1ff0bdb6d34",
+      "subject": "grep-printer-0.1.7",
+      "body": ""
+    },
+    {
+      "commit": "ad793a0d8f387be1fce20d862f26f75533b84b28",
+      "subject": "deps: update to grep-searcher 0.1.11",
+      "body": ""
+    },
+    {
+      "commit": "120e55e7c7502c843c8548f1d694ebdf72fc114c",
+      "subject": "grep-searcher-0.1.11",
+      "body": ""
+    }
+  ]
+}

--- a/bench/memory/raw-commits-ruff.json
+++ b/bench/memory/raw-commits-ruff.json
@@ -1,0 +1,2822 @@
+{
+  "repo": "ruff",
+  "num_commits_exported": 563,
+  "instructions": "Author questions from the commits below. Do NOT consult spelunk memory (spelunk memory list / spelunk memory search). Use the raw commit subjects and bodies as your only source material. Record ground-truth commit SHAs for each question.",
+  "commits": [
+    {
+      "commit": "1b0e0cf3021eb806dca338c7ee92234c37678b83",
+      "subject": "[ty] Update real-world benchmark pins (#26101)",
+      "body": ""
+    },
+    {
+      "commit": "9b0dbda2587b3ac666d95b9eb01aa9e0ab9e54aa",
+      "subject": "[ty] Use diagnostic tags in the playground (#26109)",
+      "body": ""
+    },
+    {
+      "commit": "d3ef449877f21a0596f30748908755f61b3fd1d7",
+      "subject": "[ty] Reorganize docstring parsing and Markdown modules (#26122)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nThis renames a few files and moves around some code in preparation for a\nseries of upcoming PRs which implements a new docstring rendering\narchitecture.\n\n## Test Plan\n\nThis is a pure refactor that relies on existing test coverage.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "cfafe6e4f134ec5ef74c00bde7802b3dc251228e",
+      "subject": "[ty] Extend test coverage for parsing of reStructuredText literal blocks (#26026)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nThis adds some additional test coverage that demonstrates that we parse\ncertain edge cases involving reStructuredText (reST) literal blocks\ncorrectly.\n\nIn particular, I learned that continuation lines and nest body elements\nof a reST field body [**must** be indented relative to the field name\nmarker](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#field-lists:~:text=The%20field%20body%20may%20contain%20multiple%20body%20elements%2C%20indented%20relative%20to%20the%20field%20marker.%20The%20first%20line%20after%20the%20field%20name%20marker%20determines%20the%20indentation%20of%20the%20field%20body.).\nSo although a [quoted literal\nblock](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#quoted-literal-blocks),\ndoes not require additional indentation if it appears on its own, it\nmust have indentation relative to the field name marker if it is part of\na field body.\n\nThe current parser (incidentally) handles this correctly; this helps to\nensure that we don't regress that behaviour.\n\n## Test Plan\n\nPlease see included tests.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "e588048abe091ad801c0d318aa425b7870970bce",
+      "subject": "[ty] Add context-sensitive keyword completions (#26036)",
+      "body": "## Summary\n\nWhen a statement or pattern is missing a contextual keyword, completion\ncurrently falls back to the broad scoped list. For example:\n\n```python\nfor item <CURSOR>\nwith open(path) <CURSOR>\nmatch status:\n    case 400 <CURSOR>\n```\n\nThis adds an exclusive contextual-keyword completion path. We now\nsuggest `in` after `for` and comprehension targets, `as` after `with`\nitems and exception types, and `as` or `if` after match patterns.\nPartial prefixes such as `i<CURSOR>` and `a<CURSOR>` receive the same\nfocused results.\n\nThe detector combines recovered AST ranges with token trivia so\nparenthesized operands, explicit and implicit continuations, comments,\nexisting keywords, grouped `with` items, and aliased match patterns\nfollow Python's keyword-placement rules without broad or duplicate\ncompletions.\n\nCloses https://github.com/astral-sh/ty/issues/1568."
+    },
+    {
+      "commit": "e675296239837eeb806715279de7aa2dbdf716d7",
+      "subject": "[ty] Fix override diagnostics for decorated methods (#25671)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\n\nThis corrects `invalid-explicit-override` and\n`missing-override-decorator` diagnostics for decorated methods whose\ninferred member type no longer points at the local definition.\n\nPreviously, we could either miss the local `@override` marker entirely\nor anchor the diagnostic to a definition from outside the class being\nanalyzed. An external definition is never the right target for these\noverride diagnostics, so we now use type-derived functions only when\nthey still belong to the member under analysis, and we supplement those\ncandidates with reachable local function definitions recovered from the\nclass body.\n\nTools differ on their handling of these diagnostics, but I think we've\narrived at a reasonable place. The table below summarizes whether or not\na tool emits an equivalent diagnostic (given the appropriate\nconfiguration) for each positive diagnostic expectation changed or added\nin this pull request:\n\n| Changed test case | ty | pyrefly (`1.0.0`) | zuban (`0.8.0`) | mypy\n(`2.1.0`) | pyright (`1.1.410`) |\n|"
+    },
+    {
+      "commit": "- |\n| [`lossy` inner\n`@override`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L134-L136)\n| yes | yes | yes | yes | no |\n| [`lossy2` outer\n`@override`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L137-L139)\n| yes | yes | yes | yes | no |\n|\n[`WrappedMethod`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L474-L477)\n| yes | no | yes | yes | no |\n|\n[`WrappedInvalidExplicitOverride`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L479-L482)\n| yes | no | yes | yes | no |\n|\n[`WrappedMethodWithOverrideBranch`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L485-L493)\n| yes | no | yes | yes | ?[^redeclaration-only] |\n|\n[`WrappedInvalidExplicitOverrideWithUndecoratedBranch`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L496-L504)\n| yes | no | yes | yes | ?[^redeclaration-only] |\n| [`quux` overloaded `@override` with lossy\nimplementation](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L784-L791)\n| yes | ?[^overload-placement-only] | yes | yes |\n?[^overload-placement-only] |\n\n[^redeclaration-only]: Pyright reported only a duplicate-definition\ndiagnostic for this mixed-branch case (`reportRedeclaration`). That is\nnot an equivalent override rule, but it may also obscure whether pyright\nwould attempt the override-specific check after resolving the\nduplicate-definition problem.\n[^overload-placement-only]: Pyrefly and Pyright reported only an\noverload-placement diagnostic for this case (`invalid-overload` /\n`reportInconsistentOverload`). That is not an equivalent override rule,\nbut it may obscure whether they would attempt the override-specific\ncheck after resolving the overload-placement problem.\n\nCloses https://github.com/astral-sh/ty/issues/3664.\n\n## Test Plan\n\nPlease see included tests, both new and updated to remove some\noutstanding TODOs.\n<!-- How was it tested? -->",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "bc57e1daa7e24b63f1aeb3867610514045904d7b",
+      "subject": "[ty] Improve `duplicate-base` diagnostics (#26107)",
+      "body": "## Summary\n\nOur `duplicate-base` diagnostics currently render quite poorly in the\nplayground (and, I assume, VSCode) due to a strange concatenation of\nmessages for the subdiagnostic:\n\n<details>\n<summary>Screenshot</summary>\n<img width=\"2566\" height=\"1190\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5370f29e-1a01-4d98-a861-dbf46cde3750\"\n/>\n</details>\n\nThey render much better on the CLI, but even on the CLI, they're very\nverbose, which isn't ideal:\n\n<details>\n<summary>Screenshot</summary>\n<img width=\"1602\" height=\"1672\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/06b44753-3dba-49d8-839a-fb3cccfbc081\"\n/>\n</details>\n\nThis PR removes the subdiagnostic and just uses secondary annotations on\nthe primary diagnostic. This renders much better in the playground (and,\nI assume, VSCode):\n\n<details>\n<summary>Screenshot</summary>\n<img width=\"1642\" height=\"1550\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/cd37478c-8fd2-424a-9957-bfc129b1260b\"\n/>\n</details>\n\nand is also much more concise on the CLI, albeit with some awkwardly\noverlapping annotation spans:\n\n<details>\n<summary>Screenshot</summary>\n<img width=\"1374\" height=\"1160\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b606808c-a5a8-4c71-93c9-d0920b14be3a\"\n/>\n</details>\n\nGist for the code that triggers those diagnostics:\nhttps://play.ty.dev/b6b8dd7d-14cc-42f0-8435-6283af761ff4\n\n## Test Plan\n\nmdtests updated"
+    },
+    {
+      "commit": "1bc771263382190adb6d803438cb3abd7d44e84e",
+      "subject": "[ty] Update benchmark Pyrefly to 1.1.0 (#26110)",
+      "body": "## Summary\n\nUpdate the ty benchmark harness to use Pyrefly 1.1.0.\n\nThis only changes the benchmark dependency pin and lockfile. Benchmark\noutputs and diagnostic snapshots are intentionally left unchanged.\n\n## Test Plan\n\n- `cd scripts/ty_benchmark && uv lock --upgrade-package pyrefly`\n- `cd scripts/ty_benchmark && uv run --python 3.14 pyrefly --version`\n- `uvx prek run --files scripts/ty_benchmark/pyproject.toml\nscripts/ty_benchmark/uv.lock`"
+    },
+    {
+      "commit": "5fe182951f7d069bbf975c9fa72be5734447f380",
+      "subject": "Make playground diagnostic links clickable (#26104)",
+      "body": "## Summary\n\nDiagnostic detail messages in the playground are currently rendered as\nplain text, so embedded URLs cannot be opened directly. Render HTTP and\nHTTPS URLs as links that open in a new tab while preserving the\nsurrounding diagnostic text.\n\n## Test plan\n\n\n\nhttps://github.com/user-attachments/assets/8fa25446-ba30-41ee-a04a-5cc60c212a1c"
+    },
+    {
+      "commit": "78507774470dcc73a8b21f905ecdea6a23562655",
+      "subject": "[ty] Disable LRU tracking for one-shot checks (#26106)",
+      "body": "## Summary\n\nThe `parsed_module` query uses an LRU eviction policy to bound retained\nquery values across Salsa revisions. This bookkeeping is useful for the\nlong-lived server and watch mode, but a one-shot CLI check exits after\nits first analysis and does not benefit from tracking recently used\nmodules.\n\nThis adds a database-level `disable_lru` hook and uses it for non-watch\nCLI checks. Query memoization within the check remains unchanged, while\nthe server and `ty check --watch` keep the existing LRU behavior."
+    },
+    {
+      "commit": "17d0e04aaf1cb983d04b9728d8f3e87b344e53fd",
+      "subject": "Use diagnostic tags in the playground (#26105)",
+      "body": "## Summary\n\nFollow up to\nhttps://github.com/astral-sh/ruff/pull/26058#discussion_r3424042393 to\nuse `DiagnosticTag`s directly in the playground instead of hard-coding a\ncouple of known `Unnecessary` cases.\n\n## Test Plan\n\nA new ruff_wasm test and manual testing in the local playground:\n\n\n<img width=\"523\" height=\"343\" alt=\"Screenshot 2026-06-17 at 10 53 30\"\nsrc=\"https://github.com/user-attachments/assets/64cf0fa0-1eb4-4451-baeb-8f3f1e7622d6\"\n/>\n\nThe strikethrough seems a bit aggressive to me for deprecated tags.\nCodex said we could either turn off `showDeprecated` in our Monaco\nsettings or just customize the CSS. Alternatively, I guess we could\nfilter out deprecated tags and only show the unnecessary ones, if we\nwere going to disable `showDeprecated`.\n\nBut I'm also fine with the default styling if others are."
+    },
+    {
+      "commit": "43307b0cdc98adfb4f69501839320ba2eda18483",
+      "subject": "[ty] Narrow equality across IntEnum classes (#26079)",
+      "body": "## Summary\n\n`IntEnum` members from different classes compare using their integer\nvalues, but we previously treated those members as unequal because they\nbelonged to different enum classes:\n\n```python\nfrom enum import IntEnum\n\nclass First(IntEnum):\n    ONE = 1\n\nclass Second(IntEnum):\n    ONE = 1\n\ndef handle(value: First | Second) -> None:\n    if value == First.ONE:\n        reveal_type(value)  # Literal[First.ONE, Second.ONE]\n```\n\nUsing the precise member values now modeled for standard-library enums,\nthis narrows comparisons across integer- and string-valued enum classes,\nincluding `==`, `!=`, and `match` patterns. Negative comparisons against\nbuiltin literals also exclude enum members known to compare equal to\nthat literal; for example, `value != 1` removes every finite enum member\nwhose value is `1`."
+    },
+    {
+      "commit": "6d3a09b29564dd1c78e44b1966bd708669d67572",
+      "subject": "[ty] Infer precise values for standard-library enums (#26103)",
+      "body": "## Summary\n\nEnum members with known standard-library constructors currently lose\ntheir precise value type whenever construction includes `__new__` or\n`__init__`. For example, `IntEnum.X.value` is inferred as `int` even\nwhen the declared value is exactly `1`.\n\nThis preserves literal values when their runtime class matches the\nenum's inherited `_value_` annotation:\n\n```python\nfrom enum import IntEnum\n\nclass Answer(IntEnum):\n    YES = 1\n\nreveal_type(Answer.YES.value)  # Literal[1]\n```\n\nValues that the constructor normalizes, such as `True` passed through\n`int.__new__`, continue to use the inherited annotation. User-defined\n`_value_` annotations and constructors also retain their existing\nconservative behavior."
+    },
+    {
+      "commit": "3aa9c26307edbcce83727ea8bbc594563614ab4b",
+      "subject": "Use human-readable names in LSP and playground diagnostics (#26058)",
+      "body": "## Summary\n\nThis PR follows up on #25937 to display human-readable names in the LSP\nand playground too, when preview is enabled.\n\n## Test Plan\n\nIn VS Code with `preview = true` in my `ruff.toml`:\n\n<img width=\"788\" height=\"352\" alt=\"Screenshot 2026-06-16 at 16 28 50\"\nsrc=\"https://github.com/user-attachments/assets/9352d76c-a87a-4721-9ca0-c9b130c98452\"\n/>\n\nwith `preview = false`:\n\n<img width=\"794\" height=\"318\" alt=\"Screenshot 2026-06-16 at 16 29 13\"\nsrc=\"https://github.com/user-attachments/assets/88a3346e-63a2-4e51-8d3b-fa71b36388b2\"\n/>\n\nIn the playground with preview enabled:\n\n<img width=\"730\" height=\"333\" alt=\"Screenshot 2026-06-16 at 16 58 15\"\nsrc=\"https://github.com/user-attachments/assets/3df5e40b-6b7e-4832-b0ba-6b3cb3b685b0\"\n/>\n\nand with preview disabled:\n\n<img width=\"769\" height=\"323\" alt=\"Screenshot 2026-06-16 at 16 51 30\"\nsrc=\"https://github.com/user-attachments/assets/b7261c3b-512d-43bb-9dd7-ddf825773734\"\n/>"
+    },
+    {
+      "commit": "444e2f484cf9208d667d70b2ed36f47c5aa71652",
+      "subject": "[ty] Reuse known union recognition in IDE resolution (#26102)",
+      "body": ""
+    },
+    {
+      "commit": "1d5d491001009e355fb584db1de7adb0224ead3c",
+      "subject": "[ty] Update benchmark project revisions (#25730)",
+      "body": "## Summary\n\nThis PR bumps the project revisions used by `ty_benchmark` and refreshes\nthe expected CLI diagnostic snapshots against current upstream code.\n\nThe refreshed revisions require a few corresponding dependency changes.\nHome Assistant now installs its full and test requirements separately\nand excludes `dtlssocket`, which is pulled in by `pytradfri[async]` but\nonly distributed as an sdist that requires `autoconf`; pandas-stubs now\nrequires Python 3.11 and exposes its development dependencies through a\ndependency group; and PyTorch's import environment is refreshed from its\nupstream Pyrefly linter configuration while checker versions remain\ncontrolled by this benchmark.\n\nThe benchmark harness now installs mypy only when a mypy suite is\nselected, and uses a `uv` override to pin those runs to mypy 2.1.0 even\nfor projects that declare their own mypy development dependency. This\nkeeps ty and Pyrefly runs from inheriting mypy's Python-version and\ndependency constraints while preserving one benchmark-managed mypy\nversion for mypy runs.\n\nWe also advance the dependency cutoff and update the benchmarked type\ncheckers to mypy 2.1.0, Pyright 1.1.410, and Pyrefly 1.0.0."
+    },
+    {
+      "commit": "95ddc340b74719676eb560c4098f831de472bd95",
+      "subject": "[ty] Avoid cross-TypeVar leakage in generic inference (#26099)",
+      "body": "## Summary\n\nGeneric return-type context can introduce relationships between type\nvariables while solving a call. We need those relationships during\nconstraint solving, but we previously reused them as concrete preferred\ntypes during argument inference.\n\nFor example, inferring `dict(zip(keys, values))` against `Mapping[float,\nint]` can derive a key solution containing the value TypeVar and a value\nsolution containing the key TypeVar. Treating those intermediate\nrelationships as final solutions causes both `dict` parameters to widen\nto `int | float`. This fails on `main`:\n\n```python\nfrom collections.abc import Iterable, Mapping\n\ndef build(\n    keys: Iterable[float],\n    values: Iterable[int],\n) -> Mapping[float, int]:\n    return dict(zip(keys, values))\n```\n\nThis projects inferable TypeVar artifacts within each source binding\ncontext before using solutions as preferred types. Relationships across\nseparate generic contexts remain intact, preserving constructor `self`\nremapping and similar inference."
+    },
+    {
+      "commit": "02b49d930ce10f9dc065cef0daa7a98a60ad3b44",
+      "subject": "Revert \"Display output severity in preview\" (#26050)",
+      "body": "Summary\n--\n\nThis reverts #23845 since we're now prioritizing the human-readable\nnames and category work before getting back to severity.\n\nI had to revert (the revert of) the changes to the ecosystem check\nscript and then add another normalization pass again to get CI to pass.\nI can follow up immediately to revert these changes once this is the\nbaseline.\n\nTest Plan\n--\n\nExisting tests updated following #25937\n\nI said I didn't love diagnostics like this:\n\n```\nfib.py:1:8: unused-import: [*] `os` imported but unused\n```\n\nwith both a human-readable name and a fix indicator on that PR, but I\nthink it's not actually that\nbad, and I haven't thought of a better alternative, so I think it's fine\nfor now."
+    },
+    {
+      "commit": "406bde9ee93f11027ebb0c3a2b85e7bce4169c4e",
+      "subject": "Update ecosystem-analyzer pin (#26098)",
+      "body": "## Summary\n\nUpdate the ecosystem-analyzer commit used by the pull request and weekly\nreport workflows to the latest commit on upstream `main`."
+    },
+    {
+      "commit": "bcd0853684a6d38f210557c5289dac49f1067517",
+      "subject": "[ty] Speed up large-union narrowing (#26048)",
+      "body": ""
+    },
+    {
+      "commit": "05ec34ef5c8eb22410bc9d0e9e3c04416dfaf362",
+      "subject": "[ty] Preserve non-final types in Hashable unions (#26039)",
+      "body": "## Summary\n\nIn https://github.com/astral-sh/ty/issues/1162#issuecomment-4343373191,\nwe decided to stop simplifying `Hashable | C` to `Hashable` when `C` is\nnon-final. A subclass can disable hashing even when its base class\nsatisfies `Hashable`, so the existing normalization can discard a\nmeaningful union arm:\n\n```python\nfrom collections.abc import Hashable, Sequence\n\ndef f(value: Hashable | Sequence[Hashable]) -> None:\n    ...\n```\n\nThis recognizes the standard-library protocol through both\n`typing.Hashable` and `collections.abc.Hashable`, and preserves the\nnon-final arm while retaining the existing simplification for final\nclasses and `object`.\n\nThis PR uses a relatively narrow / conservative model for determining\nhashability; https://github.com/astral-sh/ruff/pull/26040 is more\nexpansive, but I think it deserves to be reviewed separately.\n\nCloses https://github.com/astral-sh/ty/issues/1162."
+    },
+    {
+      "commit": "77194b18acd5a6e5fe7349cc4c9ee026de90c2f1",
+      "subject": "[ty] Avoid retaining empty use-def tables (#26018)",
+      "body": "## Summary\n\nWe retain a `UseDefMap` for every scope. Several of its collection\nfields are empty in most scopes, but their fixed-size headers still\nremain in every map and add up across the semantic index.\n\nThis moves two sets of fields behind optional allocations. Predicate and\nconstraint tables are omitted when no retained reachability or narrowing\nformula needs a table lookup. Bindings indexed by use, member states,\nand enclosing-scope snapshots share a second allocation that is omitted\nwhen all of those collections are empty.\n\nScopes without constraint tables use one shared empty value, preserving\nthe existing lookup APIs without propagating optional values through\nevaluation. Predicates built for those scopes are also discarded because\nno retained constraint can reference them. The remaining fields share\nstorage only to reduce the size of common `UseDefMap` values; they do\nnot represent a new semantic abstraction.\n\nThe diagnostic comparison reports no changes.\n\n## Performance\n\nThe memory report shows total retained-memory reductions of 0.29\u20131.43%\nacross Flake8, Trio, Sphinx, and Prefect. Within `semantic_index`,\nretained memory falls by 1.24\u20135.32%, saving between 491.55kB and 1.51MB."
+    },
+    {
+      "commit": "6ced73309897c5d3c372f7b07d5196b00cfa7143",
+      "subject": "[ty] Revert equality intersection optimization (#26093)",
+      "body": "## Summary\n\nThis reverts the dynamic-only guard added in #26057. Non-dynamic union\narms can still overlap alternatives removed by equality narrowing when\ntheir individual comparison result is ambiguous. For example, after\nexcluding `Color.RED` from `T | Literal[Color.RED]`, an unconstrained\n`T` must remain `T & ~Literal[Color.RED]`; dropping that negative\nconstraint incorrectly widens the result to `T`.\n\nThe regression test covers that fallthrough behavior. This restores the\nprevious narrowing while we develop a narrower optimization that only\nskips constraints for arms proven to take the selected branch.\n\nThe focused equality mdtest and file-scoped hooks pass."
+    },
+    {
+      "commit": "7e69a2a9b36d6321731d575ce9a23d392368757c",
+      "subject": "[ty] Model enum value construction (#26080)",
+      "body": "## Summary\n\nEnum construction metadata currently represents each method with an\noptional function plus a separate opaque-binding boolean. This allows\nredundant or invalid combinations and spreads the interpretation of\nthose methods across enum value inference, alias detection, and\nconstructor validation.\n\n`ResolvedEnumMethod` now represents each method as absent,\nstandard-library, user-defined, or opaque. `EnumValueConstruction`\ngroups `__init__`, `__new__`, `_generate_next_value_`, and metaclass\ntransformation state, and exposes the specific predicates needed by each\nconsumer."
+    },
+    {
+      "commit": "83df8fa8483f8285af713896f20115a6471cabf1",
+      "subject": "[ty] Migrate type property tests to new intersection syntax (#26092)",
+      "body": "Migrate the `type_properties` mdtests to the new syntax to make them\neasier to read."
+    },
+    {
+      "commit": "3328b5d12c55d50054701dc7878e9204b8940cb6",
+      "subject": "Update fix availability for always-fixable rules (#26091)",
+      "body": ""
+    },
+    {
+      "commit": "7a83f77f477eac5e56486881f47ce78eece0764c",
+      "subject": "[ty] Retain all diagnostic annotations in the server (#26006)",
+      "body": "## Summary\n\nCodex spotted on another PR that if a (sub)diagnostic has multiple\nprimary annotations, `ty_server` currently discards all but the first\none. That doesn't seem great -- we have some diagnostics right now that\nhave multiple primary annotations, e.g.\n\n\nhttps://github.com/astral-sh/ruff/blob/26777f3c636848469cd0669ccb20071a2b2a9c09/crates/ty_python_semantic/src/types/diagnostic.rs#L5222-L5228\n\nI actually don't think ^that diagnostic has great rendering right now,\nand hope to change it separately so that it does not use so many primary\nannotations. But it still doesn't really seem right for the server to\ndiscard information like this. (It's also not what the playground\ncurrently does, following the recent changes to render subdiagnostics in\nthe playground.)"
+    },
+    {
+      "commit": "469460ed48ec2a559d44949db19436623960dd64",
+      "subject": "Fix Pyodide playground asset check (#26088)",
+      "body": ""
+    },
+    {
+      "commit": "37db56f0bc137bddcd6b789233939ebc8406f379",
+      "subject": "[ty] Migrate intersection tests to new syntax (#26089)",
+      "body": "Migrate `intersection_types.md` to the new syntax to make it easier to\nread."
+    },
+    {
+      "commit": "f02c94882e15dbb5a58c206c71839f2242178f0a",
+      "subject": "[ty] Move intersection type annotation tests (#26087)",
+      "body": ""
+    },
+    {
+      "commit": "7af316247a4bdacb5f7d053e77f2921f954dc3e0",
+      "subject": "Update dependency pyodide to v314 (#26076)",
+      "body": ""
+    },
+    {
+      "commit": "b4d050abd24d30f711d42dd7ede69da037dbb2d0",
+      "subject": "Update Rust crate wasm-bindgen-test to v0.3.73 (#26068)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "8dba9d396630ae2c4a4fc371b9250fb98e628b4b",
+      "subject": "Update NPM Development dependencies to v4.20260610.1 (#26082)",
+      "body": ""
+    },
+    {
+      "commit": "954936d15b609173c16b19664767169d48666ed1",
+      "subject": "Update taiki-e/install-action action to v2.81.9 (#26081)",
+      "body": "This PR contains the following updates:\n\n| Package | Type | Update | Change | Pending |\n|"
+    },
+    {
+      "commit": "This PR was generated by [Mend Renovate](https://mend.io/renovate/).\nView the [repository job\nlog](https://developer.mend.io/github/astral-sh/ruff).\n\n<!--renovate-debug:eyJjcmVhdGVkSW5WZXIiOiI0My4yMTkuMCIsInVwZGF0ZWRJblZlciI6IjQzLjIxOS4wIiwidGFyZ2V0QnJhbmNoIjoibWFpbiIsImxhYmVscyI6WyJpbnRlcm5hbCJdfQ==-->\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "791eb38f843e95731a165d552c3f7db676c54d66",
+      "subject": "Update Rust crate get-size2 to 0.10.0 (#26074)",
+      "body": ""
+    },
+    {
+      "commit": "041a4e1d93c25a1d3147706501fdb7709a6a7625",
+      "subject": "Update NPM Development dependencies (#26072)",
+      "body": ""
+    },
+    {
+      "commit": "82471a3479da1541775c489f9244abf9956d5b28",
+      "subject": "Update Rust crate which to v8.0.3 (#26069)",
+      "body": ""
+    },
+    {
+      "commit": "e23e1ea7e08e5a1b2406591bd4100317b73bcbef",
+      "subject": "Update Rust crate serde_with to v3.21.0 (#26075)",
+      "body": ""
+    },
+    {
+      "commit": "7b85531b864c90d01976dc8d3b42856d2bae77e8",
+      "subject": "Update Rust crate bitflags to v2.13.0 (#26073)",
+      "body": ""
+    },
+    {
+      "commit": "0c6a64e8b4ee6084e25e5dd9683aa6bca5f13822",
+      "subject": "Update cargo-bins/cargo-binstall action to v1.20.0 (#26071)",
+      "body": ""
+    },
+    {
+      "commit": "f32eca12e93b5a8329e161e43d720dc5b6bf05e4",
+      "subject": "Update taiki-e/install-action action to v2.81.8 (#26070)",
+      "body": ""
+    },
+    {
+      "commit": "31b9d2a6d9cb840406160bda1fef70dabe645dcc",
+      "subject": "Update Rust crate uuid to v1.23.3 (#26067)",
+      "body": ""
+    },
+    {
+      "commit": "9f56a6198ec383dd937cc3c7d8a8af351e1c31f5",
+      "subject": "Update Rust crate regex-syntax to v0.8.11 (#26066)",
+      "body": ""
+    },
+    {
+      "commit": "100aa3c0c77315eb2a7f6d6534518f94beef60eb",
+      "subject": "Update Rust crate regex to v1.12.4 (#26065)",
+      "body": ""
+    },
+    {
+      "commit": "1d0880230283cdaae31eac8c3c92e733717bca36",
+      "subject": "Update Rust crate log to v0.4.32 (#26064)",
+      "body": ""
+    },
+    {
+      "commit": "b0ad8061f6f737bfa747fc6793385d9f0c3f32c8",
+      "subject": "Update Rust crate ignore to v0.4.26 (#26063)",
+      "body": ""
+    },
+    {
+      "commit": "612f3b710d5b7425f07ab628216929d91aa67ffb",
+      "subject": "Update prek dependencies (#26062)",
+      "body": ""
+    },
+    {
+      "commit": "b21812bca394524708a6b1fe1d38a5934239fa38",
+      "subject": "Update dependency ruff to v0.15.17 (#26061)",
+      "body": ""
+    },
+    {
+      "commit": "cb7ae9602724cee25af99bfd3c3f7b9639fc41b0",
+      "subject": "Update dependency go to v1.26.4 (#26060)",
+      "body": ""
+    },
+    {
+      "commit": "679a67bad3d49f45b62d506aade4ededa66f330a",
+      "subject": "Update dependency astral-sh/uv to v0.11.21 (#26059)",
+      "body": ""
+    },
+    {
+      "commit": "b9ea5d9b3906f64436a18818148c33c1f8036293",
+      "subject": "[ty] Avoid redundant equality intersections (#26057)",
+      "body": "## Summary\n\nThis restores the dynamic-only guard when applying removed union arms as\nnegative constraints during equality narrowing. Static alternatives have\nalready been narrowed individually, so intersecting every surviving arm\nwith the removed set creates redundant intersection types that compound\nacross repeated fallthrough narrowing.\n\nDynamic alternatives still need those negative constraints to preserve\nthe branch predicate. Keeping that distinction avoids the guarded-`Any`\nequality benchmark regression introduced by `4e7ab3ac6c` without\nchanging narrowing behavior. The targeted benchmark showed that removing\nthe guard increased runtime by about 33% locally.\n\nThe full `ty_python_semantic` suite, Clippy with warnings denied, and\nfile-scoped hooks pass."
+    },
+    {
+      "commit": "4eee08f3e5baf8c22c54d9d5f7a766e3222c8880",
+      "subject": "[ty] Make equality evaluation cycle-aware (#26055)",
+      "body": "## Summary\n\nThis makes recursive equality evaluation detect cycles at the comparison\nlevel instead of preflighting the shape of the compared type. We track\nactive `(left, right, branch, operator)` evaluations and conservatively\nrecover repeated comparisons as ambiguous.\n\nThe previous shape guard rejected every constrained type variable, even\nwhen evaluating its constraints terminates and proves that every\nrepresented value compares equal. For example:\n\n```python\nfrom typing import Any, Literal, TypeVar, reveal_type\n\nT = TypeVar(\"T\", Literal[0], Literal[False])\n\ndef f(x: Any, y: T) -> None:\n    if x != y:\n        reveal_type(x)  # Any & ~T\n```\n\nThis also keeps exact runtime aliases such as `list[Any]` atomic, while\nrecursive `Any` and upper-bounded type-variable comparisons terminate\nwithout duplicating the evaluator's recursion rules."
+    },
+    {
+      "commit": "870fc14af946822c7db6d5b9e3921021fc110094",
+      "subject": "[ty] Support enum literals as tagged-union discriminants (#25855)",
+      "body": "## Summary\n\nThis is stacked on #25788, which provides the underlying equality\nnarrowing behavior.\n\nPrior to this change, tagged-union narrowing accepted string, bytes, and\ninteger literals as discriminants, but excluded enum literals. This adds\nenum literals to the same narrowing path:\n\n```python\nfrom enum import Enum\nfrom typing import Literal, TypedDict, reveal_type\n\nclass Tag(Enum):\n    A = 1\n    B = 2\n\nclass A(TypedDict):\n    tag: Literal[Tag.A]\n    value: int\n\nclass B(TypedDict):\n    tag: Literal[Tag.B]\n    value: str\n\ndef handle(item: A | B) -> None:\n    if item[\"tag\"] == Tag.A:\n        reveal_type(item)  # A\n```\n\nCloses https://github.com/astral-sh/ty/issues/2192."
+    },
+    {
+      "commit": "5272a425c08e55996134ff5164b2f2e182560fa4",
+      "subject": "[ty] Improve equality-based narrowing for `==`, `!=`, and `match` (#25788)",
+      "body": "## Summary\n\nThis revives equality narrowing from #22799 and makes narrowing follow\nPython's `==` and `!=` behavior more closely. We narrow only when the\nresult is predictable; when custom comparison code could produce either\nresult, we leave the type unchanged.\n\nPython allows `==` and `!=` to behave independently. Here `!=` is\ncustomized, but `==` still uses normal enum equality and can narrow\n`answer`:\n\n```python\nfrom enum import Enum\nfrom typing import reveal_type\n\nclass Answer(Enum):\n    NO = 0\n    YES = 1\n\n    def __ne__(self, other: object) -> bool:\n        return True\n\ndef handle(answer: Answer) -> None:\n    if answer == Answer.NO:\n        reveal_type(answer)  # Literal[Answer.NO]\n    else:\n        reveal_type(answer)  # Literal[Answer.YES]\n```\n\n`match` value patterns are equality comparisons too, so we use the same\nrules when deciding which cases are reachable:\n\n```python\nfrom enum import StrEnum\nfrom typing import Literal, assert_never, reveal_type\n\nclass Color(StrEnum):\n    GREEN = \"g\"\n\ndef handle(color: Literal[Color.GREEN]) -> None:\n    match color:\n        case \"g\":\n            reveal_type(color)  # Literal[Color.GREEN]\n        case _:\n            assert_never(color)\n```\n\nCloses https://github.com/astral-sh/ty/issues/1454."
+    },
+    {
+      "commit": "744171f1c2b205467ed5303f21008baf6e828e73",
+      "subject": "[ty] Preserve narrowing after qualified TYPE_CHECKING (#26051)",
+      "body": "## Summary\n\nTeach semantic-index predicate construction to recognize qualified\n`TYPE_CHECKING` conditions using the same detector already used for\nidentifying type-checking blocks. This preserves narrowing established\nin the statically reachable branch for both `typing.TYPE_CHECKING` and\nqualified module aliases such as `t.TYPE_CHECKING`.\n\nAdd regression coverage for both qualified forms to the existing\nknown-constants mdtest.\n\n## Root cause\n\nOnly the bare name `TYPE_CHECKING` was eagerly evaluated while building\nthe semantic index. Qualified forms were resolved as true later during\ntype inference, after the branch flow states had already been merged and\nbranch-local narrowing had been discarded.\n\nFixes https://github.com/astral-sh/ty/issues/3779"
+    },
+    {
+      "commit": "eb180de0ee8a190f8cbd2a1ef42dd4d9c74ea298",
+      "subject": "[ty] Preserve literal types for loop variables over literal collections (#25083)",
+      "body": "## Summary\n\nThis PR preserves precise element types when inferring loop targets over\nfixed-length literal iterables.\n\nPreviously, `for key in [\"path\"]` inferred `key` as `str` because the\nlist literal widened to `list[str]`, so subsequent `TypedDict` indexing\nstill failed even though the loop source is statically a literal key.\n\nBy preserving literals, we can support narrowing like:\n\n```python\nfor key in [\"path\"]:\n  if key == \"path\":\n    example[key]\n```\n\nCloses https://github.com/astral-sh/ty/issues/3433."
+    },
+    {
+      "commit": "Co-authored-by: Ibraheem Ahmed <ibraheem@ibraheem.ca>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "e774a7afc3ec04918c3949a058a70cac671480fb",
+      "subject": "[ty] Update ecosystem-analyzer pins (#26056)",
+      "body": "## Summary\n\nUpdate the ecosystem-analyzer commit pins in both ty ecosystem workflows\nto a89fa6652f03da5f982a9a2384261401e5d43cfb, the latest commit on the\nupstream main branch.\n\nThis keeps the report and analyzer workflows aligned on the current\necosystem-analyzer implementation."
+    },
+    {
+      "commit": "c32f2341166550080926e89d55bd09725009cbda",
+      "subject": "[ty] Annotate intersection and negation types using `&` and `~` (#26035)",
+      "body": "Allow intersection types to be annotated using `A & B`, and allow\nnegation types to be annotated using `~A`. This makes some of our tests\nmuch easier to read. As an example, I migrated the type compendium tests\nto this new syntax, since these tests are mainly for human readers\nanyway.\n\nWe only allow these when annotations are deferred (3.14 or later,\nstringified annotations, or `from __future__ import\nannotations`). And we disallow them in value position (`Invalid = A &\nB`). We also emit an `experimental-syntax` lint if you use them, which\nis disabled in our mdtests.\n\nThe nice thing is that these operators don't need an import. That means\nty users on 3.14 can just use these annotations without having to import\n`ty_extensions` under a `if TYPE_CHECKING` block.\n\n~~There is a small future-compatibility risk here: If that syntax\nbecomes official and is used for something else (not intersection and\nnegation types), then we would have to make a breaking change.~~ (I\nthink this has been addressed by the new lint rule now)"
+    },
+    {
+      "commit": "4f7fc885dc53f6cfc7bb779a7c096bd90082ae7f",
+      "subject": "[ty] Fix nested capture build on main (#26049)",
+      "body": ""
+    },
+    {
+      "commit": "fbbdf7cce475b75c12e9ebfade576ea7a3fee1df",
+      "subject": "Render subdiagnostics and secondary annotations as related information in the Ruff server (#26011)",
+      "body": "## Summary\n\n- Preserve additional primary annotations, secondary annotations, and\nlocated subdiagnostics as LSP related information in `ruff_server`.\n- Keep unlocated subdiagnostics in the main diagnostic message and\ntranslate notebook annotation spans to the correct cell URI and range.\n- Add focused conversion, end-to-end, and notebook coverage.\n\n`ruff_server` previously discarded this diagnostic structure during LSP\nconversion, unlike `ty_server` and the Ruff/ty playgrounds.\n\n## Test plan\n\n\n\nhttps://github.com/user-attachments/assets/3be19a4d-6559-42d8-8673-207bb11406bb"
+    },
+    {
+      "commit": "dc3637d0b76fcde88877eb2239c81d7701ac7812",
+      "subject": "[ty] Track unused-binding captures across nested scopes (#25536)",
+      "body": "## Summary\n\nWe previously determined whether an enclosing binding was used by\nreusing the snapshots created for type inference. This misses captures\nthat originate in a descendant scope across a lazy function boundary:\n\n```python\ndef outer(i: int):\n    def inner():\n        return [[k for k in range(i)] for _ in range(2)]\n\n    return inner\n```\n\nThe read of `i` belongs to a comprehension scope nested under `inner`.\nSnapshot traversal stops at the lazy `inner` scope, so the final\nunused-binding pass could not connect that descendant read to `outer`'s\nparameter and incorrectly reported `i` as unused.\n\nThis tracks capture usage independently from type-resolution snapshots.\nWhen a scope completes, unresolved free-name uses are propagated to its\nparent until the completed scope that owns the name can claim them.\n\nWe defer that resolution until each candidate enclosing scope is\ncomplete because a later binding can change which scope owns the name:\n\n```python\ndef outer():\n    x = 0\n\n    def middle():\n        def inner():\n            return x\n\n        x = 1\n        return inner\n\n    return middle\n```\n\nHere, Python treats `x` as local to `middle` even though its binding\nfollows `inner`, so `inner` captures `x = 1` and `outer`'s `x = 0`\nremains unused. Pending captures retain the bindings visible when the\nnested scope was created and, for lazy scopes, later bindings and\nreassignments that can reach the capture.\n\nRegression coverage includes nested comprehensions, captured parameters,\nshadowed outer bindings, bindings introduced after nested functions,\nintermediate reassignments, and `nonlocal` proxy scopes.\n\nCloses https://github.com/astral-sh/ty/issues/3442."
+    },
+    {
+      "commit": "Co-authored-by: Charlie Marsh <charlie.r.marsh@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "7565240346a4a3b5cb237baa0dad7a5fe3886a37",
+      "subject": "[`flake8-tidy-imports`] Add fix safety section (`TID252`) (#17491)",
+      "body": "## Summary\n\nadd `fix safety` section to `TID252: relative_imports.rs`, for #15584 \n\nWhen there are multiple lines of quotes, the comments in between will be\ndeleted after the fix, but everything else works fine.\nBefore:\n\n![cbeddda57dcb4ebcf789623d92a3082](https://github.com/user-attachments/assets/db2122a1-6e0b-4349-b348-6c8d699549b9)\n\n\nAfter:\n\n![8168a4da225aea24256b8bc59569b1d](https://github.com/user-attachments/assets/cea0bc6b-5719-4c4e-8f59-bf306732ab2e)"
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <36778786+ntBre@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "e5b3913b11eb32ce5b83f08dc3560205ce778df5",
+      "subject": "[ty] Use simulation runners for module resolution benchmarks (#26045)",
+      "body": ""
+    },
+    {
+      "commit": "3f4aa7613908dbb05f752f972aa1ad179145420d",
+      "subject": "Revert rule name normalization changes in preview (#26044)",
+      "body": "Summary\n--\n\nReverts the name normalization part of #25937 now that human-readable\nnames are also present in the\nbaseline for future ecosystem check runs.\n\nTest Plan\n--\n\nCI on this PR"
+    },
+    {
+      "commit": "a9dce57b1e9140e6d921931e89faac0f8349d332",
+      "subject": "Use human-readable names in CLI output (#25937)",
+      "body": "## Summary\n\nThis PR updates all of our CLI output formats to use human-readable\nnames instead of rule codes in preview.\n\n## Test Plan\n\nThe first commit adds a new CLI test and then each following commit\nupdates one output format and the associated snapshots.\n\nThe last commit also updates the ecosystem check to normalize rule names\nback to codes to avoid a huge diff that causes the check to time out.\nAlternatively, we may just want to accept the time out on this PR so\nthat we can see the un-normalized report in the future."
+    },
+    {
+      "commit": "c540576cc130131c900c08c4158e01e6f4701dce",
+      "subject": "[ty] Preserve type variables in fixed tuple aliases (#26041)",
+      "body": "## Summary\n\nFixed-length tuple types retain both their exact element sequence and a\nhomogeneous specialization formed by unioning those elements. We\npreviously discovered legacy type variables only from the homogeneous\nspecialization. If union simplification removed an element, we could\nlose a type variable and reject a valid generic implicit type alias:\n\n```python\nfrom typing import TypeVar\n\nT = TypeVar(\"T\")\nAlias = tuple[object, list[T]]\n\ndef f(value: Alias[int]) -> list[int]:\n    return value[1]\n```\n\nThis discovers legacy type variables from the exact tuple representation\nwhen available, preserving the alias's generic context and type-variable\norder while leaving non-tuple specializations unchanged. Regression\ncoverage exercises an element whose type is subsumed by `object`."
+    },
+    {
+      "commit": "950d163bf0b11693b34c4c08fc7db5d4212e3485",
+      "subject": "[ty] Extract lint rule documentation into markdown files and test example code (#25863)",
+      "body": ""
+    },
+    {
+      "commit": "4fda309ba2cb04816dcd3c5526936874d923ce39",
+      "subject": "Inline parser recovery context checks (#26038)",
+      "body": ""
+    },
+    {
+      "commit": "1de944d1eb01fefde88513196dcd459b08e8000f",
+      "subject": "[ty] Improve flow snapshot performance (#26012)",
+      "body": "## Summary\n\nWhen we build a semantic index, we currently snapshot flow state by\neagerly cloning every symbol and member's bindings and declarations at\ncontrol-flow branches. We also apply scope-wide reachability constraints\nto every live place immediately, even though most places are unchanged\nbefore the branches merge.\n\nWe now represent snapshots with copy-on-write shared place states and\nrecord scope-wide reachability constraints in an append-only\nparent-linked structure. A place materializes its pending constraints\nonly when it is read or mutated. When both branches still share the same\nplace state, we merge only their path constraints, allowing\ncomplementary truthy and falsy paths to cancel without rebuilding the\nplace.\n\nThe specialized star-import snapshot path remains narrowly scoped and\navoids allocating a temporary member list.\n\n## Performance\n\nThe current [CodSpeed\ncomparison](https://github.com/astral-sh/ruff/pull/26012#issuecomment-4709947650)\nreports a 6.78% overall improvement, with 12 improved benchmarks and no\nregressions. DateType improved by 15.51%, anyio by 9.10%, and attrs by\n6.96%. CodSpeed notes that some comparisons used different runtime\nenvironments, which may affect the exact percentages.\n\nThe typing-conformance and ecosystem comparisons reported no diagnostic\nchanges, and retained memory was effectively unchanged."
+    },
+    {
+      "commit": "bcae1b70fdfbf20255fa7533bfe8d4a84c3b3c20",
+      "subject": "Match parser keywords as bytes (#26037)",
+      "body": ""
+    },
+    {
+      "commit": "3cef3416c52c7fb06715dafb38eecfd87a63c14b",
+      "subject": "Reject yield expressions after commas (#26024)",
+      "body": "## Summary\n\nReject unparenthesized `yield` expressions after the first element of an\nexpression list:\n\n```python\ndef generator():\n    1, yield 2\n```\n\nThe parser previously reused the yield-enabled expression context for\nevery tuple element. Python's grammar only allows the initial\nsimple-statement alternative to be a `yield` expression; later\ncomma-separated elements use the ordinary starred-expression grammar.\n\nThis clears the yield allowance for subsequent elements while preserving\nvalid parenthesized nested yields."
+    },
+    {
+      "commit": "841fb339d3c6587150e9700f92fef47fe6342cb3",
+      "subject": "Reject starred comprehension targets (#26023)",
+      "body": "## Summary\n\nReject bare starred targets in comprehensions:\n\n```python\n[item for *items in source]\n```\n\nThe semantic syntax checker already rejects a bare starred target in an\nordinary `for` statement. This applies the same validation to\ncomprehension clauses while preserving valid tuple and list unpacking\ntargets such as `for *items, in source`."
+    },
+    {
+      "commit": "c5cdda5016d86a43c46bb10e771182ad6153e192",
+      "subject": "[ty] Show bare `Final` as a special form on hover (#26029)",
+      "body": "## Summary\n\nA bare `Final` annotation previously stored `Unknown` as the annotation\nexpression type, so hovering over `Final` reported `Unknown`:\n\n```python\nfrom typing import Final\n\nx: Final = 1\n```\n\nAnnotation inference needs to represent two distinct results in this\ncase: the type and qualifiers contributed to the declaration, and the\ntype stored for the annotation expression itself. This introduces an\nexplicit inference result containing both values. They are identical for\nordinary annotations, while a bare `Final` keeps `Unknown` as its\nsemantic inner type and preserves the resolved `typing.Final` special\nform as its expression type.\n\nWe therefore continue to infer `x` as `Literal[1]`, while hovering over\n`Final` now reports `<special-form 'typing.Final'>`.\n\nCloses https://github.com/astral-sh/ty/issues/1593."
+    },
+    {
+      "commit": "6425f7aa567cfa48a589adeb06e7dc7511ba8ffe",
+      "subject": "[ty] Skip stub package checks in stub-free search paths (#25963)",
+      "body": ""
+    },
+    {
+      "commit": "966bc5e0295ce3765f4bc14006d05d8d495c772c",
+      "subject": "[ty] Avoid oscillating collection-use constraints (#26031)",
+      "body": "## Summary\n\nFull-scope collection inference can introduce a Salsa cycle when\nmultiple unannotated collections are constrained by the same container\nliteral:\n\n```python\nfrom typing import Any\n\ndef run(cond: bool, d: dict[Any, Any]) -> list[Any]:\n    a = {}\n    b = {}\n    if cond:\n        b = d\n    return [a.get(\"x\", 0), b.get(\"x\", 0)]\n```\n\nTo infer `a = {}` and `b = {}`, we collect constraints from later uses\nsuch as `a.get(...)` and `b.get(...)`. This creates a cycle because\ninferring the literals requires inferring the return statement, while\ninferring the calls requires resolving the literal definitions.\n\nThe conditional assignment makes `b`'s collection-use constraint\nunstable across fixed-point iterations. Without that constraint, `b`\nremains `dict[Unknown, Unknown]`, which exposes a single class\nspecialization at `b.get(...)` and records the constraint on the next\niteration. Once recorded, the literal refines to `dict[Unknown, int |\nUnknown]`; joining it with `d` produces `dict[Unknown, int | Unknown] |\ndict[Any, Any]`, which no longer exposes a single class specialization,\nso the constraint disappears again. The constraint map therefore\nalternates between `{a}` and `{a, b}` even after the expression and\nbinding types converge, eventually reaching Salsa's cycle-iteration\nlimit and panicking. The existing cycle-initial values let evaluation\nbegin but do not make this metadata monotonic.\n\nOnce the initial tainted iterations have passed, this preserves\ncollection-use constraints from previous iterations across scope,\ndefinition, expression, and statement inference. The constraint map now\ngrows monotonically and reaches a fixed point, while definition\ninference expands compact metadata only when needed and preserves its\nother retained fields. The regression coverage includes both direct\nreturns and annotated assignments.\n\nCloses https://github.com/astral-sh/ty/issues/3778."
+    },
+    {
+      "commit": "a6b3d68fd92a91562466639d678b656eef4fa7c7",
+      "subject": "[ty] Improve interface for reStructuredText literal block scanning (#26020)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nThis renames `PreformattedBlockState` to `RestLiteralBlockScanner` for\nimproved clarity and specificity. It also adjusts a few names of methods\non the `PreformattedBlockScanner` and (renamed)\n`RestLiteralBlockScanner` interfaces.\n\n/xref https://github.com/astral-sh/ty/issues/3454.\n\n## Test Plan\n\nThis is a refactor that relies on existing test coverage.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "59580b5b0dac17c9a7abeec57d78f7e6e360cece",
+      "subject": "[ty] Validate deprecated warning categories (#26025)",
+      "body": "## Summary\n\nValidate the `category` argument to `warnings.deprecated` and\n`typing_extensions.deprecated` against their declared `type[Warning] |\nNone` signature.\n\nThe synthesized signature previously modeled this argument as `Any`, so\ninvalid values such as `category=42` were silently accepted. Warning\nsubclasses and `None` remain valid, and invalid values now receive the\nstandard argument-type diagnostic."
+    },
+    {
+      "commit": "a664a9c36693f2fccfea2258b74801c130d55ec4",
+      "subject": "[`pydocstyle`] Prevent property docstrings starting with verbs (`D421`) (#23775)",
+      "body": "> Disclaimer: The implementation of this rule was generated by Anthropic\nClaude Sonnet 4.6 under human supervision, using the existing `D401`\n(`NonImperativeMood`) rule as a reference pattern. The design decisions\nwere specified by the human author, and the entirety of the generated\ncode was subsequently also reviewed by the human author.\n\n## Summary\n\nAdded a new preview rule to the `pydocstyle` checker to prevent\n`@property` docstrings from starting with return/getter verbs, as\nspecified by the [relevant Google Python style guide\nsection](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods).\n\nExample: `\"Returns the Bigtable path.\"` (wrong) vs `\"The Bigtable\npath.\"` (correct)\n\nDisallowed first words for this implementation (case-insensitive):\n`return`, `returns`, `get`, `gets`, `yield`, `yields`, `fetch`,\n`fetches`, `retrieve`, `retrieves`.\n\nThis rule is enforced whenever `D421` is enabled; it is not restricted\nto any `lint.pydocstyle.convention` value.\n\nCloses #16931\n\n## Test Plan\n\nAdded `D421.py` to the shared `pydocstyle::tests::rules` test matrix for\n`Rule::PropertyDocstringStartsWithVerb`. `LinterSettings::for_rule`\nenables preview for the rule.\n\nThe fixture `D421.py` covers:\n\n- Bad: `@property` docstrings starting with each of the 10 disallowed\nverbs, including a multi-line case\n- Good: attribute-style `@property` docstrings (`\"\"\"The bar value.\"\"\"`)\n- Good: `@cached_property` with an attribute-style docstring\n- Not flagged: regular methods and top-level functions whose docstrings\nstart with the same verbs\n\nVerified all existing `pydocstyle` tests continue to pass:\n\n```sh\nCARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always cargo nextest run -p ruff_linter -- pydocstyle\n# 80 passed\n```\n\nManual smoke-check:\n\n```sh\ncargo run --bin ruff -- check crates/ruff_linter/resources/test/fixtures/pydocstyle/D421.py --no-cache --preview --select D421\n# Found 11 errors.\n```"
+    },
+    {
+      "commit": "Co-authored-by: Amethyst Reese <amethyst@n7.gg>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "4b93e63a9db864414b48e84589ab0b6022eab258",
+      "subject": "Reject __debug__ lambda parameters (#26022)",
+      "body": "## Summary\n\nReject `__debug__` as a lambda parameter name:\n\n```python\nlambda __debug__: 0\n```\n\nFunction parameters already use the semantic syntax check that prevents\nassignments to `__debug__`, but lambda parameters only checked for\nduplicate names. This applies the existing identifier validation\nconsistently to both forms."
+    },
+    {
+      "commit": "a50dc58628691ee00a21809e19bdea71958e4f3c",
+      "subject": "Reject parenthesized star imports (#26021)",
+      "body": "## Summary\n\nReject parenthesized star imports such as:\n\n```python\nfrom module import (*)\n```\n\nPython only permits a bare star in `from` imports. The parser previously\naccepted the parenthesized form because star aliases were parsed\nindependently of the surrounding import-list delimiters.\n\nThis adds the missing parser validation while preserving ordinary\nparenthesized imports and bare star imports."
+    },
+    {
+      "commit": "8ec809cb1f0931939a063fe73a09f57d76d09d11",
+      "subject": "Detect repeated signed and complex dictionary keys (#26007)",
+      "body": "## Summary\n\nF601 hashes dictionary keys with `HashableExpr`, but it only reported\nduplicate literal AST nodes, tuples, and f-strings. Signed numbers and\nconstructed complex numbers are represented as unary or binary\nexpressions, so the numeric-key equivalences added in #25982 were\norder-dependent:\n\n```python\n{False: 1, -0: 2}  # missed\n{-0: 1, False: 2}  # reported\n```\n\nThis recognizes signed numeric and constructed complex expressions as\nliteral keys without treating arbitrary unary or binary expressions as\nliterals. F601 now reports the later key in either order for both\n`False`/`-0` and `True`/`1 + 0j`."
+    },
+    {
+      "commit": "8de183b907bfe5d4ef33614cd225236eead356e1",
+      "subject": "Detect equivalent numeric mapping keys (#26009)",
+      "body": "## Summary\n\nMapping-pattern duplicate detection and F601 compare keys through\n`HashableExpr`, but numeric normalization previously only recognized\nvalues equivalent to `True` or `False`. This meant that other values\nPython treats as the same dictionary key were considered distinct:\n\n```python\nmatch value:\n    case {2: first, 2.0: second}: ...\n```\n\nThis adds a dedicated numeric representation for integer, float,\nboolean, and complex literals so that exactly integral floats compare\nwith equivalent integers, including signed forms and zero-imaginary\ncomplex values. Tuple normalization is limited to statically known\nvalues so dynamic tuple elements do not introduce false-positive F601\ndiagnostics.\n\nNumeric normalization uses the existing `u64` integer representation.\nLarger integers retain structural comparison, avoiding\narbitrary-precision conversion in parser and linter hot paths."
+    },
+    {
+      "commit": "f136792e7a2a0f4e39e20400ad4fde9ee28f66dc",
+      "subject": "[ty] Full-scope bidirectional inference for non-empty collection literals (#25280)",
+      "body": "Extends https://github.com/astral-sh/ruff/pull/25279 to support\nfull-scope inference for all unannotated collection literals, even those\nthat are non-empty, e.g.,\n```py\nx = [1]\nx.append(\"2\")\nreveal_type(x) # revealed: list[int | str]\n```"
+    },
+    {
+      "commit": "8efa1a4fc4588b6be125dfe54f6c9a07e89a31aa",
+      "subject": "[ty] Replace individuals with `*_notified` teams in CODEOWNERS. (#25876)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nThis changes our CODEOWNERS setup for ty such that a large group of\nindividuals is no longer requested for review by default on specific\ncrates.\n\nInstead, a team named after the crate (e.g.\n`ty_python_semantic_notified`) is requested for review, and an\nindividual review request is only issued to the one person who is\nactually responsible for review (as determined by the\n`.github/pr-reviewer-pools.toml` configuration which is [consumed by the\nAstral\nbot](https://github.com/astral-sh/astral-bot/blob/0894788648d4f4c9de227984750385a609639fb6/src/astral_bot/pr_reviewer.py)).\n\n**The primary consequence of this change is that if you have a filter\nsomewhere for the things you are actually responsible for reviewing, you\nwill have to modify it from, e.g., `assignee:@me` to\n`user-review-requested:@me`.**\n\nOverall, my hope is that this change achieves the following outcomes:\n\n- As a contributor, you should have greater clarity as to who in\nparticular is responsible for providing a review of your work.\n- As a reviewer, you should be able to consume a higher-signal feed for\nwhat you are in fact responsible for reviewing, regardless of whether or\nnot you follow everything, by filtering notifications/list by\nuser-review request rather than team-review request.\n\n## Depends on\n\n- [x] https://github.com/astral-sh/astral-bot/pull/103\n\n## Test Plan\n\nTo be tested and refined during normal development.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "93c52432475fda7151b5af6a5f1093ce63573232",
+      "subject": "Handle nested `ruff:ignore` comments (#25791)",
+      "body": "Summary\n--\n\nThis PR fixes #25547 by introducing an outer `Iterator` implementation\nfor `SuppressionParser` that yields all\nnested comments within a single comment token, like ty. Because we\niterate over the suppression\ncomments rather than all tokens after #22446, we also track the\nenclosing `token_range` on\n`SuppressionComment` for use in a couple of places where we actually\nneed the whole comment's range.\nThere's also a new `parse_comment_inner` that allows us to finish\nparsing the current comment before\ntrying to emit a `ParseError` with an incomplete range.\n\nTest Plan\n--\n\nNew mdtests that hopefully cover all of the interesting cases"
+    },
+    {
+      "commit": "87072b75afcc833a9712e64d41f1fca7ec52e6b0",
+      "subject": "[ty] Reject invalid dataclass flag combinations (#25985)",
+      "body": "## Summary\n\n`dataclass` raises at runtime when `order=True` is combined with\n`eq=False`, or when `weakref_slot=True` is used without `slots=True`,\nonce the decorator is applied to a class:\n\n```python\nfrom dataclasses import dataclass\n\n@dataclass(order=True, eq=False)  # error: [invalid-dataclass]\nclass Example: ...\n```\n\nWe retain statically known invalid flag combinations on the decorator\nvalue and report the existing `invalid-dataclass` diagnostic when it is\napplied, including when the decorator is stored before use:\n\n```python\ninvalid = dataclass(order=True, eq=False)\n\n@invalid  # error: [invalid-dataclass]\nclass Example: ...\n```\n\nNon-literal boolean values remain conservative, so we only report\ncombinations that are definitely invalid. Unpacked decorator arguments\nalso continue to preserve the generated dataclass methods."
+    },
+    {
+      "commit": "d2018f9687164cab92bad882c1932fc3b64f9ed3",
+      "subject": "[ty] Clarify type variable kind names (#26008)",
+      "body": "## Summary\n\nThis is a follow-up to #25979. The `TypeVarKind` variants previously\nused the broad names `Legacy`, `Pep695`, and `ParamSpec`, making it\nunclear whether a variant represented a `TypeVar` or `ParamSpec` and\nwhich declaration syntax produced it.\n\nThis renames them to `LegacyTypeVar`, `Pep695TypeVar`, and\n`LegacyParamSpec`, complementing the existing `Pep695ParamSpec` variant.\nThe names now identify both the parameter kind and declaration style\nwithout changing behavior."
+    },
+    {
+      "commit": "0db3a9e8c02846ed1fde1a3b9f2f0ad1ee4fe0f8",
+      "subject": "[ty] Reject legacy TypeVars in PEP 695 functions (#25979)",
+      "body": "## Summary\n\nA function with its own PEP 695 type parameter list cannot also\nintroduce a traditional `TypeVar` or `ParamSpec`. Prior to this change,\nwe discovered the legacy generic context while building the signature\nbut discarded it when merging with the PEP 695 context without reporting\nan error:\n\n```python\nfrom typing import TypeVar\n\nK = TypeVar(\"K\")\n\ndef method[M](value: M, other: K) -> M | K:\n    raise NotImplementedError\n```\n\nWith #25975, we now pass the `generics_syntax_compatibility` test in the\nconformance suite."
+    },
+    {
+      "commit": "94220d1d60a9f1a8a8609b0650b11509f032ca5b",
+      "subject": "[ty] respect client's content format preference (#25957)",
+      "body": "## Summary\n\n* Respect client's content format preference in hover and completion\ndocumentation order. Previously ty would incorrectly choose Markdown\neven when the plain text is earlier.\n* Closes https://github.com/astral-sh/ty/issues/3366\n\n## Test Plan\n\n* Wrote several e2e tests for both hover and completions\n* Run the entire test suite with nextest"
+    },
+    {
+      "commit": "Co-authored-by: Micha Reiser <micha@reiser.io>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "26777f3c636848469cd0669ccb20071a2b2a9c09",
+      "subject": "Render primary-diagnostic secondary annotations in the Ruff and ty playgrounds (#25875)",
+      "body": "## Summary\n\nThis is a followup PR to https://github.com/astral-sh/ruff/pull/25490.\nThat PR added support for rendering subdiagnostics in the ty playground,\nbut omitted support for rendering secondary annotations attached\ndirectly to a primary diagnostic.\n\nThis change:\n\n- exposes primary-diagnostic secondary annotations through `ty_wasm`\n- renders them in the diagnostics panel and Monaco hover information\n- makes annotation locations navigable, including cross-file jumps\n\n## Test plan\n\nBoth videos use [this playground\ngist](https://play.ty.dev/1789f663-d4d1-46df-9c58-a965b9bf88c0).\n\n### Before (`main`)\n\n\nhttps://github.com/user-attachments/assets/e9b53694-fe8d-40cf-8784-f5f5e8a947a3\n\n### After\n\n\nhttps://github.com/user-attachments/assets/9b352c1d-57cc-4cb4-ab7a-38d738e30f07\n\n### Ruff playground screenshot\n\n<img width=\"1280\" height=\"720\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c86bc532-4272-40fb-8bc4-f7aafac6a63f\"\n/>"
+    },
+    {
+      "commit": "Co-authored-by: Micha Reiser <micha@reiser.io>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "b6ab2b32fb6d6d118be3f52f3d15570cc27c798e",
+      "subject": "Reject `_` as a match-pattern target (#25977)",
+      "body": "## Summary\n\nPython reserves `_` for wildcard patterns and does not allow it as the\nbinding target in either of these forms:\n\n```python\nmatch value:\n    case 1 as _:\n        pass\n    case {**_}:\n        pass\n```\n\nWe currently recover an AST for both forms without reporting a parser\nerror. Both are grammar errors in CPython, so this change validates the\ncapture target while parsing `as` and mapping patterns and reports\n`cannot use '_' as a target` on the underscore.\n\nWe previously tried to address the mapping-pattern case in\n[#6838](https://github.com/astral-sh/ruff/pull/6838) by representing the\nrest target as a general `PatternMatchAs` node. This keeps the existing\n`Identifier` representation and recovered AST, including statements\nafter the invalid match, while rejecting the invalid target at the\nparser boundary."
+    },
+    {
+      "commit": "c85951eb4a07b643234e14370f086d40f21b4d1a",
+      "subject": "[ty] Support options in functional dataclass calls (#25989)",
+      "body": "## Summary\n\n`dataclass` accepts the same keyword options when it is called directly\nwith a class as when it is used as a decorator factory:\n\n```python\nfrom dataclasses import dataclass\n\nclass Example:\n    value: int\n\nordered = dataclass(Example, order=True)\nordered(1) < ordered(2)\n```\n\nPreviously, our synthetic overloads only accepted these options when\n`cls` was omitted. Valid calls such as `dataclass(Example, frozen=True)`\ntherefore produced `no-matching-overload`, and direct applications\nalways used the default dataclass parameters.\n\nThis adds the keyword-only options to the direct-call overloads and\nreads dataclass arguments by parameter name, allowing the computed\nparameters to be applied consistently to decorator factories, explicit\n`None` calls, and direct class arguments."
+    },
+    {
+      "commit": "cfa4d72bace71aaff058fdfb1efb0d6a25ac26d7",
+      "subject": "[ty] Respect ParamSpec binding contexts (#25993)",
+      "body": "## Summary\n\n`find_legacy_typevars` accepts an optional binding context so that it\nonly collects variables introduced by the current definition. Prior to\nthis change, we applied that filter to legacy `TypeVar`s but ignored it\nfor `ParamSpec`, allowing an enclosing class or function's `ParamSpec`\nto be collected and inferred again.\n\nThis applies the same binding-context check to `ParamSpec` while\ncontinuing to normalize `P.args` and `P.kwargs` back to `P`."
+    },
+    {
+      "commit": "7a7bfd84c4a60b6f3d0bdfe4ac13395bd65e65da",
+      "subject": "Reject unparenthesized generator expressions in class bases (#25978)",
+      "body": "## Summary\n\nClass definitions do not allow a bare generator expression as a base,\neven though the same syntax is valid as the sole argument in a function\ncall. We currently parse the class form without an error:\n\n```python\nclass C(base for base in bases):\n    pass\n```\n\nThis change reuses the existing unparenthesized-generator diagnostic for\nclass arguments while continuing to accept explicitly parenthesized or\nunpacked generator expressions:\n\n```python\nclass C((base for base in bases)): ...\nclass C(*(base for base in bases)): ...\n```"
+    },
+    {
+      "commit": "a9de595e4031fbca8df1deffa855fc5a10256853",
+      "subject": "Detect mapping keys equivalent to booleans (#25982)",
+      "body": "## Summary\n\nMapping patterns reject duplicate literal keys, but duplicate detection\ncompared AST shapes instead of Python hash equality. As a result, values\nthat Python treats as the same key were accepted:\n\n```python\nmatch value:\n    case {1.0: first, True: second}: ...\n```\n\nThis switches mapping-key detection to `HashableExpr` and extends\nboolean-equivalent normalization through signed numeric expressions and\ncomplex values with a zero imaginary part. We now report duplicate-key\nsyntax errors for `0`/`False`, `1.0`/`True`, `-0`/`False`, and `1 +\n0j`/`True`, matching CPython."
+    },
+    {
+      "commit": "b0a887e3676908bac3c42bd5815b0a6033187e53",
+      "subject": "Use `ThinVec` for call keywords (#25999)",
+      "body": "## Summary\n\nUsing ThinVec here is impactful because it reduces the size of `Expr`:\n\n```\nArguments: 48 \u2192 40 bytes\nExprCall:  72 \u2192 64 bytes\nExpr:      80 \u2192 72 bytes\n```\n\nIn profiling, it was empty about 80% of the time."
+    },
+    {
+      "commit": "303dca1dd5ee804114c4b51d4d3a9a7c9637f475",
+      "subject": "[ty] Fix invalid type variable default tests (#25988)",
+      "body": "## Summary\n\nSeveral tests for PEP 695 type-parameter defaults used traditional\n`TypeVar`s declared outside the function. Those examples are themselves\ninvalid because a function cannot combine a PEP 695 type-parameter list\nwith traditional type variables introduced by the same function.\n\nThis updates the existing fixtures to declare both type variables in the\nPEP 695 parameter list. The tests continue to cover bound and constraint\ncompatibility for defaults without also relying on invalid legacy\ntype-variable usage.\n\n(This is a precursor to https://github.com/astral-sh/ruff/pull/25979,\nwhich starts to flag those invalid usages.)"
+    },
+    {
+      "commit": "9f2a4e3d11598c488e1b6cccab98dceb7238b366",
+      "subject": "Update ecosystem-analyzer pins (#26005)",
+      "body": "## Summary\n\nUpdate the ecosystem-analyzer commit pins in both ty ecosystem workflows\nto `c455248318c19ddc5c95c7ac45e517b2184bb0c5`, the latest commit on the\nupstream `main` branch.\n\nThis keeps the report and analyzer workflows aligned on the current\necosystem-analyzer implementation."
+    },
+    {
+      "commit": "0cbbbf48a407cc338f55c4461f1a3c04336de5c5",
+      "subject": "[ty] Speed up module resolution for projects with many search paths (#25962)",
+      "body": ""
+    },
+    {
+      "commit": "fdc07ee8698ea7475091405e931fa76efe5d4571",
+      "subject": "[ty] Add module resolution benchmark (#25961)",
+      "body": ""
+    },
+    {
+      "commit": "f78e11c18e50bf43d562238e31e14eba82b147e5",
+      "subject": "[ty] Track directory changes independently (#25960)",
+      "body": "## Summary\n\nThere are a few places where we read directory contents. Each of those\ncall sites adds a dependency on `FileRoot::revision` to ensure that the\nenclosing query is invalidated when the directory's contents change. The\ngranularity of `FileRoot` is per search path. That is, we create a\n`FileRoot` for each search path, and we bump the `FileRevision` whenever\na new file is added, a file is removed, or a file's metadata is changed\nwithin this entire subtree. This has worked fine so far, but we now also\nplan on reading directories in the module resolver\n(https://github.com/astral-sh/ruff/pull/25962), where we want more\ngranular query invalidation.\n\nThis PR extends `File` to also track the metadata and revision of\ndirectories. This allows us to have a new `directory_listing` query. It\nreads and caches the directory content and adds the dependency on\n`directory.revision`. This, in turn, allows us to remove `revision` from\n`FileRoot,` and it is now back to its original intended purpose:\nDefining the durability of a file or directory within a subtree\n(third-party dependencies have durability HIGH, whereas first-party\nfiles have a durability of Medium)\n\nI considered a new `Directory` input. In fact, that's how this\nimplementation started. However, during review, I realized that we need\nto track the exact same information as in `File` and `File` already\ntracks whether a path \"is a directory\". Ultimately, using `File` felt\neasier and is also not much of a stretch, given that this is also the\ncase on unix.\n\nthe upside of this change is that `list_modules` (used by completion)\nnow is only invalidated if the specific directory changes, and not for\nevery change to its file root.\n\n## Test Plan\n\nExisting tests"
+    },
+    {
+      "commit": "32a86842a6e53d14bee71cec03e506121af28704",
+      "subject": "Move value parsing out of lexing (#25360)",
+      "body": ""
+    },
+    {
+      "commit": "5d2f1f7745c0b5ebde66d4e754a8e8532176c7af",
+      "subject": "[ty] Highlight decorated methods consistently (#26003)",
+      "body": ""
+    },
+    {
+      "commit": "e9dd6d01b7c157e717d8107ac1e8aa6b37cd4c70",
+      "subject": "[ty] Sync vendored typeshed stubs (#25997)",
+      "body": ""
+    },
+    {
+      "commit": "09781e421d1f9a2b2f926d137caee072c227120b",
+      "subject": "[ty] Diagnose zero-step slices on lists (#25966)",
+      "body": "## Summary\n\nA slice with a step size of zero always fails for an exact `list`, but\nwe currently only report `zero-stepsize-in-slice` for string, bytes, and\ntuple literals:\n\n```python\nvalues = list(range(10))\nresult = values[1:10:0]  # error: [zero-stepsize-in-slice]\nreveal_type(result)  # list[int]\n```\n\nWe now report the diagnostic when the receiver type is `list` or another\nknown built-in while preserving the inferred result type for error\nrecovery.\n\n(A hypothetical subclass could override `__getitem__` to accept a zero\nstep, but the `list` type includes exact `list` instances that are known\nto reject it. Subclasses with their own nominal type and custom sequence\ntypes continue through normal subscript dispatch without this\ndiagnostic.)\n\nCloses https://github.com/astral-sh/ty/issues/3736."
+    },
+    {
+      "commit": "f432c0d0757717043d94d7e6e111000b33fc2e75",
+      "subject": "[ty] Reject legacy TypeVars in PEP 695 class bases (#25975)",
+      "body": "## Summary\n\nPEP 695 requires classes that use the new type parameter syntax not to\nintroduce traditional type variables through their base classes. Prior\nto this change, we prioritized the PEP 695 generic context and silently\ndiscarded a legacy context inherited from another generic base:\n\n```python\nfrom typing import TypeVar\n\nK = TypeVar(\"K\")\n\nclass Bad[V](dict[K, V]): ...\n```\n\nThis reports `invalid-generic-class` when a PEP 695 class inherits a\nsupported legacy generic context. A PEP 695 parameter with the same name\ncontinues to shadow the global TypeVar, and ordinary methods can still\nuse the traditional implicit generic-function mechanism.\n\nGeneric base types are normalized before this validation runs, so for\nthose cases, we just leave them as a TODO for now."
+    },
+    {
+      "commit": "39b09a9d692bb01d4e14f542d0f9ba5b21657f9f",
+      "subject": "Validate function type parameter default order (#25981)",
+      "body": "## Summary\n\nFunction type parameter lists did not run the same default-order\nvalidation as class and type-alias parameter lists. As a result, we\naccepted functions with a required type parameter after one with a\ndefault:\n\n```python\ndef f[T = int, U](): ...\n```\n\nThis reuses the existing type-parameter ordering check for function\ndefinitions, so we now report the same semantic syntax error that we\nalready emit for equivalent classes and type aliases."
+    },
+    {
+      "commit": "d563277ded1fe348cb5dc21ca042262a9a8c8bef",
+      "subject": "[ty] Respect `@no_type_check` in function validation (#25994)",
+      "body": "## Summary\n\n`@no_type_check` promises to suppress errors in a function declaration\nand body, but diagnostics emitted during post-inference function\nvalidation were not suppressed:\n\n```python\nfrom typing import no_type_check\n\n@no_type_check\ndef positional(x: int, __y: str): ...\n```\n\nPost-inference validation runs from the function's enclosing inference\ncontext, so the decorated function is not visible through the usual\nancestor-scope suppression check. This returns before running those\ndeclaration checks when the function itself has a known `@no_type_check`\ndecorator."
+    },
+    {
+      "commit": "f24da1291f11a98c7bc38934294ba080e06d2108",
+      "subject": "[ty] Use compact frozen representation for narrowing constraints (#25990)",
+      "body": "## Summary\n\nNarrowing analysis builds a map from each affected place to the\nconstraint contributed by an expression or pattern. These results are\ncached, but once construction finishes we only read them; retaining each\nresult as an `FxHashMap` therefore keeps hash-table storage that the\ncached value no longer needs.\n\nThis keeps `FxHashMap` in `NarrowingConstraintsBuilder` for efficient\nconstruction, then converts each completed result to a `FrozenMap`,\nwhose sorted boxed slice provides binary-search lookup without retaining\nhash-table capacity.\n\nIn the memory report, this reduced retained memory for\n`all_narrowing_constraints_for_expression` by 40.1\u201345.6% across Flake8,\nTrio, Sphinx, and Prefect, reducing total retained memory by 0.2\u20131.1%.\nThe typing-conformance and ecosystem comparisons reported no diagnostic\nchanges."
+    },
+    {
+      "commit": "ded6c002f9dea45908d3a138d0b11e3b5dc1580a",
+      "subject": "Reject multiple starred names in sequence patterns (#25976)",
+      "body": "## Summary\n\nPython permits at most one starred name in a sequence pattern, but our\nparser currently accepts multiple:\n\n```python\nmatch value:\n    case [*head, middle, *tail]:\n        pass\n```\n\nThis tracks whether a sequence pattern already contains a star and\nreports `invalid-syntax` on each later starred name. The diagnostic\npoints to the additional starred pattern and uses CPython's error\nmessage, while keeping the recovered AST available to downstream tools."
+    },
+    {
+      "commit": "f9eb8ca03d0bf92ec83873f50ec3d837c0f03bad",
+      "subject": "[ty] Fix wildcard import symbol range (#25740)",
+      "body": "## Summary\n\nI am attempting to address astral-sh/ty#3571. The caret range for the\nwildcard import is incorrect, and the correct range would be to point at\nthe symbol name, but the symbol is imported through a wildcard star. It\nis not possible to point the carets at the symbol name (which is what\nthe other tests in that file do), so instead we point the caret at the\nwildcard star.\n\n## Test Plan\n\nUpdated and passed tests."
+    },
+    {
+      "commit": "4863e91831115540315b8dc9a90f97db6d32eafa",
+      "subject": "[ty] Treat assigned enum hooks conservatively (#25958)",
+      "body": "## Summary\n\nEnum metadata currently recognizes `__init__`, `__new__`, and\n`_generate_next_value_` only when the hook is defined as a function\nwithin the class body. If a class instead assigns or reassigns one of\nthese hooks, we (incorrectly) fall through and infer / validate member\nvalues against a shadowed method:\n\n```python\nclass Token(Enum):\n    _value_: int\n\n    def __new__(cls, value: int): ...\n    __new__ = cast(Any, external_new)\n\n    TEXT = \"text\"\n\nreveal_type(Token.TEXT.value)  # int\n```\n\nThis PR resolves each hook from its final binding. When the binding is a\nsingle function definition, we can inspect its parameters and return\ntype. Everything else is considered \"opaque\" (e.g., an assignment\nthrough `Any`, a descriptor, or multiple possible bindings). An opaque\nbinding prevents validation against a hook (like `__new__`) and\nsuppresses the raw `_value_` annotation fallback, while a separate\nfunction binding still validates the original member payload. Without an\nexplicit `_value_` annotation, any opaque construction hook makes\n`.value` dynamic; with one, the annotation remains authoritative. An\nopaque `_generate_next_value_` binding affects only `auto()` members.\n\nCustom metaclass `__prepare__` and assigned `__new__` hooks are both now\ntreated like a directly defined metaclass `__new__`, because they can\nrewrite the class namespace before enum members are constructed. Alias\ndetection is also conservative whenever a construction hook can change\nstored values:\n\n```python\nclass Kind(Enum):\n    _generate_next_value_ = cast(Any, external_generator)\n\n    A = auto()\n    B = auto()\n    EXPLICIT = 1\n\nreveal_type(Kind.A.value)         # Any\nreveal_type(Kind.EXPLICIT.value)  # Literal[1]\n```"
+    },
+    {
+      "commit": "c8b63fcf950e4cdca19fcf1d1dea7bd1576301b8",
+      "subject": "[ty] Synthesize NamedTuple `__match_args__` (#25934)",
+      "body": "## Summary\n\nPython 3.10 generates `__match_args__` on named tuples so their fields\ncan be used in positional class patterns. We already synthesize other\ngenerated named-tuple attributes, but did not expose `__match_args__`.\n\n```python\nfrom typing import NamedTuple\n\nclass Point(NamedTuple):\n    x: int\n    y: str\n\nreveal_type(Point.__match_args__)  # tuple[Literal[\"x\"], Literal[\"y\"]]\n```\n\nThe gradual fallback for named tuples with unknown fields comes from\n`NamedTupleFallback`, as proposed in\nhttps://github.com/python/typeshed/pull/15906. (I've included a\ntemporary copy of that typeshed change until approved.)"
+    },
+    {
+      "commit": "406e2a85b4c0e72cdbbac65b8e4956ceb7c989ef",
+      "subject": "[ty] Sync vendored typeshed stubs (#25952)",
+      "body": "Close and reopen this PR to trigger CI"
+    },
+    {
+      "commit": "Co-authored-by: typeshedbot <>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "888bfef0a9b70bc1a37e820418f5bed720b01920",
+      "subject": "[ty] Flatten retained declaration states (#25912)",
+      "body": ""
+    },
+    {
+      "commit": "1fee3ef40a1434a81c81261da08d24cfa8b3e0e3",
+      "subject": "[ty] Store cumulative binding end offsets (#25913)",
+      "body": ""
+    },
+    {
+      "commit": "770541e04b5979b71da607feab6109144995c742",
+      "subject": "[ty] Refactor reStructuredText parameter documentation extraction to use an `IndexMap` from the start. (#25932)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nThis helps make the final container type for parameter docs clearer.\n\nAlong the way I've also added a few regression tests that lock in the\ncurrent precedence of parameter docs across formats.\n\n## Test Plan\n\nPlease see included tests.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "82b550741e8766224f23ce6d71fea262b866966b",
+      "subject": "[ty] Fast path collection literals with exact type contexts (#25878)",
+      "body": "## Summary\n\nWhen a collection literal has an exact `list`, `set`, or `dict` type\ncontext, that context can already determine the collection\nspecialization. We currently recover those element types by constructing\nand solving a general assignability constraint set, which is expensive\nwhen a contextual type argument is a large union such as Pydantic's\n`CoreSchema`.\n\nFor example:\n\n```python\nchoices: dict[Hashable, CoreSchema] = {}\n```\n\nHere, the annotation gives the literal an exact `dict` context with\nknown key and value types. An abstract context such as\n`Mapping[Hashable, CoreSchema]` is not an exact nominal collection\ncontext and continues through the general inference path.\n\nThis adds a direct path that maps the collection's identity\nspecialization to the contextual specialization and checks the literal\nelements against those contextual types speculatively. If every element\nis compatible, we reuse the contextual specialization without projecting\nand solving a constraint set.\n\nPartially specialized, bounded, constrained, union, protocol, and\ndictionary-unpacking contexts continue through the general solver.\nFailed speculative checks also fall back, preserving diagnostics and the\nexisting inferred types.\n\n## Performance\n\nIn the existing CodSpeed comparison, this improved\n`ty_micro[pydantic_core_schema_dict]` by 36.9%, the Pydantic wall-time\nbenchmark by 11.4%,\n`ty_micro[recursive_typed_dict_union_contextual_inference]` by 8.8%, and\n`static_frame` by 3.1%."
+    },
+    {
+      "commit": "a2e0d89a067c7073b491e8edf3072dc4e9c75105",
+      "subject": "[ty] Preserve negative narrowing for starred sequence patterns (#25927)",
+      "body": "## Summary\n\nStarred sequence patterns currently do not contribute a definite matched\ntype to negative narrowing. After a case such as `[first, second,\n*rest]`, we retain only the sequence protocol constraints even though\nthe pattern definitely consumes tuples with at least two elements.\n\nThis matters for APIs that accept either text or a fixed-shape\nstructured value:\n\n```python\ndef normalize_version(\n    version: str | tuple[int, int] | tuple[int, int, int],\n) -> str:\n    match version:\n        case [major, minor, *_rest]:\n            return f\"{major}.{minor}\"\n\n    return version.strip()\n```\n\nThe starred case consumes every tuple alternative, so the fallback can\nnarrow `version` to `str` and use string methods normally."
+    },
+    {
+      "commit": "3b4ed265f20f6c7b1e4569c41f749f5b5da89bb0",
+      "subject": "[ty] Narrow tuple expression match subjects (#25874)",
+      "body": "## Summary\n\nPrior to this change, we narrowed a sequence value used as a match\nsubject, but not the places used to construct an inline tuple or list\ndisplay:\n\n```py\nclass A: ...\nclass A1(A): ...\nclass B: ...\nclass B1(B): ...\n\ndef f(a: A, b: B) -> None:\n    match [a, b]:\n        case [A1(), B1()]:\n            reveal_type(a)  # revealed: A1\n            reveal_type(b)  # revealed: B1\n```\n\nA match subject is evaluated once, so we retain the bindings read by its\nnarrowable elements at subject evaluation. Successful sequence patterns\nrecursively project their fixed prefix and suffix constraints through\nnested tuple and list displays onto names, attributes, and literal\nsubscripts whose subject-time bindings are still live.\n\nThis supports later cases, starred patterns, repeated places, multiple\nreaching definitions, nested displays, and constrained `or` patterns\nwithout scanning cases for possible reassignments. Failed matches still\ndo not project element constraints because they do not identify which\nelement failed. Dictionary displays and starred subject displays remain\nconservative and are documented with TODO tests.\n\nWhen combining `or` patterns, we distinguish impossible alternatives\nfrom possible alternatives that do not constrain the subject. Impossible\nalternatives are omitted, while unconstrained alternatives correctly\nprevent the overall pattern from narrowing.\n\nCloses https://github.com/astral-sh/ty/issues/3743."
+    },
+    {
+      "commit": "71f1d58fb7082c2324af703ef6f87cbaecb57679",
+      "subject": "[ty] Avoid rebuilding unchanged specializations (#25826)",
+      "body": "## Summary\n\nApplying a type mapping currently collects a new boxed type list and\nre-enters `Specialization` interning even when none of the mapped types\nor tuple metadata change. A surrounding `GenericAlias` then performs\nanother redundant interner lookup for the unchanged specialization.\n\nThis maps specialization types lazily, allocating only after the first\nchanged type, and returns the existing specialization when mapping or\nmaterialization leaves its fields unchanged. `GenericAlias` now\npreserves its identity when the mapped specialization is unchanged as\nwell."
+    },
+    {
+      "commit": "3e2a71d629d6db131244e549d69077cd3f5ea178",
+      "subject": "[ty] Deduplicate retained scope inference types (#25846)",
+      "body": "## Summary\n\nScope inference retains a type for every expression in the scope. Many\nexpressions share the same type, but the existing frozen map stores a\ncomplete `Type` value in every entry.\n\nThis adds a frozen map representation that stores each distinct value\nonce and maps sorted keys to compact value indices. Scope inference uses\nthe new representation when freezing its expression types, and cycle\nnormalization rebuilds the table so normalized values are deduplicated\nagain."
+    },
+    {
+      "commit": "a4f73ff530306cee4734038469333f9d8b1f5bc0",
+      "subject": "[ty] Route reStructuredText parameter documentation through the `Formats` interface. (#25902)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nEn route to https://github.com/astral-sh/ty/issues/3454, this is a small\nrefactor that established the `Formats` interface as the source of truth\nfor parameter documentation across all supported docstring formats. For\nnow only the reStructuredText module conforms to that interface, but the\nGoogle and NumPy formats will be made to in subsequent changes.\n\n## Test Plan\n\nThis is a pure refactor that relies on existing test coverage.\n\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "a4fc9e69de3160d0d9b0502d74d36d3b89ef1406",
+      "subject": "[ty] Compact retained definition inference extras (#25838)",
+      "body": "## Summary\n\nMost retained `DefinitionInference` values need only one or two fields\nfrom `DefinitionInferenceExtra`, but currently allocate the full\nstructure.\n\nThis specializes the common shapes into compact enum variants and keeps\nthe existing structure as a fallback for uncommon combinations. Based on\nthe measured shape distribution, this is expected to reduce retained\nmemory by about 789 MB, or 0.78%, on the large-repository workload used\nfor this investigation."
+    },
+    {
+      "commit": "094025e32eee9a29c5f32d07569e0ebe5e639de1",
+      "subject": "[ty] Report redefined legacy TypeVars (#25854)",
+      "body": "## Summary\n\nThe `invalid-legacy-type-variable` rule already validates the assignment\nshape and declared name, but it did not report when a name had already\nbeen defined in the same scope:\n\n```python\nfrom typing import TypeVar\n\nT = TypeVar(\"T\")\nT = TypeVar(\"T\")  # error: invalid-legacy-type-variable\n```\n\nThe diagnostic points back to the preceding definition and considers\nearlier bindings and declarations that are reachable from the beginning\nof the owning scope.\n\nThe implementation reuses the existing per-place use-def snapshot and\nreachability predicates, so it only inspects definitions of the target\nname rather than scanning every definition in the scope.\n\nCloses https://github.com/astral-sh/ty/issues/3732."
+    },
+    {
+      "commit": "0a3a46573517ae206617044e95fb1460e247de87",
+      "subject": "[ty] Avoid TypeVar redefinitions in mdtests (#25889)",
+      "body": "## Summary\n\nAn mdtest section is evaluated as a single Python module, even when its\nexamples are split across multiple fenced code blocks. Some existing\nsections therefore define the same legacy `TypeVar` name more than once:\n\n```python\nT = TypeVar(\"T\")\n# ...\nT = TypeVar(\"T\")\n```\n\n#25854 will correctly diagnose the second definition, but these\nduplicates are incidental to the tests. This separates self-contained\nexamples into distinct mdtest sections and gives the remaining type\nvariables distinct names where the examples depend on shared setup. The\nexpected types and diagnostics are unchanged.\n\nThis is the preparatory base for #25854 and doesn't change behavior."
+    },
+    {
+      "commit": "db5544217d2cb2b3dc65cba794f696037454b547",
+      "subject": "[ty] Omit redundant definition inference owner keys (#25837)",
+      "body": "## Summary\n\n`DefinitionTypes` stores the queried definition key alongside common\nsingle-binding and single-declaration results, even though that key is\nalways the Salsa query input.\n\nThis omits the redundant key from those inline variants and threads the\nowner through iteration and cycle normalization so callers can\nreconstruct it. Results for other definitions continue using the\nexisting boxed fallback.\n\nBased on the measured shape counts, this is expected to reduce retained\nmemory by about 249 MB (0.25%) on the representative workload."
+    },
+    {
+      "commit": "fb186b28e7242bc1ffa4c496ebb4c06981a50869",
+      "subject": "[ty] Compact retained definition maps (#25737)",
+      "body": "## Summary\n\n`DefinitionsByNode` and `UseDefMap::definitions_by_definition` currently\nretain hash tables after semantic indexing has finished, even though the\nretained semantic index only needs deterministic keyed lookup.\n\nThis changes those retained maps to use the existing sorted `FrozenMap`\nrepresentation. The builders continue to use hash maps while\nconstructing the semantic index, then freeze the final entries into\nsorted slices before returning the cached value.\n\nOn the PyTorch memory benchmark, this reduced retained memory by 5.66 MB\n(0.40%)."
+    },
+    {
+      "commit": "f0bcbba7cb3778de22c178094a101948103cf3c1",
+      "subject": "[ty] Cache reachability evaluations during inference (#25696)",
+      "body": "## Summary\n\nPlace lookup repeatedly evaluates the same reachability constraints\nwhile inferring a region. Each evaluation walks the ternary decision\ndiagram and may infer predicate truthiness again, even when an earlier\nbinding or declaration lookup already evaluated the same node.\n\nThis change adds an inference-local reachability evaluation cache. The\nbuilder's primary reachability graph uses a dense vector indexed\ndirectly by `ScopedReachabilityConstraintId`; constraints from other\nuse-def maps use a hash map keyed by graph identity and node ID.\nIncluding graph identity is necessary because distinct reachability\ngraphs can reuse the same local node index and can contain predicates\nfrom the same scope. Speculative builders share the cache with their\nparent builder.\n\nIn reality, the impact here seems to be quite varied by project... But\nthe benchmarks are positive."
+    },
+    {
+      "commit": "b708d72ba581a2d0f0cc19920efff6238047bdd1",
+      "subject": "[ty] Add dedicated TDDs for narrowing constraints (#25834)",
+      "body": "## Summary\n\nThis started as the structural half of #25787: move narrowing\nconstraints out of the reachability graph into a dedicated ternary\ndecision diagram, where `if_uncertain` is a lazy \"don't care\" edge.\nDuboc OR and AND can then combine formulas without copying one path into\nboth outcomes of another predicate, and projected narrowing uses the\nsame representation for each place.\n\nThis PR now also includes #25835. Its cofactor-absorption reductions\nsimplify formulas such as `A or (not A and B)` to `A or B`, so\nsuccessful `if`/`elif` branches stay compact without\ncontinuation-specific predicate removal. The same reductions apply when\nconstructing the semantic-index TDD and the projected graph used during\nnarrowing.\n\n#25836 was split out as the continuation-specific follow-up from #25787.\nWith #25835 now incorporated here, its remaining branch-specific\nreductions and benchmarks need to be reevaluated against this updated\nbase.\n\n## Benchmarks\n\nUsing the original `charlie/rebench` structural checkpoint:\n\n- PyTorch: 7.79s -> 1.87s (4.18x faster)\n\nFor `isort`, comparing ty binaries on the benchmark project with 5\nwarmups and 20 runs:\n\n- before PR (`7c645a9a1`): 254.5ms \u00b1 1.6ms\n- dedicated TDDs (`698e44a`): 306.9ms \u00b1 2.3ms (1.21x slower)\n- cofactor absorption (`4a91655`): 258.9ms \u00b1 2.4ms (1.02x slower)\n- restored fast paths (`40a99f3`): 256.1ms \u00b1 1.8ms (1.01x slower)\n\nSo the initial structural checkpoint regressed `isort`, but the current\nPR state is effectively back to baseline."
+    },
+    {
+      "commit": "Co-authored-by: Douglas Creager <dcreager@dcreager.net>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "44db19b7c7f043b5c23bd3968f572df868b31078",
+      "subject": "[ty] Move final Markdown rendering pass to a submodule. (#25858)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nIn preparation for rendering Markdown for the [structured portions of\ndocstrings in a few different\nformats](https://github.com/astral-sh/ty/issues/1667), this moves our\ngeneral Markdown parsing logic (for rendering all the remaining\nnon-structured portions of a docstring) to a submodule named\n`markdown/general`. In subsequent changes it will acquire a sibling\nmodule names `markdown/structured`, both of which will be used to\nproduce the top-level `markdown::render` output.\n\nThe only thing that changed while moving the code was the Rustdoc\n`markdown/general/render.rs`, which now no-longer references\nreStructuredText as the only format for which we emit markdown (it soon\nwill not be).\n\n## Test Plan\n\nThis is a pure refactor that relies on existing test coverage.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "7c645a9a1be8258b9f9e005208a55a0b7e8e18f0",
+      "subject": "Bump 0.15.17 (#25872)",
+      "body": ""
+    },
+    {
+      "commit": "f381eb1d54997cfbfa6f63c15dd2d760f70e85e1",
+      "subject": "Prioritize human-readable names in CLI output (#25869)",
+      "body": "Summary\n--\n\nThis PR swaps the rule name and code in our `--show-fixes` output, which\npreviously looked like\nthis:\n\n<img width=\"324\" height=\"107\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/32dff652-421c-4e7a-adbd-ac87cc740965\"\n/>\n\nand now looks like this in preview:\n\n<img width=\"314\" height=\"103\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d7d942d6-d5a5-4622-b9a2-a271eb5b0663\"\n/>\n\n\nThe actual code change is just for this one flag, but I also examined\nthe other CLI flags (besides\ndiagnostic output formats, which I'll update separately) and think that\nnothing else needs to be\nupdated. The other two main candidates were `--statistics` and\n`--show-settings`, but these already\nshow both codes and names prominently. `--show-settings` even\nprioritizes them over codes:\n\n```console\n\u276f ruff check --no-cache --ignore-noqa --statistics\n1       F401    [*] unused-import\nFound 1 error.\n[*] 1 fixable with the `--fix` option.\n\n\u276f ruff check --no-cache --show-settings\n...\nlinter.rules.enabled = [\n        multiple-imports-on-one-line (E401),\n        module-import-not-at-top-of-file (E402),\n\t...\n]\n...\n```\n\nTest Plan\n--\n\nNew CLI test and the screenshots above"
+    },
+    {
+      "commit": "b9b4546ad27d8fd12acc979e312a3ee25ef8ac4f",
+      "subject": "Minor workflow simplification (#25870)",
+      "body": "## Summary\n\n`install-action` documents that you can install multiple tools with one\naction invocation like this, so there was some minor unnecessary\ncomplexity here"
+    },
+    {
+      "commit": "1e77ba02570bbe4952f7cf0e4ebb97b8b4e6e58d",
+      "subject": "[ty] Move `PreformattedBlockScanner` to format-agnostic location. (#25856)",
+      "body": ""
+    },
+    {
+      "commit": "6f2b772285aa478e8aee3f4b54dfa9ce903a0ce1",
+      "subject": "[ty] Preserve nominal type of enum.property instances (#25849)",
+      "body": "## Summary\n\nThis is a follow-up to #25681 that preserves the nominal class of\nsynthesized property instances created by `enum.property`.\n\nPreviously, `PropertyInstanceType` always fell back to\n`builtins.property`. That discarded the `enum.property` identity, so\nassignments to `enum.property` failed and enum-specific members such as\n`name`, `clsname`, and `member` were unavailable. The originating known\nclass is now retained through accessor replacement, type\ntransformations, member lookup, descriptor dispatch, relations, `super`,\nand display.\n\nThe regression coverage also checks precise getter and setter behavior.\nA TODO documents the remaining limitation that constructing a subclass\nof `enum.property` currently collapses the result to `enum.property`.\n\n## Test Plan\n\nAdded/updated mdtests."
+    },
+    {
+      "commit": "be4777c8766a38d405a69948989cdfa2674adaae",
+      "subject": "[ty] Fix site-package error when multiple versions of pythons are installed in system path (#25769)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "53f6ff7200983a67778fcba7106019d2615846f0",
+      "subject": "Allow human-readable names in suppression comments (#25614)",
+      "body": "## Summary\n\nI decided to start trying to break up\nhttps://github.com/astral-sh/ruff/pull/23701, and this looked like the\neasiest first piece. This PR allows using human-readable rule names in\nthe new `ruff:ignore` and similar suppression comments, in preview.\n\nRule names are still disallowed in `noqa` comments, and rule codes are\nstill allowed in `ruff:ignore` comments.\n\nI also updated the suppression comment docs to prioritize human-readable\nnames for `ruff:ignore` and `ruff:file-ignore`, which are themselves\nstill in preview, and added a note about names also being supported for\nthe stable range suppression comments.\n\n<hr>\n\nI did notice one surprising property here in that a `noqa` comment with\na rule name does not emit [invalid-rule-code\n(RUF102)](https://docs.astral.sh/ruff/rules/invalid-rule-code/#invalid-rule-code-ruf102),\neven on main. This seems to be an artifact of our `noqa` parsing:\n\n\nhttps://github.com/astral-sh/ruff/blob/f1d2b65af2529175c9a423ce83d57a6beaaa4c44/crates/ruff_linter/src/noqa.rs#L555-L562\n\nthat we may also want to consider updating now.\n\n## Test Plan\n\nNew mdtests"
+    },
+    {
+      "commit": "67403254192f3541bd7e1027c8f1805cf7a9c2be",
+      "subject": "[ty] Restrict uncached raw signature access (#25866)",
+      "body": "## Summary\n\nThis follows up on [the post-merge\nreview](https://github.com/astral-sh/ruff/pull/25761#discussion_r3395933654)\nof #25761.\n\n`FunctionLiteral::last_definition_raw_signature` bypasses the tracked\n`FunctionType` query and therefore must only be called for a function\ndefined in the same module. After #25761, the method was visible\nthroughout the `types` module, making it easy for a future caller to\naccidentally introduce a cross-module AST dependency and\nover-invalidation.\n\nThis restores the method's privacy and routes the existing same-module\ncallers through a dedicated `same_module_uncached_raw_signature`\nwrapper. The wrapper's name and documentation make the restriction\nexplicit, while cross-module callers continue to use the tracked query."
+    },
+    {
+      "commit": "970b1bf4a4d83359c9e28cad5f127ebbd6769682",
+      "subject": "Auto-update snapshots when syncing typeshed (#25841)",
+      "body": "## Summary\n\nI previously tried to implement this in\nhttps://github.com/astral-sh/ruff/pull/20892, but it never worked\ncorrectly, and I couldn't figure out why. So we ended up reverting it in\nhttps://github.com/astral-sh/ruff/pull/22090.\n\nI set Codex on it, and it figured out that the reason is that `CI:\n\"true\"` is set in GitHub Actions as an environment variable, and that\ncurrently takes precedence over the `--accept` flag passed to `cargo\ninsta`. That seems like a bug in `cargo-insta` (which I've proposed a\nfix for in https://github.com/mitsuhiko/insta/pull/924) -- CLI flags\nshould usually take precedence over environment variables. But for now,\nthis is easily worked around by setting `CI: \"0\"` in the workflow.\n\nAnother reason why we ended up reverting this in\nhttps://github.com/astral-sh/ruff/pull/22090 was that the test was\ncausing the workflow to take ages; it was actually timing out in some\nsituations. This redo attempts to mitigate that by:\n- Running the tests as a fourth step on a depot linux runner, instead of\na GitHub MacOS runner\n- Sharing the rust-cache with builds on the `main` branch and on PRs:\nthis workflow only usually happens every two weeks, so the default\nrust-cache settings wouldn't be effective for it"
+    },
+    {
+      "commit": "0785793750fd6c74124a189259822f1a28eb5c13",
+      "subject": "Fix handling of `ignore` comments within a `disable`/`enable` pair (#25845)",
+      "body": "Summary\n--\n\nThis PR addresses the part of\nhttps://github.com/astral-sh/ruff/pull/25791#pullrequestreview-4469517385\nthat reproduced on main.\n\nBoth of these cases were mishandled:\n\n```py\n# ruff:disable[F401, F402]\n# ruff:ignore[F401]\n# ruff:enable[F401, F402]\n\n# ruff:disable[E501]\nimport os  # ruff:ignore[F401]\n# ruff:enable[E501]\n```\n\n[Playground](https://play.ruff.rs/9095ff69-5a67-45f2-bb96-81b9d36a361c)\n\nwith both `ruff:ignore` comments generating a `RUF103` diagnostic and\nwith a particularly strange\nerror message in the second case:\n\n```\nInvalid suppression comment: trailing comments are only support for ruff:ignore suppressions\n```\n\nThe fix was to factor out the code for handling standalone `ruff:ignore`\nand `ruff:file-ignore`\ncomments to allow also calling back into it while looking ahead for the\nthe `enable` comment that\nmatches a `disable` comment.\n\nTest Plan\n--\n\nNew mdtests based on the examples in Micha's comment"
+    },
+    {
+      "commit": "7a91fa28474f9cc1d3fc16be59ada553de6dd61c",
+      "subject": "[ty] Point to invalid `__await__` definition in `invalid-await` diagnostics (#24628)",
+      "body": "## Summary\n\nCloses astral-sh/ty#3250\n\n`await x` where `x.__await__` is non-callable (e.g. `__await__ = 1`)\npointed the \"attribute defined here\" annotation at the definition of the\nattribute's *type* (`class int:` in typeshed). This PR makes it point at\nthe user's own binding instead."
+    },
+    {
+      "commit": "Co-authored-by: David Peter <mail@david-peter.de>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "3c17b510fd69b3fa0b579fa0fcfcea115483c4a3",
+      "subject": "Teach agents that `release.yml` is generated (#25862)",
+      "body": "## Summary\n\nCodex keeps trying to make edits to `release.yml` and I keep having to\nteach it that the file is generated, so you can't do that"
+    },
+    {
+      "commit": "360fbdd396c197be206c9f3cc056e111f7629e40",
+      "subject": "[ty] Fix invalid type guard call examples (#25861)",
+      "body": "## Summary\n\nThe previous examples included a missing required argument, a starred\nargument, and a literal argument. Those calls do not consistently\nproduce `invalid-type-guard-call`, so the rule page did not demonstrate\nthe diagnostic it documents.\n\nCloses astral-sh/ty#3735"
+    },
+    {
+      "commit": "ec35112201c4239b97e188d86423427fd2a6bfa4",
+      "subject": "[ty] remove `mismatched-type-name` example from `invalid-legacy-type-variable` documentation (#25852)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "4fb0547f662f7852a214099f65889b95501aa2b4",
+      "subject": "[ty] Use peer context for collection literals (#25848)",
+      "body": "## Summary\n\nUse the type of peer operands as context when inferring fresh list, set,\nand dict literals in boolean and conditional expressions. This prevents\nempty literals from introducing `Unknown` and preserves literal key\ntypes in fallback expressions such as `values or []` and\n`build_sort_spec(params) or {\"name\": -1}`.\n\nPeer context is applied speculatively and discarded if it introduces\ndiagnostics, so it remains an inference hint rather than a new\nconstraint. The implementation also preserves generic specialization by\naccumulating unguarded peer types before truthiness refinement, while\nretaining existing structured generic context when it is already useful.\n\nFixes https://github.com/astral-sh/ty/issues/3574.\nFixes https://github.com/astral-sh/ty/issues/3693.\n\n## Test Plan\n\nAdded/updated mdtests.\n\nEcosystem report is all good news. The new Apprise diagnostic is just a\nresult of us not narrowing the place `result[\"fullpath\"]` to truthy\nbased on a check of `result.get(\"fullpath\")`. This is orthogonal, just\nexposed by our better inference for `result` in the first place."
+    },
+    {
+      "commit": "1e0cd869c28505a2b58f39b1a029046bbc1a2e13",
+      "subject": "[ty] Fix `invalid-paramspec` documentation (#25853)",
+      "body": "## Summary\n\nThe `invalid-paramspec` documentation used a mismatched-name example,\nbut name mismatches are reported by `mismatched-type-name`.\n\nThis replaces it with a missing-name example that reports\n`invalid-paramspec`, adds regression coverage for that diagnostic, and\nincludes `ParamSpec` in the `mismatched-type-name` examples.\n\nCloses https://github.com/astral-sh/ty/issues/3734."
+    },
+    {
+      "commit": "49f253d7626b3935094cfda5b2cd0ff289e30945",
+      "subject": "[ty] Track the source ranges of reStructuredText field lists in docstrings (#25751)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\n\nBuilding towards https://github.com/astral-sh/ty/issues/3454, this\naugments the parsed representation of a reStructuredText field list to\ninclude the source range of that list in the original docstring. This\nhas no external effect for the moment, but will later enable us to\nprecisely replace regions of the original docstring with Markdown.\n\n## Test Plan\n\nPlease see included tests.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "88a6af71e08a9b13481c3192a30ab4181758ac1f",
+      "subject": "[ty] Replace ParameterForm with TypeForm (#25847)",
+      "body": "## Summary\n\nRemove the entire `ParameterForm` and `argument_forms` subsystem, as\nwell as the `conflicting-argument-forms` diagnostic, using `TypeForm`\ninstead for the three remaining known callables that were still using it\n(`cast`, `assert_type`, and `TypeAliasType`).\n\nImprove the projection of `TypeForm` types into their represented type\nto account for aliases, unions, intersections, and type variables, as\nwell as protecting against stack overflow.\n\nThis PR avoids scope creep into improving IDE behavior around `TypeForm`\n(highlighting of type-form arguments as type annotations). It preserves\nexisting behavior for `cast`, `assert_type`, and `TypeAliasType` via\nspecial-casing of those three callables.\n\nCloses https://github.com/astral-sh/ty/issues/3714.\n\n## Test plan\n\nAdded/updated mdtests.\n\nMain change in ecosystem is that we now accept `type[...]` types as type\nexpressions in `cast`; this matches both user expectations in\nHomeAssistant and the TypeForm PEP, which says that instances of `type`\nare TypeForms."
+    },
+    {
+      "commit": "6dfef7747239b0c4a0315460400da067d94701bf",
+      "subject": "[ty] Avoid caching same-file raw signatures (#25761)",
+      "body": "## Summary\n\n`FunctionType::last_definition_raw_signature` is a tracked query so\ncross-query callers can ask for a function signature without depending\ndirectly on the defining AST node. Several inference paths call it while\nalready operating on the same file and only need the raw last-definition\nsignature for local return-type or generic-context handling.\n\nThis exposes the underlying `FunctionLiteral` helper within the `types`\nmodule and routes those same-file inference call sites through it\ndirectly. Cross-file and external callers continue to use the tracked\n`FunctionType` query; the bypass is limited to callers that are already\nin same-file inference context."
+    },
+    {
+      "commit": "5ffba8092b3b684029b4dc71efa1ad3627726add",
+      "subject": "[ty] Restrict length narrowing to types that encode their length (#25840)",
+      "body": "## Summary\n\nRestrict exact `len()` narrowing to types that actually encode their\npossible lengths, so that we don't wrongly preserve length-narrowings on\ntypes with mutable length.\n\nCloses astral-sh/ty#3710.\n\n## Test plan\n\nAdded/updated mdtests.\n\n### Ecosystem analysis\n\n72 of the added diagnostics (48 in apprise, 19 in scrapy, plus some\nothers) are from restoring correct reachability to code that was\npreviously erroneously marked unreachable.\n\n33 new diagnostics involve cases where we previously narrowed `None` out\nof a type after a `len` call (which itself errors since `None` is not\n`Sized`), since `None` is disjoint from `ExactlySized`. We could easily\ncontinue to do this (remove any non `Sized` types when narrowing from a\n`len` check), and I don't think it's wrong to do so? But it's kind of\nodd to narrow from a failed call, and no other type checker does it, so\nI haven't done it in this PR.\n\n12 new diagnostics (all in packaging, or pip from its vendored\npackaging) come from a case where we are length-narrowing correctly,\nit's just we top-materialize `isinstance` and `object` is not assignable\nwhere a value from that tuple is used. This was silenced on main because\nwe don't support exact unpacking from an intersection at all, and we\npreviously had an intersection with `ExactlySized` here.\n\nFour new diagnostics in `ppb-vector` come from code like this:\n\n```py\ndef unpack(value: Sequence[int] | Mapping[str, int]):\n    if isinstance(value, Sequence) and len(value) == 2:\n        return value[0]\n    if isinstance(value, Mapping) and \"x\" in value and len(value) == 2:\n        return value[\"x\"]\n    raise ValueError\n```\n\nWhere retaining the intersection with `~ExactlySized[2]` allowed us to\nrule out the \"both a Sequence and a Mapping\" case in the second branch\n(since if it were a sequence of length 2 it would have already taken the\nfirst branch). This is the only case where this PR regresses results. We\ncould keep this by restoring `ExactlySized` and continuing to use it\nwith `Sequence` and `Mapping` types -- but that would add a lot of code\nfor something that has a very small ecosystem impact."
+    },
+    {
+      "commit": "2a404f1589d3690cfeb0ae94cdb0f3afca0ddef8",
+      "subject": "[ty] Restore builder-local constraint subtype cache (#25844)",
+      "body": "## Summary\n\nPR #25786 originally cached repeated constraint-set subtype checks on\n`ConstraintSetBuilder`. [During\nreview](https://github.com/astral-sh/ruff/pull/25786#discussion_r3383378278),\nthat cache was replaced with a Salsa-tracked query to allow reuse across\nbuilders. On pytest-robotframework, the tracked query does not recover\nthe same performance: current main remains roughly 25% slower than the\ncommit immediately before #25778.\n\nThis restores the builder-local `FxHashMap` cache and routes the two\ntransitive-pivot subtype checks through it. The separate\ntype-variable-bound precheck from #25786 remains unchanged.\n\nIn 80 balanced, interleaved runs of pytest-robotframework using clean\nprofiling builds, the results were:\n\n| Revision | Median | Paired change vs. pre-#25778 |\n|"
+    },
+    {
+      "commit": ": |\n| Pre-#25778 (`1676ec8013`) | 103.2 ms | \u2014 |\n| Current main (`8f2caa6a04`) | 128.3 ms | +24.9% |\n| This PR | 106.9 ms | +3.7% |\n\nThis PR is 16.9% faster than current main. All three revisions produced\nbyte-for-byte identical diagnostics. The full `ty_python_semantic` suite\n(558 tests), focused Clippy, and repository hooks pass.",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "8f2caa6a04743fcb9b10262307bd67d32e378a43",
+      "subject": "[ty] Avoid redundant constraint saturation work (#25786)",
+      "body": "## Summary\n\nThe constraint-set subtype checks introduced in #25778 can be repeated\nmany times while saturating pairs of constraints. On\npytest-robotframework, that increased median check time from 105.8 ms on\nmain to 159.9 ms with #25778.\n\nThis caches those checks for the lifetime of a constraint-set builder.\n\nAs a separate, semantics-preserving optimization, this also skips\ncalling `add_nested_typevar_sequents` when neither constraint has a type\nvariable in its bounds. In that case, the method cannot derive any\nsequents: all of its variance checks return `Bivariant`. The precheck\nvisits lazy types to match the traversal performed by `variance_of`.\n\nWith this change, pytest-robotframework takes 108.5 ms, 2.6% above main,\nwith byte-for-byte identical diagnostics. The full `ty_python_semantic`\ntest suite, focused Clippy, and repository hooks pass."
+    },
+    {
+      "commit": "071eed0a8e07ddd6c83540d490f06696411b0202",
+      "subject": "[ty] Require subtyping for transitive constraint pivots (#25778)",
+      "body": "## Summary\n\nWhen building sequent maps for constraints on different type variables,\nwe use materialized bounds as pivots to derive transitive relationships.\nWe previously accepted a pivot when those bounds were assignable.\nUnrelated classes with dynamic bases are mutually assignable, so this\nconnected otherwise independent invariant type variables and caused the\nconstraint set in the issue reproducer to grow combinatorially.\n\nThis changes those pivot checks to require subtyping. Because the bounds\ncan themselves contain type variables, the new check uses\nconstraint-set-aware subtyping rather than the ordinary subtype\nrelation. Constraint-set type-variable handling is now an independent\nmode on `TypeRelationChecker`, so it can be combined with either\nsubtyping or assignability; the mode is also included in relation and\nsignature recursion keys so cached results are not shared across\ncomparison modes.\n\nIn a local benchmark of the issue reproducer, check time fell from 14.5\nseconds with constraint-set assignability to 46 milliseconds with\nconstraint-set subtyping.\n\nCloses https://github.com/astral-sh/ty/issues/3607."
+    },
+    {
+      "commit": "1676ec801398b47995904eb12ac0a4f031a34f8a",
+      "subject": "[ty] Improve closed TypedDict precision (#25651)",
+      "body": "## Summary\n\nThis PR improves the types we infer once a TypedDict is known to be\nclosed.\n\nA closed TypedDict has a finite schema, so we now derive its key type\nfrom the union of declared string literals and its value type from the\nunion of declared item types. These types specialize direct iteration\nand the synthesized `keys()`, `values()`, and `items()` methods.\n\n```python\nclass Movie(TypedDict, closed=True):\n    name: str\n    year: int\n\nreveal_type(movie.keys())  # dict_keys[Literal[\"name\", \"year\"], str | int]\nreveal_type(movie.values())  # dict_values[Literal[\"name\", \"year\"], str | int]\n```\n\nAn empty closed TypedDict is now always falsy, including the equivalent\n`extra_items=Never` form. Closed TypedDicts with optional items and\nordinary open TypedDicts remain potentially truthy.\n\nIndexing a closed TypedDict with a non-literal `str` continues to report\n`invalid-key`, but now recovers with the union of declared value types\nrather than `Unknown`."
+    },
+    {
+      "commit": "38d022f01b97ebd19f50e10e2e019c73ca3e9010",
+      "subject": "[ty] Patch typeshed mapping key annotations during sync (#25831)",
+      "body": "## Summary\n\nUpdated our typeshed sync to:\n- patch `dict.get` and `Mapping.get` to accept `object` keys\n- patch `dict_keys.isdisjoint` and `dict_items.isdisjoint` to accept\n`object`\n- apply the typeshed patches at the end of the sync in a standalone\ncommit\n\nThe workflow pushes the completed, unpatched sync first, so a patch\nconflict can be fixed from the unfinished sync branch without rerunning\nthe full workflow. The currently vendored stubs include the patched\nsignatures immediately.\n\nUsed a typeshed-patching approach similar to mypy, with a directory of\npatch files that we apply in order. If a patch fails to apply, the final\nsync job fails while leaving the unpatched sync branch available for\nmanual repair.\n\nCloses https://github.com/astral-sh/ty/issues/2374\n\n## Rationale\n\nThese methods can safely be called with any key without erroring, so the\ncurrent annotations are too strict and cause false positives. See\nhttps://github.com/python/typeshed/issues/15271 for upstream discussion\nin typeshed.\n\nIt's reasonable to want a diagnostic in cases when the `.get()` call is\nknown to return `None`, or the `isdisjoint` call is known to be always\ntrue; switching to `object` loses that. In the short term we could\nprovide this via dedicated rule. Longer-term there is discussion\nupstream about an `Overlapping[...]` annotation form that would allow\npassing any type that is not disjoint with the annotated type.\n\nThere are other methods mentioned in that typeshed issue that in\nprinciple we might want to patch for similar reasons, but I'm preferring\nto keep the patch-set smaller and start with just the methods we've seen\ncome up.\n\n## Validation\n\n- Added mdtest regression coverage for every `get` overload form\naccepting `object`.\n- Ran the focused `call/builtins.md` mdtest.\n- Ran the full `ty_python_semantic` test suite: 558 passed.\n- Applied the exact workflow `git apply` command to the current\npost-docstring, post-format vendored baseline and verified the results\nbyte-for-byte.\n- Verified that applying the patches a second time fails rather than\nsilently succeeding.\n- Ran file-scoped `prek` hooks, including GitHub workflow validation.\n\nEcosystem results are mostly the expected false-positive removals, plus\nsome downstream additions where allowing the `.get()` call gives a\nprecise type instead of `Unknown`, causing downstream diagnostics.\n\nThis change does mean that subclass overrides of `Mapping.get` may now\nemit Liskov violations if they don't accept `object` -- I think this is\nan unavoidable part of this change?"
+    },
+    {
+      "commit": "e30ee24a75ca934be543a51b66fd9badc16e63b5",
+      "subject": "[ty] Use typeshed for PEP 728 TypedDict class attributes (#25833)",
+      "body": "## Summary\n\nThis follows up on #25823 now that\n[python/typeshed#15887](https://github.com/python/typeshed/pull/15887)\nhas been merged and vendored by #25828.\n\nThis removes the hard-coded synthesis for `TypedDict.__closed__` and\n`__extra_items__` and reads the declarations from typeshed instead.\nPython 3.15 uses `_typeshed._type_checker_internals.TypedDictFallback`;\nearlier versions fall back to `typing_extensions._TypedDict`, preserving\nthe backported attributes and existing behavior."
+    },
+    {
+      "commit": "1b9310471b7d1178633e58ee63808522609db887",
+      "subject": "[ty] Avoid builtins in inlay hints test (#25830)",
+      "body": ""
+    },
+    {
+      "commit": "ca8b1938d698061c740af5c3d58c94a1fdd35516",
+      "subject": "[ty] Anonymize vendored line numbers in IDE tests (#25829)",
+      "body": ""
+    },
+    {
+      "commit": "3d1d03dd2a95e0f61b679c06bea5634ac5e2f571",
+      "subject": "[ty] Sync vendored typeshed stubs (#25828)",
+      "body": "Close and reopen this PR to trigger CI"
+    },
+    {
+      "commit": "Co-authored-by: typeshedbot <>\nCo-authored-by: Alex Waygood <alex.waygood@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "fd90cd9df0f56009bb3a2799679abe4068d50168",
+      "subject": "Update zip dependency (#25812)",
+      "body": "Co-authored-by: Alex Waygood <Alex.Waygood@Gmail.com>\nCo-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "7dd5f3029d5ad4aaa2fbc18ffebf872d80327e47",
+      "subject": "[ty] Recognize more commonly-used reStructuredText field types (#25680)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nThis prepares us to group and render those field types in Markdown\nsections.\n\n/xref https://github.com/astral-sh/ty/issues/3454\n\n## Test Plan\n\nPlease see included tests.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "51d5705eda369fc634f19550e30d8481e82e11ce",
+      "subject": "[ty] Synthesize PEP 728 TypedDict class attributes (#25823)",
+      "body": "## Summary\n\nThis follows up on [the post-merge\nreview](https://github.com/astral-sh/ruff/pull/25591#discussion_r3389547485)\nof #25591.\n\nThe PEP 728 implementation added `__closed__` and `__extra_items__`\ndirectly to the vendored `TypedDictFallback` stub, but the next\nautomated typeshed sync would overwrite those declarations.\n\nThis removes the vendored changes and synthesizes the attributes during\nTypedDict class-member lookup when the typeshed fallback does not\nprovide them. The synthesized members retain their `ClassVar` qualifier,\nso they remain available on TypedDict classes and `type[TypedDict]`\nwhile staying unavailable on TypedDict instances."
+    },
+    {
+      "commit": "7fbef674f0bf460d8fb6b973f994384b785b0c3e",
+      "subject": "[`pylint`] Exempt Python version comparisons (`PLR2004`) (#25743)",
+      "body": "## Summary\n\nCloses #25588.\n  \nThis PR adds an exception to PLR2004 (the magic-value-comparison rule).\nThe rule fires when a literal value (like 3) is compared against\nsomething. The new exception allows PLR2004 to not fire when the literal\nis being compared against `sys.version`, `sys.version_info`, or\n`sys.implementation.version`, including subscripts and attribute access\non either.\n\nAlso added regression cases to the fixture and ran `cargo test`, `cargo\nfmt --check`, `cargo clippy -- -D warnings`, with all returning clean,\nas part of this PR."
+    },
+    {
+      "commit": "3645e34d10447e873aa99d64a224e7e250c3b458",
+      "subject": "[ty] Combine definition annotation queries (#25822)",
+      "body": "## Summary\n\nThis follows up on [the post-merge\nreview](https://github.com/astral-sh/ruff/pull/25591#discussion_r3384620120)\nof #25591.\n\nThe `extra_items` path previously queried a definition expression's type\nand qualifiers separately, even though both values come from the same\ninference result. This adds `definition_expression_annotation`, which\nreturns `TypeAndQualifiers` from that shared result for both definition\nscopes and type-parameter scopes.\n\nTypedDict extra-items construction now uses the combined annotation\nresult and applies specialization only to its inner type, preserving\nqualifiers such as `ReadOnly`."
+    },
+    {
+      "commit": "a7e193dd73458027f4371c0b56de9cd1c1c7b37e",
+      "subject": "[ty] Add support for `extra_items` (#25591)",
+      "body": "## Summary\n\nThis PR adds support for [PEP 728](https://peps.python.org/pep-0728/):\n`extra_items` and `closed` semantics for TypedDict.\n\nIn addition to the declared items, we now also model the open/closed\npolicy for a TypedDict schema:\n\n```rust\nenum TypedDictOpenness {\n    Open,\n    Closed,\n    Extra(TypedDictExtraItems),\n}\n```\n\nExtra records both the declared value type and whether the extra items\nare read-only, and `extra_items=Never` is canonicalized to `Closed`.\n\nExplicit extra items and implicitly-open TypedDicts are treated slightly\ndifferently. Explicit extra items are directly accessible through\noperations like indexing, assignment, deletion, `get`, `pop`,\n`setdefault`, `update`, etc., while an ordinary open TypedDict does not\nexpose its hidden items through those operations. For structural\nrelations and unpacking, though, an open TypedDict behaves as though it\nhas read-only extra items of type object.\n\nA literal undeclared key uses the explicit extra-items type. An\narbitrary `str` key may refer to any declared or extra item, so its safe\nvalue type is the intersection of all possible destinations. Arbitrary\nwrites are rejected if any possible destination is read-only, and\narbitrary deletion is available only when every possible item is\noptional and mutable:\n\n```python\nclass Options(TypedDict, extra_items=int):\n    label: NotRequired[str]\n\ndef update(options: Options, key: str) -> None:\n    options[\"year\"] = 2026  # allowed\n    options[key] = 2026     # rejected: key may be \"label\"\n```\n\nThe same schema capabilities determine when a TypedDict can use a\n`dict[str, T]` fallback. This requires mutable explicit extra items and\noptional, mutable declared items whose types satisfy the mutable dict\ncontract.\n\n## Remaining limitations\n\nThe core PEP 728 `open`, `closed`, and `extra_items` semantics are\nimplemented, but this PR intentionally leaves several closed-TypedDict\nprecision improvements for follow-up work\n(https://github.com/astral-sh/ruff/pull/25651):\n\n```python\nclass Closed(TypedDict, closed=True):\n    name: str\n    age: int\n```\n\n- `keys()`, `values()`, `items()`, and iteration currently produce `str`\nand `object`-based types instead of literal keys and declared-value\nunions.\n- `bool()` on an empty closed TypedDict is currently `bool` rather than\n`Literal[False]`.\n- Indexing a closed TypedDict with a non-literal `str` correctly reports\nan invalid-key diagnostic, but the resulting type is `Unknown` rather\nthan the union of its declared value types."
+    },
+    {
+      "commit": "934cfa9b8a832e283b3f1dfec3175e0b2194b3e0",
+      "subject": "[ty] Avoid resolving overload sets for ordinary functions (#25817)",
+      "body": "## Summary\n\n`FunctionLiteral` currently resolves its overload chain through a\ntracked query whenever callers need its definitions or callable\nsignature, even though most functions consist of one ordinary\ndefinition.\n\nThis records the common no-overload case when constructing the function\nliteral and returns the empty overload set plus the last definition\nbefore entering the tracked collector. Definition iteration and\nsignature construction reuse that shared result, while functions with\noverloads continue through the existing tracked implementation."
+    },
+    {
+      "commit": "13e4a58da83f5730fde0fed3aa936f786f8c8283",
+      "subject": "[ty] Address intersection receiver review feedback (#25819)",
+      "body": "## Summary\n\nThis follows up on [the post-merge\nreview](https://github.com/astral-sh/ruff/pull/25626#pullrequestreview-4466748160)\nof #25626.\n\n`functools.partial` now preserves the full intersection receiver when\ndelegating member lookup to its nominal `partial[T]` view. Bound-method\nfallback still resets the receiver when lookup switches to the separate\nunderlying function object; the implementation and regression coverage\nnow make that distinction explicit.\n\nThis also parenthesizes compound bound-method receivers in displayed\ntypes and clarifies and relocates the related intersection receiver\ndocumentation and tests."
+    },
+    {
+      "commit": "bde9bb5dcefd165cf89075ce06f4eadc593db323",
+      "subject": "[ty] Avoid caching specialization-invariant known instances (#25816)",
+      "body": "## Summary\n\n`apply_specialization` already handles atomic types before entering its\ntracked query, but several `KnownInstanceType` variants still create and\nretain query entries even though specialization always returns the\noriginal type.\n\nThis handles those specialization-invariant known instances directly.\nVariants that can depend on type variables continue through the existing\ntracked implementation."
+    },
+    {
+      "commit": "d36b3c55a49312a11c7c22f83c16ad54b3186a96",
+      "subject": "[ty] Store common definition inference results inline (#25814)",
+      "body": "## Summary\n\n`DefinitionInference` almost always retains either one binding, one\ndeclaration, or a binding and declaration for the same definition and\ntype. `DefinitionTypes` stored each of these common cases in a separate\n`Box`, adding a heap allocation for every cached result, while only the\nuncommon multi-result case needs out-of-line storage.\n\nThis stores the common singleton payloads directly in the enum and keeps\nthe `Other` variant boxed. The cycle-normalization and iteration paths\npreserve the existing behavior while operating on the inline payloads.\n\nOn a representative project, this reduced retained memory from\n287,972,361 bytes to 286,861,193 bytes, saving 1,111,168 bytes (0.39%)\nwithout diagnostic changes."
+    },
+    {
+      "commit": "7d69b13af9c12377d365723ed48c75b065d2a9b0",
+      "subject": "[ty] Preserve overloads through callable protocol decorators (#25806)",
+      "body": "## Summary\n\nThe workaround from #25030 only inspected function literals and direct\n`Callable` types. Polars types both decorators on `LazyFrame.collect` as\nan `IdentityFunction` protocol, so ty represented the decorator\nexpressions as protocol instances and discarded the overload signatures.\n\nThis follow-up resolves the protocol's bound `__call__` method through\nthe existing callable upcast path, while retaining the strict\n`Callable[P, R] -> Callable[P, R]` signature check.\n\nFixes the remaining Polars example reported in astral-sh/ty#2278.\n\n## Test plan\n\nAdd a regression test case for it."
+    },
+    {
+      "commit": "3b420e609ff3b373fcbbf614ad6efc69bda512df",
+      "subject": "[ty] Fix Reporter doc comment placement (#25772)",
+      "body": ""
+    },
+    {
+      "commit": "ba68d97f8287eb25da9dbfb7c8e42d2009bef8f6",
+      "subject": "Update NPM Development dependencies (#25802)",
+      "body": ""
+    },
+    {
+      "commit": "8b79528100e9bacb53d3b39eec26ca5886df501e",
+      "subject": "Update Rust crate log to v0.4.31 (#25798)",
+      "body": ""
+    },
+    {
+      "commit": "4b063bd2c59c03421c0cd67fa3ad41b8c1390aab",
+      "subject": "Update taiki-e/install-action action to v2.81.3 (#25804)",
+      "body": ""
+    },
+    {
+      "commit": "c7f76d802ad5e1da8f66c0b627d55fd30d8ebf44",
+      "subject": "Update Rust crate bitflags to v2.12.1 (#25803)",
+      "body": ""
+    },
+    {
+      "commit": "d75ce5bcc5ae7c9ee98296cafc99755602ee62f8",
+      "subject": "Update CodSpeedHQ/action action to v4.17.0 (#25801)",
+      "body": ""
+    },
+    {
+      "commit": "1ec89f24f02be86745b8be2e854c84a816d820fb",
+      "subject": "Update astral-sh/setup-uv action to v8.2.0 (#25800)",
+      "body": ""
+    },
+    {
+      "commit": "1d7ca2a7c3dd78813392a60e93bb64376f0b0d3c",
+      "subject": "Update Rust crate uuid to v1.23.2 (#25799)",
+      "body": ""
+    },
+    {
+      "commit": "09a78f6a033f848b86895e1b64af6a742def9755",
+      "subject": "Update Rust crate jiff to v0.2.28 (#25797)",
+      "body": ""
+    },
+    {
+      "commit": "2caa83e8499ec65f1a0e52c6b37c88872cc4ed0e",
+      "subject": "Update prek dependencies (#25796)",
+      "body": ""
+    },
+    {
+      "commit": "8828ba9fd5eb5f0a70ac1dd764ab4c1926725c09",
+      "subject": "Update dependency ruff to v0.15.16 (#25795)",
+      "body": ""
+    },
+    {
+      "commit": "73d88af96823f26829d7aee452b16df804b25edf",
+      "subject": "Update dependency astral-sh/uv to v0.11.19 (#25794)",
+      "body": ""
+    },
+    {
+      "commit": "923717ad38b2b8e80662009327fbea143ef52055",
+      "subject": "Update actions/checkout action to v6.0.3 (#25793)",
+      "body": ""
+    },
+    {
+      "commit": "e201faef6bc7c566fd0fc7814b6f6c1372ea747d",
+      "subject": "A few suppression comment refactors (#25754)",
+      "body": "## Summary\n\nI've been reading the suppression code recently for work on\nhttps://github.com/astral-sh/ruff/issues/25547 and\nhttps://github.com/astral-sh/ruff/issues/25644 and noticed a couple of\nsmall simplification opportunities that didn't really fit into the other\nPRs, so I split them off here.\n\n## Test Plan\n\nExisting tests. This should be a pure refactor without any functional\nchanges"
+    },
+    {
+      "commit": "a210a832ced32a735b1da3197ff6bfffa185840a",
+      "subject": "[ty] Avoid cycle when traversing NewType bases (#25764)",
+      "body": "## Summary\n\n`NewType` stores its base lazily, and type visitors can opt out of\nforcing lazy type attributes during Salsa cycle recovery. The `NewType`\ninstance walker ignored that choice, while traversal of the runtime\ncallable returned by `NewType` bypassed the walker and resolved the\nconcrete base directly. In the issue reproduction, this forced the\nunresolved base while recovering `infer_definition_types`, re-entered\nfunction-signature inference, and caused Salsa to panic.\n\nThis routes both forms through the same visitor hook. Ordinary traversal\nstill resolves the full base, while visitors that disable lazy\nattributes now visit only an eagerly available base and otherwise stop.\nThe regression coverage exercises both `NewType` forms alongside the\nrecursive `NamedTuple` cycle.\n\nCloses https://github.com/astral-sh/ty/issues/3682."
+    },
+    {
+      "commit": "948359fd97ce64f49e06c82a82d354e3378e37fb",
+      "subject": "Enable Clippy's `iter_over_hash_type` lint (#25732)",
+      "body": "## Summary\n\nStacks on #25726 and enables Clippy's `iter_over_hash_type` restriction\nlint across the workspace, so new hash-map and hash-set iterations must\nmake their ordering assumptions explicit.\n\nMost existing loops are order-independent and use a site-local\n`#[expect(clippy::iter_over_hash_type)]`. At the order-sensitive sites,\nthis sorts before iteration. (In practice, that should stabilize some\nparser fixtures, configuration diagnostics, union normalization, etc.).\n\nThis lint is kind of annoying, but given how much we want to crack down\non non-determinism in ty, it seems worthwhile to enable IMO."
+    },
+    {
+      "commit": "b78e92bf9de4c0965902a18f0221d34317586dfe",
+      "subject": "Respect diagnostic start and parent ranges and trailing comments in `ruff:ignore` suppressions (#25673)",
+      "body": "Summary\n--\n\nFixes #25644 by addressing the following cases:\n\n```py\nsuppressed = [  # noqa: RUF015\n    *range(10)\n][0]\n\nnot_suppressed = [  # ruff:ignore[RUF015]\n    *range(10)\n][0]\n```\n\n`ruff:ignore` now properly suppresses `RUF015`, even though only the\nstart of the diagnostic occurs within the suppression range. This is the\ncase from #25644.\n\n```py\nfrom foo import (  # noqa: F401\n        bar\n)\n\nfrom foo import (  # ruff:ignore[F401]\n        baz\n)\n```\n\n`ruff:ignore` now properly respects the `parent` range of a diagnostic\nand suppresses the unused import here, like `noqa`.\n\n\n```py\n# ruff:ignore[E262]\nx = 1  #bad\n```\n\n`ruff:ignore` now properly suppresses `E262` here by extending its\nsuppression range to include the full following line rather than\nskipping over the trailing comment. This case isn't directly related to\n`noqa` on its own, but it was another separate issue and pointed to a\nbetter solution to the other cases.\n\n[Playground](https://play.ruff.rs/b877bf42-6fda-4e6a-9d6f-ac3e9e7a1934)\n\nTest Plan\n--\n\nNew mdtests based on the cases above"
+    },
+    {
+      "commit": "f0fbe2b8c1c6268719bea59e67a2da62af4332a8",
+      "subject": "[ty] Use `Box<SystemPath>` etc. in `Files` (#25554)",
+      "body": ""
+    },
+    {
+      "commit": "e8727a74ec3cdeaf0ccd8855c93a763369d8f664",
+      "subject": "[ty] Sync vendored typeshed stubs (#25779)",
+      "body": "Close and reopen this PR to trigger CI"
+    },
+    {
+      "commit": "Co-authored-by: typeshedbot <>\nCo-authored-by: Alex Waygood <alex.waygood@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "7d0c0d1f17e82bba6c18a7208a49efc4c30b4628",
+      "subject": "Bump docstring-adder pin (#25777)",
+      "body": "## Summary\n\nPulls in https://github.com/astral-sh/docstring-adder/pull/169, so that\nwe have a version of docstring-adder that supports 3.15. This enables us\nto add docstrings for the new-in-3.15 branches in typeshed.\n\nI also switched us to temporarily use a version of Black from git,\nbecause I'm too impatient to wait for a release that includes\nhttps://github.com/psf/black/commit/f665703258bfa1916f8a6c1cbab0bc384b90cbac.\n\n## Test Plan\n\nCI on docstring-adder"
+    },
+    {
+      "commit": "6fc1354ee87d65bc8fef7c756686204076f2874a",
+      "subject": "[`flake8-async`] Add `trio.as_safe_channel` to safe decorators (`ASYNC119`) (#25775)",
+      "body": "Adds `trio.as_safe_channel` to the ASYNC119 safe-decorator allowlist.\n\nThe flake8-async spec for ASYNC119 already names `trio.as_safe_channel`\nas the\ndocumented escape hatch for this rule, but ruff was not recognizing it\nas safe.\nThe rule docstring already links to the trio docs for it.\n\nFixes #25770."
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <36778786+ntBre@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "10b729da9c4ad273e81b1afcf36fca32d3434a9f",
+      "subject": "Allow rule names in `ruff rule` (#25640)",
+      "body": "Summary\n--\n\nFrom what I can tell, there's not really an easy way to preview-gate\nthis. I don't think we have access to configuration in this subcommand,\nand it doesn't seem easy to pass it to clap even if we had it. However,\nI don't think there's much downside to being more permissive here and\nallowing this even before other human-readable names work.\n\nTest Plan\n--\n\nNew CLI test\n\nI also tested the new shell completions:\n\n```console\n\u276f source <(cargo run --quiet --bin ruff -- generate-shell-completion zsh)\n\n\u276f ruff rule unused-<TAB>\nunused-annotation              -- F842\nunused-async                   -- RUF029\nunused-class-method-argument   -- ARG003\nunused-function-argument       -- ARG001\nunused-import                  -- F401\nunused-lambda-argument         -- ARG005\nunused-loop-control-variable   -- B007\nunused-method-argument         -- ARG002\nunused-noqa                    -- RUF100\nunused-private-protocol        -- PYI046\nunused-private-type-alias      -- PYI047\nunused-private-type-var        -- PYI018\nunused-private-typed-dict      -- PYI049\nunused-static-method-argument  -- ARG004\nunused-unpacked-variable       -- RUF059\nunused-variable                -- F841\n```\n\nPart of #1773"
+    },
+    {
+      "commit": "8b630c748545726909daa7b4b8b32eb84cb049ad",
+      "subject": "Fix out of bound panic in notebooks when using suppression comments (#25629)",
+      "body": ""
+    },
+    {
+      "commit": "267af002fb9431f6f2db5ab849c1dcd6d7752733",
+      "subject": "[ty] Support `Callable()` in match statement class patterns (#25541)",
+      "body": "## Summary\nhttps://github.com/astral-sh/ty/issues/887\n\nAs titled. Covers:\n- Validating proper use in the class pattern, including disallowing\npositional sub-patterns\n- Reachability analysis\n- Narrowing\n\n## Test Plan\n\nNew mdtests"
+    },
+    {
+      "commit": "Co-authored-by: Carl Meyer <carl@astral.sh>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "2054235e33c9153e6147fc6e491b16963281ad9d",
+      "subject": "[ty] Avoid crash when hovering over Callable (#25759)",
+      "body": "## Summary\n\nWhen resolving qualifiers for an imported name, use the resolved\ndefinition's file to interpret its AST-backed definition kind.\nPreviously, hover combined a definition from typeshed with the importing\nmodule's AST, which could panic for `typing.Callable` and\n`collections.abc.Callable`.\n\nAdd regression coverage for both imports.\n\nCloses https://github.com/astral-sh/ty/issues/3698."
+    },
+    {
+      "commit": "6425b7b13a3da0b42db0a774a4892b8e0fdc3fa7",
+      "subject": "[ty] better support for enum.property (#25681)",
+      "body": "## Summary\nTreat `enum.property` as a known class with `property` like behavior so\nwe get accurate types from its `__get__` method, instead of just `Any`.\n\nCloses https://github.com/astral-sh/ty/issues/3681\n\n## Testing\nAdded mdtests"
+    },
+    {
+      "commit": "c963f8ca20583014133c1e671955e6ce3fdc6cab",
+      "subject": "[ty] Remove obsolete `asynccontextmanager` workaround (#25752)",
+      "body": "## Summary\n\nIn https://github.com/astral-sh/ruff/pull/21876 we introduced a\nspecial-cased workaround inference for `@asynccontextmanager`, since we\ndidn't at the time have the needed generics solver features to handle\nit.\n\nToday (thanks to https://github.com/astral-sh/ruff/pull/21551,\nhttps://github.com/astral-sh/ruff/pull/21902,\nhttps://github.com/astral-sh/ruff/pull/21902 and\nhttps://github.com/astral-sh/ruff/pull/22544), we have all the necessary\npieces to handle this natively, and no longer need a special-cased\nworkaround.\n\nAnd the workaround didn't correctly preserve the generic context of a\ngeneric async context manager, so removing the workaround fixes generic\nasync context managers, too.\n\nCloses https://github.com/astral-sh/ty/issues/3692.\n\n## Test plan\n\nAdded regression mdtest for the generic case. Existing tests pass.\n\nCodex analysis confirms all removed ecosystem diagnostics were false\npositives; removing them is a fix."
+    },
+    {
+      "commit": "12738a49133926ba263baa172ddc43bfb97346b1",
+      "subject": "[ty] Update conformance suite pin (#25750)",
+      "body": "Update the `python/typing` pin to the latest main. This picks up\nhttps://github.com/python/typing/pull/2300, which lets us infer a better\nsolution in a generic function call involving multiple list literals."
+    },
+    {
+      "commit": "2d04314986048c861679c7b0c86f3e0bb3b5dd63",
+      "subject": "[ty] Create fresh copies of generic callable typevars (#24949)",
+      "body": "A generic callable binds new typevars. If that callable is used more\nthan once in a particular expression, we should create separate (aka\n\"fresh\") copies of those typevars, so that the inferred types for each\ndo not conflict with each other.\n\nThis comes up in two situations:\n\n- We might invoke a generic function recursively from inside of its\nbody. In that case, the call site introduces fresh _inferable_ copies of\nthe function's typevars, which should not conflict with the existing\n_non-inferable_ copies from the function signature.\n\n- We might pass the same generic callable more than once to some other\ncall. In this case, each occurrence should have distinct copies of its\ntypevars, that do _not_ need to unify with each other. This can occur\nwhenever we compare a generic callable signature for assignability with\nsome other signature.\n\nThis PR updates these two places (call binding and signature\nassignability checking) to introduce fresh copies of the callable's\ntypevars when needed."
+    },
+    {
+      "commit": "Co-authored-by: Charlie Marsh <charlie.r.marsh@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "b5fce66ff1c0c01b00e47158b5b854fa46e886c2",
+      "subject": "[ty] Preserve deprecation on replacement functions (#25688)",
+      "body": "## Summary\n\nAn outer `@deprecated` decorator applies to the value returned by inner\ndecorators. We currently record deprecation on the original function\nbefore applying decorators, so an inner decorator that replaces that\nfunction can cause the public binding to lose its warning.\n\n```python\n@deprecated(\"use replacement directly\")\n@replace_with(replacement)\ndef old() -> None:\n    pass\n\nold()          # Previously: no warning\nreplacement()  # No warning\n```\n\nThis handles `@deprecated` in the post-decoration pass. When the current\ndecorated value is another function literal, we copy that function type\nwith the outer deprecation metadata. `old()` now warns while direct uses\nof `replacement()` remain unchanged.\n\nThis is a pared-down alternative to #25619, following [Doug's\nsuggestion](https://github.com/astral-sh/ruff/pull/25619#issuecomment-4632505308).\nThe original PR attached deprecation to place and binding metadata so it\ncould survive decorator replacements whose returned value was not\nalready deprecated. That required broad changes across place lookup and\nbinding propagation, including special handling for aliases and\nsynthetic bindings, and it introduced retained-memory and benchmark\nconcerns. This version keeps the behavior local to function decorator\ninference and avoids changing the place representation or assignment\nsemantics.\n\nThe narrower implementation deliberately preserves deprecation only when\nan inner decorator returns a function literal. Callable-instance\nreplacements remain documented as a TODO.\n\nCloses https://github.com/astral-sh/ty/issues/3623."
+    },
+    {
+      "commit": "612f2f28501fc65ce90d970c86463657a2c840a0",
+      "subject": "Switch to `gen-lsp-types` crate to provide LSP types (#24894)",
+      "body": "## Summary\n\n[gen-lsp-types](https://github.com/ribru17/gen-lsp-types) is an\nalternative to the lsp-types crate, with types generated via codegen\nfrom the official LSP Metamodel for correctness and completeness.\n\nlsp-types issues fixed in gen-lsp-types:\n\n- https://github.com/gluon-lang/lsp-types/issues/310\n- https://github.com/gluon-lang/lsp-types/issues/308\n- https://github.com/gluon-lang/lsp-types/issues/284\n- https://github.com/gluon-lang/lsp-types/issues/278\n- https://github.com/gluon-lang/lsp-types/issues/277\n- https://github.com/gluon-lang/lsp-types/issues/260\n- https://github.com/gluon-lang/lsp-types/issues/245\n- https://github.com/gluon-lang/lsp-types/issues/93\n\n## Test Plan\n\nAll affected test fixtures updated. Most (all?) are just field\nreordering, struct type name renaming"
+    },
+    {
+      "commit": "b31a5d35eb908ae8357f39576fd55ea87647353e",
+      "subject": "Match 5-character rule codes in ecosystem check (#25677)",
+      "body": "Summary\n--\n\nI noticed while extending the regex to match human-readable names that\nit also didn't cover the\nASYNC rules, which have five letters in the rule code. For example,\n#24644 revealed no new\ndiagnostics in the ecosystem, but a local run on my cached ecosystem\nrepos revealed many\ndiagnostics. This won't show up as a diff in CI on this PR but should\nhelp with ecosystem checks on\nthe ASYNC rules in the future."
+    },
+    {
+      "commit": "f8bd77bb53f369e133ecc857bd85e5f9925633f1",
+      "subject": "[ty] Share parameter lists with `Arc` (#25735)",
+      "body": "## Summary\n\n`Signature` values are cloned throughout callable binding,\ndeduplication, partial application, and specialization. Because\n`Parameters` stored its parameter vector inline, each clone copied the\ncomplete parameter list and retained another allocation.\n\nThis change moves the exact-sized parameter slice and its representation\nkind into a shared `ParametersData` allocation. Cloning a signature now\nclones one `Arc`; the uncommon implicit `self` or `cls` annotation\nupdate uses copy-on-write.\n\nOn Home Assistant, this reduced retained memory from 3,230,014,380 bytes\nto 3,212,250,858 bytes, saving 17,763,522 bytes (0.55%) without\ndiagnostic changes."
+    },
+    {
+      "commit": "a124d03bc159f7fcce1530db7cfda71ef42a2adb",
+      "subject": "Restore nextest in agent test instructions (#25745)",
+      "body": "## Summary\n\nFollowing the discussion in\nhttps://github.com/astral-sh/ruff/pull/25734, we previously removed\n`cargo nextest` from `AGENTS.md` because it was not available in local\nagent sandboxes and the fallback attempts were error-prone. I checked\nthe current local Codex sandbox, and it seems to work for me without\nissue?\n\nThis restores `cargo nextest` as the preferred test runner. I've added\n`cargo test` fallback commands for environments where nextest is\nunavailable."
+    },
+    {
+      "commit": "19158ec3943135cef07fa7e1e95747a625a2a7ca",
+      "subject": "[ty] Reuse Rayon pools across mdtests (#25734)",
+      "body": "## Summary\n\nEach ty mdtest currently constructs a new single-threaded Rayon pool to\nprevent fixture-level work from competing with concurrently running\ntests. With 339 fixtures, this repeatedly creates and tears down worker\nthreads during a full `cargo test` run.\n\nThis change caches one single-threaded pool per test-harness worker.\nFixture execution remains limited to one Rayon thread, while harness\nworkers can reuse their pool across fixtures. In paired benchmarks at\ndefault concurrency, this reduced median mdtest runtime by 7.6%; the\nimprovement was 8.4% at 12 harness threads and 16.2% in single-threaded\nharness execution."
+    },
+    {
+      "commit": "2bb936cb39b6b054d3525829b4d06587492dd2fa",
+      "subject": "Stabilize generated rule code for incremental builds (#25726)",
+      "body": "## Summary\n\nI found this while looking at some changes in `rust` itself. `map_codes`\ngroups rules in a `HashMap` and previously emitted the `Rule::noqa_code`\nmatch arms in hash iteration order. Since that order is randomized\nbetween compiler processes, an unrelated edit could change the generated\nfunction and invalidate a `ruff_linter` codegen unit even when the rule\nmapping itself was unchanged!\n\nOn main, touching then rebuilding only reused 255 of 256 `ruff_linter`\nThinLTO modules (and recompiled the module containing\n`Rule::noqa_code`); with this change, `rustc` reused all 256 modules.\nThis can make incremental rebuilds ~10-15% faster!\n\nHere's the output of `hyperfine --warmup 3 --runs 10 --prepare 'touch\ncrates/ruff_linter/src/codes.rs' 'env CARGO_INCREMENTAL=1\nCARGO_TARGET_DIR=... cargo build -p ruff_linter'`:\n\n```\n Revision             Pass 1             Pass 2    Combined mean\n\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501  \u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501  \u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501  \u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\n HEAD        2.667s \u00b1 0.052s    2.597s \u00b1 0.042s           2.632s\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n HEAD^       3.093s \u00b1 0.043s    3.038s \u00b1 0.038s           3.066s\n```"
+    },
+    {
+      "commit": "9e1cc4298c2e075b916094d759c306ac5bc254f7",
+      "subject": "Fix typo in the message emitted by ruff when a user types `ruff: enable[<rules>]` or `ruff: disable[<rules>]` where `ruff: ignore[<rules>]` is expected (#25700)",
+      "body": ""
+    },
+    {
+      "commit": "89a2816256af5f00eeba54859f33a5bec2fabfd4",
+      "subject": "[ty] Avoid AST load for callable description names (#25728)",
+      "body": "## Summary\n\n`CallableDescription` loaded the parsed module only to read the\nenclosing class name when formatting `Class.method` for function and\nbound-method diagnostics.\n\nThis now recovers the enclosing class from the semantic index and\nformats the name from the original class type metadata, avoiding that\ndirect AST node lookup while preserving the same display text."
+    },
+    {
+      "commit": "b16565efc497624f28d7462235b85f50c62f7af0",
+      "subject": "[ty] Bypass member lookup for module imports (#25723)",
+      "body": "## Summary\n\nThis PR avoids routing `from x import y` module attribute resolution\nthrough the generic `Type::member` path when we already know that `x`\nresolved to a module literal."
+    },
+    {
+      "commit": "5ac2a53ee108f23dc40a63d5378a0d6b21d821c3",
+      "subject": "[ty] Cache constraint implication checks (#25714)",
+      "body": "## Summary\n\nWhen building sequent maps, we repeatedly compare the same ordered pairs\nof range constraints to determine whether one directly implies the\nother. Each comparison performs assignability checks for the lower and\nupper bounds, even when an earlier sequent calculation has already\nchecked the same pair.\n\nThis change caches the final boolean result for each ordered constraint\npair in the constraint-set builder, including negative results. Sequent\nconstruction and solving behavior remain unchanged, while later checks\ncan reuse the existing result."
+    },
+    {
+      "commit": "8cf0c77eb2be9b32ab26bc916a101e9c17674032",
+      "subject": "[ty] Cache upper-bound satisfiability (#25710)",
+      "body": "## Summary\n\nWhen solving a constrained type variable, we repeatedly check whether\nits inferred lower bound can satisfy the declared upper bound under some\nassignment of the remaining type variables. Previously, each occurrence\nrecomputed the same constraint set and satisfiability result.\n\nThis change moves the existential assignability check into a tracked\nquery that caches the final boolean result for each source and target\npair. The solving behavior and cycle recovery remain unchanged, while\nrepeated upper-bound checks can reuse the cached result."
+    },
+    {
+      "commit": "757d823ae9f9f89682e7a003559a8b627934f062",
+      "subject": "[ty] Add support for narrowing on tuple match cases (#25493)",
+      "body": "## Summary\n\nThis PR adds precise narrowing for fixed-length sequence match patterns.\n\nFor a pattern like `[int(), str()]`, we synthesize a protocol whose\n`__len__` and indexed `__getitem__` methods\nencode the pattern\u2019s length and element types:\n\n```python\ndef f(value: object) -> None:\n    match value:\n        case [int(), str()]:\n            reveal_type(len(value))  # Literal[2]\n            reveal_type(value[0])  # int\n            reveal_type(value[1])  # str\n```\n\nWe distinguish between the type _necessary_ to match a pattern and the\ntype _guaranteed_ to match it. Positive\nnarrowing uses the necessary type, while negative narrowing and\nreachability only subtract values guaranteed to\nmatch. This allows exact sequence patterns to participate in\nexhaustiveness analysis without incorrectly treating\nrefutable nested patterns as exhaustive.\n\nCloses https://github.com/astral-sh/ty/issues/561."
+    },
+    {
+      "commit": "2e6f8b86dff0963062a6871cd04c76d8beb9b22e",
+      "subject": "[ty] Compact retained use-def bindings (#25682)",
+      "body": "## Summary\n\n`UseDefMap` currently retains every interned binding state as a\n`SmallVec`, including builder-only capacity and an optional unbound\nconstraint that are no longer needed after semantic indexing finishes.\n\nThis change packs the shadowing policy into the scope-local definition\nID and stores retained binding states as ranges into one contiguous\n`LiveBinding` array. Binding construction and interning behavior remain\nunchanged, while each `LiveBinding` shrinks from 16 to 12 bytes and\nretained states no longer carry per-vector allocation metadata.\n\nOn a large codebase, this reduced retained memory by 2.96% without a\nwall-time regression."
+    },
+    {
+      "commit": "ad70d5006a70aba57cc131e64a7b4106e80b56f3",
+      "subject": "[ty] Use same-file expression inference in reachability (#25694)",
+      "body": "## Summary\n\nReachability currently calls `infer_expression_type` for each expression\nthat it evaluates. This creates and retains a separate Salsa query for\nevery expression, even though reachability only evaluates predicates\nfrom the same file as the enclosing query.\n\nThis uses `infer_same_file_expression_type` instead. The underlying\n`infer_expression_types` query continues to provide caching and cycle\nrecovery, while cross-file callers continue through\n`infer_expression_type`; reachability avoids retaining the redundant\nsingle-expression query layer.\n\nAcross the memory-report projects, retained `infer_expression_type_impl`\nmemory fell by 88% to 95%, reducing total retained memory by 0.15% to\n0.68% without diagnostic changes."
+    },
+    {
+      "commit": "5abb3f4eaf8fed3e25900b63581d29494b588c8f",
+      "subject": "Update ecosystem-analyzer pins (#25708)",
+      "body": ""
+    },
+    {
+      "commit": "44210a4937d2a0ed3be4abdd1b17598e1dfb43aa",
+      "subject": "[ty] Share code-generator classification across specializations (#25701)",
+      "body": "## Summary\n\n`CodeGeneratorKind::from_class` currently keys its retained Salsa query\nby both the class and its specialization, even though type arguments\ncannot change whether a class is dataclass-like, a `NamedTuple`, or a\n`TypedDict`. Generic classes therefore retain duplicate classification\nentries for each specialization.\n\nThis removes specialization from the classification query and evaluates\ninherited code-generator behavior through the unspecialized MRO.\nSynthesized field and member types continue to use their specialization\nat the existing call sites; the added generic `dataclass_transform`\ncoverage verifies that `GenericModel[int]` and `GenericModel[str]`\nretain distinct constructor types."
+    },
+    {
+      "commit": "f414174695c9c2067b04c95b51709c28d27a1d03",
+      "subject": "[ty] Preserve transparent callable decorators (#25030)",
+      "body": "## Summary\n\ntemporary workaround for https://github.com/astral-sh/ty/issues/2278\n\nThis is a temporary fix to special case the `(arg: Callable[P, R]) ->\nCallable[P, R]` callable which takes in a single parameter annotated as\na `Callable[P, R]` and returns the same callable with the same type\nvariables.\n\nThis special case is ofcourse very limited because it only looks for\nspecific `Callable[P, R]` type (and a type alias that corresponds to\nthat callable) and nothing else.\n\n## Test Plan\n\nAdd a couple of test cases both for overloaded and non-overloaded\nfunction."
+    },
+    {
+      "commit": "12095e9b02dc6ad07124f8c0b41ebc91b2aeff0c",
+      "subject": "[ty] Avoid caching trivial class-header queries (#25692)",
+      "body": "## Summary\n\n`StaticClassLiteral` currently creates and retains Salsa queries for\nexplicit bases, inherited generic contexts, `TypedDict` detection,\nmetaclass resolution, inheritance-cycle detection, and code-generator\nclassification even when a class header has no bases or explicit\nmetaclass.\n\nThis records whether those syntax forms are present when constructing\nthe class literal and returns the trivial result before entering the\ntracked query when they are absent. Classes with bases or explicit\nmetaclasses continue through the existing tracked implementations.\n\nOn a large codebase, this reduced retained memory from 93.03 GB to 91.54\nGB, saving 1.49 GB (1.60%) on top of the decorator and type-parameter\nfast paths from #25689, without a runtime regression."
+    },
+    {
+      "commit": "3e70e4a1cade62de93281f007f10721bd4bbe74e",
+      "subject": "[ty] Avoid caching absent class decorators and type parameters (#25689)",
+      "body": "## Summary\n\n`StaticClassLiteral::decorators` and `pep695_generic_context` currently\ncreate and retain Salsa queries for every class, including classes with\nno decorators or PEP 695 type parameters.\n\nThis records whether either syntax form is present when constructing the\nclass literal and returns the empty result before entering the tracked\nquery when it is absent. Decorated and generic classes continue through\nthe existing tracked implementations.\n\nOn a large codebase, this reduced retained memory from 94.04 GB to 92.86\nGB (1.25%) without a measurable runtime regression."
+    },
+    {
+      "commit": "0569f2c27b58b24befb711db18b57157a67b139f",
+      "subject": "[ty] Preserve intersection receivers during attribute lookup (#25626)",
+      "body": "## Summary\n\nWhen looking up an attribute on an intersection, we search each positive\nelement independently. We previously also used that individual element\nas the receiver when binding descriptors and `Self`, which meant we lost\nconstraints:\n\n```python\ndef f(value: Intersection[A, B]):\n    reveal_type(value.method())  # A, previously\n    reveal_type(value.descriptor)  # A, previously\n```\n\nThis change separates (1) the type whose members are searched from (2)\nthe receiver used to bind the resulting attribute. We continue searching\neach intersection element independently, but bind descriptors and Self\nusing the full intersection:\n\n```python\ndef f(value: Intersection[A, B]):\n    reveal_type(value.method())  # A & B\n    reveal_type(value.descriptor)  # A & B\n```\n\nCloses https://github.com/astral-sh/ty/issues/3565.\n\nCloses https://github.com/astral-sh/ty/issues/3600."
+    },
+    {
+      "commit": "1d2286b8f4062c863c3841852c730c6ff3a230f3",
+      "subject": "remove @oconnor663 from the ty-semantic review pool (#25687)",
+      "body": ""
+    },
+    {
+      "commit": "cd72f8f33381f33562d1887c92064690d70bd941",
+      "subject": "[ty] Resolve function descriptors directly (#25675)",
+      "body": "## Summary\n\n`try_call_dunder_get` currently evaluates ordinary function descriptors\nthrough `FunctionType.__get__` and retains a Salsa query for every\nfunction and access context, even though their binding behavior is\nfixed.\n\nThis resolves function literals before entering the tracked query. Class\nmethods bind to the owner, static methods remain unbound, regular\nmethods bind to the instance, and class-level access continues to return\nthe original function. Other descriptor types continue through the\nexisting tracked implementation."
+    },
+    {
+      "commit": "9308c7d304bb69a70095bd5635cc656dd0c57b7e",
+      "subject": "[ty] dynamic class attributes are not instance attributes (#25678)",
+      "body": "## Summary\n\nValues from a dynamic class namespace are class attributes, not direct\ninstance members; treat them that way. This allows them to use the\ndescriptor protocol, matching runtime behavior. It also avoids the\nmembers of a dynamically-created metaclass being treated as existing on\nthe class using that metaclass.\n\nCloses https://github.com/astral-sh/ty/issues/3671\n\n## Testing\n\nAdded mdtests."
+    },
+    {
+      "commit": "e5b5f5c6d2b1824fcd2a6d171657db213708f9ac",
+      "subject": "[`pyupgrade`] Preserve leading empty literals to avoid syntax errors (`UP032`) (#25491)",
+      "body": "## Summary\n\nFixes part of #15874. Converting \"\" \"{}\".format(x) left a leading space\n( f\"{x}\"), a syntax error that ruff then reverted.\n\nLeading empty literals are now preserved rather than dropped, so the fix\nproduces \"\" f\"{x}\". Dropping them outright would also orphan a leading\nparenthesis ((\"\" \"{}\").format(x)) or a comment, so preserving them\navoids those cases too. Middle and trailing empty literals are still\ndropped and trimmed as before.\n\n## Test Plan\n\nNew mdtest at crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md"
+    },
+    {
+      "commit": "568519eafe29e4cc6af19ad264269627945351e2",
+      "subject": "[ruff] add import annotations for UP007 & UP045 (#23259)",
+      "body": "## Summary\n\npart of https://github.com/astral-sh/ruff/issues/19359\n\n## Test Plan\n\nadded tests & snapshots"
+    },
+    {
+      "commit": "Signed-off-by: Bhuminjay <bhuminjaysoni@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "dc79edf868725c5e611f7e3ec1b6d75f2a5d9d65",
+      "subject": "[ty] Add `missing-type-argument` lint rule (#25617)",
+      "body": "## Summary\n\nAdd a new lint that detects generic types used without explicit type\nparameters in annotations (e.g. `list` instead of `list[int]`).\nThis is equivalent to mypy's `--disallow-any-generics` and pyright's\n`reportMissingTypeArgument`.\n\nCan be enabled via:\n```\n    [rules]\n    missing-type-argument = \"warn\"\n```\nIt skips classes where all type parameters have PEP 696 defaults.\n\nThis should fix the following issue in ty:\n- https://github.com/astral-sh/ty/issues/2442\n\n## Test Plan\n\nAdded tests covering stdlib generics, user-defined generics, PEP 696\ndefaults, dotted names, function signatures, base classes, and variable annotations."
+    },
+    {
+      "commit": "Co-authored-by: Jelle Zijlstra <jelle.zijlstra@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "a3ee768a99952414183f3ae3801a939a16ac9347",
+      "subject": "[ty] Compact retained function type signatures (#25669)",
+      "body": "## Summary\n\n`FunctionType` currently stores its optional updated callable signature\nand optional updated implementation signature inline. Ordinary function\ntypes have neither, but every interned value still reserves space for\nboth.\n\nThis groups the uncommon updated signatures into one boxed payload.\nOrdinary function types retain only the function literal and an empty\noptional pointer; specialized function types pay at most one allocation\nand continue to expose the same signatures.\n\nOn a representative package, this reduced retained `FunctionType` memory\nby 56% and total retained memory by 1.05 MB (0.35%). A ten-run isolated\ncomparison showed no runtime regression."
+    },
+    {
+      "commit": "6c67d2e42f1d51b7695ec4645f5fb79e9f35106e",
+      "subject": "[ty] Update typing conformance pin (#25668)",
+      "body": "## Summary\n\nUpdate the typing conformance suite pin to the current `python/typing`\nmain revision. The updated suite makes extra keyword arguments optional\nfor open `TypedDict`s."
+    },
+    {
+      "commit": "d449c411c5002a64fa17662b00bbe4f7a95a583c",
+      "subject": "[ty] Nest member lookup query (#25667)",
+      "body": "See: https://github.com/astral-sh/ruff/pull/25661#discussion_r3364057769"
+    },
+    {
+      "commit": "96a88808b94e49c7e3e9645f6a8d7c41a4280900",
+      "subject": "[ty] Consolidate retained narrowing constraints (#25660)",
+      "body": "## Summary\n\nReachability always requests both positive and negative narrowing\nconstraints for an expression predicate. We currently retain each\npolarity in a separate Salsa query, even though both queries load the\nsame expression and traverse the same predicate.\n\nThis change computes both polarities in one tracked query and returns\nthe pair together to reachability. The positive and negative constraints\nremain separate, but we avoid retaining duplicate query metadata and\narguments."
+    },
+    {
+      "commit": "eb55c291b43615de6af22c919acc8fff07045197",
+      "subject": "[ty] Avoid caching atomic type specializations (#25663)",
+      "body": "## Summary\n\n`apply_specialization` currently creates and retains a Salsa query for\nevery input type, including atomic types whose specialization always\nreturns the original type.\n\nThis change handles those specialization-invariant variants before\nentering the tracked query. Types that can contain type variables\ncontinue through the existing tracked implementation, preserving\nspecialization and cycle behavior.\n\nOn a large codebase, this reduced retained memory by 1.06% without a\nmeasurable runtime regression."
+    },
+    {
+      "commit": "af52481787f4d5ae537796325606d5dfa89cc6d4",
+      "subject": "[ty] Avoid caching trivial member lookups (#25661)",
+      "body": "## Summary\n\n`member_lookup_with_policy` currently creates and retains a Salsa query\neven when the result is known before attribute lookup: for `__class__`,\nand for dynamic, divergent, and `Never` types.\n\nThis change handles those cases before entering the tracked query.\nMaterialized divergent fallbacks and the existing `__class__` ordering\nare preserved; all other lookups continue through the unchanged tracked\nimplementation."
+    },
+    {
+      "commit": "266acf69fad9633c4bec3cd073e486003f190c84",
+      "subject": "tell agents to surface more in reviews (#25664)",
+      "body": "Several of us have been using this guidance (or something similar) for\nCodex reviews locally, and prefer the results. You can always choose to\nignore a finding."
+    },
+    {
+      "commit": "f293d70613261a5dcd1649aa9b726b6cb8289417",
+      "subject": "[`flake8-pytest-style`] Also check `pytest_asyncio` fixtures (#25375)",
+      "body": "## Summary\n\nThe issue https://github.com/astral-sh/ruff/issues/19671 requests\ntreating pytest_asyncio.fixture with the same rule as pytest.fixture.\nLeaving the rule the same, this PR adds the is_pytest_asyncio_fixture\nfunction and matches on that pattern as well.\n\n## Test Plan\n\nUnit tests (including data and cargo insta snapshot) was updated for the\nnew style. In addition, I tested it locally to ensure it matched both\nthe old and new pattern against a local python repo.\n\nIt occurs to me that this will also introduce pytest_asyncio.fixture\nchecks against the other pytest.fixture ones, not _just_ for the\nscope=\"function\" request in the issue. I'm not entirely sure if they are\nrelevant. Meaning, PT001, PT002, etc will all now care about\npytest_asyncio.fixture as well. Maybe that's ok? If we want to limit it\njust to PT003, I will need guidance on how to do that in the existing\ncodebase structure."
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "e89b2b148e14edab0cb2a48963a11af18e8d0a65",
+      "subject": "[ty] Construct trivial constraint sets directly (#25659)",
+      "body": "## Summary\n\n`OwnedConstraintSet::always()` currently uses a `OnceLock` to retain a\nvalue that only contains the `ALWAYS_TRUE` node and empty arenas.\n\nThis constructs the value directly.\n`when_constraint_set_assignable_to_owned` now returns a `Cow`, so\ntrivial relations can return the owned value while nontrivial relations\ncontinue to borrow the Salsa-cached result.\n\nFollow-up to\nhttps://github.com/astral-sh/ruff/pull/25656#discussion_r3362972020."
+    },
+    {
+      "commit": "4ef420da4712d653b3124398b6d2cf519b0bbf7f",
+      "subject": "[ty] Avoid caching constant constraint relations (#25656)",
+      "body": "## Summary\n\n`when_constraint_set_assignable_to_owned` currently creates and retains\na Salsa query for every type pair, even when the relation is trivially\nand unconditionally satisfied.\n\nThis PR recognizes those cases before entering the tracked query and\nreturns a shared `OwnedConstraintSet::always()`."
+    },
+    {
+      "commit": "196ce476af6b533a850ba2957824bb2be483f859",
+      "subject": "Streamline ty ecosystem summary workflow (#25654)",
+      "body": "## Summary\n\n- make the ecosystem-summary skill concise and output-focused, with an\nexplicit report template and separate subagent guidance\n- capture the exact historical Ruff, ecosystem-analyzer, mypy-primer,\nPython, and dependency-cutoff inputs from a GitHub Actions run\n- move detailed minimization guidance into a reference and clarify how\nprimer projects must be reproduced\n\n## Test plan\n\n- `./scripts/collect_ty_ecosystem_run_metadata.py --help`\n- validate both updated skills with `quick_validate.py`\n- `uvx prek run --files <all changed files>`"
+    },
+    {
+      "commit": "dc1ed8e570ee399fb39dc4a23965e74dfd36b5db",
+      "subject": "Render subdiagnostics in the Ruff/ty playgrounds (#25490)",
+      "body": "## Summary\n\n@decorator-factory\n[said](https://discord.com/channels/267624335836053506/891788761371906108/1510258224719204352)\non the Python community Discord that\n\n> Maybe better error messages are a good reason to recommend pyright\nover other things.\n\nIt turns out they'd been evaluating ty's diagnostics purely on the\ndiagnostics they could see in the ty playground. That seems a bit of a\nshame, since we've improved our diagnostics a lot recently thanks to\n@sharkdp's excellent work -- but none of those improvements are visible\nin the playground right now, as the playground doesn't render any\nsubdiagnostics currently!\n\nThis PR adds subdiagnostics to the Ruff and ty playgrounds: both in the\n\"diagnostics\" panel at the bottom of the playground, and in the tooltip\nrendering when you hover over a line with a diagnostic. In both cases,\nsubdiagnostics with annotations are clickable, allowing you to jump\nstraight to the line of code being annotated (even if it's in another\nfile, even if that file is a vendored typeshed stub).\n\nObviously I'm very much not a frontend developer; this patch was very\nmuch Codex-driven. I manually tested it, however, and did several\n`/review` and `$simplify` rounds with Codex before submitting this.\n\n## Test Plan\n\n\n\nhttps://github.com/user-attachments/assets/3418d337-0f34-4e9f-8203-3da2f2008b86"
+    },
+    {
+      "commit": "8884dcd56226e16a7420ca4c9c8ed28a7e62d8c0",
+      "subject": "[ty] Avoid caching missing implicit attributes (#25649)",
+      "body": "## Summary\n\nImplicit attribute lookup currently retains a tracked query for every\nprobed member name, including names that no method in the class can\ndefine. On large projects, these missing-name queries account for most\nof the retained implicit-attribute entries.\n\nThis change aggregates the implicit attribute names for each class in a\ntracked query. Its sorted result can be compared across revisions, so an\nunrelated edit that leaves the names unchanged does not invalidate\ndependent member lookups. For example:\n\n```python\nclass C:\n    def initialize(self):\n        self.present: int = 1\n\nC().present  # Included: a method defines this implicit attribute.\nC().missing  # Not included: no method defines this name.\n```\n\nIncluded names continue through detailed implicit-attribute inference.\nNames that are _not_ included return an unbound member before we create\nan `implicit_attribute_inner` entry. (This only changes which queries we\nretain, not the inferred attribute behavior.)"
+    },
+    {
+      "commit": "dced0e433a222a94d5024e96fe35db8aa5a7e8b5",
+      "subject": "[ty] fix the divergence of recursive inference due to ambiguous overload (#25548)",
+      "body": "Co-authored-by: Jack O'Connor <oconnor663@gmail.com>"
+    },
+    {
+      "commit": "7287ad75a3313004b364d97a4cc8d8369e764e5b",
+      "subject": "Fix playground diagnostics scrollbars (#25642)",
+      "body": "## Summary\n\nThis PR fixes the diagnostics panels' issues list in both playgrounds\nnot being scrollable.\n\nThe issue stems from when the diagnostics panel was made resizable. For\nan element to be `overflow: scroll`, it must have an exact size. Because\nof the resizability of the panel, the issue list was acting as\n`overflow: hidden` instead of `scroll`\n\nTo fix this, I found a workaround: By making the top level panel a\n`container-type: size`, you can then use it's size in future `css`\n`calc`s. Through some manual testing, I found the correct `max-height`\nfor the list is `calc(100cqh - 52px)`. Here the `cqh` refers to the\nparent containers' height. The shrinking of `52px` is needed because of\nthe title bar. In my testing I found that was how large it was, and it\nworks for me on all zoom levels and panel sizes.\n\nI added the `container-type: size` via a class on the `css` style sheet\ninstead of directly on the `Panel` elements because I wasn't sure if it\nmight cause some conflicts with the default styles that get added by the\n`Panel`.\n\n## Test Plan\n\nI tested this by making the changes locally on both playgrounds. I have\nnot tested a full build from source after these changes as I can't build\nruff/ty from source, which would be required. It would be nice (and\nprobably a good idea) if someone who can build ruff/ty from source could\ntest this out locally to make sure it works from my porting into the\ngithub.\n\nNote: Based on the [mozilla\ndocs](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/container-type)\n`container-type: size` should be available on all platforms."
+    },
+    {
+      "commit": "Co-authored-by: Micha Reiser <micha@reiser.io>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "08d98615497a33a99f6431416cfce14f39473608",
+      "subject": "[ty] Refactor how we identify reStructuredText parameters in docstrings (#25605)",
+      "body": ""
+    },
+    {
+      "commit": "63cef3fdaa2b876673d90e74826fb3d4a01827bd",
+      "subject": "Preserve whitespace for Quarto cell option comments (#25641)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "aa894ffa4198bdaa415bb7ea70c71d7dee8d127b",
+      "subject": "Reserve AST Vec's with correct capacity for common cases (#25451)",
+      "body": ""
+    },
+    {
+      "commit": "7c42951802918a70ac775cf623e18364f7d5158c",
+      "subject": "[ty] Check implicit open TypedDict extra items (#25628)",
+      "body": "## Summary\n\nOpen `TypedDict` values can contain hidden extra items with value type\n`object`. This updates call binding to account for those possible values\nwhen a `**TypedDict` argument is matched against a keyword-variadic\nparameter, while continuing to ignore hidden items for callees without\n`**kwargs`.\n\nThis means calls like the following now reject the possible hidden extra\nitems instead of only checking the declared keys:\n\n```py\nclass Options(TypedDict):\n    name: str\n\ndef accepts_ints(name: str, **kwargs: int) -> None: ...\n\naccepts_ints(**Options(name=\"x\"))  # Expected `int`, found `object`\n```\n\nThe same implicit-open behavior also means `functools.partial(...,\n**typed_dict)` cannot be normalized to a precise reduced signature,\nbecause hidden extra items may bind additional keywords at runtime. We\nnow fall back to the broad `partial[ReturnType]` form for those calls,\nmatching Pyright for ordinary open `TypedDict`s."
+    },
+    {
+      "commit": "089da179f6a1e26366b860fef0b1d08ba0e5f449",
+      "subject": "[ty] Preserve literal promotion for mixed bounds (#25648)",
+      "body": "## Summary\n\nWhen inferring a literal against a union containing `Literal` and\nnon-literal elements, we incorrectly preserved the literal whenever it\nmatched any element of the union.\n\n```python\ndef f[T: Literal[1] | str](x: T) -> list[T]: ...\n\nreveal_type(f(\"a\"))  # list[str]\nreveal_type(f(1))    # list[Literal[1]]\n```\n\nWe now mark a literal as unpromotable only when it matches the literal\nportion of the type context.\n\nCloses https://github.com/astral-sh/ty/issues/3665."
+    },
+    {
+      "commit": "a70f81f779856ab4fbcd019c0add42537c6d72a3",
+      "subject": "[ty] Reuse expression cache for TypedDict union inference (#25643)",
+      "body": "## Summary\n\nWhen contextually checking a dictionary literal against a union of\nTypedDicts, we speculatively infer the literal once for each candidate.\nRecursive fields often give the same nested expression the same type\ncontext for every candidate, causing us to repeat the entire nested\ninference at every level...\n\nThis reuses our existing shared expression cache across the candidate\nchecks. We already use the same mechanism during generic-call\nmulti-inference.\n\nThe linked issue drops from roughly 1.5s to 0.03s locally.\n\nCloses https://github.com/astral-sh/ty/issues/3663."
+    },
+    {
+      "commit": "43fefbaf3463be7082f88a5f60ece4011a000107",
+      "subject": "[`ruff`] Ban `pytest` autouse fixtures (`RUF076`) (#25477)",
+      "body": "## Summary\n\n- Closes https://github.com/astral-sh/ruff/issues/12491\n\nThis PR introduces a new Ruff-specific lint rule (`RUF076`) in the\npreview namespace to ban `pytest` fixtures that set the parameter\n`autouse=True` in the decorator constructor.\n\nImplicitly running autouse fixtures is discouraged because it hides test\ndependencies and can introduce subtle side effects (especially when\ndefined in shared `conftest.py` files), making the test suite harder to\nreason about and debug. Explicit parameter injection is preferred.\n\n> [!NOTE]\n> A default banning of all autouse fixtures is opinionated; we may want\nto wait for further configuration settings (such as filtering by scope\nor restricting to `conftest.py` files) and appropriate defaults before\ntaking this rule out of preview.\n\n### Examples\n\n#### Basic\n```python\n# Avoid\n@pytest.fixture(autouse=True)\ndef my_fixture():\n    ...\n\n# Prefer\n@pytest.fixture()\ndef my_fixture():\n    ...\n\ndef test_foo(my_fixture):\n    ...\n```\n\n#### Advanced (Combining Fixtures)\nInstead of using `autouse=True` to avoid repetitive declarations in test\nparameters, multiple related fixtures can be aggregated into a single\nhigh-level fixture and requested explicitly:\n```python\n# Avoid\n@pytest.fixture(autouse=True)\ndef db():\n    return Database()\n\n@pytest.fixture(autouse=True)\ndef cache():\n    return Cache()\n\n@pytest.fixture(autouse=True)\ndef mock_email_client():\n    return MockEmailClient()\n\ndef test_user_creation():\n    ...\n\n# Prefer\n@pytest.fixture\ndef db():\n    return Database()\n\n@pytest.fixture\ndef cache():\n    return Cache()\n\n@pytest.fixture\ndef mock_email_client():\n    return MockEmailClient()\n\n# Combine related dependencies into a single high-level fixture\n@pytest.fixture\ndef app_context(db, cache, mock_email_client):\n    return AppContext(db=db, cache=cache, email=mock_email_client)\n\n# Declare only the combining fixture in the test\ndef test_user_creation(app_context):\n    ...\n```\n\n### Future Enhancements\nDeveloper `TODO` comments have been added to the checker function to\nconsider adding settings for:\n1. Only flagging this rule when the fixture is defined inside a\n`conftest.py` file.\n2. Only flagging this rule when the fixture has a specific scope (e.g.\n`function` scope, which is the default and typically the most costly),\nsupporting a whitelist or blacklist approach.\n\n### References\n- [`pytest` documentation: Sharing fixtures across classes, modules,\npackages or\nsession](https://docs.pytest.org/en/stable/how-to/fixtures.html#scope-sharing-fixtures-across-classes-modules-packages-or-session)\n- [`pytest` documentation: Fixtures can request other\nfixtures](https://docs.pytest.org/en/stable/how-to/fixtures.html#fixtures-can-request-other-fixtures)\n\n## Test Plan\n\nAdded comprehensive test cases in a new test fixture file `RUF076.py`.\nThe rule has been registered under `preview_rules` in\n`crates/ruff_linter/src/rules/ruff/mod.rs` and verified using snapshot\ntesting:\n```sh\nCARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG=\"line-tables-only\" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ruff_linter --rules pytest_fixture_autouse\n```\nWe also ran:\n- `cargo dev generate-all` to generate updated linter schemas and\ndocumentation.\n- `cargo clippy -p ruff_linter --all-targets --all-features -- -D\nwarnings` to verify code quality.\n- `uvx prek` on all changed files to ensure compliance with the\nrepository's formatting/linting hooks."
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <36778786+ntBre@users.noreply.github.com>\nCo-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "30ed3171580b86ec55795d8c2947132677e524b4",
+      "subject": "[ty] Fix anchor point for override diagnostics (#25621)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nThis corrects the range to which we anchor diagnostics for\n`invalid-explicit-override` and `missing-override-decorator` errors.\nBoth are now anchored to a definition in the file currently being\nchecked (which is where the override occurs).\n\nPreviously, we handled this incorrectly for property instances in\nparticular by assuming that [the getter was always the accessor to use\nas the diagnostic\ntarget](https://github.com/astral-sh/ruff/blob/5b9261aa2eb8b501612b1ecb33e8bde1ceb7387b/crates/ty_python_semantic/src/types/overrides.rs#L1206)\n(even if we were actually overriding a different accessor, such as the\nsetter). Now, we correctly consider all property accessors and choose\nthe override in the file being checked as the diagnostic target.\n\nCloses https://github.com/astral-sh/ty/issues/3654.\n\n## Test Plan\n\nPlease see included tests.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "59ff0f73f3ed32cab6fe38e94f46f9005a6987c7",
+      "subject": "[ty] Add generic callable assignability mdtests (#24134)",
+      "body": "## Summary\n\nAdds mdtest coverage for generic callable assignability behavior that\nshould be preserved while the underlying implementation work moves\nthrough the `SpecializationBuilder` constraint-set path.\n\nThe generic callable cases document the expected behavior for\nunconstrained, bounded, and constrained type variables. The\nunbound-method case also covers an outer class type variable\nparticipating in the method signature.\n\nThis also adds regression coverage for two related cases that now pass\non `main`: bounded generic return overrides in Liskov checks, and the\n`map(re.escape, ...)` ecosystem case involving `Unknown` unions.\n\n## Test Plan\n\nThe targeted mdtests cover generic callable assignability with\nunconstrained, bounded, and constrained type variables, unbound generic\nmethods that include outer class type variables, bounded generic return\noverrides, and the `map(re.escape, ...)` ecosystem case involving\n`Unknown` unions."
+    },
+    {
+      "commit": "Co-authored-by: Douglas Creager <dcreager@dcreager.net>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "0fd91a40c07773241f517530879f594abf6b6d6f",
+      "subject": "[ty] Enable narrowing for unions of TypedDict (#25188)",
+      "body": "## Summary\n\nSee the extensive discussion in\nhttps://github.com/astral-sh/ty/issues/3461. To perform sound narrowing\nwith a union of TypedDicts after validating that a key is present, we\ncan intersect the union with a protocol that indicates existence of the\nmember (returning `object`).\n\nCloses https://github.com/astral-sh/ty/issues/3461."
+    },
+    {
+      "commit": "Co-authored-by: Alex Waygood <alex.waygood@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "fd16b26cefdadea5219c593b1bab9b7a571199bb",
+      "subject": "[`flake8-pytest-style`] Clarify diagnostic message for single parameters (`PT007`) (#25592)",
+      "body": "## Summary\n\nClarifies the PT007 diagnostic message when a single parameter is\nprovided. In this case, the row type doesn't really matter and can be\nconfusing, so we now omit it from the diagnostic.\n\n## Test plan\n\nUpdated snapshot tests\n\n## Related\n\nFixes #14743"
+    },
+    {
+      "commit": "5b9261aa2eb8b501612b1ecb33e8bde1ceb7387b",
+      "subject": "[ty] Encapsulate Markdown fence helpers for docstring rendering (#25603)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nThis will make it easier to share those helpers across both the root\n`docstring` module and its forthcoming submodules\n([example](https://github.com/astral-sh/ruff/pull/25605)).\n\n/xref https://github.com/astral-sh/ty/issues/3454\n\n## Test Plan\n\nThis is a pure refactor that is covered by [existing\ntests](https://github.com/astral-sh/ruff/blob/e48a4a24a58db75ea4826056b8094a1c799af5e5/crates/ty_ide/src/docstring.rs#L1228-L1471).\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "85ba4a3243ee5764666859211a716e5fe11f704a",
+      "subject": "[`numpy`] Drop autofix for `np.in1d` (`NPY201`) (#25612)",
+      "body": "## Summary\n\n`np.isin` is not a drop-in replacement for `np.in1d`: for non-1D inputs,\n`np.isin` preserves the input shape whereas `np.in1d` always returns a\nflat array. Auto-fixing `np.in1d(x)` to `np.isin(x)` could therefore\nsilently change behavior, so the replacement is now reported as a manual\nfix with a guideline pointing at `np.isin(...).ravel()`.\n\nThis addresses issue #25604\n\n## Test Plan\n\nThis was tested by running `ruff check --select NPY201` on a test file\nwith `np.in1d` in it.\n\nCo-authored-by: Jackson Romero <romero@deshaw.com>"
+    },
+    {
+      "commit": "6c498ab5394edc5622d7f348e12956bf86203716",
+      "subject": "Bump 0.15.16 (#25635)",
+      "body": ""
+    },
+    {
+      "commit": "e51e132831c4e1c4a5ac00fca4c9256354ab99bf",
+      "subject": "[`flake8-async`] Implement `yield-in-context-manager-in-async-generator` (`ASYNC119`) (#24644)",
+      "body": "## Summary\n\nImplement ASYNC119 from flake8-async, which detects `yield` inside a\ncontext manager (`with` or `async with`) in an async generator function.\n\nThis pattern is unsafe because the cleanup of the context manager may be\ndelayed until the generator is closed, at which point `await` is no\nlonger allowed. This can lead to resource leaks, `RuntimeError`s from\nstructured concurrency violations, or other bugs. See [PEP\n533](https://peps.python.org/pep-0533/) for details.\n\nThe rule suppresses warnings for functions decorated with:\n- `@contextlib.asynccontextmanager`\n- `@pytest.fixture`\n- `@pytest_asyncio.fixture`\n\nThese decorators are known to handle async generator cleanup safely.\n\nPart of https://github.com/astral-sh/ruff/issues/8451\n\n## Test plan\n\n- [x] Added test fixture with error and OK cases\n- [x] Snapshot tests pass\n- [x] `cargo dev generate-all` run\n- [x] `uvx prek run -a` passes\n- [x] Tested against a real 500k+ LOC codebase \u2014 56 true positive\nfindings, no false positives"
+    },
+    {
+      "commit": "Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "7c6dcd9f2611999c449143d241c582dedf287964",
+      "subject": "[ty] Add caching for pattern match narrowing (#25613)",
+      "body": "## Summary\n\nWhen analyzing a `match` statement, we currently rebuild the narrowed\nsubject for every case by collecting all preceding unguarded patterns\ninto a union and intersecting the subject with its negation. As pattern\ntypes become richer, this can repeatedly distribute the same\nintersections and make a chain of adjacent cases exponentially\nexpensive. For example, without _this_ change,\nhttps://github.com/astral-sh/ruff/pull/25493 starts to surface\nsignificant slowdowns in select projects.\n\nAs a concrete example, this small `match` blows up with a 9x regression\nafter #25493, without the caching introduced here:\nhttps://github.com/kornia/kornia/blob/7c2fee7216599a5e6ef149d4ab2fe33dd70f18c3/kornia/io/io.py#L132-L156.\nWithout caching, every branch has to recompute the prefix in `subject &\n~(pattern_1 | pattern_2 | ... | pattern_k-1)`; with caching, we turn it\ninto:\n\n```\nT_0 = subject\nT_i = T_i-1 & ~pattern_i\n```\n\n(Prior to #25493, the sequence patterns generally contributed `Never`\nhere, making it inexpensive.)"
+    },
+    {
+      "commit": "27058fc071b542bf06395ba89cabed061d313ca6",
+      "subject": "[ty] Compact retained definition and expression identities (#25606)",
+      "body": "## Summary\n\nThe semantic index includes a huge number of `Definition` and\n`Expression` ingredients. Both retain file and file-local scope fields,\neven though the existing `ScopeId` identifies both.\n\nThis PR modifies the representations to store definition and expression\nscopes through `ScopeId`, and pack a definition place and re-export\nstate into one enum field. This preserves the existing accessors while\nreducing the fields retained by each tracked ingredient.\n\nI don't _think_ I'm breaking any Salsa rules here, but I've been wrong\nbefore!"
+    },
+    {
+      "commit": "bf80d05f007c939799f530c9e775ed9449f5b2eb",
+      "subject": "Fix CODEOWNERS syntax (#25622)",
+      "body": "Fixes a typo introduced in https://github.com/astral-sh/ruff/pull/25590"
+    },
+    {
+      "commit": "10ccd511e94a81d1e836b174f1c553a73ff3f1b3",
+      "subject": "Shrink additional parser AST collections (#25465)",
+      "body": ""
+    },
+    {
+      "commit": "0d7135f4d23e7f4d8404daed16b9ef11d14f3fb9",
+      "subject": "[ty] Upgrade Salsa (#25545)",
+      "body": ""
+    },
+    {
+      "commit": "49493a3cea83a08fa9aa143695017c816a540f1d",
+      "subject": "[ty] Show type alias value on hover (#25381)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "85207d3b7657a84252f266766cb0d56034dc21cc",
+      "subject": "[ty] sys.implementation.version is not sys.version_info (#25608)",
+      "body": "## Summary\n\nThe way we special-cased `sys.version_info` accidentally also treated\n`sys.implementation.version` as always being the Python version, but\nthis is only true for CPython. This was because both are instances of\n`sys._version_info` class in typeshed, and our special-casing operated\nat the level of that class.\n\nAdjust things so that class is no longer treated as a singleton, and our\nspecial-casing operates at the instance layer rather than the class\nlayer.\n\nThis also allows removing the now-unused\n`ExpandedClassBaseEntry::Synthetic` variant, which allows simplifying\nsome diagnostic code.\n\nCloses https://github.com/astral-sh/ty/issues/3640\n\n## Testing\n\nAdded mdtest."
+    },
+    {
+      "commit": "a8a0614348c1fcf47fc9b666eff61a103914d520",
+      "subject": "[ty] Avoid retaining duplicate function signatures (#25609)",
+      "body": "## Summary\n\nA `FunctionType` currently retains a potentially updated public callable\nsignature and a potentially updated signature for its last definition.\nFor ordinary functions and overload-only functions, the last definition\nis already part of the public callable signature; only an overloaded\nfunction with a separate implementation needs an additional retained\nsignature.\n\nRepresent the additional field as an implementation-only signature.\nOrdinary functions and overload-only functions recover their\nlast-definition signature from the updated public signature, while\noverloaded functions with a separate implementation continue to retain\nthat implementation signature explicitly."
+    },
+    {
+      "commit": "d14149de8edc04463c07f5f12846f6f1920b19bb",
+      "subject": "[ty] Compact retained definition kinds (#25610)",
+      "body": "## Summary\n\nSeveral common `DefinitionKind` variants retain separate references to\nchild AST nodes even though their parent node already retains those\nchildren. Lambda parameter definitions also retain a `usize` index.\n\nRetain parent nodes for annotated assignments, import-from submodules,\nfor statements, comprehensions, and with items, recovering their child\nnodes through the parent when needed. Store lambda parameter indices as\n`u32`.\n\nOn oaiproto, this reduces retained memory by 1,175,760 bytes (0.289%)."
+    },
+    {
+      "commit": "7d747eb22d472dfec1f869a0f5ab81b76d9cf672",
+      "subject": "[ty] Error context for not-iterable diagnostics (#24944)",
+      "body": "## Summary\n\nThe iteration protocol (lowercase) is pretty complex, which is why we\ncannot simply check if something is iterable by trying assignability to\nsome Protocol (uppercase). But in some cases, something is not iterable\nbecause it doesn't follow the semantics of the normal `Iterable`\nProtocol (again, uppercase).\n\nIn those cases, we can use the existing error context machinery to\nprovide more information about why something is not iterable. One\ncomplication here is that the `typing.Iterable`/`typing.Iterator`\nhierarchy in typeshed wants an `__iter__` method on `Iterator`(!), which\nis [mandated](https://docs.python.org/3/glossary.html#term-iterator) by\niterator protocol (lowercase), but often not provided in practice. Here,\nwe solve this by adding new variants of these protocols in\n`ty_extensions` for the sole purpose of generating these assignability\nerror context trees.\n\n## Test Plan\n\nNew and updated Markdown tests"
+    },
+    {
+      "commit": "4e3bec27b4e544d8aff816f4ff298ac93af68414",
+      "subject": "[ty] Optional lower/upper bounds in individual constraints (#25435)",
+      "body": "This is a simpler alternative to #22400. Instead of completely reworking\nour representation of individual constraints, we just wrap the lower and\nupper bounds in `Option`. If either is `None`, that bound is _missing_,\nas opposed to having an explicit `Never` lower bound / `object` upper\nbound. This is much less invasive of a change!\n\nCloses https://github.com/astral-sh/ty/issues/3558"
+    },
+    {
+      "commit": "bc83869b3af949e141feb69e213d518e9e23896f",
+      "subject": "[ty] Reuse common protocol constraints for TypedDict unions (#25598)",
+      "body": "## Summary\n\nPrior to this change, inferring generic protocol type variables from a\nunion of TypedDicts could be extremely slow... This affects calls like\n`dict(item)`, because the `dict` constructor accepts a generic\nstructural protocol.\n\nWhen every member of a TypedDict-only union produces the same protocol\nconstraints as `Mapping[str, object]`, we now\nreuse those common constraints instead of independently combining\nequivalent constraints from every union member.\n\nIdeally, we can remove this special-casing in the future, but it's now\nbeen reported twice so seems worth solving narrowly...\n\nCloses https://github.com/astral-sh/ty/issues/3625.\n\nCloses https://github.com/astral-sh/ty/issues/3521."
+    },
+    {
+      "commit": "e48a4a24a58db75ea4826056b8094a1c799af5e5",
+      "subject": "[ty] Remove special-cased inference for `len()` with `Literal` types (#25602)",
+      "body": "## Summary\n\nThis special-cased inference is unnecessary following\nhttps://github.com/astral-sh/ruff/pull/25600: we now have this\nimplemented in a more generalised way elsewhere, so we can remove this\nwithout any tests failing. It's possibly slightly slower but it's\nunlikely to be a hot path.\n\n## Test Plan\n\nexisting tests"
+    },
+    {
+      "commit": "0e6462c63b8ca559dc194874e64f7e35afe69223",
+      "subject": "[ty] expand type aliases inside type context unions (#25553)",
+      "body": "## Summary\n\nNormalize direct `TypeAlias` members before returning union narrowing\ntargets.\n\nCloses https://github.com/astral-sh/ty/issues/3567\n\n## Testing\n\nAdded mdtests."
+    },
+    {
+      "commit": "Co-authored-by: Alex Waygood <Alex.Waygood@Gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "889f6afc1bd1dded1a3c09e94e4d821c489bad63",
+      "subject": "[ty] Synthesize precise __len__ methods for literals (#25600)",
+      "body": "## Summary\n\nSmall follow-up to #25347.\n\n`len(...)` already returns precise literal lengths for string and bytes\nliterals, but the `__len__` member lookup was returning `int`, which\nprevented exact-length protocol intersections from eliminating\nincompatible literal values.\n\nWe now synthesize precise `__len__` methods for string and bytes\nliterals so checks such as `len(value) == 1` narrow unions of literals\nto the values with matching lengths:\n\n```py\ndef f(x: Literal[b\"\", b\"a\"]):\n    if len(x) == 1:\n        reveal_type(x)  # Literal[b\"a\"]\n```"
+    },
+    {
+      "commit": "d0bf758105c7fcbb800e9b8f4b0af497fffb78e0",
+      "subject": "[ty] Compact retained definition inference results (#25593)",
+      "body": "## Summary\n\nDefinition inference results currently retain separate boxed slices for\nbindings and declarations. Nearly every result has at most one binding\nand one declaration, and the binding and declaration usually refer to\nthe same definition and type.\n\nStore common singleton results in compact boxed variants, sharing the\ndeclaration type with its matching binding when possible. Preserve the\nexisting boxed-slice representation for uncommon multi-entry results.\n\nThis reduces retained memory and removes redundant allocations without\nchanging inference behavior or lookup semantics."
+    },
+    {
+      "commit": "99b34e96fb12bfcf5bce774a715e4988a21a3fc4",
+      "subject": "[ty] Support narrowing on lengths (#25347)",
+      "body": "## Summary\n\nThis PR implements exact-length narrowing for `len(...)` comparisons, as\nproposed by @AlexWaygood in\nhttps://github.com/astral-sh/ruff/pull/22134#issuecomment-4517932605.\n\nWe represent an observed length using an `ExactlySized[Length]`\nprotocol. Existing protocol relation logic can then eliminate\nincompatible fixed-length types. The concrete tuple reconstruction is\ndeliberately left to a general follow-up that simplifies tuple/protocol\nintersections inside `IntersectionBuilder`; for now, we retain the\nprotocol, as in:\n\n```python\ndef _(items: tuple[int] | tuple[str, str] | tuple[int, ...]):\n    if len(items) == 2:\n        # tuple[str, str] | (tuple[int, ...] & ExactlySized[Literal[2]])\n        reveal_type(items)\n```\n\n\nThe constraint is applied to both branches, using `ExactlySized[Length]`\nfor equality and `~ExactlySized[Length]` for inequality.\n\nWe apply this narrowing to arbitrary `Sized` values, including mutable\nobjects like `list`. I think this is somewhat debatable, since mutations\ncan make the persisted constraint stale, but it's not-inconsistent with\nother forms of narrowing.\n\nCloses https://github.com/astral-sh/ty/issues/560."
+    },
+    {
+      "commit": "a63553562cccc520e05607e468453e85c25cd826",
+      "subject": "[ty] Require literal booleans for TypedDict flags (#25594)",
+      "body": "## Summary\n\nThe TypedDict spec requires `total` and `closed` to be literal `True` or\n`False`. We currently accept any expression whose inferred type is a\nboolean literal, such as `closed=42 == 42`. This changes class-header\nand functional `TypedDict(...)` validation to inspect the argument\nsyntax instead of its inferred type."
+    },
+    {
+      "commit": "0d4da852b217c0592c37457d7e6a2539fe123c3a",
+      "subject": "[ty] Suppress importable completions that are already in scope (#25479)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "bc802a8d85e53f63188f49e4276ec1b900b2d37c",
+      "subject": "[ty] Ignore rejected member annotations for synthesized bindings (#25427)",
+      "body": "## Summary\n\nWe now emit `invalid-type-form` for an invalid annotation on a non-name\ntarget (#25324)... But it turns out that we still allow that annotation\nto participate in downstream operations, since we create an\nannotated-assignment definition for it during the indexing pass.\n\nFor example:\n\n```python\ndef accepts_inner(inner: dict[str, int]): ...\n\ndef _(x: dict[str, object]):\n    x[\"inner\"]: dict[str, float | str] = {\"a\": 1, \"b\": \"a\"}  # error: [invalid-type-form]\n    x[\"inner\"][\"c\"] = 1.0  # error: [invalid-assignment] because we infer from the RHS, not the annotation\n    x[\"inner\"] = {\"inner\": {\"a\": 1}}\n    accepts_inner(**x[\"inner\"])  # ok\n```\n\nThe rejected annotation should not widen the dictionary assigned to\n`x[\"inner\"]`, nor should it constrain the later replacement. (The same\nissue applies to rejected attribute annotations, like `obj.inner: T`.)\n\nWe now represent each syntactically indexed declaration outcome as\neither `Declared(...)` or `Rejected`. Declaration consumers only use\n`Declared(...)`."
+    },
+    {
+      "commit": "156f26bae6c49770b7953443251714e502a562a2",
+      "subject": "[ty] Removing myself from ty's codeowners (#25590)",
+      "body": ""
+    },
+    {
+      "commit": "934840356c51937b84d11684dc7d88ee881b6ddc",
+      "subject": "[ty] Register file roots for first-party search paths (#25522)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "b58b5ccbd400c7abc8218eff327d7f9bd9552eec",
+      "subject": "Update Rust crate jiff to v0.2.27 (#25571)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "afe0b4e200f269b2582b98b5a174eaf5d81d6431",
+      "subject": "Update NPM Development dependencies (#25585)",
+      "body": ""
+    },
+    {
+      "commit": "e8bdbd9daa91698acef6272d6ca23bac797b7a7f",
+      "subject": "Update Rust crate compact_str to v0.9.1 (#25587)",
+      "body": ""
+    },
+    {
+      "commit": "1a34347c24a03859a23f171727e0ed37c8e3cc74",
+      "subject": "[ty] Detect disjointness due to incompatible generic specializations (#24822)",
+      "body": "## Summary\n\nPrior to this change, we did not recognize that generic specializations\nwith\nincompatible invariant type arguments are disjoint. A single value\ncannot simultaneously inhabit two specializations of an invariant\ngeneric class when their fully static arguments are not equivalent:\n\n```python\nclass Invariant[T]: ...\nclass A: ...\nclass B: ...\n\nstatic_assert(is_disjoint_from(Invariant[A], Invariant[B]))\n```\n\nWe now recognize disjointness between classes whose inherited bases\ncontain incompatible specializations of the same invariant generic\nclass.\n\n(Covariant generic specializations are not treated as disjoint by this\nchange; for example, an empty container can inhabit both `Sequence[int]`\nand `Sequence[str]`).\n\nCloses https://github.com/astral-sh/ty/issues/3314."
+    },
+    {
+      "commit": "Co-authored-by: Carl Meyer <carl@astral.sh>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "270e930ae81a3e4ec5f17b8dd9d22794d0983603",
+      "subject": "Update Rust crate memchr to v2.8.1 (#25586)",
+      "body": ""
+    },
+    {
+      "commit": "9f7591d61d3a9e940a4103aa3f1036a9f09065b4",
+      "subject": "[ty] Reject Self in type aliases (#25529)",
+      "body": "## Summary\n\nThe\n[spec](https://typing.python.org/en/latest/spec/generics.html#valid-locations-for-self)\nsays: \"We reject type aliases containing `Self`.\" Some type checkers,\nsuch as Pyright, support class-scoped aliases containing `Self`, but\nMypy rejects them.\n\nThis change rejects `Self` in the value of explicit PEP 613 `TypeAlias`\ndeclarations and PEP 695 `type` statements:\n\n```python\nfrom typing import Self, TypeAlias\n\nclass C:\n    Alias: TypeAlias = tuple[Self]  # error\n    type OtherAlias = tuple[Self]  # error\n```\n\nFor rejected PEP 613 aliases, we recover `Self` as `Unknown` even when\n`invalid-type-form` is disabled, so suppressing the diagnostic does not\npreserve a receiver-bound `Self` type.\n\nImplicit aliases, PEP 695 alias type-parameter bounds and defaults,\ndirect `TypeAliasType(...)` definitions, and `Self` introduced\nindirectly through runtime-expression forms remain unchanged for now.\n`Self` in runtime-expression positions such as `Annotated` metadata also\nremains allowed because those expressions are not part of the alias\nvalue type expression."
+    },
+    {
+      "commit": "6b7c345c932640d3b4b90b9aa002d16f949ebb3a",
+      "subject": "Update Rust crate log to v0.4.30 (#25572)",
+      "body": ""
+    },
+    {
+      "commit": "26ac6f4fcda1e5ce414a76cb45c97dc30355e31f",
+      "subject": "Update Rust crate mimalloc to v0.1.52 (#25573)",
+      "body": ""
+    },
+    {
+      "commit": "0575be14765317b932377fc08040555f6e974afa",
+      "subject": "Update Rust crate similar to v3.1.1 (#25575)",
+      "body": ""
+    },
+    {
+      "commit": "1dbf569a3ddeda5c93c35a123955fb999c61a9d1",
+      "subject": "Update docker/setup-buildx-action action to v4.1.0 (#25580)",
+      "body": ""
+    },
+    {
+      "commit": "cd92af52208f88947f08ef33647d716428db8086",
+      "subject": "Update docker/metadata-action action to v6.1.0 (#25579)",
+      "body": ""
+    },
+    {
+      "commit": "3f4a955b4f7984480def1c2a084a4c3f079f6fee",
+      "subject": "Update docker/login-action action to v4.2.0 (#25578)",
+      "body": ""
+    },
+    {
+      "commit": "3e43d18da11e4455b8bc34ef315bf2010382bb32",
+      "subject": "Update docker/build-push-action action to v7.2.0 (#25577)",
+      "body": ""
+    },
+    {
+      "commit": "78de5152a2aa4e39378586e355211796c9e6e49d",
+      "subject": "Update taiki-e/install-action action to v2.79.9 (#25576)",
+      "body": ""
+    },
+    {
+      "commit": "d21f268f1df489b67a8ea4036428a77d616d25e1",
+      "subject": "Update Rust crate serde_json to v1.0.150 (#25574)",
+      "body": ""
+    },
+    {
+      "commit": "e5698d02b3e7d26f8800877e67d96c01c8add77d",
+      "subject": "Update Rust crate assert_fs to v1.1.4 (#25570)",
+      "body": ""
+    },
+    {
+      "commit": "4a9fa603dd0afc142f726ebc4205f880b5ceffbe",
+      "subject": "Update prek dependencies (#25569)",
+      "body": "This PR contains the following updates:\n\n| Package | Type | Update | Change | Pending |\n|"
+    },
+    {
+      "commit": "This PR was generated by [Mend Renovate](https://mend.io/renovate/).\nView the [repository job\nlog](https://developer.mend.io/github/astral-sh/ruff).\n\n<!--renovate-debug:eyJjcmVhdGVkSW5WZXIiOiI0My4yMDkuMCIsInVwZGF0ZWRJblZlciI6IjQzLjIwOS4wIiwidGFyZ2V0QnJhbmNoIjoibWFpbiIsImxhYmVscyI6WyJpbnRlcm5hbCJdfQ==-->\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "39a643445296301235057bd1cf43e8e063b3d3c2",
+      "subject": "Update dependency ruff to v0.15.15 (#25568)",
+      "body": ""
+    },
+    {
+      "commit": "0b982ea69c69f504f344fea5c8b06173183d4397",
+      "subject": "Update dependency pyright to v1.1.410 (#25566)",
+      "body": ""
+    },
+    {
+      "commit": "a1782f3e02c9bb257b8ade877d419ffcee17f76d",
+      "subject": "Update dependency astral-sh/uv to v0.11.18 (#25565)",
+      "body": ""
+    },
+    {
+      "commit": "2f7c23052820e87fb9b0510e60726bb40eb88f5f",
+      "subject": "[ty] don't needlessly disambiguate same type alias (#25563)",
+      "body": "## Summary\n\nAvoid qualifying different specializations of the same generic type\nalias in diagnostic display names.\n\nCloses https://github.com/astral-sh/ty/issues/3519\n\n## Testing\n\nAdded mdtest."
+    },
+    {
+      "commit": "9c972a6eccd4d686a6e2e14341a179c557bd02b3",
+      "subject": "[ty] fix variance inference for nested type aliases (#25567)",
+      "body": "## Summary\n\nExpand `TypeAliasType` during variance inference so alias-of-alias\nchains preserve the underlying variance.\n\nCloses https://github.com/astral-sh/ty/issues/3518\n\n## Testing\n\nAdded unit test."
+    },
+    {
+      "commit": "2965c98cb5b4fbce65aa9a271da1c38b6730ba80",
+      "subject": "[ty] treat union-bound typevars like unions for possibly-missing-attribute (#25561)",
+      "body": "## Summary\n\nTreat bounded `TypeVar`s like their upper bound when deciding whether a\n`possibly-missing-attribute` should be promoted to\n`unresolved-attribute`. We missed this case in\nhttps://github.com/astral-sh/ruff/pull/23042, and then we disabled\n`possibly-missing-attribute` by default, so on main we are silent by\ndefault when accessing an attribute that is missing on some elements of\na typevar upper-bound union.\n\n## Testing\n\nAdded mdtest."
+    },
+    {
+      "commit": "6b4082451d8bdcead0859eac9ad75351ad63e3bd",
+      "subject": "[ty] include nested `global`/`nonlocal` bindings in type inference (#25387)",
+      "body": "Here's the basic `nonlocal` case:\n\n```py\ndef f():\n    x = 42\n    def g():\n        nonlocal x\n        x = \"hello\"\n    g()  # NOTE: Inference doesn't ask whether `g` is actually called here. We assume it could be called.\n    reveal_type(x)  # revealed: Literal[42, \"hello\"]\n```\n\n`global` declarations work similarly:\n\n```py\nx = 0\ndef f():\n    global x\n    x += 1\n# NOTE: As above, the fact that `f` isn't actually called doesn't affect inference.\nreveal_type(x)  # revealed: int\n```\n\nHere's the general behavior, which is deliberately a bit unsound:\n\n- After the close of each function or class scope, we synthesize\nbindings that refer to all the nested `global` or `nonlocal` bindings\ntransitively within that scope.\n- These \"synthetic nested binding definitions\" don't shadow existing\nbindings, and they aren't shadowed by subsequent bindings, modeling the\nfact that nested function bodies can run \"at any time\".\n- Using a variable `x` in scope that doesn't bind it ends up walking to\nits defining scope and seeing its \"public type\", which includes all\nnested bindings in every scope. But if you bind `x` locally, that\nshadows the public type. On the other hand, synthetic bindings\ncorresponding to scopes nested within the current scope still count as\nlocal. (So generally parent and sibling scope bindings will get\nshadowed, but not child scope bindings.)\n\nFor more of the details here see the new mdtests, particularly\n\"Visibility of `nonlocal` bindings from nested and sibling scopes\"."
+    },
+    {
+      "commit": "d7f1a5b72ba98776126389f25da85ef3c58755f8",
+      "subject": "[ty] Preserve slice-bound types in subscript inference (#25446)",
+      "body": "## Summary\n\nPrior to this change, when a slice bound was not an integer literal,\nboolean literal, or `None`, we inferred a bare `slice[Any, Any, Any]`.\nThis erased enough information that subscription checking accepted\ninvalid slices even when `__getitem__` requires `SupportsIndex | None`\nbounds:\n\n```python\ndef get(values: list[int], start: float) -> list[int]:\n    return values[start:]  # error: [invalid-argument-type]\n```\n\n(This may have been waiting on\nhttps://github.com/astral-sh/ruff/commit/cb58704e085fe7e70d72842294575de47e47bead?)\n\nWe now preserve the inferred type of each provided slice bound in\n`slice[...]`, so ordinary argument checking diagnoses invalid bounds for\nbuilt-in sequences and user-defined `__getitem__` methods with typed\nslice parameters.\n\nCloses https://github.com/astral-sh/ty/issues/3547."
+    },
+    {
+      "commit": "5ae991932b22326902f49176663190f21f11a022",
+      "subject": "[ty] Normalize dynamic class literals in cycle recovery (#25558)",
+      "body": "## Summary\n\nA dynamically created class can capture the previous value of a\nloop-carried variable in its members or bases. Prior to this change, we\ntreated class literals as atomic during recursive type normalization, so\nthe class's interned identity kept growing on each inference cycle and\nSalsa eventually panicked after too many cycle iterations.\n\nCloses https://github.com/astral-sh/ty/issues/3627."
+    },
+    {
+      "commit": "f83e48cabc2971108870bcddcc81ed7674598476",
+      "subject": "[`pylint`] Avoid syntax errors in invalid character replacements in f-strings before Python 3.12 (`PLE2510`, `PLE2512`, `PLE2513`, `PLE2514`, `PLE2515`) (#25544)",
+      "body": "## Summary\n\nFixes #18816.\n\nWhen a raw control character appears inside an f-string replacement\nfield or format spec, replacing it with an escape sequence can introduce\ninvalid pre-3.12 syntax. This keeps the diagnostic, but suppresses the\nfix for interpolated f-string/t-string elements when the target version\nis older than Python 3.12. Literal f-string text and Python 3.12+\ntargets keep the existing fix behavior.\n\n## Test plan\n\n- `cargo test -p ruff_linter --features test-rules invalidcharacter`\n- `cargo test -p ruff_linter --features test-rules\nrules::pylint::tests::invalid_characters_pre_py312`\n- `cargo fmt --check`\n- `git diff --check`"
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "bc52b711c0c9f85080632b613e85416c70527fe7",
+      "subject": "[`pyupgrade`] Avoid converting `format` calls with more kinds of side effects (`UP032`) (#25484)",
+      "body": "## Summary\n\nFixes part of #15874: UP032 unsoundly converted str.format calls that\nrepeat a side-effecting argument. The check only\ncaught calls, so a repeated d[k] or walrus slipped through. Switch it to\ncontains_effect.\n\n## Test Plan\n\nNew mdtest at crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md."
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "8aaa13eceb7c332399b494140b17f2ffebdd02be",
+      "subject": "Run ecosystem-analyzer on all mypy_primer projects (#25549)",
+      "body": "Update to the latest version of ecosystem-analyzer. This version does\naway with the `--projects-old` and `--projects-new` flags, instead\nrunning ecosystem-analyzer on all mypy_primer projects. If panics on\npanicking projects are fixed, that will be celebrated by\necosystem-analyzer; if new panics are introduced, that will be announced\nloudly by ecosystem-analyzer, but we don't need to worry about adding\nthe project to a bad.txt file anymore. We also don't need to worry\nanymore about keeping these lists up to date with the upstream list of\nprojects in mypy_primer itself."
+    },
+    {
+      "commit": "d08cde09a057e34b87e117d5c4f6825ee6421525",
+      "subject": "[`eradicate`] Avoid flagging `ruff:ignore` comments as code (`ERA001`) (#25537)",
+      "body": "Summary\n--\n\nFixes #25535 by treating `ruff:ignore` and `ruff:file-ignore` comments\nin the same way as `ruff:enable` and `ruff:disable` comments.\n\nTest Plan\n--\n\nNew tests based on the issue"
+    },
+    {
+      "commit": "4828decefa910db8d920c7c384c57b5332a8eb9f",
+      "subject": "[ty] ty: fix typos in completion.rs comments (#25532)",
+      "body": "Signed-off-by: RoySerbi <roy676564@gmail.com>"
+    },
+    {
+      "commit": "06dd02bcf7167c4ae530e7ce30a66dfabef8160f",
+      "subject": "[ty] don't inject Unknown from non-callable elements of intersection call (#25538)",
+      "body": ""
+    },
+    {
+      "commit": "44c2a46470f66904a925803e2f6b3c794c4ce7c7",
+      "subject": "[ty] Omit redundant definitions-by-node entries (#25501)",
+      "body": "## Summary\n\nThis is a follow-up to #25498 to omit redundant entries from the\nretained mapping between AST nodes and definitions.\n\nLoop-header definitions are internal use-def bindings retrieved through\ntheir `LoopToken`, so we no longer retain mappings from their enclosing\n`while` or `for` statements.\n\nFor non-variadic parameters, we previously retained duplicate mappings\nfrom both the outer `ParameterWithDefault` node and the inner Parameter\nnode to the same definition. This PR consistently uses the inner node as\nthe key and normalizes lookups from the outer node accordingly."
+    },
+    {
+      "commit": "83b08f3b94e60eaf1c07cdb0175f63ff9de57e67",
+      "subject": "[ty] use callable type context to implicitly specialize generic class (#25471)",
+      "body": "## Summary\n\nUse a callable type context to inform the implicit specialization of a\ngeneric class.\n\nCloses https://github.com/astral-sh/ty/issues/3577.\n\n## Test Plan\n\nAdded mdtests."
+    },
+    {
+      "commit": "Co-authored-by: Douglas Creager <dcreager@dcreager.net>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "c9ce22a9585975de284b72984df0f8e7aa2568ac",
+      "subject": "[ty] Compact retained definitions by node (#25498)",
+      "body": "## Summary\n\nWhen we build the semantic index, we retain a mapping from\ndefinition-producing AST nodes to their definitions. Most nodes have\nexactly one definition, but we currently store every entry in the\nappend-friendly `Definitions` representation used while building the\nindex.\n\nThis PR compacts the mapping when we freeze the semantic index. We store\ncommon single-definition entries directly and reserve exact-size boxed\nslices for uncommon entries with zero or multiple definitions (including\nwildcard imports and synthesized loop headers).\n\n(The primary motivation here is reducing memory.)"
+    },
+    {
+      "commit": "11723aeb5b9bcdbc25240c9bb04908057c862100",
+      "subject": "[ty] Add mdtest extension functions for constraint-set assignability (#25534)",
+      "body": "This adds two new extension methods that were helpful while I was\nreviewing #25471:\n\n- `ConstraintSet.with_detailed_display` causes us to print out the full\nboolean formula of a constraint set. I put this behind a method so that\nwe aren't tempted to add mdtests that assert on the rendering of a\nconstraint set, since this can change arbitrarily (even across different\nruns of ty).\n\n- `is_constraint_set_assignable_to` lets us test the\n`ConstraintSetAssignability` typing relation, which differs from\n`Assignability` in how it handles comparisons against typevars."
+    },
+    {
+      "commit": "06e77271bb4522ded6feb45269e86b4a5e8d454c",
+      "subject": "[ty] Consolidate retained use-def definition maps (#25499)",
+      "body": "## Summary\n\nWhen we build the use-def map, we retain prior bindings for each\ndefinition and prior declarations for each binding. These were\npreviously stored in two separate hash maps, even though every entry in\nthe declarations map had a corresponding entry in the bindings map.\n\nThis PR consolidates them into a single map. Each retained definition\nstores its prior bindings and, when needed, its\nprior declarations. This removes the duplicated keys and the overhead of\nretaining a second hash table.\n\n(The primary motivation here is reducing memory.)"
+    },
+    {
+      "commit": "3a200ce85a602c0eb19639ed696fea7e4a36323c",
+      "subject": "[ty] Distinguish `typing.Callable` from `collections.abc.Callable` (#24954)",
+      "body": "## Summary\nhttps://github.com/astral-sh/ty/issues/887\n\nThis is a blocker to supporting `Callable()` in class patterns in match\nstatements (discussion\n[below](https://github.com/astral-sh/ruff/pull/24954#discussion_r3171744197)).\n`typing.Callable` is a deprecated alias to `collections.abc.Callable` -\ncalling the former raises a `TypeError` at runtime whereas the latter\ndoesn't.\n\nTo allow `Callable()` to be used in `match` statements, we need to be\nable to distinguish between the two.\n\nComplication: typeshed defines `collections.abc.Callable` as a re-export\nalias from `typing` (`collections/abc.pyi` -> `_collections_abc.pyi` ->\n`from typing import Callable as Callable`). This required some\nadditional plumbing to pass `collections.abc` through as the known\nmodule (the re-exporting module) vs `typing`\n\n## Test Plan\nNew mdtests"
+    },
+    {
+      "commit": "Co-authored-by: L\u00e9r\u00e8 <contact@lrbr.dev>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "bdf9f0022f48adb377b850e9ce9ec9810657194d",
+      "subject": "[ty] Consolidate AST ID reverse lookup (#25455)",
+      "body": "## Summary\n\nConsolidates the per-scope AST ID reverse lookup maps into a single\nfile-level map. IDs are still assigned per scope, preserving stable\nouter-scope IDs while reducing retained map overhead."
+    },
+    {
+      "commit": "aa76512529ddbfdb36d1be36654e40f5e07fe434",
+      "subject": "[`flake8-pytest-style`] Avoid fixes for ambiguous `argnames` and `argvalues` combinations (`PT006`) (#24776)",
+      "body": "Fixes #24715 and related to #22441\n\n## Summary\n\nThis prevents changes that break code (almost certainly) in rule\n[PT006](https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/#pytest-parametrize-names-wrong-type-pt006).\n\nConsider the following examples:\n```python\nimport pytest\n\nTEST_CASES = [...]\n@pytest.mark.parametrize((\"number\",), TEST_CASES)\ndef foo(number): ...\n\ndef generate_test_case():\n    ...\n\n@pytest.mark.parametrize((\"number\",), (generate_test_case(),))\ndef foo(number): ...\n\nsingle_test_case = ...\n@pytest.mark.parametrize((\"number\",), [single_test_case])\ndef foo(number): ...\n```\nBefore this change, the `argnames` would be updated, which would\nprobably break the test. After this change, no fix will be applied.\n\n## Test Plan\n\nI added one test, but mostly fixed existing tests."
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "ec248a28b30f6f20091c3d9b6f31a0ba36f57186",
+      "subject": "[ty] Avoid redundant solve for empty collection context (#25527)",
+      "body": "## Summary\n\nAvoid building and solving a `SpecializationBuilder` constraint set for\nan empty collection literal when contextual inference has already\nprovided its complete specialization.\n\nFor this case, directly apply the contextual specialization and return\nthe resulting collection instance.\n\n## Motivation\n\nProfiling pydantic exposed an expensive path for empty collection\nliterals with large contextual types. Even when the context completely\ndetermines the collection type variables and the literal has no elements\nthat could add information, inference continued through constraint\nprojection and solving.\n\nThis is especially expensive for pydantic's large schema unions.\n\n## Validation\n\nExisting tests pass, no ecosystem diagnostic changes."
+    },
+    {
+      "commit": "6b717e8d553a8076f6927894e221064a923aa13a",
+      "subject": "[ty] detect recursive expansion in constraint-set solving (#25442)",
+      "body": "## Summary\n\nCatch infinite recursive expansion in constraint-set solving.\n\nCloses https://github.com/astral-sh/ty/issues/3578\n\n## Test Plan\n\nAdded test that runs forever before this fix."
+    },
+    {
+      "commit": "b82dfe720b5656acc462390999a5b12d0df42ee0",
+      "subject": "[ty] Extend Generator assignability workaround to Python 3.13+ (#25472)",
+      "body": "## Summary\nKeep the `Generator` nominal-assignability special case enabled on\nPython 3.13+ to avoid spurious `None` inference through `close() ->\nReturnT | None`.\n\nCloses https://github.com/astral-sh/ty/issues/3583\n\n## Testing\nAdded a regression mdtest."
+    },
+    {
+      "commit": "099c89fe76117fdee24e910c286dbc4b56301ffa",
+      "subject": "[ty] Compact retained semantic maps (#25238)",
+      "body": "## Summary\n\nThis is a follow-up to #25102 to apply the same principles to a few more\ncollections. The benchmarks look good (-1% on some micro-benchmarks, +1%\non some real projects) and there are moderate memory savings."
+    },
+    {
+      "commit": "7ef96bec9a1e8029e34ac3047c3ac13281f36911",
+      "subject": "[`pydocstyle`] Improve discoverability of rules enabled for each convention (#24973)",
+      "body": "## Summary\n\nImproves discoverability of `pydocstyle` convention-based rule filtering\nby moving the authoritative documentation from the FAQ into the\n`lint.pydocstyle.convention` settings reference, per #15217.\nCloses #15217.\n\n## Test Plan\n\nDocumentation-only change no functional code modifications.\n\nVerification steps:\n1. Ran `cargo dev generate-docs` to regenerate `docs/settings.md` and\n`ruff.schema.json` from updated docstrings\n2. Ran `cargo fmt --all` to ensure Rust formatting compliance\n3. Ran `cargo clippy --workspace --all-targets --all-features -- -D\nwarnings` - no new warnings\n4. Served docs locally with `uvx --with-requirements\ndocs/requirements.txt -- mkdocs serve -f mkdocs.yml` and verified:\n- The `lint.pydocstyle.convention` section renders with the new content\n   - The FAQ back-reference links to the settings section as intended\n   \n   ## Screenshots\n   \n   ### `/ruff/settings/#lint.pydocstyle`\n\n<img width=\"1920\" height=\"957\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d35e94a0-0968-43fb-bfe5-dd2821655716\"\n/>\n\n### `/ruff/faq/#does-ruff-support-numpy-or-google-style-docstrings`\n\n<img width=\"1920\" height=\"952\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b8904757-f7c9-43c7-ac20-e0fbdb713acd\"\n/>"
+    },
+    {
+      "commit": "Signed-off-by: RafaelJohn9 <rafaeljohb@gmail.com>\nCo-authored-by: Brent Westbrook <36778786+ntBre@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "0f9b81063c8cd6c80e89c02917516be89362e48b",
+      "subject": "[ty] Deduplicate retained use-def place states (#25450)",
+      "body": "## Summary\n\nWhen we finish building a semantic index, we retain the end-of-scope and\nreachable bindings and declarations for every symbol and member. We\nalready interned some of these values, but retained symbol states and\nreachable states were still stored inline. Many of those states repeat,\nespecially for undefined places. This PR stores retained use-def states\nas compact IDs into the existing bindings and declarations arenas.\n\nI think the tradeoffs here are favorable: a 2.85% memory reduction on\nPrefect, a +1% walltime change on some real projects, a -1% a few\nothers, and up to -3% on some of the micro-benchmarks. But it's a big\nmemory win."
+    },
+    {
+      "commit": "5ce05c733252a78455d0079206927a7bc8f18159",
+      "subject": "[ty] reduce features of low-level crates depended on by `ty_python_semantic` (#25524)",
+      "body": "## Summary\n\nAccording to Codex, this gives us a small improvement in compile times"
+    },
+    {
+      "commit": "a3c71eb741d4be0225bc8fc08ee3fbcae1289772",
+      "subject": "[ty] Fix narrowing enum literal unions by member identity (#25520)",
+      "body": "## Summary\n\nPrior to this change, we failed to narrow a union containing an\nexplicitly annotated enum literal (e.g., `x: list[int] |\nLiteral[Answer.NO]`) when comparing it against the corresponding enum\nmember:\n\n```python\nfrom enum import Enum\nfrom typing import Literal\n\nclass Answer(Enum):\n    NO = 0\n    YES = 1\n\ndef f(x: list[int] | Literal[Answer.NO]):\n    if x is Answer.NO:\n        return\n    # Before: list[int] | Literal[Answer.NO]\n    # After: list[int]\n    reveal_type(x)\n```\n\nWe were comparing the outer literal types, so the intersection builder\nfailed to recognize that both types represented the\nsame enum member.\n\nNow, we compare the underlying enum-literal identities instead,\nrestoring narrowing for `is`, `is not`, `==`, and `!=`.\n\nCloses https://github.com/astral-sh/ty/issues/3606."
+    },
+    {
+      "commit": "e151e96d867e0a6567472b6283f502979d3b195b",
+      "subject": "[ty] Test tagged union narrowing for named tuples (#25519)",
+      "body": "## Summary\n\nAdd an mdtest showing that tagged-union narrowing also works for\n`NamedTuple` classes."
+    },
+    {
+      "commit": "8579296926a3dcf567fd488865d29e6ae43c8fc9",
+      "subject": "[ty] Disallow file-system access in `ty_python_core` (#25518)",
+      "body": "## Summary\n\nAll other ty crates have this in their `lib.rs` to enforce that\nfilesystem access goes via the `System` abstraction (ensuring that it is\ntracked by Salsa). This was missed in\nhttps://github.com/astral-sh/ruff/commit/461994073e2f6cac13a28e60b06038ba50214ffc."
+    },
+    {
+      "commit": "cc5a78aadafa77a9d5b711ac57b2b3138c729c5b",
+      "subject": "[ty] Nominal Tagged Union Narrowing (#24916)",
+      "body": "## Summary\nAdds narrowing for tagged unions of nominal class instances based on\nliteral attribute comparisons. Addresses part of astral-sh/ty#1479.\nRelated to astral-sh/ty#2897.\n\nThis allows ty to narrow code such as `x.tag == \"a\"`, `\"a\" == x.tag`,\n`x.tag != \"a\"`, and `match x.tag` when `x` is a union of classes whose\ntag attributes are annotated with supported literal types.\n* non-literal tag arms are preserved during positive narrowing\n* impossible literal arms are removed\n* unsupported cases such as enum literals are left for future work\n\nTo keep the performance impact small, the new place tracking is gated by\ncomparison operator. We only add base places for attribute/subscript\nexpressions when the operator can produce a relevant narrowing\nconstraint, which avoids extra Salsa narrowing queries for unrelated\ncomparisons.\n\n\n## Test Plan\n\n* Updated md tests\n* Ran ecosystem analyzer on pydantic and prefect\n* Ran memory profiler\n\nCo-authored-by: David Peter <mail@david-peter.de>"
+    },
+    {
+      "commit": "a6ad57f5c27119dca5b7ce2e68c5139bb93d5dd9",
+      "subject": "Commit `scripts/uv.lock` (#25517)",
+      "body": "## Summary\n\nSome of the scripts in this directory are standalone PEP-723 scripts,\nbut other scripts in this directory depend on the dependencies in\n`scripts/pyproject.toml` being installed. If you run any of these\nscripts with `uv run`, uv creates a `scripts/uv.lock` file, but we\nhaven't committed it up till now. We probably should, for\nreproducibility and security apart from anything else. It also makes\nlife less confusing for agents, which are often perturbed by generated\nfiles unexpectedly popping up locally."
+    },
+    {
+      "commit": "88d851449d2345e11da991794f3e9bfbbd666719",
+      "subject": "Fix potential index out of range in `LineIndex` computation (#25492)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "a8d0fffc4d72da193b2a2ae4c53277fdf1f1794d",
+      "subject": "[ty] Sync vendored typeshed stubs (#25514)",
+      "body": "Close and reopen this PR to trigger CI"
+    },
+    {
+      "commit": "Co-authored-by: typeshedbot <>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "dba3619fb385289cd43705609708efc0230ea6a6",
+      "subject": "[ty] Add disjointness for protocol method members (#25315)",
+      "body": "## Summary\n\nThis PR implements disjointness checking for protocols with method\nmembers by comparing non-`Never` return types, e.g., we now understand\nthat a fixed-length tuple whose synthesized `__len__` returns\n`Literal[3]` is disjoint from a protocol requiring `__len__` to return\n`Literal[2]`:\n\n```python\nfrom typing import Literal, Protocol\nfrom ty_extensions import is_disjoint_from, static_assert\n\nclass HasLengthTwo(Protocol):\n    def __len__(self) -> Literal[2]: ...\n\nstatic_assert(is_disjoint_from(tuple[int, int, int], HasLengthTwo))\n```\n\nThis is a prerequisite for using synthesized exact-length protocols to\nnarrow unions of fixed-length tuples and sequence patterns (see:\nhttps://github.com/astral-sh/ruff/pull/22134#issuecomment-4517932605).\n\nPer that comment, this isn't fully sound: a subclass can override an\notherwise incompatible method with a `Never`-returning implementation\nand therefore inhabit both types that we infer to be disjoint."
+    },
+    {
+      "commit": "6d2ca1a4c3466a27095439e5899dc7e7cd894090",
+      "subject": "[ty] Use compact sets for more immutable fields (#25476)",
+      "body": ""
+    },
+    {
+      "commit": "f4923acb7cb015d26a5512c9139b8b890cb28211",
+      "subject": "[ty] Derive `Default` for `FunctionDecoratorInference` (#25482)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\n\n## Test Plan\n\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "6c88390f7d49068c6fc2a0102145c3bdd5318e35",
+      "subject": "[ty] Ignore rejected assignments for synthesized bindings (#25340)",
+      "body": "## Summary\n\nPrior to this change, we were retaining \"known key\" bindings from the\nright-hand side of an assignment even when the enclosing assignment was\nrejected. For example:\n\n```python\ndef _(x: dict[str, int]):\n    x = {\"a\": \"bad\"}  # error: invalid-assignment\n    reveal_type(x[\"a\"])  # Should be int, but main shows Literal[\"bad\"]\n```\n\nSo we're respecting the new type information from `x = {\"a\": \"bad\"}`...\nBut an invalid assignment shouldn't contribute new type information!\n\nIn other words, we want to ignore the known-key bindings that we get\nfrom the dict assignment when the overall assignment is invalid.\n\nDoing so is pretty ugly because the index is built solely from syntax\n(e.g., we create definitions from `x = {\"a\": \"bad\"}`), but we're trying\nto _reject_ those definitions later during inference, using information\nwe don't have at the time of definition creation. I tried a variety of\napproaches but this ended up being the cheapest and least invasive thing\nI could find."
+    },
+    {
+      "commit": "d33907ff86b8888b11a8bfab7937aa95fe9a615a",
+      "subject": "[ty] Handle cycles in function decorator inference (#25475)",
+      "body": "## Summary\n\nHandle recursive `function_known_decorators` queries by falling back to\nan empty decorator inference result while Salsa resolves the cycle. This\nprevents a Python 3.14 descriptor annotation with an overloaded\n`__get__` method from panicking and preserves conservative `Unknown`\nbehavior during cycle recovery.\n\nCloses https://github.com/astral-sh/ty/issues/3593."
+    },
+    {
+      "commit": "042a6a172983036399530f758c6e74171bcd6216",
+      "subject": "docs: fix typo `bin/active` \u2192 `bin/activate` in tutorial (#25473)",
+      "body": "## Summary\n\nFixes a one-character typo in  (line 61).\n\nThe Linux/macOS virtual environment activation command was written as:\n\n```\nsource .venv/bin/active\n```\n\nbut should be:\n\n```\nsource .venv/bin/activate\n```\n\nThe Windows command on the same line () was already correct, making the\ndiscrepancy easy to spot.\n\n## How verified\n\nThe fix was verified by reading the file directly \u2014 is not a valid shell\nscript; the correct file installed by Python\u2019s `venv` module is always .\n\nCo-authored-by: Claude <noreply@anthropic.com>"
+    },
+    {
+      "commit": "a5cc4e79e33ecba98a1d4c837c1fd78e04efd87b",
+      "subject": "[ty] Narrow bound method overloads by receiver (#24707)",
+      "body": "## Summary\n\nGiven:\n\n```python\nfrom typing import overload\n\nclass Base:\n    @overload\n    def convert(self: \"Base\", x: int) -> int: ...\n\n    @overload\n    def convert(self: \"Child\", x: str) -> str: ...\n\n    def convert(self, x: int | str) -> int | str:\n        return x\n\nclass Child(Base): ...\n```\n\nOn main, we treat `Base().convert` as if both overloads are still\npossible, including the overload that requires `self: \"Child\"`.\n\nAfter this PR:\n\n```python\nreveal_type(Base().convert)\n# bound method Base.convert(x: int) -> int\n\nreveal_type(Child().convert)\n# Overload[(x: int) -> int, (x: str) -> str]\n```\n\nSo `Base().convert(\"x\")` is no longer considered valid via narrowing on\nthe actual receiver type.\n\nCloses https://github.com/astral-sh/ty/issues/2693.\n\nCloses https://github.com/astral-sh/ty/issues/2612.\n\nCloses https://github.com/astral-sh/ty/issues/3380.\n\nCloses https://github.com/astral-sh/ty/issues/1169."
+    },
+    {
+      "commit": "5a6c811505e5068bc98752944830d244f68b9bb6",
+      "subject": "[ty] Avoid storing redundant reachability indexes (#25453)",
+      "body": "## Summary\n\nWhen all reachability nodes for a scope are retained, their IDs already\nmatch their positions in the stored node array. In that case, this PR\navoids storing an extra bit vector for mapping node IDs back to the\narray. We only allocate that mapping when unused intermediate nodes were\nremoved.\n\nThis reduces retained memory for reachability constraints while\npreserving the existing compaction for scopes that need it. It also\nmoves node lookup into `ReachabilityConstraints::get_interior_node`, so\nboth paths use the same lookup logic."
+    },
+    {
+      "commit": "a8aceb1a5a3f74c676ee4cf9579ef3c2cd6f9336",
+      "subject": "[ty] Improve diagnostic for failed assignment to a `Callable` type. (#25308)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\nThis improves the diagnostic we show when an assignment to a `Callable`\ntype fails. That diagnostic now contains additional context that\ndescribes the inferred callable type that failed. The result is that the\nfull explanation of the failed assignment is more coherent.\n\nCloses https://github.com/astral-sh/ty/issues/866.\n\n## Test Plan\n\nPlease see updated tests.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "0fb46b21c9048178db3af25366b7e7aeebce2d30",
+      "subject": "Add missing primer projects to good.txt (#25461)",
+      "body": "## Summary\nAdd `django-modern-rest` and `pytest-autoprofile` to the ty primer\n`good.txt` list. These upstream projects completed `uvx ty check`\nwithout crashing, panicking, or timing out"
+    },
+    {
+      "commit": "49882fa3844b9f93a7985dfd277a3348975bc576",
+      "subject": "[`pyflakes`] Avoid removing the `format` call when it would change behavior (`F523`) (#25320)",
+      "body": "## Summary\n\nWhen every positional argument is unused, `F523` removes the entire\n`.format(...)` call. That changes behavior whenever the format string\nrelies on the call:\n\n* Brace escapes: `\"{{\".format(\"!\")` returns `\"{\"`, but `\"{{\"` is two\ncharacters.\n* Named placeholders: `\"{x}\".format(\"!\")` raises `KeyError`, but `\"{x}\"`\nquietly succeeds.\n\nThis detects these cases and avoids removing the entire `format` call.\nWe also tried the \"ideal\" fix described on the issue of processing the\nstring to handle escapes ourselves, but just preserving the call seemed\nlike the better tradeoff in terms of complexity.\n\n## Test plan\n\nNew mdtests based on the examples from the issue\n\nCloses #15557"
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "f46ee089e7a1dcb5019c3a525afde416fe807159",
+      "subject": "[ty] agent guidance to avoid Python 3.7 pitfall (#25466)",
+      "body": "Per title; this is a trap Codex is constantly falling into."
+    },
+    {
+      "commit": "1518f1d5fdcc92d207c5018bac6d0b9110643240",
+      "subject": "Drop excess capacity from Suites during parsing (#25368)",
+      "body": "## Summary\n\nShrink Suite vectors to drop the excess capacity during parsing. \n\nI excluded other nodes for now to get a better sense of the performance\nand memory impact.\n\nI'm a bit conflicted on this. This is a pretty huge memory improvement\nfor ty, but there are a few linter benchmarks that regress by 1-2%\nbecause some vectors need to be copied to smaller allocations, which\nhurts performance. For the linter and formatter, it's also not important\nto shrink the vectors, because the AST is never stored for long. But\nthis is different for ty where we cache the AST.\n\nI'm curious to hear what others think on this. I could also try to\nreduce the places where we call `shrink_to_fit`, e.g., only for\nstatements?"
+    },
+    {
+      "commit": "572e4b58e3d438f5e05b375702d65474b3dd040d",
+      "subject": "[ty] Compact retained semantic arrays (#25454)",
+      "body": "## Summary\n\nReduces the memory retained by Salsa-cached semantic indexes by using a\n`FrozenIndexVec` for index-addressed immutable arrays, like the\n`FrozenMap` abstraction.\n\nApart from a >1% memory reduction, we see a 1% improvement on `attrs`,\n`anyio`, `hydra-zen`, `multithreaded`; 1% regression on `pydantic` and\n`freqtrade`."
+    },
+    {
+      "commit": "d475a239bb5c5f5ace5a2b3d995c2710fcfa08c8",
+      "subject": "[ty] Use ThinVec for sparse kwargs bindings (#25457)",
+      "body": "## Summary\n\n`multi_bindings_by_use` is only populated for kwargs expressions (like\n`f(**options)`), so it is empty or very small for most scopes. This PR\nkeeps the mutable hash map while building the use-def map, then converts\nit into a sorted `ThinVec` for storage, which is much smaller\n(especially when empty). Lookups use binary search by `ScopedUseId`."
+    },
+    {
+      "commit": "ec1d5358abc115b1f89258c4b432e5013f46680a",
+      "subject": "make ecosystem-analyzer self-aware (#25460)",
+      "body": "## Summary\n\nUpdate to the latest upstream commit of ecosyste-analyzer following\nhttps://github.com/hauntsaninja/mypy_primer/pull/249 and\nhttps://github.com/astral-sh/ecosystem-analyzer/pull/72. This means that\necosystem-analyzer now checks ty by running ty on ecosystem-analyzer, a\nvery satifsying ouroboros\n\n## Test Plan\n\nci on this pr"
+    },
+    {
+      "commit": "35ee0888f4ed173ed35d2fcd31d261a085a89c21",
+      "subject": "[`ruff`] Treat `yield` before `break` from a terminal loop as terminal (`RUF075`) (#25447)",
+      "body": "## Summary\n\nCloses #25378.\n\nExtends the yield-before-return terminal check to also cover\nyield-before-break, but only when the enclosing loop is itself in a\nterminal position. break exits the innermost loop, so a yield right\nbefore it has no cleanup code after it in that case.\n\n## Test Plan\n\nmdtest passes for fallible-context-manager.md across the new and\nexisting cases"
+    },
+    {
+      "commit": "1a8520ea168d281a8c2644dd36a04b9a8e5966db",
+      "subject": "[ty] Use `TypeForm` in `ty_extensions` (#25421)",
+      "body": "## Summary\n\nI saw that TypeForm support landed, and I remembered @dcreager saying\nthat we could simplify some things once we had that.\n\n## Test Plan\n\nUpdated tests, this is mostly intended to be an internal refactor."
+    },
+    {
+      "commit": "0c1a69c011c12723717e39bba39f64957d0733cf",
+      "subject": "[ty] Add function parentheses completion (#25305)",
+      "body": "## Summary\n\nAdd an opt-in completion setting that inserts parentheses snippets for\ncallable completions.\n\nCloses https://github.com/astral-sh/ty/issues/977\n\n## Test Plan\n\n\nhttps://github.com/user-attachments/assets/4077d726-b0e3-4ed8-ab4a-63512b01298e"
+    },
+    {
+      "commit": "a963b83c5edca89db571b97ea76a5893856a28c0",
+      "subject": "More updates to ecosystem summary skills (#25458)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\n\n## Test Plan\n\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "6627489bdac3033bb191c1653deee31364061607",
+      "subject": "Further improve instructions for agents for working on ty (#25430)",
+      "body": "## Summary\n\nA bunch of followup changes from\nhttps://github.com/astral-sh/ruff/pull/25422. Mostly triggered by using\nthe skill for the first time to analyze the report in\nhttps://github.com/astral-sh/ruff/pull/24761.\n\n- Move ty-specific guidance from `AGENTS.md` to a new local\n`working-on-ty` skill. Link to the other ty-specific skills from that\nskill.\n- Add more keyword triggers to various skills so that agents are more\nlikely to automatically figure out that a skill is appropriate\n(suggested by @dhruvmanila).\n- Add more guidance to the ecosystem-minimization skill (and tweak the\nscript for setting up a primer project) so that agents are likely to\nreproduce results in a deterministic and helpful way.\n\n## Test Plan\n\nI repeatedly ran `/review` with Codex on this until the only remaining\nissues were trivial."
+    },
+    {
+      "commit": "47d742f520dc6352209710dcad9b40d55c0f3b44",
+      "subject": "[ty] Infer `bool` for `not` applied to dynamic values (#25445)",
+      "body": "## Summary\n\nPrior to this change, we treated all unary operations applied to a\ndynamic value as producing the same dynamic type. This is appropriate\nfor `+`, `-`, and `~`, whose dunder implementations may return arbitrary\nvalues, but not for `not`: Python always produces a `bool` after\nevaluating its operand's truthiness.\n\n```python\nfrom typing import Any, reveal_type\n\ndef check(value: Any) -> None:\n    result = reveal_type(not value)  # bool\n    result.nonexistent()  # error: `bool` has no attribute `nonexistent`\n```\n\nWe now allow `not` on dynamic operands to use the existing\ntruthiness-inference path, while retaining dynamic propagation for the\nother unary operators. This restores downstream checking of the\nresulting boolean value.\n\nCloses https://github.com/astral-sh/ty/issues/3572."
+    },
+    {
+      "commit": "ae44d57db5ffcf010fd2c685a4c0b75564d62381",
+      "subject": "[ty] Avoid panic for deferred dataclass field annotations (#25444)",
+      "body": "## Summary\n\nI fixed https://github.com/astral-sh/ty/issues/3493 in\nhttps://github.com/astral-sh/ruff/pull/25249, but missed the case of\ndeferred evaluation for annotations... For deferred evaluation, when we\nthen checked whether that field was a descriptor,\n`class_member_with_policy` attempted meta-type lookup on the cycle\nmarker itself and panicked.\n\nE.g., on Python 3.14, where annotations are deferred by default:\n\n```python\nfrom dataclasses import InitVar, dataclass\nfrom ty_extensions import Top\n\n@dataclass\nclass C:\n    a: Top[int]\n    int: InitVar[int] = 0\n\nC()\n```\n\nWe now apply the materialized divergent fallback before class-member\nlookup, consistent with the other lookup and descriptor operations. (The\nexample reports the expected missing argument for `a` instead of\npanicking, and is covered under Python 3.14.)\n\nCloses https://github.com/astral-sh/ty/issues/3493."
+    },
+    {
+      "commit": "f6bfc7f8cc889caef07f4cd6833e5e4fc262d041",
+      "subject": "Update Rust toolchain to 1.96 and MSRV to 1.94 (#25443)",
+      "body": "## Summary\n\n- Update the pinned Rust toolchain from 1.95 to 1.96.\n- Raise Ruff's minimum supported Rust version from 1.93 to 1.94,\nfollowing the N-2 policy.\n- Replace the now-unnecessary `zip_opt` helper with `Option::zip`, as\nRust 1.96's Clippy flags the manual implementation.\n\n## Test plan\n\n`cargo clippy --workspace --all-targets --all-features -- -D warnings`"
+    },
+    {
+      "commit": "f266e8f99d6e9f27380de3963b3d5c01f87a1150",
+      "subject": "[ty] Introduce opt-in `missing-override-decorator` rule. (#25111)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\n\nThis adds a new rule called `missing-override-decorator` that allows\nusers to opt into `@override` enforcement. The rule is ignored by\ndefault.\n\nWhen the rule is enabled, ty will report a missing override decorator on\nan override of any method other than `__init__`, `__new__`,\n`__init_subclass__` or `__post_init__`. This matches the general\nstrategy taken by other type checkers (see discussion starting\n[here](https://github.com/astral-sh/ruff/pull/25111#issuecomment-4501847451)).\n\nCloses https://github.com/astral-sh/ty/issues/155.\n\n## Test Plan\n\nPlease see included tests.\n\nNote that my approach to testing this feature departs from precedent in\nthat, unlike other rules, `missing-override-decorator` is not enabled by\ndefault in our test suite. I think we can and should change this in\nfollow-ups, but for the moment that choice makes this PR easier to\nreview by eliminating churn in unrelated tests."
+    },
+    {
+      "commit": "2110d320da20d1f6fc20b0397f75b0d08a13d5f8",
+      "subject": "[`pylint`] Narrow diagnostic range and exclude cases without exception handlers (`PLW0717`) (#25440)",
+      "body": "Summary\n--\n\nThis PR fixes #25438 by narrowing the diagnostic range from the entire\n`try` statement to only the\n`try` keyword. This was one of the two alternatives mentioned on #25438,\nand I thought this looked a\nbit nicer than only narrowing the range to the `try` body. I think this\nis also consistent with the\nrange for `too-many-statements` (`PLR0915`), which marks the function\nname:\n\nhttps://play.ruff.rs/dafe23a1-2e89-48a5-b4d7-b0825b737152\n\nI'm happy to reconsider, though. Another possible alternative along\nthese lines is marking the first\nstatement that exceeds the limit, or the last statement, or something\nlike that.\n\nThis PR also fixes #25390 by limiting the rule to `try` statements with\n`except` handlers. Either an\n`except` or a `finally` clause is required, so this avoids emitting\ndiagnostics for\ncontext-manager-like cases, such as the one reported in the issue:\n\n```py\nsession = ...\ntry:\n    print()\n    print()\n    print()\n    print()\n    print()\n    print()\nfinally:\n    session.close()\n```\n\nwhere the `try` is just ensuring that some cleanup is performed and\ncan't actually trigger the bad\nbehavior described in the rule docs of mistakenly catching the wrong\nexception.\n\nTest Plan\n--\n\nNew mdtests based on the issues"
+    },
+    {
+      "commit": "f9ba228f6c99f6364d2936ed62a0278e6856bfed",
+      "subject": "[ty] Add call hierarchy support (#25338)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "ba58c8409aa562bc5a8b97d4165031658f96a259",
+      "subject": "[`ruff`] Restore example code for Python versions before 3.15 (`RUF017`) (#25439)",
+      "body": "Summary\n--\n\nCloses #25436 by restoring the previous `Use instead:` snippet from\nbefore #23789\n\nI thought it would be cool to use the tabs like we have for\npyproject.toml vs ruff.toml snippets, but I wasn't sure if that would\nrender well in other contexts where we use rule docs and opted just to\nhave two separate code blocks."
+    },
+    {
+      "commit": "320a4827094acac27378d2a42d4a4c3a34d62867",
+      "subject": "Update snapshot source lines for mdtests (#25437)",
+      "body": "Summary\n--\n\nThis follows up on the mdtest refactor to force-update the snapshots\nthat now report different\n`source`s as noted in\nhttps://github.com/astral-sh/ruff/pull/24954#discussion_r3319740141.\n\nTest Plan\n--\n\n```shell\ncargo insta test --force-update-snapshots -p ty_python_semantic --test mdtest\n```\n\nI also followed up with the more general:\n\n```shell\ncargo insta test --force-update-snapshots\n```\n\nwhich didn't reveal any other (related) issues."
+    },
+    {
+      "commit": "e70d974f66edc7ddce176f1ce9f46d63d82d318d",
+      "subject": "[ty] Avoid treating metaclass declarations as populated values (#25432)",
+      "body": "## Summary\n\nPrior to this change, we conflated a metaclass instance-member\ndeclaration with a value populated on each newly created class object.\n\nSo in the example below, we correctly validate the stored value\n`staticmethod(identity)` against the metaclass contract `Callable[[str],\nstr]`, because `C` is an instance of `Meta`. But we then _incorrectly_\nperformed the reverse validation: we treated `Meta.factory`'s declared\n`Callable[[str], str]` type as though `Meta` had written a replacement\nvalue into `C.factory`, and rejected it against `C.factory`'s declared\nstorage type, `staticmethod[[str], str]`.\n\n```python\nfrom collections.abc import Callable\nfrom typing import ClassVar\n\nclass Meta(type):\n    factory: Callable[[str], str]\n\ndef identity(value: str) -> str:\n    return value\n\nclass C(metaclass=Meta):\n    factory: ClassVar[\"staticmethod[[str], str]\"] = staticmethod(identity)\n```\n\nWe now distinguish declarations from assignments made to metaclass\ninstance members in methods: bare declarations, including `cls.factory:\nCallable[[str], str]`, continue to constrain values supplied by the\nclass body, but no longer act as writes that overwrite the constructed\nclass namespace.\n\nCloses https://github.com/astral-sh/ty/issues/3569."
+    },
+    {
+      "commit": "b427926f2014abf7204cc433d6cb5204c8bbc49c",
+      "subject": "[`eradicate`] Fix `ERA001`/`RUF100` conflict when `noqa` is on commented-out code (#25414)",
+      "body": "## Summary\n\nFixes #25386.\n\nFor commented-out code with a trailing `# noqa: ERA001`, Ruff could\nreport both\n`ERA001` on one line and `RUF100` (unused `ERA001`) on the next \u2014 which\nis inconsistent.\n\n`ERA001` uses `comment_contains_code()` to decide if a comment is code.\nThat function\nwas analyzing the full comment body, including trailing `# noqa:\nERA001`. The allowlist\ntreats `noqa` as non-code, so lines like `# ) # noqa: ERA001` were\nskipped by `ERA001`\nwhile a nearby line without `noqa` still triggered `ERA001`. That made\nthe `noqa`\nlook unused to `RUF100`.\n\nThe fix strips a trailing inline `# noqa...` before ERA001\u2019s code\ndetection, so the\ncomment is evaluated on its code portion only (e.g. `)`). Suppression\nand detection\nthen agree: `noqa: ERA001` is used when it suppresses a real `ERA001`\nmatch.\n\nthe repro now shows ERA001 diagnostics without incorrectly flagging the\npaired noqa: ERA001 as unused.\n\n## Test Plan\n\n- Added unit tests in `detection.rs` for `# ) # noqa: ERA001` and `# \\t(\n# noqa: ERA001`\n- Extended `RUF100_5.py` with regression cases from #25386\n- Ran `cargo test -p ruff_linter ruf100_5` (snapshot updated)\n- Ran `cargo test -p ruff_linter comment_contains_code_with_multiline`\n- Ran `uvx prek run --files` on the three changed files"
+    },
+    {
+      "commit": "db5aa0a5f1b92cb91d910bf0866a967554dd94f5",
+      "subject": "Bump 0.15.15 (#25431)",
+      "body": ""
+    },
+    {
+      "commit": "366fe21ba369ccdd01eb99c1043c9a969c99230b",
+      "subject": "[ty] Improve diagnostics for syntax errors in forward annotations (#25158)",
+      "body": "## Summary\n\nFixes https://github.com/astral-sh/ty/issues/1627.\n\nHere's an example diagnostic with the current release of ty:\n\n<img width=\"2286\" height=\"286\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/46ab9154-aaf0-4451-b301-5ff12fcd8507\"\n/>\n\nOn this branch, this diagnostic becomes:\n\n<img width=\"1464\" height=\"408\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/449e0b6c-58d2-4501-91df-c267db6f48ca\"\n/>\n\nThe exact span of the node that creates the syntax error is now retained\nand highlighted in the diagnostic.\n\n## Implementation\n\nPropagating the range of the node inside the string annotation into the\ndiagnostic is trivial. However, naively implementing that quickly\nrevealed that this would make diagnostics like this unsuppressable:\n\n```py\nx: \"\"\"list[\n    yield from range(42)\n]\"\"\"\n```\n\nThe primary range of the diagnostic is now specifically the `yield from\nrange(42)` part of the string rather than the string node as a whole.\nBut I cannot add a `ty: ignore` comment that is either on or above the\n`yield from range(42)` part of the string -- the \"comment\" there would\njust become part of the string.\n\nThis PR also improves the consistency of our parser error messages in\ngeneral when it comes to capitalization.\n\n## Test Plan\n\nMdtests extended and updated"
+    },
+    {
+      "commit": "Co-authored-by: Micha Reiser <micha@reiser.io>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "e2e1e647d182b8567845039c9a65fb0608a4dcfc",
+      "subject": "[ty] Remove excess capacity from more Salsa cached collections (#25411)",
+      "body": ""
+    },
+    {
+      "commit": "1bd77e1646f2213d86b8da215f08279187867d72",
+      "subject": "[ty] Use diagnostic message as tie breaker when sorting (#25424)",
+      "body": ""
+    },
+    {
+      "commit": "7e1bc1e75f15795f12c846294b13df4535f2abbf",
+      "subject": "Add agent skills for working on ty (#25422)",
+      "body": "## Summary\n\nThis PR adds a `.agents/skills` directory to the repo, and adds three\nskills to help agents work on ty more effectively:\n- A skill to help them write better ty diagnostics\n- A skill to help them minimize a single ecosystem change more\neffectively\n- A skill to help them analyze and summarise ecosystem reports more\neffectively\n\nThe skills have been designed so that they will (hopefully) work well\nwhether a contributor is using Codex or Claude as their agent locally.\nCodex should discover these skills automatically if you're working on\nthe repo; if you use Claude locally, you _should_ hopefully be prompted\nby Claude to install the local skills due to them being listed as\nrecommended skills in `.claude/settings.json`.\n\n## Test Plan\n\nI ran `/review` locally with Codex, instructing it to be as nitpicky as\npossible, until it could find no more issues with these skills."
+    },
+    {
+      "commit": "574e10752f8cfa9e0cdbe3b01e96c4380950469b",
+      "subject": "Expand semantic syntax errors for invalid walruses (#25415)",
+      "body": "## Summary\n\nPython rejects assignment expressions in several comprehension contexts,\nbut we previously only reported the case in which a walrus rebound a\ncomprehension variable.\n\nAs a result, we accepted invalid walruses in the iterable and class-body\nportions clause of a comprehension, and missed some rebinding cases in\nfilter clauses and nested comprehensions. It turns out the rules are\nreally complicated!\n\nFor example, we now report the two newly modeled syntax errors:\n\n```py\n# error: [invalid-syntax] \"assignment expression cannot be used in a comprehension iterable expression\"\n[x for x in (values := [1])]\n\nclass C:\n    # error: [invalid-syntax] \"assignment expression within a comprehension cannot be used in a class body\"\n    [(value := item) for item in [1]]\n```\n\nWe also catch previously missed instances of the existing rebinding\nerror:\n\n```py\n# error: [invalid-syntax] \"assignment expression cannot rebind comprehension variable\"\n[x for x in [1] if (x := 0)]\n```\n\nIn general, I decided not to worry about emitting multiple diagnostics\nfor a single error. These are rare, they're fatal, and it added a lot of\ncomplexity (so in some cases we may emit two errors for a walrus that is\ninvalid for two reasons)."
+    },
+    {
+      "commit": "4a7ca062fccd80443a43aa61e5dc7e5858e88dc1",
+      "subject": "[ty] Display docs for matching parameter when hovering over the name of an argument passed by keyword. (#25283)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\n\nThis makes it so that hovering over the name of an argument passed by\nkeyword shows the matching parameter label and documentation rather than\nthe inferred type of the argument value:\n\n```py\ndef test(ab: int):\n    \"\"\"my cool test\n\n    Args:\n        ab: a nice little integer\n    \"\"\"\n    return 0\n\ntest(ab=123)\n      ^\n```\n\n````txt\n(parameter) ab: int"
+    },
+    {
+      "commit": "a nice little integer\n````\n\nTwo additional notes on this new behaviour:\n- For a parameter without any documentation, we will show just the\nparameter label: `(parameter) ab: int`.\n- We will also show the documentation for a variadic keyword parameter\n(i.e., `**kwargs`) when the argument name maps to that type of\nparameter.\n\nBy contrast, nothing changes when hovering over the argument value: it\nwill continue to show the inferred type of the value:\n\n```py\nvalue = 123\n\ndef test(ab: int):\n    \"\"\"my cool test\n\n    Args:\n        ab: a nice little integer\n    \"\"\"\n    return 0\n\ntest(ab=value)\n          ^\n```\n\n````txt\nLiteral[123]\n````\n\nCloses https://github.com/astral-sh/ty/issues/1350.\nCloses https://github.com/astral-sh/ty/issues/3538.\n\n## Test Plan\n\nPlease see included tests.\n\n<!-- How was it tested? -->",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "54327092dbfe455040690d63bb1e5e4b5f551239",
+      "subject": "Refine a few agents instructions (#25423)",
+      "body": ""
+    },
+    {
+      "commit": "3cb09eba689ebb49e799131092121928cc789c18",
+      "subject": "[ty] Support `typing.TypeForm` (#25334)",
+      "body": "## Summary\n\n`TypeForm[T]` describes a value that is a valid type expression\nrepresenting a type assignable to `T`. Unlike `type[T]`, it can describe\nforms such as parameterized generics and unions, not only runtime class\nobjects:\n\n```python\nfrom typing import assert_type\nfrom typing_extensions import TypeForm\n\ndef construct[T](form: TypeForm[T]) -> T:\n    raise NotImplementedError\n\nassert_type(construct(int), int)\nassert_type(construct(list[int]), list[int])\nassert_type(construct(int | str), int | str)\n```\n\nThis PR adds support for `TypeForm[T]`, bringing us into alignment with\nthe conformance suite.\n\nFor bare `type`, we treat it as a runtime class value, but one that\ndoesn't promise a specific represented type, so it's valid for broad\nTypeForm destinations, but not narrow ones:\n\n```python\ndef use_bare_runtime_class(runtime_type: type) -> None:\n    any_form: TypeForm[Any] = runtime_type\n    object_form: TypeForm[object] = runtime_type\n    string_form: TypeForm[str] = runtime_type  # error\n```\n\nCloses https://github.com/astral-sh/ty/issues/2668."
+    },
+    {
+      "commit": "c8cd59f189f2b6f55d542b29bddb953622add6fc",
+      "subject": "[ty] Infer class attributes assigned by metaclass initialization (#25342)",
+      "body": "## Summary\n\nPrior to this change, we didn't recognize class-object attributes\npopulated by a metaclass during class initialization. For example:\n\n```python\nclass Meta(type):\n    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:\n        cls.attr: int = 1\n\nclass C(metaclass=Meta): ...\n\nreveal_type(C.attr)  # revealed: int\n```\n\nWe now recognize attributes that a metaclass adds to a class while\ncreating it. If the metaclass overwrites an existing class-body value,\nwe use the overwritten value's type. If the class provides an annotation\nfor the generated attribute, we preserve that annotation as its public\ntype.\n\nFor example, if the class body initially gives attr a value, the\nmetaclass assignment happens later at runtime and overwrites it:\n\n```python\nclass Meta(type):\n    def __init__(cls, name, bases, namespace):\n        cls.attr: int = 1\n\nclass C(metaclass=Meta):\n    attr = \"initial value\"\n\nreveal_type(C.attr)  # int\n```\n\nCloses https://github.com/astral-sh/ty/issues/1138."
+    },
+    {
+      "commit": "2428fca93267fe46340a850b105dc0d1681b9291",
+      "subject": "[ty] Ignore and reject annotations on non-name targets (#25324)",
+      "body": "## Summary\n\nLike Mypy and Pyright, we now ignore annotations on non-name (i.e.,\nsubscript and attribute) targets, and emit a diagnostic for the invalid\nannotation -- with the exception of annotated assignments on `self` and\nclass attributes (i.e., receivers).\n\nCloses https://github.com/astral-sh/ty/issues/509."
+    },
+    {
+      "commit": "7c55833109eae24b3a9983e7d75b06463726802e",
+      "subject": "Temporarily remove Ibraheem from reviewer pool (#25416)",
+      "body": "This is what we did previously for folks on PTO"
+    },
+    {
+      "commit": "7734c74dd070d88046808d5179cecf23a41e41aa",
+      "subject": "[ty] update flaky projects (#25417)",
+      "body": ""
+    },
+    {
+      "commit": "d8607123fb90ecf0176aa8d164a583cc57634186",
+      "subject": "[ty] Reject inconsistent generic bases in dynamic classes (#25413)",
+      "body": "## Summary\n\nWe do this for static classes, but were missing the analysis for dynamic\nclasses."
+    },
+    {
+      "commit": "dfb5e926cbd2e787dca56b925754ccc3f87ed97f",
+      "subject": "[ty] Add help message to invalid-generic-class variance diagnostic (#25385)",
+      "body": "## Summary\n\nWhen a generic subclass uses an explicitly-declared TypeVar in a base\nclass position where the variance is incompatible, the existing\ndiagnostic only reported which type variable and base class were\ninvolved:\n\nVariance of type variable `T_co` is incompatible with base class\n`Invariant`\n\nThis adds a `.help()` sub-diagnostic that explains *why* it is\nincompatible and what the base class actually requires:\n\nType variable `T_co` is declared as covariant, but base class\n`Invariant` requires it to be invariant\n\n\n## Test Plan\n\nAdded a new mdtest section in\n`crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md`\ncovering all four incompatible variance combinations, verifying the\nexact diagnostic message text."
+    },
+    {
+      "commit": "Co-authored-by: David Peter <mail@david-peter.de>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "6aaa91ac2b269df1414954ccd5134f0e6f5c6d30",
+      "subject": "Update dependency ruff to v0.15.14 (#25402)",
+      "body": ""
+    },
+    {
+      "commit": "a76571bfbbe28a8e7deb195a1f5f10f6a0355095",
+      "subject": "Update prek dependencies (#25403)",
+      "body": ""
+    },
+    {
+      "commit": "60e37a4c7311e6df5ded998dfcd20f04352c6d80",
+      "subject": "Update NPM Development dependencies (#25405)",
+      "body": ""
+    },
+    {
+      "commit": "283652349bdcb299e5bce369629aee103879c126",
+      "subject": "Update dependency astral-sh/uv to v0.11.16 (#25401)",
+      "body": ""
+    },
+    {
+      "commit": "3b2a1f619e8408ba3b32f6893a9194b21f872fa3",
+      "subject": "Update Rust crate thin-vec to v0.2.18 (#25404)",
+      "body": ""
+    },
+    {
+      "commit": "a11c416b9cfa9535613dd188ecbe2dc46a91e924",
+      "subject": "Update Rust crate get-size2 to 0.9.0 (#25407)",
+      "body": ""
+    },
+    {
+      "commit": "ad5ab668cbb896d211211738ad8d292239256368",
+      "subject": "Update Rust crate dashmap to v6.2.1 (#25406)",
+      "body": ""
+    },
+    {
+      "commit": "b4c3867dcf8d3d36b1177d527eed00e1a17f2ee2",
+      "subject": "Update taiki-e/install-action action to v2.79.2 (#25408)",
+      "body": ""
+    },
+    {
+      "commit": "7c2e9fbc83d7e0a87eea99053ec01182258b73a3",
+      "subject": "[`pyflakes`] Treat function-scope bare annotations as locals per PEP 526 (`F821`) (#21540)",
+      "body": "## Summary\n\nResolves #21494 \n\nTreat function-scope annotated variables as locals per PEP 526 ,\npreventing F821 false positives.\n\n## Test Plan\n\nAdded tests for these cases in\n`crates/ruff_linter/resources/test/fixtures/pyflakes/F821_34.py`"
+    },
+    {
+      "commit": "9c6536e73c10c1aabea72a2b11b218e67c4d090c",
+      "subject": "Fix invalid IR when flattening nested `BestFitting` elements (#25398)",
+      "body": "Summary\n--\n\nThis PR fixes #25397 by dropping `StartBestFittingEntry` and\n`EndBestFittingEntry` tags in\n`RemoveSoftLinesBuffer`. #25144 changed `RemoveSoftLinesBuffer` to\ninline the most-flat variant of\n`BestFitting` elements, but it inlined them with their start and end\ntags, which caused the problem\nobserved in #25397 when these tags became nested in another\n`BestFitting` element, which interpreted\nthe first `End` tag as ending the outer `BestFitting` rather than the\nnested one. You can see this\nclearly in the IR. First, the diff between the 0.15.13 and 0.15.14 IR,\nwhich reveals the unmatched\nstart tags:\n\n<details>\n<summary>0.15.13 vs main</summary>\n\n```diff\n@@ -38,29 +38,13 @@\n                           \"lambda \",\n                           group([\"arg\"]),\n                           \": \",\n-                          best_fitting([\n-                            [\n-                              [\n-                                <interned 1> [\n-                                  \"str(\",\n-                                  group([\n-                                    indent([soft_line_break, group([\"arg\"])]),\n-                                    soft_line_break\n-                                  ]),\n-                                  \")\"\n-                                ]\n-                              ]\n-                            ]\n-                            [[group(expand: true, [<ref interned *1>])]]\n-                            [\n-                              [\n-                                \"(\",\n-                                indent([hard_line_break, <ref interned *1>]),\n-                                hard_line_break,\n-                                \")\"\n-                              ]\n+                          [\n+                            <interned 1> [\n+                              \"str(\",\n+                              group([indent([group([\"arg\"])])]),\n+                              \")\"\n                             ]\n-                          ]),\n+                          ],\n                           \", self.args\"\n                         ])\n                       ])\n@@ -105,27 +89,9 @@\n                             \"lambda \",\n                             group([\"arg\"]),\n                             \": \",\n-                            best_fitting([\n-                              [\n-                                [\n-                                  <interned 2> [\n-                                    \"str(\",\n-                                    group([\n-                                      indent([soft_line_break, group([\"arg\"])]),\n-                                      soft_line_break\n-                                    ]),\n-                                    \")\"\n-                                  ]\n-                                ]\n-                              ]\n-                              [[group(expand: true, [<ref interned *2>])]]\n-                              [\n-                                [\n-                                  \"(\",\n-                                  indent([hard_line_break, <ref interned *2>]),\n-                                  hard_line_break,\n-                                  \")\"\n-                                ]\n+                            [\n+                              <interned 2> [\n+                                \"str(\",\n+                                group([indent([group([\"arg\"])])]),\n+                                \")\"\n                               ]\n-                            ]),\n-                            \", self.args\"\n+                            ]\n                           ])\n+                          <START_WITHOUT_END<Group>>\n                         ])\n-                      ]),\n-                      \")\"\n+                        <START_WITHOUT_END<Indent>>\n+                      ])\n+                      <START_WITHOUT_END<Group>>\n                     ])\n+                    <START_WITHOUT_END<Group>>\n                   ])\n-                ]),\n-                \")})\\\"\"\n-              ]),\n-              hard_line_break,\n-              \")\"\n+                  <START_WITHOUT_END<Indent>>\n+                ])\n+                <START_WITHOUT_END<Group>>\n+              ])\n+              <START_WITHOUT_END<Indent>>\n             ])\n-          ]\n+            <START_WITHOUT_END<Group>>\n+          ])\n+          <START_WITHOUT_END<BestFittingEntry>>\n         ]\n       ])\n     ]),\n```\n\n</details>\n\nand then the diff between main and this PR, which shows the removed\nbrackets that represent the\nnested tags:\n\n<details>\n<summary>main vs PR</summary>\n\n```diff\n@@ -38,12 +38,10 @@\n                           \"lambda \",\n                           group([\"arg\"]),\n                           \": \",\n-                          [\n-                            <interned 1> [\n-                              \"str(\",\n-                              group([indent([group([\"arg\"])])]),\n-                              \")\"\n-                            ]\n+                          <interned 1> [\n+                            \"str(\",\n+                            group([indent([group([\"arg\"])])]),\n+                            \")\"\n                           ],\n                           \", self.args\"\n                         ])\n@@ -89,24 +87,15 @@\n                             \"lambda \",\n                             group([\"arg\"]),\n                             \": \",\n-                            [\n-                              <interned 2> [\n-                                \"str(\",\n-                                group([indent([group([\"arg\"])])]),\n-                                \")\"\n-                              ]\n-                            ]\n+                            <interned 2> [\n+                              \"str(\",\n+                              group([indent([group([\"arg\"])])]),\n+                              \")\"\n+                            ],\n+                            \", self.args\"\n                           ])\n-                          <START_WITHOUT_END<Group>>\n                         ])\n-                        <START_WITHOUT_END<Indent>>\n-                      ])\n-                      <START_WITHOUT_END<Group>>\n+                      ]),\n+                      \")\"\n                     ])\n-                    <START_WITHOUT_END<Group>>\n                   ])\n-                  <START_WITHOUT_END<Indent>>\n-                ])\n-                <START_WITHOUT_END<Group>>\n-              ])\n-              <START_WITHOUT_END<Indent>>\n+                ]),\n+                \")})\\\"\"\n+              ]),\n+              hard_line_break,\n+              \")\"\n             ])\n-            <START_WITHOUT_END<Group>>\n-          ])\n-          <START_WITHOUT_END<BestFittingEntry>>\n+          ]\n         ]\n       ])\n     ]),\n```\n\n</details>\n\nI think the diff between 0.15.13 and this PR is also nice to see because\nit makes it a bit more\nclear that the `BestFitting` element has been inlined:\n\n<details>\n<summary>0.15.13 vs this PR</summary>\n\n```diff\n@@ -38,29 +38,11 @@\n                           \"lambda \",\n                           group([\"arg\"]),\n                           \": \",\n-                          best_fitting([\n-                            [\n-                              [\n-                                <interned 1> [\n-                                  \"str(\",\n-                                  group([\n-                                    indent([soft_line_break, group([\"arg\"])]),\n-                                    soft_line_break\n-                                  ]),\n-                                  \")\"\n-                                ]\n-                              ]\n-                            ]\n-                            [[group(expand: true, [<ref interned *1>])]]\n-                            [\n-                              [\n-                                \"(\",\n-                                indent([hard_line_break, <ref interned *1>]),\n-                                hard_line_break,\n-                                \")\"\n-                              ]\n-                            ]\n-                          ]),\n+                          <interned 1> [\n+                            \"str(\",\n+                            group([indent([group([\"arg\"])])]),\n+                            \")\"\n+                          ],\n                           \", self.args\"\n                         ])\n                       ])\n@@ -105,29 +87,11 @@\n                             \"lambda \",\n                             group([\"arg\"]),\n                             \": \",\n-                            best_fitting([\n-                              [\n-                                [\n-                                  <interned 2> [\n-                                    \"str(\",\n-                                    group([\n-                                      indent([soft_line_break, group([\"arg\"])]),\n-                                      soft_line_break\n-                                    ]),\n-                                    \")\"\n-                                  ]\n-                                ]\n-                              ]\n-                              [[group(expand: true, [<ref interned *2>])]]\n-                              [\n-                                [\n-                                  \"(\",\n-                                  indent([hard_line_break, <ref interned *2>]),\n-                                  hard_line_break,\n-                                  \")\"\n-                                ]\n-                              ]\n-                            ]),\n+                            <interned 2> [\n+                              \"str(\",\n+                              group([indent([group([\"arg\"])])]),\n+                              \")\"\n+                            ],\n                             \", self.args\"\n                           ])\n                         ])\n@@ -155,7 +119,6 @@\n\n     def __str__(self) -> str:\n         return (\n-            f\"first stringlist of args long={list(map(lambda arg: str(\n-                        arg\n-                    ), self.args))})\"\n+            \"first string\"\n+            f\"list of args long={list(map(lambda arg: str(arg), self.args))})\"\n         )\n```\n\n</details>\n\nAnd you can also see at the bottom here that the actual formatting that\n#25144 sought to resolve\nis still fixed.\n\nTest Plan\n--\n\nNew regression test based on the code in the issue"
+    },
+    {
+      "commit": "0f3ea5adc449e00b805750b5aadf94194eabcfa5",
+      "subject": "[ty] Use constraint sets as pending state in `SpecializationBuilder` (#24540)",
+      "body": "This PR implements the bulk of the logic needed for\nhttps://github.com/astral-sh/ty/issues/2799, by building up a\n`ConstraintSet` in `SpecializationBuilder`. This constraint set holds\nthe \"pending state\" of the specialization being inferred. It will\neventually _replace_ the `types` hash map, which stores a simple mapping\nfrom typevars to inferred types, and which is always updated by unioning\ntogether types when we find multiple solutions for a typevar.\n\nFor now, we are building up both pending state representations, and\nsolving from the constraint set where we can. There are two main cases\nwhere we must fall back on the old solver:\n\n- Any specialization that involves a `ParamSpec`\n- If the constraint set returns `Unsatisfiable` or `Unconstrained`\n\nFollow-on PRs will address these remaining cases that use the old\nsolver; once they are all migrated over to the constraint set solver, we\nwill remove the `types` field.\n\nCloses astral-sh/ty#2572\nCloses astral-sh/ty#2959\nCloses astral-sh/ty#3037\nCloses astral-sh/ty#3203\nCloses astral-sh/ty#3228\nCloses astral-sh/ty#3428\nCloses astral-sh/ty#3483"
+    },
+    {
+      "commit": "38562889b9dfea7b15ce3e36670667dc395d063e",
+      "subject": "Reduce memory usage by dropping token-excess capacity and improve performance by approximating the initial tokens vec size (#25354)",
+      "body": "Co-authored-by: Dhruv Manilawala <dhruvmanila@gmail.com>"
+    },
+    {
+      "commit": "258ca11050a1b4dca1cc2ed8698261333404b866",
+      "subject": "[ty] Remove Prefect from flaky project list (#25394)",
+      "body": "## Summary\n\nInterestingly, it appears that this was \"fixed\" by\nhttps://github.com/astral-sh/ruff/pull/24927 based on a local basic,\nwhich suggest that the source of the non-determinism is in the\ninferred-variance computation, and we now avoid that in Prefect."
+    },
+    {
+      "commit": "305808d9ade492a60aebb49067e2a04fa999d61d",
+      "subject": "Update `configuration.md` (#25396)",
+      "body": ""
+    },
+    {
+      "commit": "f8592700d0862fdc48942199087ad091a2fb68af",
+      "subject": "[ty] Treat Python notebook text documents as Python source (#25393)",
+      "body": ""
+    },
+    {
+      "commit": "f2fb134161ed5842388b46e65de4435117601880",
+      "subject": "Fix line-length example for --config option (#25389)",
+      "body": "Co-authored-by: Martin Schlossarek <martin@schlossarek.me>"
+    },
+    {
+      "commit": "c0d692ef2af2e7fc20c62c189b34b1a0d0d20596",
+      "subject": "[ty] Add dd-trace-py to flaky.txt (#25391)",
+      "body": "Unfortunately this project is now flaky following\nhttps://github.com/astral-sh/ruff/commit/95eec58af266ba0f98bb923cf204f442523e813d.\nAdding it to flaky.txt means we don't get spurious/confusing diffs like\nhttps://github.com/astral-sh/ruff/pull/25017#issuecomment-4390844917\nanymore, because ecosystem-analyzer will run the project several times\nto ensure that newly reported diagnostic diffs are not flaky. The cost\nis that ecosystem-analyzer will take a little longer in CI"
+    },
+    {
+      "commit": "46f49936aba316c397d9fccab3d96d8b0f2bb3c6",
+      "subject": "Return code action for `codeAction/resolve` requests that contain no or no valid URL (#25365)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "6a3bc5b6bab7af992fa02638b8623cb0edd58e13",
+      "subject": "[ty] Show `LiteralString` when hovering the inline of a literal string (#25373)",
+      "body": "## Summary\n\nToday, ty showed the hover for `str` when hovering the inlay of a\n`LiteralString` type:\n\n```py\nfrom typing import LiteralString\ndef my_func(x: LiteralString):\n    y[: LiteralString] = x\nmy_func(x=\"hello\")\n```\n\nHovering the inlay of `y` (`[: LiteralString]` is the inlay) showed the\nhover of `str`.\n\nWe argued in https://github.com/astral-sh/ruff/pull/21548 that `str` is\ngenerally the more useful type in this position. I sort of agree, but I\nthink it's more important that the inlay and the hover show the same\ntype. I also think that it's important that the hover is consistent with\nwhen we \"bake\" the inlay, e.g. hovering `LiteralString` now also shows\n`LiteralString` and not `str`\n\n```py\nfrom typing import LiteralString\ndef my_func(x: LiteralString):\n    y: LiteralString = x\nmy_func(x=\"hello\")\n```\n\nCloses https://github.com/astral-sh/ty/issues/2860\n\n## Test Plan\n\nUpdated test"
+    },
+    {
+      "commit": "73de9b45cf98c5003918edcee658301fcc3bf723",
+      "subject": "[ty] Resolve enum names for all '|' arms for literal enum subsets (#25379)",
+      "body": "## Summary\n\nFixes https://github.com/astral-sh/ty/issues/3531\n\nCurrently, only a single enum value is retrieved when evaluating a match\nstatement against a literal of enum values. This recursively resolves a\nfull `|` union statement to get all the values.\n\n## Test Plan\n\n<!-- How was it tested? -->\n\n- Unit tests\n- Built ty and checked against repro in linked issue"
+    },
+    {
+      "commit": "Co-authored-by: Charlie Marsh <charlie.r.marsh@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "26e3516d93c06c7df936cc4356717af7ba621529",
+      "subject": "[ty] Accept complete enum-literal alias unions as enums (#25341)",
+      "body": "## Summary\n\nRelation checking needs to normalize PEP 695 unions together, so that we\ncan recognize that (e.g.) a union of aliases covering every member of an\nenum is equal to the enum itself.\n\nCloses https://github.com/astral-sh/ty/issues/3446."
+    },
+    {
+      "commit": "58b5d883d1959024ce96354365b004e218d23052",
+      "subject": "Update Rust crate thin-vec to v0.2.16 (#25372)",
+      "body": ""
+    },
+    {
+      "commit": "6ab8b737c5407bc1896ce97e56dd168b918a83f0",
+      "subject": "Use `ThinVec` in AST to shrink `Stmt` (#25361)",
+      "body": ""
+    },
+    {
+      "commit": "a69a3d946b5b4f21f348bc32fbc448b402cc3971",
+      "subject": "Run ty-ecosystem memory report on parser, ast, stdlib, and db changes (#25370)",
+      "body": ""
+    },
+    {
+      "commit": "4b18e1f500cbceb0cce32d195a0ba9177fb979b7",
+      "subject": "Run ty-ecosystem report on parser, ast, stdlib, and db changes (#25369)",
+      "body": ""
+    },
+    {
+      "commit": "0909c7ec21595906e6705850b77df1e0464e053e",
+      "subject": "[ty] Follow aliases when resolving stub mappings (#25328)",
+      "body": "## Summary\n\n`map_stub_definition` maps a stub definition to its \"real-definition\"\n(the same definition in a `py` file. This PR extends this mapping by\nresolving aliases. For:\n\n`main.py`:\n\n```py\nfrom a import bar\n\nbar\n```\n\n`a/__init__.pyi`:\n\n```py\ndef bar() -> None: ...\n```\n\n`a/__init__.py`:\n\n```py\nfrom .b import bar as bar\n\n```\n\n`a/b.py`:\n\n```py\ndef bar() -> None:\n    \"\"\"Implementation docstring\"\"\"\n```\n\n[Playground](https://play.ty.dev/f7255368-b291-4865-b4ca-6cac35a437e8)\n\nClicking on `bar` in `main.py` performs the following step:\n\n1. Resolve `bar` to `from a import bar` in `main.py`\n2. Follow the import to `a/__init__.pyi` where it finds `def bar()`\n3. `map_stub_definition` now tries to map `bar` to its implementation.\nIt finds the `from .b import bar as bar` in `a/__init__.py` and **stops\nhere**\n\n\nThe step that is missing, and this PR adds, is that stub mapping must\nfollow the import to the symbol's real definition.\n\n\nThe same applies when resolving documentation: ty first tries to get the\ndocumentation from the stub. If that's missing, ty tries to resolve the\ndocumentation from the implementation. However, that requires resolving\nthe import, because the import itself has no docstring.\n\n\nCloses https://github.com/astral-sh/ty/issues/2150"
+    },
+    {
+      "commit": "330a334df357d06d0dc8aa6e1841a46d62fcaa49",
+      "subject": "[ty] Rebalance benchmark shards (#25330)",
+      "body": ""
+    },
+    {
+      "commit": "5f284d1f525ab93e77c3a6d2c16aac65a7bea459",
+      "subject": "Recover incomplete list comprehension elements (#25326)",
+      "body": ""
+    },
+    {
+      "commit": "8e420ea2b22cd4e5add408029e024113459f423e",
+      "subject": "[ty] Fix diagnostics in ignored folders after adding new files (#25236)",
+      "body": ""
+    },
+    {
+      "commit": "0df54882ffeffbad9d8a18c6c7c7abdbe4813ea5",
+      "subject": "[`refurb`] Document `FURB192` exception change for empty sequences (#25317)",
+      "body": "`sorted([])[0]` raises `IndexError`, but `min([])` and `max([])` raise\n`ValueError`. Code that catches one specific exception type breaks after\nthe autofix, so the rule's fix-safety section now calls this out\nalongside the existing tie-breaking note.\n\nCloses #16964"
+    },
+    {
+      "commit": "928018cb0e6bf3b49f1bf71f1b02dd8b2d16141b",
+      "subject": "[`pyflakes`] Report duplicate imports in `typing.TYPE_CHECKING` block (`F811`) (#22560)",
+      "body": "## Summary\n\nSee #22554\n\n## Test Plan\n\n`cargo nextest run pyflake`"
+    },
+    {
+      "commit": "Co-authored-by: Amethyst Reese <amethyst@n7.gg>\nCo-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "7efc9a615af9b0a402d19b9df7e865e587780995",
+      "subject": "[ty] Reject incompatible explicit variance in generic base classes (#25327)",
+      "body": "## Summary\n\nPrior to this change, we accepted legacy generic subclasses whose\nexplicitly declared variance was incompatible with a specialized base\nclass. For example:\n\n```python\nfrom typing import Generic, TypeVar\n\nT = TypeVar(\"T\")\nT_co = TypeVar(\"T_co\", covariant=True)\n\nclass Invariant(Generic[T]): ...\nclass Bad(Invariant[T_co]): ...\n```\n\n`Bad` claims covariance even though its invariant base requires its type\nparameter to remain invariant.\n\nThis brings `aliases_variance.py` and `generics_variance.py` into\nconformance."
+    },
+    {
+      "commit": "50bccaad5b422a207023f37735abca3fb50b2a25",
+      "subject": "[ty] Classify property declaration semantic tokens (#25322)",
+      "body": ""
+    },
+    {
+      "commit": "d27513db6b86fa5396ed6ac04a89f8a11b784303",
+      "subject": "intersection calls: Fix test to test what it is supposed to test (#25323)",
+      "body": "The test used to use () -> Never | () -> str, which simplifies to () ->\nNever,\nso it was not actually testing an intersection call."
+    },
+    {
+      "commit": "921529b707d5a6a47114d3f2391f5adf0e12ef99",
+      "subject": "[ty] Avoid exponential blow-up in fall-through narrowing (#25278)",
+      "body": "## Summary\n\nPrior to this change, narrowing after a large fall-through `match` or\n`if`/`elif` sequence could repeatedly evaluate the same projected\nnarrowing work for each incoming path. For example:\n\n```python\ndef check(value: Value) -> None:\n    match value:\n        case \"a\":\n            pass\n        case \"b\":\n            return\n        case \"c\":\n            pass\n\n    repr(value)\n```\n\nHere, multiple non-terminal branches continue to the statement after the\n`match`. In the example above, the \"a\" and \"c\" cases both continue to\n`repr(value)`. We now reuse the narrowing work shared by those paths\ninstead of recomputing it for each case.\n\nYou can see the impact on the various micro-benchmarks:\n\n```\n\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n\u2502 Benchmark                                          \u2502     main \u2502   This PR \u2502   Change \u2502\n\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n\u2502 ty_micro[literal_match_fallthrough]                \u2502 1.9758 s \u2502 7.3575 ms \u2502 -99.627% \u2502\n\u2502 ty_micro[literal_match_fallthrough_guarded_any]    \u2502 16.967 s \u2502 27.438 ms \u2502 -99.839% \u2502\n\u2502 ty_micro[literal_equality_fallthrough_guarded_any] \u2502 14.863 s \u2502 17.969 ms \u2502 -99.879% \u2502\n\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n```\n\nCloses https://github.com/astral-sh/ty/issues/3504.\n\nCloses https://github.com/astral-sh/ty/issues/3501."
+    },
+    {
+      "commit": "539512a8a4122226b2154a1cbfba3bfd2dcbc174",
+      "subject": "[ty] Support type aliases in document symbols (#25302)",
+      "body": "## Summary\n\n- teach the `ty_ide` symbol visitor to index PEP 695 type alias\nstatements\n- cover type aliases in exported-symbol discovery and document-symbol\noutput\n\n\nAddresses the type alias item in\nhttps://github.com/astral-sh/ty/issues/1771"
+    },
+    {
+      "commit": "cebed58e70c40e6bf1cc809abae5703dffee18a1",
+      "subject": "[ty] Emit a diagnostic for subclassing with `order=True` (#21704)",
+      "body": "## Summary\n\nCloses https://github.com/astral-sh/ty/issues/1681."
+    },
+    {
+      "commit": "Co-authored-by: David Peter <mail@david-peter.de>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "0cdb61a3e53dd4a0d0f68fb6de834fb5deb56c36",
+      "subject": "Fix Markdown closing fence handling (#25310)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "8c04080b5e449b077500fff1cf1d83c2a69af4c9",
+      "subject": "[`mccabe`] Improve example (`C901`) (#25287)",
+      "body": "The C901 docstring currently pairs a 3-deep `if/else` example with a\nguard-clause rewrite under \"Use instead\". Both versions have McCabe\ncomplexity 4, so the rewrite trips (or passes) C901 identically and the\ndocs end up teaching the false equivalence \"guard clauses lower McCabe\ncomplexity.\" A reader filed #25028 to flag this.\n\nIn that thread, MichaReiser said the docs should either use an example\nthat actually reduces complexity or drop the \"Use instead\" block\naltogether. A prior attempt (#25137) was closed with the same comment,\nand a follow-up trying a lookup-table example (#25186) was also closed,\nwhich makes me think the safer option is the second one MichaReiser\noffered. I dropped the \"Use instead\" block and added a short paragraph\nnaming the techniques that genuinely reduce McCabe complexity\n(extracting helpers, lookup tables, lower branching factor), with an\nexplicit note that mechanical guard-clause inversion does not.\n\nDocstring-only. `cargo dev generate-all` and `uvx prek run --from-ref\nmain` both pass.\n\ncloses https://github.com/astral-sh/ruff/issues/25028"
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "ba87ab5d33c3c5190014ac3e70be19a122cbb065",
+      "subject": "[`flake8-comprehensions`] Document `RecursionError` edge case in `__len__` (`C416`) (#25286)",
+      "body": "C416's autofix rewrites a list comprehension like `[item for item in\nself]` into `list(self)`, but when the original is reached from inside\n`__len__`, the rewrite recurses: CPython's `list()` constructor probes\n`__length_hint__` (which dispatches to `__len__`) as a sizing\noptimization while iterating, so `list(self)` from inside `__len__`\ncalls `__len__` again. The same applies to `dict()` and `set()` calls on\n`self`.\n\nIn #13752, MichaReiser noted that extending the docs would be reasonable\nand that detecting this control flow isn't the goal. I added a paragraph\nto the C416 docstring with a runnable example of the failure mode, plus\nthe `# noqa: C416` workaround for when the comprehension is reached\n(directly or transitively) from `__len__`.\n\nThe change is docstring-only. `cargo dev generate-all` and `uvx prek run\n--from-ref main` both pass.\n\nfixes https://github.com/astral-sh/ruff/issues/13752"
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "ceca6028373d31f3a7d44a5e3e00d7c0b2dd8614",
+      "subject": "[`pyupgrade`] Clarify fix safety docs (`UP007`, `UP045`) (#25288)",
+      "body": "The current UP007 \"Fix safety\" paragraph reads \"This rule's fix is\nmarked as unsafe, as it may lead to runtime errors when alongside\nlibraries that rely on runtime type annotations, like Pydantic, on\nPython versions prior to Python 3.10...\" The filer of #17062 hit the fix\non Python 3.10+ (where the source explicitly marks the fix safe) and was\nconfused about what the docs were warning about.\n\nIn the thread, ntBre clarified the actual semantics (\"the fix is marked\nunsafe on Python versions prior to Python 3.10 but safe on and after\n3.10\") and pjonsson suggested flipping the sentence around. I rewrote\nthe paragraph to mirror the code: the fix is safe when target is 3.10+\nand there are no comments, otherwise it's unsafe for one of two reasons\n(pre-3.10 runtime introspection like Pydantic can `TypeError` on `X |\nY`, or comments inside the original would be dropped during rewrite).\nThe unusual-inner-expression caveat is kept. I applied the same rewrite\nto UP045's docstring because it had the same wording.\n\nDocstring-only. `cargo dev generate-all` and `uvx prek run --from-ref\nmain` both pass.\n\nfixes #17062"
+    },
+    {
+      "commit": "Co-authored-by: Brent Westbrook <brentrwestbrook@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "2fd7ed0a164b292869aad84d65fa545f806c8131",
+      "subject": "Avoid redundant TokenValue drops in the lexer (#25300)",
+      "body": "## Summary\n\nIf we avoid resetting the lexer value slot when it's already empty, this\napparently improves performance by 1-2%. (In optimized builds, this\nkeeps the common case to a discriminant branch instead of re-entering\nthe `TokenValue` drop path.)"
+    },
+    {
+      "commit": "95eec58af266ba0f98bb923cf204f442523e813d",
+      "subject": "[ty] Full-scope bidirectional inference for unconstrained container literals (#25279)",
+      "body": "Implements full-scope bidirectional inference for collection literals\nthat are not constrained at their definition, e.g.,\n```py\nx = []\nx.append(1)\nx.append(\"2\")\nreveal_type(x)  # revealed: list[int | str]\n```\n\nIn particular, this PR considers empty, unannotated collection literals\nto be unconstrained, e.g., `lst = []`, and looks ahead in their\ncontaining scope for potentially constraining uses, which are:\n- Return statements involving the collection object, e.g., `return lst`.\n- Annotated assignments involving the collection object, e.g., `x:\nlist[int] = lst`.\n- Bound-method calls on the collection object, e.g., `lst.append(1)`.\n- Subscript assignments on the collection object, e.g., `lst[0] =\n\"hello\"`.\n\nThe inferred type of the collection literal is the union of all\nconstraints on the element type, collected from all constraining uses in\nthe containing scope. Note that operations through reassignments,\narbitrary function calls, augmented assignments, nested bound-method\ncalls, etc., are not currently tracked.\n\nNote that because this PR only considers unconstrained collection\nliterals, for which we previously inferred `Unknown` types, the\necosystem report consists primarily of new diagnostics. These are\nideally removing false negatives, but likely introduces many false\npositives as well, because the heuristic implemented is not perfect.\nHowever, this approach is quite easily extended to unannotated\ncollection literals that are not empty, which seems to remove a couple\nhundred ecosystem diagnostics, but I'd like to intentionally limit the\nscope of this change (and the performance/memory usage impact).\n\nPart of https://github.com/astral-sh/ty/issues/1473."
+    },
+    {
+      "commit": "baf9f1977a8556fe37e3e967099b7a1c6bba9acf",
+      "subject": "Update release process docs (#25297)",
+      "body": "Summary\n--\n\n* Drops the instructions for updating the ruff-lsp repo, which has been\narchived\n* Removes the minor release guidance for ruff-vscode, which we are now\nupdating each release"
+    },
+    {
+      "commit": "4ebccb3ca966cced342a66ca7e2035f1b9579b9f",
+      "subject": "Improve instructions to agents for running prek and tests (#25298)",
+      "body": "## Summary\n\nCodex doesn't have `cargo nextest` installed in the sandbox it uses by\ndefault, and neither did Claude Code for Web when I used to use that.\nAgents generally figure out pretty quickly that they can just use `cargo\ntest` instead, but it doesn't seem worth it telling them to use `cargo\nnextest` if it's generally not available -- it still wastes valuable\ntime.\n\nAlso, following\nhttps://github.com/astral-sh/ruff/commit/73de014e8768924945b892c91f8a5fabffcdd1c8,\nprek fails every time for me locally when codex tries to invoke it. The\nprek command given in AGENTS.md leads prek to stash any unstaged\nchanges, which generally leads to it running on 0 files. Again, the\nagent generally figures out pretty quickly that it should just use\n`--files` instead, but this still wastes time. This PR modifies\nAGENTS.md so we just tell agents to use the `--files` argument to prek\ninstead."
+    },
+    {
+      "commit": "f869fa0f1c74a062d2e73af3903fe21e2ad73707",
+      "subject": "[`ruff`] Document false negative for user-defined types (`RUF013`) (#25289)",
+      "body": "RUF013 silently skips parameters whose annotation is a user-defined\nclass (including any `Enum` subclass) when the default is `None`, e.g.\n`letter: Letter = None` where `Letter(Enum)` or `value: Custom = None`\nwhere `Custom` is just an imported class. The reporter of #14018 ran\ninto both cases and asked whether at least documenting the limitation\nwas reasonable.\n\nIn that thread, MichaReiser confirmed the false negative is intentional:\nRuff doesn't know what `Letter` resolves to, since a name in scope could\nbe a type alias like `type Letter = str | None` that already includes\n`None`. dhruvmanila added the implementation context, that the resolver\nfalls back to treating unresolved annotations as `Any`-compatible. The\nexisting \"Limitations\" section only mentions the `Text = str | bytes`\nalias case, so I added a second example covering user-defined classes\n(including `Enum`) in the same style.\n\nDocstring-only. `cargo dev generate-all` and `uvx prek run --from-ref\nmain` both pass."
+    },
+    {
+      "commit": "54ffc23d281b4df86892b24613c223453d428dc4",
+      "subject": "[ty] Avoid panicking on `__new__` assigned to classes (#25282)",
+      "body": "## Summary\n\nI added a TODO since I don't think this is worth modeling properly, but\nwe also shouldn't panic on it. I've tried to clearly outline the actual\nruntime behavior in the mdtests, though it's extremely mind-bending IMO.\n\nCloses https://github.com/astral-sh/ty/issues/3491."
+    },
+    {
+      "commit": "425d4f056247a3b16baa8485994b878e6c4b6612",
+      "subject": "[ty] Infer `dict(TypedDict)` as `dict[str, object]` (#24852)",
+      "body": "## Summary\n\nGiven:\n\n```python\nfrom typing import TypedDict\n\nclass TD(TypedDict):\n    x: int\n    y: str\n\ndef _(data: TD):\n    reveal_type(dict(data))\n```\n\nWe now reveal `dict[str, object]`.\n\nWe could consider using a narrower value type (e.g., infer `dict[str,\nint]` if all values are `int`), though Mypy and Pyright don't do that (I\nsuppose it wouldn't be sound for open TypedDicts?).\n\nCloses https://github.com/astral-sh/ty/issues/3340."
+    },
+    {
+      "commit": "9ad2da3015e5faf73bdc5f1d09df3e47238e3edf",
+      "subject": "Bump 0.15.14 (#25295)",
+      "body": ""
+    },
+    {
+      "commit": "c714e84952510696c05ec21b0158a3548898f594",
+      "subject": "[ty] Modernize setup of union types in mdtests (#25291)",
+      "body": "Remember when we wrote `x = 1 if flag else None` because we couldn't\ninfer types from annotated parameters and/or couldn't understand union\ntype annotations? This PR modernizes our mdtests to simply use annotated\nfunction parameters in those cases (I manually rejected some rewrites\nwhen the new style was less clear, for example when the generated union\ntype itself was hard to spell).\n\nThe motivation for this is to set a better precedent for agents, as I've\nseen them repeating that `x if flag else y` pattern, which is really\nunnecessary, longer and harder to read in most cases."
+    },
+    {
+      "commit": "8a8e35ebfe318e2467a0f276e5d1a3a9032a55ad",
+      "subject": "[`flake8-comprehensions`] Skip `C417` for lambdas with positional-only parameters (#25272)",
+      "body": "## Summary\n\n`lambda_has_expected_arity` in the C417 (`UnnecessaryMap`) rule checked\n`parameters.args` for exactly one element to confirm the lambda takes a\nsingle argument, but never checked `parameters.posonlyargs`. A lambda\nlike `lambda x, /, y: x + y` has `posonlyargs = [x]` and `args = [y]`,\nso the slice pattern matched `y` as the sole element and the function\nincorrectly returned `true`, causing ruff to raise a false C417\ndiagnostic and offer a broken autofix for a two-parameter lambda.\n\nThe fix adds an early return when `parameters.posonlyargs` is non-empty,\nensuring lambdas that combine positional-only and regular parameters are\ncorrectly rejected before the arity check passes.\n\n## Test Plan\n\nAdded a new `# Ok` case to `C417.py`:\n\n```python\n# Ok: lambda has a positional-only parameter alongside a regular parameter;\n# total arity is 2, so rewriting to a comprehension is incorrect.\nmap(lambda x, /, y: x + y, nums)\n```\n\nThis line produces no diagnostic after the fix, confirming the false\npositive is gone."
+    },
+    {
+      "commit": "aea5ed4d278017057c2e842c6c3a2e92ad71495f",
+      "subject": "Avoid unnecessary parser lookahead for operators (#25290)",
+      "body": "## Summary\n\nWe only need to peek ahead two tokens if the first token is `not` or\n`in`. We can avoid the `peek` in the majority of cases, which apparently\nspeeds up the parser by 20-30%."
+    },
+    {
+      "commit": "e9d72bb420f26c23e6660bfce4dfa0028b931bff",
+      "subject": "[ty] Allow enum member accesses on `self` (#25077)",
+      "body": "## Summary\n\nThis allows enum members to be resolved when accessed through a\n`Self`-typed enum instance. Previously, enum member lookup handled\nclass-member patterns like `case Answer.YES:`, but not equivalent\nself-member patterns like:\n\n```py\nclass Answer(Enum):\n    NO = 0\n    YES = 1\n\n    def is_yes(self) -> bool:\n        match self:\n            case self.YES:\n                return True\n```\n\nThe lookup reuses the receiver\u2019s nominal class for nominal instances and\nbounded `Self` typevars before resolving enum metadata, so `case\nself.YES:` narrows the same way as `case Answer.YES:`."
+    },
+    {
+      "commit": "6cbd59b511a92d5f408db57bde33367c0d47b672",
+      "subject": "Set `exclude-newer = \"7 days\"` in our PEP-723 scripts (#25285)",
+      "body": "## Summary\n\nThis helps reduce spurious changes to the lockfile if you run these\nscripts on a machine that has a global `exclude-newer` value set in a\n`~/.config/uv.toml` file or similar. It also seems good more generally\nto set an `exclude-newer` value for these scripts: dependency cooldowns\nare better for security.\n\nNote that if the machine, hypothetically, also set `UV_DEFAULT_INDEX` as\nan environment variable to something other than `pypi.org/simple`, there\nwould still be changes to the lockfile, so this change may be necessary\nbut not sufficient for lockfile stability on _certain_ corporate\nmachines.\n\n## Test Plan\n\nI ensured that the `UV_DEFAULT_INDEX` environment variable was set to\n`pypi.org/simple` on my machine and then ran `mdtest.py` using `uv run`.\nI didn't run `setup_primer_project.py`, but I did lock it using `uv lock\n--script`."
+    },
+    {
+      "commit": "9999a3967ae28fe3295131e8883b6947f272a076",
+      "subject": "Update code example on how to update Neovim LSP log level (#25284)",
+      "body": "## Summary\n\nUpdate deprecated neovim syntax in the editor setup docs.\n\n`vim.lsp.set_log_level` is deprecated as of neovim 0.12. [See neovim\ndocs](https://neovim.io/doc/user/deprecated/#deprecated-0.12)\n\n## Test Plan\n\nDocs only changes. Tested locally using `mkdocs`.\n\nCo-authored-by: Oscar Caballero <oscar.caballero@veeva.com>"
+    },
+    {
+      "commit": "67d8c544f0d1c526a2fc60d4bb1358fd7956d178",
+      "subject": "[ty] Retain recursively-defined state in binary expressions (#25277)",
+      "body": "## Summary\n\nPrior to this change, a recursive implicit attribute like:\n\n```python\nfrom __future__ import annotations\nfrom typing import Final\n\nclass ScopeChain:\n    def __init__(self, parent: ScopeChain | None = None) -> None:\n        self.depth: Final = 1 if parent is None else parent.depth + 1\n```\n\n...could fail to converge during type inference. We now preserve the\nrecursive-definition marker when literal binary operations produce a new\nliteral result, so recursive literal unions continue through the\nexisting widening path instead of accumulating results indefinitely.\n\nNote: in the above snippet, the bare `Final` exposes the issue because\nwe infer the RHS to get the type, as opposed to relying on the\nannotation, but in theory it needn't be specific to `Final`... Codex\nbelieves this is the only way to trigger that panic as of now, though\nbecause it's the only site where we create a recursive attribute lookup\n_and_ retain the exact RHS literal type (e.g., the non-`Final` version,\n`self.depth = 1 if parent is None else parent.depth + 1`, promotes those\nliterals).\n\nCloses https://github.com/astral-sh/ty/issues/3499."
+    },
+    {
+      "commit": "25a3191140dc0467f9d196f35c128fefde269261",
+      "subject": "[ty] Refine Callable class-decorator fallback for unknown results (#25250)",
+      "body": "## Summary\n\nThis PR addresses a TODO from #25091 whereby we preserved the class\nbinding for every `Callable`\ndecorator. We now respect explicit return annotations on `Callable`.\n\nFor example, this now remains a replacement rather than being treated as\nclass-preserving:\n\n```python\nfrom typing import Callable, TypeVar\n\nT = TypeVar(\"T\")\n\ndef decorator_factory() -> Callable[[type[object]], T]:\n    raise NotImplementedError\n\n@decorator_factory()\nclass Decorated: ...\n\nreveal_type(Decorated)  # Unknown\n```"
+    },
+    {
+      "commit": "c423054dc09e5b644c926b6b527b6accfbe693e9",
+      "subject": "Add a recursion limit to the parser (#24810)",
+      "body": "## Summary\n\nPartial fix for #22930.\n\nWithout this malicious or machine generated code could cause a stack\noverflow with something as simple as `'(' * 5000 + '1' + ')' * 5000`.\n\nI decided to do the simplest thing and have a limit that's always\napplied with a reasonable default. Since:\n* the overhead of this check will be tiny\n* it seems inconceivable that anyone will want to have no limit \n\n## Test Plan\n\nPR includes tests."
+    },
+    {
+      "commit": "Co-authored-by: Charlie Marsh <charlie.r.marsh@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "4ff86c7ccc52fc655e17ba3ac36a5d9a6ca8849f",
+      "subject": "[ty] Support multi-inference through type aliases (#25245)",
+      "body": "Resolves https://github.com/astral-sh/ty/issues/3487."
+    },
+    {
+      "commit": "04e5894851abe47053cb4ffae054d50e19d75e13",
+      "subject": "[ty] Prefer symbols from standard library over those of the same name from third party libraries for import completions. (#25108)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\n\nThis implements a narrow change to our ranking algorithm for import\nsuggestions. After this change, we will suggest symbols from standard\nlibrary modules over those from third-party modules when the symbol\nnames are the same and we can't otherwise distinguish the completions by\nsome higher relevance signal. The change applies to all import\nsuggestion scenarios (i.e., auto-import suggestion, import statement\nsuggestions, and unresolved reference suggestions).\n\nThis does **not** prefer symbols from standard library modules to third\nparty ones in general. A query that returns fuzzy matches from both the\nstandard library and third party libraries where the names of the\ncompletions differ may still have symbols from third party libraries\nranked above standard library ones. We can of course change this in the\nfuture, but without new relevance inputs (e.g. transitive dependency\ninformation from uv) I don't think we have any good basis for going\nfurther at the moment.\n\nCloses https://github.com/astral-sh/ty/issues/3325.\n\n## Test Plan\n\nPlease see included tests.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "e1cdbbad869bea136223631f13b152beaf3a3899",
+      "subject": "[`ruff`] Add `fallible-context-manager` (`RUF075`) (#22844)",
+      "body": "## Summary\n\nAdds a new rule `RUF075` (preview) that detects\n`@contextlib.contextmanager` and `@contextlib.asynccontextmanager`\ndecorated functions where `yield` is not protected against exceptions.\n\nCloses #15629.\n\n## Details\n\nWhen a context manager yields without exception protection, cleanup code\nafter `yield` won't run if an exception is raised inside the `with`\nblock.\n\n```python\n# Bad - cleanup won't run on exception\n@contextmanager\ndef bad():\n    print(\"setup\")\n    yield\n    print(\"cleanup\")  # never runs if exception raised\n\n# Good\n@contextmanager\ndef good():\n    print(\"setup\")\n    try:\n        yield\n    finally:\n        print(\"cleanup\")  # always runs\n```\n\nThe rule does **not** flag:\n- Yields inside `try` blocks that have a `finally` or `except` handler\n- Yields as the last statement of a `with` block (cleanup is delegated\nto `__exit__`)\n- Yields in terminal position (last statement in the function body, or\nimmediately before a `return`), where there is no trailing cleanup that\ncould be skipped\n\nTerminal position is inherited through `if` / `for` / `while` / `match`\nbranches: a yield that is the last statement of a branch is terminal\nonly when the enclosing statement is itself terminal.\n\nThe rule is in preview mode.\n\n## Test Plan\n\nTests live in `crates/ruff_linter/resources/mdtest/ruff.md` and are run\nvia:\n\n```sh\ncargo nextest run -p ruff_mdtest -- mdtest::ruff\n```"
+    },
+    {
+      "commit": "6b742aa8a788e71f35d32b11234262da797824c7",
+      "subject": "[ty] Respect `dict`-compatible fallbacks in TypedDict unions (#25242)",
+      "body": "## Summary\n\nPrior to this change, this snippet would produce a TypedDict-based\n`missing-key` diagnostic, because the RHS wasn't viewed as assignable to\nthe `Mapping[int, float]` (since we were only gating on `dict`):\n\n```py\nfrom typing import TypedDict, Mapping\n\nclass Foo(TypedDict):\n    some: str\n    name: str\n\nmapping: Foo | Mapping[int, float] = {1: 5.2}\n```\n\nWe now use speculative inference to determine whether the non-TypedDict\nunion member `T` is a viable fallback type.\n\nCloses https://github.com/astral-sh/ty/issues/3488."
+    },
+    {
+      "commit": "82283221ee4ea1c1687c28fc961cc6b99ab378c0",
+      "subject": "Add visibility guidance to AGENTS.md (#25275)",
+      "body": "## Summary\n\nSee:\nhttps://github.com/astral-sh/ruff/pull/25249#discussion_r3272954022."
+    },
+    {
+      "commit": "bd2d6f635312d6fd9d85ea77181b50ae0eddbf8e",
+      "subject": "Update/regenerate various `ruff_python_stdlib` APIs (#25273)",
+      "body": "## Summary\n\n1. Manually update various functions in\n`crates/ruff_python_stdlib/src/builtins.rs` to reflect new APIs added in\nPython 3.15.\n2. Manually remove the incorrect inclusion of `frozenset` from\n`is_immutable_non_generic_type` in\n`crates/ruff_python_stdlib/src/typing.rs`. `frozenset` is a generic\ntype.\n3. Manually add `frozendict` to `is_immutable_generic_type` and\n`is_immutable_return_type` in `crates/ruff_python_stdlib/src/typing.rs`\n4. Manually updates to `scripts/generate_builtin_modules.py`: use uv to\ninvoke Python rather than relying on many different Python versions all\nbeing on `PATH`, drop support for Python 3.7 from the script (it can't\nbe installed using uv), and apply various other simplifications.\n5. Regenerate `is_builtin_module` in\n`crates/ruff_python_stdlib/src/sys/builtin_modules.rs` following the\nchanges made in (4). Note that switching to uv-managed Python installs\n(PBS) appears to mean that quite a few more stdlib modules are\nrecognised as being builtin modules, which is interesting.\n\nI also ran `scripts/generate_known_standard_library.py`, but it didn't\nmake any changes to the Rust function generated by that script.\n\n## Test Plan\n\n`cargo test`"
+    },
+    {
+      "commit": "4bae734a78b929533dc50ae4f0a40e5ef18f3fba",
+      "subject": "Update Ruff mdtest structure (#25246)",
+      "body": "Summary\n--\n\nWhile working on #25233, I realized that my suggestion to group multiple\nrules within the same\nMarkdown file using top-level headings ran afoul of a markdownlint\n[rule] against having multiple\ntop-level headings in the same file. I was a bit worried about the size\nof the resulting files if we\nfollowed this suggestion anyway, so I think the best course of action is\nto recommend directories\nfor each linter with a separate file per rule.\n\nThis PR updates our existing mdtests to this new structure and also\nupdates the recommendation in the\ncontributing docs.\n\nTest Plan\n--\n\nExisting mdtests in new locations\n\n[rule]:\nhttps://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md025"
+    },
+    {
+      "commit": "multiple-top-level-headings-in-the-same-document",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "c189569c415ae7d7004b29f59263f60bae71323b",
+      "subject": "[ty] Sync vendored typeshed stubs (#25271)",
+      "body": "Close and reopen this PR to trigger CI\n\nCloses https://github.com/astral-sh/ty/issues/2945"
+    },
+    {
+      "commit": "Co-authored-by: typeshedbot <>\nCo-authored-by: Alex Waygood <alex.waygood@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "590ad0716d4219659cedf42b1081ce78b21b7784",
+      "subject": "[ty] Add quick fix to remove redundant cast (#25211)",
+      "body": "Co-authored-by: Micha Reiser <micha@reiser.io>"
+    },
+    {
+      "commit": "eab0666c6846bdc0c44c72938cb79f9901c1abcd",
+      "subject": "[ty] Sync vendored typeshed stubs (#25172)",
+      "body": "Close and reopen this PR to trigger CI"
+    },
+    {
+      "commit": "Co-authored-by: typeshedbot <>\nCo-authored-by: Micha Reiser <micha@reiser.io>\nCo-authored-by: Alex Waygood <alex.waygood@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "eff79960538bad718708d778bafd3a859af48168",
+      "subject": "[ty] Add error context for extra callable parameters (#25269)",
+      "body": "## Summary\n\nIn an invalid assignment like the following ...\n\n```py\ndef source(x: int, extra: str) -> bool: ...\n\ntarget: Callable[[int], bool] = source\n```\n\n... we now add a new error context hint (last line):\n\n```\nerror[invalid-assignment]: Object of type `def source(x: int, extra: str) -> bool` is not assignable to `(int, /) -> bool`\n  --> src/mdtest_snippet.py:16:9\n   |\n16 | target: Callable[[int], bool] = source  # snapshot\n   |"
+    },
+    {
+      "commit": "^^^^^^ Incompatible value of type `def source(x: int, extra: str) -> bool`\n   |         |\n   |         Declared type\n   |\ninfo: unexpected extra parameter `extra`\n```\n\n## Test Plan\n\nNew Markdown test",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "f242f371cee5b7363194914f99745decb7f810c3",
+      "subject": "[ty] Preserve declaration order when synthesizing class fields (#25249)",
+      "body": "## Summary\n\nPrior to this change, field synthesis could accidentally follow\nsymbol-table order instead of class-body declaration order in\npathological cases like:\n\n```python\nfrom dataclasses import InitVar, dataclass\nfrom ty_extensions import Top\n\n@dataclass\nclass C:\n    a: Top[int]\n    int: InitVar[int] = 0\n```\n\nHere, `int` can be interned before its own declaration because it\nalready appears in `Top[int]`.\n\nThis PR carries a stable declaration ordinal through declaration lookup\nand uses it when building `own_fields()`.\n\nCloses https://github.com/astral-sh/ty/issues/3493."
+    },
+    {
+      "commit": "f9b2a8fc53bb13afac01695989cab9a93d6fcc7f",
+      "subject": "[ty] Add a clarifying comment for optional `enum_metadata` (#25268)",
+      "body": "## Summary\n\nSee:\nhttps://github.com/astral-sh/ruff/pull/25237#discussion_r3270253906."
+    },
+    {
+      "commit": "add4e82fa2f9cac094cd78c2c3d24040cb598b6c",
+      "subject": "Update maturin to v1.13.3 (#25257)",
+      "body": ""
+    },
+    {
+      "commit": "4274342e9261cf56ac89e324f3a26be537bc7e7e",
+      "subject": "[ty] Speed up include filtering for projects with many literal include patterns (#25266)",
+      "body": "## Summary\n\n- Track literal include globs in a bitset to avoid a linear scan over\nliteral pattern indices.\n- Keep the existing fast path when an include filter has no literal\npatterns.\n- Add a ty benchmark that exercises a 1024-literal include set through\n`Project::is_file_included`.\n\n## Benchmark\n\nCommand:\n\n`cargo bench -p ruff_benchmark --bench ty --no-default-features\n--features ty_instrumented ty_include_filter -- --sample-size 10`\n\nResults:\n\n- `origin/main` with this benchmark added: `[1.4059 us 1.4082 us 1.4100\nus]`\n- This PR: `[957.18 ns 961.50 ns 965.61 ns]`\n\nThis is about 1.46x faster, or a 31.7% reduction in time per literal\ninclude match in this benchmark.\n\n## Test Plan\n\n- `cargo test -p ty_project glob::include`\n- `cargo check -p ruff_benchmark --benches --no-default-features\n--features ty_instrumented`\n- `cargo bench -p ruff_benchmark --bench ty --no-default-features\n--features ty_instrumented ty_include_filter -- --sample-size 10`\n\nRefs #25244"
+    },
+    {
+      "commit": "Co-authored-by: Micha Reiser <micha@reiser.io>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "de6477006674c0465ac1b2cca1426173c3da0363",
+      "subject": "Treat generic `frozenset` annotations as immutable (#25251)",
+      "body": "## Summary\n\nCloses https://github.com/astral-sh/ruff/issues/25248."
+    },
+    {
+      "commit": "a0999f736437c710a18861d6e60e72faeeca9653",
+      "subject": "Update cloudflare/wrangler-action action to v4 (#25265)",
+      "body": ""
+    },
+    {
+      "commit": "b5b7fbf5344112f391fd2ab13244e7bf69882afd",
+      "subject": "Update NPM Development dependencies (#25263)",
+      "body": "This PR contains the following updates:\n\n| Package | Change |\n[Age](https://docs.renovatebot.com/merge-confidence/) |\n[Confidence](https://docs.renovatebot.com/merge-confidence/) |\n|"
+    },
+    {
+      "commit": "Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>\nCo-authored-by: Micha Reiser <micha@reiser.io>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "dd554406e0c212da469f56fff9c9d98988f7a048",
+      "subject": "Update Rust crate serde_with to v3.20.0 (#25264)",
+      "body": ""
+    },
+    {
+      "commit": "8a1112ae88c1a6d573ac1b81de339111f034b561",
+      "subject": "Update Rust crate filetime to v0.2.29 (#25259)",
+      "body": ""
+    },
+    {
+      "commit": "e8dcd8a813256c10f6a3d79fc0e63feede5e80e1",
+      "subject": "Update actions/setup-go action to v6.4.0 (#25262)",
+      "body": ""
+    },
+    {
+      "commit": "c2c71e23a03b98e2e4eff3262e9bace782d42e9d",
+      "subject": "Update Rust crate hashbrown to v0.17.1 (#25260)",
+      "body": ""
+    },
+    {
+      "commit": "410891287f7a2b4025346c43a2e17294d913cfe5",
+      "subject": "Update taiki-e/install-action action to v2.77.7 (#25261)",
+      "body": ""
+    },
+    {
+      "commit": "4cf6ae9567d3a20becefe2b4e183508b62000889",
+      "subject": "Update CodSpeedHQ/action action to v4.15.1 (#25253)",
+      "body": "This PR contains the following updates:\n\n| Package | Type | Update | Change |\n|"
+    },
+    {
+      "commit": "This PR was generated by [Mend Renovate](https://mend.io/renovate/).\nView the [repository job\nlog](https://developer.mend.io/github/astral-sh/ruff).\n\n<!--renovate-debug:eyJjcmVhdGVkSW5WZXIiOiI0My4xODUuMSIsInVwZGF0ZWRJblZlciI6IjQzLjE4NS4xIiwidGFyZ2V0QnJhbmNoIjoibWFpbiIsImxhYmVscyI6WyJpbnRlcm5hbCJdfQ==-->\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "688260b6396007f7024dde53828a6e2bfb7ddf1e",
+      "subject": "Update dependency go to v1.26.3 (#25255)",
+      "body": "This PR contains the following updates:\n\n| Package | Type | Update | Change |\n|"
+    },
+    {
+      "commit": "This PR was generated by [Mend Renovate](https://mend.io/renovate/).\nView the [repository job\nlog](https://developer.mend.io/github/astral-sh/ruff).\n\n<!--renovate-debug:eyJjcmVhdGVkSW5WZXIiOiI0My4xODUuMSIsInVwZGF0ZWRJblZlciI6IjQzLjE4NS4xIiwidGFyZ2V0QnJhbmNoIjoibWFpbiIsImxhYmVscyI6WyJpbnRlcm5hbCJdfQ==-->\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "9b8744fc135bef9a800e7da77281ea95541ce20e",
+      "subject": "Update pre-commit hook crate-ci/typos to v1.46.1 (#25258)",
+      "body": "This PR contains the following updates:\n\n| Package | Type | Update | Change | Pending |\n|"
+    },
+    {
+      "commit": "This PR was generated by [Mend Renovate](https://mend.io/renovate/).\nView the [repository job\nlog](https://developer.mend.io/github/astral-sh/ruff).\n\n<!--renovate-debug:eyJjcmVhdGVkSW5WZXIiOiI0My4xODUuMSIsInVwZGF0ZWRJblZlciI6IjQzLjE4NS4xIiwidGFyZ2V0QnJhbmNoIjoibWFpbiIsImxhYmVscyI6WyJpbnRlcm5hbCJdfQ==-->\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "91ea0357a251d8ebae170b37754f7921852c48be",
+      "subject": "Update dependency ruff to v0.15.13 (#25256)",
+      "body": "This PR contains the following updates:\n\n| Package | Change |\n[Age](https://docs.renovatebot.com/merge-confidence/) |\n[Confidence](https://docs.renovatebot.com/merge-confidence/) |\n|"
+    },
+    {
+      "commit": "This PR was generated by [Mend Renovate](https://mend.io/renovate/).\nView the [repository job\nlog](https://developer.mend.io/github/astral-sh/ruff).\n\n<!--renovate-debug:eyJjcmVhdGVkSW5WZXIiOiI0My4xODUuMSIsInVwZGF0ZWRJblZlciI6IjQzLjE4NS4xIiwidGFyZ2V0QnJhbmNoIjoibWFpbiIsImxhYmVscyI6WyJpbnRlcm5hbCJdfQ==-->\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "6f7303aec96f7d026e90d7bb93818ffb0af334a1",
+      "subject": "Update cargo-bins/cargo-binstall action to v1.19.1 (#25252)",
+      "body": "This PR contains the following updates:\n\n| Package | Type | Update | Change |\n|"
+    },
+    {
+      "commit": "This PR was generated by [Mend Renovate](https://mend.io/renovate/).\nView the [repository job\nlog](https://developer.mend.io/github/astral-sh/ruff).\n\n<!--renovate-debug:eyJjcmVhdGVkSW5WZXIiOiI0My4xODUuMSIsInVwZGF0ZWRJblZlciI6IjQzLjE4NS4xIiwidGFyZ2V0QnJhbmNoIjoibWFpbiIsImxhYmVscyI6WyJpbnRlcm5hbCJdfQ==-->\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "2c35d96099ba398b4877437369eb6006b6c2bf4e",
+      "subject": "Update dependency astral-sh/uv to v0.11.15 (#25254)",
+      "body": "This PR contains the following updates:\n\n| Package | Type | Update | Change |\n|"
+    },
+    {
+      "commit": "This PR was generated by [Mend Renovate](https://mend.io/renovate/).\nView the [repository job\nlog](https://developer.mend.io/github/astral-sh/ruff).\n\n<!--renovate-debug:eyJjcmVhdGVkSW5WZXIiOiI0My4xODUuMSIsInVwZGF0ZWRJblZlciI6IjQzLjE4NS4xIiwidGFyZ2V0QnJhbmNoIjoibWFpbiIsImxhYmVscyI6WyJpbnRlcm5hbCJdfQ==-->\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "cd6d425918b4ce4fce6a855bb6e2df383565b27d",
+      "subject": "[ty] Escape HTML syntax in docstring rendering (#25247)",
+      "body": "## Summary\n\nCloses https://github.com/astral-sh/ty/issues/3482\n\nFixes the HTML rendering bug by escaping HTML sensitive characters\n\n<img width=\"731\" height=\"538\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ab1f9e40-5735-45ec-8242-3659ccdcb1e6\"\n/>\n\n\n## Test Plan\n\nAdded hover integration tests and docstring unit test"
+    },
+    {
+      "commit": "85c9e749cb51a867d6453346b3d80e34aac6e5d5",
+      "subject": "[ty] Support class decorators (#25091)",
+      "body": "## Summary\n\nThis PR adds support for class decorator return types, following Carl's\ncomment in\nhttps://github.com/astral-sh/ty/issues/2604#issuecomment-3793310652:\nassume unannotated decorators preserve the class binding when their\nresult is otherwise `Unknown`, but support explicit spelling of an\nannotated decorator return type.\n\nIn more detail, the rule is roughly:\n\n- If applying the decorator gives a non-`Unknown` result...\n- And that result still retains the original class object, we preserve\nthe class.\n  - Otherwise, we replace the public binding with that result.\n- If applying the decorator gives an `Unknown` result:\n  - We fall back to the decorator\u2019s own shape.\n- Unannotated function/method decorators are treated as\n\"identity-preserving\", so we keep the current class binding.\n- Decorators with an explicit return annotation are not, so we do _not_\npreserve the binding.\n\nAs a concrete example, an unannotated decorator like the personify\nexample from #2604 is still treated as preserving the original class\n(since we don't have a static replacement type):\n\n```python\ndef personify(cls):\n    class Wrapped(cls):\n        full_name: str\n\n        def set_full_name(self, full_name: str) -> None:\n            self.full_name = full_name\n\n    return Wrapped\n\n@personify\nclass Animal: ...\n\nreveal_type(Animal)  # <class 'Animal'>\nAnimal().set_full_name(\"John\")  # error: unresolved attribute\n```\n\nBut if the decorator has an explicit return type, we use it for the\npublic class binding:\n\n```python\nclass WrapBackend:\n    def __init__(self, cls: type[object]) -> None: ...\n\n    def get(self, key: str) -> bytes | None: ...\n\n@WrapBackend\nclass CacheClient: ...\n\nreveal_type(CacheClient)  # WrapBackend\nreveal_type(CacheClient.get(\"x\"))  # bytes | None\n```\n\nThis gives us stable behavior for common untyped identity decorators\nwhile leaving the advanced and unsound returned-class inference path out\nof scope...\n\nCloses https://github.com/astral-sh/ty/issues/143."
+    },
+    {
+      "commit": "c130dcec27484813fe1a710479244ab6b4b25779",
+      "subject": "[ty] Handle aliased dict fallbacks in TypedDict unions (#25241)",
+      "body": "## Summary\n\nWhen a `TypedDict` union includes a `dict`-compatible fallback behind a\ntype alias, we need to resolve it, as in:\n\n```python\ntype IntFloatDict = dict[int, float]\ntype TypedDictOrDictAlias = TD | IntFloatDict\n\nvalue: TypedDictOrDictAlias = {1: 5.2}\n```\n\nThere are some other similar bugs that I noticed while working on this,\nwhich I'll fix in separate PRs.\n\nCloses https://github.com/astral-sh/ty/issues/3488."
+    },
+    {
+      "commit": "51a7c2e7c8e9a64f64afc59a2242d8737b5cf77d",
+      "subject": "[`ruff`] Add `incorrect-decorator-order` (`RUF074`) (#23461)",
+      "body": "## Summary\n\nImplements detection of incorrect decorator ordering on functions and\nmethods (RUF071).\nDecorators are applied bottom-up, so certain stdlib decorator\ncombinations cause runtime errors or silent wrong behavior when placed\nin the wrong order. For example, `@abstractmethod` above `@property`\nresults in `AttributeError: __isabstractmethod__`.\n\nDetects known-bad pairs involving:\n- `abc.abstractmethod` (+ deprecated `abstractclassmethod`,\n`abstractstaticmethod`, `abstractproperty`)\n- `builtins.property`, `builtins.classmethod`, `builtins.staticmethod`\n- `contextlib.contextmanager`, `contextlib.asynccontextmanager`\n- `functools.cache`, `functools.cached_property`, `functools.lru_cache`\n\n## Test Plan\n\n`cargo nextest run -p ruff_linter -E\n'test(preview_rules::rule_incorrectdecoratororder)'`\n\n Fixture covers: \n- All known-bad pairs (core + functools)\n- Qualified imports (`abc.abstractmethod`, `functools.lru_cache`)\n- Deprecated abc forms (`abstractproperty`, `abstractclassmethod`,\n`abstractstaticmethod`)\n- Decorator call forms (`@lru_cache()`, `@lru_cache(maxsize=128)`)\n- Interleaved unknown decorators\n- Multiple violations on the same function\n- Correct orderings, single decorators, unrelated decorators (no false\npositives)\n\nCloses #6697"
+    },
+    {
+      "commit": "8c930f5972841d899ff0586f9b8d45a85815a5d3",
+      "subject": "[`airflow`] Implement `airflow-task-implicit-multiple-outputs` (`AIR202`) (#25152)",
+      "body": "> [!IMPORTANT]\n> Disclosure: this PR description was AI-drafted under my direction and\nreviewed by me before posting.\n\n## Summary\n\nImplements rule `AIR202` (`airflow-task-implicit-multiple-outputs`) that\nflags `@task`-decorated functions whose `multiple_outputs` behavior is\ndetermined by Airflow's runtime inference rather than being set\nexplicitly on the decorator.\n\nAt runtime, Airflow's\n[`_infer_multiple_outputs`](https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/bases/decorator.py)\ninspects the function's return annotation: if it resolves to a subclass\nof `collections.abc.Mapping`, the return value is split into one `XCom`\nper key; otherwise the entire return value is stored as a single `XCom`.\nThis couples typing to `XCom` layout in a non-obvious way \u2014 renaming,\nremoving, or refining the return annotation silently changes a DAG's\n`XCom` behavior. Passing `multiple_outputs=` explicitly makes the\nauthor's intent clear and insulates the DAG from future changes to\ninference.\n\n### What the rule flags\n\n```python\nfrom airflow.sdk import task  # or equivalent Airflow 2.x import path\n\n\n# AIR202 \u2014 annotation in the Mapping family\n@task\ndef extract() -> dict:\n    return {\"x\": 1, \"y\": 2}\n\n\n# AIR202 \u2014 body returns a dict literal\n@task()\ndef transform():\n    return {\"a\": 1}\n\n\n# AIR202 \u2014 call-form decorator with unrelated kwargs\n@task(retries=3)\ndef with_retries() -> dict[str, int]:\n    return {\"n\": 1}\n\n\n# AIR202 \u2014 variant decorators with parens\n@task.short_circuit(trigger_rule=\"all_done\")\ndef gate() -> dict:\n    return {\"go\": True}\n```\n\n### Suggested fix\n\nThe fix is **always available** but marked **unsafe**: it inserts the\nvalue Airflow would have inferred, preserving runtime behavior at the\nmoment of the rewrite, but the author may have intended a different\n`XCom` layout and a multi-return function may not always return a dict.\n\n```python\n@task(multiple_outputs=True)\ndef extract() -> dict:\n    return {\"x\": 1, \"y\": 2}\n\n\n@task(multiple_outputs=True)\ndef transform():\n    return {\"a\": 1}\n\n\n@task(retries=3, multiple_outputs=True)\ndef with_retries() -> dict[str, int]:\n    return {\"n\": 1}\n```\n\nFor the call-form path (`@task(...)` with existing parentheses), the fix\nuses `add_argument` so existing kwargs and formatting are preserved,\nincluding on multiline decorators. For the bare form (`@task`,\n`@task.branch`), the fix appends `(multiple_outputs=...)` after the\ndecorator expression.\n\n### Detection signals\n\nThe rule fires when **either** of two independent signals holds and\n`multiple_outputs` is absent from the decorator:\n\n1. **Annotation signal** \u2014 the return annotation resolves to a member of\nthe Mapping family: `dict`, `Dict`, `Mapping`, `MutableMapping`,\n`OrderedDict`, `DefaultDict`, `Counter`, `ChainMap`, `TypedDict` (and\nthe `collections` / `typing` variants thereof).\n2. **Body signal** \u2014 the function body contains at least one `return`\nstatement whose value is a dict literal, a dict comprehension, or a\n`dict(...)` call. `ReturnStatementVisitor` is used so returns inside\nnested `if` / `for` / `while` / `try` blocks are considered, while\nreturns inside nested function definitions or class bodies are correctly\n**not** considered.\n\n### What it does NOT flag\n\n- Functions where `multiple_outputs=` is already set explicitly (either\n`True` or `False`).\n- `@task.sensor`-decorated functions \u2014 the sensor decorator hardcodes\n`multiple_outputs=False`.\n- Functions whose only dict-returning code lives in a nested function or\nclass method (the outer task is not affected).\n- Functions whose return annotation is not in the Mapping family and\nwhose body does not return a dict-shaped value.\n\n### Implementation details\n\n- Resolves `@task` / `@task.<variant>` via the semantic model, handling\nboth bare (`@task`) and call (`@task(...)`) forms via `map_callable`.\nThe supported variants list is local to the rule: `python`,\n`virtualenv`, `external_python`, `branch`, `branch_virtualenv`,\n`branch_external_python`, `short_circuit`, `docker`, `kubernetes`,\n`pyspark`.\n- Annotation matching walks subscripts (e.g., `dict[str, int]`,\n`Mapping[str, Any]`) down to the head and uses `match_typing_expr` /\nknown-module resolution.\n- Body matching uses `ReturnStatementVisitor` from\n`ruff_python_ast::helpers`, which already skips nested function and\nclass definitions \u2014 so nested-scope dict returns are correctly ignored\nwithout a custom traversal.\n- The inserted value (`True` / `False`) mirrors Airflow's inference:\n`True` when the annotation is in the Mapping family, `False` otherwise.\nWhen both signals fire but the annotation is non-Mapping (e.g., body\nreturns a dict but the annotation is `list`), the inserted value is\nstill `False` to preserve runtime behavior.\n\n## Test Plan\n\nAdded snapshot tests in `AIR202.py` covering:\n\n| Group | Cases |\n|"
+    },
+    {
+      "commit": "Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "49286a785f06fbc26e2f0b27cd498f9360e1a9f3",
+      "subject": "[ty] Fix class-body global lookup before class binding (#25224)",
+      "body": "## Summary\n\nPrior to this change, we could miss an unresolved reference when a class\nbody assigned the class name to itself:\n\n```python\nclass A:\n    A = A\n```\n\nAt runtime, the module-level binding for `A` is only created after the\nclass body finishes evaluating, so the right-hand side raises a\n`NameError`.\n\nWe already handled this correctly in the normal global fallback path by\nresolving globals through the enclosing snapshot for eager nested\nscopes, but the class-body short-circuit bypassed that logic. E.g., we\ndid it correctly here...\n\n```python\nx = 1\n\nclass C:\n    reveal_type(x)\n```\n\nBut not here:\n\n```python\nx = 1\n\nclass C:\n    reveal_type(x)  # should see global x\n    x = 2           # makes x class-local\n```\n\nCloses https://github.com/astral-sh/ty/issues/3484."
+    },
+    {
+      "commit": "fe617558df3e3d3a1f90a1aeb59238e76418f4bb",
+      "subject": "[ty] Avoid enum literal panic during cycle recovery (#25237)",
+      "body": "## Summary\n\nCloses https://github.com/astral-sh/ty/issues/3481."
+    },
+    {
+      "commit": "e2faa1d2e75312b9feb01351adb7d3df079a81d5",
+      "subject": "[ty] Avoid forcing lazy `NewType` bases during cycle recovery (#25234)",
+      "body": "## Summary\n\nPrior to this change, normalizing a `NewType` walked through its base\nvia `try_map_base_class_type`, which could force the lazy base of a\n`NewType` while another cycle was mid-recovery, which in turn could\nintroduce a new dependency back through function signature inference and\npanic on code like:\n\n```python\ndef g() -> T: ...\n\nX = NamedTuple(\"X\", [(\"x\", \"X\")]), None\nT = f()\nX = NewType(\"X\", C)\n```\n\nThis PR keeps lazy `NewType` bases lazy during recursive normalization.\n\nCloses https://github.com/astral-sh/ty/issues/3485."
+    },
+    {
+      "commit": "c9a3c24cd30f3dea6e4d821588bad14c5ca112ed",
+      "subject": "[ty] Fix find references for except handler (#25231)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\nCloses https://github.com/astral-sh/ty/issues/3387\n\nWe just needed to treat the definition of an except handler 'as' as a\nbinding, not a definition\n\n## Test Plan\n\nPreviously incorrect ty_ide test, noted in the issue, has now been fixed"
+    },
+    {
+      "commit": "18a5dd2c6c7c994e8dd5128cfefc0dc6205321c5",
+      "subject": "[ty] Preserve delimiters when folding expressions. (#24999)",
+      "body": "<!--\nThank you for contributing to Ruff/ty! To help us out with reviewing,\nplease consider the following:\n\n- Does this pull request include a summary of the change? (See below.)\n- Does this pull request include a descriptive title? (Please prefix\nwith `[ty]` for ty pull\n  requests.)\n- Does this pull request include references to any relevant issues?\n- Does this PR follow our AI policy\n(https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?\n-->\n\n## Summary\n\n<!-- What's the purpose of the change? What does it do, and why? -->\n\nThis makes it so that we preserve outer delimiters when folding\nexpressions. For instance:\n\n```py\nx = [\n    1,\n    2,\n    3,\n]\n```\n\nnow folds like so in a character-precise LSP client:\n\n```py\nx = [...]\n```\n\nrather than like so:\n\n```py\nx = ...\n```\n\nThe same behavior applies to parethesized callables, call args, sets,\ntuples, comprehensions, type parameter lists, and subscripts.\n\n**I recommend reviewing this diff commit-by-commit.**\n\nCloses https://github.com/astral-sh/ty/issues/3427.\n\n## Test Plan\n\nPlease see updated tests.\n<!-- How was it tested? -->"
+    },
+    {
+      "commit": "a2a71c59e13213dfa438ea54a00897c0c0aa80b0",
+      "subject": "[ty] Add first-class support for enum complements (#24961)",
+      "body": "## Summary\n\nPreviously, narrowing an enum by excluding one or more members eagerly\nexpanded the enum into a union of all remaining enum literals. That's\nfine for small enums, but can cause large enums to blow up during\nrepeated equality or membership narrowing. And large enums are not\nuncommon...\n\nThis PR keeps those narrowed types in a compact form, like `Color &\n~Literal[Color.RED]`, instead of immediately expanding them to\n`Literal[Color.GREEN, Color.BLUE, ...]`. The type is expanded only when\nwe need to inspect the remaining enum members individually (like for\noverload matching or attribute lookup). The net effect is that we retain\nthe existing behavior while avoiding a brutal performance penalty for\nlarge enums.\n\nNote that we do vary some behavior by enum size. For example, with more\nthan 7 elements, we use (as you can see in the ecosystem diff) the\ncompact representation (`SupportedBlockchain &\n~Literal[SupportedBlockchain.ETHEREUM_BEACONCHAIN`).\n\nFor the benchmark in the linked issue, `main` doesn't finish within 30s,\nbut this PR completes in 128ms.\n\nCloses https://github.com/astral-sh/ty/issues/1588."
+    },
+    {
+      "commit": "Co-authored-by: Codex <noreply@openai.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "d810dffab71eec0a16911b04a5eebc9c64098f7e",
+      "subject": "[ty] Allow known non-field writes on frozen dataclass subclasses (#25087)",
+      "body": "## Summary\n\nA `frozen=True` dataclass rejects writes to all declared and undeclared\nattributes; however, a non-frozen subclass of a `frozen=True` dataclass\nonly rejects writes to the attributes declared on the dataclass.\n\nThis PR synthesizes a set of `__setattr__` overloads for such subclasses\nto narrow the scope of the \"frozen\" behavior to only those attributes\ndefined by the dataclass, matching the behavior used in Mypy and Pyright\n(and at runtime).\n\nFor example, `child.y = 2` is now accepted:\n\n```python\nfrom dataclasses import dataclass\n\n@dataclass(frozen=True)\nclass Frozen:\n    x: int = 1\n\nclass Child(Frozen):\n    y: int\n\nchild = Child()\nchild.x = 2  # runtime: FrozenInstanceError\nchild.y = 2  # runtime: OK\n```\n\nCloses https://github.com/astral-sh/ty/issues/3434."
+    },
+    {
+      "commit": "2c32fedd9661fc300784f5109ab2cfedbef07823",
+      "subject": "[ty] Ignore generic specialization in layout compatibility checks (#25178)",
+      "body": "## Summary\n\nEvery time someone tries to touch this code, it gets rejected, so I\ndon't have high hopes here. Anyway...\n\nPreviously, a generic disjoint base and a subclass of that base could be\nmarked as incompatible if the type arguments didn't line up. But at\nruntime, CPython's instance layout check isn't affected by type\narguments. A concrete example is:\n\n```python\nimport asyncio\n\nclass Future(asyncio.Future): ...\nclass Task(asyncio.Task): ...\nclass SubClass(Task, Future): ...\n```\n\n`asyncio.Task` is a subclass of `asyncio.Future`, so these bases can\ncoexist in the same MRO. But before, we ended up doing a comparison like\n`Task[Unknown] <: Future[Unknown]`, which I believe ends up failing\nbecause `Unknown <: Unknown` is false under subtyping?"
+    },
+    {
+      "commit": "349ad0300ec73c601c7d22de39681418f60335e7",
+      "subject": "suppress NO_COLOR in the environment for ruff_annotate_snippets tests (#25221)",
+      "body": "I've noticed that Codex tends to set this env var in its own shell when\nit runs tests, and it currently causes some test failures."
+    },
+    {
+      "commit": "3705b8d0c741c705e645347427f1766db13949c1",
+      "subject": "Pin cargo-shear to v1.12.4 (#25218)",
+      "body": "Summary\n--\n\nThis is a follow-up to 88289f00d45fa78c60d355a51c609d290df01743 now that\nv1.12.1 should be out with the fix to\nhttps://github.com/Boshen/cargo-shear/issues/497 included. There have\nbeen 3 additional releases since that bug fix, so this PR pins to the\nlatest release.\n\nTest Plan\n--\n\nCI on this PR"
+    },
+    {
+      "commit": "cc6fa6616ea5dbe93fc84677add62e402ce6f92d",
+      "subject": "[ty] Use incremental file walk on `.gitignore` change (#25183)",
+      "body": ""
+    },
+    {
+      "commit": "505a51c06c6355fe59c2b7a2ef46892ba02f7394",
+      "subject": "Add mdtests for Ruff (#24617)",
+      "body": "Summary\n--\n\nThis PR adds the `ruff_test` crate, a parallel crate to `ty_test` for\nRuff, to\nenable the new mdtests in `ruff_linter`. I opted to follow the\n`Db`-based\nstructure of `ty_test` to simplify the integration, but we end up\nbasically just\nunpacking the files from the `Db` to call the `test_contents` function\nfrom the\nlinter.\n\nI also updated the section of the contributing guidelines on lint rule\ntesting to suggest using mdtests.\n\nTest Plan\n--\n\nI copied over the S704 tests into a new mdtest. I selected this rule\nbecause it had several separate fixture files that all used different\nsettings and each of the fixtures was relatively short. I had initially\nreached for a more complicated rule (UP046), but this seemed less likely\nto clutter the diff while still exercising most mdtest features."
+    },
+    {
+      "commit": "Co-authored-by: Micha Reiser <micha@reiser.io>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "ab1e16d2cc41f9ea060fe918734ad1128405ba06",
+      "subject": "[ty] Preserve short-circuit bindings in all condition consumers (#25160)",
+      "body": "## Summary\n\nWe already compute precise truthy and falsy flow snapshots for\nshort-circuiting boolean expressions, so walrus bindings are only\nvisible on paths where the right-hand side actually ran. Prior to this\nchange, we mostly used those snapshots for `if` conditions, and not\n(e.g.) in the following case:\n\n```python\ndef f(flag: bool):\n    assert flag and (x := 1)\n    reveal_type(x)\n```\n\nThis PR generalizes that logic into condition-flow snapshots and applies\nit anywhere we evaluate a condition before\ncontinuing under its truthy or falsy outcome: `assert`, `while`, `match`\nguards, conditional expressions, and comprehension filters."
+    },
+    {
+      "commit": "b81d55ed7006089dcbea80a135b6b8a91c1ed1fd",
+      "subject": "[ty] Ignore `_generate_next_value_` with custom construction hooks (#25210)",
+      "body": "## Summary\n\nOne oversight in my changes to\nhttps://github.com/astral-sh/ruff/pull/25196: if a custom `__new__` is\ndefined, we should treat the alias value as `Any`, rather than relying\non `_generate_next_value_`. This matches Pyright, for example.\n\nE.g., given:\n\n```python\nclass E(Enum):\n    @staticmethod\n    def _generate_next_value_(...) -> Literal[\"x\"]:\n        return \"x\"\n\n    def __new__(cls, value: str):\n        obj = object.__new__(cls)\n        obj._value_ = object()\n        return obj\n\n    A = auto()\n    B = auto()\n```\n\nPrior to this change, we treated `B` as an alias of `A`; but if\n`__new__` is defined, we don't attempt to detect the alias."
+    },
+    {
+      "commit": "3fcc98230aef17e1867bed86823292194502025f",
+      "subject": "[ty] Support for custom `_generate_next_value_` in enums (#25196)",
+      "body": "## Summary\n\nhttps://github.com/astral-sh/ty/issues/876\n\nThis PR adds support for custom `_generate_next_value_` methods on\nenums.\n\nWhen set, this return type will take precedence over inferred `auto()`\nmember types unless an explicit `_value_` annotation is set.\n\nFalls back to `Any` if custom hooks (like `__init__`) are detected.\n\nReferences:\n- https://typing.python.org/en/latest/spec/enums.html#member-values\n-\nhttps://docs.python.org/3/library/enum.html#enum.Enum._generate_next_value_\n\n## Test Plan\n\nNew mdtests"
+    },
+    {
+      "commit": "Co-authored-by: Charlie Marsh <charlie.r.marsh@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "409c13f3ec502b1549cda3eadbbe82679b03563f",
+      "subject": "Add full PEP 798 support (#25104)",
+      "body": "Fixes #25098.\n\nThis adds full support for PEP 798 through the parser, linter,\nformatter, and type checker.\nThere are a lot of changes but they are mostly straightforward. Let me\nknow though if it's better to split this up."
+    },
+    {
+      "commit": "a7ab646e3e2aeb138a0de9dee5d7a28e9e054a56",
+      "subject": "[ty] Avoid enforcing `__new__` with custom metaclasses (#25180)",
+      "body": "## Summary\n\nThis PR makes enum member validation account for custom\n`EnumMeta.__new__` methods. Prior to this change, we validated the raw\nright-hand side of an enum member against inherited `_value_,`\n`__new__,` or `__init__`. But that's too strict for Django\u2019s\n`IntegerChoices` pattern...\n\n```python\nfrom django.db import models\n\nclass Status(models.IntegerChoices):\n    GOOD = 1, \"I like this\"\n```\n\nDjango\u2019s custom metaclass strips the label out of the member value\nbefore `IntEnum` construction, so the raw `(1,\n\"I like this\")` tuple is _not_ the value that should be checked against\n`int.__new__`.\n\nWe now detect a custom enum metaclass `__new__` and treat member values\nas potentially transformed. In that case, we skip raw-RHS validation\nagainst enum construction hooks, and `.value` / `._value_` falls back to\n`Any` (unless the enum class itself declares an explicit `_value_`\nannotation).\n\nPyright has similar behavior here:\nhttps://github.com/microsoft/pyright/blob/63998f4d0720a86447f4c4a04716e34f3e703660/packages/pyright-internal/src/analyzer/enums.ts#L653-L660\n\nBut we do differ in this case:\n\n```python\nclass Status(IntegerChoices):\n    _value_: int\n    GOOD = 1, \"label\"\n```\n\nPyright exposes `Status.GOOD.value` as `int`, but still reports that the\nraw tuple is not assignable to `int`. We expose `Status.GOOD.value` as\n`int`, and don't report anything.\n\nCloses https://github.com/astral-sh/ty/issues/3468."
+    },
+    {
+      "commit": "c3bf783afda00b7ec0600b1f91f736c48df59a38",
+      "subject": "[ty] Only specialized types of generic class instances should influence variance (#25124)",
+      "body": "Resolves https://github.com/astral-sh/ty/issues/1459."
+    },
+    {
+      "commit": "73de014e8768924945b892c91f8a5fabffcdd1c8",
+      "subject": "Avoid over-aggressive prek runs in AGENTS.md (#25190)",
+      "body": "## Summary\n\nGPT is too good at instruction-following and runs this _so_ much. We\ngenerally only need `--from-ref @{upstream}`, and we should only do this\nat the end of a task."
+    },
+    {
+      "commit": "01f55e1e186fe490ef9a7fc59c0a307200678c1e",
+      "subject": "[ty] Fix panic from recursive binary inference (#25189)",
+      "body": ""
+    },
+    {
+      "commit": "4493c0fbfc0baf22d5400c5dc35f2462aa4c77f6",
+      "subject": "[ty] Avoid panic from disjoint base check (#25187)",
+      "body": "## Summary\n\nCloses https://github.com/astral-sh/ty/issues/3471."
+    },
+    {
+      "commit": "ec93ddf530b2882b22a1ca43901473df02cf70ac",
+      "subject": "[ty] Support partially specialized type context for collection literals (#24506)",
+      "body": "This regressed in https://github.com/astral-sh/ruff/pull/23848 because\nwe didn't have any test coverage for the collection literal case."
+    },
+    {
+      "commit": "2072f3f8d2b2fcc7679cb397b4fa169b60190bb3",
+      "subject": "[`pylint`] Implement `too-many-try-statements` (`W0717`) (#23970)",
+      "body": "## Summary\n\nClose #23810\n\nOpening as a draft mostly to signal that I'm getting this going. At the\ntime of opening, and as far as I can tell, this *compiles* correctly\nlocally, but it's missing tests and docs.\n\nI also have a question I would like to ask @ntBre at this early stage of\nthe PR: it seemed to me that the logic from\n`too_many_statements::num_statements` could be entirely re-used, and I\ndidn't want to duplicate it, so I moved it up the module tree to\n`ruff_linter::rules::pylint::helpers`. Is this the prefered approach, or\nis there a better way I should implement this code re-use ?\n\n## Test Plan"
+    },
+    {
+      "commit": "dd3fc71130b63a82566bc8745b6c4342ccb78b1f",
+      "subject": "[ty] Avoid panic in cyclic `__new__` (#25185)",
+      "body": "## Summary\n\nCloses https://github.com/astral-sh/ty/issues/3470."
+    },
+    {
+      "commit": "f495ff2f0cb28d3f3978d0da375b123fce7ecbc0",
+      "subject": "[ty] Don't show argument inlay for case-insensitive matches or prefix/suffixes (#25174)",
+      "body": ""
+    },
+    {
+      "commit": "d7be6c6f5da0ddab24b538f391655f258aa9d7dc",
+      "subject": "[ty] Fix async iteration over narrowed typevars (#25155)",
+      "body": "## Summary\n\nFixes the async case\n(https://github.com/astral-sh/ruff/pull/25143#issuecomment-4449423320)\nthat was left out in https://github.com/astral-sh/ruff/pull/25143"
+    },
+    {
+      "commit": "5ace2a89bdc6dcaa87089fa017db48d61030aaad",
+      "subject": "[`flake8-type-checking`] Avoid `strict` behavior when `future-annotations` are enabled (`TC001`, `TC002`, `TC003`) (#25035)",
+      "body": "## Summary\n\nFixes #23185.\n\nEnabling `lint.future-annotations = true` was silently flipping\n`TC001`/`TC002`/`TC003` into strict-mode behaviour, even when\n`lint.flake8-type-checking.strict = false`. The two settings are\northogonal \u2014 the former controls whether `from __future__ import\nannotations` is auto-inserted as a fix; the latter controls whether\ntyping-only imports whose module is already imported at runtime should\nbe flagged.\n\n## Root cause\n\nIn\n[`crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs`](https://github.com/astral-sh/ruff/blob/main/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs),\nthe skip condition for implicit runtime imports read:\n\n```rust\nif !checker.settings().future_annotations\n    && !checker.settings().flake8_type_checking.strict\n    && runtime_imports.iter().any(|import| is_implicit_import(binding, import))\n{\n    continue;\n}\n```\n\nThis required **both** `!future_annotations` **and** `!strict` to be\ntrue. The moment a user opted into `future_annotations = true`, the\nfirst clause became false and the entire skip was bypassed \u2014 making the\nrules behave as if `strict = true`, regardless of the user's explicit\n`strict = false` setting.\n\nThis also matches the direction @ntBre suggested on the issue:\n\n> This does sound like a bug to me. I think I may have gotten this logic\nwrong, and it should be an `or` instead of `and`\u2026\n\n## Solution\n\nDrop the `!future_annotations` clause. Only `!strict` should gate\nwhether implicit runtime imports are skipped. The `future_annotations`\nsetting is handled elsewhere (as part of the fix-generation path for\nadding the `__future__` import); it has no bearing on which imports are\nflagged.\n\n## Testing\n\n- **New regression test** in\n`crates/ruff_linter/src/rules/flake8_type_checking/mod.rs`:\n`future_annotations_respects_non_strict_mode`, backed by a new fixture\n`crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC001-3_future_strict.py`.\nThe test pins the exact scenario from the issue\n(`future_annotations=true`, `strict=false`, typing-only import whose\nmodule has a runtime-used sibling) and asserts zero\n`TC001`/`TC002`/`TC003` diagnostics are produced \u2014 a result that would\nhave been non-zero prior to this patch.\n- All 92 pre-existing `flake8_type_checking` lib tests still pass\nlocally; the `add_future_import` snapshot tests (which exercise the\n`future_annotations = true` path) also pass unchanged, confirming the\nfix does not regress the auto-insert-`__future__`-import behaviour.\n  - `cargo test --lib flake8_type_checking` \u2192 92 passed, 0 failed\n  - `cargo test --lib add_future_import` \u2192 12 passed, 0 failed\n\n## Checklist\n\n- [x] Fixes the root cause (not just the symptom)\n- [x] New test covers the exact failing scenario from the issue\n- [x] All existing tests pass\n- [x] No unrelated changes\n- [x] Code style matches project conventions\n- [x] Followed CONTRIBUTING.md"
+    },
+    {
+      "commit": "e76f4e3ef2b9212af05611c26c9700fe3e6c7aa5",
+      "subject": "[ty] Narrow exact finite membership checks (#25161)",
+      "body": "## Summary\n\nThis first commit in this PR makes not in narrowing use only RHS values\nthat are guaranteed to be present.\n\nPreviously, we used the iterable's homogeneous element type as the set\nof values to exclude. That was too broad for\ncases like:\n\n```python\ndef f(x: Literal[1, 2], values: set[int]):\n  if x not in values:\n      # Before: `Never`\n      reveal_type(x)\n```\n\nA `set[int]` _could_ contain 1 or 2, but it does not guarantee that\neither is present, so we shouldn't remove them from `x`. Instead, we now\nonly use exact values from fixed-length RHS types.\n\nUnfortunately, this does lead to some false positives like:\nhttps://github.com/scikit-learn/scikit-learn/blob/8b60698ca92c87a6d836d3a87c18bdfe9a3b6c67/sklearn/linear_model/_ridge.py#L252.\nBut I think those should be improved separately.\n\nCloses https://github.com/astral-sh/ty/issues/3458."
+    },
+    {
+      "commit": "a63ad9757ef6d807a412f0d2bf29c8f1d3c606fa",
+      "subject": "[`pylint`] Avoid false positives in `else` clause (`PLR1733`) (#25177)",
+      "body": "## Summary\nThe `PLR1733` (unnecessary-dict-index-lookup) rule was incorrectly\nfiring on dictionary accesses inside the `else` clause of a `for` loop.\nThe `else` clause has different control-flow semantics \u2014 it only\nexecutes when the loop completes without `break` \u2014 and iteration\nvariables from inner loops may not be in scope or may have stale values.\n\n## Root cause\nIn `unnecessary_dict_index_lookup()`, the `stmt_for.orelse` was being\nvisited along with `stmt_for.body`:\n\n```rust\nvisitor.visit_body(&stmt_for.body);\nvisitor.visit_body(&stmt_for.orelse);  // <-- this was the bug\n```\n\nThe `else` clause of a `for` loop is not part of the iteration context.\nVariables bound in the outer loop may be unbound if the loop body never\nran, or stale from the last iteration if the loop completed.\n\n## Fix\nRemove the `visitor.visit_body(&stmt_for.orelse)` call so the `else`\nclause is not checked for unnecessary dict lookups.\n\n## Validation\n```bash\n# False positive case (now correctly passes)\ncargo run -p ruff -- check test.py --isolated --select PLR1733 --preview\n# Before: 1 error (PLR1733 false positive)\n# After:  All checks passed\n\n# Existing cases still work\ncargo test -p ruff_linter unnecessary_dict_index  # PASS\n\n# Zulip pattern is still detected correctly\ncargo run -p ruff -- check test_zulip.py --isolated --select PLR1733 --preview\n# Correctly detects: mapped_arrays[mapped_label][i] += value_arrays[label][i]\n```\n\n## Before\n`ruff check` would report a false positive on `result[res_glob]` inside\nthe `else` clause of the outer `for` loop, and the autofix would suggest\n`res_priority` which is incorrect (the inner loop variable may be\nunbound/stale).\n\n## After\n`ruff check` correctly skips the `else` clause of the `for` loop \u2014 no\nfalse positive.\n\nFixes #25150"
+    },
+    {
+      "commit": "Co-authored-by: Aniket Karne <aniketkarne@gmail.com>\nCo-authored-by: Brent Westbrook <36778786+ntBre@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    }
+  ]
+}

--- a/bench/memory/raw-commits-tokio.json
+++ b/bench/memory/raw-commits-tokio.json
@@ -1,0 +1,2537 @@
+{
+  "repo": "tokio",
+  "num_commits_exported": 506,
+  "instructions": "Author questions from the commits below. Do NOT consult spelunk memory (spelunk memory list / spelunk memory search). Use the raw commit subjects and bodies as your only source material. Record ground-truth commit SHAs for each question.",
+  "commits": [
+    {
+      "commit": "7892f6020d9c914a41d0c350693fb71937d43c03",
+      "subject": "Implemented io-uring `Op<Statx>` and applied to `read_uring` and `fs::try_exists` (#8080)",
+      "body": "* implement Op<Statx> and use it to implement fs::try_exists\n\n* fix statx on unavailable platforms\n\n* complete using only io-uring operations for read_uring\n\n* Implemented io-uring::Op<Statx> and apply it accordingly to read_uring, try_exists\n\n* Added test for io uring statx operations. Checks for cancellations, shutdown, stating multiple files, ELOOP, ENAMETOOLONG, EACCES\n\n* Removed musl as supported platform for io_uring statx operations, as statx is supported on 1.25+ musl, and MSRV that uses 1.25 on all *-linux-musl platforms is 1.93\n\n* Removed pending checks for cancel_op_future since io_uring not available on Linux <5.1, removed stat permission denied test case since it doesn't work on Linux 4.19\n\n* Removed redundant cfg attributes on functions, added STATX_BTIME flag in statx operation, use assert pending in cancel ops\n\n* Uncommented stat_permission_denied test and make sure it doesn't run on platforms that don't support io_uring, removed unnecessary comments, and added TODO on symlink_metadata for when Metadata::from_statx is stabilized\n\n* Statx fd leak drop test added and added STATX_BTIME to file_metadata\n\n* Remove unnecessary utils function, refactored code in statx and statx fd leak test, and removed cfg_io_uring gates (localized the feature gate to the pertinent part of the code that uses it in read_uring)"
+    },
+    {
+      "commit": "Co-authored-by: Vrtgs <vrtgs@vrtgs.xyz>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "da044f27d7470f605dffea94fb2473da06ea2a76",
+      "subject": "net: disable some Miri tests for TCP socket (#8205)",
+      "body": "Co-authored-by: Alice Ryhl <aliceryhl@google.com>"
+    },
+    {
+      "commit": "ecb5125a6787b9d8eb818b1b00973bcd55ae77c0",
+      "subject": "runtime: document interaction with fork() (#8202)",
+      "body": ""
+    },
+    {
+      "commit": "bde89678532a8091d958268c0d36eac9362317d8",
+      "subject": "task: add `Stream` wrapper for `JoinSet` (#8189)",
+      "body": ""
+    },
+    {
+      "commit": "21e4a2a282b00c23498c9eedc372e87b00b5482f",
+      "subject": "taskdump: support taskdumps on s390x (#8192)",
+      "body": "Signed-off-by: satyamg1620 <Satyam.Gupta.3@ibm.com>"
+    },
+    {
+      "commit": "2e7930fe58cdf29671ea71a066ebc80b5006b97d",
+      "subject": "net: accept ConnectionReset in shutdown_after_tcp_reset test (#8196)",
+      "body": "The test asserts shutdown() returns Ok(()) after the peer resets the\nconnection (linger = 0). This holds on Linux and macOS, but on FreeBSD the\nkernel can finish processing the RST before shutdown() runs, so it returns\nConnectionReset and the test fails intermittently -- the oneshot only\nsynchronizes the application-level drop, not the kernel's RST processing.\n\nAccept Ok(()) or ConnectionReset for the post-reset shutdown, since both\nare valid for a connection the peer has already reset."
+    },
+    {
+      "commit": "67637b348a88ce3e035affe507bac17992851246",
+      "subject": "macros: clarify `tokio::main` expansion (#8193)",
+      "body": ""
+    },
+    {
+      "commit": "778e9d97d91cff2c3036cc5663936d479edb30cb",
+      "subject": "tests: fix typo in io_uring support functions docs (#8186)",
+      "body": ""
+    },
+    {
+      "commit": "71362aa609955d9dfce742f81773a5dc6b2a760c",
+      "subject": "net: add `SocketAddr` methods to Unix sockets (#8144)",
+      "body": ""
+    },
+    {
+      "commit": "2de86e557c576a74be7136e6fc2e21ccdf22da10",
+      "subject": "net: enable more Miri tests for TCP socket (#8180)",
+      "body": ""
+    },
+    {
+      "commit": "326bd2cc4484702260f2003697fbd1d4dcf9d20c",
+      "subject": "codec: use libc::memchr for LinesCodec delimiter scan (#8141)",
+      "body": ""
+    },
+    {
+      "commit": "32312ae0d6f0b1c6457f1323e3e7f568f448d0db",
+      "subject": "net: enable Miri tests for TCP socket (#8156)",
+      "body": ""
+    },
+    {
+      "commit": "37ced33efddccc6721588af6fbe095d34fa17d7d",
+      "subject": "time: ensure timers stay in the same runtime after `.reset()` (#8169)",
+      "body": ""
+    },
+    {
+      "commit": "923e72345c77aef4d11875d874ba67421b0412d3",
+      "subject": "time: move lazy-registration state into `Sleep` (#8132)",
+      "body": ""
+    },
+    {
+      "commit": "f619fc058793587ce8d004de8685326afcf977a2",
+      "subject": "docs: improve contributing guidelines (#8166)",
+      "body": ""
+    },
+    {
+      "commit": "82fe082ef14c2e2b2c1c29ed9873c2ca6e6109ee",
+      "subject": "fs: clarify `create_dir_all` succeeds if path exists (#8149)",
+      "body": ""
+    },
+    {
+      "commit": "1fe1b0e727dd1c48ad82173e35e125a3ba43b955",
+      "subject": "task: add `JoinMap::try_join_next` (#8099)",
+      "body": ""
+    },
+    {
+      "commit": "c6af672353b428fb525cc34a522737924f523a93",
+      "subject": "io: advance partially written buffers correctly in `write_all_vectored` (#8159)",
+      "body": ""
+    },
+    {
+      "commit": "2a05f364b79a7377bb21d6d5d14fd191b26e3ade",
+      "subject": "ci: set copyback to false for FreeBSD jobs (#8155)",
+      "body": ""
+    },
+    {
+      "commit": "c6d58ce7e7bf4a6e7e6efc1ffeb42daa3a627c17",
+      "subject": "ci: fix macOS runners (#8145)",
+      "body": ""
+    },
+    {
+      "commit": "de360cfc7eaf3cacd8fba7f6b8327e3cc98b5dc2",
+      "subject": "tokio-stream: fix duplicated word in changelog (#8143)",
+      "body": ""
+    },
+    {
+      "commit": "7d3b0ad192fa6da7f0301fb0db7472031a3d253a",
+      "subject": "sync: remove useless conversion in oneshot Receiver::poll (#8142)",
+      "body": ""
+    },
+    {
+      "commit": "0121120b6d91c438ca3a088a286ad78d293eea0b",
+      "subject": "taskdump: skip double wake on `Trace::capture`/`Trace::trace_with` (#8043)",
+      "body": ""
+    },
+    {
+      "commit": "bdcea6b2cd716b0a378626796bf5dc049608663d",
+      "subject": "fs: skip some io_uring tests on Kernels that don't support it (#8134)",
+      "body": ""
+    },
+    {
+      "commit": "ee0dc9092665a1f13df573dc5e5124999d8e9035",
+      "subject": "time: consolidate mutex locks on spurious poll (#8124)",
+      "body": ""
+    },
+    {
+      "commit": "78594a7497dcabd6850dbaf15dd3c5b4fe045d2c",
+      "subject": "Merge 'tokio-1.52.3' into 'master' (#8131)",
+      "body": ""
+    },
+    {
+      "commit": "d87569164fb61145e79e7ffe0b25783569cc8f93",
+      "subject": "chore: prepare Tokio v1.52.3 (#8130)",
+      "body": ""
+    },
+    {
+      "commit": "e1aebb031cb24bdb52289561343308f4a44a4d81",
+      "subject": "Merge 'tokio-1.51.3' into 'tokio-1.52.x' (#8129)",
+      "body": ""
+    },
+    {
+      "commit": "fd63094ee0d34b4f3f93f59507e91c65919a2d71",
+      "subject": "chore: prepare Tokio v1.51.3 (#8127)",
+      "body": ""
+    },
+    {
+      "commit": "067f229371b982412a3dc523cf58f95c3c8794ec",
+      "subject": "io: replace Vec method truncate(0) with clear (#8125)",
+      "body": "https://rust-lang.github.io/rust-clippy/master/index.html#manual_clear"
+    },
+    {
+      "commit": "8c600d0fd2cdebea4828fe9f699ced4dfd8aad3b",
+      "subject": "Merge 'tokio-1.47.5' into 'tokio-1.51.x' (#8123)",
+      "body": ""
+    },
+    {
+      "commit": "11bfc1345bbd5e901187e2b3702de10b0efbffdc",
+      "subject": "chore: prepare Tokio v1.47.5 (#8122)",
+      "body": ""
+    },
+    {
+      "commit": "f085b6211b8ebb6aba21f1f1f91e7b8b243aa815",
+      "subject": "sync: notify receivers in mpsc `OwnedPermit::release()` method (#8075)",
+      "body": ""
+    },
+    {
+      "commit": "30d25ccb8bc91ca811773ee243e71e31772275d2",
+      "subject": "sync: require that an `RwLock` has `max_readers != 0` (#8076)",
+      "body": ""
+    },
+    {
+      "commit": "9fccf5339d41c1f2f863f97b9133bc8a5a10bc28",
+      "subject": "sync: return `Empty` from `try_recv()` when mpsc is closed with outstanding permits (#8074)",
+      "body": ""
+    },
+    {
+      "commit": "ebf61b45b5184018f00bc666887ebccf3d4fe51b",
+      "subject": "sync: fix underflow in mpsc channel `len()` (#8062)",
+      "body": ""
+    },
+    {
+      "commit": "02ff0833e00adeb8cd451420f586f968deb70f78",
+      "subject": "sync: implement `PartialEq` and `Eq` for `CancellationToken` (#8110)",
+      "body": "Co-authored-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>"
+    },
+    {
+      "commit": "e56ff72fe7574867c6c9bbd171afd8717897ea43",
+      "subject": "Merge 'tokio-1.52.2' into 'master' (#8117)",
+      "body": ""
+    },
+    {
+      "commit": "4abe9d732eb01f7b092a571c3dcc4fbd266f4067",
+      "subject": "chore: prepare Tokio v1.52.2 (#8115)",
+      "body": ""
+    },
+    {
+      "commit": "f82bcf3f45eb9d0dad9d7e45251adf67223f03b6",
+      "subject": "Merge 'tokio-1.51.2' into 'tokio-1.52.x' (#8114)",
+      "body": ""
+    },
+    {
+      "commit": "7db9bc41f18dffb6953f762a5f8e2f4ddb54d80d",
+      "subject": "test: revert \"remove `churn()` task from `lifo_stealable`\" (#8114)",
+      "body": "This reverts commit 6c03e03898d71eca976ee1ad8481cf112ae722ba."
+    },
+    {
+      "commit": "64834ec7018de92fadf00d053b565263913439c1",
+      "subject": "chore: prepare Tokio v1.51.2 (#8113)",
+      "body": ""
+    },
+    {
+      "commit": "967f5715a71d5d2600b71da8c4ab652c4e644a41",
+      "subject": "runtime: revert \"steal tasks from the LIFO slot\" (#8100)",
+      "body": "This reverts commit eeb55c733ba9a83c51d08b1629dca6a5ec0f4b2b."
+    },
+    {
+      "commit": "e77885a494d91baaaeeb9590436e555dea8dd1cb",
+      "subject": "net: implement UCred::pid on FreeBSD (#8086)",
+      "body": ""
+    },
+    {
+      "commit": "0926ab195aa6decebbde71ad080521051c02a8ee",
+      "subject": "time: defer waker clone on spurious poll (#8107)",
+      "body": ""
+    },
+    {
+      "commit": "50c23d300aef05e55b07b069a0455d5cab489cdd",
+      "subject": "runtime: avoid illegal state in `FastRand` (#8078)",
+      "body": "Co-authored-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>"
+    },
+    {
+      "commit": "1cd6e65d76ba934d7545afe4b8ad93787b80c1e3",
+      "subject": "ci: small improvements for freeBSD jobs (#8102)",
+      "body": ""
+    },
+    {
+      "commit": "5ee26af3dbd606ce91adfcdfcd917ab73e6350f6",
+      "subject": "Merge tokio-1.52.x (for #8101) into master (#8106)",
+      "body": ""
+    },
+    {
+      "commit": "9271e3ed05928eafbeed9dd31d93aebaa49d2aad",
+      "subject": "Merge tokio-1.51.x (for #8101) into tokio-1.52.x (#8106)",
+      "body": ""
+    },
+    {
+      "commit": "cd1823f43efa95439b79a5a4507df65f83822004",
+      "subject": "Revert \"Pin stable to 1.94 for tokio-1.51.x\" (#8106)",
+      "body": "As we are merging tokio-1.51.x into tokio-1.52.x and then master, we\nshould not include this change.\n\nThis reverts commit bde3f20b0fd5de85a8946c4c5c623c039dcfa842."
+    },
+    {
+      "commit": "a97cf12ed9b90e3d5c1557f3afb47f43fcb84301",
+      "subject": "Merge tokio-1.47.x (commit 670a907c55c7) into tokio-1.51.x (#8105)",
+      "body": ""
+    },
+    {
+      "commit": "bde3f20b0fd5de85a8946c4c5c623c039dcfa842",
+      "subject": "Pin stable to 1.94 for tokio-1.51.x (#8105)",
+      "body": ""
+    },
+    {
+      "commit": "670a907c55c7f7b27da203208e65da60de6598b2",
+      "subject": "ci: fix CI on tokio-1.47.x (#8101)",
+      "body": "Co-authored-by: Mattia Pitossi <mattiapitossi@gmail.com>"
+    },
+    {
+      "commit": "5030b3005eae09141d6ee6725366007c767b9a97",
+      "subject": "tokio-stream: implement `FusedStream` for various stream adaptors (#8096)",
+      "body": "`MapWhile` is intentionally excluded because its current implementation\ndoes not track when the closure returns `None` early, making a correct\n`is_terminated()` impossible without a separate semantic change."
+    },
+    {
+      "commit": "26dee92b535d0a204531b6a04ee761f06c402d7e",
+      "subject": "chore: use functional slice building (#8097)",
+      "body": "Noticed some redundant procedural code."
+    },
+    {
+      "commit": "d3565a2923e24325fc5af3e597bd7a5b45437576",
+      "subject": "fs: rename Windows symlink dir test (#8098)",
+      "body": ""
+    },
+    {
+      "commit": "8f81e0814bd121683ebdfa21b494d1b77fb36403",
+      "subject": "time: avoid stack overflow in runtime constructor (#8093)",
+      "body": ""
+    },
+    {
+      "commit": "47cc31590fbc5662241355c86e331c42e6152775",
+      "subject": "tokio-stream: implement FusedStream for Fuse (#8090)",
+      "body": ""
+    },
+    {
+      "commit": "dc0f72816290074463a91e4fb479768b3fee453d",
+      "subject": "blocking: introduce a regression test for #8056 (#8068)",
+      "body": ""
+    },
+    {
+      "commit": "89713ad1eccdab8c21137a37f996f130d5a8bd31",
+      "subject": "miri tests: fstat is supported now (#8088)",
+      "body": ""
+    },
+    {
+      "commit": "6c03e03898d71eca976ee1ad8481cf112ae722ba",
+      "subject": "test: remove `churn()` task from `lifo_stealable` (#8070)",
+      "body": "Currently, the `rt_threaded::lifo_stealable` test I added in #7431\nspawns an additional task which sleeps on a 4ms timer in a loop. This\nensures that no worker remains permanently parked. This was added\nbecause it was necessary to stop the LIFO slot deadlock from occurring\nprior to changes in the logic for determining whether to notify another\nworker, which is what @Darksonn  was referring to in [this comment][1].\nRemoving the `churn()` test makes the test actually validate that\nanother worker is notified to steal the LIFO task, and that the changes\nfrom #7431 will *always* prevent a LIFO slot deadlock, regardless of the\nbehavior of other tasks on the runtime. See also [this comment][2] for\nfurther discussion.\n\n[1]: https://github.com/tokio-rs/tokio/pull/7431#discussion_r2184724657\n[2]: https://github.com/tokio-rs/tokio/pull/8069#issuecomment-4274244723"
+    },
+    {
+      "commit": "16bc4e2e28798e6fe77efdcbbf5f29172810d526",
+      "subject": "time: add `#[track_caller]` and panic docs to `timeout_at()` (#8077)",
+      "body": ""
+    },
+    {
+      "commit": "1afb39135073a56d8983fed0bde85b9f70a1ec3b",
+      "subject": "net: document pipe try_read*/try_write* readiness behavior (#8032)",
+      "body": "Add a Notes section to all five try_* methods on pipe::Sender and\npipe::Receiver explaining that the runtime's I/O driver only delivers\nreadiness events after control is yielded back to it, so calling\ntry_read/try_write before any .await returns WouldBlock even when the\noperation could otherwise succeed.\n\nThis is the same readiness model used by every other Tokio I/O type;\nthe pipe docs simply did not previously call it out. Refs #7625."
+    },
+    {
+      "commit": "Co-authored-by: Mattia Pitossi <mattiapitossi@gmail.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "b010b5ddafb316e5d540de1736f5f7bfde42ec39",
+      "subject": "test taskdump docs (#8064)",
+      "body": ""
+    },
+    {
+      "commit": "905c146aeda741ea2202f942a7c3a606dda13da5",
+      "subject": "chore: prepare to release v1.52.1 (#8059)",
+      "body": "# 1.52.1 (April 16th, 2026)\n\n## Fixed\n\n- runtime: revert [#7757] to fix [a regression][#8056] that causes\n  `spawn_blocking` to hang ([#8057])\n\n[#7757]: https://github.com/tokio-rs/tokio/pull/7757\n[#8056]: https://github.com/tokio-rs/tokio/pull/8056\n[#8057]: https://github.com/tokio-rs/tokio/pull/8057"
+    },
+    {
+      "commit": "56aaa43e91c4fbed88f0c2a5b65019ed9a0c3c61",
+      "subject": "rt: revert #7757 to fix regression in `spawn_blocking` (#8057)",
+      "body": "This reverts commit 1604bc335157be9a131e24cfde55cab3c90ebc92.\n\nUnfortunately, this commit introduced a regression that causes programs\nusing `spawn_blocking` to hang (see #8056). To fix the regression, we\nneed to undo this change and publish a v1.52.1 release as soon as\npossible.\n\nIn the future, we may wish to bring back a sharded queue for\n`spawn_blocking` tasks, either based on the implementation added in\n#7757 or a new one. However, since this is a substantial change to the\nruntime internals, I think such a change should probably be done as an\nunstable, opt-in `tokio::runtime::Builder` setting initially, so that we\ndon't regress existing users. I had hoped we could do this now, but\nunfortunately, the sharded queue implementation from #7757 is kind of\ntightly coupled with the rest of the `spawn_blocking` machinery and\ncannot be easily swapped out"
+    },
+    {
+      "commit": "and the hang still occurs with\n`NUM_SHARDS` set to 1, so there isn't an easy way to turn it on and off.\nTherefore, in the interest of getting a fix out ASAP, this is just a\nsimple revert.\n\nFixes #8056",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "57ff47ab589bfb4dab6766de78655ffef4fb250b",
+      "subject": "ci: update `trybuild` to expect output from rustc 1.95.0 (#8058)",
+      "body": ""
+    },
+    {
+      "commit": "812de3e134888d1d9e7832e4b789d51f6fd2f749",
+      "subject": "ci: bump taiki-e/cache-cargo-install-action from 1 to 3 (#8053)",
+      "body": "Bumps [taiki-e/cache-cargo-install-action](https://github.com/taiki-e/cache-cargo-install-action) from 1 to 3.\n- [Release notes](https://github.com/taiki-e/cache-cargo-install-action/releases)\n- [Changelog](https://github.com/taiki-e/cache-cargo-install-action/blob/main/CHANGELOG.md)\n- [Commits](https://github.com/taiki-e/cache-cargo-install-action/compare/v1...v3)"
+    },
+    {
+      "commit": "updated-dependencies:\n- dependency-name: taiki-e/cache-cargo-install-action\n  dependency-version: '3'\n  dependency-type: direct:production\n  update-type: version-update:semver-major\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "ba82e73c7b804324c82b6fea6966ca12f55c3826",
+      "subject": "ci: use Dependabot to keep github actions up to date (#8052)",
+      "body": ""
+    },
+    {
+      "commit": "2e85f9ddf8b47197fa6299cc295f4319fec68e53",
+      "subject": "ci: replace cirrus-ci with freebsd-vm (#8041)",
+      "body": ""
+    },
+    {
+      "commit": "a7e1cd8ff8a2012cce500fd7e6ae73400531f46d",
+      "subject": "ci: update GitHub Actions workflows to use latest tool versions (#8047)",
+      "body": ""
+    },
+    {
+      "commit": "5f7be0ac42cb3e1b739da1562f98a797cd55a606",
+      "subject": "chore: perpare 1.52.0 (#8045)",
+      "body": "# 1.52.0 (April 14th, 2026)\n\n## Added\n\n- io: `AioSource::register_borrowed` for I/O safety support ([#7992])\n- net: add `try_io` function to `unix::pipe` sender and receiver types\n  ([#8030])\n\n## Added (unstable)\n\n- runtime: `Builder::enable_eager_driver_handoff` setting enable eager\n  hand off of the I/O and time drivers before polling tasks ([#8010])\n- taskdump: add `trace_with()` for customized task dumps ([#8025])\n- taskdump: allow `impl FnMut()` in `trace_with` instead of just `fn()`\n  ([#8040])\n- fs: support `io_uring` in `AsyncRead` for `File` ([#7907])\n\n## Changed\n\n- runtime: improve `spawn_blocking` scalability with sharded queue\n  ([#7757])\n- runtime: use `compare_exchange_weak()` in worker queue ([#8028])\n\n## Fixed\n\n- runtime: overflow second half of tasks when local queue is filled\n  instead of first half ([#8029])\n\n## Documented\n\n- docs: fix typo in `oneshot::Sender::send` docs ([#8026])\n- docs: hide #[tokio::main] attribute in the docs of `sync::watch`\n  ([#8035])\n- net: add docs on `ConnectionRefused` errors with UDP sockets ([#7870])\n\n[#7757]: https://github.com/tokio-rs/tokio/pull/7757\n[#7870]: https://github.com/tokio-rs/tokio/pull/7870\n[#7907]: https://github.com/tokio-rs/tokio/pull/7907\n[#7992]: https://github.com/tokio-rs/tokio/pull/7992\n[#8010]: https://github.com/tokio-rs/tokio/pull/8010\n[#8025]: https://github.com/tokio-rs/tokio/pull/8025\n[#8026]: https://github.com/tokio-rs/tokio/pull/8026\n[#8028]: https://github.com/tokio-rs/tokio/pull/8028\n[#8029]: https://github.com/tokio-rs/tokio/pull/8029\n[#8030]: https://github.com/tokio-rs/tokio/pull/8030\n[#8035]: https://github.com/tokio-rs/tokio/pull/8035\n[#8040]: https://github.com/tokio-rs/tokio/pull/8040"
+    },
+    {
+      "commit": "36d12d2686a64b9146c674e02e3cf81d8f87163d",
+      "subject": "taskdump: allow impl FnMut() in taskdumps instead of just fn() (#8040)",
+      "body": ""
+    },
+    {
+      "commit": "f943312865b9d5007f25d2fd5bd8efa3f89d1541",
+      "subject": "fs: support io-uring in `AsyncRead` for `File` (#7907)",
+      "body": ""
+    },
+    {
+      "commit": "5db10f538b683fe88d699dfd11be31d193db011c",
+      "subject": "net: add 'try_io' function to 'unix::pipe' sender and receiver types (#8030)",
+      "body": ""
+    },
+    {
+      "commit": "bbdba7101de6ce5329d84021ce669f185cc430b3",
+      "subject": "taskdump: add `trace_with` for customized task dumps (#8025)",
+      "body": "provided trace function."
+    },
+    {
+      "commit": "7cfce54386982264f8c9d5db3f5a96caf3b99cbe",
+      "subject": "ci: update FreeBSD image to 14.4 (#8038)",
+      "body": ""
+    },
+    {
+      "commit": "81370e6202859dee53c7a42053ec0ff4427910cf",
+      "subject": "net: add docs on `ConnectionRefused` errors with udp sockets (#7870)",
+      "body": ""
+    },
+    {
+      "commit": "203af021261ab7399c18ab12f22c24f1934c7d42",
+      "subject": "runtime: overflow second half of tasks when local queue is filled instead of first half (#8029)",
+      "body": ""
+    },
+    {
+      "commit": "de230926dc6ae08650688fe4cf2fd0a913392501",
+      "subject": "net: temporarily disable `tcp_stream` `try_read_buf` test on WASI (#8036)",
+      "body": "This test is flaky on WASI until\nhttps://github.com/bytecodealliance/wasmtime/issues/13040 has been addressed.\n\nSee https://github.com/tokio-rs/tokio/issues/8034 for additional details."
+    },
+    {
+      "commit": "432ec3f2b2a21b668c1d5c5703914ac5ecbe6d8a",
+      "subject": "sync: hide `#[tokio::main]` attribute in the docs of `sync::watch` (#8035)",
+      "body": ""
+    },
+    {
+      "commit": "1604bc335157be9a131e24cfde55cab3c90ebc92",
+      "subject": "rt: improve `spawn_blocking` scalability with sharded queue (#7757)",
+      "body": ""
+    },
+    {
+      "commit": "4c7d8b2a14de81ace4d8e61cfaeb8eca26f6f68c",
+      "subject": "runtime: use `compare_exchange_weak()` in worker queue (#8028)",
+      "body": ""
+    },
+    {
+      "commit": "d7db722bb47d29b81c9b98992813115dfaed491d",
+      "subject": "io: AioSource now employs IO Safety (#7992)",
+      "body": ""
+    },
+    {
+      "commit": "fccc28f1d0041fc5bdd798dc2645dc3b5fc71ef1",
+      "subject": "runtime: optional eager I/O driver/timer handoff when polling tasks (#8010)",
+      "body": ""
+    },
+    {
+      "commit": "927df0e9d936ef6995a6b9abedabc032b8ef655c",
+      "subject": "sync: fix typo in oneshot send doc (#8026)",
+      "body": ""
+    },
+    {
+      "commit": "98df02d7a4a638b3bc76a01f41966dc83c275103",
+      "subject": "chore: prepare Tokio v1.51.1 (#8023)",
+      "body": ""
+    },
+    {
+      "commit": "3ea11e2a5fb4139ca21b441044d98994a2b126c5",
+      "subject": "sync: fix semaphore reopens after forget (#8021)",
+      "body": ""
+    },
+    {
+      "commit": "c79121391db8f8d36d4213feeb25381caee110c7",
+      "subject": "rt: do not leak fd when cancelling io_uring open operation (#7983)",
+      "body": ""
+    },
+    {
+      "commit": "ad8c59add6a1988d8c327fb3358beeeae3bbb5cd",
+      "subject": "net: surface errors from `SO_ERROR` on `recv` for UDP sockets on Linux (#8001)",
+      "body": ""
+    },
+    {
+      "commit": "654d38b13228a13498e793d8bb4f6ba50fd1016a",
+      "subject": "metrics: fix `worker_local_schedule_count` test (#8008)",
+      "body": ""
+    },
+    {
+      "commit": "857ba8093327c5ddf9e00dc6055c6f315035f854",
+      "subject": "docs: improve contributing docs on how to specify crates dependency versions (#8009)",
+      "body": ""
+    },
+    {
+      "commit": "95b9342da7009d068fea6c5d532e04934d46980c",
+      "subject": "chore: remove path deps for tokio-macros 2.7.0 (#8007)",
+      "body": ""
+    },
+    {
+      "commit": "0af06b7bab12c58161b1d0ae79bdf4452305d42f",
+      "subject": "chore: prepare Tokio v1.51.0 (#8005)",
+      "body": ""
+    },
+    {
+      "commit": "01a7f1dfabc93293743701074752ff0d8e787595",
+      "subject": "chore: prepare tokio-macros v2.7.0 (#8004)",
+      "body": ""
+    },
+    {
+      "commit": "eeb55c733ba9a83c51d08b1629dca6a5ec0f4b2b",
+      "subject": "runtime: steal tasks from the LIFO slot (#7431)",
+      "body": ""
+    },
+    {
+      "commit": "1fc450aefba4b05cdff9b7825ca5e39cccb3780e",
+      "subject": "runtime: stabilize `LocalRuntime` (#7557)",
+      "body": ""
+    },
+    {
+      "commit": "324218f9bbdc26e4bb527d036613826824f3078b",
+      "subject": "Merge tag 'tokio-1.47.4' (#8003)",
+      "body": ""
+    },
+    {
+      "commit": "aa65d0d0b8ea6eec80985b9d231390f137493071",
+      "subject": "chore: prepare Tokio v1.47.4 (#8002)",
+      "body": ""
+    },
+    {
+      "commit": "bf18ed452d6aae438e84ae008a01a74776abdc19",
+      "subject": "sync: fix panic in `Chan::recv_many` when called with non-empty vector on closed channel (#7991)",
+      "body": "`Chan::recv_many` intends to assert that no slots\nhave been consumed when exiting with `Ready` via\nthe `rx_closed` code path.\n\nInstead of asserting no items were added to the\nbuffer, it asserted buffer emptiness, incorrectly\nmaking assumptions about the provided buffer.\n\nWhen `recv_many` was called on an empty channel\nwith idle semaphore after the receiver was closed,\nthe method would panic.\n\nThe branch coverage had been previously missing.\n\nThis changeset corrects the assertion\nand adds tests covering the code path.\n\nFixes #7990."
+    },
+    {
+      "commit": "43134f1e5784993eb4fb3863933d74ac9e28f598",
+      "subject": "wasm: add wasm32-wasip2 networking support (#7933)",
+      "body": "Motivation\n\nThis adds networking support for the `wasm32-wasip2` target platform, which\nincludes more extensive support for sockets than `wasm32-wasip1`.\n\nSolution\n\nThe bulk of the changes are in https://github.com/tokio-rs/mio/pull/1931.  This\npatch mainly tweaks a few `cfg` directives to indicate `wasm32-wasip2`'s\nadditional capabilities.\n\nNote that this is a draft PR until until\nhttps://github.com/tokio-rs/mio/pull/1931 and\nhttps://github.com/rust-lang/socket2/pull/639 have been include in stable\nreleases of their respective projects.\n\nAlso note that I've added a `wasm32-wasip2` target to CI and triaged each test\nwhich was previously disabled for WASI into one of three categories:\n\n- Disabled on both WASIp1 and p2 due to not-yet-supported features such as multithreading\n- Disabled on p1 but enabled on p2\n- Disabled on p1 and _temporarily_ disabled on p2 due to `wasi-libc` bugfixes which have been merged but not yet included in a Rust release.  I'll open an issue to re-enable them when the fixes land in Rust.\n\nFuture Work\n\nIn the future, we could consider adding support for `tokio::net::lookup_host`.\nWASIp2 natively supports asynchronous DNS lookups and is single threaded,\nwhereas Tokio currently assumes DNS lookups are blocking and require\nmultithreading to emulate async lookups.  A WASIp2-specific implementation could\ndo the lookup directly without multithreading.\n\nWASIp2 also supports single-threaded, asynchronous file I/O, timers, etc.  We\ncould either support those directly or wait for WASIp3's multithreading support,\nin which case most of `tokio::fs` (as well as `tokio::net::lookup_host`, etc.)\n_should_ work unchanged via `wasi-libc` and worker threads.\n\nCurrently, building for WASIp2 requires RUSTFLAGS=\"--cfg tokio_unstable\"`.  Once\nwe have a solid maintenance plan, we can remove that requirement."
+    },
+    {
+      "commit": "b4c3246d330379430937bdbb5e1b0c37282ae23e",
+      "subject": "macros: improve overall macro hygiene (#7997)",
+      "body": "Multiple macro expansions were previously assumming the existence of\nsome standard library symbols to both be in-scope and referring to the\nright symbol, and not only having the same identifier.\n\nThis has now been refactored into using reexports from the `support`\nmodule under the `macros` module. Some other macro invocations were also\nusing absolute standard library paths instead of calling into the afore\nmentioned module through the special `$crate` macro. This has been\nchanged, thus also reexporting some other items in `support`."
+    },
+    {
+      "commit": "7947fa4bd79d7345aa7e6b189fc1fbb6983a4351",
+      "subject": "rt: add runtime name (#7924)",
+      "body": ""
+    },
+    {
+      "commit": "9f132172dbb00b1f6b6bda64bb9b194382079499",
+      "subject": "sync: fix `notify_waiters` priority in `Notify` (#7996)",
+      "body": "Previously, if a `notify_waiters()` was followed by a `notify_one()`,\nan unpolled `Notified` future created before the `notify_waiters()`\ncall would consume the `NOTIFIED` permit created by the\n`notify_one()` call.\n\nThis commit fixes this by verifying the `notify_waiters_calls` count\nbefore optimistically attempting to acquire the `NOTIFIED` permit. If\nthe count indicates a `notify_waiters()` call has already happened, the\nfuture transitions directly to `State::Done` and leaves the permit\nintact for other waiters.\n\nFixes: #7965"
+    },
+    {
+      "commit": "6752f50154025a1aa2c231b643cdb78bb4c3892f",
+      "subject": "examples: add graceful shutdown example (#7962)",
+      "body": ""
+    },
+    {
+      "commit": "6c72168a93f9598c1e25915f188cf6492d012cfc",
+      "subject": "ci: remove Rust 1.94.0 workarounds (#7987)",
+      "body": ""
+    },
+    {
+      "commit": "ee4de818065a97c0be0d6bfc18fb36725349aef8",
+      "subject": "net: use null get_peer_cred on Hurd (#7989)",
+      "body": ""
+    },
+    {
+      "commit": "a8435c0fc8612bbdf38d3ad8b2ba96d5dbc848d9",
+      "subject": "examples: add FD table pre-warming example (#7978)",
+      "body": ""
+    },
+    {
+      "commit": "467d614267ce422206d8acbccf957eb49a597467",
+      "subject": "bench: use is_multiple_of instead of manual modulo check (#7984)",
+      "body": "Addresses clippy::manual_is_multiple_of warning on latest stable."
+    },
+    {
+      "commit": "66c786540ec0bc60f506945dafd7cc7cad6b01a0",
+      "subject": "chore: Do not show \"Available on non-loom only.\" doc label (#7977)",
+      "body": "* chore: Do not show \"Available on non-loom only.\" doc label\n\nCloses #7976\n\nUses the unstable #[doc(cfg()]. https://github.com/rust-lang/rust/issues/43781\n\n* Use build.rs to detect nightly builds\n\n* Use `docsrs` instead of `nightly`. Drop build.rs\n\n* Use doc(auto_cfg(hide(config_name)))\n\n* Use same nightly on CirrusCI (FreeBSD) as on Github Actions CI"
+    },
+    {
+      "commit": "dd1196d36930bf23d5ba32402f5dadef861546fa",
+      "subject": "ci: patch workspace members to disambiguate `--package` (#7967)",
+      "body": ""
+    },
+    {
+      "commit": "2db0070eb8ab1c543f5dc93b3392645d00ce43cc",
+      "subject": "stream: impl `FromStream` for `std::collections::*` (#7966)",
+      "body": ""
+    },
+    {
+      "commit": "26de3187e759e06c25432413643ea57d8a79503c",
+      "subject": "runtime: add `tokio::runtime::worker_index()` (#7921)",
+      "body": ""
+    },
+    {
+      "commit": "d3c7f56c10a43c220e6feb12c9796f36eaffda16",
+      "subject": "ci: workaround for OpenOptionsExt in 1.94.0 (#7968)",
+      "body": ""
+    },
+    {
+      "commit": "ee04abe7970b769439e2fecd4b1dd8790e4234e1",
+      "subject": "bench: add remote_spawn benchmark for inject queue contention (#7944)",
+      "body": ""
+    },
+    {
+      "commit": "aa1e7e2b9d24a0b5ececc07d57f2d9668938ea28",
+      "subject": "stream: impl `FromStream` for `BTreeSet` (#7954)",
+      "body": ""
+    },
+    {
+      "commit": "961757f5483e394ec3c99a4c2ab5a6e705a0b740",
+      "subject": "ci: freeze rustc on 1.93.1 (#7961)",
+      "body": ""
+    },
+    {
+      "commit": "e67cd87f71304e6b4cc94ce0c1656797466e56f3",
+      "subject": "chore: link to tokioconf.com (#7953)",
+      "body": ""
+    },
+    {
+      "commit": "a502d1b5c8f0fe0de49c4a5da5fc4faaa31aba7d",
+      "subject": "loom: remove `StaticAtomicU64` (#7902)",
+      "body": ""
+    },
+    {
+      "commit": "0273e45ead199dac7725faee1e3dc35a9c8753ab",
+      "subject": "chore: prepare Tokio v1.50.0 (#7934)",
+      "body": ""
+    },
+    {
+      "commit": "e3ee4e58dc9bb7accf26dfd51b0a2146922b5269",
+      "subject": "chore: prepare tokio-macros v2.6.1 (#7943)",
+      "body": ""
+    },
+    {
+      "commit": "8c980ea75a0f8dd2799403777db700c2e8f4cda4",
+      "subject": "io: add `write_all_vectored` to `tokio-util` (#7768)",
+      "body": ""
+    },
+    {
+      "commit": "e35fd6d6b7d9a8ba37ee621835ef91372c2565cb",
+      "subject": "ci: fix patch during clippy step (#7935)",
+      "body": "* fix the ci issue\n\n* fix readme\n\n* fix ci"
+    },
+    {
+      "commit": "03fe44c10302fdb55c29dbe5b08d4f8769c80272",
+      "subject": "runtime: fix `event_interval` doc (#7932)",
+      "body": ""
+    },
+    {
+      "commit": "d18e5dfbb0cdc28725bebb28cde80a6c11ee32bc",
+      "subject": "io: fix race in `Mock::poll_write` (#7882)",
+      "body": ""
+    },
+    {
+      "commit": "f21f2693f02aec9a876ac2bd21566c85e15b682e",
+      "subject": "runtime: fix race condition during the blocking pool shutdown (#7922)",
+      "body": ""
+    },
+    {
+      "commit": "d81e8f0acbdd7d866bce4f733b3545fd834c7840",
+      "subject": "macros: remove (most) local `use` declarations in `tokio::select!` (#7929)",
+      "body": ""
+    },
+    {
+      "commit": "25e7f2641ef2555d688c267059431a2802805f1d",
+      "subject": "rt: fix missing quotation in docs (#7925)",
+      "body": ""
+    },
+    {
+      "commit": "e1a91ef114a301b542d810abab9956f2868861b9",
+      "subject": "util: fix typo in docs (#7926)",
+      "body": ""
+    },
+    {
+      "commit": "1b11840f539ced93855df362eb51149ba08903a0",
+      "subject": "task: clarify when to use `spawn_blocking` vs dedicated threads (#7923)",
+      "body": ""
+    },
+    {
+      "commit": "09f92b5aedec6085863f570fe882915d0c2740f1",
+      "subject": "sync: clarify that recv returns None once closed and no more messages (#7920)",
+      "body": "The previous documentation stated:\n  'As such, Receiver::poll returns Ok(Ready(None))'\n\nThis was misleading: when all Sender handles are dropped, recv does NOT\nimmediately return None. Buffered messages already in the channel can\nstill be received. Only after all senders are dropped AND the channel\nhas been fully drained does recv return None.\n\nAlso update the method reference from the internal Receiver::poll to the\npublic API: Receiver::recv and Receiver::poll_recv.\n\nCloses #6053"
+    },
+    {
+      "commit": "e65040f061008ca5a94d21721aa8b544c078c606",
+      "subject": "sync: clarify RwLock fairness documentation (#7919)",
+      "body": "The previous wording 'if a task that wishes to acquire the write lock is\nat the head of the queue, read locks will not be given out' was\nmisleading: it implied that readers are only blocked when the writer is\nfirst in the queue. In reality, due to the FIFO ordering, any write\nrequest queued *before* a read request will block that reader.\n\nReplace with a more accurate description: 'a read lock will not be given\nout until all write lock requests that were queued before it have been\nacquired and released.'\n\nCloses #6901"
+    },
+    {
+      "commit": "c23735d43be36d31911dd2c832f36e5e6a6078a1",
+      "subject": "runtime: fix TOCTOU issue when decreasing `num_idle_threads` (#7918)",
+      "body": ""
+    },
+    {
+      "commit": "d83921bc5181010be72704d1fe8fb9b6f10cb7e8",
+      "subject": "runtime: fix double increment of `num_idle_threads` on shutdown (#7910)",
+      "body": ""
+    },
+    {
+      "commit": "96f64f4ee2afc0a6db76390134dd183d59ca5351",
+      "subject": "codec: fix is_readable should be buffer empty or not (#7912)",
+      "body": ""
+    },
+    {
+      "commit": "00d10c22f831f7d4508444f17a84e19319eaf36b",
+      "subject": "task: fix two typos (#7913)",
+      "body": ""
+    },
+    {
+      "commit": "a25d95a8c4f443886e55b24c97d4bbee1d87283d",
+      "subject": "io: clarify the behavior of `AsyncWriteExt::shutdown()` (#7908)",
+      "body": ""
+    },
+    {
+      "commit": "9e7e1ef7ad30ad84f54a047ecd65b78e5973a9c4",
+      "subject": "io: Explain how to flush stdout/stderr (#7904)",
+      "body": ""
+    },
+    {
+      "commit": "5bcd7c1d09e8d8a89ebcb96069cac1c1fdd76877",
+      "subject": "task: fix task module feature flags in docs (#7891)",
+      "body": ""
+    },
+    {
+      "commit": "2486d497786fa0b17fab03a79c154790c3bdeaed",
+      "subject": "tests: skip issue_7144 if strace is missing (#7903)",
+      "body": ""
+    },
+    {
+      "commit": "9dacb1c53e341b1183a89800d46ee33c6eabf7ad",
+      "subject": "tokio: replace some futures with `poll_fn` (#7895)",
+      "body": ""
+    },
+    {
+      "commit": "8167f871378246ab2108d1ea144257cf95934e4f",
+      "subject": "task: add `AbortOnDrop` (#7855)",
+      "body": ""
+    },
+    {
+      "commit": "159f70bc552a5f733a54ae77e6663403baa16eaf",
+      "subject": "ci: fix ambiguity issue during tokio releases (#7848)",
+      "body": ""
+    },
+    {
+      "commit": "d1e4db1018f9124d66d0cc9673b97606ba90bf86",
+      "subject": "sync: drop rx waker when oneshot receiver is dropped (#7886)",
+      "body": ""
+    },
+    {
+      "commit": "530af3f33131da706e62f7cb569516afef685c4e",
+      "subject": "runtime: correct the default thread name in docs (#7896)",
+      "body": ""
+    },
+    {
+      "commit": "d89e998922724de80996802721e167d9ca24f4d7",
+      "subject": "net: fix GET_BUF_SIZE constant for `target_os = \"android\"` (#7889)",
+      "body": "We recently tried to upgrade Android to the newest tokio, but tests that\nuse these constants fail, since Android is provided the non-Linux\nconstants."
+    },
+    {
+      "commit": "306ed1c30b67d78c8158e601acfda3b8650008dd",
+      "subject": "stream: bump minimum tokio version to 1.38 (#7887)",
+      "body": "tokio-stream 0.1.18 added `Stream::size_hint` for\n`ReceiverStream` and `UnboundedReceiverStream` (PR #7492),\nwhich calls `Receiver::is_closed()` and `Receiver::len()`\n(added in tokio 1.37.0) and `Receiver::capacity()` and\n`Receiver::max_capacity()` (added in tokio 1.38.0).\n\nThe declared minimum of tokio 1.15.0 is no longer sufficient,\ncausing compilation failures when resolved via\n`-Z direct-minimal-versions`.\n\nRefs: #7492"
+    },
+    {
+      "commit": "7e952697e835922aba8885df88f3ec886afeabbe",
+      "subject": "signal: specialize windows `Registry` (#7885)",
+      "body": ""
+    },
+    {
+      "commit": "c0943f99f091bbcc57a93c4533de2e75a9227f90",
+      "subject": "rt: clarify the documentation of `Runtime::spawn` (#7803)",
+      "body": ""
+    },
+    {
+      "commit": "187a2146a7692440cf6a83efb5fbcc886b66a6df",
+      "subject": "runtime: shorten default thread name to fit in Linux limit (#7880)",
+      "body": "Linux thread names are truncated at 15 characters.\nCurrently, Tokio threads show up as \"tokio-runtime-w\", whereas\nshortening \"runtime\" to \"rt\" would make the thread name perfectly fit\nin the 15 character limit."
+    },
+    {
+      "commit": "f61374f931a55357dcc20a9d9b55cc0c509f90f3",
+      "subject": "io: fix incorrect and confusing AsyncWrite documentation (#7875)",
+      "body": ""
+    },
+    {
+      "commit": "0d6c7af3e43457350bdc03a6dbcafa276fab7352",
+      "subject": "runtime: wake deferred tasks before entering `block_in_place` (#7879)",
+      "body": ""
+    },
+    {
+      "commit": "9dc9b53ae164cdba6f14146cfe32d16fcdc562a0",
+      "subject": "io: implement vectored writes for `write_buf` (#7871)",
+      "body": ""
+    },
+    {
+      "commit": "c3b31ba2ab78a901502ff4ac22ec3f2896ab8805",
+      "subject": "signal: guarantee that listeners never return `None` (#7869)",
+      "body": ""
+    },
+    {
+      "commit": "b68ea4156a7d0d63ba3351fb0299ea958f16e7fe",
+      "subject": "io: hardcode platform list for `poll_write` (#7872)",
+      "body": ""
+    },
+    {
+      "commit": "8f6d0864c3158546c343e3fa34872ed584d46fd4",
+      "subject": "macros: improve error message for return type mismatch in #[tokio::main] (#7856)",
+      "body": ""
+    },
+    {
+      "commit": "63abec05259b081eafc6cdd066dca1a808c3762e",
+      "subject": "macros: use `call_site` hygiene to avoid unused qualification (#7866)",
+      "body": ""
+    },
+    {
+      "commit": "8fd44d9bdc5af48c6d76aa4f3fddd45c18d0da43",
+      "subject": "docs: fix link to tokio::select! (#7867)",
+      "body": ""
+    },
+    {
+      "commit": "450fa2d09d63b18bf121b5edf453dee265ba5a00",
+      "subject": "fs: add tests for when `fs::hard_link` fails (#7863)",
+      "body": ""
+    },
+    {
+      "commit": "8cfa309126066597909fe42ec159d12d462dbcef",
+      "subject": "time: add docs about auto-advance and when to use sleep (#7858)",
+      "body": ""
+    },
+    {
+      "commit": "bf185b61ffe579e1ada0e920847692f7480489fa",
+      "subject": "docs: fix broken links of `select!` (#7860)",
+      "body": "Co-authored-by: Martin Grigorov <martin-g@users.noreply.github.com>"
+    },
+    {
+      "commit": "27d1383581192f74994569aeb08894f32008765a",
+      "subject": "deps: bump `tokio` to `1.47.0` (#7862)",
+      "body": ""
+    },
+    {
+      "commit": "11f9d4db73d8a80e2f29ace655b525a28ca99238",
+      "subject": "macros: add test for special return types (#7857)",
+      "body": ""
+    },
+    {
+      "commit": "1280cf81de55aef040b65b202dddb09713fd4f2b",
+      "subject": "io: always cleanup `AsyncFd` registration list on deregister (#7773)",
+      "body": ""
+    },
+    {
+      "commit": "67682ac2e87e27b4791e33467a7c6e773e0c2179",
+      "subject": "io: add optimizer hint that `memchr` returns in-bounds pointer (#7792)",
+      "body": ""
+    },
+    {
+      "commit": "b88c02c55e12bb51a5efae591697998c1942d1aa",
+      "subject": "time: implement `FusedStream` for `IntervalStream` (#7854)",
+      "body": ""
+    },
+    {
+      "commit": "240cc44da87ac30188e946ed1003b0e67f64aad8",
+      "subject": "signal: remember the result of `SetConsoleCtrlHandler` (#7833)",
+      "body": "The unix implementation remembers whether it failed or not, so the\nwindows implementation should do so as well. This PR also replaces the\n`(Once, AtomicState)` pair with `OnceLock` and tries to remember the\noriginal errno value."
+    },
+    {
+      "commit": "7ed6da6733199fe4d08b9694fce646dac5944e70",
+      "subject": "runtime: add comments to `schedule_option_task_without_yield` (#7851)",
+      "body": ""
+    },
+    {
+      "commit": "7a2135f426ab560a9efb320620f80e1935c43d31",
+      "subject": "runtime: avoid lock acquisition after uring init (#7850)",
+      "body": ""
+    },
+    {
+      "commit": "0913cad381ead40ee194e881366bc136c8d8546c",
+      "subject": "runtime: revert \"avoid lock acquisition after uring init\" (#7849)",
+      "body": "This reverts commit ff9681b3c62d63ca2703976d4767f29442bc87f2."
+    },
+    {
+      "commit": "ff9681b3c62d63ca2703976d4767f29442bc87f2",
+      "subject": "runtime: avoid lock acquisition after uring init (#7843)",
+      "body": ""
+    },
+    {
+      "commit": "f1cb007a281d49104e7b0e29d4ba5c6e7a06af11",
+      "subject": "net: add `TcpStream::set_zero_linger` (#7837)",
+      "body": ""
+    },
+    {
+      "commit": "2d4853ea16082d42be421001c1511eded1481b53",
+      "subject": "examples: use `select!` instead of `join!` in connect_(tcp|udp) examples (#7842)",
+      "body": ""
+    },
+    {
+      "commit": "d65165f7b563d75db110f8ca26b5a4ae749c59e7",
+      "subject": "rt: make `is_rt_shutdown_err` method public (#7771)",
+      "body": ""
+    },
+    {
+      "commit": "71a1a3da7ad0af2200e08d75996a97f50bdf49db",
+      "subject": "tokio: update outdated unstable features section (#7839)",
+      "body": ""
+    },
+    {
+      "commit": "df73fa21884f65ac4f5556ec72814cefed94897f",
+      "subject": "runtime: panic when `event_interval` is set to 0 (#7838)",
+      "body": ""
+    },
+    {
+      "commit": "09ad5367b8de39ae2532c7c0efe4136167be015d",
+      "subject": "runtime: avoid redundant unpark in current_thread scheduler (#7834)",
+      "body": ""
+    },
+    {
+      "commit": "934f68d91c90777235e119f4b42f3de660c45bd0",
+      "subject": "runtime: don't park in `current_thread` if `before_park` defers waker (#7835)",
+      "body": ""
+    },
+    {
+      "commit": "41d1877689f8669902b003a6affce60bdfeb3025",
+      "subject": "chore: prepare tokio-test 0.4.5 (#7831)",
+      "body": ""
+    },
+    {
+      "commit": "60b083b630ed279d579368e513406d735d739511",
+      "subject": "chore: prepare tokio-stream 0.1.18 (#7830)",
+      "body": ""
+    },
+    {
+      "commit": "9cc02cc88d083113cd9889a74b382e39e430e180",
+      "subject": "chore: prepare tokio-util 0.7.18 (#7829)",
+      "body": ""
+    },
+    {
+      "commit": "d2799d791b10388e60a2a5fe5e4a33b3336e1465",
+      "subject": "task: improve the docs of `Builder::spawn_local` (#7828)",
+      "body": ""
+    },
+    {
+      "commit": "4d4870f291b69e2426232440e03c9e66fe77b525",
+      "subject": "task: doc that task drops before JoinHandle completion (#7825)",
+      "body": ""
+    },
+    {
+      "commit": "fdb150901afb0456037c6232eab8ce80116ccd02",
+      "subject": "fs: check for io-uring opcode support (#7815)",
+      "body": ""
+    },
+    {
+      "commit": "426a56278017c30e7da7b4c9365a2610f4695f76",
+      "subject": "rt: remove `allow(dead_code)` after `JoinSet` stabilization (#7826)",
+      "body": ""
+    },
+    {
+      "commit": "e3b89bbefa7564e2eba2fb9f849ef7bf87d60fad",
+      "subject": "chore: prepare Tokio v1.49.0 (#7824)",
+      "body": ""
+    },
+    {
+      "commit": "4f577b84e939c8d427d79fdc73919842d8735de2",
+      "subject": "Merge 'tokio-1.47.3' into 'master'",
+      "body": ""
+    },
+    {
+      "commit": "f320197693ee09e28f1fca0e55418081adcdfc25",
+      "subject": "chore: prepare Tokio v1.47.3 (#7823)",
+      "body": ""
+    },
+    {
+      "commit": "ea6b144cd1042d6841a7830b18f2df77c3db904b",
+      "subject": "ci: freeze rustc on nightly-2025-01-25 in `netlify.toml` (#7652)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "264e703296bccd6783a438815d91055d4517099b",
+      "subject": "Merge `tokio-1.43.4` into `tokio-1.47.x` (#7822)",
+      "body": ""
+    },
+    {
+      "commit": "dfb0f00838ca1986dee04a54a6299d35b0a4072c",
+      "subject": "chore: prepare Tokio v1.43.4 (#7821)",
+      "body": ""
+    },
+    {
+      "commit": "4a91f197b03dc335010fffcf0e0c14e1f4011b42",
+      "subject": "ci: fix wasm32-wasip1 tests (#7788)",
+      "body": "(cherry picked from commit 1b17a7e241989520704ce408045904bc2e275e3c)"
+    },
+    {
+      "commit": "601c383ab6def5a6d2f95a434c95a97b65059628",
+      "subject": "ci: upgrade FreeBSD from 14.2 to 14.3 (#7758)",
+      "body": "14.2 is no more available:\n\n```\n$ gcloud compute images list --project freebsd-org-cloud-dev --no-standard-images\nNAME                                             PROJECT                FAMILY                       DEPRECATED  STATUS\nfreebsd-13-5-release-amd64-gce                   freebsd-org-cloud-dev  freebsd-13-5                             READY\nfreebsd-13-5-stable-amd64-v20251030              freebsd-org-cloud-dev  freebsd-13-5-snap                        READY\nfreebsd-13-5-stable-amd64-v20251107              freebsd-org-cloud-dev  freebsd-13-5-snap                        READY\nfreebsd-14-3-release-amd64-ufs-gce               freebsd-org-cloud-dev  freebsd-14-3                             READY\nfreebsd-14-3-stable-amd64-ufs-20251120           freebsd-org-cloud-dev  freebsd-14-3-snap                        READY\nfreebsd-14-3-stable-amd64-ufs-20251127           freebsd-org-cloud-dev  freebsd-14-3-snap                        READY\nfreebsd-14-3-stable-amd64-zfs-20251113           freebsd-org-cloud-dev  freebsd-14-3-snap                        READY\nfreebsd-14-3-stable-amd64-zfs-20251120           freebsd-org-cloud-dev  freebsd-14-3-snap                        READY\nfreebsd-14-3-stable-amd64-zfs-20251127           freebsd-org-cloud-dev  freebsd-14-3-snap                        READY\nfreebsd-15-0-release-amd64-ufs                   freebsd-org-cloud-dev  freebsd-15-0-amd64-ufs                   READY\nfreebsd-15-0-release-amd64-zfs                   freebsd-org-cloud-dev  freebsd-15-0-amd64-zfs                   READY\nfreebsd-15-0-stable-amd64-ufs-20251120           freebsd-org-cloud-dev  freebsd-15-0-amd64-ufs-snap              READY\nfreebsd-15-0-stable-amd64-ufs-20251127           freebsd-org-cloud-dev  freebsd-15-0-amd64-ufs-snap              READY\nfreebsd-15-0-stable-amd64-zfs-20251120           freebsd-org-cloud-dev  freebsd-15-0-amd64-zfs-snap              READY\nfreebsd-15-0-stable-amd64-zfs-20251127           freebsd-org-cloud-dev  freebsd-15-0-amd64-zfs-snap              READY\nfreebsd-16-0-current-amd64-ufs-20251110          freebsd-org-cloud-dev  freebsd-16-0-snap                        READY\nfreebsd-16-0-current-amd64-zfs-20251110          freebsd-org-cloud-dev  freebsd-16-0-snap                        READY\nfreebsd-16-0-current-arm64-aarch64-ufs-20251111  freebsd-org-cloud-dev  freebsd-16-0-snap                        READY\nfreebsd-16-0-current-arm64-aarch64-zfs-20251111  freebsd-org-cloud-dev  freebsd-16-0-snap                        READY\n```\n\n(cherry picked from commit 5471a5835e8bc406c2adc2b66d3020c00ab6a685)"
+    },
+    {
+      "commit": "484cb52d8d21cb8156decbeba9569651fcc09d0d",
+      "subject": "sync: return `TryRecvError::Disconnected` from `Receiver::try_recv` after `Receiver::close` (#7686)",
+      "body": "(cherry picked from commit d060401f6c7dca4a20674e3ad63ad7f1b228aa31)"
+    },
+    {
+      "commit": "16f20c34ed9bc11eb1e7cdec441ab844b198d2cd",
+      "subject": "rt: mention `LocalRuntime` in `new_current_thread` docs (#7820)",
+      "body": ""
+    },
+    {
+      "commit": "46674789abdcd72189bb48a82c6c2121bc3922a0",
+      "subject": "signal: optimize unix signal storage to skip zero (#7819)",
+      "body": ""
+    },
+    {
+      "commit": "8f4ebfd2f7f120e6f50448509496614d7008aef3",
+      "subject": "signal: specialize unix `OsStorage` (#7818)",
+      "body": ""
+    },
+    {
+      "commit": "bd3940c14fb22718b16b8e84fbfc40a6b43a5e5f",
+      "subject": "docs: fix typos in bounded.rs and park.rs (#7817)",
+      "body": ""
+    },
+    {
+      "commit": "c27bed36acc96ae46193ff32ceb8ccc225fd58b1",
+      "subject": "examples: improve the style of `chat.rs` (#7812)",
+      "body": ""
+    },
+    {
+      "commit": "6d3feb581f2620ee4884f9699f5492f079ed0911",
+      "subject": "task: Better typed RawTask::try_read_output (#7806)",
+      "body": ""
+    },
+    {
+      "commit": "a708ad19cb9ae652d8a813554e68cb1d86593eb9",
+      "subject": "chore: fix minor typos (#7804)",
+      "body": ""
+    },
+    {
+      "commit": "4bc2a15d28554426a500ce73be969ecd9ed6dd89",
+      "subject": "io: add `SyncIoBridge` cross-references to `copy` and `copy_buf` (#7798)",
+      "body": ""
+    },
+    {
+      "commit": "33566434bba678c492a5b03b24a013d2f8710c6e",
+      "subject": "metrics: clarify that `num_alive_tasks` is not strongly consistent (#7614)",
+      "body": ""
+    },
+    {
+      "commit": "7388f2d2ea5311af4b2fa0e088d890facfbf4054",
+      "subject": "net: add support for `TCLASS` option on IPv6 (#7781)",
+      "body": "Co-authored-by: Thomas de Zeeuw <thomasdezeeuw@gmail.com>"
+    },
+    {
+      "commit": "0a3e3862697d902cffd729506cb28f6007c204d1",
+      "subject": "time: improve the readability of alternative timer (#7801)",
+      "body": ""
+    },
+    {
+      "commit": "d666068be7489a7ff49b3ac3f6b61ccee0839972",
+      "subject": "fs: handle `EINTR` in `fs::write` for io-uring (#7786)",
+      "body": ""
+    },
+    {
+      "commit": "1b17a7e241989520704ce408045904bc2e275e3c",
+      "subject": "ci: fix wasm32-wasip1 tests (#7788)",
+      "body": ""
+    },
+    {
+      "commit": "5b91709edf0f288da0b712ed5c60bf105a06d0c9",
+      "subject": "chore: fix some minor typos in the comments (#7785)",
+      "body": "Signed-off-by: xibeiyoumian <xibeiyoumian@outlook.com>"
+    },
+    {
+      "commit": "08f40652aadf1d352696c8f403430d7ace7eca74",
+      "subject": "macros: remove `extern crate proc_macro` (#7783)",
+      "body": ""
+    },
+    {
+      "commit": "6403b5370ed7bf64be11e9b97aaefa14d15bd422",
+      "subject": "readme: remove TokioConf 2026 CFP announcement (#7774)",
+      "body": ""
+    },
+    {
+      "commit": "064181f386414a543c0819af8c65866bbd879895",
+      "subject": "io: add `tokio_util::io::simplex` (#7565)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "009a2567d0376d96ff3b459c5581057ab5b11770",
+      "subject": "sync: clarify the cancellation safety of `oneshot::Receiver` (#7780)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>\nCo-authored-by: Alice Ryhl <aliceryhl@google.com>"
+    },
+    {
+      "commit": "231a3a69f9a191c88b94a9ff141865f9a8d0bf84",
+      "subject": "task: stabilize the `LocalSet::id()` (#7776)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "0fa7755e97b2b4ba4630d21a6d5316f39aaa4ee5",
+      "subject": "runtime: stabilize `runtime::id::Id` (#7125)",
+      "body": ""
+    },
+    {
+      "commit": "d3fe35593d46fd60a092e1ea7b8c0fd6cce2cf98",
+      "subject": "net: clarify the cancellation safety of the `TcpStream::peek` (#7305)",
+      "body": ""
+    },
+    {
+      "commit": "0ec0a8546105b9f250f868b77e42c82809703aab",
+      "subject": "io: document the default capacity of the `ReaderStream` (#7147)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>\nCo-authored-by: Qi <add_sp@outlook.com>"
+    },
+    {
+      "commit": "97d06ae1a69a38dfe20e65b5972f456781f2e0c1",
+      "subject": "macros: fix the hygiene issue of `join!` and `try_join!` (#7766)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "b5054e1dfff24c6166ed61100cfbfd329b16b8f8",
+      "subject": "docs: break up `CONTRIBUTING.md` into several parts (#7762)",
+      "body": ""
+    },
+    {
+      "commit": "398eef81203865c3033cdb0e88c637ec7ff0dd65",
+      "subject": "fs: support io_uring with `tokio::fs::read` (#7696)",
+      "body": ""
+    },
+    {
+      "commit": "c8116ecd7bba1dae71bfac25600420ec73fbc2b1",
+      "subject": "stream: work around the rustc bug in `StreamExt::collect` (#7754)",
+      "body": ""
+    },
+    {
+      "commit": "5471a5835e8bc406c2adc2b66d3020c00ab6a685",
+      "subject": "ci: upgrade FreeBSD from 14.2 to 14.3 (#7758)",
+      "body": "14.2 is no more available:\n\n```\n$ gcloud compute images list --project freebsd-org-cloud-dev --no-standard-images\nNAME                                             PROJECT                FAMILY                       DEPRECATED  STATUS\nfreebsd-13-5-release-amd64-gce                   freebsd-org-cloud-dev  freebsd-13-5                             READY\nfreebsd-13-5-stable-amd64-v20251030              freebsd-org-cloud-dev  freebsd-13-5-snap                        READY\nfreebsd-13-5-stable-amd64-v20251107              freebsd-org-cloud-dev  freebsd-13-5-snap                        READY\nfreebsd-14-3-release-amd64-ufs-gce               freebsd-org-cloud-dev  freebsd-14-3                             READY\nfreebsd-14-3-stable-amd64-ufs-20251120           freebsd-org-cloud-dev  freebsd-14-3-snap                        READY\nfreebsd-14-3-stable-amd64-ufs-20251127           freebsd-org-cloud-dev  freebsd-14-3-snap                        READY\nfreebsd-14-3-stable-amd64-zfs-20251113           freebsd-org-cloud-dev  freebsd-14-3-snap                        READY\nfreebsd-14-3-stable-amd64-zfs-20251120           freebsd-org-cloud-dev  freebsd-14-3-snap                        READY\nfreebsd-14-3-stable-amd64-zfs-20251127           freebsd-org-cloud-dev  freebsd-14-3-snap                        READY\nfreebsd-15-0-release-amd64-ufs                   freebsd-org-cloud-dev  freebsd-15-0-amd64-ufs                   READY\nfreebsd-15-0-release-amd64-zfs                   freebsd-org-cloud-dev  freebsd-15-0-amd64-zfs                   READY\nfreebsd-15-0-stable-amd64-ufs-20251120           freebsd-org-cloud-dev  freebsd-15-0-amd64-ufs-snap              READY\nfreebsd-15-0-stable-amd64-ufs-20251127           freebsd-org-cloud-dev  freebsd-15-0-amd64-ufs-snap              READY\nfreebsd-15-0-stable-amd64-zfs-20251120           freebsd-org-cloud-dev  freebsd-15-0-amd64-zfs-snap              READY\nfreebsd-15-0-stable-amd64-zfs-20251127           freebsd-org-cloud-dev  freebsd-15-0-amd64-zfs-snap              READY\nfreebsd-16-0-current-amd64-ufs-20251110          freebsd-org-cloud-dev  freebsd-16-0-snap                        READY\nfreebsd-16-0-current-amd64-zfs-20251110          freebsd-org-cloud-dev  freebsd-16-0-snap                        READY\nfreebsd-16-0-current-arm64-aarch64-ufs-20251111  freebsd-org-cloud-dev  freebsd-16-0-snap                        READY\nfreebsd-16-0-current-arm64-aarch64-zfs-20251111  freebsd-org-cloud-dev  freebsd-16-0-snap                        READY\n```"
+    },
+    {
+      "commit": "be99e7aa0405e58629844e43546f9107bdc08e73",
+      "subject": "benches: add spawn_blocking concurrency benchmark (#7748)",
+      "body": ""
+    },
+    {
+      "commit": "3bf2e53f0b65833824e71b6a0532513004d65d4e",
+      "subject": "net: deprecate `{TcpStream,TcpSocket}::set_linger` (#7752)",
+      "body": ""
+    },
+    {
+      "commit": "ab3996a6dd2aabce13b01f2b4de7de778a7d0c5d",
+      "subject": "time: update outdated docs of `Wheel` (#7749)",
+      "body": ""
+    },
+    {
+      "commit": "c03a37fa0b88ec20df22bec2b035852fd1eab44e",
+      "subject": "tokio: enable more tests in Miri (#7734)",
+      "body": ""
+    },
+    {
+      "commit": "73d733a3415af98d72c2cce40612c4e59adbd5d8",
+      "subject": "time: add alternative timer for better multicore scalability (#7467)",
+      "body": "This change introduces per-worker timer wheels in the time subsystem\nto reduce the lock contention.\n\nKey changes:\n- Each worker now maintains a local timer wheel.\n- Timer insertions are performed locally.\n- Timer cancellations are forwarded via a\n  dedicated cross-worker cancellation queue.\n\nRelevant RFC: https://github.com/tokio-rs/tokio/issues/7384"
+    },
+    {
+      "commit": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "749322d3510a6828d9b118027fddedbc2d174d28",
+      "subject": "task: implement `Extend` for `JoinSet` (#7195)",
+      "body": ""
+    },
+    {
+      "commit": "963b6317540e3d9408ef67e81ea528b7d0c5675c",
+      "subject": "refactor: introduce constants for default addresses and improve error handling in TCP examples (#7741)",
+      "body": "- Added `DEFAULT_ADDR` constant to `chat.rs` and `echo-tcp.rs` for better maintainability.\n- Enhanced error logging in `connect-tcp.rs` and `echo-tcp.rs` to include connection addresses.\n- Improved peer management in `chat.rs` by automatically cleaning up disconnected peers."
+    },
+    {
+      "commit": "9a1b076c0084e2bca8558818bffd2273ec5ae5bd",
+      "subject": "io: replace `Result<T, io::Error>` with `io::Result<T>` in `AsyncWrite` (#7740)",
+      "body": ""
+    },
+    {
+      "commit": "c434ed786509792db580e800f796adcad6a5915c",
+      "subject": "net: clarify the drop behavior of `unix::OwnedWriteHalf` (#7742)",
+      "body": ""
+    },
+    {
+      "commit": "4714ca168d6bd97193625657b0381e9b65a9ceff",
+      "subject": "net: clarify the platform-dependent backlog in `TcpSocket` docs (#7738)",
+      "body": ""
+    },
+    {
+      "commit": "5e3ad02fb106f72194c13bdff8317e9a99953c05",
+      "subject": "sync: fix a typo in the docs of `PollSender::is_closed` (#7737)",
+      "body": ""
+    },
+    {
+      "commit": "12412afea4b75b7297cfe6aefb0c5b742adecd6d",
+      "subject": "deps: bump `tokio` to `1.44.0` (#7733)",
+      "body": ""
+    },
+    {
+      "commit": "cae083a26f6f6127c927d72c7bb8a9ae32f46c6a",
+      "subject": "docs: fix typos in README (#7731)",
+      "body": ""
+    },
+    {
+      "commit": "fd7a8d7c65e11b983372d4ceb86c9b8e4dff4bd8",
+      "subject": "chore: add TokioConf 2026 CFP announcement (#7730)",
+      "body": "* chore: add TokioConf 2026 CFP announcement\n\n* sync readmes"
+    },
+    {
+      "commit": "d709df25717e292609d93d4002a98232e63eccd3",
+      "subject": "ci: bump miri to `nightly-2025-11-09` (#7726)",
+      "body": ""
+    },
+    {
+      "commit": "665f08b5ad15485e8dcd6c3ec5ad1bda03a2a68d",
+      "subject": "tokio: enable the `unsafe_op_in_unsafe_fn` lint at the crate level (#7711)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "d4641ba9fcb1fadd4161750df76963422721c65a",
+      "subject": "util: use `<ptr>::addr` instead of unsafe impl (#7725)",
+      "body": ""
+    },
+    {
+      "commit": "2bf80f0ac6daaa28c0ad2c7d3ed1def59ae243e8",
+      "subject": "runtime: disable io-uring on `EPERM` (#7724)",
+      "body": ""
+    },
+    {
+      "commit": "62ecff895acb574e41c8a8d5460d6c8ca4940243",
+      "subject": "stream: add `ChunksTimeout::into_remainder` (#7715)",
+      "body": ""
+    },
+    {
+      "commit": "d84a9e9af3d9e2acb8c2186b86da834621f10224",
+      "subject": "util: enable loom tests (#7644)",
+      "body": "Co-authored-by: Benjamin Ran <benjaminran@Benjamins-MacBook-Pro-3.local>"
+    },
+    {
+      "commit": "0671c205cc5c06420a4154c6edd2dfba2512b54d",
+      "subject": "sync: improve the docs for the errors of mpsc (#7722)",
+      "body": "* docs: fix documentation comments for mpsc error enums\n\n* docs: improve code docs for `TryRecvError`\n\n* docs: improve code docs for mpsc `SendError`"
+    },
+    {
+      "commit": "1ece2f1fa787f1bd1ebdc212f093fb1b5647bd82",
+      "subject": "task: remove unnecessary trait bounds on the `Debug` implementation (#7720)",
+      "body": "Remove the trait bounds of the `Debug` impl for `JoinQueue`\nand `AbortOnDropHandle`.\n\nSigned-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "12319f26d07cd0821cdb45f50cf2b13200f2d04e",
+      "subject": "sync: add missing period to `mpsc::Sender::try_send` docs (#7721)",
+      "body": ""
+    },
+    {
+      "commit": "454fd8c3477a37d12d5d11948fd6fe496924e950",
+      "subject": "chore: prepare tokio-util v0.7.17 (#7719)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "4421022c254cda51fe2dd641c2114fb3af7fb711",
+      "subject": "codec: remove unnecessary trait bounds on all `Framed` constructors (#7716)",
+      "body": ""
+    },
+    {
+      "commit": "5a709e391bdab3cf8bab9fe65d75fa2b92f4e0db",
+      "subject": "io_uring: change `Completable` to not return io::Result (#7702)",
+      "body": ""
+    },
+    {
+      "commit": "5efb1c3b16496f51f2ec959b68a1b97efd7ee234",
+      "subject": "io: doc that `AsyncWrite` does not inherit from `Write` (#7705)",
+      "body": ""
+    },
+    {
+      "commit": "f490029b8fc4552d54b527fc0052fb539e493ebf",
+      "subject": "runtime: revert \"replace manual vtable definitions with `Wake`\" (#7699)",
+      "body": "This reverts commit 4380de9fe9e0938790a2c06f4bdaa8bd91c08ed1."
+    },
+    {
+      "commit": "d25778f67d4571f9067a0004133d5a9005b6aedd",
+      "subject": "task: add tests for `task::Builder::spawn_local` (#7697)",
+      "body": ""
+    },
+    {
+      "commit": "b8318fa1723784cc7f777a900af74ada0ad0dbf7",
+      "subject": "task: add tests for `spawn_local` in panic scenarios (#7694)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "acfdb87e2b8b5daa8ffe31de53eaff0df3f04c50",
+      "subject": "task: use `#[tokio::test]` explicitly in `tests/task_builder.rs` (#7698)",
+      "body": ""
+    },
+    {
+      "commit": "d060401f6c7dca4a20674e3ad63ad7f1b228aa31",
+      "subject": "sync: return `TryRecvError::Disconnected` from `Receiver::try_recv` after `Receiver::close` (#7686)",
+      "body": ""
+    },
+    {
+      "commit": "5dacc2e2a8ca151d0e4c5d7021bac8f1fdca1987",
+      "subject": "task: add tests for `spawn_local` and `spawn_local_on` (#7609)",
+      "body": "Add tests for task collections (TaskTracker, JoinSet, JoinMap)."
+    },
+    {
+      "commit": "444d3f5c49ebc8449ba4feccae5bb1a740313953",
+      "subject": "task: add example for `spawn_local` usage on local runtime (#7689)",
+      "body": ""
+    },
+    {
+      "commit": "d23a838732077122aee71530f15d3c0bf69f11bb",
+      "subject": "runtime: add tests for spawn local on multi and current runtimes (#7687)",
+      "body": ""
+    },
+    {
+      "commit": "2137f7d953df2c65ad254aba41e7e403905dda91",
+      "subject": "process: remove obsolete `allow(deprecated)` from `is_rt_shutdown_err` (#7685)",
+      "body": ""
+    },
+    {
+      "commit": "51e9dc0943a864a74ed82bae638bb876f7a60150",
+      "subject": "Merge 'tokio-1.47.2' into 'master' (#7683)",
+      "body": ""
+    },
+    {
+      "commit": "3762a6a990ef0d5794787ceb929e6d3b78f755ae",
+      "subject": "chore: prepare Tokio v1.47.2 (#7681)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "07f6cc7e1d9b319be02960074c885a7eb423c3b8",
+      "subject": "macros: fix the hygiene issue of `join!` and `try_join!` (#7638)",
+      "body": "(cherry picked from commit eb99e476e674f81095e2f8f15cbc92f8650f5364)"
+    },
+    {
+      "commit": "308e3e68715ffa10ffb95a0b430ca063e08a6c9a",
+      "subject": "ci: add lockfile for LTS branch",
+      "body": "This is to lock the following dependencies:\n\n- `parking_lot_core` to `0.9.11`\n- `parking_lot` to `0.12.4`\n- `lock_api` to `0.4.13`\n\nSee <https://github.com/tokio-rs/tokio/issues/7653>\nfor more details.\n\nSigned-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "5a1879c2d03f201cbbc59a6cc54ed2fb23a2b1f8",
+      "subject": "Merge 'tokio-1.43.3' into 'tokio-1.47.x'",
+      "body": ""
+    },
+    {
+      "commit": "de6ef21a81fc451f904bcad8ba85dd8c96b17d76",
+      "subject": "chore: prepare Tokio v1.43.3",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "90551d234f43d2c4d9ed5189120f7b2dcb43437f",
+      "subject": "deps: bump the locked slap to `0.4.11`",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "bd4c3dddcac8185acf3e419068fd3465e776c8ac",
+      "subject": "deps: bump the locked tracing-subscriber to `0.3.20`",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "49b331855ece1c5fd6fdb4aa1cf91eebbd92244e",
+      "subject": "process: fix error when runtime is shut down on nightly-2025-10-12 (#7672)",
+      "body": "(cherry picked from commit 9e5527d1d5eadbeed46f4d5d4eb22cd96c72a39a)"
+    },
+    {
+      "commit": "da292dfb66ef34fdfbb6aa1f23c3b2456ca4d400",
+      "subject": "sync: close the `broadcast::Sender` in `broadcast::Sender::new()` (#7629)",
+      "body": "(cherry picked from commit 6d1ae6286880c828c13efb5f11b60c18fb94f947)"
+    },
+    {
+      "commit": "b9feac8d6841bc7933f3d9d508f4179800d4d579",
+      "subject": "runtime: use release in `wake_by_ref()` even if already woken (#7622)",
+      "body": "(cherry picked from commit 67869be3d75c58f9b84bc469e00439b70aff0516)"
+    },
+    {
+      "commit": "4fee6e350016c8e651adb7b9fc5d05685d874c14",
+      "subject": "ci: update macros_type_mismatch for Rust 1.90.0 (#7630)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>\n(cherry picked from commit 2af3e4430a8c546d5273e0bac669fd6696431e89)"
+    },
+    {
+      "commit": "b1e69e560c7b49557f3b43596e2090733f986457",
+      "subject": "ci: pin the rust version for wasm tests (#7518)",
+      "body": "(cherry picked from commit 987675e84353d32f6c11f6fe738f247669717a3b)"
+    },
+    {
+      "commit": "556820ff84030b37e74e11b86b7733f5795770ea",
+      "subject": "chore: prepare Tokio v1.48.0 (#7677)",
+      "body": ""
+    },
+    {
+      "commit": "fd1659a05222858b675d5515ef609ca39d825bff",
+      "subject": "chore: prepare tokio-macros v2.6.0 (#7676)",
+      "body": ""
+    },
+    {
+      "commit": "53e8acac641a614b89e35912ebed0520c6dbcf93",
+      "subject": "ci: update nightly version to 2025-10-12 (#7670)",
+      "body": ""
+    },
+    {
+      "commit": "9e5527d1d5eadbeed46f4d5d4eb22cd96c72a39a",
+      "subject": "process: fix error when runtime is shut down on nightly-2025-10-12 (#7672)",
+      "body": ""
+    },
+    {
+      "commit": "25a24de0e661d86fa059779e87e0605909465f4a",
+      "subject": "net: remove PollEvented noise from Debug formats (#7675)",
+      "body": ""
+    },
+    {
+      "commit": "c1fa25f3009d6f5374e337b999fe4fe926c8e7f2",
+      "subject": "task: clarify the behavior of several `spawn_local` methods (#7669)",
+      "body": ""
+    },
+    {
+      "commit": "e7e02fcf0f16fc906c0fac48aafd6a168ae3cf24",
+      "subject": "fs: use `FileOptions` inside `fs::File` to support uring (#7617)",
+      "body": ""
+    },
+    {
+      "commit": "f7a7f62959aafd03fd40a07a4f511476dff1e57f",
+      "subject": "ci: remove cargo-deny Unicode-DFS-2016 license exception config (#7619)",
+      "body": ""
+    },
+    {
+      "commit": "d1f1499f630c34c1d319acdc2cc86d7a1008c4b4",
+      "subject": "tokio: use cargo feature for taskdump support instead of cfg (#7655)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>\nCo-authored-by: Alice Ryhl <aliceryhl@google.com>"
+    },
+    {
+      "commit": "ad6f6189529b1067bd4628d1c62abf9a3a64281e",
+      "subject": "runtime: clarify the behavior of `Handle::block_on` (#7665)",
+      "body": ""
+    },
+    {
+      "commit": "0f9ae13c31811150d8bb7ad14127aa19c709ed49",
+      "subject": "task: add `LocalKey::try_get` (#7666)",
+      "body": "Signed-off-by: tison <wander4096@gmail.com>"
+    },
+    {
+      "commit": "9255d96b1b5d6ac85e348d718ed69ea2f80b585c",
+      "subject": "deps: bump windows-sys to version 0.61 (#7645)",
+      "body": ""
+    },
+    {
+      "commit": "ffcc9f7c9505e31dceee8f8b50de4d50cf72f502",
+      "subject": "tokio: fix the docs of feature flag (#7663)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "1a4cf319b56a8fee2a9f66d5fcdca9b6d69bd54d",
+      "subject": "sync: improve the docs of `UnboundedSender::send` (#7661)",
+      "body": ""
+    },
+    {
+      "commit": "3698a6f153c3b3484a5231901aae441e39327768",
+      "subject": "fs: support io_uring in `fs::write` (#7567)",
+      "body": ""
+    },
+    {
+      "commit": "5b4cbbc39e6c2d14907aff068244160fa8ca58dc",
+      "subject": "tokio: raise MSRV to 1.71 (#7658)",
+      "body": ""
+    },
+    {
+      "commit": "c1f0c76fa042577336326c77c07a9eeb213858ec",
+      "subject": "macros: suppress `clippy::unwrap_in_result` in `#[tokio::main]` (#7651)",
+      "body": ""
+    },
+    {
+      "commit": "d0953e833d1e5bfdafe1293316eaf5dd3bb90569",
+      "subject": "task: simplify the example of `TaskTracker` (#7657)",
+      "body": ""
+    },
+    {
+      "commit": "b157f5da76a50063f831112f8ca7ccc787120f50",
+      "subject": "runtime: add guide for choosing between runtime types (#7635)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "35470bfc6e43dac2715009cc1adc0931944cf3b5",
+      "subject": "sync: clarify bounded channel panic behavior (#7641)",
+      "body": "Signed-off-by: Xinye Tao <xinye.tao@metabit-trading.com>\nCo-authored-by: Xinye Tao <xinye.tao@metabit-trading.com>"
+    },
+    {
+      "commit": "95edd8515ee863ac550849af0a741c889ebdf314",
+      "subject": "docs: fix some docs links (#7654)",
+      "body": ""
+    },
+    {
+      "commit": "a0f7f5c94a3958093dbda6934e498e90c3fd1f17",
+      "subject": "fs: emit compilation error without `tokio_unstable` for `io-uring` (#7634)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "02486978d1a6c976b3e8b06051015b6df72cecf9",
+      "subject": "ci: freeze rustc on nightly-2025-01-25 in `netlify.toml` (#7652)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "8ccf2fb92e7568bf16318dc8f3205cad14a9bc5d",
+      "subject": "ci: unfreeze wasm tests from rustc 1.88.0 (#7537)",
+      "body": ""
+    },
+    {
+      "commit": "bce76c515f68271a457a0e494dbf027c309f46d6",
+      "subject": "task: add `try_join_next` and `try_join_next_with_id` on `JoinQueue` (#7636)",
+      "body": ""
+    },
+    {
+      "commit": "b48586f560062e5597f8ef7e9003a3b6cf3b2af0",
+      "subject": "tokio: fix typos in `tokio/CHANGELOG.md` (#7643)",
+      "body": ""
+    },
+    {
+      "commit": "eb99e476e674f81095e2f8f15cbc92f8650f5364",
+      "subject": "macros: fix the hygiene issue of `join!` and `try_join!` (#7638)",
+      "body": ""
+    },
+    {
+      "commit": "b9b532485bbb879042a1bd2ef40a50e6c1d15bb6",
+      "subject": "sync: clarify the behavior of `tokio::sync::watch::Receiver` (#7584)",
+      "body": ""
+    },
+    {
+      "commit": "1b98d5ad85f44a2d2df91b520990ded04db81371",
+      "subject": "task: add `tokio_util::task::JoinQueue` (#7590)",
+      "body": ""
+    },
+    {
+      "commit": "6d1ae6286880c828c13efb5f11b60c18fb94f947",
+      "subject": "sync: close the `broadcast::Sender` in `broadcast::Sender::new()` (#7629)",
+      "body": ""
+    },
+    {
+      "commit": "3b5a15dfdfc5dc789dcb80cef0986fb2fa5cac0a",
+      "subject": "fs: use the Cargo feature for io-uring support instead of cfg (#7621)",
+      "body": "Co-authored-by: Emile Fugulin <code@efugulin.com>"
+    },
+    {
+      "commit": "2af3e4430a8c546d5273e0bac669fd6696431e89",
+      "subject": "ci: update macros_type_mismatch for Rust 1.90.0 (#7630)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "67869be3d75c58f9b84bc469e00439b70aff0516",
+      "subject": "runtime: use release in `wake_by_ref()` even if already woken (#7622)",
+      "body": ""
+    },
+    {
+      "commit": "c6b16cc8610e4832968e6d02270ce307fbc20006",
+      "subject": "net: clarify the supported platform of `set_reuseport()` and `reuseport()` (#7628)",
+      "body": ""
+    },
+    {
+      "commit": "7c197c7784454b3e78aeddbad102d57f83dd98a4",
+      "subject": "runtime: clarify the edge case of `Builder::global_queue_interval()` (#7605)",
+      "body": ""
+    },
+    {
+      "commit": "5f3f5b0be4ec933aed2290ea9d929b5daadae321",
+      "subject": "sync: improve the docs of `sync::watch` (#7601)",
+      "body": "Co-authored-by: Alice Ryhl <aliceryhl@google.com>"
+    },
+    {
+      "commit": "32a1acc85fdd00c6affa022833290fc7cd179b19",
+      "subject": "examples: bump `http` crate from `0.2` to `1` (#7618)",
+      "body": ""
+    },
+    {
+      "commit": "7f455b2d9334c89dba03d9dd49a19cc56b791ecd",
+      "subject": "task: clarify the task ID reuse guarantees (#7577)",
+      "body": ""
+    },
+    {
+      "commit": "86de2e306b91eb9a6de7aa5a38e3359789f27bf4",
+      "subject": "util: fix `pending_only_on_first_poll_with_cancellation_token_owned_test` to use an owned cancellation token (#7613)",
+      "body": "The name of the test suggests that it should test the\nwith_cancellation_token_owned() extension method"
+    },
+    {
+      "commit": "6dc4f85f0bf1d5c22c15187a2b8cb78784ab4bda",
+      "subject": "net: clarify the behavior of `UCred::pid()` on Cygwin (#7611)",
+      "body": ""
+    },
+    {
+      "commit": "637fc1d103882dd04ce434d1fed4a0026fc7b6c2",
+      "subject": "tokio: fix minor errors in `tokio/CHANGELOG.md` (#7608)",
+      "body": ""
+    },
+    {
+      "commit": "7a0ca807be828606b14cff2c9a3d150ff9d999ce",
+      "subject": "time: add `#[track_caller]` to `FutureExt::timeout` (#7588)",
+      "body": "Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>"
+    },
+    {
+      "commit": "d8e8037de50d12162626d35498d1348538bbf38a",
+      "subject": "net: fix copy/paste errors in udp peek methods (#7604)",
+      "body": ""
+    },
+    {
+      "commit": "de978c47e04783c739222da1956ab1b8b340e255",
+      "subject": "task: remove duplicated code in `JoinMap::remove_by_id` (#7603)",
+      "body": ""
+    },
+    {
+      "commit": "024bd6093351b31f718790a43b4c9c99d2a80f7a",
+      "subject": "task: improve the example of `poll_proceed` (#7586)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "7127e257a7d7025a5f6a62eb8aab81c2191f5cdb",
+      "subject": "io: export `Chain` of `AsyncReadExt::chain` (#7599)",
+      "body": ""
+    },
+    {
+      "commit": "94b6df699b566bcbff909e24f08b17416f8e1e52",
+      "subject": "fs: fill the destination buffer with 0s for MockFile::read() (#7596)",
+      "body": ""
+    },
+    {
+      "commit": "510b9ea9dc153a163863cbbe3418f5287269b85c",
+      "subject": "macros: Update the version used for Git tag sample for release steps (#7598)",
+      "body": "Change 1.x.y to x.y.z so that it does not become obsolete again when\ntokio-macros 3.x is released"
+    },
+    {
+      "commit": "0fc23971d9dd1a1859a905b3fc9ed77fef412141",
+      "subject": "macros: add missing `local` flavor to `tokio::main` error message (#7597)",
+      "body": ""
+    },
+    {
+      "commit": "f07233f742c02cd84c48b9c6010ed7f4671e0a3a",
+      "subject": "test: add tests for time in wasm32-unknown-unknown (#7510)",
+      "body": ""
+    },
+    {
+      "commit": "8efd04e38284f2da2d1b3abc8496a511e131d1ce",
+      "subject": "sync: reword allocation failure paragraph in broadcast docs (#7595)",
+      "body": ""
+    },
+    {
+      "commit": "044eaa1a41a5a37fca7bf4902527b910c14f9ca9",
+      "subject": "fs: preserve `max_buf_size` when cloning a `File` (#7593)",
+      "body": ""
+    },
+    {
+      "commit": "03bb6e29b173ca15750e57823c9119bce9704fef",
+      "subject": "fs: add `File::max_buf_size` (#7594)",
+      "body": ""
+    },
+    {
+      "commit": "ac4c95972e0a32eb9ff612ab8588afd9c398c928",
+      "subject": "sync: fix implementation of unused `RwLock::try_*` methods (#7587)",
+      "body": "bd4ccae184b0359cb88f9ebc2ba157867e1eee0e introduced a wrapper for the\nRwLock to get rid of poisoning aspects.\n\nBy mistake (?!) its try_read/write methods actually delegate to\nread/write() and this would lead to blocking\n\nSigned-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>"
+    },
+    {
+      "commit": "14e739c306ad6501b525b6809f66291eec923fd5",
+      "subject": "readme: fix the version used as an example how to use the latest minor of LTS (#7592)",
+      "body": ""
+    },
+    {
+      "commit": "9f59c6952e0f16b5775b1b0b736b9816c0772987",
+      "subject": "ci: remove the job `test-pass` (#7575)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "86400a1920c4caef28ae5178af0fcf1a34822b92",
+      "subject": "io: fix typos in the docs of `AsyncFd` readiness guards (#7583)",
+      "body": "Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>"
+    },
+    {
+      "commit": "c9b4e4c1101ba7c8fbcec0ffe5516d928d30d669",
+      "subject": "examples: fix the write length in the `connect-tcp` example (#7581)",
+      "body": "Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>"
+    },
+    {
+      "commit": "3eb515e1a706dd37f60516bd0f040434644de7a9",
+      "subject": "examples: update outdated example name `connect` to `connect-tcp` (#7582)",
+      "body": "Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>"
+    },
+    {
+      "commit": "1ed2a1436f859e5622d1b2f2e7b3a21aeb1e55d9",
+      "subject": "process: fix unit test for trailing LF in `uname -r` (#7579)",
+      "body": "Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>"
+    },
+    {
+      "commit": "c6aceed64397e275d300e1233a3304ace02a7765",
+      "subject": "io: clarify the zero capacity case of `AsyncRead::poll_read` (#7580)",
+      "body": "Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>"
+    },
+    {
+      "commit": "4590828fb4ea28ab99eb79ab7c1bc717949203ac",
+      "subject": "stream: improve the the docs of `TcpListenerStream` (#7578)",
+      "body": "Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>"
+    },
+    {
+      "commit": "a99a3518020e1c7ea6db6f9d2e7e567637a3d7e7",
+      "subject": "sync: use `UnsafeCell::get_mut` in `Mutex::get_mut` and `RwLock::get_mut` (#7569)",
+      "body": ""
+    },
+    {
+      "commit": "d1e06f831e23e9442ea313fbe8d4d7e9399e492f",
+      "subject": "net: implement `AsRef<Self>` for `TcpStream` and `UnixStream` (#7573)",
+      "body": ""
+    },
+    {
+      "commit": "37ca2f049c552fde50a2535de6dfc61ee6e96eed",
+      "subject": "sync: remove inner mutex in `SetOnce` (#7554)",
+      "body": ""
+    },
+    {
+      "commit": "c8371d45bc0529f88dd168e83c1e8b14f9b9def6",
+      "subject": "codec: add `{FramedRead,FramedWrite}::into_parts()` (#7566)",
+      "body": ""
+    },
+    {
+      "commit": "adc3e19ba7467a192ae9ef2379549bac03e2ca1c",
+      "subject": "time: clarify the cancellation safety of the `DelayQueue` (#7564)",
+      "body": ""
+    },
+    {
+      "commit": "925c614c89d0a26777a334612e2ed6ad0e7935c3",
+      "subject": "time: reduce the generated code size of `Timeout<T>::poll` (#7535)",
+      "body": ""
+    },
+    {
+      "commit": "dd74c7c1bfd69ee997c57aade1db2326b85855df",
+      "subject": "task: implement `Ord` for `task::Id` (#7530)",
+      "body": ""
+    },
+    {
+      "commit": "23263231fdd1c52aa6498947f783b928a7f04663",
+      "subject": "net: qualify that `SO_REUSEADDR` is only set on Unix (#7533)",
+      "body": ""
+    },
+    {
+      "commit": "86528741f960b2425fe7168080744ff3f16cf195",
+      "subject": "ci: update GitHub actions/checkout to v5 (#7529)",
+      "body": ""
+    },
+    {
+      "commit": "131afd3c53afef88844bf803ff99f4a76c6c824e",
+      "subject": "net: clarify socket gets closed on drop (#7526)",
+      "body": ""
+    },
+    {
+      "commit": "9ed6f70b812d5b9d98051f7b2b617b83e1d7823e",
+      "subject": "ci: remove a typo from `spellcheck.dic` (#7524)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "46f7d87962c0c1273bc66aca99d3f3c08da93265",
+      "subject": "runtime: fix a typo in comment of `MAX_LIFO_POLLS_PER_TICK` (#7520)",
+      "body": ""
+    },
+    {
+      "commit": "987675e84353d32f6c11f6fe738f247669717a3b",
+      "subject": "ci: pin the rust version for wasm tests (#7518)",
+      "body": ""
+    },
+    {
+      "commit": "11d7c0486a9b5944452bf2d12790ae551fb395a2",
+      "subject": "task: inline the docs of `TaskTracker` while re-exporting it (#7516)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "3e84a198e4d6283f015965cd627ee5aaff69e022",
+      "subject": "fs: add io_uring `open` operation (#7321)",
+      "body": ""
+    },
+    {
+      "commit": "7497561fedbfb834b28070bd922fe4f72268730f",
+      "subject": "net: render the `cygwin` in the docs of `quickack` and `set_quickack` (#7515)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "ef5b6af7f6b641db7a1ed1f09534bc75943bf835",
+      "subject": "future: clarify the fairness of `FutureExt` for cancellation adapters (#7512)",
+      "body": "This fixes the docstrings on `FutureExt` so that the bias and fairness\nnotes are correct and consistent in all cases.\nAll cancellation-related wrappers are biased towards the completion of\nthe inner future, but they do initially check if the token is\nalready cancelled at construction time."
+    },
+    {
+      "commit": "0922aa2a0b09cf35582f15c799996c64e0b6e50a",
+      "subject": "ci: fix clippy warnings triggered under specific cfg (#7495)",
+      "body": ""
+    },
+    {
+      "commit": "2403b91d7531ee63886e28e3072d2664e2e81772",
+      "subject": "process: upgrade `Command::spawn_with` to use `FnOnce` (#7511)",
+      "body": ""
+    },
+    {
+      "commit": "f1d3b065b6c41925f9ac859156eb89043812ae35",
+      "subject": "task: fix flaky joinmap test during abort (#7509)",
+      "body": ""
+    },
+    {
+      "commit": "cf6b50a3fd44684d63fd758aae1ee2955f16c798",
+      "subject": "chore: prepare tokio-util v0.7.16 (#7507)",
+      "body": ""
+    },
+    {
+      "commit": "416e36b0dff3214a9fd9dee26f9e554d7d162b46",
+      "subject": "task: stabilise `JoinMap` (#7075)",
+      "body": ""
+    },
+    {
+      "commit": "9741c90f9f8b14a7d78d7629a29a281602d5f2b9",
+      "subject": "sync: document cancel safety on `SetOnce::wait` (#7506)",
+      "body": ""
+    },
+    {
+      "commit": "4e3f17bce3addf0bbf626e4847bab73e28328181",
+      "subject": "codec: also apply capacity to read buffer in `Framed::with_capacity` (#7500)",
+      "body": ""
+    },
+    {
+      "commit": "f020b5c4b50281a3824dfcd08a625a46b6150a2b",
+      "subject": "ci: fix incorrect tokio version in Cargo.lock",
+      "body": ""
+    },
+    {
+      "commit": "86cbf81e151772fad0f2fc8afa0fa7094d00b81d",
+      "subject": "Merge 'tokio-1.47.1' into 'master'",
+      "body": ""
+    },
+    {
+      "commit": "be8ee45b3fc2d107174e586141b1cb12c93e2ddf",
+      "subject": "chore: prepare Tokio v1.47.1 (#7504)",
+      "body": ""
+    },
+    {
+      "commit": "d9b19166cde30b8d4a65f31a94b5ee09d2dd7b8c",
+      "subject": "Merge 'tokio-1.43.2' into 'tokio-1.47.x' (#7503)",
+      "body": ""
+    },
+    {
+      "commit": "db8edc620fb369f6cc92dd9dcfdd03b832c2b02f",
+      "subject": "chore: prepare Tokio v1.43.2 (#7502)",
+      "body": ""
+    },
+    {
+      "commit": "e47565b086436a9024812d5cc0ba5672ab515e47",
+      "subject": "blocking: clarify that spawn_blocking is aborted if not yet started (#7501)",
+      "body": ""
+    },
+    {
+      "commit": "4730984d66e708b36efe84245cbf15bd483a886f",
+      "subject": "readme: add 1.47 as LTS release (#7497)",
+      "body": "(cherry picked from commit ad2e19ffe193b7bce76eab9a51037089da4bc6dc)"
+    },
+    {
+      "commit": "1979615cbf1cc4b4d296814957394703827362d0",
+      "subject": "process: fix panic from spurious pidfd wakeup (#7494)",
+      "body": ""
+    },
+    {
+      "commit": "1bc50825f3901daff595b2c45ff04c48f0267198",
+      "subject": "codec: add `FramedWrite::with_capacity` (#7493)",
+      "body": ""
+    },
+    {
+      "commit": "f669a609cf1eaa94d2bc135212f57ff913eca898",
+      "subject": "ci: add lockfile for LTS branch",
+      "body": "This is to fix CI failures from backtrace in rustdoc jobs."
+    },
+    {
+      "commit": "ad2e19ffe193b7bce76eab9a51037089da4bc6dc",
+      "subject": "readme: add 1.47 as LTS release (#7497)",
+      "body": ""
+    },
+    {
+      "commit": "5f04d14d8136254f602590ef3a984c8eca8dae3c",
+      "subject": "net: add `TcpStream::quickack` and `TcpStream::set_quickack` (#7490)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "01ea8f22eaf670ad0cfa5a1facd554ab364bfdcd",
+      "subject": "ci: add kernel-version-test workflow for io_uring tests (#7486)",
+      "body": ""
+    },
+    {
+      "commit": "9f423053fb9a9d68a2790fe1a88745f093f11c4c",
+      "subject": "sync: umplement `Stream::size_hint` for `ReceiverStream` and `UnboundedReceiverStream` (#7492)",
+      "body": ""
+    },
+    {
+      "commit": "0e5c5d64f5aa4387e7d0fb3c1a69561b170fbfcf",
+      "subject": "future: add adapters of `CancellationToken` for `FutureExt` (#7475)",
+      "body": ""
+    },
+    {
+      "commit": "1b27e17ff80af0de2e6a90129567d8d9fc7234ae",
+      "subject": "net: add `SocketAddr::as_abstract_name` (#7491)",
+      "body": ""
+    },
+    {
+      "commit": "8fc62c06c78183a2be97a476b54ae61bfa30fae4",
+      "subject": "metrics: reorder metrics to be grouped by cfg-gates (#7453)",
+      "body": ""
+    },
+    {
+      "commit": "4b96af6040b0136d3fd147b28e3775961f6a3d0a",
+      "subject": "macros: add \"local\" runtime flavor (#7375)",
+      "body": ""
+    },
+    {
+      "commit": "ce41896f8dcbc6249df3279600f45f7a65915cf6",
+      "subject": "sync: fix broken link of Python `asyncio.Event` in `SetOnce` docs (#7485)",
+      "body": ""
+    },
+    {
+      "commit": "c8ab78a84fff284958dc84b77b5222fecd0f44b2",
+      "subject": "changelog: fix incorrect PR number for 1.47.0 (#7484)",
+      "body": ""
+    },
+    {
+      "commit": "3911cb8523f190142f61c64b66881c07c0d3e7be",
+      "subject": "chore: prepare Tokio v1.47.0 (#7482)",
+      "body": ""
+    },
+    {
+      "commit": "d545aa2601e3008ce49c8c0191b0f172ce577452",
+      "subject": "sync: add `sync::Notify::notified_owned()` (#7465)",
+      "body": ""
+    },
+    {
+      "commit": "911ab21d7012a50e53971ad1292a9f18de22d4c8",
+      "subject": "sync: add `SetOnce` (#7418)",
+      "body": ""
+    },
+    {
+      "commit": "9e94fa7e15cfe6ebbd06e9ebad4642896620d924",
+      "subject": "task: remove raw-entry feature from hashbrown dep (#7252)",
+      "body": ""
+    },
+    {
+      "commit": "0d234c3cf9231288bd7ea3d8f2df65fa24b87a80",
+      "subject": "ci: unfreeze wasm-unknown-unknown from rustc 1.81 (#7471)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>\nCo-authored-by: Taiki Endo <te316e89@gmail.com>"
+    },
+    {
+      "commit": "3754e059b61553dd51064b433fb61465c4b93afe",
+      "subject": "ci: use ubuntu-24.04-arm instead of ubuntu-22.04-arm (#7470)",
+      "body": ""
+    },
+    {
+      "commit": "6d868d96ce9df27c5ec1be3bba960ebe80ee4793",
+      "subject": "sync: fix `CancellationToken` failing to cancel the ready futures (#7462)",
+      "body": "This patch fixes an issue where the `CancellationToken::run_until_cancelled` never cancels the `Future` that returns `Ready` at the first `poll`."
+    },
+    {
+      "commit": "Co-authored-by: Luca BRUNO <lucab@lucabruno.net>",
+      "subject": "",
+      "body": ""
+    },
+    {
+      "commit": "0a3fe460862720d005b8fa39cdde30575a063785",
+      "subject": "sync: remove duplicated code in `OnceCell` tests (#7458)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "154d7d5fe663302c96e25d2b6064813996264a91",
+      "subject": "ci: cleanup legacy `R-loom-multi-thread-alt` label from the labeler (#7457)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "611b7933561670c8349ddd5c100fdc76c474e3db",
+      "subject": "coop: add `cooperative` and `poll_proceed` (#7405)",
+      "body": ""
+    },
+    {
+      "commit": "888ee60e41a5afb6eeede62f80b29551f7b87bbc",
+      "subject": "metrics: properly annotate required features for 64-bit-only metrics (#7449)",
+      "body": ""
+    },
+    {
+      "commit": "7dd4d8a30e41611994f55e7f5c9cf124a1c74e2a",
+      "subject": "runtime: cleanup legacy tests of alt multi-threaded runtime (#7451)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>"
+    },
+    {
+      "commit": "085e616c873a3b64708188f1ecc393ab367cb7fe",
+      "subject": "sync: use `swap` in `AtomicWaker::wake` (#7450)",
+      "body": ""
+    },
+    {
+      "commit": "a7896d07f1d3093524c7a190b57570dad3767c7a",
+      "subject": "chore: update CI to clippy 1.88 (#7452)",
+      "body": ""
+    },
+    {
+      "commit": "aff24dfbebf79c698abf16db24930d478c099252",
+      "subject": "deps: upgrade `windows-sys` from 0.52 to 0.59 (#7117)",
+      "body": ""
+    },
+    {
+      "commit": "71cc9ab4c27db1ec2412d7f0bc86bcae7ebf1d74",
+      "subject": "deps: update to socket2 v0.6 (#7443)",
+      "body": ""
+    },
+    {
+      "commit": "02cbe4591b71bcfb7e775a9a09685885ce4f860e",
+      "subject": "runtime: improve safety comments of `Readiness<'_>` (#7415)",
+      "body": "Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>\nCo-authored-by: Eliza Weisman <eliza@buoyant.io>\nCo-authored-by: Alice Ryhl <aliceryhl@google.com>"
+    },
+    {
+      "commit": "0783797520cd04241901615e586bd0aa806aaad5",
+      "subject": "runtime: fix handling of cancelled io_uring Ops (#7436)",
+      "body": ""
+    },
+    {
+      "commit": "ab3ff69cf2258a8c696b2dca89a2cef4ff114c1c",
+      "subject": "chore: prepare to release v1.46.1 (#7444)",
+      "body": "# 1.46.1 (July 4th, 2025)\n\nThis release fixes incorrect spawn locations in runtime task hooks for tasks\nspawned using `tokio::spawn` rather than `Runtime::spawn`. This issue only\neffected the spawn location in `TaskMeta::spawned_at`, and did not effect task\nlocations in Tracing events.\n\n## Unstable\n\n- runtime: add `TaskMeta::spawn_location` tracking where a task was spawned\n  ([#7440)])\n\n[#7440]: https://github.com/tokio-rs/tokio/pull/7440"
+    },
+    {
+      "commit": "a0d5b8ab308bbeaa8090d411550d6c887d699096",
+      "subject": "runtime(unstable): fix task hook spawn locations for `tokio::spawn` (#7440)",
+      "body": "## Motivation\n\nUnfortunately, due to an oversight on my part, the capturing of spawn\nlocations was only tested with the `Runtime::spawn` method, and *not*\nwith `tokio::spawn`/`tokio::task::spawn`, which is how most tasks are\nspawned in Real Life. And, it turned out that because this was not\ntested...well, it was broken. Agh. My bad.\n\n## Solution\n\nAlthough the whole call chain for spawning tasks using `tokio::spawn`\nwas correctly annotated with `#[track_caller]`, the location wasn't\npropagated correctly because of the `context::with_current(|handle| {\n... })` closure that accesses the current runtime. Because the call to\nspawn the task occurs inside a closure, the *closure*'s location is\ncaptured instead of the caller. This means any task spawned by\n`tokio::spawn` records its location as being in\n`tokio/src/task/spawn.rs`, which is not what we'd like. This commit\nfixes that by capturing the spawn location outside the `with_current`\nclosure and passing it in explicitly.\n\nI've updated the tests to also spawn a task with `tokio::spawn`, so that\nwe ensure this works correctly."
+    },
+    {
+      "commit": "a1ee3ef218894f2441b5719812ab218ae0539c8d",
+      "subject": "chore: fix some minor typos in the comments (#7442)",
+      "body": "Signed-off-by: shangchenglumetro <shuang.cui@live.com>"
+    },
+    {
+      "commit": "171cd148a37da40dcbb8b06bf2c67634b2ba1f87",
+      "subject": "changelog: fix typo in `pipe::OpenOptions` for 1.46.0 (#7439)",
+      "body": ""
+    },
+    {
+      "commit": "3f1f268583a16c11560f8e310d5a35e9aa55b547",
+      "subject": "chore: prepare Tokio v1.46.0 (#7437)",
+      "body": ""
+    },
+    {
+      "commit": "3e890cc0171ddb210acdcfec831b7c7bcbb0d2d9",
+      "subject": "rt(unstable): add spawn `Location` to `TaskMeta` (#7417)",
+      "body": "As described in issue #7411, task spawning APIs are currently annotated\nwith `#[track_caller]`, allowing us to capture the location in the user\nsource code where the task was spawned. This is used for `tracing`\nevents used by `tokio-console` and friends. However, this information is\n*not* exposed to the runtime `on_task_spawn`, `on_before_task_poll`,\n`on_after_task_poll`, and `on_task_terminate` hooks, which is a shame,\nas it would be useful there as well.\n\nThis branch adds the task's spawn location to the `TaskMeta` struct\nprovided to the runtime's task hooks. This is implemented by storing a\n`&'static Location<'static>` in the task's `Core` alongside the\n`task::Id`. In [this comment][1], @ADD-SP suggested storing the\n`Location` in the task's `Trailer`.\n\nI opted to store it in the `Core` instead, as the `Trailer` is intended\nto store \"cold\" data that is only accessed when the task _completes_,\nand not on every poll. Since the task meta is passed to the\n`on_before_task_poll` and `on_after_task_poll` hooks, we would be\naccessing the `Trailer` on polls if we stored the `Location` there.\nTherefore, I put it in the `Core`, instead, which contains data that we\naccess every time the task is polled.\n\nCloses #7411\n\n[1]: https://github.com/tokio-rs/tokio/issues/7411#issuecomment-2993377045"
+    },
+    {
+      "commit": "69290a64327a017fd9a0cedefaac60c4993c3b54",
+      "subject": "net: derive `Clone` for `net::unix::SocketAddr` (#7422)",
+      "body": ""
+    },
+    {
+      "commit": "e2b175848b2cb25e99cd3a0486e506f889379db5",
+      "subject": "fuzz: cfg fuzz tests under cfg(test) (#7428)",
+      "body": ""
+    },
+    {
+      "commit": "b7a75b5be349aab2cee9b224c0610d7cf4fea73e",
+      "subject": "net: update `AsRawFd` doc link to current Rust stdlib location (#7429)",
+      "body": ""
+    },
+    {
+      "commit": "6b705b3053d2c777e05cb60c758202ff9d4b2e7d",
+      "subject": "net: allow `pipe::OpenOptions::read_write` on Android (#7426)",
+      "body": ""
+    },
+    {
+      "commit": "3636fd018ab6416fdfa3aab21e1e55966062dc3c",
+      "subject": "net: fix broken link of `RawFd` in `TcpSocket` docs (#7416)",
+      "body": ""
+    },
+    {
+      "commit": "2506c9fa9916a1bdffbc762f7eb2ae5c2fd23836",
+      "subject": "benches: revert \"properly gate unix benches\" (#7412)",
+      "body": "This reverts commit 933fa498d0bda193960784cb3f6a47be3bc1e492."
+    },
+    {
+      "commit": "b3a14483bf5efa1b5cf75af27f6ef0770f4c5689",
+      "subject": "sync: improve docs of `tokio_util::sync::CancellationToken` (#7408)",
+      "body": "Co-authored-by: Alice Ryhl <aliceryhl@google.com>"
+    },
+    {
+      "commit": "013f323def73f85185e2633f1b5f8939cc841318",
+      "subject": "docs: add a missing panic scenario of `time::advance` (#7394)",
+      "body": ""
+    },
+    {
+      "commit": "b92670006566302b7eb17b1a2f7cb8d868a9ab25",
+      "subject": "sync: add `DropGuardRef` for `CancellationToken` (#7407)",
+      "body": ""
+    },
+    {
+      "commit": "99a03a502eb69309024406b07c85cabb965f53d4",
+      "subject": "runtime: add `thread_park_ok` test (#7402)",
+      "body": ""
+    },
+    {
+      "commit": "933fa498d0bda193960784cb3f6a47be3bc1e492",
+      "subject": "benches: properly gate unix benches (#7392)",
+      "body": ""
+    },
+    {
+      "commit": "9f848c9f544a87f52ca406bad895a2b0ffa10e4b",
+      "subject": "rt: add check for io_uring availability at runtime (#7357)",
+      "body": ""
+    },
+    {
+      "commit": "912b862a0526511e6d88cd85c81317f7406107c1",
+      "subject": "task: add `AbortOnDropHandle::detach` (#7400)",
+      "body": ""
+    },
+    {
+      "commit": "714e5b571f2f6b329dfd830b9d3986fac7e7a0c8",
+      "subject": "runtime: move ` impl Schedule for Arc<Handle>` (#7398)",
+      "body": ""
+    },
+    {
+      "commit": "8e999e380643160f0e944fd5708de2bd3d1b0d51",
+      "subject": "macros: add biased mode to join! and try_join! (#7307)",
+      "body": ""
+    },
+    {
+      "commit": "1d980145cb51c3a352fe6947b7758f8d9125117d",
+      "subject": "io: document cancellation safety of `AsyncWriteExt::flush` (#7364)",
+      "body": ""
+    },
+    {
+      "commit": "8259133ca018d136ebbfc7b9032eb6ca4b7a3e73",
+      "subject": "task: disallow blocking in `LocalSet::{poll,drop}` (#7372)",
+      "body": ""
+    },
+    {
+      "commit": "38d88c679938f9ae92649f5780217c04f1659f45",
+      "subject": "net: add cygwin support (#7393)",
+      "body": ""
+    },
+    {
+      "commit": "c38de96b9478c29a08805a4be7e351fdca8bb43a",
+      "subject": "sync: add `same_channel` analogue to `OwnedPermit` (#7389)",
+      "body": ""
+    },
+    {
+      "commit": "2440d113ff9841060b1876628c1153f0bcf2945c",
+      "subject": "ci: enable tests using fcntl in miri (#7382)",
+      "body": ""
+    },
+    {
+      "commit": "ab8d7b82a1252b41dc072f641befb6d2afcb3373",
+      "subject": "readme: fix double period in reactor description (#7363)",
+      "body": ""
+    },
+    {
+      "commit": "9563707aaa73a802fa4d3c51c12869a037641070",
+      "subject": "time: cumulative minor improvements (#7358)",
+      "body": ""
+    },
+    {
+      "commit": "193c1574a119605e4d9081d481a6bb03e7bf26cc",
+      "subject": "examples: update rand crate to 0.9.1 (#7371)",
+      "body": ""
+    },
+    {
+      "commit": "328bd049f6a9c2819ee6bcb6752dd57a3a456aee",
+      "subject": "io: clarify behavior of seeking when `start_seek` is not used (#7366)",
+      "body": ""
+    },
+    {
+      "commit": "4380de9fe9e0938790a2c06f4bdaa8bd91c08ed1",
+      "subject": "chore: replace manual vtable definitions with `Wake` (#7342)",
+      "body": ""
+    },
+    {
+      "commit": "98f527f42d8b95dc643e053cf60d4084f4fed69d",
+      "subject": "Merge tag 'tokio-1.45.1'",
+      "body": ""
+    },
+    {
+      "commit": "3768696d92d403d98b7d559934617890f882ec02",
+      "subject": "chore: prepare Tokio v1.45.1 (#7359)",
+      "body": ""
+    },
+    {
+      "commit": "d7d4f7d08bf75daf23bec676b03cb4c88993e5d0",
+      "subject": "sync: update broadcast docs on allocation failure (#7352)",
+      "body": ""
+    },
+    {
+      "commit": "421a7b001c762a25c0b009c9ffb86f0661608f90",
+      "subject": "rt: do not track time-based metrics on wasm32-unknown-unknown (#7322)",
+      "body": ""
+    },
+    {
+      "commit": "b1bdb3c57b9adfa928644ece1da97860c558efbb",
+      "subject": "ci: update macros_type_mismatch for Rust 1.87.0 (#7339)",
+      "body": "(cherry picked from commit a48e418dcbbe7eccc7ea0f0071ca60aca21a61b7)"
+    },
+    {
+      "commit": "7ec77a067739ea2203c506fbfe6bc4aca1139ea7",
+      "subject": "time: eliminate `UnsafeCell` around the `TimerShared` (#7329)",
+      "body": ""
+    },
+    {
+      "commit": "55e3ed2a3976020d8513d5276d2afbaf2ea53c4d",
+      "subject": "runtime: eliminate unnecessary lfence while operating on `queue::Local<T>` (#7340)",
+      "body": ""
+    },
+    {
+      "commit": "17d8c2b29d94550f504d8fd76d8d8aaf66095864",
+      "subject": "runtime: various minor `LocalRuntime` improvements (#7346)",
+      "body": ""
+    },
+    {
+      "commit": "327bec2caf92af5e2732f8fdfe2e4a20d349f67e",
+      "subject": "rt: add infrastructure code for io_uring (#7320)",
+      "body": ""
+    },
+    {
+      "commit": "ea30a5ea5eee1b3970052f19e8a8b16d0a5c29f4",
+      "subject": "time: rename `cached_when` to `registered_when` (#7333)",
+      "body": ""
+    },
+    {
+      "commit": "0cf95f067347bca820099dcec1e457bbe993390b",
+      "subject": "net: fix docs for `recv_buffer_size` method (#7336)",
+      "body": ""
+    },
+    {
+      "commit": "a48e418dcbbe7eccc7ea0f0071ca60aca21a61b7",
+      "subject": "ci: update macros_type_mismatch for Rust 1.87.0 (#7339)",
+      "body": ""
+    },
+    {
+      "commit": "4cbcb687f429f2a4cee948b0462e23f86ef95822",
+      "subject": "time: address style issues (#7328)",
+      "body": ""
+    },
+    {
+      "commit": "0715e6defc4ed358f47654dadaffb3643401ffd8",
+      "subject": "time: remove outdated explicitly `drop` call of `Mutex` (#7326)",
+      "body": "This drop was firstly introduced by [#3289],\nand the next line invokes `panic!`.\n\nIn [#5434], the original `panic!` was replaced\nwith `return Err`, so dropping it explicitly\nis no longer necessary.\n\n[#3289]: https://github.com/tokio-rs/tokio/pull/3289\n[#5434]: https://github.com/tokio-rs/tokio/pull/5434"
+    },
+    {
+      "commit": "bdd64cc9d3561115d125584484404e9d1f7d7cca",
+      "subject": "runtime: add doc note that `on_*_task_poll` is unstable (#7311)",
+      "body": ""
+    },
+    {
+      "commit": "f0fdef80c46787bbc4351516d9439f66dfec403c",
+      "subject": "net: ignore `NotConnected` in `TcpStream::shutdown` (#7290)",
+      "body": ""
+    },
+    {
+      "commit": "00754c8f9c8cd0c10fd54e5304cb9cb95a759d53",
+      "subject": "chore: prepare Tokio v1.45.0 (#7308)",
+      "body": ""
+    },
+    {
+      "commit": "1ae9434e8e4a419ce25644e6c8d2b2e2e8c34750",
+      "subject": "time: revert \"use sharding for timer implementation\" related changes (#7226)",
+      "body": "The work on sharding the timer implementation has caused a measurable performance regression due to increased contention. This patch reverts the current work on sharding. The next step will be to work on a per-worker timer wheel."
+    },
+    {
+      "commit": "8895bba448534a4eb159f18e57fd845c740e1d38",
+      "subject": "ci: Test AArch64 Windows (#7288)",
+      "body": ""
+    },
+    {
+      "commit": "48ca254d92d4408accd7b1c1beab188288fadb00",
+      "subject": "time: update `sleep` documentation to reflect maximum allowed duration (#7302)",
+      "body": ""
+    },
+    {
+      "commit": "a0af02a396274b30ec1d0a27e18ac9ae6eaa2186",
+      "subject": "compat: add more documentation to `tokio_util::compat` (#7279)",
+      "body": ""
+    },
+    {
+      "commit": "0ce3a1188a56c4c133d5b789eb366c0752e9b22c",
+      "subject": "metrics: stabilize `worker_park_count` and `worker_unpark_count` (#7276)",
+      "body": ""
+    },
+    {
+      "commit": "1ea9ce11d4317d767136d489041548408348be77",
+      "subject": "ci: fix cfg!(miri) declarations in tests (#7286)",
+      "body": ""
+    },
+    {
+      "commit": "4d4d12613bb30f6b550421d6ce2c2c54eb5d341d",
+      "subject": "chore: prepare tokio-util v0.7.15 (#7283)",
+      "body": ""
+    },
+    {
+      "commit": "5490267a79a894c22cc014367e0fcd43f4ad2bb6",
+      "subject": "fs: update the mockall dev dependency to 0.13.0 (#7234)",
+      "body": ""
+    },
+    {
+      "commit": "1434b32b5a0df3b38a0d588485cd9a20a8e92a89",
+      "subject": "examples: improve echo example consistency (#7256)",
+      "body": ""
+    },
+    {
+      "commit": "159a3b2c8587cd12ad54eb16489dad6eb674d4ca",
+      "subject": "rt(unstable): remove alt multi-threaded runtime (#7275)",
+      "body": "The alternative multi-threaded runtime started as an experiment. We have been\nunable to find real-world benefit. Work has halted on this effort, so lets get\nrid of it."
+    },
+    {
+      "commit": "ce87dcfbf08dc5330386433c1e62229a3c4d5571",
+      "subject": "runtime: document the queue behavior of `spawn_blocking` (#7269)",
+      "body": ""
+    },
+    {
+      "commit": "d41d49d202708a6846e5de023962a8ee17358ba6",
+      "subject": "metrics: fix panic comment in `max_error` docs (#7273)",
+      "body": ""
+    },
+    {
+      "commit": "7a6c424f6e07d79e7c029866ed601bb948aba10a",
+      "subject": "process: add `Command::spawn_with` (#7249)",
+      "body": "Signed-off-by: Paul Mabileau <paulmabileau@hotmail.fr>"
+    },
+    {
+      "commit": "c3037adac90fbbf92a160b970f38e50b66936b4c",
+      "subject": "task: properly handle removed entries in `JoinMap` (#7264)",
+      "body": ""
+    },
+    {
+      "commit": "964fd06e0f215b26c4d969bc09e11299a29d6e11",
+      "subject": "benches: add helper functions for building runtimes (#7260)",
+      "body": ""
+    },
+    {
+      "commit": "817fa605ee6a2549fe8e6057ec23a8309d42d2e9",
+      "subject": "fs: avoid some copies in `tokio::fs::write` (#7199)",
+      "body": ""
+    },
+    {
+      "commit": "77de684ed94a2ac15504c0033f4c8fe39693f3b9",
+      "subject": "runtime: mark `runtime::Handle` unwind-safe (#7230)",
+      "body": ""
+    },
+    {
+      "commit": "83d550e51127cf3130b5c40525de1e7b6916bbe0",
+      "subject": "changelog: fix release date of v1.44.2 (#7248)",
+      "body": ""
+    },
+    {
+      "commit": "1b3d3e7cd67d0f99472591070590d031baaca029",
+      "subject": "Merge 'tokio-1.43.1-fix-release-date' into 'master' (#7247)",
+      "body": ""
+    },
+    {
+      "commit": "9e044e144baa7d99a7210b0afe3a20b3e00a8f85",
+      "subject": "changelog: fix release date of v1.43.1 (#7246)",
+      "body": ""
+    },
+    {
+      "commit": "cb08fbc6c36208962964fe5adf4509e02b9c92bd",
+      "subject": "Merge 'tokio-1.42.1' into 'tokio-1.43.x' (#7245)",
+      "body": ""
+    },
+    {
+      "commit": "e59584a661490dc4fdfd71c34e1a05c004bcee5b",
+      "subject": "changelog: fix release date of v1.42.1 (#7244)",
+      "body": ""
+    },
+    {
+      "commit": "f7fb0bdc7a4b8db7b44aa34bf869cc76e61ef246",
+      "subject": "chore: prepare Tokio v1.42.1",
+      "body": ""
+    },
+    {
+      "commit": "9faea740df38c3691eb558b4a9387e2195960a85",
+      "subject": "Merge 'tokio-1.38.x' into 'tokio.1.42.x'",
+      "body": ""
+    },
+    {
+      "commit": "2a8c551631a55be6759e630c1adbc2efc4469f06",
+      "subject": "tokio: update mio-aio dev dependency to 1.0 (#7235)",
+      "body": "This eliminates a duplicate dependency on mio"
+    },
+    {
+      "commit": "676630785bca7bb527882be576e3470dbdbe045e",
+      "subject": "Merge branch 'tokio-1.44.x' into forward-port-1.44.x",
+      "body": ""
+    },
+    {
+      "commit": "ec4b1d7215a3e1e91797ad3fb6ba0f7c7f3d2566",
+      "subject": "chore: forward port 1.43.x",
+      "body": ""
+    },
+    {
+      "commit": "e3c3a56718d201fb7bb430567f05fbb64b2ef082",
+      "subject": "Merge branch 'tokio-1.43.x' into forward-port-1.43.x",
+      "body": ""
+    },
+    {
+      "commit": "a7b658c35bd40f6811e557aeb97cbb361b612c56",
+      "subject": "chore: prepare Tokio v1.43.1 release",
+      "body": ""
+    },
+    {
+      "commit": "c1c8d1033d637d7027fdc137ec8008c5801cbc0d",
+      "subject": "Merge remote-tracking branch 'origin/tokio-1.38.x' into forward-port-1.38.x",
+      "body": ""
+    },
+    {
+      "commit": "aa303bc2051f7c21b48bb7bfcafe8fd4f39afd21",
+      "subject": "chore: prepare Tokio v1.38.2 release",
+      "body": ""
+    },
+    {
+      "commit": "7b6ccb515ff067151ed62db835f735e5653f8784",
+      "subject": "chore: backport CI fixes",
+      "body": ""
+    },
+    {
+      "commit": "4b174ce2c95fe1d1a217917db93fcc935e17e0da",
+      "subject": "sync: fix cloning value when receiving from broadcast channel",
+      "body": "The broadcast channel does not require values to implement `Sync` yet it calls\nthe `.clone()` method without synchronizing. This is unsound logic. This patch\nadds per-value synchronization on receive to handle this case. It is unlikely\nany usage of the broadcast channel is currently at risk of the unsoundeness\nissue as it requires accessing a `!Sync` type during `.clone()`, which would be\nvery unusual when using the broadcast channel."
+    },
+    {
+      "commit": "0ec4d0db4d24af74cea40cf0ceed6b7a0a5ff183",
+      "subject": "docs: remove redundant words in comment (#7224)",
+      "body": ""
+    },
+    {
+      "commit": "d83ba30d8d426c1ce4363190fbb718fd086928d1",
+      "subject": "task: explicitly state that `TaskTracker` does not abort tasks on Drop (#7223)",
+      "body": ""
+    },
+    {
+      "commit": "f339587b27de64c8dfe04c5c8f5a48ee17a24e01",
+      "subject": "deps: update hashbrown to 0.15 (#7219)",
+      "body": ""
+    },
+    {
+      "commit": "b663abe09199c63f18abf5cc024b01fdc71553a4",
+      "subject": "chore: update tokio-util version number (#7215)",
+      "body": ""
+    },
+    {
+      "commit": "9a11efc262ba361250ff944ed10258b620792841",
+      "subject": "chore: prepare tokio-util v0.7.14 (#7215)",
+      "body": ""
+    },
+    {
+      "commit": "d760b26666867f80552534433de004ddebbfeef7",
+      "subject": "Merge tokio-1.44.1 into master (#7218)",
+      "body": ""
+    },
+    {
+      "commit": "d413c9c02af8f2b4fea14b769b86484b12f46595",
+      "subject": "chore: prepare Tokio v1.44.1 (#7217)",
+      "body": ""
+    },
+    {
+      "commit": "addbfb9204be25a8621feb3f20b44a7c1f00edbd",
+      "subject": "rt: skip defer queue in `block_in_place` context (#7216)",
+      "body": ""
+    },
+    {
+      "commit": "56870433289f6906716c9d9b2a28da5c9e76352e",
+      "subject": "test: remove unused dependencies (#7214)",
+      "body": ""
+    },
+    {
+      "commit": "72c87a7724e23feac56810a2f61c11484ebb3858",
+      "subject": "test: add `io::Builder::name` for better panic messages (#7212)",
+      "body": "Introduce tokio_test::io::Builder::name to configure\nname of the mock object, to include in panic messages.\n\nAlso show number of remaining actions or action index\nin some cases to help debugging failed tests."
+    },
+    {
+      "commit": "8507e28f89916662d2f61af823993483169d912c",
+      "subject": "Remove an old custom `OnceCell` implementation in favor of `std` (#7208)",
+      "body": ""
+    },
+    {
+      "commit": "7efcab43c95feef0e020a8bac8aa31e70e3aafe2",
+      "subject": "Do not require `Unpin` for some trait impls (#7204)",
+      "body": ""
+    },
+    {
+      "commit": "e4a39d2ef6a389cceaebfa54f89ec04b5651c1e0",
+      "subject": "sync: add `CancellationToken::run_until_cancelled_owned` (#7081)",
+      "body": ""
+    },
+    {
+      "commit": "afd3678f89dd0253af9194a4945711cfd3c0662a",
+      "subject": "metrics: stabilize `worker_total_busy_duration` (#6899)",
+      "body": ""
+    },
+    {
+      "commit": "8182ecf2628d5e80dac52b8ed1ea466dbb0925b9",
+      "subject": "chore: prepare Tokio v1.44.0 (#7202)",
+      "body": ""
+    },
+    {
+      "commit": "a258bff7018940b438e5de3fb846588454df4e4d",
+      "subject": "ci: enable printing in multi thread loom tests (#7200)",
+      "body": ""
+    },
+    {
+      "commit": "e076d21f679a35ae2697165d46d111285d09e3b4",
+      "subject": "process: clarify `Child::kill` behavior (#7162)",
+      "body": ""
+    },
+    {
+      "commit": "042433cdccdf0dd33408c1751a80ddd50a077872",
+      "subject": "net: debug_assert on creating a tokio socket from a blocking one (#7166)",
+      "body": "See #5595 and #7172.\n\nThis adds a debug assertion that checks that a supplied underlying std socket is set to nonblocking mode when constructing a tokio socket object from such an object.\n\nThis only works on unix."
+    },
+    {
+      "commit": "0284d1b5c8ea5aff5b30c254200fb0a46c21d67c",
+      "subject": "macros: make `select!` budget-aware (#7164)",
+      "body": ""
+    },
+    {
+      "commit": "710bc8071ea030f0ad98817414997beab2420ad2",
+      "subject": "rt: coop should yield using waker defer strategy (#7185)",
+      "body": ""
+    },
+    {
+      "commit": "a2b12bd5799f06e912b32ac05a5ffb5cf1fe31cd",
+      "subject": "readme: adjust release schedule to once per month (#7191)",
+      "body": ""
+    },
+    {
+      "commit": "e7b593cbee9541500cef047f3a0ee70be1c55c6f",
+      "subject": "process: fix grammar of the `ChildStdin` struct doc comment (#7192)",
+      "body": ""
+    },
+    {
+      "commit": "3aaf4a53776f134b99121cbe273b6d2c93d6bf99",
+      "subject": "coop: adjust grammar in `tests/coop_budget.rs` (#7173)",
+      "body": ""
+    },
+    {
+      "commit": "8e741c1c0ed7c440eba5aa1cf4b55085aeb48dfb",
+      "subject": "tokio: mark 1.43 as LTS (#7189)",
+      "body": ""
+    },
+    {
+      "commit": "47d46455bdf0e13b2b40a0dfb22dad61addafb7c",
+      "subject": "util: optimize buffer reserve for `AnyDelimiterCodec::encode` (#7188)",
+      "body": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds three blind-authored question sets for the Decision Archaeology benchmark, plus the raw-commit source exports they were written from. Closes the content-authoring deliverable in #237.

- `bench/memory/questions-ripgrep.json` — 12 questions
- `bench/memory/questions-ruff.json` — 12 questions
- `bench/memory/questions-tokio.json` — 12 questions
- `bench/memory/raw-commits-{ripgrep,ruff,tokio}.json` — `author_questions.py --num-commits 500` exports used as the only source material
- `bench/memory/README.md` — committed-sets paragraph + reviewer-audit status

36 questions total. Each has `question`, `ground_truth_commit` (full 40-char SHA), and `reviewed_by`. Question shapes are mixed (rationale / mechanism / change-history / locator) and were written purely from raw git history — no memory-database queries during authoring, so the set is not tracking memory titles. The previous memory-derived `questions-ripgrep.json` (5 questions) is replaced in place, not duplicated.

The questions were authored by one agent and then independently reviewed by a second agent that did not consult the memory database, satisfying the blindness protocol's step-4 review with a genuine second pair of eyes. Every `reviewed_by` field records both the authoring pass and the independent QA pass.

## Test plan

Verification steps run during the independent QA review:

- **Diff scope.** `git diff origin/main..HEAD --name-status` — only the 7 `bench/memory/*` files change; `decision_archaeology.py` and `author_questions.py` are untouched.
- **JSON validity + counts + fields.** Parsed all three files with `python3 -c "import json; json.load(...)"`: each parses, each has 12 questions (36 total ≥ 30), and every object has non-empty `question`, `ground_truth_commit`, and `reviewed_by`.
- **SHA format.** Regex-checked every `ground_truth_commit` is `[0-9a-f]{40}` — all 36 pass.
- **SHAs are real commits.** Cross-checked all 36 question SHAs against the `raw-commits-<repo>.json` exports (500 commits each) — all present. Then independently spot-checked 6 SHAs across the three repos via the GitHub commits API (`gh api repos/<owner>/<repo>/commits/<sha>`); all resolve and the commit subjects match the questions, e.g.:
  - `BurntSushi/ripgrep@43e2f08` → "ignore: fix parent gitignore matching across multiple roots"
  - `astral-sh/ruff@c423054` → "Add a recursion limit to the parser (#24810)"
  - `tokio-rs/tokio@159a3b2` → "rt(unstable): remove alt multi-threaded runtime (#7275)"
- **Replacement, not duplication.** `questions-ripgrep.json` is modified in place (status `M`), with no second copy added.
- **Honest reviewer field.** No fabricated human reviewer names; `reviewed_by` strings honestly describe the authoring agent and the independent QA pass.
- **Pre-commit hooks.** `cargo fmt --check` and `cargo clippy` ran clean on the review commit.

The blindness protocol was preserved throughout: the QA review did not run `spelunk memory list`/`search` against any benchmark repo or this project.

## Reviewer audit

The protocol's step-4 second-pair-of-eyes review is satisfied by an independent QA pass (recorded in each `reviewed_by`). A final human maintainer sign-off is still recommended before these sets become the canonical baseline; whoever performs it should append their name and date to `reviewed_by`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)