### PR TITLE
fix(server): serve /v1/health before loading embedder + readiness contract (oss^50, PR A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **First-run auto-start no longer misreports failure while the model loads.**
+  `spelunk-server` now binds its listener and serves `/v1/health` **before**
+  loading the native embedder (the ~339 MB model now loads on a background task),
+  so the CLI's auto-start health check sees a live server immediately instead of
+  timing out during the first-run download. The auto-start/`spelunk server start`
+  wait was also extended to 30 s, and its failure warning now fires only on a
+  genuine liveness timeout (with firewall + `spelunk server logs` guidance).
+
+### Changed
+
+- **`spelunk-server` now binds `127.0.0.1` by default** (was `0.0.0.0`). Loopback
+  is the safer, firewall-exempt default; pass `--host 0.0.0.0` explicitly to
+  expose the server on all interfaces. The container image sets `--host 0.0.0.0`
+  in its entrypoint so published ports stay reachable. The CLI auto-spawned daemon
+  already forced `--host 127.0.0.1` and is unaffected.
+- **`/v1/health` now reports embedder readiness** via a new
+  `embedder: { state, detail }` sub-object (`loading` | `ready` | `unavailable` |
+  `disabled`). `capabilities` (`index.embed` / `search.semantic`) and
+  `embedding_dim` are populated only once the embedder is `ready`
+  (backward-compatible). While the embedder is warming up, the embed/search
+  endpoints return `503` (with `Retry-After: 5` while `loading`, terminal while
+  `unavailable`) instead of the `400` now reserved for the genuinely unconfigured
+  case.
+
 ## [0.9.1] — 2026-06-30
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,7 @@ USER spelunk
 EXPOSE 7777
 
 ENTRYPOINT ["/usr/local/bin/spelunk-server"]
-CMD ["--db", "/data/spelunk.db"]
+# The server default host is 127.0.0.1 (loopback). Inside a container that would
+# only be reachable from within the container, so bind all interfaces explicitly
+# to keep the published `-p 7777:7777` mapping reachable.
+CMD ["--host", "0.0.0.0", "--db", "/data/spelunk.db"]

--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -195,9 +195,22 @@ pub async fn ensure_server_running(start_port: u16) -> Result<(u16, bool)> {
     std::fs::write(pid_path(&state_dir), format!("{pid}\n")).context("writing server.pid")?;
     std::fs::write(port_path(&state_dir), format!("{port}\n")).context("writing server.port")?;
 
-    let ready = wait_for_health(port, Duration::from_secs(5)).await;
+    // Wait for *liveness* (the port binds, /v1/health responds) — not model
+    // readiness. Health now goes live at bind, before the model download, so
+    // 30 s comfortably covers a cold listener bind even on Windows; it only
+    // bounds the give-up time and is free in the happy path (200 ms poll,
+    // returns on first success).
+    let ready = wait_for_health(port, Duration::from_secs(30)).await;
     if !ready {
-        tracing::warn!("spelunk-server started (pid={pid}) but did not respond within 5 s");
+        // Liveness genuinely not achieved within the timeout — most commonly a
+        // firewall blocking the loopback listener. Don't warn merely because the
+        // model is still loading (health is live before that).
+        tracing::warn!(
+            "spelunk-server started (pid={pid}) but /v1/health did not respond within 30 s. \
+             A firewall may be blocking the local server (allow it, e.g. accept the Windows \
+             Defender Firewall prompt), or the process failed to start — check \
+             `spelunk server logs`."
+        );
     }
 
     Ok((port, true))
@@ -260,15 +273,20 @@ async fn cmd_start(args: ServerStartArgs) -> Result<()> {
     std::fs::write(pid_path(&state_dir), format!("{pid}\n")).context("writing server.pid")?;
     std::fs::write(port_path(&state_dir), format!("{port}\n")).context("writing server.port")?;
 
-    // Wait up to 5 s for the server to become reachable.
-    let ready = wait_for_health(port, Duration::from_secs(5)).await;
+    // Wait up to 30 s for the server to become reachable (liveness, not model
+    // readiness — /v1/health is live at bind, before any model download).
+    let ready = wait_for_health(port, Duration::from_secs(30)).await;
     if ready {
         println!("spelunk-server started (pid={pid}, port={port}).");
         println!("  Log: {}", log_path(&state_dir).display());
     } else {
+        // Fires only on genuine liveness-timeout — typically a firewall blocking
+        // the loopback listener, or a process that failed to start.
         eprintln!(
-            "warning: spelunk-server process started (pid={pid}) but did not respond \
-             on port {port} within 5 s. Check the log: {}",
+            "warning: spelunk-server process started (pid={pid}) but /v1/health did not \
+             respond on port {port} within 30 s. A firewall may be blocking the local \
+             server (allow it, e.g. accept the Windows Defender Firewall prompt), or the \
+             process failed to start. Check the log: {}",
             log_path(&state_dir).display()
         );
     }

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -17,7 +18,7 @@ use tokio::sync::mpsc;
 use utoipa::ToSchema;
 
 use super::auth::AuthContext;
-use super::{AppError, AppState, ErrorBody};
+use super::{AppError, AppState, EmbedderState, ErrorBody};
 
 // ── Request / Response types ──────────────────────────────────────────────────
 
@@ -103,26 +104,50 @@ pub struct SupersedeRequest {
 
 // ── Health ────────────────────────────────────────────────────────────────────
 
+/// Embedder readiness reported inside the health body.
+///
+/// Liveness (`status: "ok"`) is independent of this: `/v1/health` returns `200`
+/// the instant the listener binds, and this sub-object reports whether the
+/// embedder is `loading`, `ready`, `unavailable` (load failed), or `disabled`.
+#[derive(Serialize, ToSchema)]
+pub struct EmbedderStatus {
+    /// Readiness of the server-side embedder.
+    pub state: EmbedderState,
+    /// Optional human-readable detail (e.g. the load-failure summary while
+    /// `unavailable`). `null` when not useful.
+    pub detail: Option<String>,
+}
+
 /// Server capabilities reported in the health response.
 #[derive(Serialize, ToSchema)]
 pub struct HealthResponse {
-    /// Always `"ok"`.
+    /// Always `"ok"` — liveness marker, independent of embedder readiness.
     pub status: &'static str,
     /// Server version string.
     pub version: &'static str,
     /// List of feature capabilities supported by this server instance.
+    /// `index.embed` / `search.semantic` are advertised **only** when the
+    /// embedder is `ready`, so pre-readiness clients that key off `capabilities`
+    /// keep working (they see "no semantic yet").
     pub capabilities: Vec<String>,
     /// Persistent UUID v7 identifying this server instance across restarts.
     pub instance_id: String,
     /// Effective UID of the process that started the server (Unix); `null` on Windows.
     pub started_by: Option<u32>,
     /// Embedding dimension produced by this server's embedder.
-    /// `0` when no embedder is loaded (capability `index.embed` absent).
+    /// `0` until the embedder is `ready` (capability `index.embed` absent).
     pub embedding_dim: usize,
+    /// Embedder readiness. Newer clients read `embedder.state` for the finer
+    /// `loading` vs `unavailable` distinction that `capabilities` cannot express.
+    pub embedder: EmbedderStatus,
 }
 
 /// Server liveness check. No authentication required.
-/// Returns server version, capabilities, and identity fields.
+///
+/// Returns `200` the instant the listener is bound, regardless of embedder
+/// state — it never blocks on, and never fails because of, model loading.
+/// Returns server version, capabilities, identity fields, and the embedder
+/// readiness sub-object.
 #[utoipa::path(
     get,
     path = "/v1/health",
@@ -132,16 +157,23 @@ pub struct HealthResponse {
     tag = "health"
 )]
 pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
+    let embedder_state = state.embedder.state();
+    // Ready backends (native model loaded, or an external embedding URL) are the
+    // only ones that can serve embeddings, so advertise the semantic caps and a
+    // non-zero dim only then.
+    let ready_backend = state.embedder.backend();
+
     let mut capabilities = vec!["memory".to_string()];
-    if state.embedder.is_some() {
+    if let Some(backend) = &ready_backend {
         capabilities.push("index.embed".to_string());
         capabilities.push("search.semantic".to_string());
+        let _ = backend; // dim read below
     }
     if state.llm.is_some() {
         capabilities.push("explore".to_string());
         capabilities.push("llm.complete".to_string());
     }
-    let embedding_dim = state.embedder.as_ref().map_or(0, |e| e.dimension());
+    let embedding_dim = ready_backend.as_ref().map_or(0, |e| e.dimension());
     Json(HealthResponse {
         status: "ok",
         version: env!("CARGO_PKG_VERSION"),
@@ -149,7 +181,45 @@ pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
         instance_id: state.instance_id.clone(),
         started_by: state.started_by,
         embedding_dim,
+        embedder: EmbedderStatus {
+            state: embedder_state,
+            detail: state.embedder.detail(),
+        },
     })
+}
+
+/// Resolve the embedder for an embed-consuming handler, translating the slot's
+/// readiness into the correct HTTP error when it is not `ready`:
+/// - `loading`     → `503` + `Retry-After: 5` (transient — CLI keeps polling)
+/// - `unavailable` → `503` (terminal — CLI stops polling, surfaces the error)
+/// - `disabled`    → `400` (permanent misconfiguration for this request)
+fn require_embedder(
+    state: &AppState,
+    disabled_msg: &str,
+) -> Result<Arc<dyn spelunk_core::embeddings::EmbeddingBackend>, AppError> {
+    if let Some(backend) = state.embedder.backend() {
+        return Ok(backend);
+    }
+    match state.embedder.state() {
+        EmbedderState::Loading => Err(AppError::EmbedderWarmingUp {
+            terminal: false,
+            detail: state
+                .embedder
+                .detail()
+                .unwrap_or_else(|| "embedder warming up, retry shortly".to_string()),
+        }),
+        EmbedderState::Unavailable => Err(AppError::EmbedderWarmingUp {
+            terminal: true,
+            detail: state
+                .embedder
+                .detail()
+                .unwrap_or_else(|| "embedder failed to load".to_string()),
+        }),
+        // Disabled (or the improbable ready-but-no-backend race) → permanent 400.
+        EmbedderState::Disabled | EmbedderState::Ready => {
+            Err(AppError::BadRequest(disabled_msg.to_string()))
+        }
+    }
 }
 
 // ── Projects ──────────────────────────────────────────────────────────────────
@@ -221,8 +291,11 @@ pub async fn add_note(
     }
 
     // Server-side embedding: embed the entry when no client vector is supplied.
+    // Only the *ready* backend can embed; while the embedder is loading/unavailable
+    // we store the entry text-only (graceful — a memory write must not block on
+    // model warm-up), matching the existing "no embedder" degradation.
     let server_embedding: Option<Vec<f32>> = if body.embedding.is_none() {
-        if let Some(embedder) = &state.embedder {
+        if let Some(embedder) = state.embedder.backend() {
             let text = format!("title: {} | text: {}", body.title, body.body);
             match embedder.embed(&[text.as_str()]).await {
                 Ok(mut vecs) if !vecs.is_empty() => vecs.pop(),
@@ -391,12 +464,10 @@ pub async fn search_notes(
     Path(project_id): Path<String>,
     Json(body): Json<SearchRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let embedder = state.embedder.as_ref().ok_or_else(|| {
-        AppError::BadRequest(
-            "This server has no embedder configured. Semantic memory search is unavailable."
-                .to_string(),
-        )
-    })?;
+    let embedder = require_embedder(
+        &state,
+        "This server has no embedder configured. Semantic memory search is unavailable.",
+    )?;
 
     // F2LLM QA query prefix — matches the instruction format used for memory documents.
     let query_text = format!(
@@ -753,12 +824,10 @@ pub async fn index_embed(
             .into_response());
     }
 
-    let embedder = state.embedder.as_ref().ok_or_else(|| {
-        AppError::BadRequest(
-            "index.embed requires an embedder. Configure SPELUNK_EMBEDDING_URL on the server."
-                .to_string(),
-        )
-    })?;
+    let embedder = require_embedder(
+        &state,
+        "index.embed requires an embedder. Configure SPELUNK_EMBEDDING_URL on the server.",
+    )?;
 
     if body.chunks.is_empty() {
         return Ok(octet_stream(Vec::new()));
@@ -889,13 +958,11 @@ pub async fn project_search(
     }
 
     // Semantic / hybrid: require an embedder.
-    let embedder = state.embedder.as_ref().ok_or_else(|| {
-        AppError::BadRequest(
-            "semantic/hybrid search requires an embedder. \
-             Configure SPELUNK_EMBEDDING_URL on the server, or use mode=text."
-                .to_string(),
-        )
-    })?;
+    let embedder = require_embedder(
+        &state,
+        "semantic/hybrid search requires an embedder. \
+         Configure SPELUNK_EMBEDDING_URL on the server, or use mode=text.",
+    )?;
 
     // F2LLM-v2-330M query prefix: instruction + query. Documents are embedded
     // without a prefix; queries must use this format for correct retrieval.
@@ -1234,7 +1301,7 @@ mod tests {
             db: Arc::new(tokio::sync::Mutex::new(db)),
             auth: Arc::new(ApiKeyAuth::new(None)),
             conflict_threshold,
-            embedder: None,
+            embedder: super::super::EmbedderSlot::disabled(),
             llm: None,
             max_tokens_ceiling: 8192,
             rate_limiter: Arc::new(super::super::rate_limiter::RateLimiter::new(1000, 60)),
@@ -1393,8 +1460,8 @@ mod tests {
         }
     }
 
-    /// Build an app with a mock embedder of the given dimension.
-    fn make_app_with_embedder(dim: usize) -> axum::Router {
+    /// Build an app with the given embedder slot (dim used only to size the DB).
+    fn make_app_with_slot(dim: usize, embedder: super::super::EmbedderSlot) -> axum::Router {
         register_sqlite_vec();
         let db = ServerDb::open(std::path::Path::new(":memory:"), dim)
             .expect("failed to open in-memory server db");
@@ -1403,7 +1470,7 @@ mod tests {
             db: Arc::new(tokio::sync::Mutex::new(db)),
             auth: Arc::new(ApiKeyAuth::new(None)),
             conflict_threshold: 0.92,
-            embedder: Some(Arc::new(MockEmbedder { dim })),
+            embedder,
             llm: None,
             max_tokens_ceiling: 8192,
             rate_limiter: Arc::new(super::super::rate_limiter::RateLimiter::new(1000, 60)),
@@ -1411,6 +1478,14 @@ mod tests {
             started_by: None,
         };
         super::super::router(state)
+    }
+
+    /// Build an app with a ready mock embedder of the given dimension.
+    fn make_app_with_embedder(dim: usize) -> axum::Router {
+        make_app_with_slot(
+            dim,
+            super::super::EmbedderSlot::ready(Arc::new(MockEmbedder { dim })),
+        )
     }
 
     /// GET /v1/health should return JSON with `status`, `version`, and `capabilities`.
@@ -1451,6 +1526,12 @@ mod tests {
         assert!(
             json["started_by"].is_null(),
             "started_by must be null in test (None)"
+        );
+        // make_app has no embedder → disabled.
+        assert_eq!(
+            json["embedder"]["state"],
+            json!("disabled"),
+            "embedder.state must be 'disabled' when no embedder is configured"
         );
     }
 
@@ -1577,6 +1658,11 @@ mod tests {
             caps.iter().any(|c| c == "index.embed"),
             "capabilities must include index.embed when embedder is loaded"
         );
+        assert_eq!(
+            json["embedder"]["state"],
+            json!("ready"),
+            "embedder.state must be 'ready' when the embedder is loaded"
+        );
     }
 
     /// GET /v1/health with no embedder (the default make_app) must report `embedding_dim: 0`.
@@ -1598,6 +1684,170 @@ mod tests {
             json["embedding_dim"],
             json!(0),
             "embedding_dim must be 0 when no embedder is configured"
+        );
+    }
+
+    // ── Readiness / warm-up contract (oss^50) ────────────────────────────────
+
+    async fn get_health_json(app: axum::Router) -> Value {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/v1/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), http::StatusCode::OK, "health must be 200");
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).expect("health must return JSON")
+    }
+
+    /// While the embedder is `loading`, `/v1/health` is still live (200), reports
+    /// `embedder.state: "loading"`, withholds the semantic capabilities, and keeps
+    /// `embedding_dim: 0` — i.e. health is live *before* the model is ready.
+    #[tokio::test]
+    async fn health_live_while_embedder_loading() {
+        let slot = super::super::EmbedderSlot::loading();
+        let app = make_app_with_slot(4, slot);
+        let json = get_health_json(app).await;
+        assert_eq!(json["status"], json!("ok"));
+        assert_eq!(
+            json["embedder"]["state"],
+            json!("loading"),
+            "state must be 'loading' before the model is published"
+        );
+        assert_eq!(
+            json["embedding_dim"],
+            json!(0),
+            "embedding_dim must stay 0 until ready"
+        );
+        let caps = json["capabilities"].as_array().unwrap();
+        assert!(
+            !caps
+                .iter()
+                .any(|c| c == "index.embed" || c == "search.semantic"),
+            "semantic capabilities must be absent while loading: {caps:?}"
+        );
+    }
+
+    /// The readiness cell flips `loading → ready`: after `set_ready`, health
+    /// reports `ready`, advertises the caps, and surfaces the real `embedding_dim`.
+    #[tokio::test]
+    async fn health_reflects_loading_to_ready_transition() {
+        let slot = super::super::EmbedderSlot::loading();
+        // Before: loading.
+        let app = make_app_with_slot(4, slot.clone());
+        assert_eq!(
+            get_health_json(app).await["embedder"]["state"],
+            json!("loading")
+        );
+
+        // Publish the backend (as the background load task would).
+        slot.set_ready(Arc::new(MockEmbedder { dim: 4 }));
+
+        let app = make_app_with_slot(4, slot);
+        let json = get_health_json(app).await;
+        assert_eq!(json["embedder"]["state"], json!("ready"));
+        assert_eq!(json["embedding_dim"], json!(4));
+        let caps = json["capabilities"].as_array().unwrap();
+        assert!(caps.iter().any(|c| c == "index.embed"));
+    }
+
+    /// A failed load flips `loading → unavailable`, carrying the error detail.
+    #[tokio::test]
+    async fn health_reflects_load_failure() {
+        let slot = super::super::EmbedderSlot::loading();
+        slot.set_unavailable("download error: boom");
+        let app = make_app_with_slot(4, slot);
+        let json = get_health_json(app).await;
+        assert_eq!(json["embedder"]["state"], json!("unavailable"));
+        assert_eq!(
+            json["embedder"]["detail"],
+            json!("download error: boom"),
+            "detail must carry the failure summary"
+        );
+        assert_eq!(json["embedding_dim"], json!(0));
+    }
+
+    async fn post_embed(app: axum::Router) -> http::Response<Body> {
+        let body = json!({"chunks": [{"chunk_id": "abc", "content": "fn foo() {}"}]});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/projects/proj/index/embed")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        app.oneshot(req).await.unwrap()
+    }
+
+    /// While `loading`, embed endpoints return `503 + Retry-After: 5` and a body
+    /// with `state: "loading"` (transient — the CLI keeps polling).
+    #[tokio::test]
+    async fn embed_while_loading_returns_503_retry_after() {
+        let app = make_app_with_slot(4, super::super::EmbedderSlot::loading());
+        let resp = post_embed(app).await;
+        assert_eq!(
+            resp.status(),
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            "embed while loading must return 503"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(http::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some("5"),
+            "loading 503 must carry Retry-After: 5"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["state"], json!("loading"));
+    }
+
+    /// While `unavailable` (load failed), embed endpoints return a terminal `503`
+    /// with `state: "unavailable"` and no `Retry-After` (the CLI stops polling).
+    #[tokio::test]
+    async fn embed_while_unavailable_returns_terminal_503() {
+        let slot = super::super::EmbedderSlot::loading();
+        slot.set_unavailable("oom");
+        let app = make_app_with_slot(4, slot);
+        let resp = post_embed(app).await;
+        assert_eq!(resp.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            resp.headers().get(http::header::RETRY_AFTER).is_none(),
+            "terminal 503 must not advise a retry"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["state"], json!("unavailable"));
+    }
+
+    /// While `disabled`, embed endpoints keep the permanent `400` (unchanged
+    /// behaviour for the genuinely-misconfigured case).
+    #[tokio::test]
+    async fn embed_while_disabled_returns_400() {
+        let app = make_app_with_slot(4, super::super::EmbedderSlot::disabled());
+        let resp = post_embed(app).await;
+        assert_eq!(
+            resp.status(),
+            http::StatusCode::BAD_REQUEST,
+            "embed while disabled must stay 400"
+        );
+    }
+
+    /// When `ready`, embed endpoints serve `200`.
+    #[tokio::test]
+    async fn embed_while_ready_returns_200() {
+        let app = make_app_with_embedder(4);
+        let resp = post_embed(app).await;
+        assert_eq!(
+            resp.status(),
+            http::StatusCode::OK,
+            "embed while ready must return 200"
         );
     }
 }

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -4,7 +4,7 @@ pub mod handlers;
 pub mod rate_limiter;
 pub mod security;
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use axum::{
     Json, Router,
@@ -21,6 +21,121 @@ use auth::{AuthError, AuthProvider};
 use db::ServerDb;
 use rate_limiter::RateLimiter;
 
+/// Readiness state of the server-side embedder.
+///
+/// The native (in-process) embedder is loaded on a background task *after* the
+/// listener binds, so `/v1/health` is live immediately while the model is still
+/// warming up. This enum is the single source of truth for that readiness; the
+/// health body carries it and the embed endpoints branch on it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum EmbedderState {
+    /// Native embedder build/download in progress. Not ready — embed endpoints
+    /// return `503 + Retry-After` and the CLI should keep polling.
+    Loading,
+    /// Model loaded (or an external embedding backend is configured); embed
+    /// endpoints will serve.
+    Ready,
+    /// The background load failed (download error, OOM, …). Terminal for this
+    /// process; embed endpoints return `503` and the CLI should stop polling.
+    Unavailable,
+    /// No in-process model to load — the server was built without an embedder
+    /// and has no external `--embedding-url`. Embed endpoints return `400`
+    /// (permanent misconfiguration for that request).
+    Disabled,
+}
+
+/// Inner, lock-guarded contents of the embedder slot.
+struct EmbedderSlotInner {
+    state: EmbedderState,
+    /// The concrete backend once it is ready. `None` while `loading`,
+    /// `unavailable`, or `disabled`.
+    backend: Option<Arc<dyn spelunk_core::embeddings::EmbeddingBackend>>,
+    /// Optional human-readable detail (e.g. the load error) surfaced in the
+    /// health body and warm-up responses.
+    detail: Option<String>,
+}
+
+/// Shared, mutable readiness cell for the server-side embedder.
+///
+/// Health/handlers read the current state without blocking; a background load
+/// task flips it `loading → ready | unavailable`. Reads only ever hold the lock
+/// long enough to copy the state and clone an `Arc`, so there is no contention
+/// with the (single) background writer.
+#[derive(Clone)]
+pub struct EmbedderSlot(Arc<RwLock<EmbedderSlotInner>>);
+
+impl EmbedderSlot {
+    /// A slot that starts in `loading` — the native embedder is being built on
+    /// a background task and will publish itself via [`EmbedderSlot::set_ready`].
+    pub fn loading() -> Self {
+        Self(Arc::new(RwLock::new(EmbedderSlotInner {
+            state: EmbedderState::Loading,
+            backend: None,
+            detail: Some("loading embedding model".to_string()),
+        })))
+    }
+
+    /// A slot that is immediately ready with the given backend (e.g. an external
+    /// `--embedding-url` that has no local model to warm up).
+    pub fn ready(backend: Arc<dyn spelunk_core::embeddings::EmbeddingBackend>) -> Self {
+        Self(Arc::new(RwLock::new(EmbedderSlotInner {
+            state: EmbedderState::Ready,
+            backend: Some(backend),
+            detail: None,
+        })))
+    }
+
+    /// A slot with no embedder at all (no feature / no external URL). Embed
+    /// endpoints treat this as a permanent `400` misconfiguration.
+    pub fn disabled() -> Self {
+        Self(Arc::new(RwLock::new(EmbedderSlotInner {
+            state: EmbedderState::Disabled,
+            backend: None,
+            detail: None,
+        })))
+    }
+
+    /// Publish a successfully-loaded backend: state → `ready`.
+    pub fn set_ready(&self, backend: Arc<dyn spelunk_core::embeddings::EmbeddingBackend>) {
+        let mut inner = self.0.write().expect("embedder slot poisoned");
+        inner.state = EmbedderState::Ready;
+        inner.backend = Some(backend);
+        inner.detail = None;
+    }
+
+    /// Mark the background load as failed: state → `unavailable` (terminal).
+    pub fn set_unavailable(&self, detail: impl Into<String>) {
+        let mut inner = self.0.write().expect("embedder slot poisoned");
+        inner.state = EmbedderState::Unavailable;
+        inner.backend = None;
+        inner.detail = Some(detail.into());
+    }
+
+    /// Current readiness state (cheap, non-blocking copy).
+    pub fn state(&self) -> EmbedderState {
+        self.0.read().expect("embedder slot poisoned").state
+    }
+
+    /// Optional human-readable detail for the current state.
+    pub fn detail(&self) -> Option<String> {
+        self.0
+            .read()
+            .expect("embedder slot poisoned")
+            .detail
+            .clone()
+    }
+
+    /// The backend, cloned, if and only if the slot is `ready`.
+    pub fn backend(&self) -> Option<Arc<dyn spelunk_core::embeddings::EmbeddingBackend>> {
+        self.0
+            .read()
+            .expect("embedder slot poisoned")
+            .backend
+            .clone()
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<tokio::sync::Mutex<ServerDb>>,
@@ -29,10 +144,12 @@ pub struct AppState {
     /// Cosine similarity threshold above which a new entry is flagged as conflicting (0.0–1.0).
     /// Default: 0.92. Set to 1.0 to disable conflict detection.
     pub conflict_threshold: f32,
-    /// Optional server-side embedder. When set, the server embeds entries that arrive without
-    /// a pre-computed vector. If absent, entries without a vector are stored without one
-    /// (text search only).
-    pub embedder: Option<Arc<dyn spelunk_core::embeddings::EmbeddingBackend>>,
+    /// Server-side embedder readiness cell. The native embedder loads on a
+    /// background task after the listener binds, flipping this slot
+    /// `loading → ready | unavailable`; an external `--embedding-url` starts
+    /// `ready`; no embedder at all starts `disabled`. Handlers read the current
+    /// state without blocking. See [`EmbedderSlot`].
+    pub embedder: EmbedderSlot,
     /// Optional LLM backend for `/explore` and `/llm/complete`.
     pub llm: Option<Arc<dyn spelunk_core::llm::LlmBackend>>,
     /// Server-side hard ceiling for `max_tokens` on `/llm/complete`.
@@ -95,6 +212,8 @@ pub fn default_conflict_threshold() -> f32 {
         handlers::SinceQuery,
         handlers::StreamQuery,
         handlers::HealthResponse,
+        handlers::EmbedderStatus,
+        EmbedderState,
         handlers::EmbedRequest,
         handlers::EmbedChunkIn,
         handlers::EmbedResponse,
@@ -280,6 +399,14 @@ pub enum AppError {
     NotFound,
     BadRequest(String),
     ServiceUnavailable(String),
+    /// The server-side embedder is not ready. `503` for both, but `loading`
+    /// (transient) adds `Retry-After: 5` and carries `"state": "loading"` so the
+    /// CLI keeps polling, whereas `unavailable` (terminal, `terminal: true`)
+    /// carries `"state": "unavailable"` so the CLI stops and surfaces the error.
+    EmbedderWarmingUp {
+        terminal: bool,
+        detail: String,
+    },
     Internal(anyhow::Error),
 }
 
@@ -301,6 +428,30 @@ impl IntoResponse for AppError {
                 Json(ErrorBody::new("service_unavailable", &msg)),
             )
                 .into_response(),
+            AppError::EmbedderWarmingUp { terminal, detail } => {
+                let state = if terminal { "unavailable" } else { "loading" };
+                let error = if terminal {
+                    "embedder unavailable"
+                } else {
+                    "embedder warming up, retry shortly"
+                };
+                let body = Json(serde_json::json!({
+                    "error": error,
+                    "state": state,
+                    "detail": detail,
+                }));
+                if terminal {
+                    (StatusCode::SERVICE_UNAVAILABLE, body).into_response()
+                } else {
+                    // Transient: tell polite clients when to retry.
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        [(axum::http::header::RETRY_AFTER, "5")],
+                        body,
+                    )
+                        .into_response()
+                }
+            }
             AppError::Internal(e) => {
                 let msg = e.to_string();
                 // Surface dimension-mismatch and other user-facing errors as 400.

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 use spelunk_server::auth::ApiKeyAuth;
 use spelunk_server::db::ServerDb;
 use spelunk_server::rate_limiter::RateLimiter;
-use spelunk_server::{ApiDoc, AppState, default_conflict_threshold, router};
+use spelunk_server::{ApiDoc, AppState, EmbedderSlot, default_conflict_threshold, router};
 use utoipa::OpenApi;
 
 #[cfg(feature = "embed-native")]
@@ -25,8 +25,11 @@ struct Args {
     #[arg(long, default_value = "7777")]
     port: u16,
 
-    /// Host/address to bind
-    #[arg(long, default_value = "0.0.0.0")]
+    /// Host/address to bind. Defaults to loopback (`127.0.0.1`) — the safe,
+    /// firewall-exempt posture for a local server. Pass `--host 0.0.0.0`
+    /// explicitly to expose the server on all interfaces (e.g. a shared/team
+    /// server or the container image, which sets this in its entrypoint).
+    #[arg(long, default_value = "127.0.0.1")]
     host: String,
 
     /// Path to the server SQLite database
@@ -117,12 +120,17 @@ async fn main() -> Result<()> {
     let auth: Arc<dyn spelunk_server::auth::AuthProvider> =
         Arc::new(ApiKeyAuth::new(args.key.clone()));
 
-    // Build the optional server-side embedder.
-    let embedder: Option<Arc<dyn spelunk_core::embeddings::EmbeddingBackend>> = if let Some(
-        base_url,
-    ) =
-        args.embedding_url
-    {
+    // Build the server-side embedder readiness slot.
+    //
+    // The external `--embedding-url` backend is ready synchronously (it has no
+    // local model to warm up), so it starts `ready`. The bundled native embedder
+    // is CPU-/download-heavy, so we start the slot `loading` and defer the actual
+    // `NativeEmbedder::load()` to a background task spawned *after* the listener
+    // binds (below) — that way `/v1/health` is live immediately with
+    // `embedder.state = "loading"` instead of being dark for the whole first-run
+    // model download. When no embedder is configured at all, the slot is
+    // `disabled` (embed endpoints return a permanent 400).
+    let (embedder, load_native): (EmbedderSlot, bool) = if let Some(base_url) = args.embedding_url {
         let model = if args.embedding_model.is_empty() {
             "default".to_string()
         } else {
@@ -133,35 +141,22 @@ async fn main() -> Result<()> {
             .timeout(std::time::Duration::from_secs(60))
             .build()
             .context("building HTTP client for server-side embedder")?;
-        Some(Arc::new(ServerEmbedder {
-            client,
-            base_url,
-            model,
-        }))
+        let backend: Arc<dyn spelunk_core::embeddings::EmbeddingBackend> =
+            Arc::new(ServerEmbedder {
+                client,
+                base_url,
+                model,
+            });
+        (EmbedderSlot::ready(backend), false)
     } else {
         // No --embedding-url: try the bundled native embedder (embed-native feature).
         #[cfg(feature = "embed-native")]
         {
-            match embedder_native::NativeEmbedder::load() {
-                Ok(native) => {
-                    tracing::info!(
-                        "native embedding model loaded (dim={})",
-                        embedder_native::DIM
-                    );
-                    Some(Arc::new(native) as Arc<dyn spelunk_core::embeddings::EmbeddingBackend>)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "native embedding model failed to load: {e}; \
-                             running without embedder (set --embedding-url to override)"
-                    );
-                    None
-                }
-            }
+            (EmbedderSlot::loading(), true)
         }
         #[cfg(not(feature = "embed-native"))]
         {
-            None
+            (EmbedderSlot::disabled(), false)
         }
     };
 
@@ -207,13 +202,59 @@ async fn main() -> Result<()> {
         started_by,
     };
 
+    // Keep a handle to the embedder slot so the background load task can flip it
+    // `loading → ready | unavailable` after the listener binds.
+    let embedder_slot = state.embedder.clone();
+
     let app = router(state);
     let addr: SocketAddr = format!("{}:{}", args.host, args.port)
         .parse()
         .context("parsing bind address")?;
 
-    tracing::info!("spelunk-server listening on http://{addr}");
+    // Bind first: `/v1/health` must be reachable the instant the port is bound,
+    // *before* the (potentially multi-minute, ~339 MB) native model download.
     let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!("spelunk-server listening on http://{addr}");
+
+    // Load the native embedder on a background task now that health is live.
+    // `NativeEmbedder::load()` is blocking/CPU-heavy, so run it on the blocking
+    // pool; publish the backend into the slot on success (state → ready) or
+    // record the failure (state → unavailable). Only the native path warms up
+    // here — external/disabled slots are already in a terminal state.
+    #[cfg(feature = "embed-native")]
+    if load_native {
+        let slot = embedder_slot.clone();
+        tokio::spawn(async move {
+            match tokio::task::spawn_blocking(embedder_native::NativeEmbedder::load).await {
+                Ok(Ok(native)) => {
+                    tracing::info!(
+                        "native embedding model loaded (dim={})",
+                        embedder_native::DIM
+                    );
+                    slot.set_ready(
+                        Arc::new(native) as Arc<dyn spelunk_core::embeddings::EmbeddingBackend>
+                    );
+                }
+                Ok(Err(e)) => {
+                    let msg = format!("{e}");
+                    tracing::warn!(
+                        "native embedding model failed to load: {msg}; \
+                         embedder unavailable (set --embedding-url to override)"
+                    );
+                    slot.set_unavailable(msg);
+                }
+                Err(join_err) => {
+                    let msg = format!("embedder load task panicked: {join_err}");
+                    tracing::warn!("{msg}");
+                    slot.set_unavailable(msg);
+                }
+            }
+        });
+    }
+    // Silence "unused" for the non-embed-native build (no background load).
+    #[cfg(not(feature = "embed-native"))]
+    let _ = (load_native, &embedder_slot);
+
     axum::serve(listener, app).await?;
 
     Ok(())
@@ -399,5 +440,33 @@ impl spelunk_core::llm::LlmBackend for ServerLlm {
         }
 
         Ok(())
+    }
+}
+
+// ── Args default tests ────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod arg_tests {
+    use super::Args;
+    use clap::Parser;
+
+    /// The server binary default host must be loopback (127.0.0.1), not the
+    /// wildcard (0.0.0.0). The wildcard bind is now an explicit `--host 0.0.0.0`
+    /// opt-in (loopback is firewall-exempt and the safer default). oss^50 / req #6.
+    #[test]
+    fn default_host_is_loopback() {
+        let args = Args::parse_from(["spelunk-server"]);
+        assert_eq!(
+            args.host, "127.0.0.1",
+            "server binary default host must be 127.0.0.1 (loopback), not the wildcard"
+        );
+    }
+
+    /// `--host 0.0.0.0` still binds all interfaces when explicitly requested
+    /// (e.g. the container entrypoint / a shared team server).
+    #[test]
+    fn explicit_wildcard_host_is_honoured() {
+        let args = Args::parse_from(["spelunk-server", "--host", "0.0.0.0"]);
+        assert_eq!(args.host, "0.0.0.0");
     }
 }

--- a/crates/spelunk-server/tests/common/mod.rs
+++ b/crates/spelunk-server/tests/common/mod.rs
@@ -52,7 +52,7 @@ pub fn make_test_state(dim: usize, auth_key: Option<String>) -> spelunk_server::
         db: std::sync::Arc::new(tokio::sync::Mutex::new(db)),
         auth: std::sync::Arc::new(spelunk_server::auth::ApiKeyAuth::new(auth_key)),
         conflict_threshold: spelunk_server::default_conflict_threshold(),
-        embedder: None,
+        embedder: spelunk_server::EmbedderSlot::disabled(),
         llm: None,
         max_tokens_ceiling: 8192,
         rate_limiter: std::sync::Arc::new(spelunk_server::rate_limiter::RateLimiter::new(1000, 60)),

--- a/crates/spelunk-server/tests/integration_server.rs
+++ b/crates/spelunk-server/tests/integration_server.rs
@@ -357,7 +357,7 @@ async fn since_endpoint_returns_entries_after_timestamp() {
         db: Arc::new(tokio::sync::Mutex::new(db)),
         auth: Arc::new(ApiKeyAuth::new(None)),
         conflict_threshold: spelunk_server::default_conflict_threshold(),
-        embedder: None,
+        embedder: spelunk_server::EmbedderSlot::disabled(),
         llm: None,
         max_tokens_ceiling: 8192,
         rate_limiter: Arc::new(RateLimiter::new(1000, 60)),

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -18,7 +18,8 @@
         "tags": [
           "health"
         ],
-        "summary": "Server liveness check. No authentication required.\nReturns server version, capabilities, and identity fields.",
+        "summary": "Server liveness check. No authentication required.",
+        "description": "Returns `200` the instant the listener is bound, regardless of embedder\nstate — it never blocks on, and never fails because of, model loading.\nReturns server version, capabilities, identity fields, and the embedder\nreadiness sub-object.",
         "operationId": "health",
         "responses": {
           "200": {
@@ -1394,6 +1395,36 @@
           }
         }
       },
+      "EmbedderState": {
+        "type": "string",
+        "description": "Readiness state of the server-side embedder.\n\nThe native (in-process) embedder is loaded on a background task *after* the\nlistener binds, so `/v1/health` is live immediately while the model is still\nwarming up. This enum is the single source of truth for that readiness; the\nhealth body carries it and the embed endpoints branch on it.",
+        "enum": [
+          "loading",
+          "ready",
+          "unavailable",
+          "disabled"
+        ]
+      },
+      "EmbedderStatus": {
+        "type": "object",
+        "description": "Embedder readiness reported inside the health body.\n\nLiveness (`status: \"ok\"`) is independent of this: `/v1/health` returns `200`\nthe instant the listener binds, and this sub-object reports whether the\nembedder is `loading`, `ready`, `unavailable` (load failed), or `disabled`.",
+        "required": [
+          "state"
+        ],
+        "properties": {
+          "detail": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable detail (e.g. the load-failure summary while\n`unavailable`). `null` when not useful."
+          },
+          "state": {
+            "$ref": "#/components/schemas/EmbedderState",
+            "description": "Readiness of the server-side embedder."
+          }
+        }
+      },
       "ErrorBody": {
         "type": "object",
         "description": "Consistent JSON error body: `{\"error\": {\"code\": \"...\", \"message\": \"...\"}}`.",
@@ -1479,7 +1510,8 @@
           "version",
           "capabilities",
           "instance_id",
-          "embedding_dim"
+          "embedding_dim",
+          "embedder"
         ],
         "properties": {
           "capabilities": {
@@ -1487,11 +1519,15 @@
             "items": {
               "type": "string"
             },
-            "description": "List of feature capabilities supported by this server instance."
+            "description": "List of feature capabilities supported by this server instance.\n`index.embed` / `search.semantic` are advertised **only** when the\nembedder is `ready`, so pre-readiness clients that key off `capabilities`\nkeep working (they see \"no semantic yet\")."
+          },
+          "embedder": {
+            "$ref": "#/components/schemas/EmbedderStatus",
+            "description": "Embedder readiness. Newer clients read `embedder.state` for the finer\n`loading` vs `unavailable` distinction that `capabilities` cannot express."
           },
           "embedding_dim": {
             "type": "integer",
-            "description": "Embedding dimension produced by this server's embedder.\n`0` when no embedder is loaded (capability `index.embed` absent).",
+            "description": "Embedding dimension produced by this server's embedder.\n`0` until the embedder is `ready` (capability `index.embed` absent).",
             "minimum": 0
           },
           "instance_id": {
@@ -1509,7 +1545,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Always `\"ok\"`."
+            "description": "Always `\"ok\"` — liveness marker, independent of embedder readiness."
           },
           "version": {
             "type": "string",


### PR DESCRIPTION
Board: **spelunk-oss^50** (PR A of a 2-PR split). Architect design gate cleared; no ADR required.

## Problem
On the v0.9.1 Windows build, `spelunk search` reported "not indexed / no ast-grep" despite a populated `.spelunk/`. Root cause: the local `spelunk-server` never became reachable during first run, so every command silently fell to offline tier. Two stacked defects:
1. **Eager model-load before bind** — the server built the native embedder (~339 MB download) *before* `TcpListener::bind`, so `/v1/health` was dark for the whole first-run download and the CLI's 5 s auto-start check always timed out.
2. Windows Firewall blocking the loopback listener (the hard blocker; addressed by the host-default flip + docs in PR B).

## What this PR does (core — task items #1, #2, #3, #4, #6)
- **Bind + serve `/v1/health` before loading the model.** `NativeEmbedder::load()` now runs on a `spawn_blocking` background task spawned *after* the listener binds, flipping a shared readiness cell `loading → ready | unavailable`. Health returns `200` the instant the port is bound.
- **Readiness in the health body.** New `embedder: { state, detail }` sub-object (`loading | ready | unavailable | disabled`). `capabilities` (`index.embed`/`search.semantic`) and `embedding_dim` populate **only** when `ready`, so existing capability-keyed clients stay backward-compatible.
- **Warm-up status codes** on the three embed endpoints (`index/embed`, `memory/search`, `project/search`): `503 + Retry-After: 5` while `loading`; terminal `503` while `unavailable`; the existing `400` preserved **only** for the genuinely `disabled` case. (400 = permanent/misconfig, 503 = transient-or-failed.)
- **Host default flip** `0.0.0.0` → `127.0.0.1` (loopback is firewall-exempt / safer). See container check below.
- **Auto-start wait 5 s → 30 s** in both `ensure_server_running` and `cmd_start`; the failure warning now fires only on a genuine liveness timeout, with firewall + `spelunk server logs` guidance.

## Container check (required gate)
The container relied on the **implicit `0.0.0.0` default**, so the flip would have made it bind loopback-only and become unreachable. **Fixed in this PR:** the `Dockerfile` `CMD` now passes `--host 0.0.0.0` explicitly (`["--host", "0.0.0.0", "--db", "/data/spelunk.db"]`). Both `docker-compose.yml` and `docker-compose.full.yml` `build: .` and inherit that CMD — no separate compose edit needed. The CLI auto-spawn already passes `--host 127.0.0.1` explicitly and is unaffected.

## Health body shape
```jsonc
{
  "status": "ok",              // liveness — 200 the instant the port binds
  "version": "0.9.1",
  "capabilities": ["memory", ...],  // index.embed/search.semantic only when ready
  "instance_id": "...",
  "started_by": 501,           // null on Windows
  "embedding_dim": 896,        // 0 until ready
  "embedder": { "state": "loading", "detail": "loading embedding model" }
}
```

## Test plan
All with `SPELUNK_SECRET_STORE=file`.

- `cargo fmt --all --check` — clean.
- `cargo clippy -p spelunk-server -p spelunk-cli --all-targets -- -D warnings` — clean.
- `cargo test -p spelunk-server` — 35 lib + 12 integration + 11 bin unit tests pass.
- `cargo test -p spelunk-cli` — all pass, including the THREAT-MODEL req #9 loopback tests (`spawn_daemon_args_bind_loopback`, `spawn_daemon_args_do_not_bind_wildcard`).

New/updated tests exercising the contract:
- **Liveness-before-model:** `health_live_while_embedder_loading` — with the slot in `loading`, `/v1/health` is `200`, reports `embedder.state == "loading"`, withholds the semantic capabilities, and keeps `embedding_dim: 0`.
- **State transitions:** `health_reflects_loading_to_ready_transition` (after `set_ready`: `ready` + caps + real dim) and `health_reflects_load_failure` (`unavailable` + error detail).
- **Warm-up 503 vs 400:** `embed_while_loading_returns_503_retry_after` (503 + `Retry-After: 5`, body `state:"loading"`), `embed_while_unavailable_returns_terminal_503` (503, no Retry-After, `state:"unavailable"`), `embed_while_disabled_returns_400` (unchanged permanent 400), `embed_while_ready_returns_200`.
- **Host default:** `arg_tests::default_host_is_loopback` asserts the server binary now defaults to `127.0.0.1`; `explicit_wildcard_host_is_honoured` asserts `--host 0.0.0.0` still binds all interfaces.

OpenAPI snapshot (`docs/openapi.json`) regenerated for the new `EmbedderStatus`/`EmbedderState` schema. No new dependencies (pure std primitives; `Cargo.lock` unchanged).

## Out of scope — PR B (still to be dispatched)
CLI offline-degradation notice + `spelunk status` rendering of `embedder.state` + Windows firewall docs (task items #5, #7). This PR keeps the seam for it (the health contract and 503/`state` distinctions are exactly what the CLI notice needs).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)