### PR TITLE
Fix argument injection in `spelunk memory harvest` git-log calls

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -9,6 +9,32 @@ use crate::{
     storage::{NoteInput, open_memory_backend},
 };
 
+/// Reject a `--branch` / `--git-range` value that could be parsed by `git log`
+/// as an option rather than a revision (argument-injection / option-injection
+/// guard).
+///
+/// Every callsite in this file already appends a `--` separator before the
+/// pathspec position, which stops git from treating the ref as an option to
+/// `git log` itself; this check is defense-in-depth for revision walkers
+/// (like `A..B` ranges) where a leading `-` component can still be
+/// misinterpreted, and it gives a clear, immediate error instead of relying
+/// solely on the separator.
+fn reject_option_like_ref(git_ref: &str) -> Result<()> {
+    let is_option_like = |s: &str| s.starts_with('-') && s != "-";
+    let offending = git_ref
+        .split("..")
+        .find(|part| is_option_like(part))
+        .or_else(|| is_option_like(git_ref).then_some(git_ref));
+
+    if let Some(bad) = offending {
+        anyhow::bail!(
+            "Invalid --branch/--git-range value '{bad}': refs beginning with '-' are rejected \
+             to prevent them from being interpreted as git options."
+        );
+    }
+    Ok(())
+}
+
 pub(super) async fn memory_harvest(
     args: MemoryHarvestArgs,
     mem_path: &std::path::Path,
@@ -65,8 +91,10 @@ async fn memory_harvest_git(
         None => (args.git_range.clone(), format!("'{}'", args.git_range)),
     };
 
+    reject_option_like_ref(&git_ref)?;
+
     let git_out = std::process::Command::new("git")
-        .args(["log", &git_ref, "--format=%H%x00%s%x00%b%x00---"])
+        .args(["log", &git_ref, "--format=%H%x00%s%x00%b%x00---", "--"])
         .output()
         .context("running git log (is git installed and are we in a git repo?)")?;
 
@@ -458,8 +486,10 @@ async fn memory_harvest_failures(
         None => format!("'{git_ref}'"),
     };
 
+    reject_option_like_ref(&git_ref)?;
+
     let git_out = std::process::Command::new("git")
-        .args(["log", &git_ref, "--format=%H%x00%s%x00%b%x00---"])
+        .args(["log", &git_ref, "--format=%H%x00%s%x00%b%x00---", "--"])
         .output()
         .context("running git log")?;
     if !git_out.status.success() {
@@ -784,4 +814,29 @@ fn is_failure_subject(subject: &str) -> bool {
         "stack overflow",
     ];
     failure_signals.iter().any(|p| s.contains(p))
+}
+
+#[cfg(test)]
+mod option_injection_guard_tests {
+    use super::reject_option_like_ref;
+
+    #[test]
+    fn accepts_ordinary_refs_and_ranges() {
+        assert!(reject_option_like_ref("main").is_ok());
+        assert!(reject_option_like_ref("HEAD~10..HEAD").is_ok());
+        assert!(reject_option_like_ref("feature/foo..main").is_ok());
+        assert!(reject_option_like_ref("-").is_ok());
+    }
+
+    #[test]
+    fn rejects_option_like_branch() {
+        let err = reject_option_like_ref("--output=/tmp/x").unwrap_err();
+        assert!(err.to_string().contains("--output=/tmp/x"));
+    }
+
+    #[test]
+    fn rejects_option_like_range_endpoint() {
+        assert!(reject_option_like_ref("--output=/tmp/x..HEAD").is_err());
+        assert!(reject_option_like_ref("HEAD..--output=/tmp/x").is_err());
+    }
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -839,4 +839,57 @@ mod option_injection_guard_tests {
         assert!(reject_option_like_ref("--output=/tmp/x..HEAD").is_err());
         assert!(reject_option_like_ref("HEAD..--output=/tmp/x").is_err());
     }
+
+    /// A ref that is exactly the `--` end-of-options marker. It starts with
+    /// `-` and is not the single-char `-` literal, so it is rejected like any
+    /// other option-like value — it must not be special-cased into an accept,
+    /// since `git log -- --` is ambiguous/nonsensical as a revision anyway.
+    #[test]
+    fn rejects_bare_double_dash() {
+        assert!(reject_option_like_ref("--").is_err());
+    }
+
+    /// Short numeric-looking options (`git log -1`, `-n5`, etc.) must be
+    /// rejected too, not just long `--flag=value` forms — the guard checks
+    /// only the leading `-`, so this should already hold, but it's worth
+    /// pinning explicitly since `-1`/`-n` are among the most common ways to
+    /// accidentally (or maliciously) alter `git log`'s behavior.
+    #[test]
+    fn rejects_short_option_like_refs() {
+        assert!(reject_option_like_ref("-1").is_err());
+        assert!(reject_option_like_ref("-n5").is_err());
+        assert!(reject_option_like_ref("-p").is_err());
+    }
+
+    /// A very long option-like value must still be rejected (no length-based
+    /// bypass / no truncation before the check).
+    #[test]
+    fn rejects_long_option_like_ref() {
+        let long_val = format!("--output={}", "a".repeat(4096));
+        assert!(reject_option_like_ref(&long_val).is_err());
+    }
+
+    /// Refs containing shell metacharacters are not shell-parsed anywhere in
+    /// this codebase (git is always spawned via argv, never a shell), so
+    /// these are harmless from a shell-injection standpoint — but they must
+    /// still pass straight through unless they are *also* option-like
+    /// (leading `-`), proving the guard is narrowly scoped to option-shape
+    /// and doesn't accidentally reject or mangle legitimate-looking (if
+    /// unusual) ref/range strings.
+    #[test]
+    fn shell_metacharacters_alone_do_not_trigger_rejection() {
+        assert!(reject_option_like_ref("feature/$(whoami)").is_ok());
+        assert!(reject_option_like_ref("a;b|c&d").is_ok());
+        assert!(reject_option_like_ref("main..feature`x`").is_ok());
+    }
+
+    /// Combining a leading dash with shell metacharacters must still be
+    /// rejected via the option-like check (belt-and-braces: even though argv
+    /// spawning means these can't reach a shell, the leading `-` alone is
+    /// sufficient grounds for rejection).
+    #[test]
+    fn rejects_option_like_ref_with_shell_metacharacters() {
+        assert!(reject_option_like_ref("--output=/tmp/x;rm -rf /").is_err());
+        assert!(reject_option_like_ref("-$(whoami)").is_err());
+    }
 }

--- a/crates/spelunk-cli/tests/harvest_ref_injection.rs
+++ b/crates/spelunk-cli/tests/harvest_ref_injection.rs
@@ -1,0 +1,117 @@
+//! Regression test for the `spelunk memory harvest` argument-injection guard
+//! (security review finding: `--branch`/`--git-range` values starting with
+//! `-` must never reach `git log` as an option — see
+//! `crates/spelunk-cli/src/cli/cmd/memory/harvest.rs::reject_option_like_ref`).
+//!
+//! A malicious value like `--branch=--output=/tmp/x` must be rejected with a
+//! clear error before any `git` subprocess runs, and must never create or
+//! overwrite the target file.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
+use predicates::prelude::*;
+use std::fs;
+use std::process::Command as StdCommand;
+use tempfile::tempdir;
+
+fn write_harvest_config(dir: &std::path::Path, extra: &str) -> std::path::PathBuf {
+    let db_path = dir.join("memory.db");
+    let config_path = dir.join("config.toml");
+    let content = format!(
+        "db_path = {:?}\napi_base_url = \"http://127.0.0.1:1234\"\n{extra}",
+        db_path
+    );
+    fs::write(&config_path, content).expect("write config.toml");
+    config_path
+}
+
+/// Initialize a throwaway git repo with a single commit so a real HEAD exists.
+fn init_repo(dir: &std::path::Path) {
+    let run = |args: &[&str]| {
+        let status = StdCommand::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    run(&["init", "-q"]);
+    run(&["config", "user.email", "test@example.com"]);
+    run(&["config", "user.name", "Test"]);
+    fs::write(dir.join("README.md"), "hello\n").unwrap();
+    run(&["add", "."]);
+    run(&["commit", "-q", "-m", "initial commit"]);
+}
+
+#[test]
+fn harvest_rejects_option_like_branch_and_does_not_touch_victim_file() {
+    let temp = tempdir().unwrap();
+    init_repo(temp.path());
+
+    // Victim file elsewhere on disk that a successful `--output=` injection
+    // would create/overwrite via `git log --output=<path>`.
+    let victim_dir = tempdir().unwrap();
+    let victim_path = victim_dir.path().join("victim.txt");
+    assert!(!victim_path.exists());
+
+    let config_path = write_harvest_config(
+        temp.path(),
+        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
+    );
+
+    let malicious_branch_arg = format!("--branch=--output={}", victim_path.display());
+
+    let mut cmd = spelunk_bin();
+    cmd.current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .env_remove("SPELUNK_MEMORY_SERVER_URL")
+        .env_remove("SPELUNK_LLM_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("harvest")
+        .arg(&malicious_branch_arg);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("rejected").or(predicate::str::contains("Invalid")));
+
+    assert!(
+        !victim_path.exists(),
+        "option-injection via --branch must not create the victim file"
+    );
+}
+
+#[test]
+fn harvest_rejects_option_like_git_range() {
+    let temp = tempdir().unwrap();
+    init_repo(temp.path());
+
+    let victim_dir = tempdir().unwrap();
+    let victim_path = victim_dir.path().join("victim2.txt");
+
+    let config_path = write_harvest_config(
+        temp.path(),
+        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
+    );
+
+    let malicious_range_arg = format!("--git-range=--output={}", victim_path.display());
+
+    let mut cmd = spelunk_bin();
+    cmd.current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .env_remove("SPELUNK_MEMORY_SERVER_URL")
+        .env_remove("SPELUNK_LLM_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("harvest")
+        .arg(&malicious_range_arg);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("rejected").or(predicate::str::contains("Invalid")));
+
+    assert!(!victim_path.exists());
+}

--- a/crates/spelunk-cli/tests/harvest_ref_injection.rs
+++ b/crates/spelunk-cli/tests/harvest_ref_injection.rs
@@ -115,3 +115,102 @@ fn harvest_rejects_option_like_git_range() {
 
     assert!(!victim_path.exists());
 }
+
+/// Short option-shaped refs (e.g. `-1`, mimicking `git log -1`) must be
+/// rejected too, not just long `--flag=value` forms. Regression coverage
+/// for the "short option that looks like a legitimate-ish ref" edge case.
+#[test]
+fn harvest_rejects_short_option_like_branch() {
+    let temp = tempdir().unwrap();
+    init_repo(temp.path());
+
+    let config_path = write_harvest_config(
+        temp.path(),
+        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
+    );
+
+    let mut cmd = spelunk_bin();
+    cmd.current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .env_remove("SPELUNK_MEMORY_SERVER_URL")
+        .env_remove("SPELUNK_LLM_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("harvest")
+        .arg("--branch=-1");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("rejected").or(predicate::str::contains("Invalid")));
+}
+
+/// A ref value that is exactly the `--` end-of-options marker must be
+/// rejected (not silently accepted or treated as a no-op separator).
+#[test]
+fn harvest_rejects_bare_double_dash_branch() {
+    let temp = tempdir().unwrap();
+    init_repo(temp.path());
+
+    let config_path = write_harvest_config(
+        temp.path(),
+        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
+    );
+
+    let mut cmd = spelunk_bin();
+    cmd.current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .env_remove("SPELUNK_MEMORY_SERVER_URL")
+        .env_remove("SPELUNK_LLM_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("harvest")
+        .arg("--branch=--");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("rejected").or(predicate::str::contains("Invalid")));
+}
+
+/// A ref value starting with `-` but containing shell metacharacters must
+/// still be rejected by the option-like guard (belt-and-braces: no shell is
+/// ever involved since git is spawned via argv, but the leading `-` alone is
+/// grounds for rejection, and this pins that no metacharacter-based bypass
+/// exists).
+#[test]
+fn harvest_rejects_option_like_branch_with_shell_metacharacters() {
+    let temp = tempdir().unwrap();
+    init_repo(temp.path());
+
+    let victim_dir = tempdir().unwrap();
+    let victim_path = victim_dir.path().join("victim3.txt");
+
+    let config_path = write_harvest_config(
+        temp.path(),
+        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
+    );
+
+    let malicious_branch_arg = format!(
+        "--branch=--output={};touch /tmp/oss61-pwned",
+        victim_path.display()
+    );
+
+    let mut cmd = spelunk_bin();
+    cmd.current_dir(temp.path())
+        .env_remove("SPELUNK_SERVER_URL")
+        .env_remove("SPELUNK_MEMORY_SERVER_URL")
+        .env_remove("SPELUNK_LLM_URL")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("harvest")
+        .arg(&malicious_branch_arg);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("rejected").or(predicate::str::contains("Invalid")));
+
+    assert!(!victim_path.exists());
+    assert!(!std::path::Path::new("/tmp/oss61-pwned").exists());
+}

--- a/crates/spelunk-core/src/storage/git_notes/backend_impl.rs
+++ b/crates/spelunk-core/src/storage/git_notes/backend_impl.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashSet;
 
@@ -30,15 +30,7 @@ impl MemoryBackend for GitNotesBackend {
         let json = serde_json::to_string(&record)?;
         let head = self.head_sha().await?;
 
-        let status = self
-            .git()
-            .args(["notes", "--ref=spelunk", "add", "-f", "-m", &json, &head])
-            .status()
-            .await?;
-
-        if !status.success() {
-            return Err(anyhow!("git notes add failed"));
-        }
+        self.add_note_stdin(&head, &json).await?;
 
         Ok(id)
     }
@@ -95,12 +87,7 @@ impl MemoryBackend for GitNotesBackend {
             {
                 record.status = "archived".to_string();
                 let json = serde_json::to_string(&record)?;
-                let status = self
-                    .git()
-                    .args(["notes", "--ref=spelunk", "add", "-f", "-m", &json, &sha])
-                    .status()
-                    .await?;
-                return Ok(status.success());
+                return Ok(self.add_note_stdin(&sha, &json).await.is_ok());
             }
         }
         Ok(false)

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -1,5 +1,7 @@
 use anyhow::{Result, anyhow};
 use std::collections::HashSet;
+use std::process::Stdio;
+use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
 use super::memory::Note;
@@ -34,7 +36,7 @@ pub async fn append_to_git_notes(
         .map(|s| s.trim().to_string())?;
 
     // ── 2. Read existing note (may not exist) ─────────────────────────────────
-    let existing = run_git(git_root, &["notes", "--ref=spelunk", "show", &head])
+    let existing = run_git(git_root, &["notes", "--ref=spelunk", "show", "--", &head])
         .await
         .unwrap_or_default();
 
@@ -48,17 +50,26 @@ pub async fn append_to_git_notes(
     };
 
     // ── 4. Write back ─────────────────────────────────────────────────────────
-    run_git(
+    // The note body is passed via stdin (`-F -`) rather than as a `-m` argv
+    // value: this keeps arbitrary/attacker-influenced note content off the
+    // process argv (and therefore out of `ps`/process-list visibility) and
+    // means the body can never be misparsed as an option, regardless of its
+    // contents. `--` guards the trailing `<object>` (HEAD sha) so it can't be
+    // interpreted as an option either, even though `head` is always a
+    // `rev-parse`-verified sha here.
+    run_git_with_stdin(
         git_root,
         &[
             "notes",
             "--ref=spelunk",
             "add",
             "-f",
-            "-m",
-            &combined,
+            "-F",
+            "-",
+            "--",
             &head,
         ],
+        &combined,
     )
     .await?;
 
@@ -73,6 +84,44 @@ async fn run_git(dir: Option<&std::path::Path>, args: &[&str]) -> Result<String>
         cmd.current_dir(d);
     }
     let out = cmd.args(args).output().await?;
+    if out.status.success() {
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    } else {
+        Err(anyhow!(
+            "git {}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ))
+    }
+}
+
+/// Run a git subprocess, optionally in `dir`, writing `stdin_data` to its
+/// stdin and returning stdout as a `String`. Used with `-F -` invocations so
+/// note bodies never appear on argv.
+async fn run_git_with_stdin(
+    dir: Option<&std::path::Path>,
+    args: &[&str],
+    stdin_data: &str,
+) -> Result<String> {
+    let mut cmd = Command::new("git");
+    if let Some(d) = dir {
+        cmd.current_dir(d);
+    }
+    cmd.args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn()?;
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("failed to open stdin for git {}", args.join(" ")))?;
+        stdin.write_all(stdin_data.as_bytes()).await?;
+        // Drop closes stdin so git sees EOF.
+    }
+    let out = child.wait_with_output().await?;
     if out.status.success() {
         Ok(String::from_utf8_lossy(&out.stdout).into_owned())
     } else {
@@ -150,6 +199,45 @@ impl GitNotesBackend {
         }
     }
 
+    /// Write a spelunk note body to `object` via `git notes add -f -F - --
+    /// <object>`, passing `body` over stdin. Keeps note content (which may
+    /// contain arbitrary user/LLM text) off argv, and the `--` separator
+    /// stops `object` from being parsed as an option.
+    async fn add_note_stdin(&self, object: &str, body: &str) -> Result<()> {
+        let mut cmd = self.git();
+        cmd.args([
+            "notes",
+            "--ref=spelunk",
+            "add",
+            "-f",
+            "-F",
+            "-",
+            "--",
+            object,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn()?;
+        {
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| anyhow!("failed to open stdin for git notes add"))?;
+            stdin.write_all(body.as_bytes()).await?;
+        }
+        let out = child.wait_with_output().await?;
+        if out.status.success() {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "git notes add failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ))
+        }
+    }
+
     async fn head_sha(&self) -> Result<String> {
         Ok(self.run(&["rev-parse", "HEAD"]).await?.trim().to_string())
     }
@@ -200,7 +288,7 @@ impl GitNotesBackend {
     async fn read_record(&self, commit_sha: &str) -> Result<Option<NoteRecord>> {
         let out = self
             .git()
-            .args(["notes", "--ref=spelunk", "show", commit_sha])
+            .args(["notes", "--ref=spelunk", "show", "--", commit_sha])
             .output()
             .await?;
 

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -371,3 +371,125 @@ async fn append_to_git_notes_returns_err_outside_git_repo() {
     let result = append_to_git_notes(Some(non_git_dir.path()), &record).await;
     assert!(result.is_err(), "should return Err when not in a git repo");
 }
+
+// ── security regression: note bodies must go via stdin, never argv ──────────
+//
+// oss^61: `git notes add` used to receive the note body as a `-m <arg>` argv
+// value. A body that itself looked like a git option (e.g. starting with `-`)
+// could previously be misparsed as an option to `git notes add` rather than
+// literal note content. These tests prove (a) option-like / metacharacter-
+// laden bodies round-trip as *literal* note text rather than being
+// interpreted or truncated, which is only possible if they're delivered via
+// stdin (`-F -`) rather than argv (`-m`), and (b) the same holds for
+// `GitNotesBackend::add`/`archive`, which route through `add_note_stdin`.
+
+/// A note body that is itself option-shaped (starts with `-`) must be stored
+/// and read back byte-for-byte, not interpreted as a `git notes add` option
+/// or truncated. This would fail (or `git notes add` would error/misbehave)
+/// if the body were still passed via `-m <body>` on argv.
+#[tokio::test]
+#[serial]
+async fn append_to_git_notes_body_starting_with_dash_is_literal() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    let mut record = make_note_record(1, "dash body");
+    record.body = "--force-with-lease=origin/main --output=/tmp/pwned".to_string();
+
+    append_to_git_notes(Some(root), &record)
+        .await
+        .expect("append should succeed even with option-like body");
+
+    let out = std::process::Command::new("git")
+        .args(["notes", "--ref=spelunk", "show", "HEAD"])
+        .current_dir(root)
+        .output()
+        .expect("git notes show");
+    assert!(out.status.success(), "note should exist on HEAD");
+
+    let text = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(text.trim()).expect("note should be valid JSON");
+    assert_eq!(
+        parsed["body"].as_str().unwrap(),
+        "--force-with-lease=origin/main --output=/tmp/pwned",
+        "option-like body must round-trip literally, proving it was never argv-parsed"
+    );
+
+    // The exploit this guards against: if the body had leaked onto argv as an
+    // option value or been split by the shell/argv parser, it could reach
+    // paths outside the repo. Confirm no such file was created as a side
+    // effect of writing this note.
+    assert!(
+        !std::path::Path::new("/tmp/pwned").exists(),
+        "option-like note body must never be interpreted as a git option"
+    );
+    let _ = std::fs::remove_file("/tmp/pwned");
+}
+
+/// A note body containing shell metacharacters must round-trip untouched.
+/// All git spawns in this codebase use argv vectors (no shell), so this is
+/// defense-in-depth / regression coverage rather than a shell-injection PoC.
+#[tokio::test]
+#[serial]
+async fn append_to_git_notes_body_with_shell_metacharacters_is_literal() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    let mut record = make_note_record(2, "metachar body");
+    record.body = "$(rm -rf /); `echo pwned`; a && b || c; a | b > /tmp/x; a; b\nnewline".into();
+
+    append_to_git_notes(Some(root), &record)
+        .await
+        .expect("append should succeed with shell-metacharacter body");
+
+    let out = std::process::Command::new("git")
+        .args(["notes", "--ref=spelunk", "show", "HEAD"])
+        .current_dir(root)
+        .output()
+        .expect("git notes show");
+    assert!(out.status.success());
+
+    let text = String::from_utf8_lossy(&out.stdout);
+    // Body is one line of a `\n`-joined ledger; find the JSON line for id=2.
+    let line = text
+        .lines()
+        .find(|l| l.contains("\"id\":2"))
+        .expect("record for id=2 present");
+    let parsed: serde_json::Value = serde_json::from_str(line).expect("valid JSON line");
+    assert_eq!(
+        parsed["body"].as_str().unwrap(),
+        "$(rm -rf /); `echo pwned`; a && b || c; a | b > /tmp/x; a; b\nnewline",
+        "shell-metacharacter body must round-trip literally"
+    );
+}
+
+/// `GitNotesBackend::add` (used by the `MemoryBackend` trait impl, i.e. the
+/// `spelunk memory add` path) also writes via `add_note_stdin`. Confirm an
+/// option-like note title/body round-trips literally through that path too —
+/// not just through the lower-level `append_to_git_notes` free function.
+#[tokio::test]
+#[serial]
+async fn git_notes_backend_add_with_option_like_body_round_trips() {
+    let dir = make_temp_git_repo();
+    let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
+
+    let mut input = note_input("decision", "--amend");
+    input.body = "-f --force --output=/tmp/should-not-exist-oss61".to_string();
+
+    let id = backend.add(input).await.expect("add");
+
+    let notes = backend
+        .list(Some("decision"), 10, false, None)
+        .await
+        .expect("list");
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].id, id);
+    assert_eq!(notes[0].title, "--amend");
+    assert_eq!(
+        notes[0].body, "-f --force --output=/tmp/should-not-exist-oss61",
+        "option-like body must round-trip literally via GitNotesBackend::add"
+    );
+
+    assert!(!std::path::Path::new("/tmp/should-not-exist-oss61").exists());
+}

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -250,6 +250,8 @@ spelunk memory harvest --git-range v1.0..HEAD
 
 Already-harvested commits are skipped (tracked via a `git:<sha>` tag). Routine commits ("fix typo", "wip", etc.) are ignored by the LLM.
 
+`--branch` and `--git-range` values (or either endpoint of an `A..B` range) that start with `-` are rejected before reaching `git`, with a clear error — this prevents a malformed or attacker-controlled ref from being parsed as a `git log` option.
+
 ### Automatic harvesting
 
 Install the git hook and harvesting happens on every commit:

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -168,6 +168,7 @@ docker-compose's `${SPELUNK_SERVER_KEY:-}` default — is treated as no key.)
 | Threat | Mode | Likelihood | Impact | Mitigation |
 |--------|------|-----------|--------|-----------|
 | Path traversal via project_id or note body to read arbitrary server files | B | Low | High | project_id is a DB-assigned integer; note body is stored as-is but never executed. No file reads from user input. |
+| Git argument injection via `spelunk memory harvest --branch`/`--git-range` (e.g. `--branch=--output=<path>`) forwarded to `git log` with no `--` separator, letting an option-shaped value be parsed as a git flag instead of a ref (arbitrary local file clobber) | A | Low | Medium | Fixed: `reject_option_like_ref()` rejects any ref, or either endpoint of an `A..B` range, starting with `-` before the subprocess spawns; both `git log` invocations also append a trailing `--` separator as defense-in-depth. Same review applied to the git-notes write path (`git_notes/mod.rs`): all `<object>` args to `notes show`/`add` are `--`-guarded, and note bodies are written via stdin (`-F -`) instead of `-m <arg>`, so a body can't be argv-parsed as an option or exposed on `ps`. |
 
 ### D — Denial of Service
 


### PR DESCRIPTION
## Summary
- `memory_harvest_git` and `memory_harvest_failures` built `git log <ref> --format=...` from a `--branch`/`--git-range` value with no `--` separator, so a value like `--output=/path/to/victim` was parsed by git as an option (e.g. `git log --output=<file>`), letting a crafted CLI arg overwrite/truncate an arbitrary file.
- Added `reject_option_like_ref()` in `crates/spelunk-cli/src/cli/cmd/memory/harvest.rs`, called before either `git log` invocation, which rejects any ref (or range endpoint on either side of `..`) starting with `-` (except the literal `-`) with a clear error, before a `git` subprocess is ever spawned.
- Both `git log` call sites now also append a trailing `--` separator as belt-and-braces defense-in-depth.
- Applied the same review to the git-notes write path (`crates/spelunk-core/src/storage/git_notes/mod.rs`, `backend_impl.rs`): note bodies are now written via stdin (`-F -`) instead of `-m <arg>`, so arbitrary note content can never be argv-parsed as an option and no longer appears in `ps`/process listings; all `<object>` args (HEAD/commit sha) to `git notes show`/`add` are now `--`-guarded.

## Test plan
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-core -p spelunk-cli` — full workspace suite green, including:
  - New `crates/spelunk-cli/tests/harvest_ref_injection.rs`: spawns the real `spelunk` binary with `--branch=--output=<victim>` and `--git-range=--output=<victim>` against a throwaway git repo; asserts the process exits non-zero with an error mentioning the rejection, and asserts the victim file is never created (`!victim_path.exists()`).
  - New unit tests `option_injection_guard_tests` in `harvest.rs` covering accepted ordinary refs/ranges (`main`, `HEAD~10..HEAD`, `feature/foo..main`, literal `-`) vs rejected option-like refs and range endpoints on either side of `..`.
  - `integration_git_notes` (12/12) — confirms the stdin-based `git notes add`/`show`/list/archive/append round-trip still works correctly after switching from `-m` to `-F -`.
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean, no new warnings.

## Additional hardening (test-engineer + docs-writer pass)
- Test-engineer closed a coverage gap: the git-notes stdin hardening had no adversarial test of its own. Added 3 tests in `integration_git_notes.rs` driving note add/append with option-like (`--force-with-lease=...`) and shell-metacharacter (`$(...)`, backticks, `;`, `|`) note bodies, asserting literal round-trip (only possible via stdin) and no side-effect files. Also added short-option (`-1`, `-n5`), bare-`--`, and long-value edge cases to the harvest guard tests (unit + CLI black-box level).
- Docs-writer recorded memory decision #136 ("Harden git argument-injection paths in memory harvest / git-notes") and added a line to `docs/memory.md` plus a new STRIDE row in `docs/security/THREAT-MODEL.md` documenting this threat and its fix.

## Final QA re-review
Independently re-reviewed the full diff against `origin/main` (engineer + test-engineer + docs-writer commits), re-ran the full test suite, `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` — all clean. Confirmed docs changes are public-repo-appropriate (no internal/business references). Marked ready for review.