### PR TITLE
fix(index): backfill embeddings for parsed-but-unembedded chunks without --force (spelunk-oss^72)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
@@ -591,6 +591,165 @@ mod tests {
         }
     }
 
+    /// The summary branch of `reconstruct_embedding_text` must also match
+    /// `Chunk::embedding_text()`. Phase-4 LLM summaries can be written to a
+    /// chunk (`chunks.summary`) before a later re-index backfills its embedding,
+    /// so the backfill path reconstructs with a non-null `summary` and must
+    /// produce the exact `title: {name} | summary: {summary} | text: {body}`
+    /// document (spelunk-oss^72). Covers summary × docstring present/absent.
+    #[test]
+    fn reconstruct_embedding_text_matches_chunk_embedding_text_with_summary() {
+        use crate::indexer::{Chunk, ChunkKind};
+
+        let cases = [
+            (
+                Some("do_thing"),
+                Some("Does the thing."),
+                "Summarised: does the thing.",
+            ),
+            (Some("do_thing"), None, "Summarised: no docstring."),
+            (None, Some("Anonymous doc."), "Summarised: anonymous."),
+            (None, None, "Summarised: bare."),
+        ];
+        for (name, docstring, summary) in cases {
+            let chunk = Chunk {
+                file_path: "src/lib.rs".to_string(),
+                language: "rust".to_string(),
+                kind: ChunkKind::Function,
+                name: name.map(str::to_string),
+                start_line: 1,
+                end_line: 3,
+                content: "fn do_thing() {}".to_string(),
+                docstring: docstring.map(str::to_string),
+                parent_scope: None,
+                summary: Some(summary.to_string()),
+            };
+            // Metadata JSON exactly as store_chunks persists it (docstring lives
+            // in metadata; the summary is a separate stored column).
+            let metadata = serde_json::json!({
+                "docstring": chunk.docstring,
+                "parent_scope": chunk.parent_scope,
+            })
+            .to_string();
+
+            let reconstructed = reconstruct_embedding_text(
+                name,
+                Some(&metadata),
+                Some(summary.to_string()),
+                chunk.content.clone(),
+            );
+            assert_eq!(
+                reconstructed,
+                chunk.embedding_text(),
+                "reconstruction diverged for name={name:?} docstring={docstring:?} summary={summary:?}"
+            );
+        }
+    }
+
+    // ── End-to-end backfill: parse-only run leaves chunks unembedded, a
+    //    second parse run backfills them without reparsing (spelunk-oss^72) ────
+
+    /// `run_parse_phase` stores chunks but never writes embeddings — that is the
+    /// embed phase's job. So a single parse run models the real bug: an
+    /// `init`/`index` that chunked while the embedder was still loading, leaving
+    /// the `embeddings` table empty. This test drives the full parse path over a
+    /// real fixture repo twice (no `--force`) and asserts:
+    ///   (a) after run 1, every stored chunk is unembedded (embeddings empty);
+    ///   (b) run 2 reparses nothing (`indexed == 0`, all files hash-skipped);
+    ///   (c) yet run 2 still returns a NON-EMPTY `chunk_ids_and_texts` — the
+    ///       missing-embedding chunks are unioned in for the embed phase;
+    ///   (d) the backfilled ids are exactly the chunk ids stored in run 1
+    ///       (same ids ⇒ no delete+reinsert ⇒ no unchanged file was reparsed).
+    #[test]
+    fn reindex_backfills_unembedded_chunks_without_reparsing() {
+        use indicatif::MultiProgress;
+
+        let db = open_db();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("a.rs"),
+            "/// Doc for foo.\npub fn foo() -> i32 { 1 }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("b.rs"),
+            "pub struct Bar { x: i32 }\npub fn bar() {}\n",
+        )
+        .unwrap();
+
+        let args = default_args(dir.path().to_path_buf());
+        let mp = MultiProgress::new();
+
+        // ── Run 1: parse + store chunks. No embeddings are ever written here. ──
+        let first = run_parse_phase(dir.path(), &db, &args, &mp).expect("first parse phase");
+        assert!(
+            first.indexed >= 2,
+            "both fixture files must be indexed on the first run"
+        );
+        assert!(
+            !first.chunk_ids_and_texts.is_empty(),
+            "the first run must queue freshly-parsed chunks for embedding"
+        );
+
+        // Every chunk stored in run 1 is currently unembedded (embeddings empty):
+        // the set of missing-embedding chunk ids must equal the run-1 queued ids.
+        let mut queued_run1: Vec<i64> = first
+            .chunk_ids_and_texts
+            .iter()
+            .map(|(id, _)| *id)
+            .collect();
+        queued_run1.sort();
+        let mut missing_after_run1: Vec<i64> = db
+            .chunks_missing_embeddings()
+            .expect("missing after run 1")
+            .into_iter()
+            .map(|(id, ..)| id)
+            .collect();
+        missing_after_run1.sort();
+        assert_eq!(
+            missing_after_run1, queued_run1,
+            "after a parse-only run the embeddings table is empty — every stored chunk is missing its embedding"
+        );
+
+        // ── Run 2: no file changed, so nothing is reparsed. The backfill union
+        //    must still surface the unembedded chunks for the embed phase. ──────
+        let second = run_parse_phase(dir.path(), &db, &args, &mp).expect("second parse phase");
+        assert_eq!(
+            second.indexed, 0,
+            "no file changed — the hash-based skip must reparse nothing on the second run"
+        );
+        assert!(
+            !second.chunk_ids_and_texts.is_empty(),
+            "the fix must union the missing-embedding chunks into the embed batch even though indexed == 0"
+        );
+
+        // (d) The backfilled ids are exactly the run-1 chunk ids: identical ids
+        // prove the chunks were NOT deleted and reinserted (a reparse would mint
+        // fresh rowids), i.e. no unchanged file was reparsed — only its missing
+        // embeddings were queued.
+        let mut backfilled: Vec<i64> = second
+            .chunk_ids_and_texts
+            .iter()
+            .map(|(id, _)| *id)
+            .collect();
+        backfilled.sort();
+        assert_eq!(
+            backfilled, queued_run1,
+            "backfill must queue the same chunk ids stored in run 1 (no reparse / re-chunk)"
+        );
+
+        // The reconstructed embedding texts must also be byte-identical to what
+        // the first (parse-time) run produced for those same chunks.
+        let mut texts_run1: Vec<(i64, String)> = first.chunk_ids_and_texts.clone();
+        texts_run1.sort_by_key(|(id, _)| *id);
+        let mut texts_run2: Vec<(i64, String)> = second.chunk_ids_and_texts.clone();
+        texts_run2.sort_by_key(|(id, _)| *id);
+        assert_eq!(
+            texts_run2, texts_run1,
+            "backfilled embedding text must match the parse-time embedding text byte-for-byte"
+        );
+    }
+
     // ── is_file_too_large ────────────────────────────────────────────────────
 
     #[test]

--- a/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
@@ -135,16 +135,65 @@ pub(super) fn run_parse_phase(
 
     let removed = cleanup_stale(&files, root, db)?;
     let ParseAcc {
-        out: chunk_ids_and_texts,
+        out: mut chunk_ids_and_texts,
         indexed,
         ..
     } = acc;
+
+    // Backfill: pick up any chunks that exist in the index but have no
+    // embedding row yet (e.g. a prior `init`/`index` parsed & chunked while
+    // the embedder was still loading, so the embed phase was skipped). These
+    // belong to unchanged files that the hash-based skip above never re-emits,
+    // so without this union a plain `spelunk index` would report "nothing to
+    // do" and leave them permanently unembedded (spelunk-oss^72).
+    //
+    // Freshly-parsed chunks from this run also lack an embedding row, so they
+    // appear here too; dedupe against the ids we already queued to avoid
+    // embedding them twice.
+    let already: std::collections::HashSet<i64> =
+        chunk_ids_and_texts.iter().map(|(id, _)| *id).collect();
+    for (chunk_id, name, metadata, summary, content) in db.chunks_missing_embeddings()? {
+        if already.contains(&chunk_id) {
+            continue;
+        }
+        let text =
+            reconstruct_embedding_text(name.as_deref(), metadata.as_deref(), summary, content);
+        chunk_ids_and_texts.push((chunk_id, text));
+    }
 
     Ok(ParseResult {
         chunk_ids_and_texts,
         indexed,
         removed,
     })
+}
+
+/// Rebuild the exact document text that `Chunk::embedding_text()` produces,
+/// from the columns stored for a chunk. The `docstring` lives inside the
+/// `metadata` JSON (`{ "docstring": ..., "parent_scope": ... }`), mirroring how
+/// `store_chunks` persists it. Keep this in lockstep with
+/// `spelunk_core::indexer::Chunk::embedding_text`.
+fn reconstruct_embedding_text(
+    name: Option<&str>,
+    metadata: Option<&str>,
+    summary: Option<String>,
+    content: String,
+) -> String {
+    let title = name.unwrap_or("none");
+    let docstring = metadata
+        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+        .and_then(|v| {
+            v.get("docstring")
+                .and_then(|d| d.as_str().map(str::to_string))
+        });
+    let body = match docstring {
+        Some(doc) => format!("{doc}\n{content}"),
+        None => content,
+    };
+    match summary {
+        Some(summary) => format!("title: {title} | summary: {summary} | text: {body}"),
+        None => format!("title: {title} | text: {body}"),
+    }
 }
 
 // ── File collection ───────────────────────────────────────────────────────────
@@ -493,6 +542,53 @@ mod tests {
             .set_len(MAX_FILE_BYTES + 1)
             .expect("set_len on temp file");
         file
+    }
+
+    // ── reconstruct_embedding_text mirrors Chunk::embedding_text ─────────────
+
+    /// The DB-side reconstruction used to backfill unembedded chunks must
+    /// produce byte-for-byte the same document text as `Chunk::embedding_text()`
+    /// did at store time, so a backfilled embedding is identical to one written
+    /// during a normal parse (spelunk-oss^72). Covers: name present/absent and
+    /// docstring present/absent (summary is always None at store time).
+    #[test]
+    fn reconstruct_embedding_text_matches_chunk_embedding_text() {
+        use crate::indexer::{Chunk, ChunkKind};
+
+        let cases = [
+            (Some("do_thing"), Some("Does the thing.")),
+            (Some("do_thing"), None),
+            (None, Some("Anonymous doc.")),
+            (None, None),
+        ];
+        for (name, docstring) in cases {
+            let chunk = Chunk {
+                file_path: "src/lib.rs".to_string(),
+                language: "rust".to_string(),
+                kind: ChunkKind::Function,
+                name: name.map(str::to_string),
+                start_line: 1,
+                end_line: 3,
+                content: "fn do_thing() {}".to_string(),
+                docstring: docstring.map(str::to_string),
+                parent_scope: None,
+                summary: None,
+            };
+            // Metadata JSON exactly as store_chunks persists it.
+            let metadata = serde_json::json!({
+                "docstring": chunk.docstring,
+                "parent_scope": chunk.parent_scope,
+            })
+            .to_string();
+
+            let reconstructed =
+                reconstruct_embedding_text(name, Some(&metadata), None, chunk.content.clone());
+            assert_eq!(
+                reconstructed,
+                chunk.embedding_text(),
+                "reconstruction diverged for name={name:?} docstring={docstring:?}"
+            );
+        }
     }
 
     // ── is_file_too_large ────────────────────────────────────────────────────

--- a/crates/spelunk-core/src/storage/chunks.rs
+++ b/crates/spelunk-core/src/storage/chunks.rs
@@ -54,6 +54,41 @@ impl Database {
         Ok(count)
     }
 
+    /// Return chunks that have **no** matching row in the `embeddings` vec0
+    /// table, i.e. chunks that were parsed/stored but never embedded (e.g. an
+    /// `init`/`index` run where the embedder wasn't ready yet, so the embed
+    /// phase was skipped). Returns the raw fields needed to reconstruct the
+    /// exact `Chunk::embedding_text()` document format: `(chunk_id, name,
+    /// metadata_json, summary, content)`.
+    ///
+    /// A plain re-`index` skips unchanged files by file-hash, so those chunks
+    /// never reach the embed phase on their own; the index command unions the
+    /// rows returned here into the embed batch so unchanged-but-unembedded
+    /// chunks still get embedded without reparsing.
+    #[allow(clippy::type_complexity)]
+    pub fn chunks_missing_embeddings(
+        &self,
+    ) -> Result<Vec<(i64, Option<String>, Option<String>, Option<String>, String)>> {
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT c.id, c.name, c.metadata, c.summary, c.content
+             FROM chunks c
+             LEFT JOIN embeddings e ON e.chunk_id = c.id
+             WHERE e.chunk_id IS NULL
+             ORDER BY c.id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
     pub fn delete_chunks_for_file(&self, file_id: i64) -> Result<()> {
         self.conn.execute(
             "DELETE FROM chunks WHERE file_id = ?1",
@@ -254,6 +289,38 @@ mod tests {
             .insert_chunk(file_id, "function", Some("b"), 6, 9, "fn b() {}", None, 4)
             .expect("insert b");
         (a, b)
+    }
+
+    /// A chunk with no matching `embeddings` row must surface via
+    /// `chunks_missing_embeddings` (the parse phase unions these into the embed
+    /// batch so a parse-only index doesn't leave chunks permanently
+    /// unembedded — spelunk-oss^72). Once an embedding is inserted, the chunk
+    /// drops out of the result.
+    #[test]
+    fn chunks_missing_embeddings_finds_unembedded_then_clears() {
+        let db = open_db();
+        let (a, b) = seed_two_chunks(&db);
+
+        // Both chunks parsed, neither embedded yet.
+        let mut missing: Vec<i64> = db
+            .chunks_missing_embeddings()
+            .expect("query missing")
+            .into_iter()
+            .map(|(id, ..)| id)
+            .collect();
+        missing.sort();
+        assert_eq!(missing, vec![a, b], "both unembedded chunks are missing");
+
+        // Embed one; only the other remains missing.
+        db.insert_embedding(a, &[0.1f32; 896])
+            .expect("insert embedding");
+        let still_missing: Vec<i64> = db
+            .chunks_missing_embeddings()
+            .expect("query missing")
+            .into_iter()
+            .map(|(id, ..)| id)
+            .collect();
+        assert_eq!(still_missing, vec![b], "embedded chunk drops out");
     }
 
     #[test]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -55,6 +55,12 @@ spelunk index <path> [options]
 | `--summary-batch-size <n>` | 10 | Chunks per LLM summary request |
 | `--detach` | false | Re-exec in the background and return immediately (used by git hooks) |
 
+A plain `spelunk index` (no `--force`) re-indexes changed files (blake3 hash)
+and also backfills embeddings for any already-parsed chunk that has no embedding
+yet – for example if a previous run parsed the tree before the embedder had
+finished loading. Unchanged, already-embedded files are skipped, so you no
+longer need `--force` just to fill in missing embeddings.
+
 Add a `.spelunkignore` file (same syntax as `.gitignore`) to any directory to
 exclude files from indexing. It takes higher precedence than `.gitignore`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -297,7 +297,9 @@ spelunk initialised for my-project
   Embeddings: 1 840 vectors
 ```
 
-**Subsequent runs** only re-index changed files (via blake3 hash):
+**Subsequent runs** only re-index changed files (via blake3 hash), and also
+backfill embeddings for any chunk that was parsed but never embedded (for
+instance if the embedder model was still loading on the first run):
 
 ```bash
 spelunk index /path/to/your/project


### PR DESCRIPTION
## Problem
Plain `spelunk index` (no `--force`) reported "nothing new to process" when files had been parsed and chunked but never embedded — e.g. an `init`/`index` that chunked while the embedder was still loading, so the embed phase was skipped and the `embeddings` table was left empty. Because unchanged files are hash-skipped on re-index, those chunks never reached the embed phase again, so they stayed permanently unembedded and the only workaround was `--force` (a full reparse).

## Fix
`run_parse_phase` now unions any chunks with no embedding row into the embed batch, without reparsing unchanged files:

- `crates/spelunk-core/src/storage/chunks.rs`: new `chunks_missing_embeddings()` — a `LEFT JOIN embeddings … WHERE e.chunk_id IS NULL` anti-join returning the fields needed to rebuild the embedding doc text.
- `crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs`: after the normal parse pass, the missing-embedding chunks are appended to `chunk_ids_and_texts`, deduped against ids already queued this run (freshly-parsed chunks also lack an embedding row). `reconstruct_embedding_text()` rebuilds the exact document text that `Chunk::embedding_text()` produced at store time (kept in lockstep with that function). The hash-based file parse-skip is untouched — no unchanged file is reparsed; only its missing embeddings are queued.
- Result: `chunk_ids_and_texts` is now non-empty on such a run, so the "nothing new to process" early return in `index/mod.rs` is no longer hit and the embed phase backfills the missing embeddings.
- Docs updated: `docs/commands.md`, `docs/getting-started.md`.

## Test plan (commands run in the worktree, all green)
- `git fetch origin` + `git diff origin/main...HEAD` — branch is based on current `origin/main` (`bfc205fb`, PR #510); merge-base == origin/main HEAD, no drift, no silent revert.
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-core -p spelunk-cli` — PASS. New tests included:
  - `reindex_backfills_unembedded_chunks_without_reparsing` (e2e): parse-only run 1 leaves every stored chunk unembedded; run 2 reparses nothing (`indexed == 0`) yet returns a non-empty embed batch whose ids are exactly the run-1 chunk ids (same ids ⇒ no delete+reinsert ⇒ no reparse), and whose reconstructed texts are byte-identical to run 1.
  - `chunks_missing_embeddings_finds_unembedded_then_clears`: anti-join surfaces unembedded chunks and drops them once an embedding is inserted.
  - `reconstruct_embedding_text_matches_chunk_embedding_text` / `…_with_summary`: reconstruction is byte-for-byte identical to `Chunk::embedding_text()` across name/docstring/summary present-absent combinations.
  - Totals: spelunk-cli lib 179 passed / 0 failed; spelunk-core lib 214 passed / 0 failed; all suites 0 failed.
- `cargo clippy -p spelunk-core -p spelunk-cli --all-targets -- -D warnings` — clean, no warnings.
- `cargo fmt --check` — clean (exit 0).
- Docs em-dash / internal-ref scan of the diff — none (getting-started uses an en-dash, per OSS copy rules).

## Acceptance criteria
- [x] After a parse-only run (embeddings empty), plain `spelunk index` (no `--force`) embeds all existing chunks without reparsing unchanged files — verified by `reindex_backfills_unembedded_chunks_without_reparsing` (indexed == 0, same chunk ids re-queued, embed phase consumes them and calls `insert_embedding`).
- [x] Regression test proving the above exists and passes.
- [x] Code compiles; fmt/clippy clean.
