### PR TITLE
docs(security): reconcile threat model with shipped server; retarget v1.0 server audit (oss^66)

### DIFF
--- a/docs/adr/056-oss-server-tenancy-model.md
+++ b/docs/adr/056-oss-server-tenancy-model.md
@@ -97,6 +97,11 @@ and this ADR says so out loud.
   - The deployment documentation and the fleet-management example state the
     single-trust-domain model plainly, and `GET /v1/projects` is documented as
     enumerating all projects by design.
+  - The server serves plaintext HTTP only on a loopback bind. It refuses to
+    start on a non-loopback plaintext bind; a shared deployment binds loopback
+    and terminates TLS in a front proxy, so the shared key never crosses the
+    network in cleartext. `/v1/health` is an unauthenticated endpoint (no bearer
+    required or sent).
 - **Revisit if:** a genuine need appears to host mutually distrusting groups on
   one instance. That would be a new ADR introducing scoped keys and an ACL, and
   it would supersede this one.
@@ -109,8 +114,10 @@ the primary mitigation. The consequences for the threat model:
 - The shared server key is a bearer credential that grants full access to every
   project on the instance. It must be treated as a high-value secret:
   transmitted only over a secure transport, stored with restrictive
-  permissions, and rotated on exposure. Key-comparison hardening (constant-time
-  comparison) and transport hardening are tracked separately as part of the
+  permissions, and rotated on exposure. Because the key rides on the transport,
+  the server restricts plaintext HTTP to loopback and requires TLS (a front
+  proxy) for any non-loopback deployment (see Consequences). Key-comparison
+  hardening (constant-time comparison) is tracked separately as part of the
   pre-v1.0 server security review.
 - The cross-project access that the review identified is reclassified from a
   vulnerability to documented, intended behaviour under this model. It is not a

--- a/docs/security/SECURITY-PROGRAM.md
+++ b/docs/security/SECURITY-PROGRAM.md
@@ -7,21 +7,46 @@
 
 ---
 
-## Threat Model Summary
+## Architecture in scope
 
-spelunk is a **local single-user developer CLI**. It has no network listeners,
-no authentication layer, and no multi-tenancy. The relevant threats are:
+spelunk ships in two operational modes, and the security program covers both:
 
-| Threat                                   | Likelihood | Impact | Controls                                                      |
-| ---------------------------------------- | ---------- | ------ | ------------------------------------------------------------- |
-| Credential leakage into vector index     | Medium     | High   | `secrets.rs` scanner; file exclusion in `ignore` traversal    |
-| Prompt injection via indexed source code | Low        | Medium | XML delimiters in `ask.rs`; angle-bracket escaping in context |
-| Data integrity corruption (memory DB)    | Low        | Medium | Atomic transactions in `storage/memory.rs`                    |
-| Dependency vulnerability                 | Medium     | Medium | `cargo audit` + `cargo deny` in CI                            |
-| Supply chain compromise                  | Low        | High   | `cargo deny` license/source policy; `Cargo.lock` committed    |
+- **Local CLI (default).** A single-user developer CLI that indexes source
+  trees, stores chunks and memory notes in local SQLite, and reaches an
+  inference backend for embeddings and LLM calls. From v0.9 the default backend
+  is an auto-discovered `spelunk-server` bound to loopback (`127.0.0.1`); it is
+  an inference backend only and never a memory store of record.
+- **Optional shared `spelunk-server`.** An axum HTTP listener
+  (`crates/spelunk-server/`) that holds a team's memory when a developer sets an
+  explicit `server_url`. It exposes memory CRUD and semantic search over the
+  network, authenticates callers with a single shared bearer key (`ApiKeyAuth`),
+  and routes requests by a project-slug path segment.
 
-Out of scope: network attacks, multi-user access control, authentication bypass.
-Full threat model: `docs/security/THREAT-MODEL.md`.
+Because the shared server exists, **network exposure, authentication, and
+multi-user access control are IN scope** for this program. The server's tenancy
+model is a deliberate design choice, not an omission: a server instance is a
+**single trust domain**, and its shared key is the boundary (see
+[ADR-056](../adr/056-oss-server-tenancy-model.md)). Every keyholder is a full
+administrator of every project on that instance; isolation between teams is
+achieved by running separate instances, each with its own key and database.
+
+The relevant threats, across both modes:
+
+| Threat                                   | Mode | Likelihood | Impact | Controls                                                      |
+| ---------------------------------------- | ---- | ---------- | ------ | ------------------------------------------------------------- |
+| Credential leakage into vector index     | CLI  | Medium     | High   | `secrets.rs` scanner; file exclusion in `ignore` traversal    |
+| Prompt injection via indexed source code | CLI  | Low        | Medium | XML delimiters in `ask.rs`; angle-bracket escaping in context |
+| Data integrity corruption (memory DB)    | CLI  | Low        | Medium | Atomic transactions in `storage/memory.rs`                    |
+| Unauthenticated network access to server memory | Server | Medium | High | Bearer key (`ApiKeyAuth`); a non-loopback bind without a key is refused at startup |
+| Bearer key disclosure / brute force on server | Server | Low | High | Key hashed with BLAKE3; per-request constant-time compare; shared key is a high-value secret (ADR-056) |
+| Cross-project read/write on a shared server | Server | n/a | n/a | Intended under the single-trust-domain model (ADR-056), not a defect; isolate by running separate instances |
+| Server denial of service (oversized / slow requests) | Server | Low | Medium | Request-body cap, per-route timeout, concurrency and rate limits |
+| Dependency vulnerability                 | Both | Medium     | Medium | `cargo audit` + `cargo deny` in CI                            |
+| Supply chain compromise                  | Both | Low        | High   | `cargo deny` license/source policy; `Cargo.lock` committed    |
+
+Full threat model: [`docs/security/THREAT-MODEL.md`](THREAT-MODEL.md). The
+server-specific pre-v1.0 checklist is
+[`docs/security/V1-SERVER-AUDIT.md`](V1-SERVER-AUDIT.md).
 
 ---
 
@@ -70,10 +95,20 @@ Full threat model: `docs/security/THREAT-MODEL.md`.
 
 | Control                                  | Where                             |
 | ---------------------------------------- | --------------------------------- |
-| Parameterised SQL (no string formatting) | All `src/storage/*.rs`            |
-| XML delimiter isolation for LLM prompts  | `src/cli/cmd/ask.rs`              |
-| Angle-bracket escaping in RAG context    | `src/cli/cmd/ask.rs` (issue #137) |
-| Atomic transactions for memory state     | `src/storage/memory.rs`           |
+| Parameterised SQL (no string formatting) | All `storage/*.rs`                |
+| XML delimiter isolation for LLM prompts  | `cli/cmd/ask.rs`                  |
+| Angle-bracket escaping in RAG context    | `cli/cmd/ask.rs` (issue #137)    |
+| Atomic transactions for memory state     | `storage/memory.rs`              |
+
+### Server controls (shared `spelunk-server`)
+
+| Control                                          | Where                                         |
+| ------------------------------------------------ | --------------------------------------------- |
+| Bearer-key auth; key hashed (BLAKE3), constant-time compare | `crates/spelunk-server/src/auth.rs`  |
+| Refuse a non-loopback bind without a key         | `crates/spelunk-server/src/main.rs`           |
+| Request-body cap, per-route timeout, concurrency and rate limits | `crates/spelunk-server/src/lib.rs`, `handlers.rs` |
+| Title / body length caps and project-slug caps at the handler | `crates/spelunk-server/src/handlers.rs`  |
+| Generic 5xx (no internal detail leak); safe error mapping | `crates/spelunk-server/src/lib.rs`, `db.rs` |
 
 ### Operational controls
 
@@ -117,5 +152,7 @@ See `SECURITY.md` at the repo root.
 
 - [OWASP SAMM v2](https://owaspsamm.org/model/)
 - [OWASP Top 10:2025 — Establishing a Modern AppSec Program](https://owasp.org/Top10/2025/0x03_2025-Establishing_a_Modern_Application_Security_Program/)
-- [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/) (L1 subset relevant to local CLI tools)
-- `docs/security/THREAT-MODEL.md`
+- [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/) (L1 subset for the CLI; the HTTP server draws on the network-facing controls too)
+- [`docs/security/THREAT-MODEL.md`](THREAT-MODEL.md)
+- [`docs/security/V1-SERVER-AUDIT.md`](V1-SERVER-AUDIT.md)
+- [ADR-056: OSS server tenancy model](../adr/056-oss-server-tenancy-model.md)

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -1,7 +1,7 @@
 # spelunk Threat Model
 
 **Method:** Lightweight threat modeling (STRIDE-informed)  
-**Last reviewed:** June 2026 (PR #390: ADR-004 unified memory storage)  
+**Last reviewed:** July 2026 (server reconciliation: ADR-056 single-trust-domain tenancy)  
 **Reviewed by:** Architect  
 **Next review:** v1.0 release or after any new network-facing feature
 
@@ -122,6 +122,31 @@ keyless server can therefore only bind loopback (`127.0.0.1`), where it is reach
 by local processes but not by other machines. (A blank/whitespace key — e.g.
 docker-compose's `${SPELUNK_SERVER_KEY:-}` default — is treated as no key.)
 
+### Tenancy boundary: single trust domain (ADR-056)
+
+A `spelunk-server` instance is a **single trust domain**, and its shared key is
+the tenancy boundary. This is a deliberate design decision recorded in
+[ADR-056](../adr/056-oss-server-tenancy-model.md), not an unimplemented control:
+
+- Holding the server's key grants full participation in **every** project on
+  that instance: list, read, search, write, supersede, archive, and delete.
+  `GET /v1/projects` enumerating all project slugs is intended behaviour.
+- The `project_id` slug in the request path is an **addressing convenience, not
+  a security boundary**. The server implements no per-project or per-principal
+  authorization, because the OSS SQLite server has no identity, org, or role
+  model to hang one on.
+- Isolation between teams or projects that must not see each other's memory is
+  achieved by running **separate server instances**, each with its own key and
+  its own database.
+- Consequently, cross-project read/write on a single instance is documented,
+  intended behaviour under this model, not a vulnerability. A future ADR that
+  introduces a scoped-key and ACL model would supersede this decision.
+
+**Transport (ADR-056 addendum):** the server serves plaintext HTTP only on a
+loopback bind. A shared, non-loopback deployment terminates TLS in a front proxy
+so the shared key never crosses the network in cleartext. `/v1/health` is
+unauthenticated (no bearer required or sent).
+
 ---
 
 ## Threat Analysis (STRIDE)
@@ -147,7 +172,7 @@ docker-compose's `${SPELUNK_SERVER_KEY:-}` default — is treated as no key.)
 
 | Threat | Mode | Likelihood | Impact | Mitigation |
 |--------|------|-----------|--------|-----------|
-| No record of who created/deleted a memory note on the server | B | Medium | Medium | Server has no per-request audit log. `source_ref` field can record commit SHA but is not required. Consider adding `created_by` / request logging for multi-user deployments. |
+| No record of who created/deleted a memory note on the server | B | Medium | Medium | Server has no per-request audit log. `source_ref` field can record commit SHA but is not required. Under the single-trust-domain model (ADR-056) every keyholder is a full administrator, so per-principal attribution is not an isolation control; `created_by` / request logging remains a possible future operational aid for shared deployments. |
 
 ### I — Information Disclosure
 
@@ -168,7 +193,8 @@ docker-compose's `${SPELUNK_SERVER_KEY:-}` default — is treated as no key.)
 
 | Threat | Mode | Likelihood | Impact | Mitigation |
 |--------|------|-----------|--------|-----------|
-| Path traversal via project_id or note body to read arbitrary server files | B | Low | High | project_id is a DB-assigned integer; note body is stored as-is but never executed. No file reads from user input. |
+| Path traversal via project_id or note body to read arbitrary server files | B | Low | High | The `project_id` is a slug used only as a database key (capped in length at the handler), never as a filesystem path; the note body is stored as-is but never executed. No file reads derive from user-supplied request fields. |
+| Keyholder reads or deletes another project's memory on a shared instance | B | n/a | n/a | **Intended behaviour, not a defect (ADR-056).** A server instance is a single trust domain; the shared key grants full access to every project. Teams that must be isolated run separate instances. This is not an elevation of privilege because there is no lower privilege level to elevate from: one key is one trust domain. |
 | Git argument injection via `spelunk memory harvest --branch`/`--git-range` (e.g. `--branch=--output=<path>`) forwarded to `git log` with no `--` separator, letting an option-shaped value be parsed as a git flag instead of a ref (arbitrary local file clobber) | A | Low | Medium | Fixed: `reject_option_like_ref()` rejects any ref, or either endpoint of an `A..B` range, starting with `-` before the subprocess spawns; both `git log` invocations also append a trailing `--` separator as defense-in-depth. Same review applied to the git-notes write path (`git_notes/mod.rs`): all `<object>` args to `notes show`/`add` are `--`-guarded, and note bodies are written via stdin (`-F -`) instead of `-m <arg>`, so a body can't be argv-parsed as an option or exposed on `ps`. |
 
 ### D — Denial of Service

--- a/docs/security/V1-SERVER-AUDIT.md
+++ b/docs/security/V1-SERVER-AUDIT.md
@@ -1,142 +1,177 @@
 # v1.0 Server Security Audit Checklist
 
-**Scope:** spelunk-server (crates/spelunk-server after workspace restructure) — new attack surface not covered by the existing CLI security program.  
+**Scope:** `spelunk-server` (`crates/spelunk-server/`), the HTTP attack surface not covered by the CLI security program.  
 **Gate:** Must be completed before v1.0 GA. Blocks the v1.0 tag.  
-**Date drafted:** 2026-05-17
+**Date drafted:** 2026-05-17  
+**Retargeted:** 2026-07-03 to the OSS server as-built (single-trust-domain tenancy per [ADR-056](../adr/056-oss-server-tenancy-model.md)).
 
-The CLI threat model (`THREAT-MODEL.md`) remains valid for the CLI crate. This document covers threats introduced by the HTTP server.
+The CLI threat model ([`THREAT-MODEL.md`](THREAT-MODEL.md)) remains valid for the CLI crate. This document covers threats introduced by the HTTP server.
+
+**On this retarget.** The original draft was written against a cloud-shaped server
+(Postgres, `org_id` row-level security, `JWT_SECRET`, `sk-sp-` prefixed keys). The
+OSS `spelunk-server` is a single-file SQLite service with one shared bearer key and
+no identity, org, or role model. Items that assume the cloud shape are relabelled
+below as **N/A (cloud-only)** or **N/A by design (ADR-056)**; they are not
+unmet requirements. Boxes are ticked only where the sibling fix has merged and the
+code was read in this tree to confirm it; each such row cites the file that
+implements it. Applicable-but-unmet boxes stay unchecked with the owning task named.
+
+**Legend:** ☑ done (evidence cited) · ☐ applicable, not yet satisfied · N/A relabelled item (with reason).
 
 ---
 
-## 1. Injection scanning middleware
+## 1. Injection scanning
+
+The module is `crates/spelunk-server/src/security.rs` (`scan_for_injection`), not the
+originally-drafted `src/security/injection.rs` path. It carries 12 patterns, not 8.
 
 | Check | Status |
 |---|---|
-| `src/security/injection.rs` is called in POST /v1/projects/{id}/memory before any DB write | ☐ |
-| No client header or query parameter can bypass the scan | ☐ |
-| 422 response returns `field` and `category` — never the raw regex | ☐ |
-| OnceLock pattern compilation verified: no per-request recompilation | ☐ |
-| All 8 default patterns have positive and negative unit tests | ☐ |
-| Audit log (`tracing::warn!`) fires on every match | ☐ |
+| `security::scan_for_injection` is called in `POST /v1/projects/{id}/memory` before any DB write | ☑ `handlers.rs::add_note` scans `title`+`body` and returns 422 before the insert |
+| No client header or query parameter can bypass the scan | ☑ the scan runs unconditionally inside the handler on the parsed `title`/`body`; there is no bypass field |
+| 422 response returns `field` and `category`, never the raw regex | ☑ `handlers.rs` returns `{field, category, message}`; `security.rs` exposes only the `category` name, never the pattern |
+| OnceLock pattern compilation verified: no per-request recompilation | ☑ `security.rs::patterns()` compiles once via `OnceLock<Vec<Pattern>>` |
+| All default patterns have positive and negative unit tests | ☑ `security.rs` tests cover every pattern positively plus two clean-input negatives |
+| Audit log (`tracing::warn!`) fires on every match | ☐ **Not implemented.** `add_note` returns 422 but does not `tracing::warn!` on a match. Owner: open follow-up (no sibling fix merged for this row). |
 
-## 2. API key authentication
+## 2. Bearer-key authentication
 
-| Check | Status |
-|---|---|
-| API key stored as BLAKE3 hash — plaintext never persisted | ☐ |
-| Key comparison uses constant-time equality (not `==` on strings) | ☐ |
-<!-- spelunk-oss^58 (PR #502, draft): ApiKeyAuth now hashes the configured key with BLAKE3 at
-     construction and compares per-request tokens via constant_time_eq_32 on the two 32-byte
-     digests — the two rows above are implemented in crates/spelunk-server/src/auth.rs. Sign-off
-     (✅ + initials/date) still owned by whoever closes oss^66. -->
-| `sk-sp-` prefix format validated before any DB lookup | ☐ |
-| Revoked/deleted keys rejected immediately (no cache window) | ☐ |
-| Key scope enforced: project-scoped key cannot write to other projects | ☐ |
-
-## 3. Multi-tenancy isolation
+The OSS server authenticates with **one shared bearer key** (`ApiKeyAuth`,
+`crates/spelunk-server/src/auth.rs`). There is no per-key database record, no key
+prefix format, and no per-project key scope. The shared key is the tenancy
+boundary ([ADR-056](../adr/056-oss-server-tenancy-model.md)). The rows that assume a
+keys-table / scoped-key model are relabelled accordingly.
 
 | Check | Status |
 |---|---|
-| Every DB query includes an `org_id` filter (no bare table scans) | ☐ |
-| RLS enabled and tested: a valid key from org A cannot read org B's entries | ☐ |
-| Integration test: cross-org read attempt returns 403, not 404 or 200 | ☐ |
+| Configured key never held or compared as plaintext | ☑ `auth.rs::ApiKeyAuth::new` hashes the key with BLAKE3 into a 32-byte digest at construction; the plaintext is not retained (oss^58) |
+| Key comparison uses constant-time equality (not `==` on strings) | ☑ `auth.rs` hashes the provided token and compares digests with `constant_time_eq::constant_time_eq_32` (oss^58) |
+| `sk-sp-` prefix format validated before any DB lookup | N/A (cloud-only). The OSS server has no `sk-sp-` prefix and no per-key DB lookup; the key is opaque and matched by digest. |
+| Revoked/deleted keys rejected immediately (no cache window) | N/A (cloud-only). There is no key store to revoke from; a single shared key is rotated by restarting the server with a new value (ADR-056). |
+| Key scope enforced: project-scoped key cannot write to other projects | N/A by design (ADR-056). The shared key grants full access to every project on the instance; isolation is by running separate instances. |
+
+## 3. Tenancy model (single trust domain)
+
+Reframed to the OSS server's ratified model ([ADR-056](../adr/056-oss-server-tenancy-model.md)):
+a server instance is a **single trust domain**, and its shared key is the boundary.
+There is no `org_id`, no row-level security, and no cross-tenant isolation *within*
+one instance. That is intended, not a gap. Projects on one instance are addressed
+by a `project_id` slug in the path, which is a routing key, not a security boundary.
+Isolation between teams is achieved by running **separate instances**, each with its
+own key and database. The rows below are therefore N/A by design.
+
+| Check | Status |
+|---|---|
+| Every DB query includes an `org_id` filter (no bare table scans) | N/A by design (ADR-056). No `org_id` exists; queries scope by `project_id` slug, which is an addressing key, not an isolation control. |
+| RLS enabled and tested: a valid key from org A cannot read org B's entries | N/A by design (ADR-056). SQLite has no RLS and the model has no orgs; one key = one trust domain over all projects. |
+| Integration test: cross-org read attempt returns 403, not 404 or 200 | N/A by design (ADR-056). Cross-project access with the shared key is intended behaviour; there is no cross-org boundary to test. |
+
+**Operator guardrail (applicable, verify before GA):** the server must emit a
+startup notice on a keyed, non-loopback bind stating that every keyholder is a full
+administrator of all projects and that separate instances are the way to isolate.
+Status: ☑ implemented in `main.rs::should_warn_single_trust_domain` /
+`warn_single_trust_domain`, which fire the ADR-056 notice on a keyed non-loopback bind.
 
 ## 4. Input validation
 
+Path params in the OSS server are **project slugs** (e.g. `usercise/spelunk`), not
+UUIDs, so the "malformed UUID" row is reframed as a slug length/sanity cap.
+
 | Check | Status |
 |---|---|
-| Title field: max 500 characters enforced at route handler | ☐ |
-| Body field: max 50 000 characters enforced at route handler | ☐ |
-| UUID path params validated (malformed UUID returns 400, not 500) | ☐ |
-| All SQL uses parameterised queries — no string concatenation | ☐ |
-<!-- spelunk-oss^60 (PR pending, task/engineer-oss60-20260702-1743): `add_note` now enforces
-     MAX_TITLE_LEN=500 / MAX_BODY_LEN=50_000 (handlers.rs) plus an embedding-vector-length ==
-     configured-dim check, all returning 400 on violation. `project_id` slugs (not UUIDs — project
-     ids are human slugs like `usercise/spelunk`, so this is a length/sanity cap, not UUID-format
-     validation) are capped at 200 bytes, centralized in `require_project` plus explicit calls in
-     the handlers that don't route through it (add_note/index_embed/project_search/explore/
-     llm_complete). Also added in this task, beyond this table: a `tower_http` middleware stack
-     (TimeoutLayer 30s exempting /memory/stream, RequestBodyLimitLayer 2 MiB, ConcurrencyLimitLayer
-     256) and IP-keyed rate limiting on /explore + /llm/complete — see THREAT-MODEL.md's
-     "D — Denial of Service" table for the full breakdown, including the ConcurrencyLimitLayer
-     known-limitation note on streaming routes. First two rows above ready for ✅ + initials/date
-     sign-off by whoever closes oss^66; UUID-path-param row and SQL-parameterisation row are
-     unrelated to this task and remain open. -->
+| Title field: max 500 characters enforced at route handler | ☑ `handlers.rs` `MAX_TITLE_LEN = 500`, returns 400 on violation (oss^60) |
+| Body field: max 50 000 characters enforced at route handler | ☑ `handlers.rs` `MAX_BODY_LEN = 50_000`, returns 400 on violation (oss^60) |
+| Path param (project slug) validated; an over-long slug returns 400, not 500 | ☑ `handlers.rs` `MAX_SLUG_LEN = 200`, enforced in `require_project` and the handlers that bypass it (add_note / index_embed / project_search / explore / llm_complete) (oss^60) |
+| All SQL uses parameterised queries, no string concatenation | ☑ verified: `db.rs` uses `params!` throughout (no `format!`/concatenation into SQL across `crates/spelunk-server/src/`); FTS5 terms are quoted as literals via `fts5_quote_literal` (oss^65) |
+
+Beyond this table, oss^60 also added a `tower_http` middleware stack (see §DoS in
+[`THREAT-MODEL.md`](THREAT-MODEL.md#d--denial-of-service)): `RequestBodyLimitLayer`
+(2 MiB), `TimeoutLayer` (30s, exempting `/memory/stream`), `ConcurrencyLimitLayer`
+(256), plus IP-keyed rate limiting on `/explore` and `/llm/complete`, and an
+embedding-vector-length check against the configured dim.
 
 ## 5. SSE stream
 
+The OSS server has one shared key with no per-key revocation and no orgs (ADR-056),
+so the revocation-window and cross-tenant rows do not apply.
+
 | Check | Status |
 |---|---|
-| SSE connections require a valid API key on connection open | ☐ |
-| Heartbeat tick re-validates key (revoked key disconnected within 60s) | ☐ |
-| SSE events scoped to org — no cross-tenant event possible | ☐ |
-| Integration test: revoke key, verify SSE connection closes within 60s | ☐ |
+| SSE connection requires a valid key on connection open | ☑ the `/v1/projects/{id}/memory/stream` route is mounted under `auth_middleware` (`lib.rs`), so the key is checked before the stream opens |
+| Heartbeat tick re-validates key (revoked key disconnected within 60s) | N/A by design (ADR-056). There is no per-key revocation store; a single shared key is rotated by restarting the server. The keep-alive tick is a transport ping, not a re-auth. |
+| SSE events scoped to org (no cross-tenant event possible) | N/A by design (ADR-056). No orgs; the stream is scoped to a `project_id` slug within the single trust domain. |
+| Integration test: revoke key, verify SSE connection closes within 60s | N/A by design (ADR-056). No revocation mechanism to test against. |
 
 ## 6. Dependencies
 
+Verified against CI (`.github/workflows/security.yml`), which runs on every push
+and PR to `main` plus a weekly schedule.
+
 | Check | Status |
 |---|---|
-| `cargo audit` passes clean for spelunk-server crate | ☐ |
-| `cargo deny` passes (licenses + sources) | ☐ |
-| No yanked dependencies in Cargo.lock | ☐ |
+| `cargo audit` passes clean (workspace, includes spelunk-server) | ☑ `security.yml` runs `cargo audit`; it fails the job on any unignored advisory |
+| `cargo deny` passes (advisories + licenses + bans + sources) | ☑ `security.yml` runs `cargo deny check advisories licenses bans`; `deny.toml` also defines `[sources]` |
+| No yanked dependencies in Cargo.lock | ☑ `Cargo.lock` is committed and `cargo audit` reports yanked crates by default, gating the same CI job |
 
 ## 7. Configuration and secrets
 
+The OSS server has no `JWT_SECRET` and no `DATABASE_URL`; it is a single-file SQLite
+service authenticated by one bearer key. The JWT/database rows are relabelled.
+
 | Check | Status |
 |---|---|
-| Server refuses to start if JWT_SECRET is absent or < 32 bytes | ☐ |
-| DATABASE_URL never logged (trace level or above) | ☐ |
-| No secrets in default config files or committed .env files | ☐ |
-| `.env*` excluded from any server-side file operations | ☐ |
+| Server refuses to start if `JWT_SECRET` is absent or < 32 bytes | N/A (cloud-only). The OSS server has no JWT; auth is the shared `SPELUNK_SERVER_KEY`. The applicable startup guard, a non-loopback bind without a key being refused (`main.rs::check_bind_safety`), is ☑ implemented. |
+| `DATABASE_URL` never logged | N/A (cloud-only). No `DATABASE_URL`; the DB is a local SQLite file path. The applicable rule, that the bearer key is never logged, holds: ☑ `auth.rs` never logs the key or its hash. |
+| No secrets in default config files or committed `.env` files | ☑ verified: no committed `.env` and no secrets in the server's default config; `SPELUNK_SERVER_KEY` is supplied by the operator at runtime |
+| `.env*` excluded from any server-side file operations | N/A. The server does not walk the filesystem or index files; only the CLI indexer reads project trees (where `.env*` exclusion applies, and is documented in the CLI program). |
 
 ## 8. Error responses
 
 | Check | Status |
 |---|---|
-| 5xx responses do not leak stack traces or internal paths | ✅ |
-| 422 injection responses reveal category, not pattern | ☐ |
-| 401/403 responses consistent — cannot distinguish missing key from wrong key | ☐ |
+| 5xx responses do not leak stack traces or internal paths | ☑ `AppError::Internal` returns a fixed generic "Internal server error" 500 regardless of the underlying error text; the one safe case (embedding dim mismatch) is a typed 400 with a fixed message (`lib.rs`, `db.rs`) (oss^65, PR #509) |
+| 422 injection responses reveal category, not pattern | ☑ `handlers.rs` returns `{field, category, message}`; the raw regex is never exposed (see §1) |
+| 401 responses consistent (cannot distinguish a missing key from a wrong key) | ☑ `auth.rs` returns the same `AuthError("Unauthorized")` mapped to 401 for both a missing `Authorization` header and a wrong bearer token; there is no 403 path (single shared key), so the missing-vs-wrong distinction does not leak |
 
-<!-- spelunk-oss^65 (PR #509, merged): AppError::Internal no longer sniffs the error Display text
-     for substrings like "mismatch"/"required" — that was the leak: any future error whose
-     message happened to contain those words would have reached the client. The one legitimately
-     safe case (per-project embedding dimension mismatch) is now a typed DimensionMismatch error
-     mapped to a 400 with a fixed safe message (crates/spelunk-server/src/db.rs, lib.rs); every
-     other Internal error returns a fixed generic "Internal server error" 500 regardless of its
-     underlying text. Same PR also closed two adjacent robustness gaps found alongside this one
-     (not strictly in-scope for this checklist row, noted here for traceability): FTS5 MATCH
-     queries are now quoted as literal strings (crates/spelunk-core/src/utils/mod.rs
-     fts5_quote_literal(), applied in storage/search.rs + storage/memory/search.rs) so punctuation
-     in a search term no longer surfaces a raw FTS5 parse error — except an embedded-NUL-byte
-     edge case that still leaks one, tracked as a follow-up in spelunk-oss^75; and
-     `spelunk index` now applies a uniform MAX_FILE_BYTES size gate before reading any file
-     format into memory (crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs), not just the
-     tree-sitter branch. Row marked ✅ 2026-07-03 by docs-writer per test-engineer verification
-     (task comments on spelunk-oss^65); other two rows in this section are unrelated to this task
-     and remain open. -->
+<!-- Evidence note (oss^65, PR #509, merged): AppError::Internal no longer sniffs the error
+     Display text for substrings like "mismatch"/"required"; that was the leak. The one
+     legitimately safe case (per-project embedding dimension mismatch) is now a typed
+     DimensionMismatch error mapped to a 400 with a fixed safe message
+     (crates/spelunk-server/src/db.rs, lib.rs); every other Internal error returns a fixed generic
+     "Internal server error" 500. The same PR also quoted FTS5 MATCH terms as literals
+     (crates/spelunk-core/src/utils/mod.rs fts5_quote_literal, applied in storage/search.rs +
+     storage/memory/search.rs), with an embedded-NUL-byte edge case tracked as a follow-up in
+     spelunk-oss^75, and added a uniform MAX_FILE_BYTES gate in
+     crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs. -->
 
 ---
 
 ## Running the checks
 
 ```bash
-# From spelunk-server crate root (after workspace restructure)
+# From the workspace root. Export SPELUNK_SECRET_STORE=file on macOS to avoid
+# Keychain prompts during tests.
 cargo audit
-cargo deny check
+cargo deny check advisories licenses bans
 cargo clippy -p spelunk-server -- -W clippy::all -D warnings
 
-# Integration tests (require running server + postgres)
-cargo test -p spelunk-server --test integration
+# Server unit + handler tests (SQLite; no external services required)
+SPELUNK_SECRET_STORE=file cargo test -p spelunk-server
 
-# Cross-tenant isolation test
-cargo test -p spelunk-server cross_tenant
-
-# SSE revocation test
-cargo test -p spelunk-server sse_key_revocation
+# Auth, injection-scan, input-cap, and error-mapping tests live in-crate:
+#   auth.rs (constant-time key compare), security.rs (injection patterns),
+#   handlers.rs (title/body/slug caps, 422 shape, SSE past-timeout).
 ```
 
 ---
 
 ## Sign-off
 
-All checks must be marked ✅ before the v1.0 tag is created. Add initials + date next to each check when complete.
+Every **applicable** row must be ☑ (with cited evidence) before the v1.0 tag is
+created. **N/A** rows carry no obligation; they record a cloud-only item or an
+ADR-056 by-design decision, not an outstanding task.
+
+**State at retarget (2026-07-03):** the only applicable row not yet satisfied is
+the §1 injection audit-log (`tracing::warn!` on a match). Every other applicable
+row is ☑ with evidence cited above. Founder sign-off (initials + date) on this
+retarget and the remaining open row is pending review of this PR.


### PR DESCRIPTION
Reconciles the security-program docs with the server that actually shipped, and
retargets the v1.0 server audit gate to the OSS SQLite server as-built. Reviewed
directly as a PR (security-governance docs).

## What this reconciles

The docs still described spelunk as a local single-user CLI with no network
listeners, no auth, and no multi-tenancy, and put those out of scope. The product
now ships `spelunk-server` (axum HTTP listener), `ApiKeyAuth` bearer auth, and
project-slug routing. This PR brings network exposure, authentication, and
multi-user access control in scope, and records the single-trust-domain tenancy
boundary decided in ADR-056 (already merged, #499).

- **ADR-056** (cherry-picked from the ready addendum): loopback-only plaintext,
  TLS-front for non-loopback, unauthenticated `/v1/health`.
- **SECURITY-PROGRAM.md**: states the two-mode architecture (local CLI + optional
  shared server); adds server threat rows and a server controls inventory;
  cross-references ADR-056 and the audit checklist.
- **THREAT-MODEL.md**: documents the single-trust-domain boundary (shared key IS
  the boundary; cross-project access is intended; isolate by running separate
  instances); records the transport guardrail; reframes the repudiation and
  elevation-of-privilege rows.
- **V1-SERVER-AUDIT.md**: retargeted to the OSS server. Cloud-only rows
  (`org_id`/RLS/`JWT_SECRET`/`sk-sp-`) relabelled N/A; per-project-scope and
  tenant-isolation sections reframed to the single-trust-domain model as N/A by
  design; applicable boxes ticked against merged sibling fixes, each citing the
  implementing file read in this tree.

## Audit boxes now ticked (evidence in this tree)

- **§1 injection**: scan-before-write, no bypass, 422 shape (category not regex),
  OnceLock compile, per-pattern tests (`security.rs`, `handlers.rs`).
- **§2 auth**: BLAKE3 hash of the key + constant-time digest compare
  (`auth.rs`, oss^58).
- **§3 guardrail**: single-trust-domain startup notice on a keyed non-loopback
  bind (`main.rs`).
- **§4 input**: title/body caps, project-slug cap, parameterised SQL + FTS5
  literal quoting (`handlers.rs`, `db.rs`, oss^60/oss^65).
- **§5 SSE**: key required on connection open (route under `auth_middleware`).
- **§6 deps**: `cargo audit` + `cargo deny check advisories licenses bans` in CI
  (`security.yml`); `Cargo.lock` committed.
- **§7 secrets**: non-loopback-without-key refused (`check_bind_safety`); key
  never logged; no committed `.env`/secrets.
- **§8 errors**: generic 5xx (no internal-text leak), 422 category-only, 401
  missing-vs-wrong indistinguishable (`lib.rs`, `db.rs`, `auth.rs`, oss^65 #509).

## N/A by relabel (not unmet)

Cloud-only: `sk-sp-` prefix, per-key revocation store, `JWT_SECRET`,
`DATABASE_URL`, server-side `.env` handling. N/A by design (ADR-056): per-project
key scope, `org_id`/RLS cross-tenant isolation, SSE org-scoping / revocation
window.

## Applicable row still open

- **§1 injection audit log**: `add_note` returns 422 but does not `tracing::warn!`
  on a match. No sibling fix merged for this; left unchecked as a follow-up.

## Test plan

- Docs-only change plus the ADR addendum; no code changed. Pre-commit
  `cargo fmt --check` + `cargo clippy` ran green on commit.
- Every ticked box was verified by reading the cited source in this worktree
  (auth.rs, security.rs, handlers.rs, db.rs, lib.rs, main.rs) and CI config
  (.github/workflows/security.yml, deny.toml); no box is asserted without that
  evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)