### PR TITLE
fix(test): force offline index to avoid loopback embedder dim mismatch (spelunk-oss^30)

### DIFF
--- a/crates/spelunk-cli/tests/backend_kind_diagnostic.rs
+++ b/crates/spelunk-cli/tests/backend_kind_diagnostic.rs
@@ -31,9 +31,14 @@ fn setup_offline_project() -> (tempfile::TempDir, std::path::PathBuf, std::path:
     )
     .unwrap();
 
-    // Build index (parse-only; no embedding server needed).
+    // Build index. `SPELUNK_NO_SERVER=1` forces offline so the index skips the
+    // embed phase entirely (no embedding server needed); without it, loopback
+    // auto-discovery can pick up a `spelunk-server` running on 127.0.0.1:7777
+    // and route the embed call there, which fails the build with a dimension
+    // mismatch. We only care about the SQLite memory-backend path here.
     Command::cargo_bin("spelunk")
         .unwrap()
+        .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
         .arg(&config_path)
         .arg("index")
@@ -56,6 +61,7 @@ fn status_json_includes_memory_backend_field() {
         .unwrap()
         .current_dir(&project_dir)
         .env_remove("SPELUNK_SERVER_URL")
+        .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
         .arg(&config_path)
         .arg("status")
@@ -106,6 +112,7 @@ fn check_json_includes_memory_backend_field() {
         .unwrap()
         .current_dir(&project_dir)
         .env_remove("SPELUNK_SERVER_URL")
+        .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
         .arg(&config_path)
         .arg("check")
@@ -151,6 +158,7 @@ fn status_text_mentions_memory_backend() {
         .unwrap()
         .current_dir(&project_dir)
         .env_remove("SPELUNK_SERVER_URL")
+        .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
         .arg(&config_path)
         .arg("status")

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -721,7 +721,8 @@ async fn test_index_prints_note_when_no_server_configured() {
     .unwrap();
 
     let mut cmd = Command::cargo_bin("spelunk").unwrap();
-    cmd.arg("--config")
+    cmd.env("SPELUNK_NO_SERVER", "1") // ensure offline even if a local server is running
+        .arg("--config")
         .arg(&config_path)
         .arg("index")
         .arg(&project_dir)
@@ -855,8 +856,11 @@ fn test_search_index_but_no_embedder_falls_back_to_ast_grep() {
     .unwrap();
 
     // Build the index (offline — no embedder needed for parse phase).
+    // SPELUNK_NO_SERVER=1 keeps the embed phase from auto-discovering a
+    // loopback spelunk-server on 127.0.0.1:7777.
     Command::cargo_bin("spelunk")
         .unwrap()
+        .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
         .arg(&config_path)
         .arg("index")
@@ -901,6 +905,7 @@ fn test_search_explicit_hybrid_no_embedder_falls_back_to_text() {
 
     Command::cargo_bin("spelunk")
         .unwrap()
+        .env("SPELUNK_NO_SERVER", "1") // prevent accidental loopback auto-discovery
         .arg("--config")
         .arg(&config_path)
         .arg("index")
@@ -939,6 +944,7 @@ fn test_search_explicit_semantic_no_server_falls_back_to_text() {
 
     Command::cargo_bin("spelunk")
         .unwrap()
+        .env("SPELUNK_NO_SERVER", "1") // prevent accidental loopback auto-discovery
         .arg("--config")
         .arg(&config_path)
         .arg("index")

--- a/crates/spelunk-cli/tests/read_memory.rs
+++ b/crates/spelunk-cli/tests/read_memory.rs
@@ -41,9 +41,13 @@ fn indexed_project_with_memory_note() -> (tempfile::TempDir, std::path::PathBuf,
 
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/simple-project");
 
-    // Index the fixture project.
+    // Index the fixture project. SPELUNK_NO_SERVER=1 forces offline so the embed
+    // phase is skipped — these plumbing tests only need parsed chunks + a memory
+    // note, not embeddings, and without it the index would auto-discover a
+    // loopback spelunk-server on 127.0.0.1:7777 and fail on a dim mismatch.
     Command::cargo_bin("spelunk")
         .unwrap()
+        .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
         .arg(&config_path)
         .arg("index")


### PR DESCRIPTION
## Problem

Three integration tests in `crates/spelunk-cli/tests/backend_kind_diagnostic.rs` fail when a `spelunk-server` is running on the loopback port (`127.0.0.1:7777`):

```
Error: index/embed returned 9532 bytes, expected 3584 (1 × 896-dim f32)
```

## Root cause

The embedding dimension is **not** the bug — it is already 896 consistently across `spelunk-core` and `spelunk-server`. The real issue is test isolation.

These tests intend to run fully offline (their config sets no `server_url`) but only called `.env_remove("SPELUNK_SERVER_URL")`. That does not disable **loopback auto-discovery**: when a `spelunk-server` is listening on `127.0.0.1:7777`, the `index` embed phase auto-discovers it (`Tier::Server`) and routes the embed call there, which fails on a response-size mismatch. With `SPELUNK_NO_SERVER=1` the probe is short-circuited to `Tier::Offline`, the embed phase returns early, and the SQLite memory backend resolves as intended.

The same latent bug affected nine other tests whose `index` build step omitted the guard:
- 4 in `tests/e2e_cli.rs` (the search-side commands already set `SPELUNK_NO_SERVER=1`; only the index build was missing it)
- 5 in `tests/read_memory.rs`

## Fix

Add `SPELUNK_NO_SERVER=1` to the affected `index` invocations, matching the established pattern already used elsewhere in `e2e_cli.rs` ("ensure offline even if a local server is running"). Test-only change; no production code touched.

## Test plan

Run with a `spelunk-server` active on `127.0.0.1:7777` (the condition that triggers the original failures):

- `cargo test -p spelunk-cli --test backend_kind_diagnostic` → `3 passed; 0 failed`
- `cargo test -p spelunk-cli` → all 19 test binaries green, 0 failures
- `cargo build` → clean (`Finished dev profile`)