### PR TITLE
fix(server): constant-time API key comparison in auth.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.4.2",
  "cpufeatures 0.3.0",
 ]
 
@@ -955,6 +955,12 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a1ec0cfec728a79a5109075543131387f911cb4d07716436d7ae20533657a96"
 
 [[package]]
 name = "cookie"
@@ -5180,10 +5186,12 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "blake3",
  "candle-core",
  "candle-nn",
  "candle-transformers",
  "clap",
+ "constant_time_eq 0.5.0",
  "dirs",
  "futures-util",
  "hf-hub",

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -43,6 +43,8 @@ utoipa = { version = "5", features = ["axum_extras"] }
 clap = { version = "4", features = ["derive", "env"] }
 regex = { version = "1", default-features = false, features = ["std"] }
 dirs = "6"
+blake3 = "1"
+constant_time_eq = "0.5"
 candle-core = { version = "0.11.0", optional = true }
 candle-nn = { version = "0.11.0", optional = true }
 candle-transformers = { version = "0.11.0", optional = true }

--- a/crates/spelunk-server/src/auth.rs
+++ b/crates/spelunk-server/src/auth.rs
@@ -30,44 +30,104 @@ pub struct AuthError(pub String);
 
 /// OSS API-key auth provider. Checks for a `Authorization: Bearer <key>` header.
 /// When no key is configured the server accepts all requests (safe on loopback).
+///
+/// The configured key is never held or compared as plaintext after
+/// construction: it is hashed once with BLAKE3 into a fixed-length 32-byte
+/// digest, and per-request comparisons hash the provided token and compare
+/// the two digests in constant time, closing a timing side channel on a
+/// network-exposed server.
 pub struct ApiKeyAuth {
     /// `None` → accept all requests (no key configured; safe on a local loopback).
-    key: Option<String>,
+    key_hash: Option<[u8; 32]>,
 }
 
 impl ApiKeyAuth {
     /// Construct from an explicit key value.
     pub fn new(key: Option<String>) -> Self {
-        Self { key }
+        Self {
+            key_hash: key.map(|k| *blake3::hash(k.as_bytes()).as_bytes()),
+        }
     }
 
     /// Construct from the `SPELUNK_SERVER_KEY` environment variable.
     pub fn from_env() -> Self {
-        Self {
-            key: std::env::var("SPELUNK_SERVER_KEY").ok(),
-        }
+        Self::new(std::env::var("SPELUNK_SERVER_KEY").ok())
     }
 }
 
 #[async_trait::async_trait]
 impl AuthProvider for ApiKeyAuth {
     async fn authenticate(&self, headers: &HeaderMap) -> Result<AuthContext, AuthError> {
-        match &self.key {
+        match &self.key_hash {
             None => Ok(AuthContext {
                 principal: Principal::ApiKey(String::new()),
             }),
-            Some(expected) => {
+            Some(expected_hash) => {
                 let provided = headers
                     .get("Authorization")
                     .and_then(|v| v.to_str().ok())
                     .and_then(|v| v.strip_prefix("Bearer "));
                 match provided {
-                    Some(t) if t == expected => Ok(AuthContext {
-                        principal: Principal::ApiKey(t.to_owned()),
-                    }),
-                    _ => Err(AuthError("Unauthorized".into())),
+                    Some(t) => {
+                        let provided_hash = *blake3::hash(t.as_bytes()).as_bytes();
+                        if constant_time_eq::constant_time_eq_32(expected_hash, &provided_hash) {
+                            Ok(AuthContext {
+                                principal: Principal::ApiKey(t.to_owned()),
+                            })
+                        } else {
+                            Err(AuthError("Unauthorized".into()))
+                        }
+                    }
+                    None => Err(AuthError("Unauthorized".into())),
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with_bearer(token: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+        headers
+    }
+
+    #[tokio::test]
+    async fn accepts_correct_key() {
+        let auth = ApiKeyAuth::new(Some("correct-horse-battery-staple".into()));
+        let headers = headers_with_bearer("correct-horse-battery-staple");
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_ok());
+        match result.unwrap().principal {
+            Principal::ApiKey(k) => assert_eq!(k, "correct-horse-battery-staple"),
+            _ => panic!("expected ApiKey principal"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_key_different_length_and_first_byte() {
+        // Configured key starts with 'c' and is 29 chars; the wrong key
+        // below starts with 'z' (differs at byte 0) and is a different
+        // length, so neither a length short-circuit nor a first-byte
+        // short-circuit would let this slip through undetected.
+        let auth = ApiKeyAuth::new(Some("correct-horse-battery-staple".into()));
+        let headers = headers_with_bearer("zzz-totally-wrong-key");
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn no_key_configured_accepts_all() {
+        let auth = ApiKeyAuth::new(None);
+        let headers = HeaderMap::new();
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_ok());
     }
 }

--- a/crates/spelunk-server/src/auth.rs
+++ b/crates/spelunk-server/src/auth.rs
@@ -130,4 +130,115 @@ mod tests {
         let result = auth.authenticate(&headers).await;
         assert!(result.is_ok());
     }
+
+    #[tokio::test]
+    async fn rejects_missing_authorization_header() {
+        // A key is configured but the request carries no header at all —
+        // distinct code path from a present-but-wrong Bearer token.
+        let auth = ApiKeyAuth::new(Some("correct-horse-battery-staple".into()));
+        let headers = HeaderMap::new();
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_provided_token() {
+        let auth = ApiKeyAuth::new(Some("correct-horse-battery-staple".into()));
+        let headers = headers_with_bearer("");
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_prefix_of_real_key() {
+        // A token that is an exact prefix of the configured key is the
+        // canonical case a naive byte-by-byte compare would leak timing
+        // information on (more matching bytes before the first mismatch).
+        // Hashing first means this has no timing advantage over any other
+        // wrong key.
+        let auth = ApiKeyAuth::new(Some("correct-horse-battery-staple".into()));
+        let headers = headers_with_bearer("correct-horse");
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_key_plus_extra_suffix() {
+        // The inverse of the prefix case: provided token is the real key
+        // with trailing bytes appended.
+        let auth = ApiKeyAuth::new(Some("correct-horse-battery-staple".into()));
+        let headers = headers_with_bearer("correct-horse-battery-staple-extra");
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_same_length_single_byte_difference() {
+        // Same length as the real key, differs only in the last byte —
+        // complements the existing "differs in length and first byte" test
+        // by ruling out any residual length-based or leading-byte shortcut.
+        let auth = ApiKeyAuth::new(Some("correct-horse-battery-staple".into()));
+        let headers = headers_with_bearer("correct-horse-battery-staplE");
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_key_when_configured_key_is_empty() {
+        // Degenerate config: an empty string was configured as the key.
+        // This must still require an exact (empty) match, not silently
+        // behave like "no key configured" (which is represented by `None`,
+        // not `Some("")`).
+        let auth = ApiKeyAuth::new(Some(String::new()));
+        let headers = headers_with_bearer("anything");
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn accepts_empty_key_with_empty_token() {
+        let auth = ApiKeyAuth::new(Some(String::new()));
+        let headers = headers_with_bearer("");
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_very_long_wrong_token() {
+        // Guards against any accidental length-dependent behavior
+        // (e.g. panics, allocation issues) reappearing on large input,
+        // since hashing must handle arbitrary-length tokens uniformly.
+        let auth = ApiKeyAuth::new(Some("correct-horse-battery-staple".into()));
+        let long_wrong = "x".repeat(10_000);
+        let headers = headers_with_bearer(&long_wrong);
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_unicode_token_against_ascii_key() {
+        let auth = ApiKeyAuth::new(Some("correct-horse-battery-staple".into()));
+        let headers = headers_with_bearer("correct-hörse-bättery-staplé");
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_unicode_key_even_with_matching_unicode_token() {
+        // `HeaderValue::to_str()` (called in `authenticate`) rejects any
+        // non-visible-ASCII bytes per RFC 7230, so a raw UTF-8 bearer token
+        // is always unauthenticated — even a byte-for-byte match against a
+        // (pathological) unicode configured key never reaches the digest
+        // compare. Uses `HeaderValue::from_bytes` directly since
+        // `HeaderValue::from_str`/`format!` would panic first on non-ASCII
+        // input, which would only test the test helper, not `authenticate`.
+        let auth = ApiKeyAuth::new(Some("clé-secrète-🔑".into()));
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_bytes("Bearer clé-secrète-🔑".as_bytes()).unwrap(),
+        );
+        let result = auth.authenticate(&headers).await;
+        assert!(result.is_err());
+    }
 }

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -130,7 +130,7 @@ docker-compose's `${SPELUNK_SERVER_KEY:-}` default — is treated as no key.)
 
 | Threat | Mode | Likelihood | Impact | Mitigation |
 |--------|------|-----------|--------|-----------|
-| Client impersonates a legitimate spelunk user to the server | B | Medium | High | Bearer token auth — but **optional**; server runs unauthenticated by default. Operators must explicitly pass `--api-key`. |
+| Client impersonates a legitimate spelunk user to the server | B | Medium | High | Bearer token auth — but **optional**; server runs unauthenticated by default. Operators must explicitly pass `--key` / `SPELUNK_SERVER_KEY`. |
 | Attacker spoofs the embedding/LLM backend to return adversarial responses | A | Low | Medium | No server certificate validation is documented; if `api_base_url` is remote and HTTP (not HTTPS), responses can be intercepted. Recommend HTTPS for any non-localhost backend. |
 
 ### T — Tampering
@@ -156,7 +156,7 @@ docker-compose's `${SPELUNK_SERVER_KEY:-}` default — is treated as no key.)
 | Credentials in source code indexed into vector DB | A | Medium | High | `secrets.rs` scanner drops matching chunks before storage; `.env*`/`*.pem`/`*.key` files excluded |
 | **Source code sent to third-party embedding service** | A | **High** | **High** | **No mitigation in spelunk itself.** If `api_base_url` points to a cloud service, every indexed chunk (post-secret-scan) is transmitted. Users must be informed via docs. |
 | **Memory notes sent to third-party LLM** | A | **Medium** | **High** | **No mitigation in spelunk itself.** `spelunk ask` and `memory harvest` send memory content + code context to the configured LLM endpoint. |
-| Server memory accessible without auth | B | Medium | High | No `--api-key` by default; any process that can reach the port reads all notes |
+| Server memory accessible without auth | B | Medium | High | No `--key` / `SPELUNK_SERVER_KEY` by default; any process that can reach the port reads all notes |
 | Server bound to 0.0.0.0 exposes data on LAN/internet | B | Medium | High | **Enforced:** a non-loopback bind requires a key — `spelunk-server` refuses to start on `0.0.0.0`/LAN/public addresses without `--key` / `SPELUNK_SERVER_KEY`; loopback (`127.0.0.1`) is the default (spelunk-oss^52 / PR #490) |
 | Indexed content contains credentials missed by scanner | A | Medium | Medium | Pattern gaps tracked in #138 |
 | CLI bearer credential (`server_key`) readable as plaintext at rest (e.g. user syncs `~/.config` into a dotfiles repo or backup) | A | Medium | High | The `server_key` is stored in the OS keychain (macOS Keychain / Linux Secret Service / Windows Credential Manager), not in `config.toml`; a legacy plaintext key is migrated out and stripped on next run. Headless fallback is an owner-only (`0600`) `secrets.toml`; `SPELUNK_SERVER_KEY` is the CI escape hatch. The credential is never logged. |
@@ -326,6 +326,6 @@ From this threat model, the following requirements are binding:
 3. **LLM context must use XML delimiters** with angle-bracket escaping of all retrieved content (issue #137).
 4. **Atomic transactions for memory state transitions** — `supersede()` and `insert_with_supersession()` (issue #136).
 5. **CI must gate on `cargo audit` and `cargo deny`.**
-6. **spelunk-server documentation must warn** that the server is unauthenticated by default and should only be exposed beyond localhost when `--api-key` is set.
+6. **spelunk-server documentation must warn** that the server is unauthenticated by default and should only be exposed beyond localhost when `--key` / `SPELUNK_SERVER_KEY` is set.
 7. **Config documentation must warn** that setting `api_base_url` to a non-local address transmits source code and memory content to that endpoint.
 8. **Secret scanner must run on the git-notes write-through path.** `add.rs` must call `contains_secret(body)` (and optionally `contains_secret(title)`) before calling `append_to_git_notes()`. If a match is found, the git-notes write must be skipped (with a `tracing::warn!`) and the primary SQLite write must still succeed. This closes the gap identified in the [git-notes memory](#git-notes-memory-prref-notespelunk) section above. **This is a binding requirement for any release with `store_in_git_notes = true` as the default.**

--- a/docs/security/V1-SERVER-AUDIT.md
+++ b/docs/security/V1-SERVER-AUDIT.md
@@ -25,6 +25,10 @@ The CLI threat model (`THREAT-MODEL.md`) remains valid for the CLI crate. This d
 |---|---|
 | API key stored as BLAKE3 hash — plaintext never persisted | ☐ |
 | Key comparison uses constant-time equality (not `==` on strings) | ☐ |
+<!-- spelunk-oss^58 (PR #502, draft): ApiKeyAuth now hashes the configured key with BLAKE3 at
+     construction and compares per-request tokens via constant_time_eq_32 on the two 32-byte
+     digests — the two rows above are implemented in crates/spelunk-server/src/auth.rs. Sign-off
+     (✅ + initials/date) still owned by whoever closes oss^66. -->
 | `sk-sp-` prefix format validated before any DB lookup | ☐ |
 | Revoked/deleted keys rejected immediately (no cache window) | ☐ |
 | Key scope enforced: project-scoped key cannot write to other projects | ☐ |


### PR DESCRIPTION
## Summary
- `ApiKeyAuth` previously compared the bearer token against the configured key with `t == expected` on `&str` — a non-constant-time comparison that short-circuits on length and on the first differing byte, a timing side channel on a network-exposed server. The plaintext key was also held for the lifetime of the process.
- `ApiKeyAuth` now stores only a BLAKE3 digest (`[u8; 32]`) of the configured key, computed once at construction. Per request, the provided token is hashed the same way and the two fixed-length digests are compared with `constant_time_eq::constant_time_eq_32`, removing both the length-based and first-byte-based early-return channels.
- No-key (loopback/unauthenticated) behavior is unchanged: `key_hash: None` still accepts all requests.
- Fixed doc drift in `docs/security/THREAT-MODEL.md`: three references to a `--api-key` flag corrected to the real `--key` / `SPELUNK_SERVER_KEY` flag/env var used by `spelunk-server`.
- Added `blake3` and `constant_time_eq` to `crates/spelunk-server/Cargo.toml`.

## Test plan
1. `SPELUNK_SECRET_STORE=file cargo test -p spelunk-server` — 71 passed, 0 failed, 3 ignored (model-download tests unrelated to this change). Includes 3 new unit tests in `auth.rs`:
   - `accepts_correct_key` — correct bearer token is authenticated.
   - `rejects_wrong_key_different_length_and_first_byte` — a wrong key that differs in both length and first byte from the configured key is rejected (rules out any accidental short-circuit).
   - `no_key_configured_accepts_all` — loopback default behavior (no key configured) is preserved.
   - Existing integration tests `protected_endpoint_rejects_missing_token` / `protected_endpoint_accepts_correct_token` in `tests/integration_server.rs` still pass unchanged.
2. `cargo fmt --check` — clean.
3. `SPELUNK_SECRET_STORE=file cargo clippy -p spelunk-server --all-targets -- -D warnings` — clean.
4. Independently re-verified by QA: re-ran the full `spelunk-server` test suite, `cargo fmt --check`, and `cargo clippy -p spelunk-server --all-targets -- -D warnings` against this branch — all green.

## Update (test-engineer + docs-writer pass, post-initial-QA)
- **test-engineer** added 10 more unit tests covering the timing-attack-relevant edge cases the original 3 didn't exercise: missing header, empty token, prefix-of-real-key, key-plus-suffix, same-length single-byte diff, empty configured key (vs `None`), 10k-char token, and unicode token/key (documents a pre-existing `HeaderValue::to_str()` ASCII-only rejection, not a regression). `auth.rs` now has 13 unit tests; full suite is 81 passed / 0 failed / 3 ignored (unrelated model-download tests).
- **docs-writer** confirmed no remaining `--api-key` references anywhere in `docs/`, recorded memory decision #135, and added a cross-reference note in `docs/security/V1-SERVER-AUDIT.md` §2 pointing at this PR (checklist sign-off left to oss^66, which owns that audit doc).
- **QA (final re-review):** re-ran `SPELUNK_SECRET_STORE=file cargo test -p spelunk-server` (81 passed), `cargo fmt --check` (clean), `cargo clippy --all-targets -- -D warnings` (clean) independently against the final branch state. Diff, tests, and docs all reviewed. Approved — marking ready for review.
