### PR TITLE
spelunk-oss^49: c# + kotlin + swift indexing (batch 2)

### DIFF
--- a/crates/spelunk-core/src/indexer/graph/builtins.rs
+++ b/crates/spelunk-core/src/indexer/graph/builtins.rs
@@ -168,6 +168,96 @@ pub(super) fn is_ruby_builtin(name: &str) -> bool {
     )
 }
 
+pub(super) fn is_csharp_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "WriteLine"
+            | "Write"
+            | "ToString"
+            | "Equals"
+            | "GetHashCode"
+            | "GetType"
+            | "Parse"
+            | "TryParse"
+            | "Format"
+            | "Add"
+            | "Remove"
+            | "Contains"
+            | "Count"
+            | "Select"
+            | "Where"
+            | "First"
+            | "FirstOrDefault"
+            | "Any"
+            | "All"
+            | "ToList"
+            | "ToArray"
+            | "nameof"
+            | "typeof"
+    )
+}
+
+pub(super) fn is_kotlin_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "println"
+            | "print"
+            | "listOf"
+            | "mutableListOf"
+            | "mapOf"
+            | "mutableMapOf"
+            | "setOf"
+            | "arrayOf"
+            | "emptyList"
+            | "emptyMap"
+            | "let"
+            | "run"
+            | "apply"
+            | "also"
+            | "with"
+            | "require"
+            | "requireNotNull"
+            | "check"
+            | "error"
+            | "TODO"
+            | "lazy"
+            | "map"
+            | "filter"
+            | "forEach"
+            | "toString"
+    )
+}
+
+pub(super) fn is_swift_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "print"
+            | "debugPrint"
+            | "assert"
+            | "assertionFailure"
+            | "precondition"
+            | "fatalError"
+            | "map"
+            | "filter"
+            | "reduce"
+            | "forEach"
+            | "compactMap"
+            | "flatMap"
+            | "sorted"
+            | "append"
+            | "insert"
+            | "remove"
+            | "contains"
+            | "count"
+            | "min"
+            | "max"
+            | "abs"
+            | "String"
+            | "Int"
+            | "Array"
+    )
+}
+
 pub(super) fn is_c_builtin(name: &str) -> bool {
     matches!(
         name,

--- a/crates/spelunk-core/src/indexer/graph/edges.rs
+++ b/crates/spelunk-core/src/indexer/graph/edges.rs
@@ -398,6 +398,233 @@ pub(super) fn ruby_edges(node: &tree_sitter::Node<'_>, src: &[u8]) -> Vec<(Strin
     out
 }
 
+pub(super) fn csharp_edges(node: &tree_sitter::Node<'_>, src: &[u8]) -> Vec<(String, EdgeKind)> {
+    let mut out = Vec::new();
+    match node.kind() {
+        // using System; / using System.Collections.Generic;
+        "using_directive" => {
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i as u32)
+                    && matches!(child.kind(), "identifier" | "qualified_name")
+                    && let Ok(text) = child.utf8_text(src)
+                {
+                    out.push((text.to_owned(), EdgeKind::Imports));
+                    break;
+                }
+            }
+        }
+        // Foo() / obj.Method() / Type.Method() — callee is the `function` field.
+        "invocation_expression" => {
+            if let Some(func) = node.child_by_field_name("function") {
+                match func.kind() {
+                    "identifier" => {
+                        if let Ok(name) = func.utf8_text(src)
+                            && !is_csharp_builtin(name)
+                        {
+                            out.push((name.to_owned(), EdgeKind::Calls));
+                        }
+                    }
+                    // obj.Method() / Type.Method() — method name is the `name` field.
+                    "member_access_expression" => {
+                        if let Some(name_node) = func.child_by_field_name("name")
+                            && let Ok(name) = name_node.utf8_text(src)
+                            && !is_csharp_builtin(name)
+                        {
+                            out.push((name.to_owned(), EdgeKind::Calls));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        // class Service : Base, IGreeter { … } — the base type and interfaces are
+        // listed in a `base_list`, which the grammar does not distinguish
+        // syntactically, so every entry is modelled as Extends.
+        "class_declaration"
+        | "struct_declaration"
+        | "record_declaration"
+        | "interface_declaration" => {
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i as u32)
+                    && child.kind() == "base_list"
+                {
+                    for j in 0..child.child_count() {
+                        if let Some(base) = child.child(j as u32)
+                            && matches!(
+                                base.kind(),
+                                "identifier" | "qualified_name" | "generic_name"
+                            )
+                            && let Ok(text) = base.utf8_text(src)
+                        {
+                            out.push((text.to_owned(), EdgeKind::Extends));
+                        }
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+pub(super) fn kotlin_edges(node: &tree_sitter::Node<'_>, src: &[u8]) -> Vec<(String, EdgeKind)> {
+    let mut out = Vec::new();
+    match node.kind() {
+        // import com.demo.util.Helper
+        "import_header" => {
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i as u32)
+                    && child.kind() == "identifier"
+                    && let Ok(text) = child.utf8_text(src)
+                {
+                    out.push((text.to_owned(), EdgeKind::Imports));
+                    break;
+                }
+            }
+        }
+        // foo() / println(x) — the callee is the leading `simple_identifier`.
+        // obj.method() nests differently (navigation_expression) and is not
+        // captured here, matching the conservative approach the other langs take.
+        "call_expression" => {
+            if let Some(callee) = node.child(0)
+                && callee.kind() == "simple_identifier"
+                && let Ok(name) = callee.utf8_text(src)
+                && !is_kotlin_builtin(name)
+            {
+                out.push((name.to_owned(), EdgeKind::Calls));
+            }
+        }
+        // class Service(…) : Base(), Greeter — supertypes are `delegation_specifier`
+        // children. Kotlin does not distinguish class inheritance from interface
+        // implementation syntactically, so every supertype is modelled as Extends.
+        "class_declaration" | "object_declaration" => {
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i as u32)
+                    && child.kind() == "delegation_specifier"
+                    && let Some(name) = user_type_name(&child, src)
+                {
+                    out.push((name, EdgeKind::Extends));
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+pub(super) fn swift_edges(node: &tree_sitter::Node<'_>, src: &[u8]) -> Vec<(String, EdgeKind)> {
+    let mut out = Vec::new();
+    match node.kind() {
+        // import Foundation
+        "import_declaration" => {
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i as u32)
+                    && child.kind() == "identifier"
+                    && let Ok(text) = child.utf8_text(src)
+                {
+                    out.push((text.to_owned(), EdgeKind::Imports));
+                    break;
+                }
+            }
+        }
+        // foo() / self.run() / print(x) — the callee is either a leading
+        // `simple_identifier` or a `navigation_expression` (obj.method).
+        "call_expression" => {
+            if let Some(callee) = node.child(0) {
+                match callee.kind() {
+                    "simple_identifier" => {
+                        if let Ok(name) = callee.utf8_text(src)
+                            && !is_swift_builtin(name)
+                        {
+                            out.push((name.to_owned(), EdgeKind::Calls));
+                        }
+                    }
+                    // self.run() / obj.method() — method name is the
+                    // `simple_identifier` inside the trailing `navigation_suffix`.
+                    "navigation_expression" => {
+                        if let Some(name) = navigation_suffix_name(&callee, src)
+                            && !is_swift_builtin(&name)
+                        {
+                            out.push((name, EdgeKind::Calls));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        // class Service: Base, Greeter { … } — supertypes are `inheritance_specifier`
+        // children. Swift does not distinguish superclass from protocol conformance
+        // syntactically, so each is modelled as Extends.
+        "class_declaration" => {
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i as u32)
+                    && child.kind() == "inheritance_specifier"
+                    && let Some(name) = user_type_name(&child, src)
+                {
+                    out.push((name, EdgeKind::Extends));
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Extract a type name from a node wrapping a `user_type` → `type_identifier`
+/// (Kotlin `delegation_specifier`, Swift `inheritance_specifier`). Falls back to
+/// a directly-nested `type_identifier`.
+fn user_type_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i as u32) {
+            match child.kind() {
+                "type_identifier" => return child.utf8_text(src).ok().map(str::to_owned),
+                "user_type" | "constructor_invocation" => {
+                    for j in 0..child.child_count() {
+                        if let Some(g) = child.child(j as u32)
+                            && g.kind() == "type_identifier"
+                        {
+                            return g.utf8_text(src).ok().map(str::to_owned);
+                        }
+                        // constructor_invocation nests user_type → type_identifier
+                        if let Some(g) = child.child(j as u32)
+                            && g.kind() == "user_type"
+                        {
+                            for k in 0..g.child_count() {
+                                if let Some(t) = g.child(k as u32)
+                                    && t.kind() == "type_identifier"
+                                {
+                                    return t.utf8_text(src).ok().map(str::to_owned);
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+/// Return the method name from a Swift `navigation_expression` (`obj.method`),
+/// i.e. the `simple_identifier` inside its `navigation_suffix`.
+fn navigation_suffix_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i as u32)
+            && child.kind() == "navigation_suffix"
+        {
+            for j in 0..child.child_count() {
+                if let Some(g) = child.child(j as u32)
+                    && g.kind() == "simple_identifier"
+                {
+                    return g.utf8_text(src).ok().map(str::to_owned);
+                }
+            }
+        }
+    }
+    None
+}
+
 pub(super) fn c_edges(node: &tree_sitter::Node<'_>, src: &[u8]) -> Vec<(String, EdgeKind)> {
     let mut out = Vec::new();
     match node.kind() {

--- a/crates/spelunk-core/src/indexer/graph/mod.rs
+++ b/crates/spelunk-core/src/indexer/graph/mod.rs
@@ -152,11 +152,43 @@ fn enclosing_scope(node: &tree_sitter::Node<'_>, src: &[u8], language: &str) -> 
         ("ruby", "singleton_method") => "name",
         ("ruby", "class") => "name",
         ("ruby", "module") => "name",
+        // C# exposes a direct `name` field on each declaration.
+        ("csharp", "class_declaration") => "name",
+        ("csharp", "struct_declaration") => "name",
+        ("csharp", "interface_declaration") => "name",
+        ("csharp", "record_declaration") => "name",
+        ("csharp", "method_declaration") => "name",
+        ("csharp", "constructor_declaration") => "name",
+        // Swift exposes a `name` field on class/struct/enum/extension
+        // (`class_declaration`), protocols, and functions.
+        ("swift", "class_declaration") => "name",
+        ("swift", "protocol_declaration") => "name",
+        ("swift", "function_declaration") => "name",
+        // Kotlin has no `name` field — its scopes are resolved below.
+        ("kotlin", "class_declaration" | "object_declaration") => {
+            return kotlin_scope_name(node, src, "type_identifier");
+        }
+        ("kotlin", "function_declaration") => {
+            return kotlin_scope_name(node, src, "simple_identifier");
+        }
         _ => return None,
     };
     node.child_by_field_name(field)
         .and_then(|n| n.utf8_text(src).ok())
         .map(str::to_owned)
+}
+
+/// Resolve a Kotlin scope name from an unnamed child of the given kind
+/// (`type_identifier` for classes/objects, `simple_identifier` for functions).
+fn kotlin_scope_name(node: &tree_sitter::Node<'_>, src: &[u8], child_kind: &str) -> Option<String> {
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i as u32)
+            && child.kind() == child_kind
+        {
+            return child.utf8_text(src).ok().map(str::to_owned);
+        }
+    }
+    None
 }
 
 /// Emit edges (if any) produced by `node`, deduplicating via `seen`.
@@ -180,6 +212,9 @@ fn collect(
         "c" | "cpp" => edges::c_edges(node, src),
         "php" => edges::php_edges(node, src),
         "ruby" => edges::ruby_edges(node, src),
+        "csharp" => edges::csharp_edges(node, src),
+        "kotlin" => edges::kotlin_edges(node, src),
+        "swift" => edges::swift_edges(node, src),
         "html" => edges::html_edges(node, src),
         "css" => edges::css_edges(node, src),
         _ => vec![],

--- a/crates/spelunk-core/src/indexer/parser/mod.rs
+++ b/crates/spelunk-core/src/indexer/parser/mod.rs
@@ -23,6 +23,9 @@ pub const SUPPORTED_LANGUAGES: &[&str] = &[
     "hcl",
     "php",
     "ruby",
+    "csharp",
+    "kotlin",
+    "swift",
     "sql",
     "proto",
     // text formats (sliding-window / heading-based, no tree-sitter)
@@ -59,6 +62,9 @@ pub fn detect_language(path: &std::path::Path) -> Option<&'static str> {
         "tf" | "hcl" => Some("hcl"),
         "php" | "phtml" => Some("php"),
         "rb" | "rake" | "gemspec" => Some("ruby"),
+        "cs" => Some("csharp"),
+        "kt" | "kts" => Some("kotlin"),
+        "swift" => Some("swift"),
         "sql" | "sequel" => Some("sql"),
         "proto" => Some("proto"),
         #[cfg(feature = "rich-formats")]

--- a/crates/spelunk-core/src/indexer/parser/ts_walker.rs
+++ b/crates/spelunk-core/src/indexer/parser/ts_walker.rs
@@ -26,6 +26,9 @@ pub(super) fn ts_language(name: &str) -> Result<tree_sitter::Language> {
         "hcl" => SupportLang::Hcl,
         "php" => SupportLang::Php,
         "ruby" => SupportLang::Ruby,
+        "csharp" => SupportLang::CSharp,
+        "kotlin" => SupportLang::Kotlin,
+        "swift" => SupportLang::Swift,
         "sql" => return Ok(tree_sitter_sequel::LANGUAGE.into()),
         "proto" => return Ok(tree_sitter_proto::LANGUAGE.into()),
         other => bail!("unsupported language: {other}"),
@@ -145,6 +148,39 @@ pub(super) fn node_specs(language: &str) -> Vec<NodeSpec> {
             s("singleton_method", Method, Some("name")),
             s("class", Class, Some("name")),
             s("module", Module, Some("name")),
+        ],
+        // C#: classes, structs, interfaces, enums, records, methods, and
+        // constructors. tree-sitter-c-sharp exposes a direct `name` field on each,
+        // so no custom name walker is needed. (Properties/fields are not chunked,
+        // matching the existing languages, which chunk types + callables only.)
+        "csharp" => vec![
+            s("class_declaration", Class, Some("name")),
+            s("struct_declaration", Struct, Some("name")),
+            s("interface_declaration", Interface, Some("name")),
+            s("enum_declaration", Enum, Some("name")),
+            s("record_declaration", Struct, Some("name")),
+            s("method_declaration", Method, Some("name")),
+            s("constructor_declaration", Method, Some("name")),
+        ],
+        // Kotlin: classes/interfaces/enums (all `class_declaration`), objects
+        // (incl. named `object` singletons), and functions. The grammar does not
+        // expose a `name` field — names are unnamed `type_identifier` /
+        // `simple_identifier` children — so extraction is handled by kotlin_decl_name.
+        "kotlin" => vec![
+            s("class_declaration", Class, None),
+            s("object_declaration", Class, None),
+            s("function_declaration", Function, None),
+        ],
+        // Swift: `class_declaration` is a unified node covering class/struct/enum/
+        // extension (distinguished by the `declaration_kind` field); protocols are a
+        // separate `protocol_declaration`. Functions and initializers round it out.
+        // Most expose a direct `name` field; `init_declaration` has none, handled by
+        // swift_init_name.
+        "swift" => vec![
+            s("class_declaration", Class, Some("name")),
+            s("protocol_declaration", Interface, Some("name")),
+            s("function_declaration", Function, Some("name")),
+            s("init_declaration", Method, None),
         ],
         // HCL/Terraform: top-level blocks (resource, data, module, locals, …).
         // Name extraction is handled by hcl_block_name (identifier + string labels).
@@ -293,7 +329,38 @@ pub(super) fn extract_name(
         "hcl" => hcl_block_name(node, src),
         "proto" => proto_named_child(node, src),
         "sql" => sql_object_name(node, src),
+        "kotlin" => kotlin_decl_name(node, src),
+        "swift" => swift_init_name(node),
         _ => None,
+    }
+}
+
+/// Extract the declared name from a Kotlin declaration node. tree-sitter-kotlin
+/// (the `-sg` grammar) does not expose a `name` field: classes/interfaces/enums
+/// and named objects carry their name as a `type_identifier` child, and functions
+/// as a `simple_identifier` child. A `companion object` has no name — returns None.
+fn kotlin_decl_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
+    let want = match node.kind() {
+        "class_declaration" | "object_declaration" => "type_identifier",
+        "function_declaration" => "simple_identifier",
+        _ => return None,
+    };
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i as u32)
+            && child.kind() == want
+        {
+            return child.utf8_text(src).ok().map(str::to_owned);
+        }
+    }
+    None
+}
+
+/// Swift `init_declaration` nodes have no name field; label them `init`.
+fn swift_init_name(node: &tree_sitter::Node<'_>) -> Option<String> {
+    if node.kind() == "init_declaration" {
+        Some("init".to_owned())
+    } else {
+        None
     }
 }
 

--- a/crates/spelunk-core/tests/lang_csharp_kotlin_swift.rs
+++ b/crates/spelunk-core/tests/lang_csharp_kotlin_swift.rs
@@ -1,0 +1,381 @@
+//! Indexer coverage for C#, Kotlin, and Swift (spelunk-oss^49, batch 2).
+//!
+//! Asserts that `SourceParser::parse` produces the expected semantic chunks and
+//! that `EdgeExtractor::extract` produces the expected import/call/inheritance
+//! edges, mirroring the pattern established for the original 14 languages and the
+//! batch-1 php/ruby coverage.
+
+use spelunk_core::indexer::graph::{EdgeExtractor, EdgeKind};
+use spelunk_core::indexer::parser::detect_language;
+use spelunk_core::indexer::{ChunkKind, SourceParser};
+use std::path::Path;
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const CSHARP_SRC: &str = r#"using System;
+using System.Collections.Generic;
+
+namespace Demo {
+    public interface IGreeter { void Greet(); }
+
+    public abstract class Base { }
+
+    public class Service : Base, IGreeter {
+        public Service() { }
+        public string Name { get; set; }
+        public void Greet() {
+            Helper();
+            this.Run();
+            Console.WriteLine("hi");
+        }
+        private void Run() { }
+    }
+
+    public struct Point { public int X; }
+    public enum Color { Red, Green }
+    public record Pair(int A, int B);
+}
+"#;
+
+const KOTLIN_SRC: &str = r#"package com.demo
+
+import kotlin.collections.List
+import com.demo.util.Helper
+
+interface Greeter { fun greet() }
+
+open class Base
+
+class Service(val name: String) : Base(), Greeter {
+    override fun greet() {
+        helper()
+        process()
+        println("hi")
+    }
+    fun process() {}
+
+    companion object {
+        fun create(): Service = Service("x")
+    }
+}
+
+object Singleton {
+    fun ping() {}
+}
+
+fun topLevel(): Int = 42
+"#;
+
+const SWIFT_SRC: &str = r#"import Foundation
+import UIKit
+
+protocol Greeter {
+    func greet()
+}
+
+class Base {}
+
+class Service: Base, Greeter {
+    var name: String = ""
+    init(name: String) { self.name = name }
+    func greet() {
+        helper()
+        self.run()
+        print("hi")
+    }
+    func run() {}
+}
+
+struct Point {
+    var x: Int
+}
+
+enum Color {
+    case red, green
+}
+
+extension Service {
+    func extra() {}
+}
+
+func topLevel() -> Int { return 42 }
+"#;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn names_of(chunks: &[spelunk_core::indexer::Chunk], kind: ChunkKind) -> Vec<String> {
+    let want = kind.to_string();
+    chunks
+        .iter()
+        .filter(|c| c.kind.to_string() == want)
+        .filter_map(|c| c.name.clone())
+        .collect()
+}
+
+fn has_edge(edges: &[spelunk_core::indexer::graph::Edge], target: &str, kind: EdgeKind) -> bool {
+    edges
+        .iter()
+        .any(|e| e.target_name == target && e.kind == kind)
+}
+
+// ── extension detection ────────────────────────────────────────────────────
+
+#[test]
+fn detects_csharp_kotlin_swift_extensions() {
+    assert_eq!(detect_language(Path::new("Service.cs")), Some("csharp"));
+    assert_eq!(detect_language(Path::new("Service.kt")), Some("kotlin"));
+    assert_eq!(detect_language(Path::new("build.kts")), Some("kotlin"));
+    assert_eq!(detect_language(Path::new("Service.swift")), Some("swift"));
+}
+
+// ── C# chunks ────────────────────────────────────────────────────────────────
+
+#[test]
+fn csharp_chunks_types_and_members() {
+    let chunks = SourceParser::parse(CSHARP_SRC, "Service.cs", "csharp").unwrap();
+
+    assert!(
+        names_of(&chunks, ChunkKind::Class).contains(&"Service".to_string()),
+        "expected class `Service`"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Class).contains(&"Base".to_string()),
+        "expected class `Base`"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Interface).contains(&"IGreeter".to_string()),
+        "expected interface `IGreeter`"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Struct).contains(&"Point".to_string()),
+        "expected struct `Point`"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Struct).contains(&"Pair".to_string()),
+        "expected record `Pair` (mapped to Struct)"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Enum).contains(&"Color".to_string()),
+        "expected enum `Color`"
+    );
+    let methods = names_of(&chunks, ChunkKind::Method);
+    assert!(
+        methods.contains(&"Greet".to_string()),
+        "expected method `Greet`"
+    );
+    assert!(
+        methods.contains(&"Run".to_string()),
+        "expected method `Run`"
+    );
+    // Constructor is captured as a Method named after the type.
+    assert!(
+        methods.contains(&"Service".to_string()),
+        "expected constructor `Service`"
+    );
+}
+
+// ── C# edges ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn csharp_edges_usings_calls_inheritance() {
+    let edges = EdgeExtractor::extract(CSHARP_SRC, "Service.cs", "csharp").unwrap();
+
+    assert!(
+        has_edge(&edges, "System", EdgeKind::Imports),
+        "expected using System"
+    );
+    assert!(
+        has_edge(&edges, "System.Collections.Generic", EdgeKind::Imports),
+        "expected using System.Collections.Generic"
+    );
+    // Helper() and this.Run() — user calls (Console.WriteLine is a builtin, skipped).
+    assert!(
+        has_edge(&edges, "Helper", EdgeKind::Calls),
+        "expected call to Helper()"
+    );
+    assert!(
+        has_edge(&edges, "Run", EdgeKind::Calls),
+        "expected member call Run()"
+    );
+    assert!(
+        !has_edge(&edges, "WriteLine", EdgeKind::Calls),
+        "Console.WriteLine is a builtin and should be skipped"
+    );
+    // class Service : Base, IGreeter — both modelled as Extends (grammar does not
+    // distinguish base class from interface).
+    assert!(
+        has_edge(&edges, "Base", EdgeKind::Extends),
+        "expected extends Base"
+    );
+    assert!(
+        has_edge(&edges, "IGreeter", EdgeKind::Extends),
+        "expected supertype IGreeter"
+    );
+}
+
+// ── Kotlin chunks ──────────────────────────────────────────────────────────
+
+#[test]
+fn kotlin_chunks_classes_objects_functions() {
+    let chunks = SourceParser::parse(KOTLIN_SRC, "Service.kt", "kotlin").unwrap();
+
+    let classes = names_of(&chunks, ChunkKind::Class);
+    assert!(
+        classes.contains(&"Service".to_string()),
+        "expected class `Service`"
+    );
+    assert!(
+        classes.contains(&"Base".to_string()),
+        "expected class `Base`"
+    );
+    assert!(
+        classes.contains(&"Greeter".to_string()),
+        "expected interface `Greeter` (mapped to Class)"
+    );
+    // Named object `Singleton` is captured; anonymous companion object is not named.
+    assert!(
+        classes.contains(&"Singleton".to_string()),
+        "expected object `Singleton`"
+    );
+    let functions = names_of(&chunks, ChunkKind::Function);
+    assert!(
+        functions.contains(&"greet".to_string()),
+        "expected fun `greet`"
+    );
+    assert!(
+        functions.contains(&"process".to_string()),
+        "expected fun `process`"
+    );
+    assert!(
+        functions.contains(&"topLevel".to_string()),
+        "expected top-level fun `topLevel`"
+    );
+    assert!(
+        functions.contains(&"create".to_string()),
+        "expected companion-object fun `create`"
+    );
+}
+
+// ── Kotlin edges ─────────────────────────────────────────────────────────────
+
+#[test]
+fn kotlin_edges_imports_calls_inheritance() {
+    let edges = EdgeExtractor::extract(KOTLIN_SRC, "Service.kt", "kotlin").unwrap();
+
+    assert!(
+        has_edge(&edges, "com.demo.util.Helper", EdgeKind::Imports),
+        "expected import of com.demo.util.Helper"
+    );
+    // helper() and process() — user calls (println is a builtin, skipped).
+    assert!(
+        has_edge(&edges, "helper", EdgeKind::Calls),
+        "expected call to helper()"
+    );
+    assert!(
+        has_edge(&edges, "process", EdgeKind::Calls),
+        "expected call to process()"
+    );
+    assert!(
+        !has_edge(&edges, "println", EdgeKind::Calls),
+        "println is a builtin and should be skipped"
+    );
+    // class Service : Base(), Greeter — both supertypes modelled as Extends.
+    assert!(
+        has_edge(&edges, "Base", EdgeKind::Extends),
+        "expected supertype Base"
+    );
+    assert!(
+        has_edge(&edges, "Greeter", EdgeKind::Extends),
+        "expected supertype Greeter"
+    );
+}
+
+// ── Swift chunks ─────────────────────────────────────────────────────────────
+
+#[test]
+fn swift_chunks_types_protocols_functions_inits() {
+    let chunks = SourceParser::parse(SWIFT_SRC, "Service.swift", "swift").unwrap();
+
+    let classes = names_of(&chunks, ChunkKind::Class);
+    // class/struct/enum/extension all parse as `class_declaration` → Class.
+    assert!(
+        classes.contains(&"Service".to_string()),
+        "expected class `Service`"
+    );
+    assert!(
+        classes.contains(&"Base".to_string()),
+        "expected class `Base`"
+    );
+    assert!(
+        classes.contains(&"Point".to_string()),
+        "expected struct `Point`"
+    );
+    assert!(
+        classes.contains(&"Color".to_string()),
+        "expected enum `Color`"
+    );
+    assert!(
+        names_of(&chunks, ChunkKind::Interface).contains(&"Greeter".to_string()),
+        "expected protocol `Greeter` (mapped to Interface)"
+    );
+    let functions = names_of(&chunks, ChunkKind::Function);
+    assert!(
+        functions.contains(&"greet".to_string()),
+        "expected func `greet`"
+    );
+    assert!(
+        functions.contains(&"run".to_string()),
+        "expected func `run`"
+    );
+    assert!(
+        functions.contains(&"extra".to_string()),
+        "expected extension func `extra`"
+    );
+    assert!(
+        functions.contains(&"topLevel".to_string()),
+        "expected top-level func `topLevel`"
+    );
+    // init_declaration is captured as a Method named `init`.
+    assert!(
+        names_of(&chunks, ChunkKind::Method).contains(&"init".to_string()),
+        "expected initializer captured as `init`"
+    );
+}
+
+// ── Swift edges ──────────────────────────────────────────────────────────────
+
+#[test]
+fn swift_edges_imports_calls_inheritance() {
+    let edges = EdgeExtractor::extract(SWIFT_SRC, "Service.swift", "swift").unwrap();
+
+    assert!(
+        has_edge(&edges, "Foundation", EdgeKind::Imports),
+        "expected import Foundation"
+    );
+    assert!(
+        has_edge(&edges, "UIKit", EdgeKind::Imports),
+        "expected import UIKit"
+    );
+    // helper() and self.run() — user calls (print is a builtin, skipped).
+    assert!(
+        has_edge(&edges, "helper", EdgeKind::Calls),
+        "expected call to helper()"
+    );
+    assert!(
+        has_edge(&edges, "run", EdgeKind::Calls),
+        "expected self.run() navigation call"
+    );
+    assert!(
+        !has_edge(&edges, "print", EdgeKind::Calls),
+        "print is a builtin and should be skipped"
+    );
+    // class Service: Base, Greeter — both modelled as Extends.
+    assert!(
+        has_edge(&edges, "Base", EdgeKind::Extends),
+        "expected supertype Base"
+    );
+    assert!(
+        has_edge(&edges, "Greeter", EdgeKind::Extends),
+        "expected supertype Greeter"
+    );
+}


### PR DESCRIPTION
Batch 2 of spelunk-oss^49 — teaches the semantic indexer to produce full chunks + graph edges for **C#, Kotlin, and Swift**, completing the suggested first five (php + ruby landed as batch 1, #489). Mirrors the validated batch-1 4-part pattern (NodeSpecs + name extraction + edges/dispatch + registration). The long-tail languages stay deferred.

All three grammars are already in-tree via `ast-grep-language` 0.44 (`SupportLang::CSharp` / `Kotlin` / `Swift`) — **no dependency or lockfile changes**. Real node-kinds/fields were probed against each grammar's actual AST, not guessed.

## Per-language model

**C#** (`.cs`) — clean, direct `name` field on every declaration (no name walker):
- Chunks: `class_declaration`→Class, `struct_declaration`→Struct, `interface_declaration`→Interface, `enum_declaration`→Enum, `record_declaration`→Struct, `method_declaration`/`constructor_declaration`→Method.
- Edges: `using_directive`→Imports; `invocation_expression`→Calls (callee `identifier`, or `member_access_expression`→`name` for `obj.Method()`); `base_list` entries→Extends. Skip-list `is_csharp_builtin`.

**Kotlin** (`.kt`, `.kts`) — grammar (tree-sitter-kotlin-sg) exposes **no `name` field**, so a custom name walker reads the unnamed `type_identifier` (types/objects) / `simple_identifier` (functions):
- Chunks: `class_declaration`→Class (covers class/interface/enum), `object_declaration`→Class (named objects; anonymous `companion object` correctly yields no name), `function_declaration`→Function.
- Edges: `import_header`→Imports; `call_expression`→Calls (leading `simple_identifier` callee); `delegation_specifier`→Extends. Skip-list `is_kotlin_builtin` (incl. scope fns `run`/`let`/`apply`).

**Swift** (`.swift`) — `class_declaration` is a **unified node** for class/struct/enum/extension (distinguished by the `declaration_kind` field); protocols are separate. `name` fields exist on all except `init`:
- Chunks: `class_declaration`→Class, `protocol_declaration`→Interface, `function_declaration`→Function, `init_declaration`→Method (named `init` via walker).
- Edges: `import_declaration`→Imports; `call_expression`→Calls (leading `simple_identifier`, or `navigation_expression`→`navigation_suffix` for `self.run()`); `inheritance_specifier`→Extends. Skip-list `is_swift_builtin`.

### Deviations from the clean per-kind pattern (flagged for review)
- **C#, Kotlin, Swift all lack a syntactic distinction between superclass and interface/protocol** in their base/supertype lists (unlike Java's separate `superclass`/`interfaces` fields). All supertypes are therefore modelled as `Extends`, not split into Extends/Implements.
- **Kotlin** has no `name` field at all → custom name walker (both in `node_specs` name extraction and `enclosing_scope`).
- **Swift** overloads `class_declaration` across class/struct/enum/extension → all map to `Class` chunk kind (analogous to Ruby's `call`-node overload in batch 1).

## Test plan
New `crates/spelunk-core/tests/lang_csharp_kotlin_swift.rs` — 7 tests, fixtures per language asserting:
- **Extension detection**: `.cs`→csharp, `.kt`/`.kts`→kotlin, `.swift`→swift.
- **Chunks**: types/protocols/methods/functions/inits captured with correct kind + name for each language.
- **Edges**: imports, user calls (with builtins like `Console.WriteLine`/`println`/`print` correctly skipped), and inheritance/supertype edges.

Gates (all with `SPELUNK_SECRET_STORE=file`):
- `cargo fmt --all --check` — clean
- `cargo clippy -p spelunk-core --all-targets -- -D warnings` — clean (0 warnings)
- `cargo test -p spelunk-core` — **269 passed, 0 failed** (incl. the 7 new tests); pre-existing 16-language specs unchanged and green.

Diff is purely additive (+425 / −0 in source + one new test file); no existing source or spec file touched.