### PR TITLE
spelunk-oss^50 PR B (CLI offline UX + status + firewall docs)

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -21,7 +21,7 @@
 //! The probe runs lazily on the first call that needs Tier 1 and its result
 //! is cached for the process lifetime.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::OnceCell;
 
 use crate::config::Config;
@@ -63,6 +63,45 @@ fn read_server_port_file() -> Option<u16> {
 }
 
 static TIER: OnceCell<Tier> = OnceCell::const_new();
+
+/// Server-side embedder readiness, mirrored from the `/v1/health` `embedder.state`
+/// field (spelunk-oss^50 PR A). The CLI uses this to distinguish, when semantic
+/// search is unavailable, between "no server reachable", "server up but the model
+/// is still warming up", and "the model failed to load" — so it can print an
+/// actionable one-line notice rather than silently degrading (task item #5).
+///
+/// Serialized lowercase to match the server's health body and to feed
+/// `spelunk status --format json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EmbedderState {
+    /// Native embedder build/download in progress — not ready yet, keep polling.
+    Loading,
+    /// Model loaded; embed endpoints will serve.
+    Ready,
+    /// Background load failed (download error, OOM, …). Terminal for that process.
+    Unavailable,
+    /// Server started with no in-process model to load (external embedding URL,
+    /// or no embedder feature). Treated as ready.
+    Disabled,
+    /// Field absent from the health body (server pre-dates PR A). Unknown state.
+    #[default]
+    Unknown,
+}
+
+impl EmbedderState {
+    /// Lowercase wire string (matches the server's `embedder.state` field and
+    /// feeds `spelunk status --format json`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EmbedderState::Loading => "loading",
+            EmbedderState::Ready => "ready",
+            EmbedderState::Unavailable => "unavailable",
+            EmbedderState::Disabled => "disabled",
+            EmbedderState::Unknown => "unknown",
+        }
+    }
+}
 
 /// Feature availability for a server-connected tier.
 #[derive(Debug, Clone, Serialize)]
@@ -139,6 +178,12 @@ pub enum Tier {
         /// Consumed by `is_auto_discovered()` and sub-issue #324 UX wiring.
         #[allow(dead_code)]
         auto_discovered: bool,
+        /// Server-side embedder readiness, mirrored from the `/v1/health`
+        /// `embedder.state` field (spelunk-oss^50). `Unknown` when the field is
+        /// absent (server pre-dates PR A). Lets the CLI distinguish "server up
+        /// but model still warming up / failed to load" from a ready server when
+        /// semantic search is unavailable (task item #5; rendered by `status`).
+        embedder_state: EmbedderState,
     },
 }
 
@@ -161,6 +206,18 @@ impl Tier {
     pub fn caps(&self) -> Option<&Capabilities> {
         match self {
             Tier::Server { caps, .. } => Some(caps),
+            Tier::Offline => None,
+        }
+    }
+
+    /// Server-side embedder readiness for a `Server` tier, or `None` when
+    /// offline. `EmbedderState::Unknown` is returned for a reachable server that
+    /// pre-dates the `embedder.state` health field. Used by the offline notice
+    /// (`search`/`index`) and by `spelunk status` to explain why semantic search
+    /// is unavailable (spelunk-oss^50).
+    pub fn embedder_state(&self) -> Option<EmbedderState> {
+        match self {
+            Tier::Server { embedder_state, .. } => Some(*embedder_state),
             Tier::Offline => None,
         }
     }
@@ -351,7 +408,7 @@ async fn probe_url(
 
     match req.send().await {
         Ok(resp) if resp.status().is_success() => {
-            let (caps, server_dim) = parse_health(url, resp).await;
+            let (caps, server_dim, embedder_state) = parse_health(url, resp).await;
 
             // If the server advertises index.embed, its embedding dimension must match ours.
             if caps.index_embed && server_dim != 0 {
@@ -384,6 +441,7 @@ async fn probe_url(
                 url: url.to_string(),
                 caps,
                 auto_discovered,
+                embedder_state,
             })
         }
         Ok(resp) => {
@@ -406,12 +464,23 @@ async fn probe_url(
     }
 }
 
-/// Parse the health response body and return `(Capabilities, embedding_dim)`.
+/// Parse the health response body and return `(Capabilities, embedding_dim,
+/// embedder_state)`.
 ///
 /// `embedding_dim` is `0` when the field is absent (old server without the field)
 /// or when no embedder is loaded. A `0` dim skips the dimension check in `probe_url`
 /// for backward compatibility.
-async fn parse_health(url: &str, resp: reqwest::Response) -> (Capabilities, usize) {
+///
+/// `embedder_state` mirrors the `/v1/health` `embedder.state` field shipped in
+/// spelunk-oss^50 PR A (`embedder: { state, detail }`). It is `Unknown` when the
+/// sub-object is absent (older server) or the body is legacy plain-text.
+async fn parse_health(url: &str, resp: reqwest::Response) -> (Capabilities, usize, EmbedderState) {
+    #[derive(serde::Deserialize)]
+    struct EmbedderBody {
+        #[serde(default)]
+        state: EmbedderState,
+    }
+
     #[derive(serde::Deserialize)]
     struct HealthBody {
         #[serde(default)]
@@ -422,10 +491,19 @@ async fn parse_health(url: &str, resp: reqwest::Response) -> (Capabilities, usiz
         /// Absent on old servers that pre-date this field; defaults to 0 (skip check).
         #[serde(default)]
         embedding_dim: usize,
+        /// Embedder readiness sub-object (spelunk-oss^50). Absent on older servers
+        /// → `embedder_state` stays `Unknown`.
+        #[serde(default)]
+        embedder: Option<EmbedderBody>,
     }
 
     match resp.json::<HealthBody>().await {
         Ok(body) => {
+            let embedder_state = body
+                .embedder
+                .as_ref()
+                .map(|e| e.state)
+                .unwrap_or(EmbedderState::Unknown);
             // Warn if the server was started by a different user on this host.
             if let Some(server_uid) = body.started_by {
                 let my_uid = current_uid();
@@ -446,12 +524,17 @@ async fn parse_health(url: &str, resp: reqwest::Response) -> (Capabilities, usiz
             (
                 Capabilities::from_server_caps(&cap_strs),
                 body.embedding_dim,
+                embedder_state,
             )
         }
         Err(_) => {
             // Legacy server returns plain-text "ok" — conservative fallback.
-            // embedding_dim = 0 skips the dimension check.
-            (Capabilities::legacy_memory_only(), 0)
+            // embedding_dim = 0 skips the dimension check; state Unknown.
+            (
+                Capabilities::legacy_memory_only(),
+                0,
+                EmbedderState::Unknown,
+            )
         }
     }
 }
@@ -602,6 +685,7 @@ mod tests {
             url: "http://example.com".to_string(),
             caps: Capabilities::all(),
             auto_discovered: false,
+            embedder_state: EmbedderState::Ready,
         };
         assert!(tier.is_server());
     }
@@ -618,6 +702,7 @@ mod tests {
             url: "http://spelunk.internal:7777".to_string(),
             caps: Capabilities::all(),
             auto_discovered: false,
+            embedder_state: EmbedderState::Ready,
         };
         assert_eq!(tier.server_url(), Some("http://spelunk.internal:7777"));
     }
@@ -635,6 +720,7 @@ mod tests {
             url: "http://example.com".to_string(),
             caps: caps.clone(),
             auto_discovered: false,
+            embedder_state: EmbedderState::Ready,
         };
         assert!(tier.caps().is_some());
     }
@@ -651,11 +737,13 @@ mod tests {
             url: "http://127.0.0.1:7777".to_string(),
             caps: Capabilities::all(),
             auto_discovered: true,
+            embedder_state: EmbedderState::Ready,
         };
         let explicit = Tier::Server {
             url: "http://server.example.com:7777".to_string(),
             caps: Capabilities::all(),
             auto_discovered: false,
+            embedder_state: EmbedderState::Ready,
         };
         assert!(auto.is_auto_discovered());
         assert!(!explicit.is_auto_discovered());
@@ -674,6 +762,7 @@ mod tests {
             url: "http://127.0.0.1:7777".to_string(),
             caps: Capabilities::all(),
             auto_discovered: true,
+            embedder_state: EmbedderState::Ready,
         };
         let cfg = Config::default(); // server_url = None
         let eff = tier.effective_config(&cfg, std::path::Path::new("/tmp/proj"));
@@ -703,6 +792,7 @@ mod tests {
             url: "http://team.example.com:7777".to_string(),
             caps: Capabilities::all(),
             auto_discovered: false,
+            embedder_state: EmbedderState::Ready,
         };
         let cfg = Config {
             server_url: Some("http://team.example.com:7777".to_string()),
@@ -738,6 +828,7 @@ mod tests {
             url: "http://example.com".to_string(),
             caps: Capabilities::all(),
             auto_discovered: false,
+            embedder_state: EmbedderState::Ready,
         };
         assert!(require_tier1("explore", &tier, Some("http://example.com")).is_ok());
     }
@@ -949,5 +1040,114 @@ mod tests {
             msg.contains("server_url"),
             "error must mention 'server_url' for actionable guidance: {msg}"
         );
+    }
+
+    // ── EmbedderState (spelunk-oss^50) ───────────────────────────────────────
+
+    #[test]
+    fn embedder_state_default_is_unknown() {
+        assert_eq!(EmbedderState::default(), EmbedderState::Unknown);
+    }
+
+    #[test]
+    fn embedder_state_deserializes_lowercase_wire_values() {
+        // Must match the server's `#[serde(rename_all = "lowercase")]` values.
+        for (wire, want) in [
+            ("loading", EmbedderState::Loading),
+            ("ready", EmbedderState::Ready),
+            ("unavailable", EmbedderState::Unavailable),
+            ("disabled", EmbedderState::Disabled),
+        ] {
+            let got: EmbedderState =
+                serde_json::from_value(serde_json::Value::String(wire.to_string())).unwrap();
+            assert_eq!(got, want, "wire {wire:?} should deserialize to {want:?}");
+            assert_eq!(want.as_str(), wire, "as_str round-trips the wire value");
+        }
+    }
+
+    #[test]
+    fn tier_embedder_state_accessor() {
+        let tier = Tier::Server {
+            url: "http://127.0.0.1:7777".to_string(),
+            caps: Capabilities::all(),
+            auto_discovered: true,
+            embedder_state: EmbedderState::Loading,
+        };
+        assert_eq!(tier.embedder_state(), Some(EmbedderState::Loading));
+        assert_eq!(Tier::Offline.embedder_state(), None);
+    }
+
+    /// Health body carrying the PR-A `embedder: { state, detail }` sub-object.
+    fn health_body_with_embedder(state: &str) -> serde_json::Value {
+        serde_json::json!({
+            "status": "ok",
+            "version": "0.9.1",
+            "capabilities": ["memory"],
+            "instance_id": "00000000-0000-0000-0000-000000000001",
+            "started_by": null,
+            "embedding_dim": 0,
+            "embedder": { "state": state, "detail": null }
+        })
+    }
+
+    /// `probe_url` must surface the server's `embedder.state` on `Tier::Server`.
+    #[tokio::test]
+    async fn probe_url_carries_embedder_state_loading() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(health_body_with_embedder("loading")),
+            )
+            .mount(&server)
+            .await;
+
+        let tier = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true)
+            .await
+            .expect("probe ok");
+        assert_eq!(tier.embedder_state(), Some(EmbedderState::Loading));
+    }
+
+    #[tokio::test]
+    async fn probe_url_carries_embedder_state_unavailable() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(health_body_with_embedder("unavailable")),
+            )
+            .mount(&server)
+            .await;
+
+        let tier = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true)
+            .await
+            .expect("probe ok");
+        assert_eq!(tier.embedder_state(), Some(EmbedderState::Unavailable));
+    }
+
+    /// A server that pre-dates the `embedder` field → `Unknown` (not an error).
+    #[tokio::test]
+    async fn probe_url_absent_embedder_field_is_unknown() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // `health_body` (no `embedder` key) simulates an older server.
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body(&["memory"], 0)))
+            .mount(&server)
+            .await;
+
+        let tier = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true)
+            .await
+            .expect("probe ok");
+        assert_eq!(tier.embedder_state(), Some(EmbedderState::Unknown));
     }
 }

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -141,7 +141,14 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         return Ok(());
     }
 
-    if tier.is_server() {
+    // Embed only when the server's embedder is actually ready to serve
+    // (`caps.index_embed` is advertised only in the `ready` state). When the
+    // server is reachable but the model is still `loading` or has failed
+    // (`unavailable`), skip embedding and print a visible, differentiated
+    // notice rather than letting the embed request 503 out mid-index or
+    // silently producing an unembedded index (spelunk-oss^50 #5).
+    let embed_ready = matches!(tier.caps(), Some(c) if c.index_embed);
+    if tier.is_server() && embed_ready {
         embed_phase::run_embed_phase(
             result.chunk_ids_and_texts,
             &db,
@@ -152,18 +159,8 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
             &mp,
         )
         .await?;
-    } else if cfg.server_url.is_some() {
-        eprintln!(
-            "Warning: spelunk-server at {} is unreachable — skipping embedding phase.",
-            cfg.server_url.as_deref().unwrap_or("?")
-        );
-        eprintln!(
-            "Chunks are indexed for text/ast-grep search. Re-run `spelunk index` when the server is back to add embeddings."
-        );
     } else {
-        eprintln!(
-            "Note: configure server_url in ~/.config/spelunk/config.toml to enable semantic search."
-        );
+        eprint_embed_skipped_notice(tier, &cfg);
     }
 
     let stats = db.stats()?;
@@ -195,6 +192,63 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     }
 
     run_phases_3_to_5(&args, &cfg, &db, &root_canonical, &db_path).await
+}
+
+/// Build the differentiated notice lines shown when the embedding phase is
+/// skipped, so an unembedded index is never a silent surprise (spelunk-oss^50
+/// #5). Pure so it can be unit-tested; the four cases mirror PR A's readiness
+/// contract. `server_url` is `cfg.server_url` (used only for the offline case).
+fn embed_skipped_lines(
+    embedder_state: Option<capability::EmbedderState>,
+    server_url: Option<&str>,
+) -> Vec<String> {
+    use capability::EmbedderState;
+    match embedder_state {
+        Some(EmbedderState::Loading) => vec![
+            "Note: the embedder is still warming up — chunks indexed for text/ast-grep search."
+                .to_string(),
+            "Re-run `spelunk index` in a moment to add embeddings (check `spelunk server status`)."
+                .to_string(),
+        ],
+        Some(EmbedderState::Unavailable) => vec![
+            "Warning: the embedder failed to load — chunks indexed for text/ast-grep search only."
+                .to_string(),
+            "See `spelunk server logs` for the load error, then re-run `spelunk index`."
+                .to_string(),
+        ],
+        // Reachable server without a ready embedder for any other reason
+        // (`disabled`, or an older server that never advertised `index.embed`).
+        Some(_) => vec![
+            "Note: this server has no embedder — chunks indexed for text/ast-grep search only."
+                .to_string(),
+        ],
+        // Offline: no server reachable.
+        None => {
+            if let Some(url) = server_url {
+                vec![
+                    format!(
+                        "Warning: spelunk-server at {url} is unreachable — skipping embedding phase."
+                    ),
+                    "On Windows, allow the loopback listener through Defender Firewall (accept the prompt on `spelunk server start`)."
+                        .to_string(),
+                    "Chunks are indexed for text/ast-grep search. Re-run `spelunk index` once the server is reachable to add embeddings."
+                        .to_string(),
+                ]
+            } else {
+                vec![
+                    "Note: start a local server (`spelunk server start`) to enable semantic search."
+                        .to_string(),
+                ]
+            }
+        }
+    }
+}
+
+/// Print the embed-skipped notice to stderr.
+fn eprint_embed_skipped_notice(tier: &capability::Tier, cfg: &Config) {
+    for line in embed_skipped_lines(tier.embedder_state(), cfg.server_url.as_deref()) {
+        eprintln!("{line}");
+    }
 }
 
 // ── Phases 3–5 (shared between inline and background-phases mode) ─────────────
@@ -313,5 +367,61 @@ mod tests {
     fn batch_size_defaults_to_64() {
         let cli = TestCli::try_parse_from(["spelunk", "some/path"]).expect("parse");
         assert_eq!(cli.index.batch_size, 64);
+    }
+
+    // ── embed_skipped_lines: 0-chunks / offline notice (#5) ─────────────────────
+
+    #[test]
+    fn embed_skipped_loading_advises_retry() {
+        let lines = embed_skipped_lines(Some(capability::EmbedderState::Loading), None);
+        assert!(!lines.is_empty(), "notice must not be silent");
+        let joined = lines.join("\n");
+        assert!(joined.contains("warming up"));
+        assert!(joined.contains("Re-run `spelunk index`"));
+    }
+
+    #[test]
+    fn embed_skipped_unavailable_points_at_logs() {
+        let lines = embed_skipped_lines(Some(capability::EmbedderState::Unavailable), None);
+        let joined = lines.join("\n");
+        assert!(joined.contains("failed to load"));
+        assert!(joined.contains("spelunk server logs"));
+    }
+
+    #[test]
+    fn embed_skipped_unreachable_server_mentions_firewall() {
+        // Offline (no reachable server) with a configured server_url: the notice
+        // names the URL and the Windows firewall cause, replacing the old silent
+        // 0-chunk embed.
+        let lines = embed_skipped_lines(None, Some("http://127.0.0.1:7777"));
+        let joined = lines.join("\n");
+        assert!(joined.contains("http://127.0.0.1:7777"));
+        assert!(joined.contains("unreachable"));
+        assert!(joined.contains("Firewall"));
+    }
+
+    #[test]
+    fn embed_skipped_no_server_suggests_starting_one() {
+        let lines = embed_skipped_lines(None, None);
+        let joined = lines.join("\n");
+        assert!(joined.contains("spelunk server start"));
+    }
+
+    #[test]
+    fn embed_skipped_is_never_silent() {
+        for state in [
+            Some(capability::EmbedderState::Loading),
+            Some(capability::EmbedderState::Unavailable),
+            Some(capability::EmbedderState::Disabled),
+            Some(capability::EmbedderState::Unknown),
+            None,
+        ] {
+            for url in [Some("http://x:1"), None] {
+                assert!(
+                    !embed_skipped_lines(state, url).is_empty(),
+                    "state {state:?} url {url:?} produced no notice"
+                );
+            }
+        }
     }
 }

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -204,10 +204,13 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
             Err(e) => Err(e),
         };
 
-        // In auto mode, if the embedding call fails (e.g. embedder unreachable),
-        // fall back to ast-grep silently.
+        // In auto mode, if the embedding call fails (e.g. embedder unreachable or
+        // still warming up), fall back to ast-grep. Print a visible, one-line
+        // notice first so the degradation isn't silent and a downstream
+        // "ast-grep not found" error isn't misattributed (spelunk-oss^50 #5).
         if auto_mode && query_vec_result.is_err() && snapshot_id.is_none() {
             sp.finish_and_clear();
+            eprint_semantic_unavailable_notice(tier, &cfg);
             return search_live(
                 &args.query,
                 &args.format,
@@ -587,4 +590,103 @@ pub(crate) fn search_live(
     }
 
     Ok(())
+}
+
+/// Build the one-line notice explaining why `auto`-mode search is falling back
+/// from semantic to ast-grep, differentiating the cases the readiness contract
+/// exposes (spelunk-oss^50 #5).
+///
+/// Pure so it can be unit-tested without capturing stderr; `has_server_url` is
+/// `cfg.server_url.is_some()`.
+fn semantic_unavailable_message(
+    embedder_state: Option<capability::EmbedderState>,
+    has_server_url: bool,
+) -> String {
+    use capability::EmbedderState;
+    match embedder_state {
+        Some(EmbedderState::Loading) => "[semantic search unavailable: model still warming up — \
+             retry shortly (`spelunk server status`); using ast-grep]"
+            .to_string(),
+        Some(EmbedderState::Unavailable) => {
+            "[semantic search unavailable: embedder failed to load — \
+             see `spelunk server logs`; using ast-grep]"
+                .to_string()
+        }
+        Some(_) => "[semantic search unavailable on this server; using ast-grep]".to_string(),
+        None => {
+            if has_server_url {
+                "[no server reachable — on Windows, allow the loopback listener through \
+                 Defender Firewall (`spelunk server status`); using ast-grep]"
+                    .to_string()
+            } else {
+                "[no server running — start one with `spelunk server start` to enable \
+                 semantic search; using ast-grep]"
+                    .to_string()
+            }
+        }
+    }
+}
+
+/// Print the semantic-unavailable notice to stderr so structured
+/// (`--json`/`--jsonl`) output on stdout stays clean.
+fn eprint_semantic_unavailable_notice(tier: &capability::Tier, cfg: &Config) {
+    eprintln!(
+        "{}",
+        semantic_unavailable_message(tier.embedder_state(), cfg.server_url.is_some())
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::EmbedderState;
+
+    // ── semantic_unavailable_message: auto-mode fallback notice (#5) ────────────
+
+    #[test]
+    fn notice_loading_advises_retry() {
+        let msg = semantic_unavailable_message(Some(EmbedderState::Loading), true);
+        assert!(msg.contains("warming up"));
+        assert!(msg.contains("ast-grep"));
+    }
+
+    #[test]
+    fn notice_unavailable_points_at_logs() {
+        let msg = semantic_unavailable_message(Some(EmbedderState::Unavailable), true);
+        assert!(msg.contains("failed to load"));
+        assert!(msg.contains("spelunk server logs"));
+    }
+
+    #[test]
+    fn notice_no_server_with_configured_url_mentions_firewall() {
+        // Offline (no reachable server) but a server_url was configured →
+        // the likely Windows cause is a blocked loopback listener.
+        let msg = semantic_unavailable_message(None, true);
+        assert!(msg.contains("no server reachable"));
+        assert!(msg.contains("Firewall"));
+    }
+
+    #[test]
+    fn notice_no_server_no_url_suggests_starting_one() {
+        let msg = semantic_unavailable_message(None, false);
+        assert!(msg.contains("spelunk server start"));
+    }
+
+    #[test]
+    fn notice_is_never_silent() {
+        // Every case yields a visible, non-empty notice — the whole point of #5
+        // is that the fallback is no longer silent.
+        for state in [
+            Some(EmbedderState::Loading),
+            Some(EmbedderState::Unavailable),
+            Some(EmbedderState::Ready),
+            Some(EmbedderState::Disabled),
+            Some(EmbedderState::Unknown),
+            None,
+        ] {
+            for has_url in [true, false] {
+                assert!(!semantic_unavailable_message(state, has_url).is_empty());
+            }
+        }
+    }
 }

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -45,9 +45,12 @@ use crate::{
 /// - `memory_backend` — stable identifier for the active memory backend:
 ///   `"sqlite"`, `"git-notes"`, or `"remote"` (see issue #308)
 ///
-/// Additional fields (`tier`, `server_url`, `capabilities`, `snapshot_count`,
-/// `drift_candidates`, `usage_7d`) are present for backward compatibility and
-/// richer tooling; treat them as unstable extensions.
+/// Additional fields (`tier`, `server_url`, `capabilities`, `embedder_state`,
+/// `snapshot_count`, `drift_candidates`, `usage_7d`) are present for backward
+/// compatibility and richer tooling; treat them as unstable extensions.
+/// `embedder_state` mirrors the server's `/v1/health` readiness
+/// (`"loading"`/`"ready"`/`"unavailable"`/`"disabled"`); it is `null` when
+/// offline or when the reachable server pre-dates the readiness field.
 pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
     let fmt = crate::utils::effective_format(&args.format);
 
@@ -110,6 +113,13 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
             ),
         };
 
+        // Server-side embedder readiness (spelunk-oss^50). `null` when offline
+        // or when talking to a server that pre-dates the readiness field.
+        let embedder_state_json: serde_json::Value = match tier.embedder_state() {
+            Some(capability::EmbedderState::Unknown) | None => serde_json::Value::Null,
+            Some(s) => serde_json::Value::String(s.as_str().to_string()),
+        };
+
         // Serialize languages as [{name, file_count}, ...]
         let languages_json: Vec<serde_json::Value> = languages
             .iter()
@@ -141,6 +151,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
                 "tier": tier_str,
                 "server_url": tier_url,
                 "capabilities": caps_json,
+                "embedder_state": embedder_state_json,
                 "embedding_count": stats.embedding_count,
                 "snapshot_count": stats.snapshot_count,
                 "drift_candidates": drift,
@@ -333,6 +344,7 @@ fn print_tier_section(tier: &Tier, cfg: &Config) {
             url,
             caps,
             auto_discovered,
+            embedder_state,
         } => {
             let url_label = if *auto_discovered {
                 format!("{url}  \x1b[2m(local, auto)\x1b[0m")
@@ -346,6 +358,11 @@ fn print_tier_section(tier: &Tier, cfg: &Config) {
                 "ast-grep + text"
             };
             println!("  search          {search_label}");
+            // Embedder readiness: explain *why* semantic search isn't in the
+            // search line yet when the server is up but the model isn't ready.
+            if let Some(line) = embedder_status_line(embedder_state) {
+                println!("{line}");
+            }
             let mem_label = if caps.memory_push {
                 "git-notes + server sync"
             } else {
@@ -369,6 +386,32 @@ fn print_tier_section(tier: &Tier, cfg: &Config) {
     println!();
 }
 
+/// Render the `embedder` line for `spelunk status` (text mode) from the
+/// server-side readiness state, or `None` when there is nothing useful to show
+/// (an older server that never reported readiness). Pure so it can be unit
+/// tested without capturing stdout (spelunk-oss^50).
+fn embedder_status_line(state: &capability::EmbedderState) -> Option<String> {
+    use capability::EmbedderState;
+    let line = match state {
+        EmbedderState::Loading => {
+            "  embedder        \x1b[33mloading\x1b[0m  [model warming up — retry shortly]"
+                .to_string()
+        }
+        EmbedderState::Unavailable => {
+            "  embedder        \x1b[31munavailable\x1b[0m  [model failed to load — see `spelunk server logs`]"
+                .to_string()
+        }
+        EmbedderState::Ready => "  embedder        ready".to_string(),
+        EmbedderState::Disabled => {
+            "  embedder        disabled  [external embedding backend]".to_string()
+        }
+        // Older server without the readiness field: stay quiet rather than
+        // print a confusing "unknown".
+        EmbedderState::Unknown => return None,
+    };
+    Some(line)
+}
+
 pub(crate) fn format_age(unix_ts: i64) -> String {
     let Some(then) = chrono::DateTime::<chrono::Utc>::from_timestamp(unix_ts, 0) else {
         return "unknown".to_string();
@@ -383,5 +426,49 @@ pub(crate) fn format_age(unix_ts: i64) -> String {
         format!("{}h ago", secs / 3600)
     } else {
         format!("{}d ago", secs / 86400)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::EmbedderState;
+
+    // ── embedder_status_line: `spelunk status` rendering of each state ──────────
+
+    #[test]
+    fn embedder_line_loading_advises_warmup() {
+        let line = embedder_status_line(&EmbedderState::Loading).expect("loading renders a line");
+        assert!(line.contains("loading"));
+        assert!(line.contains("warming up"));
+    }
+
+    #[test]
+    fn embedder_line_unavailable_points_at_logs() {
+        let line =
+            embedder_status_line(&EmbedderState::Unavailable).expect("unavailable renders a line");
+        assert!(line.contains("unavailable"));
+        assert!(line.contains("failed to load"));
+        assert!(line.contains("spelunk server logs"));
+    }
+
+    #[test]
+    fn embedder_line_ready_is_plain() {
+        let line = embedder_status_line(&EmbedderState::Ready).expect("ready renders a line");
+        assert!(line.contains("ready"));
+    }
+
+    #[test]
+    fn embedder_line_disabled_notes_external_backend() {
+        let line = embedder_status_line(&EmbedderState::Disabled).expect("disabled renders a line");
+        assert!(line.contains("disabled"));
+        assert!(line.contains("external"));
+    }
+
+    #[test]
+    fn embedder_line_unknown_renders_nothing() {
+        // Older server without the readiness field: no line rather than a
+        // confusing "unknown".
+        assert!(embedder_status_line(&EmbedderState::Unknown).is_none());
     }
 }

--- a/docs/server.md
+++ b/docs/server.md
@@ -40,6 +40,15 @@ To opt out entirely and keep spelunk fully offline, set `SPELUNK_NO_SERVER=1`
 With it set, spelunk never autostarts a server and inference-only features exit
 with a clear message instead.
 
+### Windows: allow the local listener through the firewall
+
+On Windows, the first time the local server binds its loopback port, Windows
+Defender Firewall may show a prompt — **accept it**. If it's blocked, `spelunk`
+can't reach the server and quietly drops to text/ast-grep search (you'll see a
+one-line "no server reachable" notice). If you dismissed the prompt, run
+`spelunk server start` again to re-trigger it, then `spelunk server status` to
+confirm the server is reachable.
+
 How discovery decides whether to reuse or start a server is documented in
 [CLI capability tiers → Loopback auto-discovery](architecture/capability-tiers.md#loopback-auto-discovery).
 The `instance_id` and `started_by` UID checks described there are implemented


### PR DESCRIPTION
Follow-on to **PR A #486** (server-side readiness contract, merged). PR B wires the CLI side of spelunk-oss^50: it consumes the `/v1/health` `embedder: { state, detail }` readiness signal that PR A shipped, so semantic-search degradation is **visible and differentiated** instead of silently falling to ast-grep with a misleading "ast-grep not found" error (the Windows v0.9.1 UAT symptom).

## What's in this PR (CLI scope: #5, #7 + `status`)

- **Tier wiring** (`capability.rs`): new `EmbedderState` enum (`loading`/`ready`/`unavailable`/`disabled`, plus `Unknown` for servers that pre-date PR A). Carried on `Tier::Server`, parsed from the health `embedder.state` field in `parse_health`, set in `probe_url`, and exposed via `Tier::embedder_state()`. Absent field → `Unknown` (backward compatible).
- **#5 — search offline notice** (`search.rs`): auto-mode fallback to ast-grep now prints a one-line stderr notice differentiating the three cases the contract exposes — *no server reachable* (firewall / `spelunk server status` hint), *server up but `loading`* ("model still warming up, retry shortly"), *server up but `unavailable`* (surface load error, `spelunk server logs`). Replaces the silent fallback.
- **#5 — index offline notice** (`index/mod.rs`): embedding phase now runs only when the server's embedder is actually ready (`caps.index_embed`); otherwise it prints the same differentiated notice instead of producing a silent 0-chunk (unembedded) index or 503-ing mid-index.
- **`spelunk status` rendering** (`status.rs`): text output shows an `embedder` line per state; `--format json` gains an `embedder_state` field (`null` when offline / pre-PR-A server).
- **#7 — Windows firewall docs** (`docs/server.md`): concise Defender Firewall note for the loopback listener (accept the prompt on `spelunk server start`). Kept minimal.

No new dependencies; `Cargo.lock` unchanged.

## Test plan
Run with `SPELUNK_SECRET_STORE=file`:

- `cargo fmt --all --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean (whole workspace).
- `cargo test -p spelunk-cli` — all green (137 lib + all integration suites, 0 failures).

New tests added:
- `capability.rs`: `EmbedderState` default/lowercase-wire deserialization, `Tier::embedder_state()` accessor, and `probe_url` carrying `loading`/`unavailable`/absent(→`Unknown`) from a mocked `/v1/health`.
- `status.rs`: `embedder_status_line` rendering for each state (incl. `Unknown` → no line).
- `search.rs`: `semantic_unavailable_message` wording per case (warming-up, load-failed, no-server-with-url→firewall, no-server→start-one) + never-silent invariant.
- `index/mod.rs`: `embed_skipped_lines` on the 0-chunks / unreachable-server paths + never-silent invariant.

THREAT-MODEL req #9 loopback test (`spawn_daemon_args_bind_loopback`) stays green.

Linked: PR A #486.

🤖 Generated with [Claude Code](https://claude.com/claude-code)