### PR TITLE
perf(embedder): distribute pre-quantized Q8_0 GGUF (safetensors cleanup + gated direct-GGUF loader + attribution)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,6 @@ Contributions welcome. See [Building from source](docs/building.md) for setup in
 ## License
 
 [MIT](LICENSE)
+
+spelunk-server bundles a third-party embedding model (Apache-2.0). See
+[Third-party models](docs/third-party-models.md) for attribution.

--- a/crates/spelunk-server/src/embedder_native.rs
+++ b/crates/spelunk-server/src/embedder_native.rs
@@ -20,7 +20,7 @@ const MODEL_ID: &str = "codefuse-ai/F2LLM-v2-330M";
 /// recorded in the NOTICE / model card for our redistributed Q8_0 GGUF. Update
 /// this in lockstep with regenerating and re-uploading the pre-quantized
 /// artifact.
-const MODEL_REVISION: &str = "main";
+const MODEL_REVISION: &str = "1239cdd544b24c247ed75df2ae22e5a401ac4659";
 
 /// Optional Hugging Face repo id holding our **own pre-quantized Q8_0 GGUF**
 /// (e.g. `spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF`). Read from

--- a/crates/spelunk-server/src/embedder_native.rs
+++ b/crates/spelunk-server/src/embedder_native.rs
@@ -14,6 +14,26 @@ use tokenizers::Tokenizer;
 pub const DIM: usize = 896;
 
 const MODEL_ID: &str = "codefuse-ai/F2LLM-v2-330M";
+/// Upstream revision (commit SHA) of `codefuse-ai/F2LLM-v2-330M` we download and
+/// quantize from. Pinning the revision makes the on-device quantize path
+/// reproducible (the same weights every first run) and is the provenance anchor
+/// recorded in the NOTICE / model card for our redistributed Q8_0 GGUF. Update
+/// this in lockstep with regenerating and re-uploading the pre-quantized
+/// artifact.
+const MODEL_REVISION: &str = "main";
+
+/// Optional Hugging Face repo id holding our **own pre-quantized Q8_0 GGUF**
+/// (e.g. `spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF`). Read from
+/// `SPELUNK_EMBEDDER_GGUF_REPO` at load time.
+///
+/// When set, `load()` downloads `QUANT_GGUF` directly from that repo via the
+/// existing hf-hub cache — first-run download drops to ~339 MB and there is no
+/// on-device safetensors download or quantize step. When unset (the default),
+/// the loader keeps the download-safetensors-and-quantize-on-device path, so
+/// merging this change alters nothing until the GGUF repo exists and an operator
+/// sets the env var. Activation = upload the artifact, then default this on.
+const GGUF_REPO_ENV: &str = "SPELUNK_EMBEDDER_GGUF_REPO";
+
 /// Hard ceiling for token sequences (max_position_embeddings).
 const MAX_SEQ_LEN: usize = 40960;
 /// Number of sequences processed in one padded forward pass.
@@ -401,12 +421,23 @@ fn causal_mask(seq: usize, dtype: DType, device: &Device) -> Result<Tensor> {
 impl NativeEmbedder {
     /// Load the F2LLM-v2-330M model, quantized to Q8_0.
     ///
-    /// On first call the ~650 MB safetensors weights are downloaded into
-    /// `~/.local/share/spelunk/models/` via the hf-hub cache, quantized to Q8_0,
-    /// and written to a ~355 MB GGUF (`f2llm-v2-330m-q8_0.gguf`) in the same
-    /// directory. Subsequent calls read the GGUF directly with no network access
-    /// and no safetensors load. Uses Metal/GPU on macOS when built with the
-    /// `metal` cargo feature, CPU otherwise.
+    /// Two acquisition paths select the Q8_0 GGUF cached in
+    /// `~/.local/share/spelunk/models/`:
+    ///
+    /// * **Default (dev / pre-activation):** download the ~638 MB BF16
+    ///   safetensors from the pinned upstream revision of
+    ///   `codefuse-ai/F2LLM-v2-330M`, quantize on device to a ~339 MB GGUF
+    ///   (`f2llm-v2-330m-q8_0.gguf`), then delete the cached safetensors so
+    ///   steady-state disk is ~339 MB rather than ~1.5 GB.
+    /// * **Direct GGUF (activated via `SPELUNK_EMBEDDER_GGUF_REPO`):** download
+    ///   our own pre-quantized GGUF straight from the named HF repo through the
+    ///   same hf-hub cache (checksum/resume reused) — first-run download is
+    ///   ~339 MB and there is no on-device quantize step.
+    ///
+    /// Either way subsequent calls read the cached GGUF directly with no network
+    /// access. The tokenizer and config are always fetched from the pinned
+    /// upstream revision. Uses Metal/GPU on macOS when built with the `metal`
+    /// cargo feature, CPU otherwise.
     pub fn load() -> Result<Self> {
         let cache_dir = model_cache_dir()?;
         std::fs::create_dir_all(&cache_dir)
@@ -425,7 +456,12 @@ impl NativeEmbedder {
             .with_cache_dir(cache_dir)
             .build()
             .context("building HuggingFace Hub API client")?;
-        let repo = api.repo(Repo::new(MODEL_ID.to_string(), RepoType::Model));
+        // Tokenizer + config always come from the pinned upstream revision.
+        let repo = api.repo(Repo::with_revision(
+            MODEL_ID.to_string(),
+            RepoType::Model,
+            MODEL_REVISION.to_string(),
+        ));
 
         let tokenizer_path = repo
             .get("tokenizer.json")
@@ -441,13 +477,43 @@ impl NativeEmbedder {
         )
         .context("parsing F2LLM-v2-330M config.json")?;
 
-        // Build the quantized GGUF once from the safetensors download.
+        // Acquire the Q8_0 GGUF if it isn't already cached.
         if !gguf_path.exists() {
-            tracing::info!("quantizing F2LLM-v2-330M to Q8_0 GGUF (first run; one-time)…");
-            let weight_paths = download_weights(&repo)?;
-            write_quantized_gguf(&weight_paths, &gguf_path)
-                .context("writing quantized F2LLM-v2-330M GGUF")?;
-            tracing::info!("wrote quantized model to {}", gguf_path.display());
+            match prequantized_gguf_repo() {
+                // Activated: pull our own pre-quantized GGUF directly.
+                Some(gguf_repo) => {
+                    tracing::info!(
+                        "fetching pre-quantized F2LLM-v2-330M Q8_0 GGUF from {gguf_repo} (first run)…"
+                    );
+                    let downloaded = api
+                        .repo(Repo::new(gguf_repo.clone(), RepoType::Model))
+                        .get(QUANT_GGUF)
+                        .with_context(|| format!("downloading {QUANT_GGUF} from {gguf_repo}"))?;
+                    // hf-hub returns a path inside its own blob/snapshot layout;
+                    // copy it to the stable cache path the loader reads from.
+                    if downloaded != gguf_path {
+                        std::fs::copy(&downloaded, &gguf_path).with_context(|| {
+                            format!(
+                                "caching {} -> {}",
+                                downloaded.display(),
+                                gguf_path.display()
+                            )
+                        })?;
+                    }
+                    tracing::info!("fetched pre-quantized model to {}", gguf_path.display());
+                }
+                // Default / dev fallback: download safetensors and quantize.
+                None => {
+                    tracing::info!("quantizing F2LLM-v2-330M to Q8_0 GGUF (first run; one-time)…");
+                    let weight_paths = download_weights(&repo)?;
+                    write_quantized_gguf(&weight_paths, &gguf_path)
+                        .context("writing quantized F2LLM-v2-330M GGUF")?;
+                    tracing::info!("wrote quantized model to {}", gguf_path.display());
+                    // Reclaim ~638 MB: the BF16 safetensors are only needed to
+                    // build the GGUF; the loader reads the GGUF from here on.
+                    cleanup_safetensors(&weight_paths);
+                }
+            }
         }
 
         let weights = Qwen3EmbedWeights::from_gguf(&gguf_path, &config, &device)
@@ -571,6 +637,59 @@ fn model_cache_dir() -> Result<PathBuf> {
         .ok_or_else(|| anyhow::anyhow!("could not determine local data directory"))
 }
 
+/// HF repo id of our pre-quantized Q8_0 GGUF, from `SPELUNK_EMBEDDER_GGUF_REPO`.
+///
+/// Returns `None` (the default) when the variable is unset or blank, keeping the
+/// download-safetensors-and-quantize path active. This is the single config gate
+/// that activates direct-GGUF distribution; flipping the default to
+/// `Some("spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF")` is the activation step, done
+/// only once the artifact has been uploaded.
+fn prequantized_gguf_repo() -> Option<String> {
+    std::env::var(GGUF_REPO_ENV)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Delete the cached BF16 safetensors after the Q8_0 GGUF has been written.
+///
+/// The hf-hub cache stores each file as a content-addressed blob under `blobs/`
+/// with a symlink from `snapshots/<rev>/<file>`. We resolve the symlink to its
+/// blob and remove both, reclaiming ~638 MB; the loader only ever reads the
+/// GGUF after this point. Best-effort: a failure to reclaim disk is logged, not
+/// fatal (the GGUF is already written and valid).
+fn cleanup_safetensors(weight_paths: &[PathBuf]) {
+    let mut reclaimed: u64 = 0;
+    for path in weight_paths {
+        // Resolve the blob the snapshot symlink points at (if it is one).
+        let blob = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+        for target in [&blob, path] {
+            match std::fs::metadata(target) {
+                Ok(meta) if meta.is_file() => {
+                    let len = meta.len();
+                    match std::fs::remove_file(target) {
+                        Ok(()) => reclaimed += len,
+                        Err(e) => tracing::warn!(
+                            "could not delete cached safetensors {}: {e}",
+                            target.display()
+                        ),
+                    }
+                }
+                _ => {}
+            }
+            if blob == *path {
+                break; // not a symlink; only one path to remove
+            }
+        }
+    }
+    if reclaimed > 0 {
+        tracing::info!(
+            "reclaimed {:.0} MB by deleting cached BF16 safetensors after quantization",
+            reclaimed as f64 / 1_048_576.0
+        );
+    }
+}
+
 fn l2_normalise(v: &mut [f32]) {
     let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
     if norm > 0.0 {
@@ -644,6 +763,71 @@ impl spelunk_core::embeddings::EmbeddingBackend for NativeEmbedder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The direct-GGUF path is gated: with `SPELUNK_EMBEDDER_GGUF_REPO` unset or
+    /// blank, `prequantized_gguf_repo()` returns `None`, so `load()` keeps the
+    /// default download-safetensors-and-quantize path. This is what makes the PR
+    /// safe to merge before the HF GGUF repo exists — merging changes nothing
+    /// until an operator sets the variable. Uses `serial` because it mutates a
+    /// process-global env var.
+    #[test]
+    #[serial_test::serial(gguf_repo_env)]
+    fn prequantized_gguf_repo_gate_defaults_off() {
+        // SAFETY: guarded by #[serial] so no other test reads/writes this var
+        // concurrently; we restore it before returning.
+        let prev = std::env::var(GGUF_REPO_ENV).ok();
+
+        unsafe { std::env::remove_var(GGUF_REPO_ENV) };
+        assert_eq!(
+            prequantized_gguf_repo(),
+            None,
+            "unset env var must keep the quantize-on-first-run default path"
+        );
+
+        unsafe { std::env::set_var(GGUF_REPO_ENV, "   ") };
+        assert_eq!(
+            prequantized_gguf_repo(),
+            None,
+            "blank/whitespace env var must be treated as unset"
+        );
+
+        unsafe { std::env::set_var(GGUF_REPO_ENV, "spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF") };
+        assert_eq!(
+            prequantized_gguf_repo().as_deref(),
+            Some("spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF"),
+            "set env var must activate the direct-GGUF path with the repo id"
+        );
+
+        // Trimming: surrounding whitespace is stripped from the repo id.
+        unsafe { std::env::set_var(GGUF_REPO_ENV, "  org/repo  ") };
+        assert_eq!(prequantized_gguf_repo().as_deref(), Some("org/repo"));
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var(GGUF_REPO_ENV, v) },
+            None => unsafe { std::env::remove_var(GGUF_REPO_ENV) },
+        }
+    }
+
+    /// `cleanup_safetensors` removes the cached weight files (reclaiming disk)
+    /// and tolerates already-absent paths without erroring — it is best-effort
+    /// and must never fail the load after the GGUF is already written.
+    #[test]
+    fn cleanup_safetensors_removes_files_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("model-00001-of-00002.safetensors");
+        let b = dir.path().join("model-00002-of-00002.safetensors");
+        std::fs::write(&a, vec![0u8; 4096]).unwrap();
+        std::fs::write(&b, vec![0u8; 4096]).unwrap();
+        assert!(a.exists() && b.exists());
+
+        let paths = vec![a.clone(), b.clone()];
+        cleanup_safetensors(&paths);
+        assert!(!a.exists(), "safetensors must be deleted to reclaim disk");
+        assert!(!b.exists(), "safetensors must be deleted to reclaim disk");
+
+        // Second call over now-missing paths must not panic or error.
+        cleanup_safetensors(&paths);
+    }
 
     /// Build a `[1, n_kv, seq, head_dim]` tensor where every element of kv-head
     /// `k` equals `k` — so the head index is recoverable from any of its values.

--- a/docs/embedder-artifact/LICENSE
+++ b/docs/embedder-artifact/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/embedder-artifact/NOTICE
+++ b/docs/embedder-artifact/NOTICE
@@ -1,0 +1,39 @@
+F2LLM-v2-330M-Q8_0-GGUF
+=======================
+
+This artifact is a modified, redistributed copy of:
+
+    codefuse-ai/F2LLM-v2-330M
+    https://huggingface.co/codefuse-ai/F2LLM-v2-330M
+    Licensed under the Apache License, Version 2.0.
+
+Source revision (pinned)
+-------------------------
+    Upstream revision: <PINNED_UPSTREAM_REVISION>
+    (the commit/revision the GGUF below was quantized from)
+
+Modification (Apache-2.0 Section 4(b))
+--------------------------------------
+The original BF16 safetensors weights have been quantized to Q8_0 and
+packaged as a single GGUF file:
+
+    f2llm-v2-330m-q8_0.gguf
+    sha256: <GGUF_SHA256>
+
+Quantization detail: projection matmul weights and the token-embedding
+table are stored Q8_0; RMSNorm weights are kept F32. No other changes are
+made to the weights.
+
+License
+-------
+The Apache License, Version 2.0 governs this artifact. The full license
+text is included in the accompanying LICENSE file and is also available at:
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Original work is Copyright its respective authors (codefuse-ai). This NOTICE
+file is provided to satisfy Apache-2.0 Section 4(d); it does not modify the
+license terms.
+
+Redistributed by the Spelunk project (https://github.com/spelunk-cloud/spelunk)
+for use as the bundled embedding model in spelunk-server.

--- a/docs/embedder-artifact/NOTICE
+++ b/docs/embedder-artifact/NOTICE
@@ -9,7 +9,7 @@ This artifact is a modified, redistributed copy of:
 
 Source revision (pinned)
 -------------------------
-    Upstream revision: <PINNED_UPSTREAM_REVISION>
+    Upstream revision: 1239cdd544b24c247ed75df2ae22e5a401ac4659
     (the commit/revision the GGUF below was quantized from)
 
 Modification (Apache-2.0 Section 4(b))
@@ -18,7 +18,7 @@ The original BF16 safetensors weights have been quantized to Q8_0 and
 packaged as a single GGUF file:
 
     f2llm-v2-330m-q8_0.gguf
-    sha256: <GGUF_SHA256>
+    sha256: 2c12aad2951f1d9a3b457f890a2586d1ee19b755b377c0fb424e856e615b8f2b
 
 Quantization detail: projection matmul weights and the token-embedding
 table are stored Q8_0; RMSNorm weights are kept F32. No other changes are

--- a/docs/embedder-artifact/README.md
+++ b/docs/embedder-artifact/README.md
@@ -29,12 +29,12 @@ first run; distributing it pre-quantized cuts the first-run download from
 
 | File | Approx. size | sha256 |
 |------|--------------|--------|
-| `f2llm-v2-330m-q8_0.gguf` | ~339 MB | `<GGUF_SHA256>` |
+| `f2llm-v2-330m-q8_0.gguf` | ~339 MB | `2c12aad2951f1d9a3b457f890a2586d1ee19b755b377c0fb424e856e615b8f2b` |
 
 ## Provenance
 
 - **Base model:** `codefuse-ai/F2LLM-v2-330M`
-- **Pinned source revision:** `<PINNED_UPSTREAM_REVISION>`
+- **Pinned source revision:** `1239cdd544b24c247ed75df2ae22e5a401ac4659`
 - **Quantization:** Q8_0 from the original BF16 weights (see above)
 - **Architecture / dim:** Qwen3 decoder, 896-dim embeddings
 

--- a/docs/embedder-artifact/README.md
+++ b/docs/embedder-artifact/README.md
@@ -1,0 +1,55 @@
+---
+license: apache-2.0
+base_model: codefuse-ai/F2LLM-v2-330M
+tags:
+  - gguf
+  - quantized
+  - embeddings
+  - sentence-similarity
+library_name: gguf
+---
+
+# F2LLM-v2-330M Q8_0 GGUF
+
+Q8_0-quantized GGUF build of [`codefuse-ai/F2LLM-v2-330M`](https://huggingface.co/codefuse-ai/F2LLM-v2-330M),
+distributed for use as the bundled embedding model in
+[Spelunk](https://github.com/spelunk-cloud/spelunk).
+
+## What this is
+
+A single GGUF file containing the F2LLM-v2-330M weights quantized from the
+original BF16 safetensors to **Q8_0**:
+
+- Projection matmul weights and the token-embedding table → **Q8_0**
+- RMSNorm weights → **F32** (kept full precision; negligible size)
+
+This is the same artifact `spelunk-server` would otherwise produce on-device on
+first run; distributing it pre-quantized cuts the first-run download from
+~638 MB to ~339 MB and keeps steady-state disk use at ~339 MB.
+
+| File | Approx. size | sha256 |
+|------|--------------|--------|
+| `f2llm-v2-330m-q8_0.gguf` | ~339 MB | `<GGUF_SHA256>` |
+
+## Provenance
+
+- **Base model:** `codefuse-ai/F2LLM-v2-330M`
+- **Pinned source revision:** `<PINNED_UPSTREAM_REVISION>`
+- **Quantization:** Q8_0 from the original BF16 weights (see above)
+- **Architecture / dim:** Qwen3 decoder, 896-dim embeddings
+
+## License & attribution
+
+Licensed under the **Apache License, Version 2.0**, inherited from the base
+model. The full license text is in [`LICENSE`](./LICENSE) and the modification
+notice is in [`NOTICE`](./NOTICE).
+
+This is a **modified** copy of `codefuse-ai/F2LLM-v2-330M`: the weights have been
+quantized to Q8_0 from the original BF16 weights. No other modifications were
+made.
+
+## Usage in Spelunk
+
+`spelunk-server` downloads this GGUF directly when the
+`SPELUNK_EMBEDDER_GGUF_REPO` config points at this repository. Otherwise it falls
+back to downloading the upstream BF16 safetensors and quantizing on device.

--- a/docs/third-party-models.md
+++ b/docs/third-party-models.md
@@ -1,0 +1,40 @@
+# Third-party models
+
+spelunk-server bundles a native embedding model rather than calling an external
+embedding endpoint. `cargo-about` (see `about.toml`) covers Rust dependency
+licenses, but it does not cover the model weights downloaded at runtime, so they
+are attributed here.
+
+## F2LLM-v2-330M (embedder)
+
+- **Model:** `codefuse-ai/F2LLM-v2-330M`
+- **Upstream:** https://huggingface.co/codefuse-ai/F2LLM-v2-330M
+- **Pinned source revision:** `main` (tracked by the `MODEL_REVISION` constant in
+  `crates/spelunk-server/src/embedder_native.rs`; update both together when the
+  pin moves).
+- **License:** Apache License 2.0 (declared via the upstream Hugging Face
+  model-card license tag). Full text:
+  https://www.apache.org/licenses/LICENSE-2.0
+- **Use in spelunk:** loaded by `spelunk-server` as the 896-dim semantic
+  embedding backend (Qwen3 decoder architecture, candle runtime).
+
+### Modification notice (Apache-2.0 §4)
+
+spelunk redistributes a **modified** copy of these weights: the original BF16
+safetensors are **quantized to Q8_0** (projection matmuls and the token-embedding
+table are stored Q8_0; RMSNorm weights are kept F32) and packaged as a single
+GGUF file. No other changes are made to the weights.
+
+By default spelunk performs this quantization **on the user's device** on first
+run, downloading the original BF16 safetensors from the pinned upstream revision
+and writing the Q8_0 GGUF locally. spelunk may alternatively distribute the
+pre-quantized GGUF from a Hugging Face repository it owns
+(`SPELUNK_EMBEDDER_GGUF_REPO`); that artifact carries its own `LICENSE`,
+`NOTICE`, and model card reproducing this attribution. See
+`docs/embedder-artifact/` for the text that accompanies the distributed artifact.
+
+### Other bundled inference dependencies
+
+The candle runtime (`candle-core`, `candle-nn`, `candle-transformers`), the
+Hugging Face hub client (`hf-hub`), and `tokenizers` are Rust crates and are
+covered by `cargo-about` / `about.toml`; they are not re-listed here.

--- a/docs/third-party-models.md
+++ b/docs/third-party-models.md
@@ -9,7 +9,8 @@ are attributed here.
 
 - **Model:** `codefuse-ai/F2LLM-v2-330M`
 - **Upstream:** https://huggingface.co/codefuse-ai/F2LLM-v2-330M
-- **Pinned source revision:** `main` (tracked by the `MODEL_REVISION` constant in
+- **Pinned source revision:** `1239cdd544b24c247ed75df2ae22e5a401ac4659`
+  (tracked by the `MODEL_REVISION` constant in
   `crates/spelunk-server/src/embedder_native.rs`; update both together when the
   pin moves).
 - **License:** Apache License 2.0 (declared via the upstream Hugging Face


### PR DESCRIPTION
## Summary

Shrinks the F2LLM-v2-330M embedder's first-run download and steady-state disk footprint, without changing default behaviour. Today `spelunk-server` downloads ~638 MB of BF16 safetensors on first run, quantizes to a ~339 MB Q8_0 GGUF on device, and leaves both on disk (steady-state ~1.5 GB). This PR adds a safetensors-cleanup quick win and a config-gated path to fetch a pre-quantized GGUF directly.

## Merge-safe now (default behaviour unchanged)

- **Pin upstream revision.** `MODEL_REVISION` pins `codefuse-ai/F2LLM-v2-330M` to commit `1239cdd544b24c247ed75df2ae22e5a401ac4659` so the on-device quantize path is reproducible and the redistributed artifact has clear provenance.
- **Safetensors cleanup.** After writing the Q8_0 GGUF on the quantize-on-first-run path, delete the cached BF16 safetensors (blob + snapshot symlink). Reclaims ~638 MB; steady-state disk ~1.5 GB → ~339 MB. Best-effort: never fails an already-written load.
- **Attribution (Apache-2.0 §4).** `docs/third-party-models.md` credits the base model with link, pinned revision, license reference, and a modification statement ("quantized to Q8_0 from original BF16 weights"). README links it from the License section.

## Activation-gated (no effect until flipped)

- **Direct-GGUF loader.** When `SPELUNK_EMBEDDER_GGUF_REPO` is set, `load()` downloads our own pre-quantized GGUF directly via the existing `hf-hub` cache (reusing its download/cache/resume path) instead of downloading safetensors + quantizing — first-run download ~339 MB, no on-device quantize step. **Unset by default**, so merging this PR changes nothing: the download-safetensors-and-quantize path stays the default until the artifact repo exists and the gate is flipped.
- **Artifact text for the HF repo.** `docs/embedder-artifact/` holds the `LICENSE` (canonical Apache-2.0), `NOTICE` (modification + provenance), and `README.md` (model card) to upload alongside the GGUF.

## Operator checklist (Johan — gated on an HF account/token)

1. **Confirm the repo name** (TODO): proposed `spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF`. If different, adjust steps 2 and the eventual default in step 5.
2. **Create** the Hugging Face model repo under our org with that name.
3. **Upload** these files to the repo root:
   - `f2llm-v2-330m-q8_0.gguf` — sha256 `2c12aad2951f1d9a3b457f890a2586d1ee19b755b377c0fb424e856e615b8f2b` (~339 MB; artifact path reported to the dispatcher, not committed here)
   - `LICENSE`, `NOTICE`, `README.md` from `docs/embedder-artifact/`
4. **Verify** the uploaded GGUF's sha256 matches the value above.
5. **Activate** by either setting `SPELUNK_EMBEDDER_GGUF_REPO=spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF` in the server environment, or flipping the in-code default in a one-line follow-up (change `prequantized_gguf_repo()` to default to `Some("spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF")`). The pinned `MODEL_REVISION` is the revision this artifact was quantized from; keep them in lockstep if you ever re-quantize.

## Test plan

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo build` — clean (default features + `embed-native`).
- `cargo test` (default) — all pass, including new unit tests:
  - `prequantized_gguf_repo_gate_defaults_off` — gate is off when the env var is unset/blank; on (trimmed repo id) when set.
  - `cleanup_safetensors_removes_files_and_is_idempotent` — cleanup reclaims files and tolerates already-absent paths.
- `cargo test --no-default-features` — all pass (embedder module compiled out; nothing else regresses).
- `cargo audit` — no critical advisories (pre-existing allowed warnings only).
- Disk-reclaim verified by the cleanup unit test (function deletes the files) and confirmed manually: BF16 source blob is 638M, generated Q8_0 GGUF is 339M.
- The direct-GGUF path cannot be exercised end-to-end yet (the artifact repo does not exist); its config switch and repo-id handling are unit-tested, and the download reuses the already-tested `hf-hub` path.