### PR TITLE
fix(login): persist token as server_key; remove redundant api_key field (#437)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/login.rs
+++ b/crates/spelunk-cli/src/cli/cmd/login.rs
@@ -6,7 +6,7 @@
 //!    verification_uri_complete?, expires_in, interval }`
 //! 2. Print the verification URL and user code for the operator.
 //! 3. Poll POST /v1/auth/device/token every `interval` seconds until:
-//!    - 200 OK  →  parse { api_key }  →  write to config  →  print "Login successful."
+//!    - 200 OK  →  parse { api_key }  →  save as `server_key`  →  print "Login successful."
 //!    - 400 authorization_pending  →  keep polling (show progress dot)
 //!    - 400 slow_down              →  increase interval by 5 s (RFC 8628 §3.5)
 //!    - 400 expired_token          →  exit 1 with timeout message
@@ -110,11 +110,11 @@ pub async fn login(args: LoginArgs) -> Result<()> {
         let result = poll_token(&client, cloud_url, &device.device_code).await;
 
         match result {
-            PollOutcome::Success(api_key) => {
+            PollOutcome::Success(token) => {
                 // Write to config before printing the success message so that a
                 // write error surfaces before the user thinks they are logged in.
-                config::save_api_key(&api_key)
-                    .context("saving api_key to ~/.config/spelunk/config.toml")?;
+                config::save_server_key(&token)
+                    .context("saving server_key to ~/.config/spelunk/config.toml")?;
                 println!("\nLogin successful.");
                 return Ok(());
             }
@@ -341,27 +341,27 @@ mod tests {
         assert_eq!(device.user_code, "ABCD-EFGH");
     }
 
-    /// save_api_key_to creates the file and writes the key.
+    /// save_server_key_to creates the file and writes the key.
     #[test]
-    fn save_api_key_creates_file() {
+    fn save_server_key_creates_file() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
-        config::save_api_key_to("sk-sp-test", &path).unwrap();
+        config::save_server_key_to("sk-sp-test", &path).unwrap();
         let contents = std::fs::read_to_string(&path).unwrap();
-        assert!(contents.contains("api_key"), "should contain api_key");
+        assert!(contents.contains("server_key"), "should contain server_key");
         assert!(
             contents.contains("sk-sp-test"),
             "should contain the key value"
         );
     }
 
-    /// save_api_key_to preserves existing keys.
+    /// save_server_key_to preserves existing keys.
     #[test]
-    fn save_api_key_preserves_other_keys() {
+    fn save_server_key_preserves_other_keys() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
         std::fs::write(&path, "server_url = \"http://localhost:7777\"\n").unwrap();
-        config::save_api_key_to("sk-sp-test", &path).unwrap();
+        config::save_server_key_to("sk-sp-test", &path).unwrap();
         let contents = std::fs::read_to_string(&path).unwrap();
         assert!(
             contents.contains("server_url"),
@@ -373,43 +373,46 @@ mod tests {
         );
     }
 
-    /// save_api_key_to replaces an existing api_key entry.
+    /// save_server_key_to replaces an existing server_key entry.
     #[test]
-    fn save_api_key_replaces_existing() {
+    fn save_server_key_replaces_existing() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
-        std::fs::write(&path, "api_key = \"sk-sp-old\"\n").unwrap();
-        config::save_api_key_to("sk-sp-new", &path).unwrap();
+        std::fs::write(&path, "server_key = \"sk-sp-old\"\n").unwrap();
+        config::save_server_key_to("sk-sp-new", &path).unwrap();
         let contents = std::fs::read_to_string(&path).unwrap();
         assert!(!contents.contains("sk-sp-old"), "old key should be gone");
         assert!(contents.contains("sk-sp-new"), "new key should be present");
     }
 
-    /// remove_api_key_from removes the api_key line.
+    /// remove_server_key_from removes the server_key line.
     #[test]
-    fn remove_api_key_removes_line() {
+    fn remove_server_key_removes_line() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
         std::fs::write(
             &path,
-            "server_url = \"http://localhost:7777\"\napi_key = \"sk-sp-test\"\n",
+            "server_url = \"http://localhost:7777\"\nserver_key = \"sk-sp-test\"\n",
         )
         .unwrap();
-        config::remove_api_key_from(&path).unwrap();
+        config::remove_server_key_from(&path).unwrap();
         let contents = std::fs::read_to_string(&path).unwrap();
-        assert!(!contents.contains("api_key"), "api_key should be removed");
+        assert!(
+            !contents.contains("server_key"),
+            "server_key should be removed"
+        );
         assert!(
             contents.contains("server_url"),
             "server_url should still be present"
         );
     }
 
-    /// remove_api_key_from is a no-op when the file does not exist.
+    /// remove_server_key_from is a no-op when the file does not exist.
     #[test]
-    fn remove_api_key_no_op_when_file_missing() {
+    fn remove_server_key_no_op_when_file_missing() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
         // Must not error even when file is absent.
-        config::remove_api_key_from(&path).unwrap();
+        config::remove_server_key_from(&path).unwrap();
     }
 }

--- a/crates/spelunk-cli/src/cli/cmd/logout.rs
+++ b/crates/spelunk-cli/src/cli/cmd/logout.rs
@@ -1,11 +1,12 @@
-//! `spelunk logout` — remove the stored `api_key` from the global config.
+//! `spelunk logout` — remove the stored `server_key` from the global config.
 
 use anyhow::{Context as _, Result};
 
 use spelunk_core::config;
 
 pub async fn logout() -> Result<()> {
-    config::remove_api_key().context("removing api_key from ~/.config/spelunk/config.toml")?;
-    println!("Logged out. Your api_key has been removed from ~/.config/spelunk/config.toml");
+    config::remove_server_key()
+        .context("removing server_key from ~/.config/spelunk/config.toml")?;
+    println!("Logged out. Your server_key has been removed from ~/.config/spelunk/config.toml");
     Ok(())
 }

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -270,16 +270,12 @@ pub struct Config {
     #[serde(default, alias = "memory_server_url")]
     pub server_url: Option<String>,
 
-    /// Bearer token for cloud/spelunk-server auth — the **canonical, resolved**
-    /// token every auth path sends as `Authorization: Bearer …`.
-    /// Set in `~/.config/spelunk/config.toml` (personal) or via `SPELUNK_SERVER_KEY`.
+    /// Bearer token for cloud/spelunk-server auth — the single token every auth
+    /// path sends as `Authorization: Bearer …`.
+    /// Set in `~/.config/spelunk/config.toml` (personal), written by
+    /// `spelunk login`, or overridden via `SPELUNK_SERVER_KEY`.
     /// Do NOT commit this to `.spelunk/config.toml`.
     /// The old `memory_server_key` TOML key is accepted as a backward-compat alias.
-    ///
-    /// After [`Config::load`] this holds the effective token resolved from, in
-    /// precedence order: `SPELUNK_SERVER_KEY` (env) → [`Config::api_key`]
-    /// (config.toml, written by `spelunk login`) → `server_key`/`memory_server_key`
-    /// (config.toml). Read this field for auth, not `api_key` (spelunk#437).
     #[serde(default, alias = "memory_server_key")]
     pub server_key: Option<String>,
 
@@ -341,19 +337,6 @@ pub struct Config {
     /// primary SQLite write is unaffected.
     #[serde(default = "Config::default_store_in_git_notes")]
     pub store_in_git_notes: bool,
-
-    /// API key for spelunk.cloud, written by `spelunk login`.
-    ///
-    /// Format: `sk-sp-…`.  Set in `~/.config/spelunk/config.toml`; never
-    /// committed to project-level `.spelunk/config.toml`.
-    ///
-    /// At load time this is folded into the effective bearer token (see
-    /// [`Config::load`]): when no `SPELUNK_SERVER_KEY` env override is set,
-    /// `api_key` takes precedence over a config-file `server_key`. Every auth
-    /// path reads the resolved [`Config::server_key`], so do not read `api_key`
-    /// directly for auth.
-    #[serde(default)]
-    pub api_key: Option<String>,
 }
 
 impl Config {
@@ -404,7 +387,6 @@ impl Default for Config {
             specs_dir: Self::default_specs_dir(),
             llm_context_length: Self::default_llm_context_length(),
             store_in_git_notes: Self::default_store_in_git_notes(),
-            api_key: None,
         }
     }
 }
@@ -461,26 +443,9 @@ impl Config {
             );
             cfg.server_url = Some(v);
         }
-        // ── Cloud/server bearer token resolution (spelunk#437) ───────────────
-        // A single effective bearer token feeds every cloud/server auth path,
-        // all of which read `cfg.server_key`. We keep `server_key` as the
-        // canonical field and fold in the cloud `api_key` (written by
-        // `spelunk login`) so that token is actually used for auth. The existing
-        // `SPELUNK_SERVER_KEY` already covers the env-injection case (CI /
-        // headless / containers), so no new env var is added. Precedence,
-        // highest first:
-        //   1. SPELUNK_SERVER_KEY  (env)
-        //   2. api_key             (config.toml, written by `spelunk login`)
-        //   3. server_key          (config.toml / project, incl. memory_server_key alias)
-        // Env beats config; within config the cloud key wins over the legacy
-        // self-hosted key. The token value is never logged.
-        let env_server_key = std::env::var("SPELUNK_SERVER_KEY")
-            .ok()
-            .filter(|v| !v.is_empty());
-        let toml_server_key = cfg.server_key.take();
-        cfg.server_key = env_server_key
-            .or_else(|| cfg.api_key.clone())
-            .or(toml_server_key);
+        if let Ok(v) = std::env::var("SPELUNK_SERVER_KEY") {
+            cfg.server_key = Some(v);
+        }
         if let Ok(v) = std::env::var("SPELUNK_PROJECT_ID") {
             cfg.project_id = Some(v);
         }
@@ -569,19 +534,20 @@ impl Config {
     }
 }
 
-/// Write (or update) `api_key` in `~/.config/spelunk/config.toml`.
+/// Write (or update) `server_key` in `~/.config/spelunk/config.toml`.
 ///
-/// Uses a line-level read-modify-write so that other keys in the file are
-/// preserved.  The file is created (with the `api_key` line) if absent.
+/// This is the token `spelunk login` persists. Uses a line-level
+/// read-modify-write so that other keys in the file are preserved.  The file is
+/// created (with the `server_key` line) if absent.
 ///
 /// The value is **not** shell-quoted before writing — it is written as a bare
-/// TOML string with double quotes, e.g. `api_key = "sk-sp-…"`.
-pub fn save_api_key(key: &str) -> Result<()> {
-    save_api_key_to(key, &spelunk_config_dir().join("config.toml"))
+/// TOML string with double quotes, e.g. `server_key = "sk-sp-…"`.
+pub fn save_server_key(key: &str) -> Result<()> {
+    save_server_key_to(key, &spelunk_config_dir().join("config.toml"))
 }
 
-/// Same as [`save_api_key`] but writes to an explicit path (useful in tests).
-pub fn save_api_key_to(key: &str, config_path: &Path) -> Result<()> {
+/// Same as [`save_server_key`] but writes to an explicit path (useful in tests).
+pub fn save_server_key_to(key: &str, config_path: &Path) -> Result<()> {
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating config dir {}", parent.display()))?;
@@ -594,24 +560,24 @@ pub fn save_api_key_to(key: &str, config_path: &Path) -> Result<()> {
         String::new()
     };
 
-    let new_line = format!("api_key = {}\n", toml_quote(key));
-    let updated = upsert_toml_line(&existing, "api_key", &new_line);
+    let new_line = format!("server_key = {}\n", toml_quote(key));
+    let updated = upsert_toml_line(&existing, "server_key", &new_line);
 
     std::fs::write(config_path, updated)
         .with_context(|| format!("writing {}", config_path.display()))?;
     Ok(())
 }
 
-/// Remove `api_key` from `~/.config/spelunk/config.toml`.
+/// Remove `server_key` from `~/.config/spelunk/config.toml`.
 ///
-/// No-op if the file does not exist or the key is absent.  Other keys are
-/// preserved.
-pub fn remove_api_key() -> Result<()> {
-    remove_api_key_from(&spelunk_config_dir().join("config.toml"))
+/// This is what `spelunk logout` clears. No-op if the file does not exist or the
+/// key is absent.  Other keys are preserved.
+pub fn remove_server_key() -> Result<()> {
+    remove_server_key_from(&spelunk_config_dir().join("config.toml"))
 }
 
-/// Same as [`remove_api_key`] but operates on an explicit path (useful in tests).
-pub fn remove_api_key_from(config_path: &Path) -> Result<()> {
+/// Same as [`remove_server_key`] but operates on an explicit path (useful in tests).
+pub fn remove_server_key_from(config_path: &Path) -> Result<()> {
     if !config_path.exists() {
         return Ok(());
     }
@@ -622,10 +588,10 @@ pub fn remove_api_key_from(config_path: &Path) -> Result<()> {
         .lines()
         .filter(|line| {
             let trimmed = line.trim();
-            // Keep every line that is NOT an `api_key = …` assignment.
+            // Keep every line that is NOT a `server_key = …` assignment.
             // strip_prefix avoids a raw byte-index slice and handles the
-            // "api_key" prefix unambiguously.
-            let after_key = trimmed.strip_prefix("api_key");
+            // "server_key" prefix unambiguously.
+            let after_key = trimmed.strip_prefix("server_key");
             !matches!(after_key, Some(rest) if rest.trim_start().starts_with('='))
         })
         .map(|line| format!("{line}\n"))
@@ -1229,87 +1195,6 @@ project_id = "my-proj"
         }
         let cfg = Config::load(Some(&config_path)).unwrap();
         assert_eq!(cfg.server_key, Some("env-token".to_string()));
-    }
-
-    // ── cloud token resolution (spelunk#437) ─────────────────────────────────
-
-    /// `SPELUNK_SERVER_KEY` env overrides the config.toml `api_key` written by
-    /// `spelunk login` (env-injection path for CI / headless / containers).
-    #[test]
-    #[serial_test::serial]
-    fn env_spelunk_server_key_overrides_config_api_key() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-        std::fs::write(&config_path, "api_key = \"sk-sp-login\"\n").unwrap();
-
-        unsafe {
-            std::env::set_var("SPELUNK_SERVER_KEY", "server-env");
-        }
-        let cfg = Config::load(Some(&config_path)).unwrap();
-        assert_eq!(cfg.server_key, Some("server-env".to_string()));
-    }
-
-    /// The token `spelunk login` writes (config.toml `api_key`) is actually used
-    /// for auth — it resolves into `server_key` with no env override set.
-    #[test]
-    #[serial_test::serial]
-    fn config_api_key_resolves_into_server_key() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-        std::fs::write(&config_path, "api_key = \"sk-sp-login\"\n").unwrap();
-
-        let cfg = Config::load(Some(&config_path)).unwrap();
-        assert_eq!(cfg.server_key, Some("sk-sp-login".to_string()));
-    }
-
-    /// config.toml `api_key` takes precedence over config.toml `server_key`
-    /// when no env override is set (cloud key beats legacy self-hosted key).
-    #[test]
-    #[serial_test::serial]
-    fn config_api_key_beats_config_server_key() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-        std::fs::write(
-            &config_path,
-            "api_key = \"sk-sp-login\"\nserver_key = \"legacy-server\"\n",
-        )
-        .unwrap();
-
-        let cfg = Config::load(Some(&config_path)).unwrap();
-        assert_eq!(cfg.server_key, Some("sk-sp-login".to_string()));
-    }
-
-    /// An existing self-hosted config with only `server_key` and no cloud
-    /// `api_key` is unchanged — back-compat for unknown OSS-server users.
-    #[test]
-    #[serial_test::serial]
-    fn config_server_key_only_is_unchanged() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-        std::fs::write(&config_path, "server_key = \"self-hosted\"\n").unwrap();
-
-        let cfg = Config::load(Some(&config_path)).unwrap();
-        assert_eq!(cfg.server_key, Some("self-hosted".to_string()));
-    }
-
-    /// An empty `SPELUNK_SERVER_KEY` does not clobber a real config token.
-    #[test]
-    #[serial_test::serial]
-    fn empty_env_server_key_does_not_clobber_config() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-        std::fs::write(&config_path, "api_key = \"sk-sp-login\"\n").unwrap();
-
-        unsafe {
-            std::env::set_var("SPELUNK_SERVER_KEY", "");
-        }
-        let cfg = Config::load(Some(&config_path)).unwrap();
-        assert_eq!(cfg.server_key, Some("sk-sp-login".to_string()));
     }
 
     #[test]

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -270,10 +270,17 @@ pub struct Config {
     #[serde(default, alias = "memory_server_url")]
     pub server_url: Option<String>,
 
-    /// Bearer token for spelunk-server auth.
+    /// Bearer token for cloud/spelunk-server auth — the **canonical, resolved**
+    /// token every auth path sends as `Authorization: Bearer …`.
     /// Set in `~/.config/spelunk/config.toml` (personal) or via `SPELUNK_SERVER_KEY`.
     /// Do NOT commit this to `.spelunk/config.toml`.
     /// The old `memory_server_key` TOML key is accepted as a backward-compat alias.
+    ///
+    /// After [`Config::load`] this holds the effective token resolved from, in
+    /// precedence order: `SPELUNK_API_KEY` (env) → `SPELUNK_SERVER_KEY` (env) →
+    /// [`Config::api_key`] (config.toml, written by `spelunk login`) →
+    /// `server_key`/`memory_server_key` (config.toml). Read this field for auth,
+    /// not `api_key` (spelunk#437).
     #[serde(default, alias = "memory_server_key")]
     pub server_key: Option<String>,
 
@@ -340,6 +347,13 @@ pub struct Config {
     ///
     /// Format: `sk-sp-…`.  Set in `~/.config/spelunk/config.toml`; never
     /// committed to project-level `.spelunk/config.toml`.
+    ///
+    /// At load time this is folded into the effective bearer token (see
+    /// [`Config::load`]): when no `SPELUNK_API_KEY`/`SPELUNK_SERVER_KEY` env
+    /// override is set, `api_key` takes precedence over a config-file
+    /// `server_key`. The override env var is `SPELUNK_API_KEY`. Every auth path
+    /// reads the resolved [`Config::server_key`], so do not read `api_key`
+    /// directly for auth.
     #[serde(default)]
     pub api_key: Option<String>,
 }
@@ -402,7 +416,8 @@ impl Config {
     ///   1. Defaults
     ///   2. `~/.config/spelunk/config.toml` (global personal)
     ///   3. `.spelunk/config.toml` discovered by walking up from CWD (project-level, team-wide)
-    ///   4. Environment variables: `SPELUNK_SERVER_URL`, `SPELUNK_SERVER_KEY`, `SPELUNK_PROJECT_ID`
+    ///   4. Environment variables: `SPELUNK_SERVER_URL`, `SPELUNK_API_KEY`,
+    ///      `SPELUNK_SERVER_KEY`, `SPELUNK_PROJECT_ID`
     ///
     /// Pass `path` to override the global config location (used by `--config` flag).
     pub fn load(path: Option<&Path>) -> Result<Self> {
@@ -449,9 +464,24 @@ impl Config {
             );
             cfg.server_url = Some(v);
         }
-        if let Ok(v) = std::env::var("SPELUNK_SERVER_KEY") {
-            cfg.server_key = Some(v);
-        }
+        // ── Cloud/server bearer token resolution (spelunk#437) ───────────────
+        // A single effective bearer token feeds every cloud/server auth path,
+        // all of which read `cfg.server_key`. We keep `server_key` as the
+        // canonical field for backward compatibility with existing self-hosted
+        // configs, and fold in the cloud `api_key` (written by `spelunk login`)
+        // and the new `SPELUNK_API_KEY` env override. Precedence, highest first:
+        //   1. SPELUNK_API_KEY     (env, new)
+        //   2. SPELUNK_SERVER_KEY  (env, existing)
+        //   3. api_key             (config.toml, written by `spelunk login`)
+        //   4. server_key          (config.toml / project, incl. memory_server_key alias)
+        // Env beats config; within a source the cloud key wins over the legacy
+        // self-hosted key. The token value is never logged.
+        let env_token = |name: &str| std::env::var(name).ok().filter(|v| !v.is_empty());
+        let toml_server_key = cfg.server_key.take();
+        cfg.server_key = env_token("SPELUNK_API_KEY")
+            .or_else(|| env_token("SPELUNK_SERVER_KEY"))
+            .or_else(|| cfg.api_key.clone())
+            .or(toml_server_key);
         if let Ok(v) = std::env::var("SPELUNK_PROJECT_ID") {
             cfg.project_id = Some(v);
         }
@@ -708,6 +738,7 @@ mod tests {
             std::env::remove_var("SPELUNK_SERVER_URL");
             std::env::remove_var("SPELUNK_MEMORY_SERVER_URL");
             std::env::remove_var("SPELUNK_SERVER_KEY");
+            std::env::remove_var("SPELUNK_API_KEY");
             std::env::remove_var("SPELUNK_PROJECT_ID");
             std::env::remove_var("SPELUNK_MODE");
             std::env::remove_var("SPELUNK_NO_SERVER");
@@ -1200,6 +1231,117 @@ project_id = "my-proj"
         }
         let cfg = Config::load(Some(&config_path)).unwrap();
         assert_eq!(cfg.server_key, Some("env-token".to_string()));
+    }
+
+    // ── cloud token resolution (spelunk#437) ─────────────────────────────────
+
+    /// `SPELUNK_API_KEY` supplies the bearer with no config file present.
+    #[test]
+    #[serial_test::serial]
+    fn env_spelunk_api_key_supplies_token_without_config() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml"); // intentionally absent
+
+        unsafe {
+            std::env::set_var("SPELUNK_API_KEY", "sk-sp-from-env");
+        }
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.server_key, Some("sk-sp-from-env".to_string()));
+    }
+
+    /// `SPELUNK_API_KEY` env overrides the config.toml `server_key`.
+    #[test]
+    #[serial_test::serial]
+    fn env_spelunk_api_key_overrides_config_server_key() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "server_key = \"config-token\"\n").unwrap();
+
+        unsafe {
+            std::env::set_var("SPELUNK_API_KEY", "sk-sp-env");
+        }
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.server_key, Some("sk-sp-env".to_string()));
+    }
+
+    /// `SPELUNK_API_KEY` env wins over `SPELUNK_SERVER_KEY` env.
+    #[test]
+    #[serial_test::serial]
+    fn env_spelunk_api_key_overrides_env_server_key() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+
+        unsafe {
+            std::env::set_var("SPELUNK_API_KEY", "sk-sp-api");
+            std::env::set_var("SPELUNK_SERVER_KEY", "server-env");
+        }
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.server_key, Some("sk-sp-api".to_string()));
+    }
+
+    /// The token `spelunk login` writes (config.toml `api_key`) is actually used
+    /// for auth — it resolves into `server_key` with no env override set.
+    #[test]
+    #[serial_test::serial]
+    fn config_api_key_resolves_into_server_key() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "api_key = \"sk-sp-login\"\n").unwrap();
+
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.server_key, Some("sk-sp-login".to_string()));
+    }
+
+    /// config.toml `api_key` takes precedence over config.toml `server_key`
+    /// when no env override is set (cloud key beats legacy self-hosted key).
+    #[test]
+    #[serial_test::serial]
+    fn config_api_key_beats_config_server_key() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "api_key = \"sk-sp-login\"\nserver_key = \"legacy-server\"\n",
+        )
+        .unwrap();
+
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.server_key, Some("sk-sp-login".to_string()));
+    }
+
+    /// An existing self-hosted config with only `server_key` and no cloud
+    /// `api_key` is unchanged — back-compat for unknown OSS-server users.
+    #[test]
+    #[serial_test::serial]
+    fn config_server_key_only_is_unchanged() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "server_key = \"self-hosted\"\n").unwrap();
+
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.server_key, Some("self-hosted".to_string()));
+    }
+
+    /// An empty `SPELUNK_API_KEY` does not clobber a real config token.
+    #[test]
+    #[serial_test::serial]
+    fn empty_env_api_key_does_not_clobber_config() {
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "api_key = \"sk-sp-login\"\n").unwrap();
+
+        unsafe {
+            std::env::set_var("SPELUNK_API_KEY", "");
+        }
+        let cfg = Config::load(Some(&config_path)).unwrap();
+        assert_eq!(cfg.server_key, Some("sk-sp-login".to_string()));
     }
 
     #[test]

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -277,10 +277,9 @@ pub struct Config {
     /// The old `memory_server_key` TOML key is accepted as a backward-compat alias.
     ///
     /// After [`Config::load`] this holds the effective token resolved from, in
-    /// precedence order: `SPELUNK_API_KEY` (env) → `SPELUNK_SERVER_KEY` (env) →
-    /// [`Config::api_key`] (config.toml, written by `spelunk login`) →
-    /// `server_key`/`memory_server_key` (config.toml). Read this field for auth,
-    /// not `api_key` (spelunk#437).
+    /// precedence order: `SPELUNK_SERVER_KEY` (env) → [`Config::api_key`]
+    /// (config.toml, written by `spelunk login`) → `server_key`/`memory_server_key`
+    /// (config.toml). Read this field for auth, not `api_key` (spelunk#437).
     #[serde(default, alias = "memory_server_key")]
     pub server_key: Option<String>,
 
@@ -349,10 +348,9 @@ pub struct Config {
     /// committed to project-level `.spelunk/config.toml`.
     ///
     /// At load time this is folded into the effective bearer token (see
-    /// [`Config::load`]): when no `SPELUNK_API_KEY`/`SPELUNK_SERVER_KEY` env
-    /// override is set, `api_key` takes precedence over a config-file
-    /// `server_key`. The override env var is `SPELUNK_API_KEY`. Every auth path
-    /// reads the resolved [`Config::server_key`], so do not read `api_key`
+    /// [`Config::load`]): when no `SPELUNK_SERVER_KEY` env override is set,
+    /// `api_key` takes precedence over a config-file `server_key`. Every auth
+    /// path reads the resolved [`Config::server_key`], so do not read `api_key`
     /// directly for auth.
     #[serde(default)]
     pub api_key: Option<String>,
@@ -416,8 +414,7 @@ impl Config {
     ///   1. Defaults
     ///   2. `~/.config/spelunk/config.toml` (global personal)
     ///   3. `.spelunk/config.toml` discovered by walking up from CWD (project-level, team-wide)
-    ///   4. Environment variables: `SPELUNK_SERVER_URL`, `SPELUNK_API_KEY`,
-    ///      `SPELUNK_SERVER_KEY`, `SPELUNK_PROJECT_ID`
+    ///   4. Environment variables: `SPELUNK_SERVER_URL`, `SPELUNK_SERVER_KEY`, `SPELUNK_PROJECT_ID`
     ///
     /// Pass `path` to override the global config location (used by `--config` flag).
     pub fn load(path: Option<&Path>) -> Result<Self> {
@@ -467,19 +464,21 @@ impl Config {
         // ── Cloud/server bearer token resolution (spelunk#437) ───────────────
         // A single effective bearer token feeds every cloud/server auth path,
         // all of which read `cfg.server_key`. We keep `server_key` as the
-        // canonical field for backward compatibility with existing self-hosted
-        // configs, and fold in the cloud `api_key` (written by `spelunk login`)
-        // and the new `SPELUNK_API_KEY` env override. Precedence, highest first:
-        //   1. SPELUNK_API_KEY     (env, new)
-        //   2. SPELUNK_SERVER_KEY  (env, existing)
-        //   3. api_key             (config.toml, written by `spelunk login`)
-        //   4. server_key          (config.toml / project, incl. memory_server_key alias)
-        // Env beats config; within a source the cloud key wins over the legacy
+        // canonical field and fold in the cloud `api_key` (written by
+        // `spelunk login`) so that token is actually used for auth. The existing
+        // `SPELUNK_SERVER_KEY` already covers the env-injection case (CI /
+        // headless / containers), so no new env var is added. Precedence,
+        // highest first:
+        //   1. SPELUNK_SERVER_KEY  (env)
+        //   2. api_key             (config.toml, written by `spelunk login`)
+        //   3. server_key          (config.toml / project, incl. memory_server_key alias)
+        // Env beats config; within config the cloud key wins over the legacy
         // self-hosted key. The token value is never logged.
-        let env_token = |name: &str| std::env::var(name).ok().filter(|v| !v.is_empty());
+        let env_server_key = std::env::var("SPELUNK_SERVER_KEY")
+            .ok()
+            .filter(|v| !v.is_empty());
         let toml_server_key = cfg.server_key.take();
-        cfg.server_key = env_token("SPELUNK_API_KEY")
-            .or_else(|| env_token("SPELUNK_SERVER_KEY"))
+        cfg.server_key = env_server_key
             .or_else(|| cfg.api_key.clone())
             .or(toml_server_key);
         if let Ok(v) = std::env::var("SPELUNK_PROJECT_ID") {
@@ -738,7 +737,6 @@ mod tests {
             std::env::remove_var("SPELUNK_SERVER_URL");
             std::env::remove_var("SPELUNK_MEMORY_SERVER_URL");
             std::env::remove_var("SPELUNK_SERVER_KEY");
-            std::env::remove_var("SPELUNK_API_KEY");
             std::env::remove_var("SPELUNK_PROJECT_ID");
             std::env::remove_var("SPELUNK_MODE");
             std::env::remove_var("SPELUNK_NO_SERVER");
@@ -1235,51 +1233,21 @@ project_id = "my-proj"
 
     // ── cloud token resolution (spelunk#437) ─────────────────────────────────
 
-    /// `SPELUNK_API_KEY` supplies the bearer with no config file present.
+    /// `SPELUNK_SERVER_KEY` env overrides the config.toml `api_key` written by
+    /// `spelunk login` (env-injection path for CI / headless / containers).
     #[test]
     #[serial_test::serial]
-    fn env_spelunk_api_key_supplies_token_without_config() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml"); // intentionally absent
-
-        unsafe {
-            std::env::set_var("SPELUNK_API_KEY", "sk-sp-from-env");
-        }
-        let cfg = Config::load(Some(&config_path)).unwrap();
-        assert_eq!(cfg.server_key, Some("sk-sp-from-env".to_string()));
-    }
-
-    /// `SPELUNK_API_KEY` env overrides the config.toml `server_key`.
-    #[test]
-    #[serial_test::serial]
-    fn env_spelunk_api_key_overrides_config_server_key() {
+    fn env_spelunk_server_key_overrides_config_api_key() {
         clear_spelunk_env();
         let tmp = TempDir::new().unwrap();
         let config_path = tmp.path().join("config.toml");
-        std::fs::write(&config_path, "server_key = \"config-token\"\n").unwrap();
+        std::fs::write(&config_path, "api_key = \"sk-sp-login\"\n").unwrap();
 
         unsafe {
-            std::env::set_var("SPELUNK_API_KEY", "sk-sp-env");
-        }
-        let cfg = Config::load(Some(&config_path)).unwrap();
-        assert_eq!(cfg.server_key, Some("sk-sp-env".to_string()));
-    }
-
-    /// `SPELUNK_API_KEY` env wins over `SPELUNK_SERVER_KEY` env.
-    #[test]
-    #[serial_test::serial]
-    fn env_spelunk_api_key_overrides_env_server_key() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-
-        unsafe {
-            std::env::set_var("SPELUNK_API_KEY", "sk-sp-api");
             std::env::set_var("SPELUNK_SERVER_KEY", "server-env");
         }
         let cfg = Config::load(Some(&config_path)).unwrap();
-        assert_eq!(cfg.server_key, Some("sk-sp-api".to_string()));
+        assert_eq!(cfg.server_key, Some("server-env".to_string()));
     }
 
     /// The token `spelunk login` writes (config.toml `api_key`) is actually used
@@ -1328,17 +1296,17 @@ project_id = "my-proj"
         assert_eq!(cfg.server_key, Some("self-hosted".to_string()));
     }
 
-    /// An empty `SPELUNK_API_KEY` does not clobber a real config token.
+    /// An empty `SPELUNK_SERVER_KEY` does not clobber a real config token.
     #[test]
     #[serial_test::serial]
-    fn empty_env_api_key_does_not_clobber_config() {
+    fn empty_env_server_key_does_not_clobber_config() {
         clear_spelunk_env();
         let tmp = TempDir::new().unwrap();
         let config_path = tmp.path().join("config.toml");
         std::fs::write(&config_path, "api_key = \"sk-sp-login\"\n").unwrap();
 
         unsafe {
-            std::env::set_var("SPELUNK_API_KEY", "");
+            std::env::set_var("SPELUNK_SERVER_KEY", "");
         }
         let cfg = Config::load(Some(&config_path)).unwrap();
         assert_eq!(cfg.server_key, Some("sk-sp-login".to_string()));


### PR DESCRIPTION
Closes #437.

## TL;DR
`spelunk login` wrote its token to a separate `cfg.api_key` field that **no auth path read** (everything sends `Authorization: Bearer {cfg.server_key}`), so the token was dead. Rather than add a new env var or reconcile two fields, this points `login`/`logout` at the single canonical `server_key` and removes `api_key` entirely.

This is safe: `login`/`logout` were only added in the previous PR and have no users yet, so changing the config key they use breaks nothing (founder-confirmed, 2026-06-23).

## Changes
- `config::save_api_key`/`remove_api_key` → `save_server_key`/`remove_server_key`, writing/removing `server_key` in `~/.config/spelunk/config.toml`.
- `spelunk login` persists the device-flow token as `server_key`; `spelunk logout` clears it.
- Removed the `Config::api_key` field.

## On #437's other asks
- **Env var for the cloud token** — already satisfied by the existing `SPELUNK_SERVER_KEY` (works with no `config.toml`; CI/headless/containers). No new env var added, per founder review.
- **api_key/server_key disconnect** — resolved by collapsing to one field; the token `login` writes is now the one auth uses.
- Token never logged; `SPELUNK_SERVER_KEY` env-over-config precedence already covered by `env_spelunk_server_key_overrides_config`.

## Test plan
- `cargo test -p spelunk-core --lib config::` — pass (46).
- `cargo test -p spelunk-cli --bins` — pass (67), including renamed `save_server_key_*` / `remove_server_key_*` tests asserting `server_key` is written/removed and other keys preserved.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo audit` — only pre-existing transitive advisories; no deps added.

## Follow-ups (not in this PR)
- **docs-writer:** auth/config reference — document that `spelunk login` stores `server_key` and `SPELUNK_SERVER_KEY` overrides it; CHANGELOG `[Unreleased]` entry.
- Out of scope (#437 is token-only): `server_url` vs cloud `cloud_url` URL split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)