### PR TITLE
test(secret-scanner): exercise real generate_summaries via wiremock

### DIFF
--- a/crates/spelunk-cli/tests/secret_scanner.rs
+++ b/crates/spelunk-cli/tests/secret_scanner.rs
@@ -103,70 +103,139 @@ fn docstring_secret_drops_whole_chunk() {
 
 // ── summary secret → summary not persisted/embedded ────────────────────────────
 
+/// Build the SSE body `ServerInferenceClient::llm_complete` expects: one
+/// `data: {"kind":"token",...}` event carrying the whole payload, followed by
+/// a `data: {"kind":"done"}` terminator. See
+/// `crates/spelunk-cli/src/server_client.rs`'s `llm_complete` for the parser
+/// this must satisfy (event boundary = `\n\n`, `data: ` prefix per line).
+fn sse_token_response(content: &str) -> String {
+    format!(
+        "data: {}\n\ndata: {}\n\n",
+        serde_json::json!({"kind": "token", "content": content}),
+        serde_json::json!({"kind": "done"}),
+    )
+}
+
+/// Exercise the *real* `generate_summaries` wiring end-to-end: run `spelunk
+/// index` against a fixture project with `server_url` configured (so
+/// summaries are generated, matching `index_fixture_project`'s mock-server
+/// convention from `plumbing_helpers.rs`/`e2e_cli.rs`/`embed.rs`), but with the
+/// `/llm/complete` endpoint additionally mocked to return a summary containing
+/// a secret. This proves the guard in
+/// `crates/spelunk-cli/src/cli/cmd/index/summaries.rs` — which is `pub(super)`
+/// and otherwise unreachable from this external test file — actually runs and
+/// actually strips the secret, rather than re-testing a hand-written
+/// reimplementation of the same logic.
 #[test]
 fn summary_secret_is_not_persisted() {
-    // Unit-level coverage lives in `crates/spelunk-core/src/indexer/secrets.rs`
-    // for pattern matching. The wiring itself — `generate_summaries` in
-    // `crates/spelunk-cli/src/cli/cmd/index/summaries.rs` runs
-    // `contains_secret(&summary)` before `db.update_chunk_summary` and
-    // substitutes `""` on a match — is exercised here against a real chunks
-    // table (built with the same schema/migrations as production, minus the
-    // sqlite-vec extension which is irrelevant to the `chunks` table).
-    let tmp = TempDir::new().expect("create temp dir");
-    let db_path = tmp.path().join("spelunk.db");
-    let conn = rusqlite::Connection::open(&db_path).expect("create db");
-    conn.execute_batch(include_str!(
-        "../../spelunk-core/migrations/001_initial.sql"
-    ))
+    let tmp = TempDir::new().expect("create temp project dir");
+    let src_dir = tmp.path().join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(
+        src_dir.join("lib.rs"),
+        "pub fn clean_fn(x: i32) -> i32 {\n    x + 1\n}\n",
+    )
     .unwrap();
-    conn.execute_batch(include_str!(
-        "../../spelunk-core/migrations/010_summaries.sql"
-    ))
+    std::fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"summary-secret-fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
     .unwrap();
-    // Note: paths are relative to this test file
-    // (crates/spelunk-cli/tests/secret_scanner.rs), so `../../spelunk-core/...`
-    // resolves to `crates/spelunk-core/...`.
 
-    conn.execute(
-        "INSERT INTO files (path, language, hash, indexed_at) VALUES ('src/lib.rs', 'rust', 'deadbeef', 0)",
-        [],
-    )
-    .unwrap();
-    let file_id = conn.last_insert_rowid();
-    conn.execute(
-        "INSERT INTO chunks (file_id, node_type, name, start_line, end_line, content)
-         VALUES (?1, 'function', 'clean_fn', 1, 3, 'fn clean_fn() {}')",
-        rusqlite::params![file_id],
-    )
-    .unwrap();
-    let chunk_id = conn.last_insert_rowid();
+    let db_tmp = TempDir::new().expect("create temp db dir");
+    let db_path = db_tmp.path().join("spelunk.db");
 
     let secret_summary = format!("Uses aws_secret_access_key = \"{FAKE_AWS_SECRET}\" internally");
 
-    // Mirror the guard added to `generate_summaries`: a secret-bearing
-    // summary is replaced with "" before it is stored.
-    let to_store = if spelunk_core::indexer::secrets::contains_secret(&secret_summary) {
-        ""
-    } else {
-        secret_summary.as_str()
-    };
-    conn.execute(
-        "UPDATE chunks SET summary = ?1 WHERE id = ?2",
-        rusqlite::params![to_store, chunk_id],
-    )
-    .unwrap();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mock_server = rt.block_on(async {
+        use wiremock::matchers::{method, path, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    let stored: Option<String> = conn
-        .query_row(
-            "SELECT summary FROM chunks WHERE id = ?1",
-            [chunk_id],
-            |r| r.get(0),
-        )
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "ok",
+                "version": "test",
+                "capabilities": ["memory", "index.embed", "search.semantic", "explore", "plan"],
+            })))
+            .mount(&server)
+            .await;
+
+        // New Tier 1 index/embed — echoes back constant vectors so parsing/
+        // embedding succeeds and the summary pass is reached.
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+            .respond_with(plumbing_helpers::IndexEmbedResponder)
+            .mount(&server)
+            .await;
+
+        // `/llm/complete` — the real endpoint `generate_summaries` calls via
+        // `ServerLlmAdapter`/`ServerInferenceClient::llm_complete`. Returns a
+        // one-chunk JSON array whose summary contains a fake AWS secret, in
+        // the exact SSE wire format the client parses.
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/llm/complete$"))
+            .respond_with(move |_: &wiremock::Request| {
+                let body = serde_json::json!([{"id": 1, "summary": secret_summary}]).to_string();
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_token_response(&body))
+            })
+            .mount(&server)
+            .await;
+
+        server
+    });
+
+    let mock_url = mock_server.uri();
+    let config_path =
+        plumbing_helpers::write_config_with_server(tmp.path(), &db_path, &mock_url, &mock_url);
+
+    // Run the real `spelunk index` (no `--no-summaries`), same as production:
+    // parse → embed → summary generation, all through `generate_summaries`.
+    plumbing_helpers::spelunk_bin_in(tmp.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg("--db")
+        .arg(&db_path)
+        .arg(tmp.path())
+        .assert()
+        .success();
+
+    // Inspect the DB directly, same rigor as `docstring_secret_drops_whole_chunk`:
+    // the secret must never have landed in `chunks.summary`.
+    let conn = rusqlite::Connection::open(&db_path).expect("open db");
+    let mut stmt = conn.prepare("SELECT summary FROM chunks").unwrap();
+    let summaries: Vec<Option<String>> = stmt
+        .query_map([], |r| r.get(0))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert!(
+        !summaries.is_empty(),
+        "expected at least one chunk to have been indexed"
+    );
+    for s in summaries.iter().flatten() {
+        assert!(
+            !s.contains(FAKE_AWS_SECRET),
+            "secret leaked into chunks.summary via generate_summaries: {s}"
+        );
+    }
+    // The chunk that received the secret-bearing summary must have been
+    // stored as "" (matching the guard's substitution), not left NULL/unset —
+    // proving the real `contains_secret` → `update_chunk_summary("")` path ran.
+    let empty_summary_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM chunks WHERE summary = ''", [], |r| {
+            r.get(0)
+        })
         .unwrap();
     assert_eq!(
-        stored.as_deref(),
-        Some(""),
-        "a secret-bearing summary must be stored as empty, never the secret text"
+        empty_summary_count, 1,
+        "expected exactly one chunk with its secret-bearing summary replaced by \"\""
     );
 }
 


### PR DESCRIPTION
## Summary
- The LLM-summary secret regression test (`summary_secret_is_not_persisted` in `crates/spelunk-cli/tests/secret_scanner.rs`) previously reimplemented the secret-scan guard inline against a hand-built DB, never calling the real `generate_summaries` code path — it would still pass even if the actual guard in `crates/spelunk-cli/src/cli/cmd/index/summaries.rs` were broken or inverted.
- Rewrote the test to run the real `spelunk index` binary end-to-end against a fixture project, with `wiremock` mocking `/v1/health`, `/v1/projects/{id}/index/embed`, and `/v1/projects/{id}/llm/complete` (the real SSE endpoint `generate_summaries` calls), returning a summary containing a fake AWS secret. The test then asserts directly against `chunks.summary` in the DB that the secret never landed, with the same rigor as the existing `docstring_secret_drops_whole_chunk` test.
- Added a `spelunk memory add --kind decision` entry (#134) documenting that the secret scanner is defense-in-depth, not a security boundary, per the original PR #498 handover note.

## Test plan
- [x] Break-and-confirm (QA-independent, in addition to the engineer's own): inverted the guard (`contains_secret` → `!contains_secret`) in `summaries.rs`, reran `cargo test -p spelunk-cli --test secret_scanner` — `summary_secret_is_not_persisted` failed with `secret leaked into chunks.summary via generate_summaries: ...`. Restored the guard; confirmed `git diff`/`git status --porcelain` clean afterward.
- [x] `SPELUNK_SECRET_STORE=file cargo test -p spelunk-core -p spelunk-cli` — all green (secret_scanner.rs: 4/4 pass).
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy -p spelunk-core -p spelunk-cli --all-targets -- -D warnings` — clean.
- [x] Decision memory entry verified: `spelunk memory show 134` (run from `code/spelunk-oss`) returns the expected content, above the prior baseline of #133.
- [x] Scope check: diff touches only `crates/spelunk-cli/tests/secret_scanner.rs`; no internal/business references (public OSS repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)