### PR TITLE
docs: formalise int8(chunk)/float(memory) vector-storage split (spelunk-oss^20)

### DIFF
--- a/crates/spelunk-core/src/embeddings/mod.rs
+++ b/crates/spelunk-core/src/embeddings/mod.rs
@@ -18,7 +18,15 @@ pub trait EmbeddingBackend: Send + Sync {
     fn dimension(&self) -> usize;
 }
 
-/// Serialise a float vector to raw little-endian bytes for sqlite-vec storage.
+/// Serialise a float vector to raw little-endian f32 bytes for a sqlite-vec
+/// `float[N]` column.
+///
+/// Used for the memory-note vector table (`note_embeddings`, `FLOAT[896]`),
+/// which stays full-precision: the table is small, so the int8 footprint win
+/// that justifies [`vec_to_int8_blob`] for the large chunk/snapshot index does
+/// not apply, and float keeps the memory search path free of the int8
+/// distance-rescale (`INT8_SCALE`). See `docs/architecture.md` ("Why two
+/// vector-storage formats").
 pub fn vec_to_blob(v: &[f32]) -> Vec<u8> {
     v.iter().flat_map(|f| f.to_le_bytes()).collect()
 }
@@ -31,7 +39,9 @@ pub fn vec_to_blob(v: &[f32]) -> Vec<u8> {
 /// ~127× the corresponding f32 distance — callers rescale by `INT8_SCALE`).
 ///
 /// Used only for the chunk/snapshot vector tables (`embeddings`,
-/// `snapshot_embeddings`); memory note vectors keep full-precision f32 storage.
+/// `snapshot_embeddings`); memory note vectors keep full-precision f32 storage
+/// via [`vec_to_blob`]. See `docs/architecture.md` ("Why two vector-storage
+/// formats") for why the split is deliberate.
 pub fn vec_to_int8_blob(v: &[f32]) -> Vec<u8> {
     v.iter()
         .map(|&x| ((x * 127.0).round().clamp(-127.0, 127.0) as i8) as u8)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,37 @@ See `Chunk::embedding_text()` in `src/indexer/chunker.rs`.
 Vectors are L2-normalised and stored as sqlite-vec `INT8[896]` (chunk and
 snapshot embeddings); memory-entry embeddings stay `FLOAT[896]`.
 
+#### Why two vector-storage formats (int8 for chunks, float for memory)
+
+This split is **deliberate**, not an oversight. The two vector tables are sized
+for different jobs:
+
+| Table | Type | Rationale |
+| --- | --- | --- |
+| `embeddings` (chunks), `snapshot_embeddings` | `INT8[896]` | The code index scales with the corpus — thousands to millions of chunks. int8 scalar quantisation is 4× smaller on disk and, because F2LLM vectors are L2-normalised, lossless enough for ranking. The int8 L2 distance comes back ~127× the f32 distance, so the search path rescales by `embeddings::INT8_SCALE` on read. |
+| `note_embeddings` (memory) | `FLOAT[896]` | The memory-note table is tiny (tens to low-thousands of rows per project), so the int8 footprint win is negligible. Keeping full-precision f32 avoids the int8 quantise-on-write + distance-rescale-on-read nuance for a table that never grows large, and keeps the memory insert/search path (`MemoryStore::insert_embedding` / `search`, fed by `embeddings::vec_to_blob`) free of `vec_int8(...)` wrapping and `INT8_SCALE` division. |
+
+Concretely, the two paths never mix:
+- **int8 path** — `Database::{insert_embedding,search_similar}` and the snapshot
+  equivalents go through `embeddings::vec_to_int8_blob` + `vec_int8(?)` on write
+  and divide the raw distance by `embeddings::INT8_SCALE` on read
+  (`storage/db.rs`, `storage/snapshots.rs`, `storage/search.rs`).
+- **float path** — memory notes go through `embeddings::vec_to_blob` (raw
+  little-endian f32) into `MemoryStore::insert_embedding`, and `MemoryStore::search`
+  matches on the raw f32 query blob with no rescale
+  (`storage/memory/notes.rs`, `storage/memory/search.rs`). The server-side memory
+  store (`spelunk-server/src/db.rs`) mirrors this float layout.
+
+If memory ever grows to corpus scale, migrating `note_embeddings` to int8 would
+be the obvious follow-up — but until then the int8 cost (a second quantised path
+to maintain, plus a forced memory re-embed/re-harvest on migration) buys nothing.
+
+The dimension upgrade for pre-0.9 `FLOAT[768]` databases is handled **per store**:
+`Database::apply_dim_upgrade_migration` rebuilds the chunk/snapshot tables as
+`INT8[896]`, while `MemoryStore::migrate` rebuilds `note_embeddings` as
+`FLOAT[896]` (each guarded by its own marker table). There is no path that leaves
+memory stranded on the stale 768-dim layout.
+
 ### Backend abstraction
 
 The `EmbeddingBackend` and `LlmBackend` traits (in spelunk-core's `embeddings/` and `llm/`) are the only interface between spelunk and inference. spelunk-core ships **no** concrete implementations; the concrete backends live in `spelunk-server` (the native F2LLM embedder in `embedder_native.rs`, plus OpenAI-compatible HTTP clients). The CLI reaches inference only through `ServerLlmClient` / `ServerEmbedClient` in `crates/spelunk-cli/src/server_client.rs`.


### PR DESCRIPTION
Resolves the consistency follow-up flagged in QA of #441.

## Decision
**Keep memory note embeddings as `FLOAT[896]`; document the deliberate divergence** (rather than migrating them to int8). The int8 win is a corpus-scaling property of the large chunk/snapshot index; the `note_embeddings` table is tiny, so int8 buys nothing there while adding a second quantised path, forcing a memory re-embed, and dragging the `INT8_SCALE` rescale into the memory search path.

This is a confirm-and-document outcome (no schema/contract change) — a living-docs note, not a new ADR.

## 896-dim verification: PASS
No stale `FLOAT[768]` in the memory path:
- Fresh stores create `note_embeddings` as `FLOAT[896]` (`crates/spelunk-core/migrations/004_memory.sql`).
- Pre-0.9 upgrade handled by a dedicated path — `MemoryStore::migrate` rebuilds any `FLOAT[768]` `note_embeddings` as `FLOAT[896]` (marker-guarded). `Database::apply_dim_upgrade_migration` only handles `embeddings`/`snapshot_embeddings` → int8. Memory not being touched by the chunk upgrade is by design, not a gap.

## Changes
- `docs/architecture.md` — new "Why two vector-storage formats" subsection.
- `crates/spelunk-core/src/embeddings/mod.rs` — doc-comment only (no logic) identifying `vec_to_blob` as the memory-note float path, cross-linking the architecture doc.

`cargo check` passes; fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)