### PR TITLE
release: cut v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased] — 0.9.0
+## [Unreleased]
+
+## [0.9.0] — 2026-06-26
 
 ### Breaking changes — migration required
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4709,7 +4709,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"


### PR DESCRIPTION
## What

Cuts the **v0.9.0** release:

- Roll CHANGELOG `[Unreleased] — 0.9.0` → `## [0.9.0] — 2026-06-26` (fresh empty `[Unreleased]` placeholder left at top).
- Bump the three workspace crates `0.8.3` → `0.9.0`: `spelunk-core`, `spelunk-cli`, `spelunk-server` (+ matching `Cargo.lock` entries).

No code changes — every 0.9.0 feature is already on `main`:

- F2LLM-v2-330M candle embedder, 896-dim, Metal/GPU on macOS (#439)
- Q8_0 + int8 quantization and raw-f32 embed protocol (#441)
- `spelunk login` / `logout` and two-way local↔cloud memory sync
- v0.9 indexing + server-protocol docs (#442)

## After merge

Tag the merge commit `v0.9.0` to trigger the release build. (No tag is pushed by this PR.)

## Test plan

- [x] `cargo metadata --locked` passes — `Cargo.lock` is consistent with the bumped manifests.
- [x] Pre-commit hook (`cargo fmt --check`, `cargo clippy`, `cargo check`) passed; full workspace compiles at 0.9.0.
- [x] Diff is limited to CHANGELOG + the three crate versions + their `Cargo.lock` entries (no unrelated lock churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)