### PR TITLE
feat(cli): pre-flight embedding-dim check guards against stale loopback server

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -284,7 +284,16 @@ async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
 
     // ── 2. Explicit server_url from config / env ─────────────────────────────
     if let Some(url) = url {
-        return probe_url(url, key, REMOTE_PROBE_TIMEOUT, false).await;
+        return match probe_url(url, key, REMOTE_PROBE_TIMEOUT, false).await {
+            Ok(tier) => tier,
+            Err(e) => {
+                // Dim mismatch on an explicitly-configured server: surface the error
+                // to the terminal and fall back to offline so the process exits cleanly
+                // rather than hanging on a deep-in-command failure.
+                tracing::error!("{e}");
+                Tier::Offline
+            }
+        };
     }
 
     // ── 3. Loopback auto-discovery ───────────────────────────────────────────
@@ -294,7 +303,10 @@ async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
         tracing::debug!(
             "loopback auto-discovery: found server.port={port}, probing {loopback_url}"
         );
-        let tier = probe_url(&loopback_url, None, LOOPBACK_PROBE_TIMEOUT, true).await;
+        // Loopback probes never produce hard errors (auto_discovered=true), so unwrap is safe.
+        let tier = probe_url(&loopback_url, None, LOOPBACK_PROBE_TIMEOUT, true)
+            .await
+            .unwrap_or(Tier::Offline);
         if tier.is_server() {
             return tier;
         }
@@ -304,7 +316,9 @@ async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
     // Step 3b: default port 7777
     let default_url = format!("http://127.0.0.1:{DEFAULT_LOOPBACK_PORT}");
     tracing::debug!("loopback auto-discovery: probing default {default_url}");
-    let tier = probe_url(&default_url, None, LOOPBACK_PROBE_TIMEOUT, true).await;
+    let tier = probe_url(&default_url, None, LOOPBACK_PROBE_TIMEOUT, true)
+        .await
+        .unwrap_or(Tier::Offline);
     if tier.is_server() {
         return tier;
     }
@@ -313,18 +327,23 @@ async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
     Tier::Offline
 }
 
-/// Probe a single URL and return the resulting `Tier`.
+/// Probe a single URL and return the resulting `Tier`, or a hard error string
+/// for an explicit-URL dimension mismatch.
+///
+/// `auto_discovered = true` means the URL was found via the loopback probe rather
+/// than set explicitly in config or environment. The distinction controls whether a
+/// dimension mismatch is a soft downgrade (loopback) or a hard error (explicit URL).
 async fn probe_url(
     url: &str,
     key: Option<&str>,
     timeout: std::time::Duration,
     auto_discovered: bool,
-) -> Tier {
+) -> Result<Tier, String> {
     let client = match reqwest::Client::builder().timeout(timeout).build() {
         Ok(c) => c,
         Err(e) => {
             tracing::warn!("could not build HTTP client for server probe: {e}");
-            return Tier::Offline;
+            return Ok(Tier::Offline);
         }
     };
 
@@ -335,12 +354,40 @@ async fn probe_url(
 
     match req.send().await {
         Ok(resp) if resp.status().is_success() => {
-            let caps = parse_capabilities(url, resp).await;
-            Tier::Server {
+            let (caps, server_dim) = parse_health(url, resp).await;
+
+            // If the server advertises index.embed, its embedding dimension must match ours.
+            if caps.index_embed && server_dim != 0 {
+                let expected = spelunk_core::embeddings::EMBEDDING_DIM;
+                if server_dim != expected {
+                    if auto_discovered {
+                        // Loopback auto-discovery: downgrade gracefully — the user did
+                        // not explicitly configure this server.
+                        tracing::warn!(
+                            "spelunk-server at {url} serves {server_dim}-dim embeddings; \
+                             this CLI expects {expected}-dim. Ignoring loopback server. \
+                             Restart the server (`spelunk server start`) or set \
+                             SPELUNK_NO_SERVER=1 to suppress this probe."
+                        );
+                        return Ok(Tier::Offline);
+                    } else {
+                        // Explicit server_url: surface as a hard error so the user
+                        // gets actionable guidance before any command runs.
+                        return Err(format!(
+                            "spelunk-server at {url} serves {server_dim}-dim embeddings; \
+                             this CLI expects {expected}-dim.\n\
+                             Upgrade or replace the server, or remove server_url from \
+                             ~/.config/spelunk/config.toml."
+                        ));
+                    }
+                }
+            }
+
+            Ok(Tier::Server {
                 url: url.to_string(),
                 caps,
                 auto_discovered,
-            }
+            })
         }
         Ok(resp) => {
             if !auto_discovered {
@@ -349,7 +396,7 @@ async fn probe_url(
                     resp.status()
                 );
             }
-            Tier::Offline
+            Ok(Tier::Offline)
         }
         Err(e) => {
             if !auto_discovered {
@@ -357,18 +404,27 @@ async fn probe_url(
                     "spelunk-server at {url} unreachable — running in offline mode: {e}"
                 );
             }
-            Tier::Offline
+            Ok(Tier::Offline)
         }
     }
 }
 
-async fn parse_capabilities(url: &str, resp: reqwest::Response) -> Capabilities {
+/// Parse the health response body and return `(Capabilities, embedding_dim)`.
+///
+/// `embedding_dim` is `0` when the field is absent (old server without the field)
+/// or when no embedder is loaded. A `0` dim skips the dimension check in `probe_url`
+/// for backward compatibility.
+async fn parse_health(url: &str, resp: reqwest::Response) -> (Capabilities, usize) {
     #[derive(serde::Deserialize)]
     struct HealthBody {
         #[serde(default)]
         capabilities: Vec<String>,
         instance_id: Option<String>,
         started_by: Option<u32>,
+        /// Embedding dimension produced by this server's embedder.
+        /// Absent on old servers that pre-date this field; defaults to 0 (skip check).
+        #[serde(default)]
+        embedding_dim: usize,
     }
 
     match resp.json::<HealthBody>().await {
@@ -390,11 +446,15 @@ async fn parse_capabilities(url: &str, resp: reqwest::Response) -> Capabilities 
                 tracing::debug!("server instance_id: {id}");
             }
             let cap_strs: Vec<&str> = body.capabilities.iter().map(String::as_str).collect();
-            Capabilities::from_server_caps(&cap_strs)
+            (
+                Capabilities::from_server_caps(&cap_strs),
+                body.embedding_dim,
+            )
         }
         Err(_) => {
             // Legacy server returns plain-text "ok" — conservative fallback.
-            Capabilities::legacy_memory_only()
+            // embedding_dim = 0 skips the dimension check.
+            (Capabilities::legacy_memory_only(), 0)
         }
     }
 }
@@ -771,5 +831,126 @@ mod tests {
             );
         }
         unsafe { std::env::remove_var("SPELUNK_NO_SERVER") };
+    }
+
+    // ── Embedding-dim pre-flight checks ──────────────────────────────────────
+
+    /// Helper: build a health JSON body with the given capabilities and dim.
+    fn health_body(caps: &[&str], dim: usize) -> serde_json::Value {
+        serde_json::json!({
+            "status": "ok",
+            "version": "0.9.0",
+            "capabilities": caps,
+            "instance_id": "00000000-0000-0000-0000-000000000001",
+            "started_by": null,
+            "embedding_dim": dim
+        })
+    }
+
+    /// Auto-discovered loopback server with wrong dim → `Tier::Offline` (soft downgrade).
+    #[tokio::test]
+    async fn probe_loopback_dim_mismatch_downgrades_to_offline() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // Return a health body claiming 768-dim embeddings — wrong for the current CLI (896).
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body(
+                &["memory", "index.embed", "search.semantic"],
+                768,
+            )))
+            .mount(&server)
+            .await;
+
+        let result = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true).await;
+        assert!(
+            matches!(result, Ok(Tier::Offline)),
+            "auto-discovered loopback with wrong dim must downgrade to Offline; got {result:?}"
+        );
+    }
+
+    /// Auto-discovered loopback server with correct dim → `Tier::Server`.
+    #[tokio::test]
+    async fn probe_loopback_dim_match_returns_server() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body(
+                &["memory", "index.embed", "search.semantic"],
+                spelunk_core::embeddings::EMBEDDING_DIM,
+            )))
+            .mount(&server)
+            .await;
+
+        let result = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true).await;
+        assert!(
+            matches!(result, Ok(Tier::Server { .. })),
+            "auto-discovered loopback with correct dim must return Server; got {result:?}"
+        );
+    }
+
+    /// Auto-discovered loopback server with no embedder (dim 0) → `Tier::Server`
+    /// (dim 0 means no `index.embed` check is relevant).
+    #[tokio::test]
+    async fn probe_loopback_dim_zero_no_embedder_returns_server() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // No index.embed capability, dim 0.
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body(&["memory"], 0)))
+            .mount(&server)
+            .await;
+
+        let result = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true).await;
+        assert!(
+            matches!(result, Ok(Tier::Server { .. })),
+            "server with no embedder (dim 0) must still return Server; got {result:?}"
+        );
+    }
+
+    /// Explicit server_url with wrong dim → hard `Err` with an actionable message.
+    #[tokio::test]
+    async fn probe_explicit_url_dim_mismatch_returns_error() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body(
+                &["memory", "index.embed", "search.semantic"],
+                768,
+            )))
+            .mount(&server)
+            .await;
+
+        // auto_discovered = false → explicit server_url path → must be a hard Err.
+        let result = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, false).await;
+        assert!(
+            result.is_err(),
+            "explicit server_url with wrong dim must return Err; got {result:?}"
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("768"),
+            "error must mention the server's dim (768): {msg}"
+        );
+        let expected = spelunk_core::embeddings::EMBEDDING_DIM;
+        assert!(
+            msg.contains(&expected.to_string()),
+            "error must mention the expected dim ({expected}): {msg}"
+        );
+        assert!(
+            msg.contains("server_url"),
+            "error must mention 'server_url' for actionable guidance: {msg}"
+        );
     }
 }

--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -287,11 +287,8 @@ async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
         return match probe_url(url, key, REMOTE_PROBE_TIMEOUT, false).await {
             Ok(tier) => tier,
             Err(e) => {
-                // Dim mismatch on an explicitly-configured server: surface the error
-                // to the terminal and fall back to offline so the process exits cleanly
-                // rather than hanging on a deep-in-command failure.
-                tracing::error!("{e}");
-                Tier::Offline
+                eprintln!("error: {e}");
+                std::process::exit(2);
             }
         };
     }

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -116,6 +116,9 @@ pub struct HealthResponse {
     pub instance_id: String,
     /// Effective UID of the process that started the server (Unix); `null` on Windows.
     pub started_by: Option<u32>,
+    /// Embedding dimension produced by this server's embedder.
+    /// `0` when no embedder is loaded (capability `index.embed` absent).
+    pub embedding_dim: usize,
 }
 
 /// Server liveness check. No authentication required.
@@ -138,12 +141,14 @@ pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
         capabilities.push("explore".to_string());
         capabilities.push("llm.complete".to_string());
     }
+    let embedding_dim = state.embedder.as_ref().map_or(0, |e| e.dimension());
     Json(HealthResponse {
         status: "ok",
         version: env!("CARGO_PKG_VERSION"),
         capabilities,
         instance_id: state.instance_id.clone(),
         started_by: state.started_by,
+        embedding_dim,
     })
 }
 
@@ -1371,6 +1376,43 @@ mod tests {
         );
     }
 
+    /// A minimal mock embedder that always returns a single zero vector of `dim` dimensions.
+    /// Used to verify that `embedding_dim` is surfaced correctly in the health response.
+    struct MockEmbedder {
+        dim: usize,
+    }
+
+    #[async_trait::async_trait]
+    impl spelunk_core::embeddings::EmbeddingBackend for MockEmbedder {
+        async fn embed(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+            Ok(texts.iter().map(|_| vec![0.0_f32; self.dim]).collect())
+        }
+
+        fn dimension(&self) -> usize {
+            self.dim
+        }
+    }
+
+    /// Build an app with a mock embedder of the given dimension.
+    fn make_app_with_embedder(dim: usize) -> axum::Router {
+        register_sqlite_vec();
+        let db = ServerDb::open(std::path::Path::new(":memory:"), dim)
+            .expect("failed to open in-memory server db");
+        let instance_id = db.get_or_create_instance_id().expect("instance_id in test");
+        let state = AppState {
+            db: Arc::new(tokio::sync::Mutex::new(db)),
+            auth: Arc::new(ApiKeyAuth::new(None)),
+            conflict_threshold: 0.92,
+            embedder: Some(Arc::new(MockEmbedder { dim })),
+            llm: None,
+            max_tokens_ceiling: 8192,
+            rate_limiter: Arc::new(super::super::rate_limiter::RateLimiter::new(1000, 60)),
+            instance_id,
+            started_by: None,
+        };
+        super::super::router(state)
+    }
+
     /// GET /v1/health should return JSON with `status`, `version`, and `capabilities`.
     #[tokio::test]
     async fn health_returns_json_with_capabilities() {
@@ -1506,6 +1548,56 @@ mod tests {
             resp.status(),
             http::StatusCode::PAYLOAD_TOO_LARGE,
             "batch >256 must return 413"
+        );
+    }
+
+    /// GET /v1/health with a mock embedder of dim 4 must report `embedding_dim: 4`.
+    #[tokio::test]
+    async fn health_embedding_dim_with_embedder() {
+        let app = make_app_with_embedder(4);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/v1/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).expect("health must return JSON");
+        assert_eq!(
+            json["embedding_dim"],
+            json!(4),
+            "embedding_dim must match the mock embedder dimension (4)"
+        );
+        // Capabilities must include index.embed when embedder is present.
+        let caps = json["capabilities"].as_array().unwrap();
+        assert!(
+            caps.iter().any(|c| c == "index.embed"),
+            "capabilities must include index.embed when embedder is loaded"
+        );
+    }
+
+    /// GET /v1/health with no embedder (the default make_app) must report `embedding_dim: 0`.
+    #[tokio::test]
+    async fn health_embedding_dim_without_embedder() {
+        let (app, _) = make_app(0.92);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/v1/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).expect("health must return JSON");
+        assert_eq!(
+            json["embedding_dim"],
+            json!(0),
+            "embedding_dim must be 0 when no embedder is configured"
         );
     }
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1478,7 +1478,8 @@
           "status",
           "version",
           "capabilities",
-          "instance_id"
+          "instance_id",
+          "embedding_dim"
         ],
         "properties": {
           "capabilities": {
@@ -1487,6 +1488,11 @@
               "type": "string"
             },
             "description": "List of feature capabilities supported by this server instance."
+          },
+          "embedding_dim": {
+            "type": "integer",
+            "description": "Embedding dimension produced by this server's embedder.\n`0` when no embedder is loaded (capability `index.embed` absent).",
+            "minimum": 0
           },
           "instance_id": {
             "type": "string",


### PR DESCRIPTION
## Summary

- **Server (`spelunk-server`):** `GET /v1/health` response gains `embedding_dim: usize` — the dimension of the loaded embedder, or `0` when none is configured. Zero-cost wire change: old clients that don't read this field are unaffected.
- **CLI (`spelunk-cli`):** `probe_url` now reads `embedding_dim` from the health response and rejects servers where it doesn't match `spelunk_core::embeddings::EMBEDDING_DIM`:
  - **Auto-discovered loopback** (user didn't configure this server): downgrades to `Tier::Offline` with a `tracing::warn!` message. No hard failure.
  - **Explicit `server_url`**: hard error surfaced before any command runs, with an actionable message naming both dimensions and the config key to remove.
- `SPELUNK_NO_SERVER=1` still short-circuits before any dim check.
- The `bytes.len() != expected` assertion in `embed_phase.rs` is kept as belt-and-suspenders.
- `HealthBody.embedding_dim` uses `#[serde(default)]` so old servers that don't emit this field get `0`, which skips the check entirely (backward-compat).

## Tests

6 new unit tests added:

- `health_embedding_dim_with_embedder` — mock embedder dim 4 -> health returns `embedding_dim: 4`
- `health_embedding_dim_without_embedder` — no embedder -> health returns `embedding_dim: 0`
- `probe_loopback_dim_mismatch_downgrades_to_offline` — wiremock server at 768-dim, loopback probe -> `Tier::Offline`
- `probe_loopback_dim_match_returns_server` — wiremock server at 896-dim, loopback probe -> `Tier::Server`
- `probe_loopback_dim_zero_no_embedder_returns_server` — wiremock server, no embedder (dim 0) -> `Tier::Server`
- `probe_explicit_url_dim_mismatch_returns_error` — explicit URL, 768-dim server -> `Err` with actionable message

## Test plan

- [ ] `cargo test --workspace` passes with all 6 new tests green
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes clean
- [ ] Manually: start an old 768-dim spelunk-server on loopback, run `spelunk index .` — confirm it falls back to offline embedding with a `warn`-level log, no cryptic byte-count error
- [ ] Manually: with `server_url` set in config pointing at a 768-dim server, run `spelunk index .` — confirm a clear error is printed and the process exits non-zero before any indexing begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)