### PR TITLE
docs: fix circular build-from-source reference chain (spelunk-oss^29)

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -1,8 +1,10 @@
 # Building from Source
 
-Most users should use the precompiled binary — see [Getting Started](getting-started.md).
+Most users should install from a prebuilt binary — see [Getting Started](getting-started.md).
 Build from source if you want to modify spelunk, run the latest unreleased code, or
-target a platform without a prebuilt release.
+target a platform without a prebuilt release (including Intel Macs —
+`x86_64-apple-darwin` prebuilt binaries are no longer published; see
+[Getting Started](getting-started.md#1-install-spelunk) for context).
 
 ## Prerequisites
 
@@ -16,15 +18,22 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 Rust 1.80 or later is required (spelunk uses the 2024 edition).
 
-### Inference server
+### No external inference server required
 
-spelunk calls any OpenAI-compatible inference server for embeddings and chat.
-[LM Studio](https://lmstudio.ai/) is the recommended option for local use —
-download it and load an embedding model before running any commands.
-See [Getting Started](getting-started.md#2-set-up-an-inference-server)
-for model recommendations and alternative servers (Ollama, vLLM).
+From v0.9.0, `spelunk-server` bundles a native embedder
+(codefuse-ai/F2LLM-v2-330M, 896-dim, via candle). No LM Studio, Ollama, or
+other external inference server is needed. The CLI auto-starts the server on
+first use; model weights are downloaded once and cached under
+`~/.local/share/spelunk/models/`.
+
+If you want GPU acceleration on macOS, build `spelunk-server` with the `metal`
+feature (see [Build feature flags](#build-feature-flags) below).
 
 ## Build
+
+This is a Cargo workspace with three crates: `spelunk-core` (library),
+`spelunk-cli` (`spelunk` binary), and `spelunk-server` (`spelunk-server` binary).
+Build them all together:
 
 ```bash
 git clone https://github.com/spelunk-cloud/spelunk
@@ -37,19 +46,66 @@ cargo build
 cargo build --release
 ```
 
-Copy the binary to your `$PATH`:
+This produces both binaries under `target/release/`. Copy them to your `$PATH`:
 
 ```bash
-cp target/release/spelunk ~/.local/bin/
+cp target/release/spelunk target/release/spelunk-server ~/.local/bin/
 # or
-sudo cp target/release/spelunk /usr/local/bin/
+sudo cp target/release/spelunk target/release/spelunk-server /usr/local/bin/
 ```
 
 Verify:
 
 ```bash
 spelunk --version
+spelunk-server --version
 ```
+
+### Building individual binaries
+
+```bash
+# CLI only
+cargo build --release -p spelunk-cli
+
+# Server only
+cargo build --release -p spelunk-server
+```
+
+## Build feature flags
+
+### spelunk-server features
+
+| Feature | Default | Description |
+|---|---|---|
+| `embed-native` | yes | Bundle the F2LLM-v2-330M native embedder via candle (CPU). Disable to build a server that relies on an external OpenAI-compatible embedding endpoint. |
+| `metal` | no | Enable Metal GPU acceleration on macOS. Requires the `embed-native` feature. Add when building the macOS release binary for best performance. |
+
+Enable non-default features with `--features`:
+
+```bash
+# macOS release build with Metal GPU acceleration
+cargo build --release -p spelunk-server --features metal
+
+# Server without the bundled embedder (external endpoint required)
+cargo build --release -p spelunk-server --no-default-features
+```
+
+### spelunk-cli features
+
+| Feature | Default | Description |
+|---|---|---|
+| `rich-formats` | no | Enable parsing of PDF, DOCX, and XLSX files during indexing (pulls in `lopdf`, `docx-rs`, and `calamine`). |
+
+```bash
+# CLI with rich document format support
+cargo build --release -p spelunk-cli --features rich-formats
+```
+
+### spelunk-core features
+
+| Feature | Default | Description |
+|---|---|---|
+| `rich-formats` | no | Same as above — `spelunk-cli/rich-formats` propagates to this crate automatically. |
 
 ## Running tests
 
@@ -73,3 +129,5 @@ cargo audit
   version, check that all `tree-sitter-*` grammar crates are compatible (see `Cargo.toml`).
 - Release builds enable LTO and `codegen-units = 1` for a smaller, faster binary.
   Expect a longer compile on first release build.
+- Shared dependency versions are declared in the workspace root `Cargo.toml` under
+  `[workspace.dependencies]`. Bump versions there, not in each crate's `Cargo.toml`.

--- a/docs/building.md
+++ b/docs/building.md
@@ -2,9 +2,8 @@
 
 Most users should install from a prebuilt binary — see [Getting Started](getting-started.md).
 Build from source if you want to modify spelunk, run the latest unreleased code, or
-target a platform without a prebuilt release (including Intel Macs —
-`x86_64-apple-darwin` prebuilt binaries are no longer published; see
-[Getting Started](getting-started.md#1-install-spelunk) for context).
+target a platform without a prebuilt release (Intel Macs included — no
+`x86_64-apple-darwin` prebuilt is published).
 
 ## Prerequisites
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,21 +55,28 @@ spelunk --version
 Download the tarball for your platform from the
 [releases page](https://github.com/spelunk-cloud/spelunk/releases) and put both
 binaries on your `$PATH`. Release tarballs are named
-`spelunk-<version>-<target>.tar.gz`:
+`spelunk-<version>-<target>.tar.gz`.
+
+Supported targets: `aarch64-apple-darwin` (Apple Silicon Mac),
+`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`.
+
+> **Intel Macs (`x86_64-apple-darwin`):** prebuilt binaries are not published for
+> this target — Apple deprecated the architecture and Apple Silicon replaced it on
+> new hardware six years ago. Intel Mac users must build from source; see
+> [Building from source](building.md) (`cargo build --release` works unmodified on
+> `x86_64-apple-darwin`).
 
 ```bash
-# Example: macOS (universal). Replace <version> with the release tag, e.g. v0.8.0
-curl -L https://github.com/spelunk-cloud/spelunk/releases/download/<version>/spelunk-<version>-universal-apple-darwin.tar.gz \
+# Example: macOS Apple Silicon. Replace <version> with the release tag, e.g. v0.8.0
+curl -L https://github.com/spelunk-cloud/spelunk/releases/download/<version>/spelunk-<version>-aarch64-apple-darwin.tar.gz \
   | tar -xz && chmod +x spelunk spelunk-server && sudo mv spelunk spelunk-server /usr/local/bin/
 
 # Verify
 spelunk --version
 ```
 
-Per-arch targets (`x86_64-apple-darwin`, `aarch64-apple-darwin`,
-`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`) follow the same
-pattern — swap the target in the filename. Building from source? See
-[Building](building.md).
+Swap the target in the filename for Linux. Building from source? See
+[Building from source](building.md).
 
 ### Running spelunk-server as a service (optional)
 
@@ -78,12 +85,6 @@ a launchd plist (`packaging/spelunk-server.plist`) for macOS and a systemd unit
 (`packaging/spelunk-server.service`) for Linux. Most users don't need these —
 `spelunk` autostarts the server on demand (see section 2) — but they're useful
 on a shared or always-on host.
-> **Intel Macs (`x86_64-apple-darwin`):** we no longer publish a prebuilt binary for
-> this target — Apple deprecated the architecture, and Apple Silicon replaced it on
-> new hardware six years ago. Intel Mac users should build from source instead; see
-> [Building](building.md) (`cargo build --release` works unmodified on `x86_64-apple-darwin`).
-
-> Building from source? See [Building](building.md).
 
 ## 2. Cold start: working search in under a minute
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,9 +106,9 @@ spelunk search "where do we validate auth tokens"
 No config file, no Docker, no external embedder. The server bundles a native
 embedding model (codefuse-ai/F2LLM-v2-330M, 896-dim, GPU-accelerated on macOS
 via candle); the weights are downloaded once on first use, quantized to Q8_0,
-and cached as a GGUF under `~/.local/share/spelunk/models/`. There is no LM
-Studio or other external inference server to run by default. The next section covers the
-always-available commands that work even before you index.
+and cached as a GGUF under `~/.local/share/spelunk/models/`. No LM Studio or
+other external inference server is needed. The next section covers commands
+that work even before you index.
 
 You can manage the background server explicitly if you want:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -37,7 +37,7 @@ Two install paths live outside this workflow:
 > **Note:** `x86_64-apple-darwin` (Intel Mac) prebuilt binaries were dropped —
 > Apple deprecated the architecture and Apple Silicon replaced it on new
 > hardware six years ago. Intel Mac users build from source (see
-> `docs/getting-started.md`).
+> `docs/building.md`).
 
 ## Cutting a release
 


### PR DESCRIPTION
## Summary

- **releasing.md**: corrected Intel Mac cross-reference from `getting-started.md` to `building.md` (this was the circular reference root cause)
- **getting-started.md**: removed phantom tarball targets (`x86_64-apple-darwin`, `universal-apple-darwin`) that never existed in release.yml; moved Intel Mac callout to a proper position with the correct link; tightened prose
- **building.md**: added workspace crate structure overview, both binaries in build/install commands, feature flags table (embed-native, metal, rich-formats), individual binary build examples, Intel Mac note in intro

All cross-references verified against `release.yml` and `Cargo.toml`. No code changes.

## Test plan

- [ ] All internal doc links resolve (`[Building from source](building.md)`, `[Getting Started](getting-started.md)`, `[Build feature flags](#build-feature-flags)`)
- [ ] Feature flags table matches Cargo.toml features (`embed-native`, `metal`, `rich-formats`)
- [ ] Tarball targets in getting-started.md match those published by release.yml (`aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`)
- [ ] No phantom `x86_64-apple-darwin` or `universal-apple-darwin` tarballs referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)