### PR TITLE
ci: add docker ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+
+  # Dev-only (Dockerfile + docker-compose*.yml); manual bumps are easy to forget,
+  # so let Dependabot keep the base image current.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Why

Dependabot already covers `cargo` and `github-actions` here. Docker is only used for local development (root `Dockerfile` + `docker-compose.yml` / `docker-compose.full.yml`), but that's precisely why the base image is easy to forget when updating manually. A little automation keeps it current at no cost.

## What changed

Adds a `docker` ecosystem to `.github/dependabot.yml` (weekly, PR limit 10) — same cadence as the existing entries. `directory: /` covers the root Dockerfile and both compose files.

## Test plan

Config-only. GitHub validates `dependabot.yml` on push; the first docker update run appears under Insights → Dependency graph → Dependabot after merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)