### PR TITLE
build(deps): upgrade candle 0.10.2 → 0.11.0 (grouped) + dependabot group rule (spelunk-oss^33)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      candle:
+        patterns:
+          - "candle-*"
 
   - package-ecosystem: github-actions
     directory: /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "candle-core"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+checksum = "5ecb245093b0f791b89d3420c3df9c6d49c60ab63ba54db896bf8a3baf486706"
 dependencies = [
  "byteorder",
  "candle-metal-kernels",
@@ -573,6 +573,7 @@ dependencies = [
  "float8",
  "gemm 0.19.0",
  "half",
+ "libc",
  "libm",
  "memmap2",
  "num-traits",
@@ -582,19 +583,21 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr",
  "rayon",
- "safetensors 0.7.0",
+ "safetensors 0.8.0",
  "thiserror 2.0.18",
  "tokenizers 0.22.2",
  "yoke 0.8.3",
- "zip 7.2.0",
+ "zerocopy",
+ "zip 8.6.0",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6b5a4cae6b4e1ab0efcee4dc05272d11b374a3d1ba121b3a961e36be54ab60"
+checksum = "242e83c6acf639bb273c929d73c67a882bb4dd08a140f121096e19ba2f213d3e"
 dependencies = [
+ "block2",
  "half",
  "objc2",
  "objc2-foundation",
@@ -606,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "candle-nn"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+checksum = "eaa10b6ccc365b33210ce404fbf45e60d3e0bdac1004463cf1052e6ee1c1739a"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
@@ -617,16 +620,16 @@ dependencies = [
  "num-traits",
  "objc2-metal",
  "rayon",
- "safetensors 0.7.0",
+ "safetensors 0.8.0",
  "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "candle-transformers"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
+checksum = "3bcbbf7ff00ff6fe2af22b93600195917fe90e90ff48424a140d1a926c44b1c1"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -643,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "candle-ug"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0fc3167cbc99c8ec1be618cb620aa21dca95038f118c3579a79370e3dc5f77"
+checksum = "257411c33abf7d898a31ac20d80813dfe96ff09e23a73039e22ab293aea9b871"
 dependencies = [
  "ug",
  "ug-metal",
@@ -1406,9 +1409,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -4727,13 +4730,15 @@ dependencies = [
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
 dependencies = [
  "hashbrown 0.16.1",
+ "libc",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -5324,7 +5329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6899,6 +6904,18 @@ dependencies = [
  "memchr",
  "typed-path",
  "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -45,9 +45,9 @@ utoipa = { version = "5", features = ["axum_extras"] }
 clap = { version = "4", features = ["derive", "env"] }
 regex = { version = "1", default-features = false, features = ["std"] }
 dirs = "6"
-candle-core = { version = "0.10.2", optional = true }
-candle-nn = { version = "0.10.2", optional = true }
-candle-transformers = { version = "0.10.2", optional = true }
+candle-core = { version = "0.11.0", optional = true }
+candle-nn = { version = "0.11.0", optional = true }
+candle-transformers = { version = "0.11.0", optional = true }
 hf-hub = { version = "0.5", optional = true }
 tokenizers = { version = "0.23", optional = true }
 


### PR DESCRIPTION
## What

Upgrades all three candle crates from `0.10.2` to `0.11.0` in **one** PR, and adds a Dependabot group so future candle bumps arrive together.

## Why the grouped PR

Dependabot opened three separate bumps — #460 (candle-transformers), #461 (candle-core), #463 (candle-nn) — and **each fails on its own**. candle's crates must resolve to a **single** version across the dependency tree; bumping one to `0.11.0` while the others stay `0.10.2` is an unsatisfiable resolution. They have to move together, which is what this PR does.

## Crates bumped

In `crates/spelunk-server/Cargo.toml` (all optional, behind the `embed-native` feature):
- `candle-core` 0.10.2 → 0.11.0
- `candle-nn` 0.10.2 → 0.11.0
- `candle-transformers` 0.10.2 → 0.11.0

`Cargo.lock` re-resolved to **exactly one** `candle-core` at `0.11.0` (verified via `grep -A1 'name = "candle-core"' Cargo.lock` → single entry). The `metal` feature is feature-flags only, no version change.

## API changes

None required. The candle API surface used by `crates/spelunk-server/src/embedder_native.rs` is source-compatible across 0.10→0.11:
- `candle_core::quantized` — `GgmlDType`, `QMatMul`, `QTensor`, `gguf_file` (read/write)
- `candle_core` — `Tensor`, `Device`, `DType`, `IndexOp`, `safetensors::load`
- `candle_nn` — `Embedding`, `RmsNorm`, `Module`, `Activation`, `rotary_emb::rope`, `ops::softmax_last_dim`
- `candle_transformers` — `models::qwen3::Config`, `utils::repeat_kv`

The upgrade builds clean with no code edits.

## Dependabot group rule

Added under the existing `cargo` `/` entry in `.github/dependabot.yml`:

```yaml
groups:
  candle:
    patterns:
      - "candle-*"
```

Future candle updates now come as a single grouped PR, so the split-version failure cannot recur.

## Supersedes

Supersedes #460, #461, #463 — they auto-close when this merges (left untouched).

## Test plan

All run from the workspace root on macOS:

- `cargo update -p candle-core --precise 0.11.0` → re-resolved; lock has one `candle-core` 0.11.0
- `cargo build -p spelunk-server --features embed-native` → **Finished** (no errors)
- `cargo build -p spelunk-server --features metal` → **Finished** (Metal/GPU path, macOS)
- `cargo test -p spelunk-server --features embed-native` → **28 + 2 + 12 passed, 0 failed** (1 ignored: the end-to-end `embeddings_discriminate_*` test downloads the ~650 MB F2LLM model, not run in this environment). The two native-embedder unit tests (`repeat_kv_interleaves_gqa_heads_not_tiles`, `repeat_kv_output_is_contiguous`) exercise the candle 0.11 `repeat_kv` API and pass.
- `cargo fmt --check` → clean
- `cargo clippy -p spelunk-server --features embed-native -- -D warnings` → clean
- `cargo audit` → no new advisories from the bumped deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)