### PR TITLE
release: cut v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,12 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Reduced steady-state disk usage: the cached BF16 safetensors are deleted after
-  the Q8_0 GGUF is written, and the upstream embedder revision is now pinned to an
-  exact commit. An opt-in direct-GGUF loader (enabled via
-  `SPELUNK_EMBEDDER_GGUF_REPO`) can download a pre-quantized Q8_0 GGUF instead of
-  quantizing locally. (#474)
+- The native embedder now downloads a **pre-quantized Q8_0 GGUF by default**
+  (~339 MB) instead of downloading the ~638 MB BF16 weights and quantizing on
+  device. Set `SPELUNK_EMBEDDER_GGUF_REPO=off` to build from the upstream weights
+  on device, or point it at another repo to override. Cached BF16 safetensors are
+  removed after the GGUF is written; the upstream embedder revision is pinned.
+  (#474, #479)
 
 ## [0.9.0] — 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-06-30
+
+### Fixed
+
+- **Single-chunk embedder OOM on large files.** The native embedder now caps a
+  single chunk's attention by a RAM-aware memory budget; chunks that would exceed
+  the budget are truncated (or skipped) instead of allocating an attention tensor
+  large enough to exhaust memory and crash indexing of large files. (#475)
+- **`spelunk org switch`** now persists the selected `workos_org_id`, refreshes the
+  access token against the correct organization, and uses the production WorkOS
+  client id. (#478)
+- Corrected stale and inaccurate `--help` text across all commands. (#477)
+
+### Added
+
+- **Official Windows build.** Releases now publish an `x86_64-pc-windows-msvc`
+  `.zip` artifact and an `install.ps1` one-liner installer, with Windows added to
+  the CI build and test matrix. (#453, #444)
+- OS-keychain credential storage for the CLI bearer credential, with automatic
+  migration of any existing plaintext-config credential into the keychain.
+  `SPELUNK_SECRET_STORE=file` forces the previous file-based store for headless
+  environments. (#456)
+- Organization name is now shown in the `spelunk login` confirmation. (#452)
+- `spelunk-server --version` flag; `--help` output is now prefixed with the
+  version line. (#449)
+- Pre-flight embedding-dimension check in the CLI probe, guarding against a stale
+  loopback server with a mismatched embedding dimension. (#457)
+- Enterprise MDM deployment example for `spelunk` and `spelunk-server`. (#472)
+
+### Changed
+
+- Reduced steady-state disk usage: the cached BF16 safetensors are deleted after
+  the Q8_0 GGUF is written, and the upstream embedder revision is now pinned to an
+  exact commit. An opt-in direct-GGUF loader (enabled via
+  `SPELUNK_EMBEDDER_GGUF_REPO`) can download a pre-quantized Q8_0 GGUF instead of
+  quantizing locally. (#474)
+
 ## [0.9.0] — 2026-06-26
 
 ### Breaking changes — migration required

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5051,7 +5051,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"


### PR DESCRIPTION
## What

Cuts the **v0.9.1** patch release:

- Roll CHANGELOG `[Unreleased]` → `## [0.9.1] — 2026-06-30` (fresh empty `[Unreleased]` placeholder left at top).
- Bump the three workspace crates `0.9.0` → `0.9.1`: `spelunk-core`, `spelunk-cli`, `spelunk-server` (+ matching `Cargo.lock` entries).

No code changes — every 0.9.1 item is already on `main`.

### Fixed
- Single-chunk embedder OOM on large files — RAM-aware memory-budget cap; oversized chunks truncated/skipped (#475)
- `spelunk org switch` — persist `workos_org_id`, refresh token against the correct org, use production WorkOS client id (#478)
- Corrected stale and inaccurate `--help` text across all commands (#477)

### Added
- **Official Windows build** — `x86_64-pc-windows-msvc` `.zip` + `install.ps1`, with Windows in the CI build/test matrix (#453, #444)
- OS-keychain credential storage for the CLI bearer credential, with plaintext-config migration (`SPELUNK_SECRET_STORE=file` forces file store for headless) (#456)
- Organization name shown in `spelunk login` confirmation (#452)
- `spelunk-server --version` flag; `--help` prefixed with the version line (#449)
- Pre-flight embedding-dimension check in the CLI probe (guards against a stale loopback server) (#457)
- Enterprise MDM deployment example for `spelunk` / `spelunk-server` (#472)

### Changed
- Reduced steady-state disk usage — delete cached BF16 safetensors after the Q8_0 GGUF is written, and pin the upstream embedder revision to an exact commit. An opt-in direct-GGUF loader (`SPELUNK_EMBEDDER_GGUF_REPO`) can fetch a pre-quantized Q8_0 GGUF instead of quantizing locally (#474)

## After merge

Tag the merge commit `v0.9.1` to trigger the release build (including the Windows artifacts). No tag is pushed by this PR.

## Test plan

- [x] `cargo build` — all three crates compile at 0.9.1; `Cargo.lock` synced (entries show 0.9.1).
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --all-targets --features rich-formats -- -D warnings` — clean.
- [x] `SPELUNK_SECRET_STORE=file cargo test` — pass (default features).
- [x] `SPELUNK_SECRET_STORE=file cargo test --no-default-features` — pass.
- [x] Diff limited to CHANGELOG + the three crate versions + their `Cargo.lock` entries (no unrelated lock churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)