### PR TITLE
ci: fix macOS test job link failure (drop embed-native, bust stale cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,18 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            # Linux links the native embedder (ort/fastembed) so the
+            # `embed-native` path stays under test on at least one platform.
+            test-flags: ""
+          - os: macos-latest
+            # macOS drops `embed-native`: ort's build script bakes absolute
+            # `-lclang_rt.osx` / ONNX-download-cache link paths that don't
+            # survive a restored `target/` cache or a runner-image rotation,
+            # producing `ld: library 'clang_rt.osx' not found`. The embedder is
+            # EXPERIMENTAL / NOT RECOMMENDED and is covered on the Linux leg.
+            test-flags: "--no-default-features"
     steps:
       - uses: actions/checkout@v7
 
@@ -68,15 +79,18 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          # `-v2` bump abandons the poisoned pre-2026-06-24 macOS caches that
+          # held stale ort link directives. Keep restore-keys on the same
+          # `-v2-` prefix so we never fall back into a poisoned cache.
+          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-v2-
 
       - name: Install ast-grep
         run: npm install --global @ast-grep/cli
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose ${{ matrix.test-flags }}
 
   openapi-snapshot:
     name: OpenAPI snapshot check


### PR DESCRIPTION
## Problem

The `Test (macos-latest)` CI leg fails while linking `spelunk-server`:

```
ld: warning: search path '.../ort.pyke.io/dfbin/aarch64-apple-darwin/<hash>' not found
ld: warning: search path '.../Xcode_16.4.app/.../usr/lib/clang/17/lib/darwin' not found
ld: library 'clang_rt.osx' not found
error: linking with `cc` failed: exit status: 1
```

It surfaced on [run 28033460216](https://github.com/spelunk-cloud/spelunk/actions/runs/28033460216) (PR #438), but **that PR is a login/token refactor that never touches embeddings** — and `main` is red too. The same branch flipped green→red across consecutive runs with no relevant diff:

| Time (2026-06-23) | Branch | macOS |
|---|---|---|
| 13:45 | task/engineer-…1339 | ✅ |
| 14:20 | task/engineer-…1339 | ✅ |
| 14:27 | task/engineer-…1339 | ❌ |
| 16:03 | main | ❌ |

## Root cause

Not a missing `CC` — a **poisoned `target/` cache**. `spelunk-server` defaults to `embed-native` (`ort` + `fastembed`). The test job caches `target/` keyed only on `Cargo.lock`. On a cache hit, `ort-sys`'s build-script output comes back **Fresh** (not re-run) with absolute link directives baked in — `-lclang_rt.osx` plus a `-L` into ort's ONNX-runtime download cache (`~/Library/Caches/ort.pyke.io/...`, which is **not** in the cached paths). Neither directory exists on the restoring runner, so `ld` can't resolve `libclang_rt.osx.a` and the link aborts. (A mid-day macOS runner-image rotation likely seeded the first poisoned cache.)

## Fix

- **macOS test leg runs `cargo test --no-default-features`**, dropping `embed-native`. The native embedder is self-labeled *EXPERIMENTAL / NOT RECOMMENDED* and stays under test on the Linux leg, so the fragile native link is removed from macOS without losing coverage.
- **Bump the test-job cache key to `-v2-`** (key + restore-keys) to abandon the poisoned pre-existing macOS caches.

## Verification

Locally on macOS:
- `cargo test --no-default-features --no-run` compiles the entire workspace (incl. `spelunk-server` + `integration_server`) with no ort/fastembed.
- `cargo test --no-default-features -p spelunk-server` → **12 passed, 0 failed**, including `search_without_embedder_returns_400` (the no-embedder path is an intended, tested branch).
- The pre-commit hook's `clippy` (default features) compiled `ort`/`fastembed` clean from scratch, confirming the native link only breaks from stale cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)