### PR TITLE
fix(cli): org-switch workos_org_id + token refresh + prod client id (oss^39/^40/^41)

### DIFF
--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -55,6 +55,10 @@ gix-fs = ">=0.21.1"
 gix-transport = ">=0.56.0"
 
 [dev-dependencies]
+# test-support exposes spelunk-core's in-memory secret-store double
+# (config::secret_store::MemoryStore) so unit tests inject it instead of
+# hitting the real OS keychain. Dev-only: not enabled for release builds.
+spelunk-core = { path = "../spelunk-core", features = ["test-support"] }
 assert_cmd = "2.2"
 predicates = "3.1"
 tempfile = { workspace = true }

--- a/crates/spelunk-cli/src/cli/cmd/auth_api.rs
+++ b/crates/spelunk-cli/src/cli/cmd/auth_api.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
-use spelunk_core::config::AuthTokens;
+use spelunk_core::config::{AuthTokens, Config};
 
 /// Default cloud API base URL (used only for `GET /v1/me`).
 pub const DEFAULT_CLOUD_URL: &str = "https://api.spelunk.cloud";
@@ -31,7 +31,7 @@ pub const DEFAULT_CLOUD_URL: &str = "https://api.spelunk.cloud";
 pub const DEFAULT_WORKOS_URL: &str = "https://api.workos.com";
 
 /// Embedded PUBLIC-CLIENT `client_id` for the **production** WorkOS environment.
-pub const WORKOS_CLIENT_ID_PROD: &str = "client_01KTY5G10DF7854DNX5EWC9R6Y";
+pub const WORKOS_CLIENT_ID_PROD: &str = "client_01KTY5G1EK45Y93B0RB9Q1D2Q2";
 
 /// Embedded PUBLIC-CLIENT `client_id` for the **dev / staging** WorkOS environment.
 pub const WORKOS_CLIENT_ID_DEV: &str = "client_01KTY5JEJSZQD6R3QBXZS19WVF";
@@ -390,6 +390,86 @@ pub async fn refresh_token(
     token_or_error(resp, "refreshing token").await
 }
 
+/// Ensure the access token in `auth` is fresh before a cloud-api call.
+///
+/// WorkOS access tokens are short-lived (~5 min), so a token read straight from
+/// the stored `[auth]` table is frequently already expired by the time the CLI
+/// runs — every cloud-api call would then `401`. This guard refreshes proactively
+/// when the token is at/past expiry (with a small skew window, see
+/// [`AuthTokens::is_expired`]) using the stored refresh token directly against
+/// WorkOS (refresh grant, ADR-047), persists the rotated tokens to `[auth]`, and
+/// returns the tokens to use.
+///
+/// When the token is still valid, `auth` is returned unchanged (no network
+/// call). A refresh failure (revoked/expired refresh token) surfaces a clear
+/// "run `spelunk login`" error rather than a raw 401 from the downstream call.
+///
+/// `persist` is invoked with the rotated tokens so the caller controls *where*
+/// they are written (the global config in production, a temp path in tests).
+pub async fn ensure_fresh_token(
+    client: &reqwest::Client,
+    workos_url: &str,
+    client_id: &str,
+    auth: &AuthTokens,
+    persist: impl FnOnce(&AuthTokens) -> Result<()>,
+) -> Result<AuthTokens> {
+    if !auth.is_expired() {
+        return Ok(auth.clone());
+    }
+
+    let rotated = refresh_token(client, workos_url, client_id, &auth.refresh_token, None)
+        .await
+        .map_err(|e| e.context("session expired and token refresh failed — run `spelunk login`"))?
+        .into_auth_tokens();
+    persist(&rotated)?;
+    Ok(rotated)
+}
+
+/// Resolve the bearer token to send to cloud-api, refreshing the stored WorkOS
+/// access token first if it has expired.
+///
+/// The CLI's effective bearer (`cfg.server_key`) is the `[auth]` access token
+/// when the user logged in via WorkOS. Because access tokens are short-lived,
+/// commands that hit cloud-api directly (e.g. `spelunk sync`, `spelunk memory
+/// pull`) must guard against using an already-expired token, which would 401.
+///
+/// Behaviour:
+///   - When `[auth]` tokens are present AND the bearer was derived from them
+///     (the WorkOS-login case) AND they are expired, refresh directly against
+///     WorkOS, persist the rotated tokens, and return the fresh access token.
+///   - Otherwise return `cfg.server_key` unchanged — a bare/team `server_key`
+///     or an env override is not refreshable here, and a still-valid token needs
+///     no network round-trip.
+///
+/// A refresh failure surfaces a clear "run `spelunk login`" error.
+pub async fn ensure_fresh_server_key(cfg: &Config) -> Result<Option<String>> {
+    // Only the WorkOS-login bearer (server_key derived from [auth].access_token)
+    // is refreshable; a team/env key is returned as-is.
+    let Some(auth) = cfg
+        .auth
+        .as_ref()
+        .filter(|a| Some(a.access_token.as_str()) == cfg.server_key.as_deref())
+    else {
+        return Ok(cfg.server_key.clone());
+    };
+
+    if !auth.is_expired() {
+        return Ok(cfg.server_key.clone());
+    }
+
+    let client = build_client()?;
+    let client_id = workos_client_id(DEFAULT_CLOUD_URL);
+    let fresh = ensure_fresh_token(
+        &client,
+        &workos_url(),
+        &client_id,
+        auth,
+        spelunk_core::config::save_auth_tokens,
+    )
+    .await?;
+    Ok(Some(fresh.access_token))
+}
+
 /// `GET /v1/me` (cloud-api) — fetch the caller's identity and org memberships.
 ///
 /// Authenticated with the stored WorkOS access token as a bearer. Used to
@@ -557,6 +637,16 @@ mod tests {
         }
     }
 
+    /// Guard the embedded prod `client_id` against an accidental revert to a
+    /// stale WorkOS environment (prod rotated on 2026-06-30).
+    #[test]
+    fn prod_client_id_is_current_rotated_value() {
+        assert_eq!(
+            WORKOS_CLIENT_ID_PROD, "client_01KTY5G1EK45Y93B0RB9Q1D2Q2",
+            "prod client_id must track the rotated WorkOS prod environment"
+        );
+    }
+
     #[test]
     fn is_prod_cloud_url_only_matches_canonical_host() {
         assert!(is_prod_cloud_url("https://api.spelunk.cloud"));
@@ -564,6 +654,110 @@ mod tests {
         assert!(is_prod_cloud_url("https://API.SPELUNK.CLOUD"));
         assert!(!is_prod_cloud_url("https://staging.spelunk.cloud"));
         assert!(!is_prod_cloud_url("http://127.0.0.1:8080"));
+    }
+
+    // ── ensure_fresh_token (expiry guard, spelunk-oss^40) ────────────────────────
+
+    /// A still-valid access token is returned unchanged with NO network call and
+    /// NO persist call (the persist closure would panic if invoked).
+    #[tokio::test]
+    async fn ensure_fresh_token_noop_when_valid() {
+        let auth = AuthTokens {
+            access_token: "at-valid".into(),
+            refresh_token: "rt".into(),
+            // Far in the future ⇒ not expired.
+            expires_at: 5_000_000_000,
+            org_id: "org_1".into(),
+        };
+        let client = build_client().unwrap();
+        // workos_url points nowhere reachable; it must never be hit.
+        let out = ensure_fresh_token(&client, "http://127.0.0.1:1", "client_test", &auth, |_| {
+            panic!("persist must not be called when the token is still valid");
+        })
+        .await
+        .expect("a valid token needs no refresh");
+        assert_eq!(out, auth);
+    }
+
+    /// An expired access token is refreshed via WorkOS, the rotated tokens are
+    /// handed to `persist`, and the fresh tokens are returned.
+    #[tokio::test]
+    async fn ensure_fresh_token_refreshes_and_persists_when_expired() {
+        use std::sync::{Arc, Mutex};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let fresh_jwt =
+            fake_jwt(&serde_json::json!({ "exp": 5_000_000_000_i64, "org_id": "org_1" }));
+        Mock::given(method("POST"))
+            .and(path("/user_management/authenticate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": fresh_jwt,
+                "refresh_token": "rt-rotated",
+                "organization_id": "org_1",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let expired = AuthTokens {
+            access_token: "at-expired".into(),
+            refresh_token: "rt-old".into(),
+            expires_at: 0, // definitely past expiry
+            org_id: "org_1".into(),
+        };
+
+        let persisted: Arc<Mutex<Option<AuthTokens>>> = Arc::new(Mutex::new(None));
+        let sink = persisted.clone();
+        let client = build_client().unwrap();
+        let out = ensure_fresh_token(&client, &server.uri(), "client_test", &expired, |t| {
+            *sink.lock().unwrap() = Some(t.clone());
+            Ok(())
+        })
+        .await
+        .expect("an expired token should refresh");
+
+        assert_eq!(out.refresh_token, "rt-rotated");
+        assert_eq!(out.access_token, fresh_jwt);
+        assert_eq!(
+            persisted.lock().unwrap().as_ref().unwrap().refresh_token,
+            "rt-rotated",
+            "rotated tokens must be persisted"
+        );
+    }
+
+    /// When the refresh grant is rejected (revoked/expired refresh token), the
+    /// error carries a clear "run `spelunk login`" hint instead of a raw 401.
+    #[tokio::test]
+    async fn ensure_fresh_token_refresh_failure_says_run_login() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/user_management/authenticate"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": "invalid_grant"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let expired = AuthTokens {
+            access_token: "at-expired".into(),
+            refresh_token: "rt-revoked".into(),
+            expires_at: 0,
+            org_id: "org_1".into(),
+        };
+        let client = build_client().unwrap();
+        let err = ensure_fresh_token(&client, &server.uri(), "client_test", &expired, |_| Ok(()))
+            .await
+            .expect_err("a revoked refresh token must error");
+        assert!(
+            err.to_string().contains("spelunk login"),
+            "error should tell the user to re-login, got: {err}"
+        );
     }
 
     // ── Wire-level tests for initiate_device ─────────────────────────────────────
@@ -769,7 +963,7 @@ mod tests {
 
     /// After a device login yields an initial token for org A, passing `--org
     /// <beta-slug>` re-scopes via `switch_org`: GET /v1/me resolves the slug to
-    /// a local UUID and POST /authenticate (refresh grant + organization_id)
+    /// its WorkOS org id and POST /authenticate (refresh grant + organization_id)
     /// returns tokens scoped to the target org.
     #[tokio::test]
     async fn login_then_switch_org_resolves_slug_and_refreshes() {
@@ -779,6 +973,7 @@ mod tests {
         use crate::cli::cmd::org::switch_org;
 
         const BETA_UUID: &str = "22222222-2222-2222-2222-222222222222";
+        const BETA_WORKOS: &str = "org_beta01";
 
         let server = MockServer::start().await;
 
@@ -788,25 +983,27 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "orgs": [
                     { "id": "11111111-1111-1111-1111-111111111111",
-                      "name": "Acme", "slug": "acme", "role": "admin" },
-                    { "id": BETA_UUID, "name": "Beta Corp", "slug": "beta", "role": "member" }
+                      "name": "Acme", "slug": "acme",
+                      "workos_org_id": "org_acme01", "role": "admin" },
+                    { "id": BETA_UUID, "name": "Beta Corp", "slug": "beta",
+                      "workos_org_id": BETA_WORKOS, "role": "member" }
                 ]
             })))
             .expect(1)
             .mount(&server)
             .await;
 
-        // POST /authenticate (refresh grant) — must carry the resolved local UUID.
+        // POST /authenticate (refresh grant) — must carry the resolved WorkOS org id.
         let beta_jwt = fake_jwt(&serde_json::json!({
             "exp": 5_000_000_000_i64,
-            "org_id": BETA_UUID
+            "org_id": BETA_WORKOS
         }));
         Mock::given(method("POST"))
             .and(path("/user_management/authenticate"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "access_token": beta_jwt,
                 "refresh_token": "rt-beta",
-                "organization_id": BETA_UUID,
+                "organization_id": BETA_WORKOS,
             })))
             .expect(1)
             .mount(&server)
@@ -833,7 +1030,8 @@ mod tests {
         .await
         .expect("login-then-switch should succeed");
 
-        assert_eq!(switched.org_id, BETA_UUID);
+        // Rotated session org_id is the WorkOS org id echoed by /authenticate.
+        assert_eq!(switched.org_id, BETA_WORKOS);
         assert_eq!(switched.refresh_token, "rt-beta");
         assert_eq!(switched.expires_at, 5_000_000_000_i64);
     }
@@ -858,7 +1056,8 @@ mod tests {
             .and(path("/v1/me"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "orgs": [
-                    { "id": BETA_UUID, "name": "Beta Corp", "slug": "beta", "role": "member" }
+                    { "id": BETA_UUID, "name": "Beta Corp", "slug": "beta",
+                      "workos_org_id": "org_beta01", "role": "member" }
                 ]
             })))
             .mount(&server)

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -21,6 +21,7 @@ use super::MemoryPushArgs;
 use super::sync::push_local_oneway;
 use crate::{
     capability,
+    cli::cmd::auth_api,
     config::Config,
     storage::{CloudSyncClient, MemoryStore},
 };
@@ -48,7 +49,9 @@ pub async fn memory_push(
     let src_path = args.source.as_deref().unwrap_or(mem_path);
     let local = MemoryStore::open(src_path)
         .with_context(|| format!("opening local memory at {}", src_path.display()))?;
-    let client = CloudSyncClient::new(&base_url, &project_id, cfg.server_key.as_deref())?;
+    // Refresh a stale WorkOS access token before the cloud-api call (oss^40).
+    let key = auth_api::ensure_fresh_server_key(cfg).await?;
+    let client = CloudSyncClient::new(&base_url, &project_id, key.as_deref())?;
 
     println!("Pushing local memory to {base_url}…");
     let summary = push_local_oneway(&local, &client, args.include_archived).await?;

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -27,6 +27,7 @@ use anyhow::{Context, Result};
 use super::{MemoryPullArgs, MemorySyncArgs};
 use crate::{
     capability,
+    cli::cmd::auth_api,
     config::Config,
     storage::{BatchPushItem, CloudSyncClient, MemoryStore},
 };
@@ -36,7 +37,11 @@ use crate::{
 /// Sync always speaks to an explicit `server_url` — it is the cloud-convergence
 /// path, not the inference loopback. Errors with actionable guidance when the
 /// project is offline or missing a `project_id`.
-fn sync_target(cfg: &Config) -> Result<(String, String, Option<String>)> {
+///
+/// The bearer key is resolved through [`auth_api::ensure_fresh_server_key`] so a
+/// WorkOS access token that has expired since `spelunk login` is refreshed (and
+/// the rotated tokens persisted) before the cloud-api call, rather than 401-ing.
+async fn sync_target(cfg: &Config) -> Result<(String, String, Option<String>)> {
     let base_url = cfg.server_url.clone().ok_or_else(|| {
         anyhow::anyhow!(
             "sync requires a server. Set `server_url` in your spelunk config \
@@ -49,7 +54,8 @@ fn sync_target(cfg: &Config) -> Result<(String, String, Option<String>)> {
              or via `SPELUNK_PROJECT_ID` so sync can address the project."
         )
     })?;
-    Ok((base_url, project_id, cfg.server_key.clone()))
+    let key = auth_api::ensure_fresh_server_key(cfg).await?;
+    Ok((base_url, project_id, key))
 }
 
 /// `spelunk memory pull` — one-way delta pull + apply.
@@ -60,7 +66,7 @@ pub async fn memory_pull(
 ) -> Result<()> {
     let tier = capability::get_tier(cfg).await;
     capability::require_tier1("memory pull", tier, cfg.server_url.as_deref())?;
-    let (base_url, project_id, key) = sync_target(cfg)?;
+    let (base_url, project_id, key) = sync_target(cfg).await?;
 
     let local = MemoryStore::open(mem_path)
         .with_context(|| format!("opening local memory at {}", mem_path.display()))?;
@@ -79,7 +85,7 @@ pub async fn memory_sync(
 ) -> Result<()> {
     let tier = capability::get_tier(cfg).await;
     capability::require_tier1("sync", tier, cfg.server_url.as_deref())?;
-    let (base_url, project_id, key) = sync_target(cfg)?;
+    let (base_url, project_id, key) = sync_target(cfg).await?;
 
     let src_path = args.source.as_deref().unwrap_or(mem_path);
     let local = MemoryStore::open(src_path)

--- a/crates/spelunk-cli/src/cli/cmd/org.rs
+++ b/crates/spelunk-cli/src/cli/cmd/org.rs
@@ -1,15 +1,21 @@
 //! `spelunk org switch <org>` — silently re-scope the session to another
 //! organisation without a new device login (ADR-047).
 //!
-//! Resolves the org slug to its local UUID via cloud-api `GET /v1/me`, then
-//! uses the stored refresh token directly against WorkOS `/authenticate`
-//! (refresh grant) with `organization_id`, and persists the rotated tokens.
+//! Resolves the org argument to its **WorkOS org id** (`org_…`) — that is what
+//! WorkOS's `/authenticate` refresh grant expects in `organization_id`, NOT the
+//! cloud-api local org UUID. Resolution rules:
+//!
+//! - a raw `org_…` value is already a WorkOS org id and is used directly;
+//! - a slug or a local org UUID is mapped to its `workos_org_id` via cloud-api
+//!   `GET /v1/me`.
+//!
+//! The resolved WorkOS org id is then sent to WorkOS `/authenticate` (refresh
+//! grant) using the stored refresh token, and the rotated tokens are persisted.
 //! Shared org-resolution and token-persistence helpers also back
 //! `spelunk login --org`.
 
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
-use uuid::Uuid;
 
 use spelunk_core::config::{self, AuthTokens};
 
@@ -33,8 +39,9 @@ pub enum OrgCommand {
 
 #[derive(Args, Debug)]
 pub struct OrgSwitchArgs {
-    /// Organization to switch to. Accepts a local org UUID or an org slug; a
-    /// slug is resolved to its UUID via `GET /v1/me` before switching.
+    /// Organization to switch to. Accepts a WorkOS org id (`org_…`), an org
+    /// slug, or a local org UUID. A slug or local UUID is resolved to its
+    /// WorkOS org id via `GET /v1/me` before switching.
     pub org: String,
 }
 
@@ -70,11 +77,15 @@ async fn org_switch(workos_url: &str, cloud_url: &str, client_id: &str, org: &st
 
 /// Silently switch the session to `org` using the stored refresh token.
 ///
-/// `org` may be a local org UUID or a slug. A slug is resolved to its local org
-/// UUID via cloud-api `GET /v1/me`; the UUID is then sent as `organization_id`
-/// to WorkOS `/authenticate` (refresh grant), which rotates the tokens scoped
-/// to that organisation (or returns an `organization_not_found` membership
-/// error).
+/// `org` may be a WorkOS org id (`org_…`), an org slug, or a local org UUID.
+/// A slug or local UUID is resolved to its **WorkOS org id** via cloud-api
+/// `GET /v1/me`; that WorkOS org id is then sent as `organization_id` to WorkOS
+/// `/authenticate` (refresh grant), which rotates the tokens scoped to that
+/// organisation (or returns an `organization_not_found` membership error).
+///
+/// The access token used for the `GET /v1/me` lookup is refreshed first if it
+/// has expired (WorkOS access tokens are ~5-minute-lived), so a paused session
+/// does not fail the lookup with a `401`.
 pub async fn switch_org(
     client: &reqwest::Client,
     workos_url: &str,
@@ -83,44 +94,70 @@ pub async fn switch_org(
     auth: &AuthTokens,
     org: &str,
 ) -> Result<AuthTokens> {
-    let org_uuid = resolve_org_uuid(client, cloud_url, auth, org).await?;
+    let workos_org_id =
+        resolve_workos_org_id(client, workos_url, cloud_url, client_id, auth, org).await?;
     let success = auth_api::refresh_token(
         client,
         workos_url,
         client_id,
         &auth.refresh_token,
-        Some(&org_uuid),
+        Some(&workos_org_id),
     )
     .await?;
     Ok(success.into_auth_tokens())
 }
 
-/// Resolve `arg` to a local org UUID.
+/// Resolve `arg` to a **WorkOS org id** (`org_…`).
 ///
-/// A value that already parses as a UUID is used directly. Otherwise `arg` is
-/// treated as a slug and matched against the caller's `orgs[]` from `GET /v1/me`,
-/// returning the matching entry's `id` (the local org UUID). No match is a clear
-/// error.
-async fn resolve_org_uuid(
+/// - A value already shaped like a WorkOS org id (`org_…`) is used directly,
+///   with no `GET /v1/me` lookup.
+/// - Any other value (a slug or a local org UUID) is matched against the
+///   caller's `orgs[]` from `GET /v1/me` and mapped to the matching entry's
+///   `workos_org_id`. No match — or a matched entry whose `workos_org_id` is
+///   absent — is a clear error.
+///
+/// The `/v1/me` call refreshes an expired access token first (persisting the
+/// rotated tokens) so a paused session does not 401.
+async fn resolve_workos_org_id(
     client: &reqwest::Client,
+    workos_url: &str,
     cloud_url: &str,
+    client_id: &str,
     auth: &AuthTokens,
     arg: &str,
 ) -> Result<String> {
-    if Uuid::parse_str(arg).is_ok() {
+    if is_workos_org_id(arg) {
         return Ok(arg.to_string());
     }
 
-    let me = auth_api::fetch_me(client, cloud_url, &auth.access_token).await?;
-    resolve_slug_to_uuid(&me.orgs, arg)
+    let fresh =
+        auth_api::ensure_fresh_token(client, workos_url, client_id, auth, persist_tokens).await?;
+    let me = auth_api::fetch_me(client, cloud_url, &fresh.access_token).await?;
+    resolve_arg_to_workos_org_id(&me.orgs, arg)
 }
 
-/// Find the `orgs[]` entry whose slug equals `slug` and return its local UUID.
-fn resolve_slug_to_uuid(orgs: &[MeOrg], slug: &str) -> Result<String> {
-    orgs.iter()
-        .find(|o| o.slug == slug)
-        .map(|o| o.id.clone())
-        .ok_or_else(|| anyhow::anyhow!("not a member of org '{slug}', or unknown org"))
+/// Whether `arg` is already a WorkOS org id (`org_…`), in which case it is the
+/// value WorkOS expects and needs no `/v1/me` lookup.
+fn is_workos_org_id(arg: &str) -> bool {
+    arg.starts_with("org_")
+}
+
+/// Find the `orgs[]` entry matching `arg` (by slug or local UUID) and return its
+/// WorkOS org id (`workos_org_id`).
+///
+/// WorkOS's refresh grant keys `organization_id` on the provider org id, not the
+/// cloud-api local UUID, so this maps either human identifier onto the right one.
+fn resolve_arg_to_workos_org_id(orgs: &[MeOrg], arg: &str) -> Result<String> {
+    let entry = orgs
+        .iter()
+        .find(|o| o.slug == arg || o.id == arg)
+        .ok_or_else(|| anyhow::anyhow!("not a member of org '{arg}', or unknown org"))?;
+    entry.workos_org_id.clone().ok_or_else(|| {
+        anyhow::anyhow!(
+            "org '{arg}' has no WorkOS org id on record; cannot switch \
+             (re-run `spelunk login` or contact support)"
+        )
+    })
 }
 
 /// Persist rotated/issued tokens to the `[auth]` table (written `0600`).
@@ -138,30 +175,63 @@ mod tests {
                 id: "11111111-1111-1111-1111-111111111111".into(),
                 name: "Acme".into(),
                 slug: "acme".into(),
-                workos_org_id: None,
+                workos_org_id: Some("org_acme".into()),
             },
             MeOrg {
                 id: "22222222-2222-2222-2222-222222222222".into(),
                 name: "Beta".into(),
                 slug: "beta".into(),
-                workos_org_id: None,
+                workos_org_id: Some("org_beta".into()),
             },
         ]
     }
 
-    /// A slug resolves to the matching entry's local org UUID.
+    /// `org_…` is already a WorkOS org id — no lookup, used verbatim.
     #[test]
-    fn resolve_slug_to_uuid_matches_slug() {
-        let uuid = resolve_slug_to_uuid(&me_orgs(), "beta").unwrap();
-        assert_eq!(uuid, "22222222-2222-2222-2222-222222222222");
+    fn is_workos_org_id_recognises_provider_ids() {
+        assert!(is_workos_org_id("org_01ABCDEF"));
+        assert!(!is_workos_org_id("beta"));
+        assert!(!is_workos_org_id("22222222-2222-2222-2222-222222222222"));
     }
 
-    /// An unknown slug is a clear membership error.
+    /// A slug resolves to the matching entry's WorkOS org id (NOT its local UUID).
     #[test]
-    fn resolve_slug_to_uuid_unknown_errors() {
-        let err = resolve_slug_to_uuid(&me_orgs(), "gamma").unwrap_err();
+    fn resolve_arg_to_workos_org_id_matches_slug() {
+        let id = resolve_arg_to_workos_org_id(&me_orgs(), "beta").unwrap();
+        assert_eq!(id, "org_beta");
+    }
+
+    /// A local org UUID resolves to that entry's WorkOS org id.
+    #[test]
+    fn resolve_arg_to_workos_org_id_matches_local_uuid() {
+        let id = resolve_arg_to_workos_org_id(&me_orgs(), "11111111-1111-1111-1111-111111111111")
+            .unwrap();
+        assert_eq!(id, "org_acme");
+    }
+
+    /// An unknown arg is a clear membership error.
+    #[test]
+    fn resolve_arg_to_workos_org_id_unknown_errors() {
+        let err = resolve_arg_to_workos_org_id(&me_orgs(), "gamma").unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("gamma"), "error should name the slug: {msg}");
+        assert!(msg.contains("gamma"), "error should name the arg: {msg}");
+    }
+
+    /// A matched entry whose `workos_org_id` is absent is a clear error, never a
+    /// silent fall-through to the local UUID.
+    #[test]
+    fn resolve_arg_to_workos_org_id_missing_workos_id_errors() {
+        let orgs = vec![MeOrg {
+            id: "33333333-3333-3333-3333-333333333333".into(),
+            name: "Gamma".into(),
+            slug: "gamma".into(),
+            workos_org_id: None,
+        }];
+        let err = resolve_arg_to_workos_org_id(&orgs, "gamma").unwrap_err();
+        assert!(
+            err.to_string().contains("WorkOS org id"),
+            "error should explain the missing WorkOS org id: {err}"
+        );
     }
 
     // ── switch_org wire-level tests (WorkOS-direct, ADR-047) ──────────────────
@@ -178,6 +248,9 @@ mod tests {
         use spelunk_core::config::AuthTokens;
 
         const BETA_UUID: &str = "22222222-2222-2222-2222-222222222222";
+        /// WorkOS provider org id for Beta — this is what must reach WorkOS as
+        /// `organization_id`, NOT the local `BETA_UUID`.
+        const BETA_WORKOS: &str = "org_beta01";
         const CLIENT_ID: &str = "client_test";
 
         fn auth() -> AuthTokens {
@@ -228,14 +301,14 @@ mod tests {
         }
 
         /// Asserts the WorkOS form body carries the expected `organization_id`
-        /// (the resolved local UUID) and the refresh grant fields.
+        /// (the resolved WorkOS org id, `org_…`) and the refresh grant fields.
         struct AssertForm(&'static str);
         impl Respond for AssertForm {
             fn respond(&self, request: &Request) -> ResponseTemplate {
                 let body = String::from_utf8_lossy(&request.body);
                 assert!(
                     body.contains(&format!("organization_id={}", self.0)),
-                    "organization_id must be the local org UUID, got body: {body}"
+                    "organization_id must be the WorkOS org id, got body: {body}"
                 );
                 assert!(
                     body.contains("grant_type=refresh_token"),
@@ -245,8 +318,9 @@ mod tests {
             }
         }
 
-        /// `switch_org(<slug>)` calls GET /v1/me, resolves the slug to its local
-        /// UUID, and POSTs that UUID as `organization_id` to WorkOS.
+        /// `switch_org(<slug>)` calls GET /v1/me, resolves the slug to its WorkOS
+        /// org id, and POSTs that WorkOS org id (NOT the local UUID) as
+        /// `organization_id` to WorkOS.
         #[tokio::test]
         async fn slug_resolves_via_me_then_switches() {
             let server = MockServer::start().await;
@@ -256,8 +330,10 @@ mod tests {
                 .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                     "orgs": [
                         { "id": "11111111-1111-1111-1111-111111111111",
-                          "name": "Acme", "slug": "acme", "role": "member" },
-                        { "id": BETA_UUID, "name": "Beta", "slug": "beta", "role": "admin" }
+                          "name": "Acme", "slug": "acme",
+                          "workos_org_id": "org_acme01", "role": "member" },
+                        { "id": BETA_UUID, "name": "Beta", "slug": "beta",
+                          "workos_org_id": BETA_WORKOS, "role": "admin" }
                     ]
                 })))
                 .expect(1)
@@ -266,7 +342,7 @@ mod tests {
 
             Mock::given(method("POST"))
                 .and(path("/user_management/authenticate"))
-                .respond_with(AssertForm(BETA_UUID))
+                .respond_with(AssertForm(BETA_WORKOS))
                 .expect(1)
                 .mount(&server)
                 .await;
@@ -283,19 +359,31 @@ mod tests {
             .await
             .expect("slug switch should succeed");
             assert_eq!(tokens.refresh_token, "rt-new");
-            assert_eq!(tokens.org_id, BETA_UUID);
+            // Rotated session org_id comes from the JWT/echo = the WorkOS org id.
+            assert_eq!(tokens.org_id, BETA_WORKOS);
         }
 
-        /// A UUID arg is passed straight through as `organization_id` with no
-        /// GET /v1/me lookup.
+        /// A local org UUID arg is resolved via GET /v1/me to its WorkOS org id,
+        /// which is what reaches WorkOS as `organization_id`.
         #[tokio::test]
-        async fn uuid_passed_directly_skips_me() {
+        async fn local_uuid_resolves_to_workos_org_id() {
             let server = MockServer::start().await;
 
-            // No /v1/me mock mounted: if it is hit, the request 404s.
+            Mock::given(method("GET"))
+                .and(path("/v1/me"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "orgs": [
+                        { "id": BETA_UUID, "name": "Beta", "slug": "beta",
+                          "workos_org_id": BETA_WORKOS, "role": "admin" }
+                    ]
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
             Mock::given(method("POST"))
                 .and(path("/user_management/authenticate"))
-                .respond_with(AssertForm(BETA_UUID))
+                .respond_with(AssertForm(BETA_WORKOS))
                 .expect(1)
                 .mount(&server)
                 .await;
@@ -310,8 +398,36 @@ mod tests {
                 BETA_UUID,
             )
             .await
-            .expect("uuid switch should succeed");
-            assert_eq!(tokens.org_id, BETA_UUID);
+            .expect("local-uuid switch should succeed");
+            assert_eq!(tokens.org_id, BETA_WORKOS);
+        }
+
+        /// An `org_…` arg is already a WorkOS org id and is passed straight
+        /// through as `organization_id` with no GET /v1/me lookup.
+        #[tokio::test]
+        async fn workos_org_id_passed_directly_skips_me() {
+            let server = MockServer::start().await;
+
+            // No /v1/me mock mounted: if it is hit, the request 404s.
+            Mock::given(method("POST"))
+                .and(path("/user_management/authenticate"))
+                .respond_with(AssertForm(BETA_WORKOS))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let client = reqwest::Client::new();
+            let tokens = switch_org(
+                &client,
+                &server.uri(),
+                &server.uri(),
+                CLIENT_ID,
+                &auth(),
+                BETA_WORKOS,
+            )
+            .await
+            .expect("workos-org-id switch should succeed");
+            assert_eq!(tokens.org_id, BETA_WORKOS);
         }
 
         /// A slug not present in `orgs[]` is a clear membership error and no
@@ -324,7 +440,8 @@ mod tests {
                 .and(path("/v1/me"))
                 .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                     "orgs": [
-                        { "id": BETA_UUID, "name": "Beta", "slug": "beta", "role": "admin" }
+                        { "id": BETA_UUID, "name": "Beta", "slug": "beta",
+                          "workos_org_id": BETA_WORKOS, "role": "admin" }
                     ]
                 })))
                 .mount(&server)
@@ -332,7 +449,7 @@ mod tests {
 
             Mock::given(method("POST"))
                 .and(path("/user_management/authenticate"))
-                .respond_with(ResponseTemplate::new(200).set_body_json(workos_success(BETA_UUID)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(workos_success(BETA_WORKOS)))
                 .expect(0)
                 .mount(&server)
                 .await;
@@ -365,7 +482,8 @@ mod tests {
                 .and(path("/v1/me"))
                 .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                     "orgs": [
-                        { "id": BETA_UUID, "name": "Beta", "slug": "beta", "role": "admin" }
+                        { "id": BETA_UUID, "name": "Beta", "slug": "beta",
+                          "workos_org_id": BETA_WORKOS, "role": "admin" }
                     ]
                 })))
                 .mount(&server)

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -673,7 +673,14 @@ mod tests {
         assert_eq!(vec, Some(vec![0.1_f32, 0.2, 0.3]));
 
         // Rotated tokens were persisted to the injected config path.
-        let cfg = spelunk_core::config::Config::load(Some(&config_path)).unwrap();
+        // Inject an in-memory secret store so the test never touches the real
+        // OS keychain (DI; cf. config.rs tests). #473 only isolated the
+        // spawned-binary integration tests in tests/*, not these in-process ones.
+        let cfg = spelunk_core::config::Config::load_with_store(
+            Some(&config_path),
+            &spelunk_core::config::secret_store::MemoryStore::default(),
+        )
+        .unwrap();
         assert_eq!(cfg.server_key.as_deref(), Some(at_new.as_str()));
         assert_eq!(cfg.auth.unwrap().refresh_token, "rt-new");
     }
@@ -822,7 +829,11 @@ mod tests {
         };
         spelunk_core::config::save_auth_tokens_to(&tokens, &path).unwrap();
 
-        let mut cfg = crate::config::Config::load(Some(&path)).unwrap();
+        let mut cfg = crate::config::Config::load_with_store(
+            Some(&path),
+            &spelunk_core::config::secret_store::MemoryStore::default(),
+        )
+        .unwrap();
         // from_config needs an inference URL to build a client at all.
         cfg.inference_url = Some("http://127.0.0.1:7777".into());
         let client = ServerInferenceClient::from_config(&cfg).expect("client builds");
@@ -849,7 +860,11 @@ mod tests {
         let path = tmp.path().join("config.toml");
         std::fs::write(&path, "server_key = \"sk-legacy\"\n").unwrap();
 
-        let mut cfg = crate::config::Config::load(Some(&path)).unwrap();
+        let mut cfg = crate::config::Config::load_with_store(
+            Some(&path),
+            &spelunk_core::config::secret_store::MemoryStore::default(),
+        )
+        .unwrap();
         cfg.inference_url = Some("http://127.0.0.1:7777".into());
         let client = ServerInferenceClient::from_config(&cfg).expect("client builds");
 


### PR DESCRIPTION
## Summary
Fixes three bugs in the WorkOS CLI auth path found during live cloud UAT (2026-06-30). The canonical `spelunk login → org switch → sync` flow was broken against prod; this restores it.

- **spelunk-oss^39** — `org switch` resolved a slug to the cloud-api **local** org UUID and passed it to WorkOS `/authenticate` as `organization_id`, which WorkOS can't match. `resolve_workos_org_id` now returns the **WorkOS** `org_…` id: a raw `org_…` is used directly (no `/v1/me`); a slug or local UUID is mapped to its `workos_org_id` via `GET /v1/me`.
- **spelunk-oss^40** — cloud-api calls used the stored access token as-is. WorkOS access tokens are ~5-min-lived, so a paused session 401s (`invalid_token`). New `ensure_fresh_token` (org switch) and `ensure_fresh_server_key` (sync/pull/push) refresh via the stored refresh token before the call and persist the rotated tokens; a refresh failure surfaces a clear "run `spelunk login`" error instead of a raw 401.
- **spelunk-oss^41** — `WORKOS_CLIENT_ID_PROD` was still the old, rotated-out prod client id; updated to `client_01KTY5G1EK45Y93B0RB9Q1D2Q2` (public identifier). `SPELUNK_WORKOS_CLIENT_ID` override still works.

Companion: cloud-api#149 makes `GET /v1/me` reachable with a no-org token (the other half of the deadlock).

## Files changed
- `crates/spelunk-cli/src/cli/cmd/org.rs` — `resolve_workos_org_id` (+ `org_…`/slug/UUID branches), refresh-before-`/v1/me`, updated unit tests.
- `crates/spelunk-cli/src/cli/cmd/auth_api.rs` — `WORKOS_CLIENT_ID_PROD`; `ensure_fresh_token`; `ensure_fresh_server_key`; tests.
- `crates/spelunk-cli/src/cli/cmd/memory/{sync,push}.rs` — route the bearer through `ensure_fresh_server_key` (sync_target now async).

## Test plan
Ran the CI-equivalent gate locally (macOS):
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets --features rich-formats -- -D warnings` — clean.
- `cargo test --features rich-formats` and `cargo test --no-default-features` — **98 passed**, including the new `org.rs`/`auth_api.rs` unit tests (slug→`workos_org_id` resolution, `org_…`/UUID branches, expiry-guard + refresh-then-retry).
  - 3 pre-existing `server_client::tests::*` failures are a **local-macOS artifact only**: those tests call the real `Config::load` (real Keychain) rather than injecting a `MemoryStore`, so they hit a Keychain prompt that auto-cancels in a headless shell (`Platform secure storage failure: User canceled`). On Linux CI there's no Keychain → the documented file fallback is used → they pass. `server_client.rs`/`config.rs` are untouched by this PR. Linux CI here is authoritative.

Refs: spelunk-oss^39, spelunk-oss^40, spelunk-oss^41; companion cloud-api#149.