### PR TITLE
feat(cli): add --version to spelunk-server; prefix --help with version (spelunk-oss^26)

### DIFF
--- a/crates/spelunk-cli/src/cli/mod.rs
+++ b/crates/spelunk-cli/src/cli/mod.rs
@@ -26,7 +26,13 @@ pub use cmd::status::StatusArgs;
 
 /// spelunk — local code intelligence
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = None,
+    before_help = concat!("spelunk v", env!("CARGO_PKG_VERSION"))
+)]
 pub struct Cli {
     /// Path to config file (default: ~/.config/spelunk/config.toml)
     #[arg(short, long, global = true)]

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -14,7 +14,12 @@ use utoipa::OpenApi;
 mod embedder_native;
 
 #[derive(Parser, Debug)]
-#[command(name = "spelunk-server", about = "Shared memory server for spelunk")]
+#[command(
+    name = "spelunk-server",
+    version,
+    about = "Shared memory server for spelunk",
+    before_help = concat!("spelunk-server v", env!("CARGO_PKG_VERSION"))
+)]
 struct Args {
     /// Port to listen on
     #[arg(long, default_value = "7777")]

--- a/docs/server.md
+++ b/docs/server.md
@@ -184,6 +184,10 @@ SPELUNK_SERVER_KEY=your-key docker compose -f docker-compose.full.yml up -d
 # Build
 cargo build --release --bin spelunk-server
 
+# Check version
+./target/release/spelunk-server --version
+# spelunk-server 0.9.0
+
 # Run
 ./target/release/spelunk-server \
   --db /var/lib/spelunk/spelunk.db \


### PR DESCRIPTION
## Summary

- Adds `version` attribute to `spelunk-server` clap `#[command]`, enabling `-V`/`--version` flag outputting `spelunk-server 0.9.0`
- Adds `before_help = concat!("spelunk-server v", env!("CARGO_PKG_VERSION"))` to spelunk-server and the spelunk CLI, prepending version to `--help` output
- Adds `--version` usage example to `docs/server.md`

## Test plan

- `./target/release/spelunk-server --version` outputs `spelunk-server 0.9.0`
- `./target/release/spelunk --version` outputs `spelunk 0.9.0`
- `./target/release/spelunk-server --help` shows `spelunk-server v0.9.0` before the help text
- `./target/release/spelunk --help` shows `spelunk v0.9.0` before the help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)