### PR TITLE
test: isolate the OS keychain in CLI integration tests (no more macOS Keychain prompts)

### DIFF
--- a/crates/spelunk-cli/tests/backend_kind_diagnostic.rs
+++ b/crates/spelunk-cli/tests/backend_kind_diagnostic.rs
@@ -1,7 +1,9 @@
 //! Integration tests for issue #308: `memory_backend` field in
 //! `spelunk status --format json` and `spelunk check --format json`.
 
-use assert_cmd::Command;
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
 use predicates::prelude::*;
 use std::fs;
 use tempfile::tempdir;
@@ -36,8 +38,7 @@ fn setup_offline_project() -> (tempfile::TempDir, std::path::PathBuf, std::path:
     // auto-discovery can pick up a `spelunk-server` running on 127.0.0.1:7777
     // and route the embed call there, which fails the build with a dimension
     // mismatch. We only care about the SQLite memory-backend path here.
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
         .arg(&config_path)
@@ -57,8 +58,7 @@ fn setup_offline_project() -> (tempfile::TempDir, std::path::PathBuf, std::path:
 fn status_json_includes_memory_backend_field() {
     let (_temp, project_dir, config_path) = setup_offline_project();
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .current_dir(&project_dir)
         .env_remove("SPELUNK_SERVER_URL")
         .env("SPELUNK_NO_SERVER", "1")
@@ -108,8 +108,7 @@ fn status_json_includes_memory_backend_field() {
 fn check_json_includes_memory_backend_field() {
     let (_temp, project_dir, config_path) = setup_offline_project();
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .current_dir(&project_dir)
         .env_remove("SPELUNK_SERVER_URL")
         .env("SPELUNK_NO_SERVER", "1")
@@ -154,8 +153,7 @@ fn check_json_includes_memory_backend_field() {
 fn status_text_mentions_memory_backend() {
     let (_temp, project_dir, config_path) = setup_offline_project();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .current_dir(&project_dir)
         .env_remove("SPELUNK_SERVER_URL")
         .env("SPELUNK_NO_SERVER", "1")

--- a/crates/spelunk-cli/tests/cat_chunks.rs
+++ b/crates/spelunk-cli/tests/cat_chunks.rs
@@ -1,9 +1,8 @@
 //! Component tests for `spelunk plumbing cat-chunks`.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_bin, spelunk_cmd};
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
@@ -116,8 +115,7 @@ fn cat_chunks_exits_nonzero_when_db_missing() {
     )
     .unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")
@@ -138,8 +136,7 @@ fn cat_chunks_exits_nonzero_missing_argument() {
     let config_path = tmp.path().join("config.toml");
     std::fs::write(&config_path, "llm_model = \"x\"\n").unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")

--- a/crates/spelunk-cli/tests/context.rs
+++ b/crates/spelunk-cli/tests/context.rs
@@ -4,6 +4,9 @@
 //! entry point, printing handoffs, open questions, decisions, and requirements
 //! in one shot.
 
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
 use assert_cmd::Command;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
@@ -99,8 +102,7 @@ fn setup_context_project() -> (TempDir, PathBuf, PathBuf) {
     ];
 
     for (kind, title, body) in entries {
-        Command::cargo_bin("spelunk")
-            .unwrap()
+        spelunk_bin()
             .arg("--config")
             .arg(&config_path)
             .arg("memory")
@@ -136,7 +138,7 @@ fn write_config_for_context(dir: &Path, db_path: &Path, api_base: &str) -> PathB
 /// Does NOT pass `--db`; the command derives `memory.db` from `db_path` in
 /// the config, which matches where `setup_context_project` seeds entries.
 fn context_cmd(_db_path: &Path, config_path: &Path) -> Command {
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     // Run from the temp dir so find_project_db doesn't walk up and discover
     // the real .spelunk/index.db in the project root.
     if let Some(dir) = config_path.parent() {
@@ -504,8 +506,7 @@ fn context_exits_nonzero_when_config_invalid() {
     )
     .expect("write config");
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .current_dir(&tmp)
         .arg("--config")
         .arg(&config_path)

--- a/crates/spelunk-cli/tests/cross_project_memory.rs
+++ b/crates/spelunk-cli/tests/cross_project_memory.rs
@@ -20,6 +20,9 @@
 //!  13. MemoryStore unit assertions: source_project is None for local notes,
 //!      archived notes are excluded from list().
 
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
 use assert_cmd::Command;
 use rusqlite::Connection;
 use std::fs;
@@ -310,7 +313,7 @@ fn setup_linked_projects() -> (
 /// - `--config` points to the primary config.toml (which has `db_path = <index.db>`).
 /// - `memory --db <primary_mem>` routes memory reads to the primary's memory.db.
 fn memory_cmd(home: &Path, primary_root: &Path, config: &Path, primary_mem: &Path) -> Command {
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin_in(home);
     cmd.env("HOME", home)
         .env("SPELUNK_REGISTRY_DIR", registry_dir(home))
         // Unset XDG_CONFIG_HOME so dirs::config_dir() uses $HOME/.config on Linux,
@@ -334,7 +337,7 @@ fn context_cmd(
     primary_mem: &Path,
     primary_index: &Path,
 ) -> Command {
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin_in(home);
     cmd.env("HOME", home)
         .env("SPELUNK_REGISTRY_DIR", registry_dir(home))
         .env_remove("XDG_CONFIG_HOME")
@@ -541,8 +544,7 @@ fn untagged_dep_decision_is_not_surfaced() {
         "active",
     );
 
-    let raw = Command::cargo_bin("spelunk")
-        .unwrap()
+    let raw = spelunk_bin_in(&home)
         .env("HOME", &home)
         .env("SPELUNK_REGISTRY_DIR", registry_dir(&home))
         .env_remove("XDG_CONFIG_HOME")
@@ -587,8 +589,7 @@ fn dep_note_kind_is_not_surfaced_even_if_locked() {
         "active",
     );
 
-    let raw = Command::cargo_bin("spelunk")
-        .unwrap()
+    let raw = spelunk_bin_in(&home)
         .env("HOME", &home)
         .env("SPELUNK_REGISTRY_DIR", registry_dir(&home))
         .env_remove("XDG_CONFIG_HOME")
@@ -678,8 +679,7 @@ fn single_project_no_deps_works_unchanged() {
         "active",
     );
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin_in(&home)
         .env("HOME", &home)
         .env("SPELUNK_REGISTRY_DIR", registry_dir(&home))
         .env_remove("XDG_CONFIG_HOME")
@@ -988,8 +988,7 @@ fn archived_dep_decision_is_not_surfaced() {
         "archived", // <-- archived
     );
 
-    let raw = Command::cargo_bin("spelunk")
-        .unwrap()
+    let raw = spelunk_bin_in(&home)
         .env("HOME", &home)
         .env("SPELUNK_REGISTRY_DIR", registry_dir(&home))
         .env_remove("XDG_CONFIG_HOME")
@@ -1072,8 +1071,7 @@ fn dep_question_is_never_surfaced_cross_project() {
         "active",
     );
 
-    let raw = Command::cargo_bin("spelunk")
-        .unwrap()
+    let raw = spelunk_bin_in(&home)
         .env("HOME", &home)
         .env("SPELUNK_REGISTRY_DIR", registry_dir(&home))
         .env_remove("XDG_CONFIG_HOME")
@@ -1163,8 +1161,7 @@ fn multiple_deps_results_are_aggregated_not_duplicated() {
     reg.add_dep(primary_id, dep_a_id);
     reg.add_dep(primary_id, dep_b_id);
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin_in(&home)
         .env("HOME", &home)
         .env("SPELUNK_REGISTRY_DIR", registry_dir(&home))
         .env_remove("XDG_CONFIG_HOME")
@@ -1248,8 +1245,7 @@ fn missing_dep_memory_db_is_skipped_silently() {
     reg.add_dep(primary_id, dep_a_id);
     reg.add_dep(primary_id, dep_b_id);
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin_in(&home)
         .env("HOME", &home)
         .env("SPELUNK_REGISTRY_DIR", registry_dir(&home))
         .env_remove("XDG_CONFIG_HOME")

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -1,14 +1,15 @@
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::tempdir;
 
 mod plumbing_helpers;
-use plumbing_helpers::{FIXTURE_PROJECT_ID, IndexEmbedResponder, write_config_with_server};
+use plumbing_helpers::{
+    FIXTURE_PROJECT_ID, IndexEmbedResponder, spelunk_bin, spelunk_bin_in, write_config_with_server,
+};
 
 #[test]
 fn test_help_output() {
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.arg("--help")
         .assert()
         .success()
@@ -22,7 +23,7 @@ fn test_help_output() {
 
 #[test]
 fn test_invalid_command() {
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.arg("nonexistent-command")
         .assert()
         .failure()
@@ -33,7 +34,7 @@ fn test_invalid_command() {
 
 #[test]
 fn test_languages_output() {
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.arg("languages")
         .assert()
         .success()
@@ -58,7 +59,7 @@ fn test_status_empty_project() {
     )
     .unwrap();
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.current_dir(temp.path())
         .arg("--config")
         .arg(&config_path)
@@ -135,7 +136,7 @@ async fn test_index_and_status() {
     .unwrap();
 
     // 1. Index the project
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.arg("--config")
         .arg(&config_path)
         .arg("index")
@@ -144,7 +145,7 @@ async fn test_index_and_status() {
         .success();
 
     // 2. Check status
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
@@ -157,7 +158,7 @@ async fn test_index_and_status() {
         .stdout(predicate::str::contains("Chunks:     1"));
 
     // 3. Search for the function (semantic search via server embedding)
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
@@ -243,8 +244,7 @@ async fn test_index_encodes_project_id_with_slashes_as_single_segment() {
         .unwrap();
 
         // Index the project — must reach the embedding phase without a 404.
-        Command::cargo_bin("spelunk")
-            .unwrap()
+        spelunk_bin()
             .arg("--config")
             .arg(&config_path)
             .arg("index")
@@ -330,7 +330,7 @@ async fn test_status_shows_offline_tier() {
     )
     .unwrap();
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.env("SPELUNK_NO_SERVER", "1") // ensure offline even if a local server is running
         .arg("--config")
         .arg(&config_path)
@@ -339,7 +339,7 @@ async fn test_status_shows_offline_tier() {
         .assert()
         .success();
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.env("SPELUNK_NO_SERVER", "1")
         .current_dir(&project_dir)
         .arg("--config")
@@ -387,7 +387,7 @@ async fn test_status_shows_server_tier() {
         &mock_server.uri(),
     );
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.arg("--config")
         .arg(&config_path)
         .arg("index")
@@ -395,7 +395,7 @@ async fn test_status_shows_server_tier() {
         .assert()
         .success();
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
@@ -445,7 +445,7 @@ async fn test_status_json_includes_tier_fields() {
         &mock_server.uri(),
     );
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.arg("--config")
         .arg(&config_path)
         .arg("index")
@@ -453,8 +453,7 @@ async fn test_status_json_includes_tier_fields() {
         .assert()
         .success();
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
@@ -518,8 +517,7 @@ async fn test_status_json_stable_schema() {
     .unwrap();
 
     // Index the project so there is data to query.
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("SPELUNK_NO_SERVER", "1") // ensure offline even if a local server is running
         .arg("--config")
         .arg(&config_path)
@@ -528,8 +526,7 @@ async fn test_status_json_stable_schema() {
         .assert()
         .success();
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(&project_dir)
         .arg("--config")
@@ -644,7 +641,7 @@ async fn test_check_reports_server_reachable() {
         &mock_server.uri(),
     );
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.arg("--config")
         .arg(&config_path)
         .arg("index")
@@ -652,7 +649,7 @@ async fn test_check_reports_server_reachable() {
         .assert()
         .success();
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
@@ -683,7 +680,7 @@ async fn test_check_reports_server_unreachable() {
     )
     .unwrap();
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.arg("--config")
         .arg(&config_path)
         .arg("index")
@@ -691,7 +688,7 @@ async fn test_check_reports_server_unreachable() {
         .assert()
         .success();
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
@@ -720,7 +717,7 @@ async fn test_index_prints_note_when_no_server_configured() {
     )
     .unwrap();
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.env("SPELUNK_NO_SERVER", "1") // ensure offline even if a local server is running
         .arg("--config")
         .arg(&config_path)
@@ -751,7 +748,7 @@ fn test_status_json_offline_tier() {
     )
     .unwrap();
 
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.env("SPELUNK_NO_SERVER", "1") // ensure offline even if a local server is running
         .arg("--config")
         .arg(&config_path)
@@ -760,8 +757,7 @@ fn test_status_json_offline_tier() {
         .assert()
         .success();
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .env("SPELUNK_NO_SERVER", "1")
         .current_dir(&project_dir)
         .arg("--config")
@@ -812,7 +808,7 @@ fn test_search_no_index_falls_back_to_ast_grep_or_clean_message() {
 
     // With no index, auto mode must not fail with a hard error.
     // It either returns ast-grep results or a clean "No results found." message.
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     let assert = cmd
         .current_dir(&project_dir)
         .arg("--config")
@@ -858,8 +854,7 @@ fn test_search_index_but_no_embedder_falls_back_to_ast_grep() {
     // Build the index (offline — no embedder needed for parse phase).
     // SPELUNK_NO_SERVER=1 keeps the embed phase from auto-discovering a
     // loopback spelunk-server on 127.0.0.1:7777.
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
         .arg(&config_path)
@@ -869,7 +864,7 @@ fn test_search_index_but_no_embedder_falls_back_to_ast_grep() {
         .success();
 
     // Now search in auto mode: embedder is unavailable, so fallback kicks in.
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     let assert = cmd
         .current_dir(&project_dir)
         .arg("--config")
@@ -903,8 +898,7 @@ fn test_search_explicit_hybrid_no_embedder_falls_back_to_text() {
     )
     .unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("SPELUNK_NO_SERVER", "1") // prevent accidental loopback auto-discovery
         .arg("--config")
         .arg(&config_path)
@@ -916,8 +910,7 @@ fn test_search_explicit_hybrid_no_embedder_falls_back_to_text() {
     // Explicit --mode hybrid with no server → succeeds with text search silently
     // (ADR-004: inference-only routing; fallback is resolved at capability detection,
     // no per-query notice is emitted).
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
@@ -942,8 +935,7 @@ fn test_search_explicit_semantic_no_server_falls_back_to_text() {
     let db_path = temp.path().join("index.db");
     fs::write(&config_path, format!("db_path = {:?}\n", db_path)).unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("SPELUNK_NO_SERVER", "1") // prevent accidental loopback auto-discovery
         .arg("--config")
         .arg(&config_path)
@@ -955,8 +947,7 @@ fn test_search_explicit_semantic_no_server_falls_back_to_text() {
     // Explicit --mode semantic with no server configured → silent fallback to
     // text search (ADR-004: no explicit server_url = inference-only routing,
     // fallback notice is suppressed; same as the hybrid test above).
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("SPELUNK_NO_SERVER", "1") // prevent accidental loopback auto-discovery
         .current_dir(&project_dir)
         .arg("--config")
@@ -977,9 +968,7 @@ fn test_search_explicit_semantic_no_server_falls_back_to_text() {
 fn test_server_status_not_running() {
     let tmp = tempdir().unwrap();
     // Point HOME to an empty tmpdir so no real state files interfere.
-    Command::cargo_bin("spelunk")
-        .unwrap()
-        .env("HOME", tmp.path())
+    spelunk_bin_in(tmp.path())
         .arg("server")
         .arg("status")
         .assert()
@@ -991,8 +980,7 @@ fn test_server_status_not_running() {
 #[test]
 fn test_server_logs_missing_file() {
     let tmp = tempdir().unwrap();
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("HOME", tmp.path())
         .arg("server")
         .arg("logs")
@@ -1005,8 +993,7 @@ fn test_server_logs_missing_file() {
 #[test]
 fn test_server_stop_not_running() {
     let tmp = tempdir().unwrap();
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("HOME", tmp.path())
         .arg("server")
         .arg("stop")
@@ -1028,8 +1015,7 @@ fn test_server_start_binary_not_found() {
     // Unix-style path like /tmp/... is interpreted as a relative path and will
     // also not exist, so any clearly non-existent path works here.
     let nonexistent = tmp.path().join("spelunk-server-does-not-exist-xyzzy");
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("HOME", tmp.path())
         .arg("server")
         .arg("start")
@@ -1067,8 +1053,7 @@ fn test_init_non_tty_prints_skip_notice() {
 
     // stdin is piped (not a TTY) when launched via assert_cmd, so
     // is_terminal() returns false — the non-interactive branch runs.
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .current_dir(tmp.path())
         .env("HOME", tmp.path())
         .env("SPELUNK_NO_SERVER", "1")
@@ -1225,8 +1210,7 @@ async fn test_memory_add_then_search_round_trip_on_local_store_with_auto_discove
 
     // Build a local index so memory commands have a DB to resolve `mem_path`
     // from (offline embedding — SPELUNK_NO_SERVER keeps `index` from probing).
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("HOME", &home)
         .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
@@ -1239,8 +1223,7 @@ async fn test_memory_add_then_search_round_trip_on_local_store_with_auto_discove
     // Add a note via the auto-discovery path. No SPELUNK_NO_SERVER, so the
     // loopback server embeds the note (via /index/embed) while the note text +
     // metadata are written to the LOCAL memory.db.
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("HOME", &home)
         .env("SPELUNK_STATE_DIR", &state_dir)
         .env_remove("SPELUNK_NO_SERVER")
@@ -1265,8 +1248,7 @@ async fn test_memory_add_then_search_round_trip_on_local_store_with_auto_discove
     // locally-stored note — proving add and search share one store. The server
     // only embedded the query; the `/memory/search` guard ensures no memory rows
     // were fetched from the server.
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("HOME", &home)
         .env("SPELUNK_STATE_DIR", &state_dir)
         .env_remove("SPELUNK_NO_SERVER")
@@ -1283,8 +1265,7 @@ async fn test_memory_add_then_search_round_trip_on_local_store_with_auto_discove
 
     // Cross-check: `memory list` (which has always read memory.db) sees the same
     // note. Before ADR-004 `search` and `list` could disagree; now they cannot.
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("HOME", &home)
         .env("SPELUNK_STATE_DIR", &state_dir)
         .env_remove("SPELUNK_NO_SERVER")
@@ -1328,8 +1309,7 @@ async fn test_memory_timeline_reads_local_store_with_auto_discovered_server() {
     )
     .unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("HOME", &home)
         .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
@@ -1339,8 +1319,7 @@ async fn test_memory_timeline_reads_local_store_with_auto_discovered_server() {
         .assert()
         .success();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("HOME", &home)
         .env("SPELUNK_STATE_DIR", &state_dir)
         .env_remove("SPELUNK_NO_SERVER")
@@ -1360,8 +1339,7 @@ async fn test_memory_timeline_reads_local_store_with_auto_discovered_server() {
         .assert()
         .success();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("HOME", &home)
         .env("SPELUNK_STATE_DIR", &state_dir)
         .env_remove("SPELUNK_NO_SERVER")

--- a/crates/spelunk-cli/tests/embed.rs
+++ b/crates/spelunk-cli/tests/embed.rs
@@ -5,9 +5,8 @@
 //! a fixed 768-dimensional vector, so no real server is needed.
 
 mod plumbing_helpers;
-use plumbing_helpers::{FIXTURE_PROJECT_ID, IndexEmbedResponder};
+use plumbing_helpers::{FIXTURE_PROJECT_ID, IndexEmbedResponder, spelunk_bin};
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
 use wiremock::matchers::{method, path, path_regex};
@@ -51,8 +50,7 @@ async fn embed_exits_0_with_empty_piped_stdin() {
     let config = write_server_config(&tmp, &mock.uri());
 
     // Pipe empty stdin — command should succeed (no lines to embed).
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -89,8 +87,7 @@ async fn embed_document_mode_produces_jsonl_vector() {
     let tmp = TempDir::new().unwrap();
     let config = write_server_config(&tmp, &mock.uri());
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -142,8 +139,7 @@ async fn embed_query_mode_produces_jsonl_vector() {
     let tmp = TempDir::new().unwrap();
     let config = write_server_config(&tmp, &mock.uri());
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -183,8 +179,7 @@ async fn embed_multiple_lines_produce_multiple_vectors() {
     let tmp = TempDir::new().unwrap();
     let config = write_server_config(&tmp, &mock.uri());
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -208,8 +203,7 @@ fn embed_exits_nonzero_when_no_server_configured() {
     let config = tmp.path().join("config.toml");
     std::fs::write(&config, "embedding_model = \"test-model\"\n").unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")

--- a/crates/spelunk-cli/tests/graph_edges.rs
+++ b/crates/spelunk-cli/tests/graph_edges.rs
@@ -1,9 +1,8 @@
 //! Component tests for `spelunk plumbing graph-edges`.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_bin, spelunk_cmd};
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
@@ -145,8 +144,7 @@ fn graph_edges_exits_nonzero_when_db_missing() {
     )
     .unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")

--- a/crates/spelunk-cli/tests/harvest_upfront_check.rs
+++ b/crates/spelunk-cli/tests/harvest_upfront_check.rs
@@ -5,6 +5,9 @@
 //! These tests don't need a running server or a real git repo; they only
 //! exercise the early server-gate check.
 
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
@@ -29,7 +32,7 @@ fn write_harvest_config(dir: &std::path::Path, extra: &str) -> std::path::PathBu
 
 /// Build a `spelunk --config <cfg> memory harvest --git-range HEAD~1..HEAD` command.
 fn harvest_cmd(config_path: &std::path::Path, dir: &std::path::Path) -> Command {
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.current_dir(dir)
         .env_remove("SPELUNK_SERVER_URL")
         .env_remove("SPELUNK_MEMORY_SERVER_URL")

--- a/crates/spelunk-cli/tests/hash_file.rs
+++ b/crates/spelunk-cli/tests/hash_file.rs
@@ -5,9 +5,8 @@
 //! (e.g. `src/lib.rs`), so the path argument must match what was indexed.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_bin, spelunk_cmd};
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::Path;
 use tempfile::TempDir;
@@ -164,8 +163,7 @@ fn hash_file_exits_nonzero_when_db_missing() {
     let real_file = tmp.path().join("real.rs");
     std::fs::write(&real_file, "fn x() {}").unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")
@@ -186,8 +184,7 @@ fn hash_file_exits_nonzero_missing_argument() {
     let config_path = tmp.path().join("config.toml");
     std::fs::write(&config_path, "llm_model = \"x\"\n").unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")

--- a/crates/spelunk-cli/tests/integration_compose.rs
+++ b/crates/spelunk-cli/tests/integration_compose.rs
@@ -8,9 +8,8 @@
 //! non-deterministic; tests assert structure and non-emptiness only.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_bin, spelunk_cmd};
 
-use assert_cmd::Command;
 use std::path::Path;
 
 // ── Test 1: search --format jsonl vs embed | knn ────────────────────────────
@@ -24,8 +23,7 @@ fn porcelain_search_jsonl_returns_valid_chunk_ids() {
     let (_tmp, db_path, config_path) = index_fixture_project();
 
     // `spelunk search "test" --db <db> --format jsonl --no-stale-check`
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("search")
@@ -70,8 +68,7 @@ fn plumbing_knn_returns_valid_chunk_ids() {
 
     // Step 1: embed a query string via `spelunk plumbing embed --query`
     // The mock server returns [0.1f32; 768] for every request.
-    let embed_output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let embed_output = spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")
@@ -129,8 +126,7 @@ fn status_json_file_count_matches_ls_files_count() {
     //
     // Run from the temp dir so the registry won't match any registered project
     // via CWD, forcing resolve_project_and_deps to fall back to cfg.db_path.
-    let status_output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let status_output = spelunk_bin()
         .current_dir(_tmp.path())
         .arg("--config")
         .arg(&config_path)
@@ -184,8 +180,7 @@ fn parse_file_content_appears_in_cat_chunks() {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/simple-project/src/lib.rs");
 
     // parse-file: parse lib.rs without DB.
-    let parse_output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let parse_output = spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")

--- a/crates/spelunk-cli/tests/knn.rs
+++ b/crates/spelunk-cli/tests/knn.rs
@@ -8,9 +8,8 @@
 //! Error-path tests (bad JSON on stdin, missing DB) run without a server.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_bin, spelunk_cmd};
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
@@ -54,8 +53,7 @@ fn knn_exits_nonzero_when_db_missing() {
     )
     .unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")
@@ -120,8 +118,7 @@ fn knn_returns_jsonl_results_for_valid_vector() {
         "vector": vec,
     });
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -169,8 +166,7 @@ fn knn_lang_filter_restricts_to_language() {
         "vector": vec,
     });
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -220,8 +216,7 @@ fn knn_min_score_filter_respects_threshold() {
         "vector": vec,
     });
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")

--- a/crates/spelunk-cli/tests/ls_files.rs
+++ b/crates/spelunk-cli/tests/ls_files.rs
@@ -1,9 +1,8 @@
 //! Component tests for `spelunk plumbing ls-files`.
 
 mod plumbing_helpers;
-use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_cmd};
+use plumbing_helpers::{index_fixture_project, parse_jsonl, spelunk_bin, spelunk_cmd};
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
@@ -125,8 +124,7 @@ fn ls_files_exits_nonzero_when_db_missing() {
     )
     .unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")
@@ -155,8 +153,7 @@ fn plumbing_exits_2_on_error() {
     )
     .unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")

--- a/crates/spelunk-cli/tests/memory_add_secret_gate.rs
+++ b/crates/spelunk-cli/tests/memory_add_secret_gate.rs
@@ -12,6 +12,9 @@
 //! exercise it run inside a temporary `git init` directory.  Tests that only
 //! check the error/SQLite side can use a plain temp dir.
 
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::{Path, PathBuf};
@@ -37,7 +40,7 @@ fn write_config(dir: &Path, mem_db: &Path, git_notes: bool) -> PathBuf {
 
 /// Build `spelunk --config <cfg> memory --db <mem_db> add --kind note …` command.
 fn memory_add_cmd(dir: &Path, cfg: &Path, mem_db: &Path) -> Command {
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.current_dir(dir)
         // Avoid picking up any server config from the real user environment.
         .env_remove("SPELUNK_SERVER_URL")

--- a/crates/spelunk-cli/tests/memory_list_format.rs
+++ b/crates/spelunk-cli/tests/memory_list_format.rs
@@ -4,7 +4,7 @@
 //! colored text summary instead of emitting one JSON object per line.
 
 mod plumbing_helpers;
-use plumbing_helpers::{parse_jsonl, write_config};
+use plumbing_helpers::{parse_jsonl, spelunk_bin, write_config};
 
 use assert_cmd::Command;
 use tempfile::TempDir;
@@ -20,8 +20,7 @@ fn project_with_memory_note() -> (TempDir, std::path::PathBuf, std::path::PathBu
     // No server needed for `memory add`/`memory list` on the local backend.
     let config_path = write_config(tmp.path(), &db_path, "http://127.0.0.1:1");
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("memory")
@@ -42,7 +41,7 @@ fn project_with_memory_note() -> (TempDir, std::path::PathBuf, std::path::PathBu
 
 /// Build a `spelunk --config <cfg> memory --db <mem> list` Command.
 fn memory_list_cmd(mem_path: &std::path::Path, config_path: &std::path::Path) -> Command {
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.arg("--config")
         .arg(config_path)
         .arg("memory")

--- a/crates/spelunk-cli/tests/memory_reconcile.rs
+++ b/crates/spelunk-cli/tests/memory_reconcile.rs
@@ -13,6 +13,9 @@
 //!    transaction rolls back (no partial import).
 //! 8. Exit codes: 0 on success and on no-op; non-zero only on real fault.
 
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
 use assert_cmd::Command;
 use rusqlite::Connection;
 use std::path::{Path, PathBuf};
@@ -200,7 +203,7 @@ fn reconcile_cmd(config_path: &Path, server_db: &Path) -> Command {
     let tmp_dir = config_path
         .parent()
         .expect("config_path must have a parent");
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.current_dir(tmp_dir)
         .env("SPELUNK_NO_SERVER", "1")
         .env("SPELUNK_NO_RECONCILE_NUDGE", "1")
@@ -918,7 +921,7 @@ fn rollback_on_mid_transaction_failure_leaves_no_partial_import() {
 
         // Bootstrap reconcile: run from boot_dir so config resolves correctly.
         // Use --all-projects (only boot-for-rollback slug exists in bootstrap_db).
-        let mut boot_cmd = Command::cargo_bin("spelunk").unwrap();
+        let mut boot_cmd = spelunk_bin();
         boot_cmd
             .current_dir(&boot_dir)
             .env("SPELUNK_NO_SERVER", "1")

--- a/crates/spelunk-cli/tests/parse_file.rs
+++ b/crates/spelunk-cli/tests/parse_file.rs
@@ -4,9 +4,8 @@
 //! on disk and emits JSONL chunks.
 
 mod plumbing_helpers;
-use plumbing_helpers::parse_jsonl;
+use plumbing_helpers::{parse_jsonl, spelunk_bin};
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::Path;
 use tempfile::TempDir;
@@ -37,8 +36,7 @@ fn parse_file_emits_jsonl_for_rust_file() {
     let tmp = TempDir::new().unwrap();
     let config = dummy_config(&tmp);
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -76,8 +74,7 @@ fn parse_file_finds_function_and_struct_chunks() {
     let tmp = TempDir::new().unwrap();
     let config = dummy_config(&tmp);
 
-    let output = Command::cargo_bin("spelunk")
-        .unwrap()
+    let output = spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -114,8 +111,7 @@ fn parse_file_exits_1_for_unsupported_file_type() {
     let unknown = tmp.path().join("file.xyz123");
     std::fs::write(&unknown, "some content").unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -132,8 +128,7 @@ fn parse_file_exits_nonzero_for_missing_file() {
     let tmp = TempDir::new().unwrap();
     let config = dummy_config(&tmp);
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -150,8 +145,7 @@ fn parse_file_exits_nonzero_missing_argument() {
     let config = dummy_config(&tmp);
 
     // Missing required positional argument → clap error.
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config)
         .arg("plumbing")

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -9,6 +9,56 @@ use assert_cmd::Command;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
+/// Build a `spelunk` test command that never touches the OS keychain and never
+/// reads or writes the developer's real `~/.config/spelunk`.
+///
+/// Every integration test spawns the real `spelunk` binary, and each spawned
+/// process runs `Config::load`, which resolves a secret store. In auto mode
+/// (`SPELUNK_SECRET_STORE` unset) that selects the OS keychain whenever one is
+/// present — which on macOS is always — triggering a Keychain access prompt on
+/// every test binary. "Always Allow" never sticks because each rebuilt test
+/// binary is a fresh app to the Keychain ACL. CI (Linux, no Secret Service) is
+/// silent only by accident of the auto fallback.
+///
+/// This constructor pins two things on the child process:
+///
+/// * `SPELUNK_SECRET_STORE=file` — force the plaintext file store, so a spawned
+///   CLI can never reach the keychain. Production behaviour is unchanged: real
+///   users still get the keychain in auto mode; only tests pin the backend.
+/// * `HOME` / `XDG_CONFIG_HOME` redirected to a throwaway temp dir — so the file
+///   store writes its `secrets.toml` into an isolated `~/.config/spelunk` under
+///   the temp HOME, never the developer's real config dir.
+///
+/// The temp dir is intentionally leaked (its path is kept for the lifetime of
+/// the process) so the child can read/write it after this function returns; the
+/// OS reclaims it on the next reboot. Tests that already manage their own `HOME`
+/// (e.g. for registry isolation) should use [`spelunk_bin_in`] instead so the
+/// keychain pin composes with their existing home dir.
+pub fn spelunk_bin() -> Command {
+    let home = TempDir::new()
+        .expect("create temp HOME for spelunk test command")
+        .keep();
+    spelunk_bin_in(&home)
+}
+
+/// Like [`spelunk_bin`], but uses the caller-supplied `home` directory as the
+/// isolated `HOME` instead of allocating a throwaway temp dir.
+///
+/// Use this from tests that set `HOME` themselves (registry isolation, seeded
+/// config under `<home>/.config/spelunk`, etc.). It applies the same keychain
+/// pin (`SPELUNK_SECRET_STORE=file`) and home redirection so those tests stop
+/// prompting for Keychain access while keeping their existing home semantics.
+pub fn spelunk_bin_in(home: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    cmd.env("SPELUNK_SECRET_STORE", "file") // never the OS keychain in tests
+        .env("HOME", home)
+        // `spelunk_config_dir()` uses `dirs::home_dir()` (HOME on Unix); unset
+        // XDG_CONFIG_HOME so the file store lands under `<home>/.config/spelunk`
+        // and never the developer's real config dir.
+        .env_remove("XDG_CONFIG_HOME");
+    cmd
+}
+
 /// Path (relative to the workspace root) of the synthetic fixture project.
 pub const FIXTURE_DIR: &str = "tests/fixtures/simple-project";
 
@@ -23,7 +73,7 @@ pub const FIXTURE_PROJECT_ID: &str = "test-org/test-project";
 /// command.  The correct invocation shape is:
 ///   spelunk --config <cfg> plumbing --db <db> <subcommand> [args]
 pub fn spelunk_cmd(db_path: &Path, config_path: &Path) -> Command {
-    let mut cmd = Command::cargo_bin("spelunk").unwrap();
+    let mut cmd = spelunk_bin();
     cmd.arg("--config")
         .arg(config_path)
         .arg("plumbing")
@@ -160,8 +210,7 @@ pub fn index_fixture_project() -> (TempDir, PathBuf, PathBuf) {
 
     // Pass `--db` explicitly so the index is written to our temp DB path,
     // not to `<fixture>/.spelunk/index.db` (the default project-local location).
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin_in(tmp.path())
         .arg("--config")
         .arg(&config_path)
         .arg("index")

--- a/crates/spelunk-cli/tests/read_memory.rs
+++ b/crates/spelunk-cli/tests/read_memory.rs
@@ -1,9 +1,8 @@
 //! Component tests for `spelunk plumbing read-memory`.
 
 mod plumbing_helpers;
-use plumbing_helpers::{parse_jsonl, spelunk_cmd, write_config};
+use plumbing_helpers::{parse_jsonl, spelunk_bin, spelunk_cmd, write_config};
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
 
@@ -45,8 +44,7 @@ fn indexed_project_with_memory_note() -> (tempfile::TempDir, std::path::PathBuf,
     // phase is skipped — these plumbing tests only need parsed chunks + a memory
     // note, not embeddings, and without it the index would auto-discover a
     // loopback spelunk-server on 127.0.0.1:7777 and fail on a dim mismatch.
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .env("SPELUNK_NO_SERVER", "1")
         .arg("--config")
         .arg(&config_path)
@@ -63,8 +61,7 @@ fn indexed_project_with_memory_note() -> (tempfile::TempDir, std::path::PathBuf,
     // workspace's .spelunk/memory.db instead).
     let mem_path = db_path.with_file_name("memory.db");
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("memory")
@@ -209,8 +206,7 @@ fn read_memory_exits_nonzero_when_db_missing() {
     )
     .unwrap();
 
-    Command::cargo_bin("spelunk")
-        .unwrap()
+    spelunk_bin()
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")


### PR DESCRIPTION
## Problem

Running `cargo test` on macOS triggers repeated **Keychain access prompts**. "Always Allow" never sticks because each rebuilt test binary is a new application to the Keychain ACL, so the grant has to be re-approved every build. CI on Linux is silent only by accident.

## Root cause

The CLI integration tests in `crates/spelunk-cli/tests/*` spawn the real `spelunk` binary via `assert_cmd::Command::cargo_bin("spelunk")` (94 sites across 18 files). Each spawned process runs `Config::load`, which calls `secret_store::default_store(&spelunk_config_dir())`. In auto mode (`SPELUNK_SECRET_STORE` unset) `default_store` selects the OS keychain (`KeyringStore`) whenever one is reachable — which on macOS is always — producing a Keychain read prompt per test binary. On headless Linux CI there is no Secret Service, so it falls back to the file store and stays silent.

Separately, `spelunk_config_dir()` resolves via `dirs::home_dir()` (i.e. `HOME` on Unix) with no override, so naively forcing the file store without isolating `HOME` would read/write `secrets.toml` in the developer's real `~/.config/spelunk`.

## Fix

Add a single shared test-command constructor in `crates/spelunk-cli/tests/plumbing_helpers.rs`:

- `spelunk_bin()` — builds the command with `SPELUNK_SECRET_STORE=file` (never the keychain) and redirects `HOME` / removes `XDG_CONFIG_HOME` to a throwaway temp dir, so the file store's `secrets.toml` never touches the developer's real config dir.
- `spelunk_bin_in(home)` — same keychain pin for the tests that already manage their own `HOME` (registry-isolation tests in `cross_project_memory.rs`, the `server status` test in `e2e_cli.rs`), composing with their existing home dir.

All 94 direct `cargo_bin("spelunk")` spawn sites were replaced with the shared constructor. The only remaining `cargo_bin("spelunk")` in the whole test tree is inside `spelunk_bin_in` itself, so it is now **structurally impossible** for a spawned test CLI to reach the OS keychain on a plain `cargo test`.

**No production/runtime behaviour change.** Real users still get the keychain in auto mode; only the tests pin the backend. Test-only files were touched (18 files under `crates/spelunk-cli/tests/`).

## Test plan

Commands run from the worktree (the `SPELUNK_SECRET_STORE=file` prefix is only a safety net for the non-interactive run; the structural grep below proves the fix holds without it):

- `SPELUNK_SECRET_STORE=file cargo test` → all green (cli + core + server suites, 0 failed, 0 warnings)
- `SPELUNK_SECRET_STORE=file cargo test --no-default-features` → all green (0 failed)
- `cargo clippy --all-targets -- -D warnings` → exit 0, no warnings
- `cargo fmt --check` → clean

Structural proof that no spawned CLI can reach the keychain even on a bare `cargo test`:

- `grep -rn 'cargo_bin("spelunk")' crates/spelunk-cli/tests/` → **exactly one** hit, inside the `spelunk_bin_in` constructor.
- `grep -n SPELUNK_SECRET_STORE crates/spelunk-cli/tests/plumbing_helpers.rs` → the constructor sets `cmd.env("SPELUNK_SECRET_STORE", "file")`.
- 95 call sites now route through `spelunk_bin()` / `spelunk_bin_in()`.

The interactive "zero Keychain prompts on a bare `cargo test`" check will be confirmed by the developer on macOS; the grep above makes it a structural guarantee rather than a runtime hope.