### PR TITLE
Fix deny.toml for cargo-deny 0.18+ (drop removed bans.allow-workspace)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -177,10 +177,6 @@ allow = [
     #"ansi_term@0.11.0",
     #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
 ]
-# If true, workspace members are automatically allowed even when using deny-by-default
-# This is useful for organizations that want to deny all external dependencies by default
-# but allow their own workspace crates without having to explicitly list them
-allow-workspace = false
 # List of crates to deny
 deny = [
     #"ansi_term@0.11.0",


### PR DESCRIPTION
## What

Removes the `allow-workspace = false` key from `[bans]` in `deny.toml`.

## Why

cargo-deny 0.18 removed the `allow-workspace` key under `[bans]`. A fresh local `cargo deny check` (0.18.3) now fails before running any checks:

```
error[unexpected-keys]: found 1 unexpected keys, expected: [...]
    ┌─ deny.toml:183:1
183 │ allow-workspace = false
[ERROR] failed to deserialize config from 'deny.toml'
```

CI doesn't hit this because its tool cache pins an older cargo-deny, so contributors running the check locally are the only ones affected. This is a pre-existing issue, unrelated to any feature work.

The key was set to `false`, which is the default (workspace members are not auto-allowed), so removing it is behavior-neutral.

## Test plan

1. With cargo-deny 0.18.3 installed, run `cargo deny check bans licenses` at the repo root.
2. Before: fails to deserialize the config (`unexpected-keys`).
3. After: `bans ok, licenses ok`.

(The `advisories` check separately fails on 0.18.3 due to a CVSS 4.0 entry in the rustsec advisory DB that this parser version can't read — that's an upstream/tooling issue, out of scope for this change.)