### PR TITLE
docs(changelog): roll [Unreleased] for the v0.9.0 cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`spelunk login` / `spelunk logout`** — authenticate the CLI against
+  spelunk.cloud using the OAuth 2.0 Device Authorization Grant (RFC 8628).
+  `spelunk login` initiates the flow, prints a verification URL and user code to
+  enter in the browser, polls for approval (with back-off on
+  `authorization_pending` / `slow_down`), and on success stores the issued
+  `api_key` in `~/.config/spelunk/config.toml`. `spelunk logout` removes the
+  stored credential. `--cloud-url` (or `SPELUNK_CLOUD_URL`) overrides the
+  default `https://api.spelunk.cloud` endpoint. (ADR-037 P3, #430)
+
+- **Two-way memory sync with spelunk.cloud (`spelunk sync` / `spelunk memory
+  sync`).** When a team server is configured, `spelunk sync` (top-level alias
+  for `spelunk memory sync`) now performs a real two-way sync: it pushes local
+  memory entries the cloud has not seen and pulls remote entries into the local
+  `memory.db`, applying changes keep-both so concurrent edits on multiple
+  machines are preserved. A new `spelunk memory pull` does a one-way delta pull.
+  Sync is identity-keyed on a time-ordered UUID carried by each entry, so it is
+  idempotent (re-running never duplicates) and drift-free across machine clocks;
+  archived entries propagate as tombstones. (ADR-037 P1, #425)
+
+- **Sync modes (`mode = offline | local_first | cloud_first`).** A new `mode`
+  config field (and `SPELUNK_MODE` env override) controls how the CLI reconciles
+  local and cloud memory. The default preserves existing behaviour: with no
+  `server_url` the CLI is `offline`; with a `server_url` set it is `local_first`.
+  `SPELUNK_NO_SERVER=1` remains a hard kill-switch. (ADR-037 P1, #425)
+
+### Changed
+
+- **Cloud project slug auto-resolves to its server UUID.** When a team
+  `server_url` routes projects by an internal UUID, a human `project_id` slug is
+  now resolved to that UUID on first use via `GET /v1/projects` and cached in
+  `.spelunk/cloud-project-id.lock`; a raw-UUID `project_id` is used directly, and
+  a loopback/unset server is left untouched. The cache is invalidated
+  automatically if the slug changes, and `SPELUNK_NO_SLUG_CACHE=1` forces a fresh
+  lookup. This makes the human-readable `project_id` work transparently against
+  cloud-api routing. (ADR-005, #428)
+
+### Dependencies
+
+- `tower-http` 0.6.11 → 0.7.0 (#431)
+- `actions/checkout` 6 → 7 (CI) (#432)
+- Refreshed `Cargo.lock` to latest semver-compatible versions; no new advisories
+  (#433)
+
 ## [0.8.3] — 2026-06-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   `spelunk login` initiates the flow, prints a verification URL and user code to
   enter in the browser, polls for approval (with back-off on
   `authorization_pending` / `slow_down`), and on success stores the issued
-  `api_key` in `~/.config/spelunk/config.toml`. `spelunk logout` removes the
-  stored credential. `--cloud-url` (or `SPELUNK_CLOUD_URL`) overrides the
-  default `https://api.spelunk.cloud` endpoint. (ADR-037 P3, #430)
+  token as `server_key` in `~/.config/spelunk/config.toml`. `spelunk logout`
+  removes the stored credential. `--cloud-url` (or `SPELUNK_CLOUD_URL`)
+  overrides the default `https://api.spelunk.cloud` endpoint. (ADR-037 P3,
+  #430)
 
 - **Two-way memory sync with spelunk.cloud (`spelunk sync` / `spelunk memory
   sync`).** When a team server is configured, `spelunk sync` (top-level alias
@@ -38,6 +39,15 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **`spelunk login` token is now actually used for auth.** The device-flow
+  token is written to the canonical `server_key` config field that every auth
+  path already reads, so a freshly logged-in CLI authenticates against the
+  cloud without further config. Previously the token was written to a separate
+  `api_key` field that no auth consumer read, leaving login effectively inert;
+  that field has been removed. `SPELUNK_SERVER_KEY` remains the environment
+  override for CI and headless use (no new env var was introduced). (#438,
+  spelunk#437)
+
 - **Cloud project slug auto-resolves to its server UUID.** When a team
   `server_url` routes projects by an internal UUID, a human `project_id` slug is
   now resolved to that UUID on first use via `GET /v1/projects` and cached in
@@ -46,6 +56,17 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   automatically if the slug changes, and `SPELUNK_NO_SLUG_CACHE=1` forces a fresh
   lookup. This makes the human-readable `project_id` work transparently against
   cloud-api routing. (ADR-005, #428)
+
+### Fixed
+
+- **`spelunk login` no longer fails with `411 Length Required` on Cloud Run /
+  GFE-fronted hosts.** The device-init request (`POST /v1/auth/device`) was a
+  bodyless POST, so no `Content-Length` header was set and Google Front End
+  (Cloud Run's fronting proxy) rejected it before it reached cloud-api,
+  breaking login on its very first request against prod. The request now sends
+  a JSON body, so `Content-Length` and `Content-Type` are set; the body also
+  carries the machine hostname as `client_hint` (falling back to an empty
+  object when the hostname cannot be resolved). (#436, GH #434)
 
 ### Dependencies
 


### PR DESCRIPTION
## What this rolls and why

Populates the previously-empty `## [Unreleased]` section of `CHANGELOG.md` with every user-facing change merged to `main` since the `v0.8.3` tag, so the upcoming **v0.9.0** release cut is just a version bump + tag (no scramble to write changelog copy at cut time).

Entries grouped per Keep a Changelog (Added / Changed / Dependencies), matching the existing house style:

- **Added** — `spelunk login` / `spelunk logout` device-auth flow (ADR-037 P3, #430); local↔cloud two-way memory sync via `spelunk sync` / `spelunk memory sync` + new `spelunk memory pull` (ADR-037 P1, #425); sync modes (`mode = offline | local_first | cloud_first`, ADR-037 P1, #425).
- **Changed** — cloud project slug auto-resolves to its server UUID for cloud-api routing (ADR-005, #428).
- **Dependencies** — tower-http 0.7 (#431), actions/checkout-7 (#432), semver-compatible cargo update (#433).

Each entry was written against the actual command surface and diffs (confirmed `spelunk login`/`logout`, `spelunk sync` alias, `spelunk memory pull`), not just commit subjects.

**No version files were touched.** `Cargo.toml` (3 crates) and `Cargo.lock` stay at 0.8.3, and `[Unreleased]` is *not* renamed — that roll is the founder-owned release-cut step.

## Test plan

- Rendered CHANGELOG diff reviewed against `git log v0.8.3..HEAD --oneline --no-merges`; every substantive feature/dep commit is represented and no internal-only churn (fuzz repair, UUID-cursor refactor) leaked into user-facing entries.
- Confirmed no version files touched: `git diff --stat main` shows **only** `CHANGELOG.md` changed (1 file, +45). `git diff main -- Cargo.toml Cargo.lock crates/*/Cargo.toml` is empty.
- Pre-commit hook ran `cargo fmt --check` + `cargo clippy` clean.

## Remaining for the v0.9.0 cut (not in this PR)

a. **Login 411 fix (spelunk#434) must merge first** — it will add its own `Fixed` entry under `[Unreleased]` before the cut.
b. Version bump 0.8.3 → 0.9.0 across the 3 crates + `Cargo.lock`.
c. Roll `[Unreleased]` → `[0.9.0]` (with the release date).
d. Tag `v0.9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)