### PR TITLE
security(server): ADR-056 single-trust-domain guardrails (warning + docs)

### DIFF
--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -225,6 +225,10 @@ fn require_embedder(
 // ── Projects ──────────────────────────────────────────────────────────────────
 
 /// List all projects registered on this server.
+///
+/// Enumerates every project on the instance, by design: this server is a
+/// single trust domain (ADR-056) and any valid key is a full administrator of
+/// every project on it, so there is no per-caller filtering to apply here.
 #[utoipa::path(
     get,
     path = "/v1/projects",

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -126,6 +126,16 @@ async fn main() -> Result<()> {
         );
     }
 
+    // Single-trust-domain notice (ADR-056): a keyed, non-loopback bind is a
+    // shared/team server. The shared key is the *only* boundary — every
+    // keyholder is a full administrator of every project on this instance
+    // (list, read, write, supersede, archive, delete). This is intended
+    // behaviour, not a bug; teams that must not see each other's memory need
+    // separate server instances (separate keys, separate databases), not a
+    // per-project ACL on one instance. Loopback binds are a single developer's
+    // own machine, so the notice does not apply there.
+    warn_single_trust_domain(&args.host, api_key.is_some());
+
     // Build the auth provider from the configured key.
     let auth: Arc<dyn spelunk_server::auth::AuthProvider> =
         Arc::new(ApiKeyAuth::new(api_key.clone()));
@@ -312,6 +322,31 @@ fn check_bind_safety(host: &str, key_is_set: bool) -> Result<()> {
         );
     }
     Ok(())
+}
+
+/// Whether a keyed, non-loopback bind is a shared/team server that should get
+/// the ADR-056 single-trust-domain notice: the shared key is the tenancy
+/// boundary, and every keyholder is a full administrator of every project on
+/// the instance — this is intended behaviour, not a defect. `false` for a
+/// loopback bind (a developer's own machine) or when no key is set
+/// (`check_bind_safety` already refuses a keyless non-loopback bind, so in
+/// practice this is never `true` with `key_is_set == false`).
+fn should_warn_single_trust_domain(host: &str, key_is_set: bool) -> bool {
+    !host_is_loopback(host) && key_is_set
+}
+
+/// Emit the ADR-056 single-trust-domain notice (see
+/// `should_warn_single_trust_domain` for the firing condition).
+fn warn_single_trust_domain(host: &str, key_is_set: bool) {
+    if should_warn_single_trust_domain(host, key_is_set) {
+        tracing::warn!(
+            "Shared server: every keyholder can read, modify and permanently delete \
+             ALL projects' memory on this server. This instance is a single trust \
+             domain — the shared key is the only access boundary, not a per-project \
+             one. Run separate servers (separate keys) if you need isolation between \
+             teams or projects. See docs/adr/056-oss-server-tenancy-model.md."
+        );
+    }
 }
 
 // ── Effective UID helper ──────────────────────────────────────────────────────
@@ -607,5 +642,46 @@ mod arg_tests {
             super::normalize_api_key(Some("  secret  ")).as_deref(),
             Some("secret")
         );
+    }
+
+    // ── ADR-056 single-trust-domain notice ──────────────────────────────────
+
+    /// The notice fires for a keyed shared bind (`0.0.0.0` + key) — the
+    /// scenario the ADR calls out: every keyholder is a full administrator of
+    /// every project on the instance, and an operator standing up a shared
+    /// server must be told that explicitly.
+    #[test]
+    fn trust_domain_warning_fires_for_non_loopback_with_key() {
+        for h in ["0.0.0.0", "::", "192.168.1.10", "example.com"] {
+            assert!(
+                super::should_warn_single_trust_domain(h, true),
+                "{h} with a key should trigger the single-trust-domain notice"
+            );
+        }
+    }
+
+    /// The notice is suppressed on loopback (a developer's own machine, not a
+    /// shared deployment) regardless of whether a key is set.
+    #[test]
+    fn trust_domain_warning_suppressed_on_loopback() {
+        for h in ["127.0.0.1", "::1", "localhost"] {
+            assert!(
+                !super::should_warn_single_trust_domain(h, true),
+                "{h} with a key should NOT trigger the notice (loopback)"
+            );
+            assert!(
+                !super::should_warn_single_trust_domain(h, false),
+                "{h} without a key should NOT trigger the notice (loopback)"
+            );
+        }
+    }
+
+    /// The notice is suppressed when no key is set. In practice
+    /// `check_bind_safety` already refuses a keyless non-loopback bind before
+    /// this check runs, but the predicate itself must not fire either way —
+    /// there is no "shared key" boundary to warn about without a key.
+    #[test]
+    fn trust_domain_warning_suppressed_without_key() {
+        assert!(!super::should_warn_single_trust_domain("0.0.0.0", false));
     }
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -41,6 +41,7 @@
           "projects"
         ],
         "summary": "List all projects registered on this server.",
+        "description": "Enumerates every project on the instance, by design: this server is a\nsingle trust domain (ADR-056) and any valid key is a full administrator of\nevery project on it, so there is no per-caller filtering to apply here.",
         "operationId": "list_projects",
         "responses": {
           "200": {

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -10,6 +10,14 @@ network adds is that **TLS becomes mandatory.**
 public or shared-network interface. Put a TLS-terminating reverse proxy in front
 of it and keep the server itself bound to loopback.
 
+> **Trust model.** Everything on the other side of that proxy — every holder of
+> the shared `SPELUNK_SERVER_KEY` — is a full administrator of every project on
+> this server instance; there is no per-project access control. See
+> [Trust model](server.md#trust-model) and
+> [ADR-056](adr/056-oss-server-tenancy-model.md) before sharing a key with more
+> than one mutually-trusting group. If you need isolation between teams, run
+> separate server instances (separate keys), not one shared instance.
+
 > Spelunk does not run your agents. This page is about exposing the *memory +
 > retrieval* server so remote agents can use it as a peer. It is not an agent
 > runtime.

--- a/docs/server.md
+++ b/docs/server.md
@@ -139,10 +139,51 @@ Archived entries are skipped by default; pass `--include-archived` to push them.
 ## Multiple projects
 
 One server instance supports multiple projects. Each project has its own
-namespace — entries from `project_id = "api"` are invisible to clients
-configured with `project_id = "frontend"`.
+*namespace* — entries from `project_id = "api"` are not mixed with entries
+from `project_id = "frontend"`. This is an addressing convenience, **not an
+access-control boundary**: see [Trust model](#trust-model) below.
 
 Projects are auto-created on first write — no registration step required.
+
+`GET /v1/projects` enumerates every project slug on the instance. This is
+intended behaviour, by design — it is not a data leak to be fixed, it follows
+directly from the trust model below.
+
+## Trust model
+
+**A `spelunk-server` instance is a single trust domain.** The shared API key
+(`--key` / `SPELUNK_SERVER_KEY`) is the *only* access boundary the server has.
+It answers exactly one question — "does this bearer token match the
+configured key?" — and nothing more: there is no per-project or per-user
+authorization layer. Concretely, holding a server's key grants **full
+administrator access to every project on that instance**: list, read, search,
+write, supersede, archive, and permanently delete, regardless of which project
+slug a request names.
+
+This is a deliberate decision, not an oversight — see
+[ADR-056](adr/056-oss-server-tenancy-model.md) for the full rationale. The
+project-id in the URL path is an addressing convenience for routing requests
+to the right namespace; it was never a security boundary, and this document
+says so explicitly so no one has to infer it from behaviour.
+
+**What this means for you:**
+
+- A shared/team server is for **one group that already trusts each other** —
+  the same trust you'd extend by giving someone commit access to the repo.
+  Don't put memory for two teams or organisations that must not see each
+  other's data on one instance.
+- **Isolation between teams or projects is achieved by running separate server
+  instances** — each with its own key and its own database — not by relying on
+  project slugs within one instance. Two groups that must not see each other's
+  memory run two servers.
+- The server enforces this at startup: binding to a non-loopback address with
+  a key configured (a shared/team deployment) logs a prominent warning
+  restating exactly this — every keyholder is a full administrator of every
+  project on the instance.
+- If you need per-project or per-user access control within a single
+  instance, this server does not provide it (and is not planned to for
+  v1.0 — see ADR-056's "Revisit if" clause). The managed cloud product
+  provides organization-scoped isolation if you need that instead.
 
 ## Embedding dimension
 

--- a/examples/mdm/README.md
+++ b/examples/mdm/README.md
@@ -79,6 +79,17 @@ That is the whole rollout. No config file is required for the local-only case.
 A long-lived `spelunk-server` holds the team's shared memory, and every laptop
 points at it. This shape uses all three files.
 
+> **Trust model.** A `spelunk-server` instance is a single trust domain: the
+> shared `SPELUNK_SERVER_KEY` is the only access boundary, and every keyholder
+> is a full administrator of every project on that instance — they can list,
+> read, write, supersede, archive, and delete any project's memory, not just
+> their own team's. There is no per-project or per-user ACL. If you are
+> deploying this server to more than one team or organisation that must not see
+> each other's memory, deploy **separate server instances with separate keys**
+> for each — do not put them on one shared instance and rely on project slugs
+> for isolation. See
+> [ADR-056](../../docs/adr/056-oss-server-tenancy-model.md).
+
 Steps:
 
 1. **Install the binaries** on the laptops (as in Shape A) and on the host that


### PR DESCRIPTION
## Summary

Per [ADR-056](docs/adr/056-oss-server-tenancy-model.md) (ratified, merged), a `spelunk-server` instance is a single trust domain: the shared API key is the tenancy boundary, and every keyholder is a full administrator of every project on the instance. Cross-project access via a shared key is intended behaviour, not a defect — but it must be explicit and impossible to stumble into. This PR ships the guardrails ADR-056 calls for.

- **Startup warning:** `spelunk-server` now emits a prominent `tracing::warn!` when it binds a non-loopback address with a key configured (a shared/team deployment), restating that every keyholder can read, modify and permanently delete all projects' memory on the instance and that separate server instances (separate keys) are the way to get isolation. Suppressed on loopback binds and when no key is set.
- **Docs:** adds a "Trust model" section to `docs/server.md`, a pointer from `docs/self-hosting.md`, and a callout in `examples/mdm/README.md`'s shared-server deployment shape — all explaining the single-trust-domain model and linking ADR-056.
- **API docs:** `GET /v1/projects` now documents (utoipa doc comment, regenerated into `docs/openapi.json`) that it enumerates every project on the instance by design.

No handler behavior changes and no new ACL — that's the ratified decision. `GET /v1/health` was already outside the auth middleware (unauthenticated by construction) and needed no change.

## Test plan

- [x] `SPELUNK_SECRET_STORE=file cargo test -p spelunk-server` — all 21 unit tests + 12 integration tests pass, including 3 new tests on the extracted warning predicate:
  - `trust_domain_warning_fires_for_non_loopback_with_key` — fires for `0.0.0.0`, `::`, a LAN IP, and a hostname, all with a key set.
  - `trust_domain_warning_suppressed_on_loopback` — suppressed for `127.0.0.1`/`::1`/`localhost` regardless of key.
  - `trust_domain_warning_suppressed_without_key` — suppressed when no key is configured.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] Manual: `SPELUNK_SECRET_STORE=file cargo run -p spelunk-server -- --host 0.0.0.0 --key test` and confirmed the warning line appears in the startup log; `--host 127.0.0.1 --key test` and confirmed it does not.