### PR TITLE
security(cli): reject non-loopback http://, drop bearer from /v1/health probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Security
 
+- **Breaking: non-loopback `http://` URLs are now rejected as invalid config.**
+  `server_url` and any configured inference URL must be `https://` unless they
+  point at loopback (`127.0.0.1`, `::1`, `localhost`) — the CLI attaches your
+  `Authorization: Bearer` token to these requests, so a plaintext non-loopback
+  URL previously sent it in the clear. There is no opt-out. **If your
+  `.spelunk/config.toml` has `server_url = "http://<host>:<port>"` pointing at
+  anything other than loopback, spelunk will now refuse to start** with a
+  one-line error telling you to switch to `https://` (put a TLS-terminating
+  reverse proxy in front — see [Self-hosting](docs/self-hosting.md)) or move
+  the server to loopback. Loopback `http://` and all `https://` URLs are
+  unaffected.
+- **The CLI no longer sends the bearer token to `/v1/health`.** That endpoint
+  is unauthenticated on the server side (see below), so the probe no longer
+  attaches `Authorization` to it — matching the server, which never required
+  it. Authenticated endpoints (search, memory, inference) are unaffected.
 - **Suppressed two `quick-xml` DoS advisories with no upstream fix
   (RUSTSEC-2026-0194, RUSTSEC-2026-0195).** `quick-xml` is pulled transitively by
   the `calamine` (XLSX/ODS) and `docx-rs` (DOCX) document parsers used during

--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -309,13 +309,12 @@ pub async fn get_tier(cfg: &Config) -> &'static Tier {
     let explicit_offline = spelunk_core::config::no_server_env_set()
         || cfg.mode == Some(spelunk_core::config::SyncMode::Offline);
     let url = cfg.server_url.clone();
-    let key = cfg.server_key.clone();
     TIER.get_or_init(|| async move {
         if explicit_offline {
             tracing::debug!("sync mode is explicitly offline — skipping all server probes");
             return Tier::Offline;
         }
-        probe(url.as_deref(), key.as_deref()).await
+        probe(url.as_deref()).await
     })
     .await
 }
@@ -329,7 +328,7 @@ const LOOPBACK_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_mi
 /// Default loopback port for `spelunk-server`.
 const DEFAULT_LOOPBACK_PORT: u16 = 7777;
 
-async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
+async fn probe(url: Option<&str>) -> Tier {
     // ── 1. SPELUNK_NO_SERVER short-circuit ───────────────────────────────────
     if matches!(
         std::env::var("SPELUNK_NO_SERVER").as_deref(),
@@ -341,7 +340,7 @@ async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
 
     // ── 2. Explicit server_url from config / env ─────────────────────────────
     if let Some(url) = url {
-        return match probe_url(url, key, REMOTE_PROBE_TIMEOUT, false).await {
+        return match probe_url(url, REMOTE_PROBE_TIMEOUT, false).await {
             Ok(tier) => tier,
             Err(e) => {
                 eprintln!("error: {e}");
@@ -358,7 +357,7 @@ async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
             "loopback auto-discovery: found server.port={port}, probing {loopback_url}"
         );
         // Loopback probes never produce hard errors (auto_discovered=true), so unwrap is safe.
-        let tier = probe_url(&loopback_url, None, LOOPBACK_PROBE_TIMEOUT, true)
+        let tier = probe_url(&loopback_url, LOOPBACK_PROBE_TIMEOUT, true)
             .await
             .unwrap_or(Tier::Offline);
         if tier.is_server() {
@@ -370,7 +369,7 @@ async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
     // Step 3b: default port 7777
     let default_url = format!("http://127.0.0.1:{DEFAULT_LOOPBACK_PORT}");
     tracing::debug!("loopback auto-discovery: probing default {default_url}");
-    let tier = probe_url(&default_url, None, LOOPBACK_PROBE_TIMEOUT, true)
+    let tier = probe_url(&default_url, LOOPBACK_PROBE_TIMEOUT, true)
         .await
         .unwrap_or(Tier::Offline);
     if tier.is_server() {
@@ -389,10 +388,14 @@ async fn probe(url: Option<&str>, key: Option<&str>) -> Tier {
 /// dimension mismatch is a soft downgrade (loopback) or a hard error (explicit URL).
 async fn probe_url(
     url: &str,
-    key: Option<&str>,
     timeout: std::time::Duration,
     auto_discovered: bool,
 ) -> Result<Tier, String> {
+    // Non-loopback plaintext http:// is invalid config — reject before sending
+    // anything. No opt-out (Johan, 2026-07-02 — see spelunk-oss^63): the fix is
+    // always "use https, or loopback".
+    spelunk_core::config::validate_transport_url(url)?;
+
     let client = match reqwest::Client::builder().timeout(timeout).build() {
         Ok(c) => c,
         Err(e) => {
@@ -401,10 +404,9 @@ async fn probe_url(
         }
     };
 
-    let mut req = client.get(format!("{}/v1/health", url.trim_end_matches('/')));
-    if let Some(k) = key {
-        req = req.bearer_auth(k);
-    }
+    // `/v1/health` is an unauthenticated endpoint (spelunk-oss^56) — do not send
+    // a bearer to it (spelunk-oss^63).
+    let req = client.get(format!("{}/v1/health", url.trim_end_matches('/')));
 
     match req.send().await {
         Ok(resp) if resp.status().is_success() => {
@@ -912,7 +914,7 @@ mod tests {
             unsafe { std::env::set_var("SPELUNK_NO_SERVER", val) };
             // server_url = None so that, absent the short-circuit, the probe would
             // attempt loopback auto-discovery; the short-circuit must win.
-            let tier = probe(None, None).await;
+            let tier = probe(None).await;
             assert!(
                 matches!(tier, Tier::Offline),
                 "SPELUNK_NO_SERVER={val} should force Tier::Offline, got {tier:?}"
@@ -952,7 +954,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let result = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true).await;
+        let result = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, true).await;
         assert!(
             matches!(result, Ok(Tier::Offline)),
             "auto-discovered loopback with wrong dim must downgrade to Offline; got {result:?}"
@@ -975,7 +977,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let result = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true).await;
+        let result = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, true).await;
         assert!(
             matches!(result, Ok(Tier::Server { .. })),
             "auto-discovered loopback with correct dim must return Server; got {result:?}"
@@ -997,7 +999,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let result = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true).await;
+        let result = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, true).await;
         assert!(
             matches!(result, Ok(Tier::Server { .. })),
             "server with no embedder (dim 0) must still return Server; got {result:?}"
@@ -1021,7 +1023,7 @@ mod tests {
             .await;
 
         // auto_discovered = false → explicit server_url path → must be a hard Err.
-        let result = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, false).await;
+        let result = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, false).await;
         assert!(
             result.is_err(),
             "explicit server_url with wrong dim must return Err; got {result:?}"
@@ -1039,6 +1041,80 @@ mod tests {
         assert!(
             msg.contains("server_url"),
             "error must mention 'server_url' for actionable guidance: {msg}"
+        );
+    }
+
+    // ── transport-scheme validation (spelunk-oss^63) ─────────────────────────
+
+    /// A non-loopback `http://` URL must be rejected before any request is
+    /// sent — no mock is mounted, so a request would fail with "connection
+    /// refused" or similar rather than surfacing the validation error; the
+    /// assertion on the error message proves the reject happened pre-flight.
+    #[tokio::test]
+    async fn probe_url_rejects_non_loopback_http_no_request_sent() {
+        // Deliberately no MockServer / no listener on this address — if
+        // `probe_url` tried to send a request it would get a connection error,
+        // not this validation message.
+        let result = probe_url("http://team-server:7777", REMOTE_PROBE_TIMEOUT, false).await;
+        let err = result.expect_err("non-loopback http:// must be a hard error");
+        assert!(err.contains("loopback"), "got: {err}");
+        assert!(err.contains("https"), "got: {err}");
+    }
+
+    /// Same rejection applies to the loopback auto-discovery path (defensive;
+    /// auto-discovery URLs are always loopback in practice).
+    #[tokio::test]
+    async fn probe_url_rejects_non_loopback_http_even_when_auto_discovered() {
+        let result = probe_url("http://team-server:7777", LOOPBACK_PROBE_TIMEOUT, true).await;
+        assert!(result.is_err());
+    }
+
+    /// Loopback `http://` and `https://` URLs are accepted (proceed to the
+    /// actual health request against a mock server).
+    #[tokio::test]
+    async fn probe_url_accepts_loopback_http_and_https() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body(&["memory"], 0)))
+            .mount(&server)
+            .await;
+
+        // wiremock serves over http on 127.0.0.1, which is loopback.
+        let result = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, false).await;
+        assert!(
+            matches!(result, Ok(Tier::Server { .. })),
+            "loopback http:// must be accepted; got {result:?}"
+        );
+    }
+
+    /// `/v1/health` must never carry an `Authorization` header — it is an
+    /// unauthenticated endpoint (spelunk-oss^56 server-side companion).
+    #[tokio::test]
+    async fn probe_url_health_request_carries_no_bearer_header() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body(&["memory"], 0)))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, false).await;
+        assert!(matches!(result, Ok(Tier::Server { .. })), "got {result:?}");
+
+        // Assert no request in wiremock's log carried an Authorization header.
+        let requests = server.received_requests().await.expect("requests recorded");
+        assert_eq!(requests.len(), 1);
+        assert!(
+            !requests[0].headers.contains_key("authorization"),
+            "the /v1/health probe must not send an Authorization header"
         );
     }
 
@@ -1105,7 +1181,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let tier = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true)
+        let tier = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, true)
             .await
             .expect("probe ok");
         assert_eq!(tier.embedder_state(), Some(EmbedderState::Loading));
@@ -1125,7 +1201,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let tier = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true)
+        let tier = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, true)
             .await
             .expect("probe ok");
         assert_eq!(tier.embedder_state(), Some(EmbedderState::Unavailable));
@@ -1145,7 +1221,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let tier = probe_url(&server.uri(), None, REMOTE_PROBE_TIMEOUT, true)
+        let tier = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, true)
             .await
             .expect("probe ok");
         assert_eq!(tier.embedder_state(), Some(EmbedderState::Unknown));

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -152,6 +152,13 @@ impl ServerInferenceClient {
             .resolve_inference_url()?
             .trim_end_matches('/')
             .to_string();
+        if let Err(msg) = spelunk_core::config::validate_transport_url(&base_url) {
+            // Fail loudly and immediately: the alternative is silently sending a
+            // bearer token in the clear. No opt-out (Johan, 2026-07-02 — see
+            // spelunk-oss^63): the fix is always "use https, or loopback".
+            eprintln!("error: {msg}");
+            std::process::exit(2);
+        }
         let project_id = cfg.project_id.clone().unwrap_or_default();
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(300))
@@ -929,5 +936,91 @@ mod tests {
         assert_eq!(a.get_version(), Some(uuid::Version::SortRand));
         let chunk_id = format!("query:{a}");
         assert!(chunk_id.starts_with("query:"));
+    }
+
+    // ── transport-scheme validation (spelunk-oss^63) ─────────────────────────
+    //
+    // `from_config` hard-exits the process on an invalid (non-loopback http://)
+    // inference URL, so the exit path itself isn't exercised in-process here
+    // (that would kill the test binary). These tests instead cover the pure
+    // validator directly (used identically by `capability.rs::probe_url`) and
+    // confirm `from_config` still builds normally for every URL shape the
+    // validator accepts.
+
+    #[test]
+    fn transport_validator_rejects_non_loopback_http() {
+        let err = spelunk_core::config::validate_transport_url("http://team-server:7777")
+            .expect_err("non-loopback http:// must be rejected");
+        assert!(err.contains("loopback"));
+        assert!(err.contains("https"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_config_accepts_loopback_http_inference_url() {
+        unsafe {
+            std::env::remove_var("SPELUNK_SERVER_KEY");
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        let mut cfg = crate::config::Config::load_with_store(
+            Some(&path),
+            &spelunk_core::config::secret_store::MemoryStore::default(),
+        )
+        .unwrap();
+        cfg.inference_url = Some("http://127.0.0.1:7777".into());
+        assert!(
+            ServerInferenceClient::from_config(&cfg).is_some(),
+            "loopback http:// inference URL must be accepted"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn from_config_accepts_https_inference_url() {
+        unsafe {
+            std::env::remove_var("SPELUNK_SERVER_KEY");
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        let mut cfg = crate::config::Config::load_with_store(
+            Some(&path),
+            &spelunk_core::config::secret_store::MemoryStore::default(),
+        )
+        .unwrap();
+        cfg.inference_url = Some("https://team-server:7777".into());
+        assert!(
+            ServerInferenceClient::from_config(&cfg).is_some(),
+            "https:// inference URL (any host) must be accepted"
+        );
+    }
+
+    /// `/v1/health`-style probes aside, inference requests built via
+    /// `send_authed`/`authed` still attach the bearer — this is expected (those
+    /// routes ARE authenticated); this test just documents/pins that behaviour
+    /// so a future edit doesn't accidentally strip auth from real inference
+    /// calls while fixing the health probe.
+    #[tokio::test]
+    async fn inference_requests_still_carry_bearer_when_present() {
+        let inference = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/search"))
+            .and(header("authorization", "Bearer sk-test"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "query_vector": [0.1_f32],
+                "mode": "semantic",
+            })))
+            .expect(1)
+            .mount(&inference)
+            .await;
+
+        let client = ServerInferenceClient::for_test(
+            &inference.uri(),
+            "proj",
+            Some("sk-test".to_string()),
+            None,
+        );
+        let vec = client.search_query("q", "semantic", 1).await.unwrap();
+        assert_eq!(vec, Some(vec![0.1_f32]));
     }
 }

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -880,6 +880,13 @@ pub fn is_loopback_url(url: &str) -> bool {
 /// clear. There is no opt-out env var (Johan, 2026-07-02 — see spelunk-oss^63):
 /// the fix is always "use https, or loopback".
 ///
+/// Like [`is_loopback_url`], this is a lightweight string check on the literal
+/// host — there is no DNS resolution. A `/etc/hosts` alias or other custom DNS
+/// entry that resolves to a loopback address but isn't spelled `127.x.x.x`,
+/// `::1`, or `localhost` is **not** recognised as loopback and is rejected;
+/// this is intentional (fail closed, not open) and the known limitation of a
+/// string-based check.
+///
 /// Returns `Ok(())` for a valid URL, or a one-line `Err` naming the fix.
 pub fn validate_transport_url(url: &str) -> Result<(), String> {
     if url.starts_with("https://") {
@@ -1299,6 +1306,38 @@ project_id = "my-proj"
     fn validate_transport_url_rejects_unknown_scheme() {
         let err = validate_transport_url("ftp://team-server:7777").unwrap_err();
         assert!(err.contains("http"));
+    }
+
+    /// IPv6 non-loopback addresses must be rejected too, not just the IPv4 case
+    /// — the check is symmetric across address families.
+    #[test]
+    fn validate_transport_url_rejects_non_loopback_ipv6_http() {
+        assert!(validate_transport_url("http://[2001:db8::1]:7777").is_err());
+        assert!(validate_transport_url("http://[fe80::1]:7777").is_err());
+    }
+
+    /// Known limitation, asserted so it can't silently regress into a security
+    /// hole: this is a *string* check with no DNS resolution. A hostname alias
+    /// (e.g. an `/etc/hosts` entry) that an OS resolver would send to
+    /// 127.0.0.1 is NOT recognised as loopback here and is correctly rejected
+    /// (fail closed) rather than accepted on the assumption it "means"
+    /// loopback. If a caller ever needs alias support, that requires an
+    /// explicit, reviewed allow-list — not a silent DNS lookup at validation
+    /// time (which would also make validation do network I/O).
+    #[test]
+    fn validate_transport_url_rejects_hostname_alias_even_if_it_would_resolve_to_loopback() {
+        let err = validate_transport_url("http://my-loopback-alias:7777")
+            .expect_err("a non-literal loopback hostname must be rejected, not DNS-resolved");
+        assert!(err.contains("loopback"));
+    }
+
+    /// `localhost` with an explicit port-less bare form and a trailing slash
+    /// path both still resolve to the same host extraction as the bracketed
+    /// IPv6 case — pin the unbracketed `::1` (no port) form too, since the
+    /// bracket-stripping logic in `is_loopback_url` is easy to regress.
+    #[test]
+    fn validate_transport_url_accepts_bare_ipv6_loopback_no_port() {
+        assert!(validate_transport_url("http://[::1]/").is_ok());
     }
 
     // ── looks_like_uuid (ADR-005) ────────────────────────────────────────────

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -871,6 +871,34 @@ pub fn is_loopback_url(url: &str) -> bool {
     matches!(host, "localhost" | "127.0.0.1" | "::1") || host.starts_with("127.")
 }
 
+/// Validate that `url` is an acceptable transport for sending a bearer token /
+/// talking to a spelunk-server: either `https://` (any host), or `http://` to a
+/// loopback host (`127.0.0.1`, `::1`, `localhost`).
+///
+/// A non-loopback `http://` URL is invalid config — plaintext HTTP outside the
+/// loopback interface would send the bearer token (and query content) in the
+/// clear. There is no opt-out env var (Johan, 2026-07-02 — see spelunk-oss^63):
+/// the fix is always "use https, or loopback".
+///
+/// Returns `Ok(())` for a valid URL, or a one-line `Err` naming the fix.
+pub fn validate_transport_url(url: &str) -> Result<(), String> {
+    if url.starts_with("https://") {
+        return Ok(());
+    }
+    if url.starts_with("http://") {
+        if is_loopback_url(url) {
+            return Ok(());
+        }
+        return Err(format!(
+            "invalid server URL {url:?}: plaintext http:// is only allowed to a loopback \
+             address (127.0.0.1/::1/localhost); use https:// for any other host"
+        ));
+    }
+    Err(format!(
+        "invalid server URL {url:?}: expected an http:// or https:// URL"
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1233,6 +1261,44 @@ project_id = "my-proj"
     fn is_loopback_url_rejects_address_with_127_in_path() {
         // Should NOT match just because "127" appears somewhere
         assert!(!is_loopback_url("http://example.com/proxy/127.0.0.1"));
+    }
+
+    // ── validate_transport_url (spelunk-oss^63: loopback-only plaintext http) ──
+
+    #[test]
+    fn validate_transport_url_rejects_non_loopback_http() {
+        let err = validate_transport_url("http://team-server:7777")
+            .expect_err("non-loopback http:// must be rejected");
+        assert!(err.contains("http://team-server:7777"));
+        assert!(err.contains("https"));
+        assert!(err.contains("loopback"));
+    }
+
+    #[test]
+    fn validate_transport_url_rejects_non_loopback_ip_http() {
+        assert!(validate_transport_url("http://192.168.1.100:7777").is_err());
+        assert!(validate_transport_url("http://10.0.0.1:7777").is_err());
+    }
+
+    #[test]
+    fn validate_transport_url_accepts_loopback_http() {
+        assert!(validate_transport_url("http://127.0.0.1:7777").is_ok());
+        assert!(validate_transport_url("http://localhost:7777").is_ok());
+        assert!(validate_transport_url("http://[::1]:7777").is_ok());
+        assert!(validate_transport_url("http://127.5.6.7:7777").is_ok());
+    }
+
+    #[test]
+    fn validate_transport_url_accepts_any_https() {
+        assert!(validate_transport_url("https://team-server:7777").is_ok());
+        assert!(validate_transport_url("https://example.com").is_ok());
+        assert!(validate_transport_url("https://127.0.0.1:7777").is_ok());
+    }
+
+    #[test]
+    fn validate_transport_url_rejects_unknown_scheme() {
+        let err = validate_transport_url("ftp://team-server:7777").unwrap_err();
+        assert!(err.contains("http"));
     }
 
     // ── looks_like_uuid (ADR-005) ────────────────────────────────────────────

--- a/docs/architecture/capability-tiers.md
+++ b/docs/architecture/capability-tiers.md
@@ -42,13 +42,20 @@ once.
 
 ```toml
 # ~/.config/spelunk/config.toml  (personal — never commit)
-server_url = "http://spelunk.internal:7777"
+server_url = "https://spelunk.internal.example.com"
 server_key = "sk-..."
 
 # .spelunk/config.toml  (project-level — safe to commit if key is in env)
 project_id = "acme/my-app"
-server_url = "http://spelunk.internal:7777"   # key via SPELUNK_SERVER_KEY env var
+server_url = "https://spelunk.internal.example.com"   # key via SPELUNK_SERVER_KEY env var
 ```
+
+> `server_url` must be `https://` unless it resolves to loopback
+> (`127.0.0.1` / `::1` / `localhost`); a non-loopback `http://` value is
+> rejected at config-load time with no override, since the bearer token is
+> attached to every server-mediated request. See
+> [Server setup → Trust model](../server.md#trust-model) and
+> [Self-hosting](../self-hosting.md).
 
 Environment variable overrides:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -361,9 +361,15 @@ Add `.spelunk/config.toml` at your repo root (commit it):
 
 ```toml
 # .spelunk/config.toml — commit this, no secrets
-server_url = "http://spelunk.internal:7777"
+server_url = "https://spelunk.internal.example.com"
 project_id = "my-awesome-app"
 ```
+
+> **`server_url` must be `https://` unless it points at loopback**
+> (`127.0.0.1` / `::1` / `localhost`) — a non-loopback `http://` URL is
+> rejected at startup, with no opt-out, because the CLI attaches your bearer
+> token to these requests. See [Self-hosting](self-hosting.md) for putting TLS
+> in front of a deployed server.
 
 Each developer provides their API key. Prefer the `SPELUNK_SERVER_KEY`
 environment variable, which works everywhere (including CI / headless):

--- a/docs/server.md
+++ b/docs/server.md
@@ -96,9 +96,16 @@ Each developer adds a `.spelunk/config.toml` at the project root (commit it):
 
 ```toml
 # .spelunk/config.toml — commit this, it's not a secret
-server_url = "http://spelunk.internal:7777"
+server_url = "https://spelunk.internal.example.com"
 project_id = "my-awesome-app"
 ```
+
+> **`server_url` must be `https://` unless it points at loopback**
+> (`127.0.0.1` / `::1` / `localhost`). The CLI attaches your bearer token to
+> requests built from this URL, so a non-loopback `http://` config is rejected
+> at startup with no override — see [Self-hosting](self-hosting.md) for how to
+> put TLS in front of a deployed server. Loopback `http://` (e.g. while
+> developing against a server on your own machine) is fine.
 
 Personal config (`~/.config/spelunk/config.toml` — never commit):
 
@@ -247,7 +254,9 @@ cargo build --release --bin spelunk-server
 
 ## API reference
 
-All routes require `Authorization: Bearer <key>` except `/v1/health`.
+All routes require `Authorization: Bearer <key>` except `/v1/health`, which is
+unauthenticated by design (it's the liveness probe used before a client knows
+whether a key is even needed) — the CLI never attaches a bearer token to it.
 
 ```
 GET    /v1/health


### PR DESCRIPTION
## Summary

Firm, no-opt-out direction from Johan (spelunk-oss^63):

- **Non-loopback `http://` is invalid config — hard-rejected, no escape hatch.** Added `spelunk_core::config::validate_transport_url` (reuses `is_loopback_url`): accepts any `https://` URL, accepts `http://` only to loopback (`127.0.0.1`/`::1`/`localhost`), rejects everything else with a one-line "use https, or loopback" error. Wired into both `capability.rs::probe_url` (server_url probing, including the loopback auto-discovery path defensively) and `server_client.rs::ServerInferenceClient::from_config` (inference URL) — validation happens before any request is built, so nothing is ever sent to a rejected URL.
- **`/v1/health` no longer carries a bearer.** It's an unauthenticated endpoint server-side (spelunk-oss^56, already merged). Removed the `key`/`Authorization` plumbing from the health-probe path end-to-end (`probe`/`probe_url`). Authenticated inference routes (search, memory, etc.) are unaffected — pinned by a dedicated test.

Docs (`CHANGELOG.md`, `docs/getting-started.md`, `docs/server.md`, `docs/architecture/capability-tiers.md`) updated to stop recommending non-loopback `http://` examples and to call out the breaking change.

**Known follow-up, tracked separately — not a blocker for this PR:** the R1 (local Docker) remote-agent workflow in `docs/remote-agents.md` documents `SPELUNK_SERVER_URL=http://host.docker.internal:7777` / `http://172.17.0.1:7777`, which are non-loopback by the string-based check and will now be rejected. This is a real conflict but is a separate scope/behavior decision (extend loopback-equivalence vs. change the R1 pattern vs. accept as an intentional breaking change), filed as **spelunk-oss^70** for architect triage. The code here correctly implements Johan's no-opt-out direction as scoped; `remote-agents.md` is intentionally left untouched pending that decision.

## Test plan

1. `SPELUNK_SECRET_STORE=file cargo fmt --check` — clean.
2. `SPELUNK_SECRET_STORE=file cargo clippy -p spelunk-cli -p spelunk-core --all-targets -- -D warnings` — clean.
3. `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli -p spelunk-core` — all suites green (153+ spelunk-cli tests, 195+ spelunk-core tests), including:
   - `validate_transport_url_rejects_non_loopback_http` / `_rejects_non_loopback_ip_http` / `_rejects_non_loopback_ipv6_http` / `_accepts_loopback_http` / `_accepts_any_https` / `_rejects_unknown_scheme` / `_rejects_hostname_alias_even_if_it_would_resolve_to_loopback` (fail-closed on DNS aliases, no resolution performed)
   - `probe_url_rejects_non_loopback_http_no_request_sent` — proves the reject happens pre-flight (no mock server listening, so a real request would surface as a connection error, not this validation message)
   - `probe_url_health_request_carries_no_bearer_header` — asserts against wiremock's recorded request log that no `authorization` header was sent
   - `from_config_accepts_loopback_http_inference_url` / `_accepts_https_inference_url`
   - `inference_requests_still_carry_bearer_when_present` — pins that authenticated routes are unaffected
4. Manually verify: set `server_url = "http://team-server:7777"` in `.spelunk/config.toml` and run any server-tier command — expect immediate exit(2) with a one-line error naming the fix, no network request attempted.

## Related

- spelunk-oss^56 (server-side companion: auth-exempt `/v1/health`, refuse plaintext non-loopback bind) — already merged/done.
- spelunk-oss^70 (follow-up, architect): reconcile `docs/remote-agents.md` R1 Docker workflow with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)