### PR TITLE
feat(sync): require explicit --project on first sync; never auto-name

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -255,6 +255,12 @@ pub struct MemorySyncArgs {
     /// Include archived entries in the push (propagates tombstones)
     #[arg(long)]
     pub include_archived: bool,
+    /// Cloud project slug to sync into. Required when no `project_id` is
+    /// configured. On first sync the server lazily creates this project from the
+    /// slug; repeat syncs with the same slug reuse it. The slug is never
+    /// auto-derived from the folder or git remote (project-taxonomy).
+    #[arg(long)]
+    pub project: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -32,28 +32,53 @@ use crate::{
     storage::{BatchPushItem, CloudSyncClient, MemoryStore},
 };
 
+/// Resolve the project slug to sync into, or halt with actionable guidance.
+///
+/// Precedence: an explicit `--project <slug>` overrides any configured
+/// `project_id`; otherwise the configured `project_id` is used. When neither is
+/// present the call **halts** — sync never auto-derives a name from the folder
+/// or git remote (founder decision 2026-07-01, project-taxonomy). The returned
+/// slug is sent verbatim to the server, which lazily creates the project on
+/// first sync and reuses it on subsequent syncs.
+fn resolve_sync_project(cli_project: Option<&str>, cfg: &Config) -> Result<String> {
+    cli_project
+        .map(str::to_string)
+        .or_else(|| cfg.project_id.clone())
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No project specified. Re-run as `spelunk sync --project <slug>` \
+                 to choose the cloud project to sync into.\n\
+                 (The project is created on first sync from the slug you pass; \
+                 the slug is never guessed from the folder or git remote.)"
+            )
+        })
+}
+
 /// Resolve the cloud sync target (base URL, server-side project id, key).
 ///
 /// Sync always speaks to an explicit `server_url` — it is the cloud-convergence
 /// path, not the inference loopback. Errors with actionable guidance when the
-/// project is offline or missing a `project_id`.
+/// server is missing, or when no project slug is available (see
+/// [`resolve_sync_project`]).
+///
+/// `cli_project` is the optional `--project <slug>` override; when `None` the
+/// configured `project_id` is used.
 ///
 /// The bearer key is resolved through [`auth_api::ensure_fresh_server_key`] so a
 /// WorkOS access token that has expired since `spelunk login` is refreshed (and
 /// the rotated tokens persisted) before the cloud-api call, rather than 401-ing.
-async fn sync_target(cfg: &Config) -> Result<(String, String, Option<String>)> {
+async fn sync_target(
+    cfg: &Config,
+    cli_project: Option<&str>,
+) -> Result<(String, String, Option<String>)> {
     let base_url = cfg.server_url.clone().ok_or_else(|| {
         anyhow::anyhow!(
             "sync requires a server. Set `server_url` in your spelunk config \
              (e.g. ~/.config/spelunk/config.toml or .spelunk/config.toml)."
         )
     })?;
-    let project_id = cfg.project_id.clone().ok_or_else(|| {
-        anyhow::anyhow!(
-            "`project_id` is not configured. Set it in `.spelunk/config.toml` \
-             or via `SPELUNK_PROJECT_ID` so sync can address the project."
-        )
-    })?;
+    let project_id = resolve_sync_project(cli_project, cfg)?;
     let key = auth_api::ensure_fresh_server_key(cfg).await?;
     Ok((base_url, project_id, key))
 }
@@ -66,7 +91,7 @@ pub async fn memory_pull(
 ) -> Result<()> {
     let tier = capability::get_tier(cfg).await;
     capability::require_tier1("memory pull", tier, cfg.server_url.as_deref())?;
-    let (base_url, project_id, key) = sync_target(cfg).await?;
+    let (base_url, project_id, key) = sync_target(cfg, None).await?;
 
     let local = MemoryStore::open(mem_path)
         .with_context(|| format!("opening local memory at {}", mem_path.display()))?;
@@ -85,7 +110,7 @@ pub async fn memory_sync(
 ) -> Result<()> {
     let tier = capability::get_tier(cfg).await;
     capability::require_tier1("sync", tier, cfg.server_url.as_deref())?;
-    let (base_url, project_id, key) = sync_target(cfg).await?;
+    let (base_url, project_id, key) = sync_target(cfg, args.project.as_deref()).await?;
 
     let src_path = args.source.as_deref().unwrap_or(mem_path);
     let local = MemoryStore::open(src_path)
@@ -270,5 +295,118 @@ mod tests {
     fn parse_iso_to_secs_falls_back_on_garbage() {
         // Must not panic; returns some positive epoch (now).
         assert!(parse_iso_to_secs("not-a-timestamp") > 0);
+    }
+
+    // ── resolve_sync_project (spelunk-oss^47) ──────────────────────────────
+    // Sync must never invent a project name. With neither `--project` nor a
+    // configured `project_id`, the call halts with a message pointing the user
+    // at `--project <slug>`; with an explicit slug (or configured id), that slug
+    // is threaded through verbatim so it reaches the outbound request.
+
+    fn cfg_with_project(id: Option<&str>) -> Config {
+        Config {
+            project_id: id.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolve_sync_project_halts_when_nothing_configured_or_passed() {
+        let cfg = cfg_with_project(None);
+        let err = resolve_sync_project(None, &cfg).unwrap_err();
+        let msg = err.to_string();
+        // Actionable: names the exact re-run and refuses to guess.
+        assert!(msg.contains("--project <slug>"), "msg: {msg}");
+        assert!(
+            msg.contains("never guessed") || msg.contains("git remote"),
+            "must state it won't auto-derive: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_sync_project_uses_cli_flag_when_passed() {
+        let cfg = cfg_with_project(None);
+        let slug = resolve_sync_project(Some("acme/app"), &cfg).unwrap();
+        assert_eq!(slug, "acme/app");
+    }
+
+    #[test]
+    fn resolve_sync_project_falls_back_to_configured_id() {
+        let cfg = cfg_with_project(Some("team/proj"));
+        let slug = resolve_sync_project(None, &cfg).unwrap();
+        assert_eq!(slug, "team/proj");
+    }
+
+    #[test]
+    fn resolve_sync_project_cli_flag_overrides_configured_id() {
+        let cfg = cfg_with_project(Some("team/proj"));
+        let slug = resolve_sync_project(Some("other/slug"), &cfg).unwrap();
+        assert_eq!(slug, "other/slug");
+    }
+
+    #[test]
+    fn resolve_sync_project_treats_blank_slug_as_absent() {
+        // A whitespace-only `--project ""` must not silently pass an empty slug.
+        let cfg = cfg_with_project(None);
+        assert!(resolve_sync_project(Some("   "), &cfg).is_err());
+    }
+
+    // ── end-to-end first-run path (spelunk-oss^47 QA handback) ─────────────
+    // The story's target path: a first-run user has a non-loopback team
+    // `server_url`, NO configured `project_id`, and passes `--project <slug>`.
+    // Before the fix this was rejected at dispatch by `cfg.validate()` before
+    // `resolve_sync_project` ever ran. This test walks the same two gates the
+    // dispatcher + `memory_sync` cross — (1) config validation must accept the
+    // `--project`-only config, (2) the resolved slug must reach the outbound
+    // request — proving the path is live end to end (minus the auth/tier
+    // machinery, which is orthogonal to this story).
+    #[tokio::test]
+    async fn first_run_project_flag_only_passes_dispatch_and_reaches_wire() {
+        use crate::storage::{BatchPushItem, CloudSyncClient};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // A non-loopback team server_url with NO project_id — a genuine first run.
+        let cfg = Config {
+            server_url: Some("http://spelunk.internal:7777".to_string()),
+            project_id: None,
+            ..Default::default()
+        };
+        let cli_project = Some("acme/app");
+
+        // Gate 1 — dispatch: `--project` makes a project available, so the
+        // non-loopback server_url no longer blocks (regression under test).
+        let project_available = cli_project.is_some() || cfg.project_id.is_some();
+        cfg.validate_with_project(project_available)
+            .expect("first-run --project must pass dispatch validation");
+
+        // Gate 2 — resolution: the explicit slug wins and is what sync targets.
+        let slug = resolve_sync_project(cli_project, &cfg).unwrap();
+        assert_eq!(slug, "acme/app");
+
+        // Wire: the resolved slug must land, percent-encoded, in the request
+        // path so the server can lazily create/reuse that project.
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/acme%2Fapp/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 1, "skipped": 0, "failed": 0,
+                "results": [{"status": "created", "external_id": "e1", "id": "cloud-1"}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = CloudSyncClient::new(&server.uri(), &slug, None).unwrap();
+        let res = client
+            .push_batch(vec![BatchPushItem {
+                kind: "decision".into(),
+                title: "T".into(),
+                body: Some("B".into()),
+                external_id: "e1".into(),
+                source_commit: None,
+            }])
+            .await
+            .expect("push to the lazily-created project must succeed");
+        assert_eq!(res.created, 1);
     }
 }

--- a/crates/spelunk-cli/src/main.rs
+++ b/crates/spelunk-cli/src/main.rs
@@ -74,7 +74,13 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Command::Sync(args) => {
-            cfg.validate()?;
+            // An explicit `--project <slug>` supplies the project identity that a
+            // first-run user has not yet persisted as `project_id`, so it
+            // satisfies the non-loopback-`server_url` requirement here. The
+            // missing-project case is still gated (with a better, actionable
+            // message) by `resolve_sync_project` inside `memory_sync`.
+            let project_available = args.project.is_some() || cfg.project_id.is_some();
+            cfg.validate_with_project(project_available)?;
             let mem_path = config::resolve_db(None, &cfg.db_path).with_file_name("memory.db");
             cli::cmd::memory_sync(args, &mem_path, &cfg).await
         }

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -591,8 +591,23 @@ impl Config {
     /// `project_id` is allowed to be absent — it will be derived at runtime by
     /// `Config::resolve_project_id()` (see spelunk#307 / section D of #303).
     pub fn validate(&self) -> Result<()> {
+        self.validate_with_project(self.project_id.is_some())
+    }
+
+    /// Like [`validate`](Self::validate) but lets the caller assert that a
+    /// project identity is available from a source outside the config — e.g. an
+    /// explicit `spelunk sync --project <slug>` flag.
+    ///
+    /// `spelunk sync` supplies its slug lazily (the project is created on first
+    /// sync; ADR / founder decision 2026-07-01), so at config-validation time
+    /// `project_id` may legitimately be `None` while `--project` carries the
+    /// slug. Pass `project_available = true` in that case so the non-loopback
+    /// `server_url` requirement is satisfied without a persisted `project_id`.
+    /// The actual slug resolution (and the halt-with-guidance when *no* slug is
+    /// available) is done by the sync command itself.
+    pub fn validate_with_project(&self, project_available: bool) -> Result<()> {
         if let Some(url) = &self.server_url
-            && self.project_id.is_none()
+            && !project_available
             && !is_loopback_url(url)
         {
             anyhow::bail!(
@@ -1135,6 +1150,49 @@ project_id = "my-proj"
             ..Default::default()
         };
         assert!(cfg.validate().is_err());
+    }
+
+    // ── validate_with_project() — --project satisfies the requirement (oss^47) ─
+
+    #[test]
+    fn validate_with_project_true_passes_non_loopback_without_project_id() {
+        // First-run `spelunk sync --project <slug>`: a non-loopback server_url is
+        // set, no project_id is persisted, but the caller asserts a project slug
+        // is available from --project. This must pass (previously blocked sync).
+        let cfg = Config {
+            server_url: Some("http://spelunk.internal:7777".to_string()),
+            project_id: None,
+            ..Default::default()
+        };
+        assert!(cfg.validate_with_project(true).is_ok());
+    }
+
+    #[test]
+    fn validate_with_project_false_still_fails_non_loopback_without_project_id() {
+        // No --project and no configured project_id → the requirement still bites.
+        let cfg = Config {
+            server_url: Some("http://spelunk.internal:7777".to_string()),
+            project_id: None,
+            ..Default::default()
+        };
+        assert!(cfg.validate_with_project(false).is_err());
+    }
+
+    #[test]
+    fn validate_delegates_to_validate_with_project() {
+        // validate() == validate_with_project(project_id.is_some()).
+        let with_id = Config {
+            server_url: Some("http://spelunk.internal:7777".to_string()),
+            project_id: Some("p".to_string()),
+            ..Default::default()
+        };
+        assert!(with_id.validate().is_ok());
+        let without_id = Config {
+            server_url: Some("http://spelunk.internal:7777".to_string()),
+            project_id: None,
+            ..Default::default()
+        };
+        assert!(without_id.validate().is_err());
     }
 
     // ── is_loopback_url ──────────────────────────────────────────────────────

--- a/crates/spelunk-core/src/storage/remote/sync.rs
+++ b/crates/spelunk-core/src/storage/remote/sync.rs
@@ -361,6 +361,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn push_batch_threads_explicit_slug_into_request_path() {
+        // spelunk-oss^47: an explicit project slug (e.g. from `spelunk sync
+        // --project acme/new-app`) must reach the server verbatim in the request
+        // path, so the server can lazily create/reuse that project on first sync.
+        // The mock only matches the slug-scoped path, so a match proves it.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/acme%2Fnew-app/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 1, "skipped": 0, "failed": 0,
+                "results": [{"status": "created", "external_id": "e1", "id": "cloud-1"}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = CloudSyncClient::new(&server.uri(), "acme/new-app", None).unwrap();
+        let res = client.push_batch(vec![item("e1")]).await.unwrap();
+        assert_eq!(res.created, 1);
+    }
+
+    #[tokio::test]
     async fn delete_remote_treats_404_as_success() {
         let server = MockServer::start().await;
         Mock::given(method("DELETE"))


### PR DESCRIPTION
## Summary

`spelunk sync` now requires an **explicit project** and never invents one. Interim founder-decided behaviour (2026-07-01, project-taxonomy):

- **No project configured or passed** → sync halts with an actionable message pointing at `spelunk sync --project <slug>`. It never auto-derives a name from the folder or git remote.
- **`--project <slug>` supplied** → the slug is threaded verbatim into the outbound request (`/v1/projects/{slug}/memory/batch`, percent-encoded). The server (cloud-api^38) lazily creates the project from the slug on first sync and reuses it on repeat syncs.

### What changed
- `MemorySyncArgs` gains `--project <slug>`.
- New `resolve_sync_project(cli_project, cfg)`: precedence `--project` > configured `project_id`; blank/whitespace treated as absent; otherwise halts with guidance. Never calls the auto-deriving `Config::resolve_project_id()`.
- `Config::validate()` now delegates to `Config::validate_with_project(project_available)` (a true no-op refactor: `validate()` passes `self.project_id.is_some()`, so byte-for-byte prior behaviour for all existing callers). The `Sync` arm in `main.rs` passes `args.project.is_some() || cfg.project_id.is_some()`, so a first-run user with a non-loopback `server_url` and no persisted `project_id` can rely solely on `--project` without being rejected at dispatch. All other arms (`context`, `memory`/pull, `index`) call `validate()` unchanged.

This closes a QA-caught regression where the pre-dispatch `validate()` gate rejected the `--project`-only first-run path before the resolver ever ran.

## Test plan (all run with `SPELUNK_SECRET_STORE=file`)

- `cargo build` → clean.
- `cargo test -p spelunk-core --lib` → 177 passed. Includes:
  - `validate_delegates_to_validate_with_project` (delegation is a no-op)
  - `validate_with_project_true_passes_non_loopback_without_project_id` (fix)
  - `validate_with_project_false_still_fails_non_loopback_without_project_id` (missing-project still bites)
  - `push_batch_threads_explicit_slug_into_request_path` (`acme/new-app` → `/v1/projects/acme%2Fnew-app/memory/batch`)
- `cargo test -p spelunk-cli` → all binaries green, 0 failures. Includes:
  - `resolve_sync_project_halts_when_nothing_configured_or_passed`
  - `resolve_sync_project_uses_cli_flag_when_passed` / `_falls_back_to_configured_id` / `_cli_flag_overrides_configured_id`
  - `resolve_sync_project_treats_blank_slug_as_absent` (blank `--project "   "` still halts)
  - `first_run_project_flag_only_passes_dispatch_and_reaches_wire` (end-to-end: non-loopback `server_url` + no `project_id` + `--project acme/app` → passes dispatch AND reaches the wire)

## Context
Server side is cloud-api^38 (lazy project creation from slug). Out of scope: git-remote derivation, `init`-time naming, registry persistence.