### PR TITLE
spelunk-oss^49: php + ruby indexing (batch 1)

### DIFF
--- a/crates/spelunk-core/src/indexer/graph/builtins.rs
+++ b/crates/spelunk-core/src/indexer/graph/builtins.rs
@@ -105,6 +105,69 @@ pub(super) fn is_go_builtin(name: &str) -> bool {
     )
 }
 
+pub(super) fn is_php_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "isset"
+            | "unset"
+            | "empty"
+            | "count"
+            | "echo"
+            | "print"
+            | "printf"
+            | "sprintf"
+            | "var_dump"
+            | "die"
+            | "exit"
+            | "array"
+            | "in_array"
+            | "array_map"
+            | "array_filter"
+            | "array_merge"
+            | "implode"
+            | "explode"
+            | "strlen"
+            | "str_replace"
+            | "trim"
+            | "is_array"
+            | "is_null"
+            | "is_string"
+            | "gettype"
+            | "intval"
+            | "strval"
+    )
+}
+
+pub(super) fn is_ruby_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "puts"
+            | "print"
+            | "p"
+            | "pp"
+            | "raise"
+            | "require"
+            | "require_relative"
+            | "loop"
+            | "lambda"
+            | "proc"
+            | "attr_accessor"
+            | "attr_reader"
+            | "attr_writer"
+            | "new"
+            | "freeze"
+            | "dup"
+            | "clone"
+            | "send"
+            | "format"
+            | "sprintf"
+            | "Integer"
+            | "String"
+            | "Array"
+            | "Hash"
+    )
+}
+
 pub(super) fn is_c_builtin(name: &str) -> bool {
     matches!(
         name,

--- a/crates/spelunk-core/src/indexer/graph/edges.rs
+++ b/crates/spelunk-core/src/indexer/graph/edges.rs
@@ -245,6 +245,159 @@ pub(super) fn java_edges(node: &tree_sitter::Node<'_>, src: &[u8]) -> Vec<(Strin
     out
 }
 
+pub(super) fn php_edges(node: &tree_sitter::Node<'_>, src: &[u8]) -> Vec<(String, EdgeKind)> {
+    let mut out = Vec::new();
+    match node.kind() {
+        // require/require_once/include "file.php" — the path is a `string` child
+        // whose text sits inside a `string_content` node.
+        "require_expression" | "include_expression" => {
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i as u32)
+                    && child.kind() == "string"
+                    && let Ok(text) = child.utf8_text(src)
+                {
+                    let path = text.trim_matches('"').trim_matches('\'').to_owned();
+                    if !path.is_empty() {
+                        out.push((path, EdgeKind::Imports));
+                    }
+                    break;
+                }
+            }
+        }
+        // use App\Models\User; — namespace import.
+        "namespace_use_declaration" => {
+            if let Ok(text) = node.utf8_text(src) {
+                let path = text
+                    .trim_start_matches("use ")
+                    .trim_end_matches(';')
+                    .trim()
+                    .to_owned();
+                if !path.is_empty() {
+                    out.push((path, EdgeKind::Imports));
+                }
+            }
+        }
+        // foo() — the callee is in the `function` field.
+        "function_call_expression" => {
+            if let Some(func) = node.child_by_field_name("function")
+                && func.kind() == "name"
+                && let Ok(name) = func.utf8_text(src)
+                && !is_php_builtin(name)
+            {
+                out.push((name.to_owned(), EdgeKind::Calls));
+            }
+        }
+        // $obj->method() / self::method() — the method name is in the `name` field.
+        "member_call_expression" | "scoped_call_expression" => {
+            if let Some(name_node) = node.child_by_field_name("name")
+                && let Ok(name) = name_node.utf8_text(src)
+                && !is_php_builtin(name)
+            {
+                out.push((name.to_owned(), EdgeKind::Calls));
+            }
+        }
+        // class C extends Base implements I, J { … }
+        "class_declaration" => {
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i as u32) {
+                    match child.kind() {
+                        "base_clause" => {
+                            for j in 0..child.child_count() {
+                                if let Some(base) = child.child(j as u32)
+                                    && base.kind() == "name"
+                                    && let Ok(text) = base.utf8_text(src)
+                                {
+                                    out.push((text.to_owned(), EdgeKind::Extends));
+                                }
+                            }
+                        }
+                        "class_interface_clause" => {
+                            for j in 0..child.child_count() {
+                                if let Some(iface) = child.child(j as u32)
+                                    && iface.kind() == "name"
+                                    && let Ok(text) = iface.utf8_text(src)
+                                {
+                                    out.push((text.to_owned(), EdgeKind::Implements));
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+pub(super) fn ruby_edges(node: &tree_sitter::Node<'_>, src: &[u8]) -> Vec<(String, EdgeKind)> {
+    let mut out = Vec::new();
+    match node.kind() {
+        // Ruby has no dedicated import/mixin syntax — require, require_relative,
+        // include, extend, and ordinary calls are all `call` nodes whose callee
+        // is the `method` field.  Classify by the method name.
+        "call" => {
+            if let Some(method) = node.child_by_field_name("method")
+                && method.kind() == "identifier"
+                && let Ok(name) = method.utf8_text(src)
+            {
+                match name {
+                    "require" | "require_relative" | "load" | "autoload" => {
+                        if let Some(args) = node.child_by_field_name("arguments") {
+                            for i in 0..args.child_count() {
+                                if let Some(arg) = args.child(i as u32)
+                                    && arg.kind() == "string"
+                                    && let Ok(text) = arg.utf8_text(src)
+                                {
+                                    let path = text.trim_matches('"').trim_matches('\'').to_owned();
+                                    if !path.is_empty() {
+                                        out.push((path, EdgeKind::Imports));
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    // include Mod / extend Mod / prepend Mod — mixin, modelled as Implements.
+                    "include" | "extend" | "prepend" => {
+                        if let Some(args) = node.child_by_field_name("arguments") {
+                            for i in 0..args.child_count() {
+                                if let Some(arg) = args.child(i as u32)
+                                    && arg.kind() == "constant"
+                                    && let Ok(text) = arg.utf8_text(src)
+                                {
+                                    out.push((text.to_owned(), EdgeKind::Implements));
+                                }
+                            }
+                        }
+                    }
+                    other if !is_ruby_builtin(other) => {
+                        out.push((other.to_owned(), EdgeKind::Calls));
+                    }
+                    _ => {}
+                }
+            }
+        }
+        // class Service < Base — single inheritance via the `superclass` field.
+        "class" => {
+            if let Some(superclass) = node.child_by_field_name("superclass") {
+                // `superclass` node wraps `< Base`; the constant is its named child.
+                for i in 0..superclass.child_count() {
+                    if let Some(child) = superclass.child(i as u32)
+                        && child.kind() == "constant"
+                        && let Ok(text) = child.utf8_text(src)
+                    {
+                        out.push((text.to_owned(), EdgeKind::Extends));
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
 pub(super) fn c_edges(node: &tree_sitter::Node<'_>, src: &[u8]) -> Vec<(String, EdgeKind)> {
     let mut out = Vec::new();
     match node.kind() {

--- a/crates/spelunk-core/src/indexer/graph/mod.rs
+++ b/crates/spelunk-core/src/indexer/graph/mod.rs
@@ -145,6 +145,13 @@ fn enclosing_scope(node: &tree_sitter::Node<'_>, src: &[u8], language: &str) -> 
         ("go", "method_declaration") => "name",
         ("java", "class_declaration") => "name",
         ("java", "method_declaration") => "name",
+        ("php", "function_definition") => "name",
+        ("php", "method_declaration") => "name",
+        ("php", "class_declaration") => "name",
+        ("ruby", "method") => "name",
+        ("ruby", "singleton_method") => "name",
+        ("ruby", "class") => "name",
+        ("ruby", "module") => "name",
         _ => return None,
     };
     node.child_by_field_name(field)
@@ -171,6 +178,8 @@ fn collect(
         "go" => edges::go_edges(node, src),
         "java" => edges::java_edges(node, src),
         "c" | "cpp" => edges::c_edges(node, src),
+        "php" => edges::php_edges(node, src),
+        "ruby" => edges::ruby_edges(node, src),
         "html" => edges::html_edges(node, src),
         "css" => edges::css_edges(node, src),
         _ => vec![],

--- a/crates/spelunk-core/src/indexer/parser/mod.rs
+++ b/crates/spelunk-core/src/indexer/parser/mod.rs
@@ -21,6 +21,8 @@ pub const SUPPORTED_LANGUAGES: &[&str] = &[
     "html",
     "css",
     "hcl",
+    "php",
+    "ruby",
     "sql",
     "proto",
     // text formats (sliding-window / heading-based, no tree-sitter)
@@ -55,6 +57,8 @@ pub fn detect_language(path: &std::path::Path) -> Option<&'static str> {
         "html" | "htm" => Some("html"),
         "css" => Some("css"),
         "tf" | "hcl" => Some("hcl"),
+        "php" | "phtml" => Some("php"),
+        "rb" | "rake" | "gemspec" => Some("ruby"),
         "sql" | "sequel" => Some("sql"),
         "proto" => Some("proto"),
         #[cfg(feature = "rich-formats")]

--- a/crates/spelunk-core/src/indexer/parser/ts_walker.rs
+++ b/crates/spelunk-core/src/indexer/parser/ts_walker.rs
@@ -24,6 +24,8 @@ pub(super) fn ts_language(name: &str) -> Result<tree_sitter::Language> {
         "html" => SupportLang::Html,
         "css" => SupportLang::Css,
         "hcl" => SupportLang::Hcl,
+        "php" => SupportLang::Php,
+        "ruby" => SupportLang::Ruby,
         "sql" => return Ok(tree_sitter_sequel::LANGUAGE.into()),
         "proto" => return Ok(tree_sitter_proto::LANGUAGE.into()),
         other => bail!("unsupported language: {other}"),
@@ -124,6 +126,25 @@ pub(super) fn node_specs(language: &str) -> Vec<NodeSpec> {
             s("media_statement", Module, None),
             s("keyframes_statement", Function, None),
             s("supports_statement", Module, None),
+        ],
+        // PHP: functions, methods, classes, interfaces, traits, enums. The grammar
+        // exposes a direct `name` field on each, so no custom name walker is needed.
+        "php" => vec![
+            s("function_definition", Function, Some("name")),
+            s("method_declaration", Method, Some("name")),
+            s("class_declaration", Class, Some("name")),
+            s("interface_declaration", Interface, Some("name")),
+            s("trait_declaration", Trait, Some("name")),
+            s("enum_declaration", Enum, Some("name")),
+        ],
+        // Ruby: methods (incl. `def self.x` singletons), classes, and modules.
+        // Each exposes a direct `name` field (`name`/`constant`), so the field
+        // path handles extraction with no custom walker.
+        "ruby" => vec![
+            s("method", Method, Some("name")),
+            s("singleton_method", Method, Some("name")),
+            s("class", Class, Some("name")),
+            s("module", Module, Some("name")),
         ],
         // HCL/Terraform: top-level blocks (resource, data, module, locals, …).
         // Name extraction is handled by hcl_block_name (identifier + string labels).

--- a/crates/spelunk-core/tests/lang_php_ruby.rs
+++ b/crates/spelunk-core/tests/lang_php_ruby.rs
@@ -1,0 +1,236 @@
+//! Indexer coverage for PHP and Ruby (spelunk-oss^49, batch 1).
+//!
+//! Asserts that `SourceParser::parse` produces the expected semantic chunks and
+//! that `EdgeExtractor::extract` produces the expected import/call/inheritance
+//! edges, mirroring the pattern established for the original 14 languages.
+
+use spelunk_core::indexer::graph::{EdgeExtractor, EdgeKind};
+use spelunk_core::indexer::parser::detect_language;
+use spelunk_core::indexer::{ChunkKind, SourceParser};
+use std::path::Path;
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const PHP_SRC: &str = r#"<?php
+require 'lib.php';
+use App\Models\User;
+
+function greet($name) {
+    return "hi " . $name;
+}
+
+interface Greeter {
+    public function greet();
+}
+
+trait Loggable {
+    public function log() {}
+}
+
+class Base {}
+
+class Service extends Base implements Greeter {
+    use Loggable;
+
+    public function greet() {
+        helper();
+        $this->run();
+        return greet("x");
+    }
+}
+"#;
+
+const RUBY_SRC: &str = r#"require 'set'
+require_relative 'helper'
+
+module Util
+  def self.log(msg)
+    puts msg
+  end
+end
+
+class Service < Base
+  include Util
+
+  def run
+    do_work(1)
+    Util.log("x")
+  end
+end
+
+def top_level
+  42
+end
+"#;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn names_of(chunks: &[spelunk_core::indexer::Chunk], kind: ChunkKind) -> Vec<String> {
+    let want = kind.to_string();
+    chunks
+        .iter()
+        .filter(|c| c.kind.to_string() == want)
+        .filter_map(|c| c.name.clone())
+        .collect()
+}
+
+fn has_edge(edges: &[spelunk_core::indexer::graph::Edge], target: &str, kind: EdgeKind) -> bool {
+    edges
+        .iter()
+        .any(|e| e.target_name == target && e.kind == kind)
+}
+
+// ── extension detection ────────────────────────────────────────────────────
+
+#[test]
+fn detects_php_and_ruby_extensions() {
+    assert_eq!(detect_language(Path::new("index.php")), Some("php"));
+    assert_eq!(detect_language(Path::new("view.phtml")), Some("php"));
+    assert_eq!(detect_language(Path::new("app.rb")), Some("ruby"));
+    assert_eq!(detect_language(Path::new("Rakefile.rake")), Some("ruby"));
+    assert_eq!(detect_language(Path::new("gem.gemspec")), Some("ruby"));
+}
+
+// ── PHP chunks ─────────────────────────────────────────────────────────────
+
+#[test]
+fn php_chunks_functions_classes_interfaces_traits() {
+    let chunks = SourceParser::parse(PHP_SRC, "svc.php", "php").unwrap();
+
+    assert!(
+        names_of(&chunks, ChunkKind::Function).contains(&"greet".to_string()),
+        "expected top-level function `greet`"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Class).contains(&"Service".to_string()),
+        "expected class `Service`"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Class).contains(&"Base".to_string()),
+        "expected class `Base`"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Interface).contains(&"Greeter".to_string()),
+        "expected interface `Greeter`"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Trait).contains(&"Loggable".to_string()),
+        "expected trait `Loggable`"
+    );
+    // The class method `greet` is captured as a Method chunk.
+    assert!(
+        names_of(&chunks, ChunkKind::Method).contains(&"greet".to_string()),
+        "expected method `greet`"
+    );
+}
+
+// ── PHP edges ──────────────────────────────────────────────────────────────
+
+#[test]
+fn php_edges_imports_calls_inheritance() {
+    let edges = EdgeExtractor::extract(PHP_SRC, "svc.php", "php").unwrap();
+
+    // require 'lib.php'
+    assert!(
+        has_edge(&edges, "lib.php", EdgeKind::Imports),
+        "expected require import of lib.php"
+    );
+    // use App\Models\User;
+    assert!(
+        has_edge(&edges, "App\\Models\\User", EdgeKind::Imports),
+        "expected namespace use import"
+    );
+    // helper() and greet() calls (builtins are skipped, these are user fns)
+    assert!(
+        has_edge(&edges, "helper", EdgeKind::Calls),
+        "expected call to helper()"
+    );
+    assert!(
+        has_edge(&edges, "greet", EdgeKind::Calls),
+        "expected call to greet()"
+    );
+    // $this->run() member call
+    assert!(
+        has_edge(&edges, "run", EdgeKind::Calls),
+        "expected member call run()"
+    );
+    // class Service extends Base implements Greeter
+    assert!(
+        has_edge(&edges, "Base", EdgeKind::Extends),
+        "expected extends Base"
+    );
+    assert!(
+        has_edge(&edges, "Greeter", EdgeKind::Implements),
+        "expected implements Greeter"
+    );
+}
+
+// ── Ruby chunks ────────────────────────────────────────────────────────────
+
+#[test]
+fn ruby_chunks_methods_classes_modules() {
+    let chunks = SourceParser::parse(RUBY_SRC, "svc.rb", "ruby").unwrap();
+
+    assert!(
+        names_of(&chunks, ChunkKind::Module).contains(&"Util".to_string()),
+        "expected module `Util`"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Class).contains(&"Service".to_string()),
+        "expected class `Service`"
+    );
+    let methods = names_of(&chunks, ChunkKind::Method);
+    assert!(
+        methods.contains(&"run".to_string()),
+        "expected method `run`"
+    );
+    assert!(
+        methods.contains(&"top_level".to_string()),
+        "expected top-level def `top_level`"
+    );
+    // `def self.log` is a singleton_method → captured with name `log`.
+    assert!(
+        methods.contains(&"log".to_string()),
+        "expected method `log`"
+    );
+}
+
+// ── Ruby edges ─────────────────────────────────────────────────────────────
+
+#[test]
+fn ruby_edges_requires_calls_mixins_inheritance() {
+    let edges = EdgeExtractor::extract(RUBY_SRC, "svc.rb", "ruby").unwrap();
+
+    // require 'set' / require_relative 'helper'
+    assert!(
+        has_edge(&edges, "set", EdgeKind::Imports),
+        "expected require import of set"
+    );
+    assert!(
+        has_edge(&edges, "helper", EdgeKind::Imports),
+        "expected require_relative import of helper"
+    );
+    // include Util → mixin (Implements)
+    assert!(
+        has_edge(&edges, "Util", EdgeKind::Implements),
+        "expected include Util mixin edge"
+    );
+    // class Service < Base
+    assert!(
+        has_edge(&edges, "Base", EdgeKind::Extends),
+        "expected extends Base"
+    );
+    // do_work(1) and Util.log("x") calls (puts is a builtin → skipped)
+    assert!(
+        has_edge(&edges, "do_work", EdgeKind::Calls),
+        "expected call to do_work"
+    );
+    assert!(
+        has_edge(&edges, "log", EdgeKind::Calls),
+        "expected call to Util.log"
+    );
+    assert!(
+        !has_edge(&edges, "puts", EdgeKind::Calls),
+        "puts is a builtin and should be skipped"
+    );
+}


### PR DESCRIPTION
## Summary

Upgrades **PHP** and **Ruby** from fallback-only structural search to full Spelunk-quality indexing — semantic chunking plus import/call/inheritance graph edges — mirroring the existing 14-language pattern. Follow-up to spelunk-oss^48 (grammar consolidation, #487), which put the shared `ast-grep-language` grammars in-tree.

This is **batch 1** of spelunk-oss^49; c#/kotlin/swift are tracked as follow-on PRs (one small batch per PR per the task's own guidance).

Both grammars are already in the enabled all-27 `ast-grep-language` set (`SupportLang::Php` / `SupportLang::Ruby`), so no dependency changes — `Cargo.toml`/`Cargo.lock` are untouched. Node kinds and field names were read from each grammar's actual AST (via a throwaway probe), not guessed.

### PHP (`.php`, `.phtml`)
- **Chunks:** `function_definition`, `method_declaration`, `class_declaration`, `interface_declaration`, `trait_declaration`, `enum_declaration` — all via the direct `name` field.
- **Edges:** `require_expression`/`include_expression` + `namespace_use_declaration` → Imports; `function_call_expression` + `member_call_expression`/`scoped_call_expression` → Calls; `base_clause` → Extends, `class_interface_clause` → Implements.

### Ruby (`.rb`, `.rake`, `.gemspec`)
- **Chunks:** `method`, `singleton_method` (`def self.x`), `class`, `module` — all via the `name` field.
- **Edges:** Ruby has no dedicated import/mixin syntax, so `call` nodes are classified by callee identifier — `require`/`require_relative`/`load` → Imports, `include`/`extend`/`prepend` → Implements (mixin), everything else → Calls. `class` `superclass` field → Extends.

Per-language builtin skip-lists (`is_php_builtin`, `is_ruby_builtin`) suppress noise-y stdlib calls, matching the existing languages.

### Files
- `parser/ts_walker.rs` — `ts_language()` + `node_specs()`
- `parser/mod.rs` — `SUPPORTED_LANGUAGES` + extension mapping
- `graph/edges.rs` — `php_edges()` / `ruby_edges()`
- `graph/mod.rs` — dispatch + enclosing-scope tracking
- `graph/builtins.rs` — skip-lists
- `tests/lang_php_ruby.rs` — new fixture-based tests

## Node-model note
Ruby overloads the `call` node for imports, mixins, and ordinary calls (no distinct import statement), so classification is by method name rather than node kind — the one deviation from the cleaner per-kind pattern the other languages use. PHP fit the existing pattern directly.

## Test plan
New `crates/spelunk-core/tests/lang_php_ruby.rs` (5 tests) with `.php` and `.rb` fixtures asserting:
- extension detection (`.php`/`.phtml` → php, `.rb`/`.rake`/`.gemspec` → ruby)
- PHP chunks: function `greet`, classes `Service`/`Base`, interface `Greeter`, trait `Loggable`, method `greet`
- PHP edges: `require 'lib.php'` + `use App\Models\User` imports, `helper()`/`greet()`/`run()` calls, `extends Base`, `implements Greeter`
- Ruby chunks: module `Util`, class `Service`, methods `run`/`top_level`/`log`
- Ruby edges: `require`/`require_relative` imports, `include Util` mixin, `< Base` extends, `do_work`/`log` calls, `puts` builtin skipped

Ran with `SPELUNK_SECRET_STORE=file`:
- `cargo test -p spelunk-core` — all pass (0 failures); the pre-existing 14-language specs are unchanged.
- `cargo fmt --all --check` — clean
- `cargo clippy -p spelunk-core --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)