### PR TITLE
feat(login): auto-select org (or interactive selector) after no-org device login

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/login.rs
+++ b/crates/spelunk-cli/src/cli/cmd/login.rs
@@ -22,8 +22,18 @@
 //! org via the refresh grant. When the operator is already logged in with a
 //! valid refresh token and passes `--org`, login short-circuits straight to the
 //! silent org-switch (no device re-entry).
+//!
+//! No-org token, no `--org` (first-run UX)
+//! ---------------------------------------
+//! WorkOS does not auto-select an org even for single-org users, so a plain
+//! `spelunk login` yields a token with an empty `org_id`. Rather than leave the
+//! operator with a session that can't do anything until they run
+//! `spelunk org switch`, the `None` arm resolves an org itself:
+//!   - one org   → auto-select it silently;
+//!   - many orgs → an interactive selector on a TTY (require `--org` otherwise);
+//!   - zero orgs → a clear onboarding message, and no dangling session written.
 
-use std::io::Write as _;
+use std::io::{IsTerminal as _, Write as _};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -31,7 +41,7 @@ use clap::Args;
 
 use spelunk_core::config::{self, AuthTokens};
 
-use super::auth_api::{self, DEFAULT_CLOUD_URL, PollOutcome};
+use super::auth_api::{self, DEFAULT_CLOUD_URL, MeOrg, PollOutcome};
 use super::org::{persist_tokens, switch_org};
 
 // ── CLI args ──────────────────────────────────────────────────────────────────
@@ -160,7 +170,7 @@ pub async fn login(args: LoginArgs) -> Result<()> {
 
     // A device login always yields a token first; honour `--org` as a
     // login-then-switch by re-scoping the freshly-issued session.
-    let (tokens, entered_org) = match &args.org {
+    match &args.org {
         Some(org_slug) => {
             let switched = switch_org(
                 &client,
@@ -171,12 +181,127 @@ pub async fn login(args: LoginArgs) -> Result<()> {
                 org_slug,
             )
             .await?;
-            (switched, Some(org_slug.clone()))
+            finish_login(&cloud_url, switched, Some(org_slug.as_str())).await
         }
-        None => (tokens, None),
-    };
+        // No `--org`: if WorkOS already scoped the token to an org (browser-side
+        // pick), keep it. Otherwise resolve one ourselves so the first run does
+        // not leave a session that needs a follow-up `org switch`.
+        None if !tokens.org_id.is_empty() => finish_login(&cloud_url, tokens, None).await,
+        None => resolve_org_after_login(&client, &workos_url, &cloud_url, &client_id, tokens).await,
+    }
+}
 
-    finish_login(&cloud_url, tokens, entered_org.as_deref()).await
+/// Resolve an org for a freshly-issued **no-org** token (no `--org` given).
+///
+/// Fetches the caller's memberships via `GET /v1/me` and:
+/// - **1 org** → silently `switch_org` to it (auto-select);
+/// - **N orgs** → interactive selector on a TTY; a non-TTY/agent shell errors
+///   with an actionable "pass `--org`" message and a non-zero exit;
+/// - **0 orgs** → a clear onboarding message and a non-zero exit, leaving no
+///   dangling no-org session persisted.
+async fn resolve_org_after_login(
+    client: &reqwest::Client,
+    workos_url: &str,
+    cloud_url: &str,
+    client_id: &str,
+    tokens: AuthTokens,
+) -> Result<()> {
+    let me = auth_api::fetch_me(client, cloud_url, &tokens.access_token)
+        .await
+        .context("fetching your organizations after login")?;
+
+    let interactive = std::io::stdin().is_terminal()
+        && std::io::stderr().is_terminal()
+        && !spelunk_core::utils::is_agent_mode();
+
+    match choose_org(&me.orgs, interactive)? {
+        OrgChoice::Switch(org) => {
+            // Prefer the WorkOS org id (skips a redundant /v1/me in switch_org);
+            // fall back to the slug when the membership lacks a workos_org_id.
+            let target = org
+                .workos_org_id
+                .clone()
+                .unwrap_or_else(|| org.slug.clone());
+            let switched =
+                switch_org(client, workos_url, cloud_url, client_id, &tokens, &target).await?;
+            // We already know the human name; pass the slug as the display hint.
+            finish_login(cloud_url, switched, Some(&org.slug)).await
+        }
+    }
+}
+
+/// The outcome of resolving an org for a no-org login.
+#[derive(Debug)]
+enum OrgChoice {
+    /// Switch the session to this membership.
+    Switch(MeOrg),
+}
+
+/// Decide which org a no-org login should scope to, given the caller's
+/// memberships and whether we may prompt interactively.
+///
+/// Pure and side-effect-free apart from the interactive prompt (which only runs
+/// when `interactive` is true), so every branch is unit-testable:
+/// - 0 orgs → onboarding error;
+/// - 1 org → auto-select;
+/// - N + TTY → prompt;
+/// - N + non-TTY → actionable "pass `--org`" error.
+fn choose_org(orgs: &[MeOrg], interactive: bool) -> Result<OrgChoice> {
+    match orgs.len() {
+        0 => anyhow::bail!(
+            "Your account is not a member of any organization yet.\n\
+             Create one at https://spelunk.cloud/onboarding, then run `spelunk login` again."
+        ),
+        1 => Ok(OrgChoice::Switch(orgs[0].clone())),
+        _ if interactive => {
+            let idx = prompt_org_selection(orgs)?;
+            Ok(OrgChoice::Switch(orgs[idx].clone()))
+        }
+        _ => {
+            let slugs = orgs
+                .iter()
+                .map(|o| o.slug.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "You are a member of multiple organizations; a non-interactive shell \
+                 cannot prompt.\n\
+                 Re-run with `spelunk login --org <slug>` (one of: {slugs})."
+            )
+        }
+    }
+}
+
+/// Prompt the operator to pick one of `orgs` (guaranteed len >= 2) on a TTY.
+///
+/// Lists each org as `name (slug)` and reads a 1-based index from stdin,
+/// re-prompting on invalid input. Returns the chosen 0-based index.
+fn prompt_org_selection(orgs: &[MeOrg]) -> Result<usize> {
+    eprintln!();
+    eprintln!("You are a member of multiple organizations. Select one:");
+    for (i, o) in orgs.iter().enumerate() {
+        eprintln!("  {}. {} ({})", i + 1, o.name, o.slug);
+    }
+    eprintln!();
+
+    let stdin = std::io::stdin();
+    loop {
+        eprint!("Enter a number [1-{}]: ", orgs.len());
+        std::io::stderr().flush().ok();
+
+        let mut line = String::new();
+        let n = stdin
+            .read_line(&mut line)
+            .context("reading org selection")?;
+        if n == 0 {
+            // EOF (e.g. stdin closed mid-prompt) — don't loop forever.
+            anyhow::bail!("no organization selected (input closed)");
+        }
+        match line.trim().parse::<usize>() {
+            Ok(choice) if (1..=orgs.len()).contains(&choice) => return Ok(choice - 1),
+            _ => eprintln!("Please enter a number between 1 and {}.", orgs.len()),
+        }
+    }
 }
 
 /// Persist tokens and print the success message naming the org entered.
@@ -209,4 +334,95 @@ async fn finish_login(
 /// Print the "logged in to <org>" confirmation with a switch hint.
 fn print_logged_in(org: &str) {
     println!("Logged in to {org}. Use `spelunk org switch` to change.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn org(id: &str, name: &str, slug: &str, workos: Option<&str>) -> MeOrg {
+        MeOrg {
+            id: id.into(),
+            name: name.into(),
+            slug: slug.into(),
+            workos_org_id: workos.map(str::to_string),
+        }
+    }
+
+    fn one_org() -> Vec<MeOrg> {
+        vec![org(
+            "11111111-1111-1111-1111-111111111111",
+            "Acme",
+            "acme",
+            Some("org_acme"),
+        )]
+    }
+
+    fn two_orgs() -> Vec<MeOrg> {
+        vec![
+            org(
+                "11111111-1111-1111-1111-111111111111",
+                "Acme",
+                "acme",
+                Some("org_acme"),
+            ),
+            org(
+                "22222222-2222-2222-2222-222222222222",
+                "Beta Corp",
+                "beta",
+                Some("org_beta"),
+            ),
+        ]
+    }
+
+    /// Exactly one org → auto-select it (no prompt), even when non-interactive.
+    #[test]
+    fn choose_org_single_org_auto_selects() {
+        let OrgChoice::Switch(picked) = choose_org(&one_org(), false).unwrap();
+        assert_eq!(picked.slug, "acme");
+        // Interactivity is irrelevant for a single org — same result on a TTY.
+        let OrgChoice::Switch(picked) = choose_org(&one_org(), true).unwrap();
+        assert_eq!(picked.slug, "acme");
+    }
+
+    /// Zero orgs → a clear onboarding error, never a dangling session.
+    #[test]
+    fn choose_org_zero_orgs_points_at_onboarding() {
+        let err = choose_org(&[], true).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("onboarding"),
+            "0-org error should point at onboarding, got: {msg}"
+        );
+        assert!(
+            msg.contains("not a member of any organization"),
+            "0-org error should explain the cause, got: {msg}"
+        );
+    }
+
+    /// Multiple orgs on a non-interactive shell → actionable `--org` error naming
+    /// the available slugs, with no prompt (and thus a non-zero exit upstream).
+    #[test]
+    fn choose_org_multi_non_interactive_requires_org_flag() {
+        let err = choose_org(&two_orgs(), false).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--org"),
+            "multi/non-TTY error should tell the user to pass --org, got: {msg}"
+        );
+        assert!(
+            msg.contains("acme") && msg.contains("beta"),
+            "error should list the candidate slugs, got: {msg}"
+        );
+    }
+
+    /// The scripted path is `--org`, resolved by `switch_org`; `choose_org` is only
+    /// reached when `--org` is absent, so a multi-org non-interactive caller must
+    /// be told to use it rather than hang on a prompt.
+    #[test]
+    fn choose_org_multi_non_interactive_does_not_prompt() {
+        // `interactive = false` must return Err synchronously (no stdin read),
+        // proving the non-TTY guard prevents a blocking prompt.
+        assert!(choose_org(&two_orgs(), false).is_err());
+    }
 }


### PR DESCRIPTION
## Summary

After `spelunk login`, the WorkOS device grant returns a token with **no `org_id`** (WorkOS doesn't auto-select even for single-org users). Previously the CLI persisted that no-org token as-is, forcing a second `spelunk org switch <slug>` before anything worked. This closes that first-run gap.

In the post-device-login path when `--org` is absent **and** the issued token has no `org_id`, the CLI now resolves an org itself via `GET /v1/me` `orgs[]`:

- **Exactly one org** → silently `switch_org` to it (auto-select); prints `Logged in to <name>`.
- **Multiple orgs on a TTY** → interactive selector listing `name (slug)`; the choice scopes the session.
- **Multiple orgs, non-TTY / agent shell** → actionable error naming the candidate slugs and telling the user to pass `--org <slug>`, with a non-zero exit and **no blocking prompt / hang**.
- **Zero orgs** → clear onboarding message (points at `https://spelunk.cloud/onboarding`), non-zero exit, and **no dangling no-org session persisted**.

The scripted `spelunk login --org <slug>` path is **unchanged**; the branch decision is factored into a pure `choose_org(orgs, interactive)` so every branch is unit-testable. Interactivity requires both stdin and stderr to be TTYs and respects agent mode (`AGENT=true`).

Refs: ADR-047 (CLI→WorkOS direct), ADR-044 (CLI org selection). Depends on the no-org `/v1/me` (already deployed).

## Test plan

All run with `SPELUNK_SECRET_STORE=file` exported.

- `cargo fmt --all` — clean (also enforced by the pre-commit hook on push).
- `cargo clippy -p spelunk-cli --all-targets -- -D warnings` — clean.
- `cargo test -p spelunk-cli` — all pass. New unit tests in `login.rs` cover the decision matrix:
  - `choose_org_single_org_auto_selects` — 1 org auto-selects (interactive and non-interactive).
  - `choose_org_zero_orgs_points_at_onboarding` — 0 orgs → onboarding error.
  - `choose_org_multi_non_interactive_requires_org_flag` — N orgs + non-TTY → `--org` error listing slugs.
  - `choose_org_multi_non_interactive_does_not_prompt` — N orgs + non-TTY returns `Err` synchronously (no stdin read → cannot hang).
  - The `--org` scripted path + membership-error handling remain covered by the existing `login_then_switch_org_*` wire tests in `auth_api.rs`.
- `cargo audit` — no new advisories; no dependencies added (`Cargo.lock` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)