### PR TITLE
fix(release): unbreak 0.9.1 cross-platform build (openssl + libdbus)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,20 +53,57 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ matrix.target }}-
 
+      # The `keyring` crate's `sync-secret-service` feature links libdbus (a C
+      # library) on Linux, so the dev package + pkg-config must be present.
+      - name: Install Linux build dependencies (x86_64)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config \
+            libdbus-1-dev
+
+      # For the aarch64 cross-build we need the cross toolchain *and* the arm64
+      # build of libdbus. The latter requires enabling the arm64 architecture
+      # and pointing apt at the ports mirror (the default mirrors are amd64-only).
       - name: Install aarch64 cross-compilation toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
+          CODENAME="$(. /etc/os-release && echo "$VERSION_CODENAME")"
+          # Restrict the existing (amd64) sources so apt doesn't try to fetch
+          # arm64 indexes from amd64-only mirrors.
+          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+            sudo sed -i '/^Architectures:/d' /etc/apt/sources.list.d/ubuntu.sources
+            sudo sed -i '/^URIs:/a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources
+          fi
+          # Add an arm64-only ports source.
+          sudo tee /etc/apt/sources.list.d/arm64-ports.sources >/dev/null <<EOF
+          Types: deb
+          URIs: http://ports.ubuntu.com/ubuntu-ports/
+          Suites: ${CODENAME} ${CODENAME}-updates ${CODENAME}-backports ${CODENAME}-security
+          Components: main universe restricted multiverse
+          Architectures: arm64
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
+          sudo dpkg --add-architecture arm64
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             gcc-aarch64-linux-gnu \
             g++-aarch64-linux-gnu \
-            libc6-dev-arm64-cross
+            libc6-dev-arm64-cross \
+            pkg-config \
+            libdbus-1-dev:arm64
 
       - name: Build release binaries
         shell: bash
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          # Let pkg-config resolve the arm64 libdbus when cross-compiling.
+          PKG_CONFIG_ALLOW_CROSS: "1"
         run: |
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            export PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig
+          fi
           FEATURES="${{ matrix.features }}"
           if [ -n "$FEATURES" ]; then
             cargo build --release --target ${{ matrix.target }} --features "$FEATURES"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,12 +396,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,16 +1117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,21 +1501,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1544,12 +1519,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2879,7 +2848,6 @@ dependencies = [
  "indicatif",
  "libc",
  "log",
- "native-tls",
  "num_cpus",
  "rand 0.9.4",
  "reqwest",
@@ -2990,22 +2958,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -3562,7 +3514,7 @@ dependencies = [
  "bitflags 2.13.0",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -3631,23 +3583,6 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -3891,59 +3826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-src"
-version = "300.6.1+3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3993,15 +3875,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -4570,12 +4443,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4586,7 +4457,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -4748,15 +4618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5068,7 +4929,6 @@ dependencies = [
  "gix-transport",
  "ignore",
  "indicatif",
- "openssl",
  "percent-encoding",
  "predicates",
  "pretty_assertions",
@@ -5159,8 +5019,6 @@ dependencies = [
  "futures-util",
  "hf-hub",
  "libc",
- "openssl",
- "openssl-sys",
  "pretty_assertions",
  "regex",
  "reqwest",
@@ -5553,16 +5411,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -6091,10 +5939,8 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
- "der",
  "flate2",
  "log",
- "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
@@ -6103,7 +5949,6 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-root-certs",
  "webpki-roots",
 ]
 
@@ -6332,15 +6177,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ rusqlite    = { version = "0.40", features = ["bundled"] }
 sqlite-vec  = "0.1"
 reqwest     = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 uuid        = { version = "1", features = ["v4", "v7", "serde"] }
-openssl     = { version = "0.10", features = ["vendored"] }
-openssl-sys = { version = "0.9", features = ["vendored"] }
 tempfile    = "3"
 pretty_assertions = "1"
 serial_test = "3"

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -41,7 +41,6 @@ indicatif = "0.18"
 futures-util = "0.3"
 ignore = "0.4"
 reqwest = { workspace = true }
-openssl = { workspace = true }
 percent-encoding = "2.3"
 blake3 = "1"
 regex = { version = "1", default-features = false, features = ["std"] }

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -34,8 +34,6 @@ rusqlite = { workspace = true }
 sqlite-vec = { workspace = true }
 uuid = { workspace = true }
 reqwest = { workspace = true }
-openssl = { workspace = true }
-openssl-sys = { workspace = true }
 axum = { version = "0.8", features = ["macros"] }
 tower-http = { version = "0.7", features = ["auth"] }
 async-stream = "0.3"
@@ -48,7 +46,7 @@ dirs = "6"
 candle-core = { version = "0.11.0", optional = true }
 candle-nn = { version = "0.11.0", optional = true }
 candle-transformers = { version = "0.11.0", optional = true }
-hf-hub = { version = "0.5", optional = true }
+hf-hub = { version = "0.5", optional = true, default-features = false, features = ["tokio", "ureq", "rustls-tls"] }
 tokenizers = { version = "0.23", optional = true }
 
 # macOS-only: `hw.memsize` sysctl in `total_system_ram` (Linux reads


### PR DESCRIPTION
## Problem

The `v0.9.1` release build failed on **every Linux target and the newly added Windows target**; only macOS aarch64 passed ([run 28465929976](https://github.com/spelunk-cloud/spelunk/actions/runs/28465929976)). Two independent native-C-library dependencies that CI doesn't provide:

| Platform | Failed crate | Cause |
|---|---|---|
| Windows (`x86_64-pc-windows-msvc`) | `openssl-sys` (vendored) | Dead `openssl`/`openssl-sys` deps — a CI hack (4e2a79be) to vendor openssl for the `native-tls` path. Vendored openssl needs perl to build. Not referenced in any source; `native-tls` is only pulled by `hf-hub`. |
| Linux ×3 | `libdbus-sys` | 0.9.1 newly added the `keyring` crate, whose `sync-secret-service` feature links libdbus on Linux. `libdbus-1-dev` wasn't installed. |

## Fix

**Windows / openssl** — switch `hf-hub` to rustls (`default-features = false` + `["tokio","ureq","rustls-tls"]`). This removes `native-tls` from the entire tree, so the unused vendored `openssl`/`openssl-sys` deps (workspace + spelunk-server + spelunk-cli) are deleted outright. `openssl-sys`, `native-tls`, `tokio-native-tls`, and `schannel` all drop from `Cargo.lock`.

**Linux / libdbus** — install `pkg-config` + `libdbus-1-dev` in `release.yml`. For the aarch64 cross-build, enable the arm64 architecture against the ports mirror, install `libdbus-1-dev:arm64`, and point pkg-config at the arm64 sysroot (`PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_LIBDIR`).

macOS is unaffected (Keychain + rustls, no system libs).

## Test plan

- [x] `cargo check --workspace` (default features incl. `embed-native`) passes on macOS.
- [x] `cargo fmt --check` + `cargo clippy` clean (pre-commit hook).
- [x] Confirmed `native-tls`, `openssl-sys`, `tokio-native-tls`, `schannel` removed from `Cargo.lock`; `dbus-secret-service` retained (Linux keyring backend, now satisfied by the CI libdbus install).
- [x] `release.yml` validated: YAML parses; all bash `run:` scripts pass `bash -n`; heredoc dedents to valid deb822.
- [ ] Full green release run — validated by re-tagging `v0.9.1` after merge.

> ⚠️ The aarch64-Linux leg (arm64 multiarch apt against the ports mirror) is the most fragile part. If it fails on a future runner-image change, the clean fallback is moving `keyring` to the pure-Rust `async-secret-service` backend (no system libs), or dropping aarch64-Linux from the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)