### PR TITLE
docs: fix stale ONNX comment in embed_phase MAX_BATCH

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -7,8 +7,9 @@ use crate::{capability::Tier, config::Config, storage::Database};
 
 /// Maximum chunks per request — server enforces 256 (returns 413 if exceeded).
 /// Keep well below that ceiling so each HTTP call completes within the client
-/// timeout: at ONNX_BATCH_SIZE=32 on the server, 64 chunks = 2 ONNX calls
-/// (~30-40 s on CPU), leaving plenty of headroom under the 120 s limit.
+/// timeout: the server's candle embedder (F2LLM-v2-330M) runs inference in
+/// padded sub-batches of EMBED_BATCH_SIZE=8, so 64 chunks = 8 forward passes,
+/// leaving plenty of headroom under the 120 s limit.
 const MAX_BATCH: usize = 64;
 
 #[derive(Serialize)]


### PR DESCRIPTION
## What

Comment-only fix. The `MAX_BATCH` constant in
`crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs` carried a rationale
referencing `ONNX_BATCH_SIZE=32` and "ONNX calls" — stale since the native
embedder switched from ONNX/fastembed to the candle-native F2LLM-v2-330M
embedder (the `vendor/fastembed` tree is now gone; the `embed-native` feature
in `crates/spelunk-server/Cargo.toml` uses candle, not ort).

## Change

Reworded the comment to match server-side reality: the candle embedder
processes each request in padded sub-batches of `EMBED_BATCH_SIZE = 8`
(`crates/spelunk-server/src/embedder_native.rs:22`), so the client's 64-chunk
cap means 8 forward passes per request. Same intent preserved — keeping each
HTTP call within the 120 s client timeout with headroom.

No behaviour change; `MAX_BATCH = 64` and the 256 server ceiling are unchanged.

## Test plan

- `cargo build -p spelunk-cli` — green.
- Pre-commit hook ran `cargo fmt --check` and `cargo clippy` across the
  workspace — both clean.
- No runtime change to verify (comment-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)