### PR TITLE
fix(security): server error-leak, raw FTS5 errors, unbounded file reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- **Server robustness/info-leak hardening (error-string sniffing, raw FTS5 errors, unbounded
+  file reads).** [spelunk-oss^65]
+  - `AppError::Internal` no longer inspects the error message text (previously it returned the
+    raw error string to the client whenever it contained `"mismatch"` or `"required"`). The one
+    legitimately-safe case — a project's configured embedding dimension not matching an
+    incoming vector — is now a typed `DimensionMismatch` error mapped to a 400 with a fixed
+    safe message; everything else funnels through `AppError::Internal` to a fixed generic
+    `"Internal server error"` 500, regardless of what the underlying error's `Display` text
+    says. Closes the V1-SERVER-AUDIT §8 "5xx do not leak stack traces or internal paths" gap.
+  - Full-text search queries (`spelunk search --mode text` and the server's `/v1/search`
+    hybrid search) are now quoted as FTS5 string literals before being bound to `MATCH`
+    (internal `"` doubled per FTS5 escaping rules), so punctuation in a search term — `"`,
+    `:`, `OR`/`NOT`/`NEAR`, unbalanced parens, etc. — no longer surfaces a raw FTS5 query-parse
+    error to the caller. **Known gap:** a query term containing an embedded NUL byte still
+    leaks a raw FTS5 parse error despite the quoting (FTS5's own parser appears to treat `\0`
+    as an early string terminator, independent of SQLite's NUL-safe `TEXT` binding); tracked as
+    a follow-up in spelunk-oss^75.
+  - `spelunk index` now enforces a `MAX_FILE_BYTES` (64 MiB) cap via `metadata().len()` before
+    reading a file into memory, applied uniformly across every format (text/Markdown/tree-sitter
+    source, PDF, DOCX, XLSX) — previously the cap only bounded an already-read buffer on the
+    tree-sitter branch, so a very large or maliciously crafted file of any other supported
+    format could still be read fully into memory first. Oversized files are now skipped with a
+    warning instead. This is local-indexing hardening, distinct from and complementary to the
+    server-side request-body caps shipped in 0.9.2 above.
+
 ## [0.9.2] — 2026-07-03
 
 ### Security

--- a/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
@@ -20,6 +20,33 @@ use crate::{
     storage::Database,
 };
 
+/// Upper bound on the size of any single file read into memory during
+/// indexing, checked via `metadata().len()` *before* the file is opened for
+/// reading. Applied uniformly to every format (text, markdown, tree-sitter
+/// source, PDF, DOCX, XLSX, …) — a single gate, not one per branch — so a
+/// multi-GB file (or a compression-bomb office/PDF doc) can't be read fully
+/// into memory and OOM-kill the indexer. This is distinct from (and
+/// complementary to) `MAX_PARSE_BYTES` in `spelunk_core::indexer::parser`,
+/// which only bounds how much of an *already-read* buffer tree-sitter will
+/// attempt to GLR-parse before falling back to a sliding window.
+const MAX_FILE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Return `true` (and log a warning) if `path` is over `MAX_FILE_BYTES`,
+/// checked via a `metadata()` call — no file content is read either way.
+/// Callers must skip the file without reading it when this returns `true`.
+fn is_file_too_large(path: &std::path::Path, path_str: &str) -> bool {
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.len() > MAX_FILE_BYTES => {
+            tracing::warn!(
+                "skipping {path_str}: file too large ({} bytes > {MAX_FILE_BYTES} byte cap)",
+                meta.len()
+            );
+            true
+        }
+        _ => false,
+    }
+}
+
 pub(super) struct ParseResult {
     /// (chunk_id, embedding_text) pairs awaiting embedding.
     pub chunk_ids_and_texts: Vec<(i64, String)>,
@@ -179,6 +206,10 @@ fn process_doc_file(
     args: &IndexArgs,
     acc: &mut ParseAcc,
 ) -> Result<bool> {
+    if is_file_too_large(path, path_str) {
+        acc.skipped += 1;
+        return Ok(true);
+    }
     let bytes = match std::fs::read(path) {
         Ok(b) => b,
         Err(e) => {
@@ -211,6 +242,10 @@ fn process_pdf_file(
     args: &IndexArgs,
     acc: &mut ParseAcc,
 ) -> Result<bool> {
+    if is_file_too_large(path, path_str) {
+        acc.skipped += 1;
+        return Ok(true);
+    }
     let bytes = match std::fs::read(path) {
         Ok(b) => b,
         Err(e) => {
@@ -273,6 +308,10 @@ fn process_text_file(
 
     // Skip binary files (e.g. compiled output with wrong extension)
     if matches!(language, "text" | "markdown") && is_binary_file(path) {
+        return Ok(());
+    }
+    if is_file_too_large(path, path_str) {
+        acc.skipped += 1;
         return Ok(());
     }
     let source = match std::fs::read_to_string(path) {
@@ -405,4 +444,124 @@ fn cleanup_stale(files: &[ignore::DirEntry], root: &std::path::Path, db: &Databa
         }
     }
     Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::OnceLock;
+
+    /// Register the sqlite-vec extension exactly once per test process.
+    fn register_sqlite_vec() {
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            #[allow(clippy::missing_transmute_annotations)]
+            unsafe {
+                rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                    sqlite_vec::sqlite3_vec_init as *const (),
+                )));
+            }
+        });
+    }
+
+    fn open_db() -> Database {
+        register_sqlite_vec();
+        Database::open(std::path::Path::new(":memory:")).expect("open in-memory Database")
+    }
+
+    fn default_args(path: std::path::PathBuf) -> IndexArgs {
+        IndexArgs {
+            path,
+            db: None,
+            batch_size: 64,
+            force: false,
+            recount: false,
+            no_summaries: false,
+            summary_batch_size: 10,
+            background_phases: false,
+            detach: false,
+        }
+    }
+
+    /// A sparse file whose reported length is over `MAX_FILE_BYTES`, created
+    /// via `set_len` so no actual bytes are written/allocated on disk — the
+    /// test itself must not read megabytes of data to prove the cap works.
+    fn make_oversized_sparse_file() -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().expect("create temp file");
+        file.as_file()
+            .set_len(MAX_FILE_BYTES + 1)
+            .expect("set_len on temp file");
+        file
+    }
+
+    // ── is_file_too_large ────────────────────────────────────────────────────
+
+    #[test]
+    fn is_file_too_large_true_over_cap() {
+        let file = make_oversized_sparse_file();
+        assert!(is_file_too_large(file.path(), "oversized.txt"));
+    }
+
+    #[test]
+    fn is_file_too_large_false_under_cap() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"small file content").unwrap();
+        assert!(!is_file_too_large(file.path(), "small.txt"));
+    }
+
+    // ── process_text_file: oversized files are skipped before any read ──────
+
+    /// An oversized text file must be skipped without ever being read into
+    /// memory. We assert this indirectly but strongly: `process_text_file`
+    /// only calls `db.upsert_file` (recording a content hash) *after*
+    /// `std::fs::read_to_string` succeeds. If the size gate didn't
+    /// short-circuit before the read, the file would still get indexed (a
+    /// sparse file reads back as all-zero bytes, which is valid UTF-8) and
+    /// `db.file_hash` would return `Some(..)`. Asserting it stays `None`
+    /// proves the read (and everything downstream of it) never happened —
+    /// not just that some later step errored out.
+    #[test]
+    fn process_text_file_oversized_is_skipped_before_read() {
+        let db = open_db();
+        let dir = tempfile::tempdir().unwrap();
+        // `.rs` (tree-sitter language) rather than `.txt`, so the unrelated
+        // is_binary_file() sniff (which only applies to "text"/"markdown"
+        // languages) doesn't short-circuit before we reach the size gate —
+        // a sparse file reads back as all-zero bytes, which is_binary_file
+        // would otherwise flag as binary regardless of the size cap.
+        let path = dir.path().join("huge.rs");
+        {
+            let f = std::fs::File::create(&path).unwrap();
+            f.set_len(MAX_FILE_BYTES + 1).unwrap();
+        }
+        let args = default_args(dir.path().to_path_buf());
+        let mut acc = ParseAcc {
+            out: Vec::new(),
+            indexed: 0,
+            skipped: 0,
+        };
+
+        let path_str = "huge.rs";
+        let result = process_text_file(&path, path_str, &db, &args, &mut acc);
+
+        assert!(result.is_ok(), "oversized file must be skipped, not error");
+        assert_eq!(acc.indexed, 0, "oversized file must not be indexed");
+        assert_eq!(acc.skipped, 1, "oversized file must be counted as skipped");
+        assert!(
+            db.file_hash(path_str).unwrap().is_none(),
+            "oversized file must never reach upsert_file — proves the read never happened"
+        );
+    }
+
+    /// A file just at the cap boundary is allowed through to the normal read
+    /// path (sanity check that the gate uses `>`, not `>=`, matching the doc
+    /// comment "over the size cap").
+    #[test]
+    fn process_text_file_at_cap_boundary_is_not_skipped_by_size_gate() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        // Exactly at the cap: must NOT be flagged as too large.
+        file.as_file().set_len(MAX_FILE_BYTES).unwrap();
+        assert!(!is_file_too_large(file.path(), "boundary.bin"));
+    }
 }

--- a/crates/spelunk-core/src/storage/memory/search.rs
+++ b/crates/spelunk-core/src/storage/memory/search.rs
@@ -63,8 +63,9 @@ impl MemoryStore {
              LIMIT {limit}"
         );
         let mut stmt = self.conn.prepare(&sql)?;
+        let fts_query = crate::utils::fts5_quote_literal(query);
         let notes = if let Some(ts) = as_of {
-            stmt.query_map(rusqlite::params![query, ts], |row| {
+            stmt.query_map(rusqlite::params![fts_query, ts], |row| {
                 let bm25_score: f64 = row.get(12)?;
                 let mut note = row_to_note(row)?;
                 note.distance = Some(-bm25_score);
@@ -72,7 +73,7 @@ impl MemoryStore {
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?
         } else {
-            stmt.query_map(rusqlite::params![query], |row| {
+            stmt.query_map(rusqlite::params![fts_query], |row| {
                 let bm25_score: f64 = row.get(12)?;
                 let mut note = row_to_note(row)?;
                 // Negate so that higher relevance → lower distance (ascending convention).
@@ -166,5 +167,90 @@ impl MemoryStore {
             .query_map(rusqlite::params![query_blob], row_to_note_with_distance)?
             .collect::<rusqlite::Result<Vec<_>>>()?;
         Ok(notes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MemoryStore;
+    use std::sync::OnceLock;
+
+    fn register_sqlite_vec() {
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            #[allow(clippy::missing_transmute_annotations)]
+            unsafe {
+                rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                    sqlite_vec::sqlite3_vec_init as *const (),
+                )));
+            }
+        });
+    }
+
+    fn open_store() -> MemoryStore {
+        register_sqlite_vec();
+        MemoryStore::open(std::path::Path::new(":memory:"))
+            .expect("failed to open in-memory MemoryStore")
+    }
+
+    /// A search term containing FTS5-special punctuation must never surface a
+    /// raw FTS5 parse error from `search_text` — it's always treated as a
+    /// literal term (quoted internally), so the call returns `Ok` (results or
+    /// empty) regardless of punctuation.
+    #[test]
+    fn search_text_with_punctuation_never_errors() {
+        let store = open_store();
+        store
+            .add_note(
+                "note",
+                "Config parsing",
+                "handles foo:bar style keys",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+
+        let queries = [
+            "foo:bar",
+            "\"unterminated quote",
+            "a OR NOT b",
+            "weird (parens",
+            "trailing*",
+            "-leading-dash",
+            "",
+        ];
+        for q in queries {
+            let result = store.search_text(q, 10, None);
+            assert!(
+                result.is_ok(),
+                "query {q:?} must not surface a raw FTS5 parse error, got: {:?}",
+                result.err()
+            );
+        }
+    }
+
+    /// Quoting the term as an FTS5 literal must not break normal matching.
+    #[test]
+    fn search_text_plain_term_still_matches() {
+        let store = open_store();
+        store
+            .add_note(
+                "note",
+                "Config parsing",
+                "handles foo:bar style keys",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+
+        let results = store.search_text("parsing", 10, None).expect("search ok");
+        assert!(
+            !results.is_empty(),
+            "expected the seeded note to match a plain-word query"
+        );
     }
 }

--- a/crates/spelunk-core/src/storage/memory/search.rs
+++ b/crates/spelunk-core/src/storage/memory/search.rs
@@ -237,14 +237,11 @@ mod tests {
         }
     }
 
-    /// KNOWN GAP (filed as a spelunk-oss follow-up, see task comment on
-    /// spelunk-oss^65): a query term containing an embedded NUL byte still
-    /// surfaces a raw FTS5 "unterminated string" parse error via this
-    /// memory-search path too (same root cause as the code-search path in
-    /// `storage::search::tests`). `#[ignore]`d because it currently fails —
-    /// documents the bug rather than passing. Remove `#[ignore]` once fixed.
+    /// A query term containing an embedded NUL byte must not surface a raw
+    /// FTS5 "unterminated string" parse error via this memory-search path
+    /// too (same fix as the code-search path in `storage::search::tests`).
+    /// See spelunk-oss^65 follow-up.
     #[test]
-    #[ignore = "known bug: embedded NUL byte still leaks a raw FTS5 parse error, see spelunk-oss^65 follow-up"]
     fn search_text_embedded_nul_byte_still_leaks_raw_parse_error() {
         let store = open_store();
         store

--- a/crates/spelunk-core/src/storage/memory/search.rs
+++ b/crates/spelunk-core/src/storage/memory/search.rs
@@ -220,6 +220,12 @@ mod tests {
             "trailing*",
             "-leading-dash",
             "",
+            "a NEAR b",
+            "a NEAR/3 b",
+            "content:secret",
+            "\"\"\"\"\"",
+            "^prefix",
+            "((()))",
         ];
         for q in queries {
             let result = store.search_text(q, 10, None);
@@ -229,6 +235,36 @@ mod tests {
                 result.err()
             );
         }
+    }
+
+    /// KNOWN GAP (filed as a spelunk-oss follow-up, see task comment on
+    /// spelunk-oss^65): a query term containing an embedded NUL byte still
+    /// surfaces a raw FTS5 "unterminated string" parse error via this
+    /// memory-search path too (same root cause as the code-search path in
+    /// `storage::search::tests`). `#[ignore]`d because it currently fails —
+    /// documents the bug rather than passing. Remove `#[ignore]` once fixed.
+    #[test]
+    #[ignore = "known bug: embedded NUL byte still leaks a raw FTS5 parse error, see spelunk-oss^65 follow-up"]
+    fn search_text_embedded_nul_byte_still_leaks_raw_parse_error() {
+        let store = open_store();
+        store
+            .add_note(
+                "note",
+                "Config parsing",
+                "handles foo:bar style keys",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+
+        let result = store.search_text("\0embedded nul", 10, None);
+        assert!(
+            result.is_ok(),
+            "query with embedded NUL must not surface a raw FTS5 parse error, got: {:?}",
+            result.err()
+        );
     }
 
     /// Quoting the term as an FTS5 literal must not break normal matching.

--- a/crates/spelunk-core/src/storage/search.rs
+++ b/crates/spelunk-core/src/storage/search.rs
@@ -94,7 +94,8 @@ impl Database {
              ORDER BY score
              LIMIT ?2",
         )?;
-        let rows = stmt.query_map(rusqlite::params![query, limit as i64], |row| {
+        let fts_query = crate::utils::fts5_quote_literal(query);
+        let rows = stmt.query_map(rusqlite::params![fts_query, limit as i64], |row| {
             let bm25_score: f64 = row.get(8)?;
             Ok(crate::search::SearchResult {
                 chunk_id: row.get(0)?,
@@ -167,5 +168,79 @@ impl Database {
             .collect();
 
         Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Database;
+    use std::sync::OnceLock;
+
+    /// Register the sqlite-vec extension exactly once per test process.
+    fn register_sqlite_vec() {
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            #[allow(clippy::missing_transmute_annotations)]
+            unsafe {
+                rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                    sqlite_vec::sqlite3_vec_init as *const (),
+                )));
+            }
+        });
+    }
+
+    fn open_db() -> Database {
+        register_sqlite_vec();
+        Database::open(std::path::Path::new(":memory:")).expect("failed to open in-memory Database")
+    }
+
+    fn seed_chunk(db: &Database, content: &str) {
+        let file_id = db
+            .upsert_file("src/lib.rs", Some("rust"), "deadbeef")
+            .expect("upsert file");
+        db.insert_chunk(file_id, "function", Some("f"), 1, 5, content, None, 4)
+            .expect("insert chunk");
+    }
+
+    /// A search term containing FTS5-special punctuation (unbalanced `"`,
+    /// a bare `:`, and boolean-looking keywords) must never surface a raw
+    /// FTS5 parse error — it should be treated as a literal string and either
+    /// return matches or an empty result, but always `Ok`.
+    #[test]
+    fn search_text_with_punctuation_never_errors() {
+        let db = open_db();
+        seed_chunk(&db, "fn parse_config() { /* handles foo:bar */ }");
+
+        let queries = [
+            "foo:bar",
+            "\"unterminated quote",
+            "a OR NOT b",
+            "weird (parens",
+            "trailing*",
+            "-leading-dash",
+            "",
+        ];
+        for q in queries {
+            let result = db.search_text(q, 10);
+            assert!(
+                result.is_ok(),
+                "query {q:?} must not surface a raw FTS5 parse error, got: {:?}",
+                result.err()
+            );
+        }
+    }
+
+    /// A literal-quoted term still matches real content containing that
+    /// literal substring, so quoting doesn't silently break search relevance.
+    #[test]
+    fn search_text_quoted_colon_term_still_matches() {
+        let db = open_db();
+        seed_chunk(&db, "fn parse_config() { /* handles foo:bar */ }");
+
+        let results = db.search_text("parse_config", 10).expect("search ok");
+        assert!(
+            !results.is_empty(),
+            "expected the seeded chunk to match a plain-word query"
+        );
     }
 }

--- a/crates/spelunk-core/src/storage/search.rs
+++ b/crates/spelunk-core/src/storage/search.rs
@@ -219,6 +219,12 @@ mod tests {
             "trailing*",
             "-leading-dash",
             "",
+            "a NEAR b",
+            "a NEAR/3 b",
+            "content:secret", // attempted FTS5 column-filter injection
+            "\"\"\"\"\"",     // consecutive quotes
+            "^prefix",
+            "((()))",
         ];
         for q in queries {
             let result = db.search_text(q, 10);
@@ -228,6 +234,29 @@ mod tests {
                 result.err()
             );
         }
+    }
+
+    /// KNOWN GAP (filed as spelunk-oss follow-up, see task comment on
+    /// spelunk-oss^65): a query term containing an embedded NUL byte still
+    /// surfaces a raw FTS5 "unterminated string" parse error. `fts5_quote_literal`
+    /// doubles internal `"` characters correctly, but FTS5's own query-string
+    /// parser appears to treat the embedded `\0` as an early string terminator
+    /// (distinct from SQLite's NUL-safe text binding), so the closing `"` we
+    /// appended is never seen by the parser. This is `#[ignore]`d because it
+    /// currently fails — it documents the bug rather than passing. Remove
+    /// `#[ignore]` once fixed.
+    #[test]
+    #[ignore = "known bug: embedded NUL byte still leaks a raw FTS5 parse error, see spelunk-oss^65 follow-up"]
+    fn search_text_embedded_nul_byte_still_leaks_raw_parse_error() {
+        let db = open_db();
+        seed_chunk(&db, "fn parse_config() { /* handles foo:bar */ }");
+
+        let result = db.search_text("\0embedded nul", 10);
+        assert!(
+            result.is_ok(),
+            "query with embedded NUL must not surface a raw FTS5 parse error, got: {:?}",
+            result.err()
+        );
     }
 
     /// A literal-quoted term still matches real content containing that
@@ -242,5 +271,20 @@ mod tests {
             !results.is_empty(),
             "expected the seeded chunk to match a plain-word query"
         );
+    }
+
+    /// A term shaped like an FTS5 column filter (`content:...`) must be
+    /// treated as a literal string to search for, not interpreted as
+    /// targeting the `content` column. Quoted, it should behave like any
+    /// other safe literal search (no match on an unrelated nonsense term,
+    /// no error).
+    #[test]
+    fn search_text_column_filter_syntax_is_literal_not_a_filter() {
+        let db = open_db();
+        seed_chunk(&db, "fn parse_config() { /* handles foo:bar */ }");
+
+        let result = db.search_text("content:nonexistent_term_xyz", 10);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
     }
 }

--- a/crates/spelunk-core/src/storage/search.rs
+++ b/crates/spelunk-core/src/storage/search.rs
@@ -236,17 +236,13 @@ mod tests {
         }
     }
 
-    /// KNOWN GAP (filed as spelunk-oss follow-up, see task comment on
-    /// spelunk-oss^65): a query term containing an embedded NUL byte still
-    /// surfaces a raw FTS5 "unterminated string" parse error. `fts5_quote_literal`
-    /// doubles internal `"` characters correctly, but FTS5's own query-string
-    /// parser appears to treat the embedded `\0` as an early string terminator
-    /// (distinct from SQLite's NUL-safe text binding), so the closing `"` we
-    /// appended is never seen by the parser. This is `#[ignore]`d because it
-    /// currently fails — it documents the bug rather than passing. Remove
-    /// `#[ignore]` once fixed.
+    /// A query term containing an embedded NUL byte must not surface a raw
+    /// FTS5 "unterminated string" parse error. `fts5_quote_literal` strips
+    /// embedded `\0` before quoting, since FTS5's own query-string parser
+    /// treats `\0` as an early string terminator (distinct from SQLite's
+    /// NUL-safe text binding), which would otherwise hide the closing `"` we
+    /// append. See spelunk-oss^65 follow-up.
     #[test]
-    #[ignore = "known bug: embedded NUL byte still leaks a raw FTS5 parse error, see spelunk-oss^65 follow-up"]
     fn search_text_embedded_nul_byte_still_leaks_raw_parse_error() {
         let db = open_db();
         seed_chunk(&db, "fn parse_config() { /* handles foo:bar */ }");

--- a/crates/spelunk-core/src/utils/mod.rs
+++ b/crates/spelunk-core/src/utils/mod.rs
@@ -91,10 +91,16 @@ pub fn effective_format(format: &str) -> &str {
 ///
 /// An empty term quotes to `""`, which is a valid (empty) FTS5 string that
 /// simply matches nothing.
+///
+/// Embedded NUL bytes (`\0`) are stripped before quoting. FTS5's query-string
+/// parser (independent of SQLite's NUL-safe TEXT binding) treats `\0` as an
+/// early string terminator, so the closing `"` this function appends would
+/// never be seen by FTS5 and a raw "unterminated string" parse error would
+/// leak to the caller instead of being treated as part of the literal.
 pub fn fts5_quote_literal(term: &str) -> String {
     let mut out = String::with_capacity(term.len() + 2);
     out.push('"');
-    for c in term.chars() {
+    for c in term.chars().filter(|&c| c != '\0') {
         if c == '"' {
             out.push('"');
         }
@@ -310,10 +316,10 @@ mod tests {
     }
 
     #[test]
-    fn fts5_quote_embedded_nul_is_preserved_not_special() {
+    fn fts5_quote_embedded_nul_is_stripped() {
         let term = "before\0after";
         let quoted = fts5_quote_literal(term);
-        assert_eq!(quoted, "\"before\0after\"");
+        assert_eq!(quoted, "\"beforeafter\"");
     }
 
     // ── strip_ansi ────────────────────────────────────────────────────────────

--- a/crates/spelunk-core/src/utils/mod.rs
+++ b/crates/spelunk-core/src/utils/mod.rs
@@ -76,6 +76,34 @@ pub fn effective_format(format: &str) -> &str {
     }
 }
 
+/// Quote a user-supplied search term as a literal FTS5 string, so it is
+/// always treated as plain text rather than FTS5 query syntax.
+///
+/// FTS5 `MATCH` interprets punctuation like `"`, `:`, `(`, `)`, `*`, `-`,
+/// `OR`/`AND`/`NOT` as query-language syntax. Passing a user's raw search
+/// term straight through can throw a parse error (which would otherwise leak
+/// as a raw internal error to the caller) or silently change the query's
+/// meaning. Wrapping the whole term in double quotes forces FTS5 to treat it
+/// as one literal string token; any internal `"` is escaped by doubling it
+/// (`"` → `""`), per FTS5's string-literal escaping rule. Advanced FTS query
+/// syntax (column filters, boolean operators, prefix matching, …) is
+/// intentionally not exposed — every term is always literal.
+///
+/// An empty term quotes to `""`, which is a valid (empty) FTS5 string that
+/// simply matches nothing.
+pub fn fts5_quote_literal(term: &str) -> String {
+    let mut out = String::with_capacity(term.len() + 2);
+    out.push('"');
+    for c in term.chars() {
+        if c == '"' {
+            out.push('"');
+        }
+        out.push(c);
+    }
+    out.push('"');
+    out
+}
+
 /// Strip ANSI escape sequences and unsafe control characters from a string.
 ///
 /// Allows newline, carriage return, and tab. Strips all other C0 control
@@ -240,6 +268,34 @@ mod tests {
         // already-forward-slash and bare names are unchanged
         assert_eq!(normalize_index_path("src/lib.rs"), "src/lib.rs");
         assert_eq!(normalize_index_path("lib.rs"), "lib.rs");
+    }
+
+    // ── fts5_quote_literal ───────────────────────────────────────────────────
+
+    #[test]
+    fn fts5_quote_plain_term() {
+        assert_eq!(fts5_quote_literal("hello world"), "\"hello world\"");
+    }
+
+    #[test]
+    fn fts5_quote_escapes_internal_quotes() {
+        assert_eq!(fts5_quote_literal("say \"hi\""), "\"say \"\"hi\"\"\"");
+    }
+
+    #[test]
+    fn fts5_quote_colon_term_stays_literal() {
+        // `foo:` looks like an FTS5 column filter; quoting keeps it literal.
+        assert_eq!(fts5_quote_literal("foo:bar"), "\"foo:bar\"");
+    }
+
+    #[test]
+    fn fts5_quote_boolean_keywords_stay_literal() {
+        assert_eq!(fts5_quote_literal("a OR NOT b"), "\"a OR NOT b\"");
+    }
+
+    #[test]
+    fn fts5_quote_empty_term() {
+        assert_eq!(fts5_quote_literal(""), "\"\"");
     }
 
     // ── strip_ansi ────────────────────────────────────────────────────────────

--- a/crates/spelunk-core/src/utils/mod.rs
+++ b/crates/spelunk-core/src/utils/mod.rs
@@ -298,6 +298,24 @@ mod tests {
         assert_eq!(fts5_quote_literal(""), "\"\"");
     }
 
+    #[test]
+    fn fts5_quote_near_keyword_stays_literal() {
+        assert_eq!(fts5_quote_literal("a NEAR/3 b"), "\"a NEAR/3 b\"");
+    }
+
+    #[test]
+    fn fts5_quote_consecutive_internal_quotes_all_escaped() {
+        // Every internal `"` must be doubled, including runs of them.
+        assert_eq!(fts5_quote_literal("\"\"\""), "\"\"\"\"\"\"\"\"");
+    }
+
+    #[test]
+    fn fts5_quote_embedded_nul_is_preserved_not_special() {
+        let term = "before\0after";
+        let quoted = fts5_quote_literal(term);
+        assert_eq!(quoted, "\"before\0after\"");
+    }
+
     // ── strip_ansi ────────────────────────────────────────────────────────────
 
     #[test]

--- a/crates/spelunk-server/src/db.rs
+++ b/crates/spelunk-server/src/db.rs
@@ -6,6 +6,30 @@ use uuid::Uuid;
 
 use spelunk_core::embeddings::blob_to_vec;
 
+/// Typed error for an embedding-dimension mismatch on a project. Kept distinct
+/// from `anyhow::Error` so callers (the HTTP layer) can map it to a safe,
+/// specific 400 response without sniffing the error message for substrings —
+/// see `AppError::BadRequest` in `lib.rs`.
+#[derive(Debug)]
+pub struct DimensionMismatch {
+    pub slug: String,
+    pub expected: usize,
+    pub got: usize,
+}
+
+impl std::fmt::Display for DimensionMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "embedding dimension mismatch for project '{}': server expects {}, got {}. \
+             All clients on the same project must use the same embedding model.",
+            self.slug, self.expected, self.got
+        )
+    }
+}
+
+impl std::error::Error for DimensionMismatch {}
+
 /// Shared state for all DB operations on the server.
 pub struct ServerDb {
     pub conn: Connection,
@@ -123,13 +147,12 @@ impl ServerDb {
         if let Some(mut p) = existing {
             // Validate dimension if already set.
             if p.embedding_dim != 0 && p.embedding_dim != incoming_dim {
-                anyhow::bail!(
-                    "embedding dimension mismatch for project '{}': server expects {}, got {}. \
-                     All clients on the same project must use the same embedding model.",
-                    slug,
-                    p.embedding_dim,
-                    incoming_dim
-                );
+                return Err(DimensionMismatch {
+                    slug: slug.to_string(),
+                    expected: p.embedding_dim,
+                    got: incoming_dim,
+                }
+                .into());
             }
             // Set dimension on first note.
             if p.embedding_dim == 0 {

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -2140,6 +2140,29 @@ mod tests {
         );
     }
 
+    /// `ServerDb::upsert_project`'s own per-project dimension check (distinct
+    /// from the server-wide `validate_embedding_dim` guard exercised above)
+    /// must return the typed `DimensionMismatch` error rather than a plain
+    /// `anyhow` string. The regression coverage for how that error then
+    /// renders over HTTP (safe 400, no substring sniffing, no raw text) lives
+    /// in `app_error_tests` in `lib.rs`, which exercises
+    /// `AppError::into_response` directly.
+    #[test]
+    fn upsert_project_dimension_mismatch_is_typed_error() {
+        register_sqlite_vec();
+        let db =
+            ServerDb::open(std::path::Path::new(":memory:"), 4).expect("open in-memory server db");
+        db.upsert_project("proj", 4).expect("first upsert sets dim");
+        let err = db
+            .upsert_project("proj", 7)
+            .expect_err("second upsert with different dim must error");
+        let mismatch = err
+            .downcast_ref::<super::super::db::DimensionMismatch>()
+            .expect("error must be the typed DimensionMismatch, not a generic anyhow error");
+        assert_eq!(mismatch.expected, 4);
+        assert_eq!(mismatch.got, 7);
+    }
+
     /// A correctly-sized title/body/vector must still succeed (guards against
     /// an off-by-one in the cap checks rejecting valid input).
     #[tokio::test]

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -415,6 +415,75 @@ pub fn router_with_limits(
         .with_state(state)
 }
 
+// ── AppError response mapping tests ────────────────────────────────────────────
+
+#[cfg(test)]
+mod app_error_tests {
+    use axum::response::IntoResponse;
+
+    use super::AppError;
+    use crate::db::DimensionMismatch;
+
+    /// Extract the response status + JSON body as a string for assertions.
+    async fn body_string(resp: axum::response::Response) -> (axum::http::StatusCode, String) {
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    /// A `DimensionMismatch` wrapped in `AppError::Internal` must map to a 400
+    /// with the typed, safe message — not fall through to the generic 500.
+    #[tokio::test]
+    async fn dimension_mismatch_maps_to_typed_bad_request() {
+        let err = anyhow::Error::new(DimensionMismatch {
+            slug: "proj".to_string(),
+            expected: 896,
+            got: 4,
+        });
+        let (status, body) = body_string(AppError::Internal(err).into_response()).await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(body.contains("dimension mismatch"));
+        assert!(body.contains("proj"));
+    }
+
+    /// Any other error — even one whose `Display` text happens to contain the
+    /// words "mismatch" or "required" — must NEVER have its raw text reach the
+    /// client body. Only the fixed, generic "Internal server error" message is
+    /// allowed through for `AppError::Internal` errors that aren't the one
+    /// explicitly-typed, known-safe variant. This is the regression test for
+    /// the substring-sniffing leak: the old code matched on `msg.contains(...)`
+    /// and echoed the raw error string back to the client.
+    #[tokio::test]
+    async fn generic_internal_error_never_leaks_raw_text_even_with_trigger_words() {
+        let secret_path = "/Users/johan/.ssh/id_ed25519";
+        let err = anyhow::anyhow!(
+            "column count mismatch: table 'chunks' required 12 columns but got 3 at {secret_path}"
+        );
+        let (status, body) = body_string(AppError::Internal(err).into_response()).await;
+        assert_eq!(status, axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(!body.contains("mismatch"));
+        assert!(!body.contains("required"));
+        assert!(!body.contains(secret_path));
+        assert!(!body.contains("chunks"));
+        assert_eq!(
+            body,
+            r#"{"error":{"code":"internal_error","message":"Internal server error"}}"#
+        );
+    }
+
+    /// A plain anyhow error with no special substrings still gets the generic
+    /// message (baseline, no leak).
+    #[tokio::test]
+    async fn plain_internal_error_returns_generic_message() {
+        let err = anyhow::anyhow!("disk I/O error at /var/lib/spelunk/server.db");
+        let (status, body) = body_string(AppError::Internal(err).into_response()).await;
+        assert_eq!(status, axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(!body.contains("/var/lib/spelunk"));
+    }
+}
+
 // ── OpenAPI spec endpoint ─────────────────────────────────────────────────────
 
 /// Serve the OpenAPI spec as JSON. Import into Postman via
@@ -530,12 +599,14 @@ impl IntoResponse for AppError {
                 }
             }
             AppError::Internal(e) => {
-                let msg = e.to_string();
-                // Surface dimension-mismatch and other user-facing errors as 400.
-                if msg.contains("mismatch") || msg.contains("required") {
+                // Only a known, explicitly-typed user-facing error is ever
+                // surfaced to the client; everything else gets a generic
+                // message so raw error text (paths, SQL, etc.) never reaches
+                // the response body. No substring sniffing of the message.
+                if let Some(mismatch) = e.downcast_ref::<crate::db::DimensionMismatch>() {
                     (
                         StatusCode::BAD_REQUEST,
-                        Json(ErrorBody::new("bad_request", &msg)),
+                        Json(ErrorBody::new("bad_request", &mismatch.to_string())),
                     )
                         .into_response()
                 } else {

--- a/docs/security/V1-SERVER-AUDIT.md
+++ b/docs/security/V1-SERVER-AUDIT.md
@@ -93,9 +93,27 @@ The CLI threat model (`THREAT-MODEL.md`) remains valid for the CLI crate. This d
 
 | Check | Status |
 |---|---|
-| 5xx responses do not leak stack traces or internal paths | ☐ |
+| 5xx responses do not leak stack traces or internal paths | ✅ |
 | 422 injection responses reveal category, not pattern | ☐ |
 | 401/403 responses consistent — cannot distinguish missing key from wrong key | ☐ |
+
+<!-- spelunk-oss^65 (PR #509, merged): AppError::Internal no longer sniffs the error Display text
+     for substrings like "mismatch"/"required" — that was the leak: any future error whose
+     message happened to contain those words would have reached the client. The one legitimately
+     safe case (per-project embedding dimension mismatch) is now a typed DimensionMismatch error
+     mapped to a 400 with a fixed safe message (crates/spelunk-server/src/db.rs, lib.rs); every
+     other Internal error returns a fixed generic "Internal server error" 500 regardless of its
+     underlying text. Same PR also closed two adjacent robustness gaps found alongside this one
+     (not strictly in-scope for this checklist row, noted here for traceability): FTS5 MATCH
+     queries are now quoted as literal strings (crates/spelunk-core/src/utils/mod.rs
+     fts5_quote_literal(), applied in storage/search.rs + storage/memory/search.rs) so punctuation
+     in a search term no longer surfaces a raw FTS5 parse error — except an embedded-NUL-byte
+     edge case that still leaks one, tracked as a follow-up in spelunk-oss^75; and
+     `spelunk index` now applies a uniform MAX_FILE_BYTES size gate before reading any file
+     format into memory (crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs), not just the
+     tree-sitter branch. Row marked ✅ 2026-07-03 by docs-writer per test-engineer verification
+     (task comments on spelunk-oss^65); other two rows in this section are unrelated to this task
+     and remain open. -->
 
 ---
 


### PR DESCRIPTION
## Summary
Grouped [security][low] robustness fixes per spelunk-oss^65 (architect decision: all three in one PR):

1. **AppError::Internal substring-sniffing leak** (`crates/spelunk-server/src/lib.rs`) — replaced `msg.contains("mismatch") || msg.contains("required")` with a typed `DimensionMismatch` error (`crates/spelunk-server/src/db.rs`), downcast explicitly in `AppError::into_response`. Every other `Internal` error now always gets the fixed generic `"Internal server error"` message; no raw error text (paths, SQL, etc.) can reach the client body.
2. **Raw FTS5 MATCH parse errors** (`crates/spelunk-core/src/storage/search.rs:93`, `storage/memory/search.rs:59`) — added `fts5_quote_literal()` (`crates/spelunk-core/src/utils/mod.rs`) which wraps the user's search term in `"..."` (escaping internal `"` as `""`) before binding to `MATCH`, so punctuation like `"` or `foo:` is always treated as a literal string rather than FTS5 query syntax. Advanced FTS syntax stays out of scope by design.
3. **Unbounded whole-file read during `spelunk index`** (`crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs`) — added a single `MAX_FILE_BYTES` (64MB) gate checked via `metadata().len()` *before* any read, applied uniformly to every format (text/markdown/tree-sitter source, and PDF/DOCX/XLSX under `rich-formats`), not just the tree-sitter branch's existing `MAX_PARSE_BYTES` (which only bounds an already-read buffer). Oversized files are skipped with a warning.

## Test plan
- [x] `crates/spelunk-server/src/lib.rs::app_error_tests` — `DimensionMismatch` maps to typed 400; a trigger-word-containing generic error never leaks raw text (`mismatch`/`required`/paths/table names all absent from the body); baseline generic-error test.
- [x] `crates/spelunk-server/src/handlers.rs` — `upsert_project_dimension_mismatch_is_typed_error` (unit test on `ServerDb`), existing `add_note_mismatched_embedding_dim_returns_400` still green.
- [x] `crates/spelunk-core/src/storage/search.rs::tests` + `storage/memory/search.rs::tests` — punctuation queries (`"`, `foo:bar`, `OR NOT`, `(`, `*`, `-`, empty) against real FTS5 tables never error; plain-word matching still works post-quoting.
- [x] `crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs::tests` — `is_file_too_large` unit tests (over/under/at-cap-boundary via sparse files, no full read); `process_text_file_oversized_is_skipped_before_read` asserts `db.file_hash` stays `None` after processing an oversized file, proving the read never happened (not just that a later step errored).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `SPELUNK_SECRET_STORE=file cargo test -p spelunk-server -p spelunk-cli -p spelunk-core` — all green (176+65+206+... tests, 0 failed).

## Related
- spelunk-oss^65 (Agentic OS task)
- V1-SERVER-AUDIT §8 (oss^66)
- oss^60 (server input caps — complementary, not overlapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)