### PR TITLE
fix(bench): agent.py --save-patch silently dropped patches on unmatched allowlist pathspecs (spelunk-oss^96)

### DIFF
--- a/bench/agents/agent.py
+++ b/bench/agents/agent.py
@@ -548,22 +548,41 @@ def main() -> None:
                 "*.yml",
                 "*.md",
             ]
-            subprocess.run(
-                ["git", "add", "--", *SOURCE_PATHSPECS],
-                cwd=repo_path,
-                capture_output=True,
-                text=True,
-                timeout=30,
-                check=True,
+            # Never hand the allowlist itself to `git add`: git treats any
+            # pathspec with zero matches across the whole repo as fatal
+            # (exit 128, "pathspec '*.rs' did not match any files") and then
+            # stages nothing at all — not even the pathspecs that did match.
+            # Since a task repo only ever contains files for a few of the 18
+            # extensions above, that made patch capture fail on essentially
+            # every run, silently saving `patch_file: null` even when a
+            # correct fix sat in the working tree. Instead, resolve the
+            # allowlist to concrete changed files first — `git diff
+            # --name-only` (tracked, modified) and `git ls-files --others`
+            # (untracked, new) both tolerate unmatched pathspecs cleanly —
+            # and stage only those. Keep in lockstep with
+            # harness_common.extract_patch, which uses the same approach.
+            def run_git(git_args: list) -> str:
+                return subprocess.run(
+                    git_args,
+                    cwd=repo_path,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=True,
+                ).stdout
+
+            modified = run_git(
+                ["git", "diff", "--name-only", "--", *SOURCE_PATHSPECS]
+            ).splitlines()
+            untracked = run_git(
+                ["git", "ls-files", "--others", "--exclude-standard", "--", *SOURCE_PATHSPECS]
+            ).splitlines()
+            changed_files = [f for f in (*modified, *untracked) if f.strip()]
+            if changed_files:
+                run_git(["git", "add", "--", *changed_files])
+            diff = run_git(
+                ["git", "diff", "--cached", "HEAD", "--", *SOURCE_PATHSPECS]
             )
-            diff = subprocess.run(
-                ["git", "diff", "--cached", "HEAD", "--", *SOURCE_PATHSPECS],
-                cwd=repo_path,
-                capture_output=True,
-                text=True,
-                timeout=30,
-                check=True,
-            ).stdout
             patch_path = Path(args.save_patch)
             patch_path.parent.mkdir(parents=True, exist_ok=True)
             patch_path.write_text(diff)


### PR DESCRIPTION
## Problem

`agent.py`'s `--save-patch` handler ran `git add -- <18-extension allowlist>` directly. Git treats **any** pathspec with zero matches across the repo as fatal (exit 128, `pathspec '*.rs' did not match any files`) — and when that fires it stages **nothing at all**, not even the extensions that did match. Since virtually every SWE-bench task repo contains files for only a few of the 18 allowlisted extensions, patch capture failed on essentially every real run: the `except Exception` wrapper swallowed it into a stderr warning and the result JSON reported `patch_file: null` even when a correct fix sat in the working tree — indistinguishable from the agent producing no fix.

## Fix

Never hand the allowlist itself to `git add`. Resolve it to concrete changed files first:

1. `git diff --name-only -- <pathspecs>` (tracked, modified — tolerates unmatched pathspecs)
2. `git ls-files --others --exclude-standard -- <pathspecs>` (untracked, new — same)
3. `git add --` only that concrete list, skipped entirely when empty
4. `git diff --cached HEAD -- <pathspecs>` for the final patch (unchanged)

Same approach as `harness_common.extract_patch` introduced on #518 — the two are deliberately kept in lockstep (see the code comment).

## Test plan

Verified end-to-end against a real SWE-bench checkout (`astropy__astropy-12907` at base commit `d16bfe05a`, git 2.55, only 10/18 allowlisted extensions present), driving `agent.py --save-patch` with a mock OpenAI-compatible endpoint so the full CLI path runs:

- **Before (main):** `git add` exits 128, `Warning: failed to save patch` on stderr, `patch_file: null`, nothing staged — with a real edit in the working tree. Reproduces the reported failure exactly.
- **After (this branch):** `patch_file` set; the patch contains exactly the tracked `.py` edit plus a new untracked `.py` file, and the tracked hunk matches the pre-run `git diff` byte-for-byte.
- **Junk exclusion still holds:** untracked `ISSUE.txt` and `.spelunk/index.db` do not appear in the patch.
- **No-change run:** writes a 0-byte patch with no warning (`patch_file` set, empty diff = agent made no fix).
- `python3 -m py_compile` passes.

## Historical-validity note

Scanned for affected historical results: no `agent.py`-era result files exist in `bench/results/` (the checked-in `swebench-local-*.json` from May predate `agent.py` and use a different schema/capture path), and no `bench/patches/` output directory has ever been produced here. Upcoming batch runs are the first real consumer of this path, so no historical numbers need to be marked untrusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)