### PR TITLE
docs(mdm): enterprise MDM deployment example for spelunk + spelunk-server

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -394,3 +394,11 @@ spelunk memory push
 ```
 
 For full setup and deployment guide: **[Server setup](server.md)** — Docker, configuration, API reference.
+
+### Enterprise / MDM deployment
+
+Rolling spelunk out to a managed fleet? The
+[`examples/mdm/`](../examples/mdm/README.md) directory shows how to deploy and
+pre-configure `spelunk` and `spelunk-server` via MDM (managed config file,
+fleet-wide environment, and a macOS profile for a managed server daemon),
+grounded in spelunk's real config surface.

--- a/examples/mdm/README.md
+++ b/examples/mdm/README.md
@@ -1,0 +1,174 @@
+# Enterprise MDM deployment for spelunk
+
+This directory shows how an administrator can deploy and pre-configure
+`spelunk` and `spelunk-server` across a managed fleet using Mobile Device
+Management (MDM). It is example configuration and documentation only; nothing
+here changes how spelunk behaves at runtime.
+
+> These templates are community examples. Test them on a single device before
+> rolling out to a fleet, and adapt the paths, ports, and credentials to your
+> environment.
+
+## How spelunk reads its configuration
+
+Knowing the configuration surface is the whole game for an MDM rollout, so it
+is worth being precise. `spelunk` resolves settings in this order (later
+layers win):
+
+1. Built-in defaults.
+2. The global config file `~/.config/spelunk/config.toml` (personal, per user).
+   spelunk uses `~/.config` on every platform, including macOS; it does not use
+   `~/Library/Application Support`.
+3. The project config file `.spelunk/config.toml`, discovered by walking up from
+   the working directory (team-wide, committed to the repo, no secrets).
+4. Environment variables (for example `SPELUNK_SERVER_URL`, `SPELUNK_SERVER_KEY`,
+   `SPELUNK_PROJECT_ID`, `SPELUNK_MODE`, `SPELUNK_NO_SERVER`).
+
+Credentials persist in the OS keychain by default (macOS Keychain, Linux Secret
+Service, Windows Credential Manager), never in the config file. The
+`SPELUNK_SERVER_KEY` environment variable overrides the stored credential and is
+the recommended way to push a shared API key to managed or headless hosts.
+
+### A note on macOS managed preferences
+
+Many macOS apps expose a managed-preferences (MCX) domain so an MDM can force
+application settings through a `com.apple.ManagedClient.preferences` payload.
+**spelunk does not have one.** It reads TOML files and environment variables,
+not a macOS preference domain. So an MDM rollout for spelunk deploys those two
+things:
+
+- the config file (and/or environment) that pre-configures the CLI, and
+- optionally, a managed `spelunk-server` daemon.
+
+The macOS profile in this directory uses the managed-preferences payload only
+for the supported, generic purpose of installing a launchd job, not to set
+spelunk's own settings.
+
+## What is in this directory
+
+| File | Purpose |
+|------|---------|
+| `spelunk-config.toml` | Example global config to push to `~/.config/spelunk/config.toml`. Every key is a real field read by `spelunk`. |
+| `spelunk.env.example` | Example managed environment (shared API key, server URL, fleet policy) to deliver via launchd, a profile script, or Group Policy. |
+| `macos/cloud.spelunk.server.mobileconfig` | macOS configuration profile that installs a managed `spelunk-server` LaunchDaemon on a shared or always-on host. |
+
+## Two deployment shapes
+
+Most fleets are one of two shapes. Pick the one that matches you.
+
+### Shape A: developer laptops, no shared server
+
+Each machine runs fully self-contained. spelunk autostarts a local
+`spelunk-server` on demand for inference; there is nothing to provision and no
+shared state.
+
+Steps:
+
+1. **Install the binaries.** Package `spelunk` and `spelunk-server` for your MDM
+   (a managed `.pkg` on macOS, a `.deb` on Debian/Ubuntu, or the install script
+   wrapped in a script payload). Both binaries must land on the system `PATH`,
+   for example `/usr/local/bin`.
+2. **Optionally push fleet policy** by deploying `spelunk.env.example` values,
+   for example `SPELUNK_NO_SERVER=1` on air-gapped machines or a pinned
+   `SPELUNK_MODE`.
+
+That is the whole rollout. No config file is required for the local-only case.
+
+### Shape B: shared team memory server
+
+A long-lived `spelunk-server` holds the team's shared memory, and every laptop
+points at it. This shape uses all three files.
+
+Steps:
+
+1. **Install the binaries** on the laptops (as in Shape A) and on the host that
+   will run the shared server.
+2. **Run the managed server.** On a macOS server host, install
+   `macos/cloud.spelunk.server.mobileconfig` (it installs a system-scoped
+   LaunchDaemon). On Linux, deploy the systemd unit from
+   `packaging/spelunk-server.service`. Set a real `SPELUNK_SERVER_KEY` on the
+   server.
+3. **Pre-configure the laptops** so users do not have to. Push
+   `spelunk-config.toml` to `~/.config/spelunk/config.toml` (server URL, project
+   slug, sync mode) and deliver the shared `SPELUNK_SERVER_KEY` via the managed
+   environment in `spelunk.env.example`.
+
+After this, `spelunk memory` commands on every laptop transparently use the
+shared server with no per-user setup.
+
+## Pushing spelunk configuration
+
+Because spelunk reads files and environment rather than a macOS preference
+domain, you deploy configuration with your MDM's generic file or script
+mechanism. The mechanics differ per platform and per MDM, but the targets are
+always the same.
+
+### The config file
+
+Write `spelunk-config.toml` (edited for your environment) to each user's
+`~/.config/spelunk/config.toml`.
+
+- **macOS / Linux:** an MDM script payload that creates `~/.config/spelunk/` and
+  copies the file in for each managed user. Keep the file readable only by its
+  owner if it contains anything sensitive (it should not; keep secrets in the
+  environment).
+- **Windows:** the equivalent path resolves under the user profile; deploy the
+  file with a managed script or login script.
+
+A team-wide subset can instead live in a committed `.spelunk/config.toml` at the
+repository root (`server_url`, `project_id`), which needs no MDM at all. Use the
+global file for machine-level defaults and the project file for repo-level ones.
+
+### The environment
+
+Deliver the variables in `spelunk.env.example` through whatever your platform
+supports:
+
+- **macOS:** a launchd `EnvironmentVariables` payload (the server profile here
+  shows the pattern), or a managed shell profile drop-in.
+- **Linux:** a file under `/etc/profile.d/`, a systemd `Environment=` directive,
+  or your MDM's environment payload.
+- **Windows:** machine or user environment variables via Group Policy or an
+  Intune configuration profile.
+
+`SPELUNK_SERVER_KEY` is the variable to prioritise here: it carries the shared
+credential and overrides the keychain, so it works on headless and freshly
+imaged machines with no interactive login.
+
+## Customising the templates
+
+1. **macOS profile:** regenerate every `PayloadUUID` with `uuidgen`, set
+   `PayloadOrganization`, confirm the `spelunk-server` binary path, and set a
+   real `SPELUNK_SERVER_KEY`. Adjust `--port` and `--db` for your host.
+2. **Config file:** set `server_url` and `project_id`, or delete them for the
+   local-only Shape A. Uncomment the inference keys only if you run your own
+   embedding/LLM endpoint.
+3. **Environment file:** set the shared key and server URL, or set
+   `SPELUNK_NO_SERVER=1` for an offline fleet. Do not set both a server URL and
+   the offline kill-switch.
+
+## Verifying a rollout
+
+On a managed machine after deployment:
+
+```bash
+spelunk --version            # binaries are on PATH
+spelunk status               # index + config health
+spelunk context              # confirms the configured server is reachable
+```
+
+If you deployed a shared server, `spelunk context` on a laptop should surface
+team memory from it. If you deployed `SPELUNK_NO_SERVER=1`, server-only features
+report that they are unavailable instead of starting anything.
+
+## Further reading
+
+- [Getting started](../../docs/getting-started.md) - install paths and the team
+  setup walkthrough.
+- [Self-hosting](../../docs/self-hosting.md) - exposing `spelunk-server` to
+  remote machines over TLS.
+- [Commands reference](../../docs/commands.md) - the full list of environment
+  variables and config keys.
+- `packaging/spelunk-server.plist` / `packaging/spelunk-server.service` - the
+  per-user LaunchAgent and the Linux systemd unit the macOS profile here is
+  based on.

--- a/examples/mdm/macos/cloud.spelunk.server.mobileconfig
+++ b/examples/mdm/macos/cloud.spelunk.server.mobileconfig
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  macOS configuration profile (.mobileconfig) for spelunk.
+
+  WHAT THIS DOES
+  This profile installs a managed launchd LaunchDaemon that keeps a shared,
+  always-on `spelunk-server` running on a managed host (for example a build
+  host or a team server). It is the macOS-native, MDM-deployable form of the
+  LaunchAgent shipped in packaging/spelunk-server.plist, promoted to a
+  system-scoped LaunchDaemon so it runs without an interactive login session.
+
+  WHAT THIS DOES NOT DO
+  spelunk has NO macOS managed-preferences (MCX) domain. The CLI and server
+  read their settings from TOML config files and environment variables, not
+  from a macOS preference domain. So this profile does not push spelunk's
+  application settings the way an MCX "Forced preferences" payload would. To
+  pre-configure spelunk itself (server_url, project_id, models cache, etc.),
+  deploy the config file and/or environment via an MDM file or script payload
+  see ../README.md ("Pushing spelunk configuration").
+
+  BEFORE YOU DEPLOY
+  1. Regenerate every PayloadUUID below (`uuidgen`) so this profile does not
+     collide with another org's profile.
+  2. Set PayloadOrganization to your organization name.
+  3. Confirm the binary path matches where your fleet installs spelunk-server
+     (the install script places it in /usr/local/bin when run as root).
+  4. Adjust the --port, --db path, and SPELUNK_SERVER_KEY to suit your
+     deployment. For a shared server, ALWAYS set an API key (see README).
+-->
+<plist version="1.0">
+<dict>
+	<key>PayloadDisplayName</key>
+	<string>spelunk-server (managed LaunchDaemon)</string>
+	<key>PayloadDescription</key>
+	<string>Installs and keeps the shared spelunk-server daemon running on a managed macOS host.</string>
+	<key>PayloadIdentifier</key>
+	<string>cloud.spelunk.server.profile</string>
+	<key>PayloadOrganization</key>
+	<string>Example Organization</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>f29e1c06-4a76-4d48-9d15-c8f535f1d8fd</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>spelunk-server LaunchDaemon</string>
+			<key>PayloadDescription</key>
+			<string>com.apple.ManagedClient.preferences payload that writes a launchd LaunchDaemon job.</string>
+			<key>PayloadIdentifier</key>
+			<string>cloud.spelunk.server.profile.launchd</string>
+			<key>PayloadType</key>
+			<string>com.apple.ManagedClient.preferences</string>
+			<key>PayloadUUID</key>
+			<string>0f951f58-5016-4716-8b8e-11b938807e8e</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PayloadContent</key>
+			<dict>
+				<!--
+				  The launchd domain. macOS materialises this payload as a
+				  LaunchDaemon plist named cloud.spelunk.server, owned by root
+				  and run at boot, with no interactive login required.
+				-->
+				<key>cloud.spelunk.server</key>
+				<dict>
+					<key>Forced</key>
+					<array>
+						<dict>
+							<key>mcx_preference_settings</key>
+							<dict>
+								<key>Label</key>
+								<string>cloud.spelunk.server</string>
+								<key>ProgramArguments</key>
+								<array>
+									<!-- Path the install script uses when run as root. -->
+									<string>/usr/local/bin/spelunk-server</string>
+									<string>--host</string>
+									<string>0.0.0.0</string>
+									<string>--port</string>
+									<string>7777</string>
+									<!-- Persistent DB path for a shared/always-on host. -->
+									<string>--db</string>
+									<string>/var/lib/spelunk/spelunk.db</string>
+								</array>
+								<key>EnvironmentVariables</key>
+								<dict>
+									<!--
+									  Set a real API key for any shared server.
+									  An unset key leaves the server unauthenticated
+									  (dev only). You can also inject it out-of-band
+									  rather than committing it into the profile.
+									-->
+									<key>SPELUNK_SERVER_KEY</key>
+									<string>replace-with-your-shared-api-key</string>
+									<key>RUST_LOG</key>
+									<string>info</string>
+								</dict>
+								<key>RunAtLoad</key>
+								<true/>
+								<key>KeepAlive</key>
+								<true/>
+								<key>StandardOutPath</key>
+								<string>/var/log/spelunk-server.log</string>
+								<key>StandardErrorPath</key>
+								<string>/var/log/spelunk-server.err</string>
+							</dict>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/examples/mdm/spelunk-config.toml
+++ b/examples/mdm/spelunk-config.toml
@@ -1,0 +1,53 @@
+# Example managed spelunk configuration.
+#
+# Deploy this file to each user's global config path so a fleet of machines
+# points at the same shared spelunk-server without any per-user setup:
+#
+#   ~/.config/spelunk/config.toml
+#
+# spelunk uses ~/.config on every platform (macOS included); it does NOT use
+# ~/Library/Application Support. Push it there with your MDM's file/script
+# payload (see README.md, "Pushing spelunk configuration").
+#
+# Every key below is a real field read by Config::load in
+# crates/spelunk-core/src/config.rs. Remove the ones you do not need; all are
+# optional and fall back to sensible defaults.
+#
+# IMPORTANT: do NOT bake a personal credential into this file. The shared API
+# key for a team server is better delivered as the SPELUNK_SERVER_KEY
+# environment variable (see spelunk.env.example); that takes precedence and
+# keeps the secret out of a world-readable config file.
+
+# --- Shared team memory server -----------------------------------------------
+# When set, the CLI shares memory (decisions, requirements, context) through a
+# long-lived deployed server. Leave unset to keep every machine fully local.
+server_url = "http://spelunk.internal:7777"
+
+# Human-readable project slug. Required when server_url points at a non-loopback
+# host. The CLI resolves the slug to the server's internal id on first use.
+project_id = "acme/my-app"
+
+# Sync mode: "offline" | "local_first" | "cloud_first".
+# "local_first" (the default when server_url is set) reads and writes locally,
+# then syncs to the shared server best-effort. Pin it explicitly if you want a
+# fleet to always behave the same way regardless of server reachability.
+mode = "local_first"
+
+# --- Optional: point at your own inference endpoint --------------------------
+# By default spelunk-server bundles a native embedder, so most fleets leave
+# these unset. Set them only if you run a shared OpenAI-compatible endpoint
+# (LM Studio, Ollama, vLLM, ...) for embeddings/LLM.
+# api_base_url    = "http://inference.internal:1234"
+# embedding_model = "text-embedding-embeddinggemma-300m-qat"
+# llm_model       = "google/gemma-3n-e4b"
+# batch_size      = 32
+
+# --- Optional: directory conventions -----------------------------------------
+# Where `spelunk plan create` and spec discovery look (relative to project root).
+# plans_dir = "docs/plans"
+# specs_dir = "docs/specs"
+
+# --- Optional: git-notes memory ----------------------------------------------
+# `spelunk memory add` also appends entries to refs/notes/spelunk by default.
+# Set to false to opt a fleet out of writing git notes.
+# store_in_git_notes = true

--- a/examples/mdm/spelunk.env.example
+++ b/examples/mdm/spelunk.env.example
@@ -1,0 +1,40 @@
+# Example managed environment for spelunk.
+#
+# Environment variables override the config file and are the right place for
+# secrets and for fleet-wide policy that must not be user-overridable. Each
+# variable below is read by spelunk today (see crates/spelunk-cli and
+# crates/spelunk-core; the full reference is docs/commands.md). Deliver these
+# with your MDM (a launchd EnvironmentVariables payload, a shell profile drop,
+# or Group Policy on Windows; see README.md).
+
+# --- Shared team server credential -------------------------------------------
+# Takes precedence over the keychain-stored credential and `spelunk login`
+# tokens. The non-interactive escape hatch for managed and headless hosts.
+SPELUNK_SERVER_KEY=replace-with-your-shared-api-key
+
+# Point every machine at the same shared server (overrides config server_url).
+SPELUNK_SERVER_URL=http://spelunk.internal:7777
+
+# Project slug (overrides config project_id).
+SPELUNK_PROJECT_ID=acme/my-app
+
+# --- Fleet behaviour policy --------------------------------------------------
+# Sync mode override: offline | local_first | cloud_first. An invalid value is
+# a hard error, so a managed value here pins behaviour deterministically.
+SPELUNK_MODE=local_first
+
+# Hard offline kill-switch. Set to 1/true/yes on air-gapped or no-network
+# fleets: spelunk never autostarts or contacts any server. Overrides everything
+# above. (Mutually exclusive in spirit with SPELUNK_SERVER_URL: pick one.)
+# SPELUNK_NO_SERVER=1
+
+# Secret-store backend for any credential spelunk persists:
+#   auto     - keychain, file fallback (default)
+#   keychain - require the OS keychain (error if unavailable)
+#   file     - force an owner-only ~/.config/spelunk/secrets.toml
+# On headless / no-keychain managed hosts, "file" is the predictable choice.
+# SPELUNK_SECRET_STORE=auto
+
+# --- Optional: cloud / login overrides ---------------------------------------
+# Only relevant if your fleet uses the hosted spelunk.cloud login flow.
+# SPELUNK_CLOUD_URL=https://api.spelunk.cloud


### PR DESCRIPTION
## Summary

Adds `examples/mdm/` documenting how an enterprise admin deploys and pre-configures `spelunk` and `spelunk-server` across a managed fleet via MDM, modelled (in structure and tone) on the claude-code `examples/mdm` template but adapted to spelunk's actual configuration surface.

New files:
- `examples/mdm/README.md` - what to deploy, two rollout shapes (laptops-only vs shared server), how to push config/env via a generic MDM (Jamf/Intune-agnostic), customisation, and verification steps.
- `examples/mdm/spelunk-config.toml` - example global config for `~/.config/spelunk/config.toml`; every key is a real field.
- `examples/mdm/spelunk.env.example` - example managed environment (shared API key, server URL, fleet policy); every variable is one spelunk reads today.
- `examples/mdm/macos/cloud.spelunk.server.mobileconfig` - macOS configuration profile that installs a managed `spelunk-server` LaunchDaemon (system-scoped form of `packaging/spelunk-server.plist`).

Also adds a short "Enterprise / MDM deployment" pointer to `docs/getting-started.md`.

This is documentation and example config only. No CLI command, feature, or runtime behaviour changes.

## How it was grounded

The example reflects spelunk's real config surface, read from the codebase:
- Config files and precedence from `Config::load` in `crates/spelunk-core/src/config.rs`: defaults -> `~/.config/spelunk/config.toml` -> `.spelunk/config.toml` -> env vars. spelunk uses `~/.config` on every platform (not `~/Library/Application Support`).
- Config keys used in the example (`server_url`, `project_id`, `mode`, `api_base_url`, `embedding_model`, `llm_model`, `batch_size`, `plans_dir`, `specs_dir`, `store_in_git_notes`) are all real `Config` fields.
- Environment variables used (`SPELUNK_SERVER_KEY`, `SPELUNK_SERVER_URL`, `SPELUNK_PROJECT_ID`, `SPELUNK_MODE`, `SPELUNK_NO_SERVER`, `SPELUNK_SECRET_STORE`, `SPELUNK_CLOUD_URL`) are all read by the CLI/server today.
- The server profile uses real `spelunk-server` args (`--host`, `--port`, `--db`, `SPELUNK_SERVER_KEY`) from `crates/spelunk-server/src/main.rs`.

Honest limitation, documented rather than papered over: spelunk has **no** macOS managed-preferences (MCX) domain. It reads TOML + environment, not a macOS preference domain, so the rollout deploys those (config file + environment) rather than a forced-preference payload. The `.mobileconfig` uses the managed-preferences payload only for the generic, supported purpose of installing a launchd LaunchDaemon, not to set spelunk's own settings.

## Test plan

- `plutil -lint examples/mdm/macos/cloud.spelunk.server.mobileconfig` -> `OK` (profile XML/plist is well-formed).
- TOML parse of `examples/mdm/spelunk-config.toml` via Python `tomllib` -> parses; keys = `server_url`, `project_id`, `mode`.
- Verified every config key in the example exists as a `pub` field (or documented alias) in `crates/spelunk-core/src/config.rs`.
- Verified every environment variable in the example is referenced in `crates/`.
- `cargo build` (full workspace) -> `Finished` (nothing broken; docs/example-only change).
- Pre-commit hook ran `cargo fmt --check` and `cargo clippy` -> passed.
- Checked new content contains no em-dashes (en-dashes / restructured instead).