### PR TITLE
docs: v0.9 embedder changelog + indexing/protocol docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ caches locally; there is no external embedding service to run. (#439)
 
 The weights are quantized to **Q8_0** and cached as a GGUF (`f2llm-v2-330m-q8_0.gguf`)
 in `~/.local/share/spelunk/models/`: the ~650 MB BF16 safetensors are downloaded once,
-quantized, and written to a ~355 MB GGUF, so subsequent loads read the GGUF directly
+quantized, and written to a ~339 MB GGUF, so subsequent loads read the GGUF directly
 with no network access and no safetensors load (roughly half the on-disk footprint).
 (#441)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,35 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased] — 0.9.0-dev
+## [Unreleased] — 0.9.0
 
 ### Breaking changes — migration required
 
 **Default embedder is now F2LLM-v2-330M via candle, 896-dim, GPU-accelerated on macOS.**
 
 The bundled native embedder has switched from fastembed-rs / Nomic Embed Text v1.5
-(768-dim, ONNX) to **codefuse-ai/F2LLM-v2-330M** (896-dim, Qwen3 decoder, safetensors)
-served via the `candle` runtime. On macOS the prebuilt binary uses Metal GPU
-acceleration; Linux falls back to CPU.
+(768-dim, ONNX) to **codefuse-ai/F2LLM-v2-330M** (896-dim, Qwen3 decoder) served via
+the `candle` runtime. On macOS the prebuilt binary uses Metal GPU acceleration; Linux
+falls back to CPU. The model auto-downloads from Hugging Face Hub on first run and
+caches locally; there is no external embedding service to run. (#439)
 
-**Re-index required:** existing local indexes have 768-dim embeddings and will not
-produce correct results against the 896-dim model. Run `spelunk index <project>`
-after upgrading. The old embeddings table is automatically dropped and recreated
-on first open.
+The weights are quantized to **Q8_0** and cached as a GGUF (`f2llm-v2-330m-q8_0.gguf`)
+in `~/.local/share/spelunk/models/`: the ~650 MB BF16 safetensors are downloaded once,
+quantized, and written to a ~355 MB GGUF, so subsequent loads read the GGUF directly
+with no network access and no safetensors load (roughly half the on-disk footprint).
+(#441)
 
-**Model download on first run:** F2LLM-v2-330M weights (~650 MB) are downloaded
-from Hugging Face Hub into `~/.local/share/spelunk/models/` on first `spelunk-server`
-startup. Subsequent starts use the cached weights with no network access.
+**Re-index required.** Two changes make existing local indexes incompatible:
 
----
+- The embedding dimension changed 768 → 896, so vectors from the old model will not
+  produce correct results against F2LLM.
+- Chunk and snapshot embeddings are now stored as sqlite-vec **`INT8[896]`** instead of
+  `FLOAT[768]`, which makes the on-disk vector index roughly **4× smaller**. (Memory
+  entry embeddings stay `FLOAT[896]`.)
 
-## [Unreleased] — 0.8.4-dev
+On first open after upgrading, spelunk detects the old `FLOAT[768]` `vec0` tables and
+drops and recreates them as `INT8[896]` automatically. Run `spelunk index <project>`
+to re-embed. (#439, #441)
 
 ### Added
 
@@ -77,6 +83,14 @@ startup. Subsequent starts use the cached weights with no network access.
   users keep working with no flag-day and `SPELUNK_SERVER_KEY` still overrides
   for CI and headless use.
 
+- **`POST /v1/projects/{id}/index/embed` now returns raw bytes instead of JSON.**
+  The embedding response body is `application/octet-stream`: raw little-endian
+  `f32` bytes, row-major `[n_chunks × 896]`, in request order, with no per-row
+  `chunk_id` framing (the client maps response row `i` to request chunk `i` by
+  position). This drops per-element JSON serialize/parse on both server and CLI
+  and shrinks the payload roughly 3× (3584 bytes per vector vs ~11 KB of JSON).
+  `docs/openapi.json` is updated to match. (#441)
+
 - **Cloud project slug auto-resolves to its server UUID.** When a team
   `server_url` routes projects by an internal UUID, a human `project_id` slug is
   now resolved to that UUID on first use via `GET /v1/projects` and cached in
@@ -85,6 +99,15 @@ startup. Subsequent starts use the cached weights with no network access.
   automatically if the slug changes, and `SPELUNK_NO_SLUG_CACHE=1` forces a fresh
   lookup. This makes the human-readable `project_id` work transparently against
   cloud-api routing. (ADR-005, #428)
+
+### Fixed
+
+- **Retrieval quality: corrected grouped-query-attention (GQA) handling in the
+  F2LLM embedder.** The first v0.9 build mis-handled the model's 16 attention
+  heads / 8 KV heads (`n_rep = 2`), producing degraded embeddings. The fix
+  changes the vectors F2LLM produces, so search results differ from (and improve
+  on) that initial build. Re-indexing with the fixed embedder is required to get
+  the corrected vectors. (#19, #441)
 
 ### Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,13 @@ for KNN queries. The extension is registered via `sqlite3_auto_extension`
 before any connection is opened (see `crates/spelunk-cli/src/main.rs` and
 `crates/spelunk-server/src/main.rs`).
 
+Chunk and snapshot embeddings are stored as `INT8[896]` (F2LLM vectors are
+L2-normalised, so int8 is lossless enough for ranking and ~4x smaller on disk);
+the int8 L2 distance is rescaled back to the f32 scale by `INT8_SCALE` on read
+(`storage/search.rs`, `storage/snapshots.rs`). Memory-entry embeddings stay
+`FLOAT[896]`. On first open, `db.rs` detects pre-0.9 `FLOAT[768]` `vec0` tables
+and drops and recreates them as `INT8[896]` (re-index required).
+
 ### Incremental indexing
 Each file is hashed with blake3. On re-index, unchanged files are skipped.
 Changed files: delete old chunks + embeddings, reparse, re-embed.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ AI coding agents lose context between sessions and can't trace how code connects
 - **Persistent memory** — store decisions, requirements, and context in git notes. Retrieve them next session, or share them via a server with your team.
 - **Code graph** — trace callers, callees, and imports across file boundaries without reading every file.
 - **Works without any server** — memory, code graph, and full-text/ast-grep search work with just the binary. No API keys, no configuration.
-- **Semantic search built in** — a local `spelunk-server` is autostarted on demand with a bundled native embedder (Nomic Embed Text v1.5); no external inference server required. You can still point spelunk at your own OpenAI-compatible endpoint (LM Studio, Ollama, vLLM) if you prefer.
+- **Semantic search built in** — a local `spelunk-server` is autostarted on demand with a bundled native embedder (codefuse-ai/F2LLM-v2-330M, 896-dim, GPU-accelerated on macOS); no external inference server required. You can still point spelunk at your own OpenAI-compatible endpoint (LM Studio, Ollama, vLLM) if you prefer.
 - **100% local** — your code never leaves your machine. The server is self-hosted (local by default).
 - **Agent-native** — JSON output (`AGENT=true`), git hooks, and a structured memory system built for the agent workflow loop.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@ code and prior decisions, then reason over the results yourself.
 
 Core features (memory, full-text and ast-grep search, code graph, conventions) work without any inference server.
 
-**Semantic search and AI features** go through `spelunk-server`, which is autostarted locally on demand from v0.8.0. It bundles a native embedder (Nomic Embed Text v1.5) — no external embedding server is required by default. Manage it with `spelunk server start|stop|status|logs`. Commands that need the server are marked **(requires server)** below; with `SPELUNK_NO_SERVER=1` they fall back to text/ast-grep search or error clearly. To use your own OpenAI-compatible endpoint instead of the native embedder, set `api_base_url` in `~/.config/spelunk/config.toml`.
+**Semantic search and AI features** go through `spelunk-server`, which is autostarted locally on demand from v0.8.0. It bundles a native embedder (codefuse-ai/F2LLM-v2-330M, 896-dim, GPU-accelerated on macOS) — no external embedding server is required by default. Manage it with `spelunk server start|stop|status|logs`. Commands that need the server are marked **(requires server)** below; with `SPELUNK_NO_SERVER=1` they fall back to text/ast-grep search or error clearly. To use your own OpenAI-compatible endpoint instead of the native embedder, set `api_base_url` in `~/.config/spelunk/config.toml`.
 
 ---
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -6,7 +6,7 @@
 
 **What's built-in:** memory (local SQLite `memory.db`, optionally mirrored to git-notes), code graph, full-text and ast-grep search, and extracted conventions work with just the CLI binary — no server needed. A project's memory always lives in its local `memory.db`; that is the canonical store of record for every memory command.
 
-**What's server-backed:** semantic/hybrid search (`spelunk search --mode auto|semantic|hybrid`), `spelunk explore`, and `spelunk memory harvest` use `spelunk-server` for **inference** (embeddings + LLM). From v0.8.0 the server is autostarted locally on demand and bundles a native embedder (Nomic Embed Text v1.5, via fastembed-rs) — there is no external embedding server to run by default. The auto-discovered loopback server is **inference-only**: it never stores memory. For `memory search` the CLI sends only the query to the loopback embedder and runs the vector search locally against `memory.db` — note text never leaves the local store. If you force offline mode (`SPELUNK_NO_SERVER=1`), these commands fall back to text/ast-grep search or error clearly, and all memory commands operate on `memory.db`.
+**What's server-backed:** semantic/hybrid search (`spelunk search --mode auto|semantic|hybrid`), `spelunk explore`, and `spelunk memory harvest` use `spelunk-server` for **inference** (embeddings + LLM). From v0.8.0 the server is autostarted locally on demand and bundles a native embedder (codefuse-ai/F2LLM-v2-330M, 896-dim, GPU-accelerated on macOS via candle) — there is no external embedding server to run by default. The auto-discovered loopback server is **inference-only**: it never stores memory. For `memory search` the CLI sends only the query to the loopback embedder and runs the vector search locally against `memory.db` — note text never leaves the local store. If you force offline mode (`SPELUNK_NO_SERVER=1`), these commands fall back to text/ast-grep search or error clearly, and all memory commands operate on `memory.db`.
 
 **Where does memory live?** Always `memory.db` for the active project — **unless** you have *explicitly* configured a team `server_url`, which relocates the store of record to that shared server (the team-memory tier). An auto-discovered loopback server does **not** change where memory lives.
 
@@ -455,7 +455,7 @@ Read lines from stdin and emit one JSONL embedding vector per line. Each output 
 
 | Flag | Description |
 |------|-------------|
-| `--query` | Apply the query retrieval prefix (`task: code retrieval | query: …`). Use this flag when the output will be piped into `knn`. Omit it when embedding document text for storage. |
+| `--query` | Apply the F2LLM query instruction prefix (`Instruct: …\nQuery: …`). Use this flag when the output will be piped into `knn`. Omit it when embedding document text for storage. |
 
 Exit codes: `0` = at least one vector emitted, `2` = stdin is a terminal (not a pipe) or embedding backend unreachable.
 
@@ -468,11 +468,12 @@ echo "authentication" | spelunk plumbing embed --query | spelunk plumbing knn --
 Example output:
 
 ```json
-{"model":"nomic-embed-text-v1.5","dimensions":768,"vector":[0.021,-0.043,...]}
+{"model":"f2llm-v2-330m","dimensions":896,"vector":[0.021,-0.043,...]}
 ```
 
-(The model name and dimensionality reflect whichever embedder the server is
-using — the bundled native embedder is Nomic Embed Text v1.5 at 768 dimensions.)
+(The model name reflects the `embedding_model` config value and the
+dimensionality reflects whichever embedder the server is using — the bundled
+native embedder is codefuse-ai/F2LLM-v2-330M at 896 dimensions.)
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,20 +97,27 @@ Each file is hashed with blake3. On re-index, unchanged files are skipped entire
 
 ### Embedding format
 
-Chunks are embedded using EmbeddingGemma's recommended format:
+Chunks are embedded with **codefuse-ai/F2LLM-v2-330M** (Qwen3 decoder, 896-dim),
+served by `spelunk-server` via the candle runtime (Metal/GPU on macOS, CPU on
+Linux). Documents use the format:
 ```
-title: {name} | text: {content}
+title: {name | "none"} | text: {content}
 ```
 
-Queries use: `task: code retrieval | query: {q}`
+Queries use an instruction prefix: `Instruct: {instruction}\nQuery: {q}`. For
+example, code search uses `Instruct: Given a code search query, retrieve the
+relevant code snippets\nQuery: {q}`.
 
 See `Chunk::embedding_text()` in `src/indexer/chunker.rs`.
 
+Vectors are L2-normalised and stored as sqlite-vec `INT8[896]` (chunk and
+snapshot embeddings); memory-entry embeddings stay `FLOAT[896]`.
+
 ### Backend abstraction
 
-The `EmbeddingBackend` and `LlmBackend` traits are the only interface between spelunk and inference. The concrete implementation (LM Studio) is gated behind a feature flag and re-exported in `src/backends.rs`.
+The `EmbeddingBackend` and `LlmBackend` traits (in spelunk-core's `embeddings/` and `llm/`) are the only interface between spelunk and inference. spelunk-core ships **no** concrete implementations; the concrete backends live in `spelunk-server` (the native F2LLM embedder in `embedder_native.rs`, plus OpenAI-compatible HTTP clients). The CLI reaches inference only through `ServerLlmClient` / `ServerEmbedClient` in `crates/spelunk-cli/src/server_client.rs`.
 
-To add a new backend: implement the trait, add a feature flag, gate the re-export. Nothing outside `src/embeddings/`, `src/llm/`, and `src/backends.rs` imports a concrete backend.
+To add a new backend: implement the trait in spelunk-server and wire it into the server's endpoint handlers. Nothing in spelunk-core imports a concrete backend.
 
 ### Secret scanning
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,7 @@ Every command accepts `-c, --config <path>` to override the default config file
 v0.8.0 binary (`spelunk <command> --help`).
 
 From v0.8.0 a local `spelunk-server` is autostarted on demand and provides
-embeddings (native, via fastembed-rs) and — when a chat model is configured —
+embeddings (native, via the candle-served F2LLM-v2-330M model) and — when a chat model is configured —
 LLM inference. Commands that need semantic search or an LLM (`search` in
 semantic/auto mode, `explore`, `memory harvest`) use that server; the
 always-available commands (`graph`, text/ast-grep `search`, `memory add/list`,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,10 +103,10 @@ spelunk search "where do we validate auth tokens"
 ```
 
 No config file, no Docker, no external embedder. The server bundles a native
-embedding model (Nomic Embed Text v1.5, via fastembed-rs); the weights are
-downloaded once on first use and cached under
-`~/.local/share/spelunk/models/`. There is no LM Studio or other external
-inference server to run by default. The next section covers the
+embedding model (codefuse-ai/F2LLM-v2-330M, 896-dim, GPU-accelerated on macOS
+via candle); the weights are downloaded once on first use, quantized to Q8_0,
+and cached as a GGUF under `~/.local/share/spelunk/models/`. There is no LM
+Studio or other external inference server to run by default. The next section covers the
 always-available commands that work even before you index.
 
 You can manage the background server explicitly if you want:
@@ -204,8 +204,9 @@ For how discovery works and how to point the CLI at a remote server, see
 
 ### Using your own inference server (advanced)
 
-By default the bundled `spelunk-server` provides embeddings (native, via
-fastembed-rs) and — when a chat model is configured — LLM inference. If you'd
+By default the bundled `spelunk-server` provides embeddings (native, via the
+candle-served F2LLM-v2-330M model) and — when a chat model is configured — LLM
+inference. If you'd
 rather have spelunk talk directly to your own OpenAI-compatible endpoint (e.g.
 LM Studio on port `1234`, Ollama on `11434`, or a vLLM proxy) instead of the
 native embedder, point it there in `~/.config/spelunk/config.toml`:

--- a/docs/plumbing-and-porcelain.md
+++ b/docs/plumbing-and-porcelain.md
@@ -60,7 +60,7 @@ echo "auth flow" \
   | jq -r '"\(.score | . * 100 | round)%  \(.file_path):\(.start_line)  \(.name // "(anon)")"'
 ```
 
-`embed --query` prepends the retrieval prefix expected by EmbeddingGemma, producing a JSON object with a `vector` field. `knn` reads that object from stdin and emits one result object per line, sorted by similarity score descending.
+`embed --query` prepends the F2LLM instruction prefix expected for queries (`Instruct: …\nQuery: {q}`), producing a JSON object with a `vector` field. `knn` reads that object from stdin and emits one result object per line, sorted by similarity score descending.
 
 ### List stale files and re-index only those
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -141,7 +141,7 @@ All clients writing to the same project must use the same embedding model.
 The server records the embedding dimension on the first write and rejects
 subsequent writes with a different dimension.
 
-Default: 768 dimensions (EmbeddingGemma 300M).
+Default: 896 dimensions (codefuse-ai/F2LLM-v2-330M, the bundled native embedder).
 
 If your team uses a different model, configure the server at startup:
 
@@ -214,6 +214,13 @@ POST   /v1/projects/{project_id}/search           (query embedding proxy for CLI
 POST   /v1/projects/{project_id}/explore          (SSE — LLM reasoning loop)
 POST   /v1/projects/{project_id}/llm/complete     (SSE — raw LLM completion)
 ```
+
+`POST /index/embed` accepts a JSON batch of chunks (max 256) and returns the
+vectors as `application/octet-stream`: raw little-endian `f32` bytes, row-major
+`[n_chunks × dim]` (896 with the default embedder), in request order, with no
+per-row framing. The client maps response row `i` to request chunk `i` by
+position. The server does not store the vectors — the CLI is the only persistent
+store for index data. See `docs/openapi.json` for the full schema.
 
 ### Conflict detection
 


### PR DESCRIPTION
## Summary

Refreshes the CHANGELOG and in-repo prose docs for the v0.9 embedder work, which merged after the `[Unreleased]` block was last rolled (PR #435). Covers **PR #439** (candle-served F2LLM-v2-330M) and **PR #441** (Q8_0 + int8 quantization, octet-stream wire format, #19 GQA fix).

**Docs only — no source changed.**

## CHANGELOG
- **Consolidated** the two `[Unreleased]` blocks (`0.9.0-dev` + `0.8.4-dev`) into a single `[Unreleased] — 0.9.0` section (login/sync folds into the 0.9.0 tag), keeping Keep-a-Changelog grouping (Breaking / Added / Changed / Fixed / Dependencies).
- Added the #441 facts: Q8_0 weights cached as a GGUF (~355 MB vs ~650 MB BF16 safetensors), chunk + snapshot vectors stored as sqlite-vec `INT8[896]` (~4x smaller index, re-index required), and the #19 GQA retrieval-quality fix.
- Documented the `/index/embed` wire-format change to `application/octet-stream` (raw LE f32, row-major `[n_chunks × 896]`, request order, no `chunk_id` framing).
- Corrected the stale "~650 MB / safetensors" line to the quantized GGUF.

## Prose docs
Replaced stale `nomic` / `fastembed` / `768` / `EmbeddingGemma` / `task: code retrieval | query:` references with F2LLM-v2-330M / candle / 896-dim / `Instruct: …\nQuery: …` across: `CLAUDE.md`, `README.md`, `SKILL.md`, `docs/architecture.md`, `docs/server.md`, `docs/getting-started.md`, `docs/commands.md`, `docs/plumbing-and-porcelain.md`, `docs/agent-guide.md`. Added the octet-stream embed-response note to `docs/server.md`, and an int8 storage note to `CLAUDE.md` and `docs/architecture.md`.

## Notes for review
- **GGUF size:** the task brief cited ~339 MB, but the merged `embedder_native.rs` source comment says **~355 MB** in two places, so I used ~355 MB to match the shipped code. Please confirm the intended figure before the final edit.
- Out-of-scope stale hits left untouched: `bench/`, `baselines/`, `tmp/`, `vendor/fastembed/`, `docs/plans/`, `docs/adr/` (historical artifacts / vendored / plans), and the user-supplied external OpenAI-endpoint config examples in `docs/getting-started.md` / `CHANGELOG.md` (legitimate alternate-model examples).
- Pre-existing em-dashes in relocated changelog bullets and untouched doc sentences were left as-is to keep the diff scoped; new copy I wrote avoids them.

**Held for founder review before the 0.9.0 tag** — do not merge/tag; Johan does the final changelog edit + version bump + tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)