### PR TITLE
fix(bench): correct default TASKS_FILE path in setup_repos.sh

### DIFF
--- a/bench/setup_repos.sh
+++ b/bench/setup_repos.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-TASKS_FILE="${SCRIPT_DIR}/../agents/tasks_50.json"
+TASKS_FILE="${SCRIPT_DIR}/agents/tasks_50.json"
 TASKS=0          # 0 = all
 
 # Default to the shared spelunk-bench checkout if it exists


### PR DESCRIPTION
## Summary
- `SCRIPT_DIR` in `bench/setup_repos.sh` resolves to `bench/` itself, so the default `TASKS_FILE=${SCRIPT_DIR}/../agents/tasks_50.json` pointed at repo-root `agents/tasks_50.json`, which does not exist. Running `bash bench/setup_repos.sh` with no `--tasks-file` override failed with `FileNotFoundError`.
- Changed the default to `${SCRIPT_DIR}/agents/tasks_50.json`, matching the documented default of `bench/agents/tasks_50.json` in the usage header.

## Test plan
- [x] `bash bench/setup_repos.sh --tasks 1` (no `--tasks-file` override): tasks file resolves to `bench/agents/tasks_50.json`, metadata for 1 task fetched from HuggingFace, existing checkout skipped as already current, 0 failures.
- [x] Same run against a fresh `--repos-dir` confirmed the default path resolution before clone/checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)