### PR TITLE
feat(bench): rerunnable SWE-Bench+ leakage-filter script for Track B (spelunk-oss^85)

### DIFF
--- a/bench/agents/README.md
+++ b/bench/agents/README.md
@@ -115,7 +115,7 @@ export DEEPSEEK_API_KEY=sk-...
 bash bench/agents/swebench_run.sh --condition spelunk_full --seed 42
 ```
 
-## Contamination control — leakage-filtered instances
+## Contamination control: leakage-filtered instances
 
 Track-B (SWE-bench) numbers are reported on two instance sets, **always
 separately**, and every published figure names its `instance_filter`:
@@ -126,8 +126,8 @@ separately**, and every published figure names its `instance_filter`:
 | `swebench_plus_filtered`   | Verified minus SWE-Bench+ leakage/suspicious instances   |
 
 **Why.** SWE-Bench+ (arXiv:2410.06992) found ~32.67% of passing SWE-bench
-patches benefited from *solution leakage* — the fix appears in the issue report
-or comments — plus a large share of *suspicious* passes on weak tests (55.36%
+patches benefited from *solution leakage*: the fix appears in the issue report
+or comments. Also, a large share of *suspicious* passes on weak tests (55.36%
 of the Verified sample they inspected). A resolve_rate on the full set is
 inflated by these. Reporting a `swebench_plus_filtered` figure alongside `full`
 shows how much of a result survives contamination control.
@@ -156,14 +156,14 @@ pin the revision via `--labels-source`. Target survivor count is 150–300; the
 script warns if the intersection falls outside that band. `--dry-run` reports
 counts and the `tasks_50.json` overlap without writing.
 
-> **Status:** `tasks_filtered.json` is **not yet committed** — it requires the
+> **Status:** `tasks_filtered.json` is **not yet committed**. It requires the
 > SWE-Bench+ label set, which is not distributed as a fetchable file. The script
 > above generates it once that input is supplied. Do not hand-author the list.
 
 ### Overlap with `tasks_50.json`
 
 Of the 50-slice, **24** instances are in SWE-bench Verified (the other 26 come
-from the SWE-bench *full* split — see `setup_repos.sh`, issue #252). Only those
+from the SWE-bench *full* split; see `setup_repos.sh`, issue #252). Only those
 24 can ever survive the filter; the survivor subset is reported by
 `build_filtered_tasks.py --overlap-with bench/agents/tasks_50.json` once the
 label set is available.

--- a/bench/agents/README.md
+++ b/bench/agents/README.md
@@ -115,6 +115,59 @@ export DEEPSEEK_API_KEY=sk-...
 bash bench/agents/swebench_run.sh --condition spelunk_full --seed 42
 ```
 
+## Contamination control — leakage-filtered instances
+
+Track-B (SWE-bench) numbers are reported on two instance sets, **always
+separately**, and every published figure names its `instance_filter`:
+
+| `instance_filter`          | Instance set                                              |
+|----------------------------|----------------------------------------------------------|
+| `full`                     | SWE-bench Verified, unfiltered (500 instances)           |
+| `swebench_plus_filtered`   | Verified minus SWE-Bench+ leakage/suspicious instances   |
+
+**Why.** SWE-Bench+ (arXiv:2410.06992) found ~32.67% of passing SWE-bench
+patches benefited from *solution leakage* — the fix appears in the issue report
+or comments — plus a large share of *suspicious* passes on weak tests (55.36%
+of the Verified sample they inspected). A resolve_rate on the full set is
+inflated by these. Reporting a `swebench_plus_filtered` figure alongside `full`
+shows how much of a result survives contamination control.
+
+**Reporting rule.** Never publish a single blended Track-B number. Every figure
+carries its `instance_filter`; `full` and `swebench_plus_filtered` are reported
+side by side.
+
+### Generating the filtered list
+
+`build_filtered_tasks.py` intersects Verified with a SWE-Bench+ exclude set and
+writes `tasks_filtered.json` (with a provenance header):
+
+```bash
+python bench/agents/build_filtered_tasks.py \
+    --labels swebench_plus_verified_exclude.json \
+    --labels-source "arXiv:2410.06992 replication pkg, rev <sha/date>" \
+    --out bench/agents/tasks_filtered.json
+```
+
+`--labels` is the SWE-Bench+ per-instance leakage/suspicious label set for
+Verified (list of instance_ids to exclude, or an `id -> reason` map). SWE-Bench+
+publishes a new post-cutoff dataset rather than a single filtered-Verified file,
+so a maintainer must obtain these labels from the authors' released artifact and
+pin the revision via `--labels-source`. Target survivor count is 150–300; the
+script warns if the intersection falls outside that band. `--dry-run` reports
+counts and the `tasks_50.json` overlap without writing.
+
+> **Status:** `tasks_filtered.json` is **not yet committed** — it requires the
+> SWE-Bench+ label set, which is not distributed as a fetchable file. The script
+> above generates it once that input is supplied. Do not hand-author the list.
+
+### Overlap with `tasks_50.json`
+
+Of the 50-slice, **24** instances are in SWE-bench Verified (the other 26 come
+from the SWE-bench *full* split — see `setup_repos.sh`, issue #252). Only those
+24 can ever survive the filter; the survivor subset is reported by
+`build_filtered_tasks.py --overlap-with bench/agents/tasks_50.json` once the
+label set is available.
+
 ## Notes
 
 - `resolved` is always `false` in agent output from `agent.py` — resolution

--- a/bench/agents/build_filtered_tasks.py
+++ b/bench/agents/build_filtered_tasks.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Build a leakage-filtered SWE-bench instance list (SWE-Bench+ intersection).
+
+Intersects SWE-bench Verified with a SWE-Bench+ leakage/suspicious label set
+(arXiv 2410.06992) and writes the surviving instance_ids, plus a provenance
+header, to bench/agents/tasks_filtered.json.
+
+Reporting rule (see bench/agents/README.md): filtered and unfiltered Track-B
+numbers are ALWAYS reported separately, and every published figure names its
+`instance_filter` — one of {"swebench_plus_filtered", "full"}.
+
+    instance_filter = "full"                 -> SWE-bench Verified, unfiltered
+    instance_filter = "swebench_plus_filtered" -> the list this script produces
+
+------------------------------------------------------------------------------
+The SWE-Bench+ label set
+------------------------------------------------------------------------------
+SWE-Bench+ (arXiv 2410.06992) is not a filtered subset published as a single
+machine-readable file; the paper releases a NEW post-cutoff dataset and reports
+that a large fraction of SWE-bench passing patches benefit from solution
+leakage (~32.67% overall) or weak tests. To reproduce a *contamination-
+controlled Verified subset* we need the per-instance leakage/suspicious labels
+for Verified. Supply them via --labels as a JSON file of instance_ids to
+EXCLUDE, or a JSON object mapping instance_id -> label.
+
+Accepted --labels formats (auto-detected):
+  1. ["repo__name-1234", ...]                        # flat exclude list
+  2. {"repo__name-1234": "solution_leakage", ...}    # id -> reason
+  3. {"exclude": [...], "source": "...", ...}        # object with "exclude" key
+
+Obtain the labels from the SWE-Bench+ authors' released artifact (paper page /
+replication package) and pin the revision you used; record it via --labels-source
+so it lands in the output provenance header.
+
+------------------------------------------------------------------------------
+Usage
+------------------------------------------------------------------------------
+    python bench/agents/build_filtered_tasks.py \
+        --labels swebench_plus_verified_exclude.json \
+        --labels-source "arXiv:2410.06992 replication pkg, rev <sha/date>" \
+        --out bench/agents/tasks_filtered.json
+
+    # Verified loads from the HuggingFace datasets cache / hub.
+    # Override the dataset revision for reproducibility:
+    python bench/agents/build_filtered_tasks.py \
+        --labels labels.json --dataset-revision <hf_revision>
+
+    # Dry run: report counts + tasks_50 overlap without writing.
+    python bench/agents/build_filtered_tasks.py --labels labels.json --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import sys
+from pathlib import Path
+
+VERIFIED_DATASET = "princeton-nlp/SWE-bench_Verified"
+FILTER_NAME = "swebench_plus_filtered"
+MIN_EXPECTED = 150
+MAX_EXPECTED = 300
+
+
+def load_verified(dataset: str, revision: str | None) -> set[str]:
+    from datasets import load_dataset  # imported lazily so --help needs no deps
+
+    kwargs = {"split": "test"}
+    if revision:
+        kwargs["revision"] = revision
+    ds = load_dataset(dataset, **kwargs)
+    return {row["instance_id"] for row in ds}
+
+
+def parse_exclude(labels_path: Path) -> set[str]:
+    data = json.loads(labels_path.read_text())
+    if isinstance(data, list):
+        return set(data)
+    if isinstance(data, dict):
+        if "exclude" in data:
+            return set(data["exclude"])
+        return set(data.keys())  # id -> reason mapping
+    raise ValueError(f"unrecognised --labels shape: {type(data).__name__}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Intersect SWE-bench Verified with a SWE-Bench+ leakage label set.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    ap.add_argument("--labels", required=True, type=Path,
+                    help="JSON of SWE-Bench+ instance_ids to EXCLUDE (see module docstring).")
+    ap.add_argument("--labels-source", default="unspecified",
+                    help="Human-readable provenance for --labels (paper rev/date); recorded in output.")
+    ap.add_argument("--out", type=Path, default=Path(__file__).with_name("tasks_filtered.json"))
+    ap.add_argument("--dataset", default=VERIFIED_DATASET)
+    ap.add_argument("--dataset-revision", default=None,
+                    help="Pin the HuggingFace dataset revision for reproducibility.")
+    ap.add_argument("--overlap-with", type=Path, default=Path(__file__).with_name("tasks_50.json"),
+                    help="Existing task list to report survival overlap against.")
+    ap.add_argument("--dry-run", action="store_true", help="Report counts, do not write --out.")
+    args = ap.parse_args(argv)
+
+    if not args.labels.exists():
+        ap.error(f"--labels not found: {args.labels}")
+
+    verified = load_verified(args.dataset, args.dataset_revision)
+    exclude = parse_exclude(args.labels)
+
+    # Labels not present in Verified are almost always a version/split mismatch.
+    stray = sorted(exclude - verified)
+    kept = sorted(verified - exclude)
+
+    header = {
+        "instance_filter": FILTER_NAME,
+        "generated_by": Path(__file__).name,
+        "generated_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
+        "verified_dataset": args.dataset,
+        "verified_dataset_revision": args.dataset_revision or "default",
+        "verified_count": len(verified),
+        "swebench_plus_source": args.labels_source,
+        "swebench_plus_ref": "arXiv:2410.06992",
+        "excluded_count": len(exclude & verified),
+        "kept_count": len(kept),
+    }
+
+    print(f"Verified instances:     {len(verified)}", file=sys.stderr)
+    print(f"Exclude labels:         {len(exclude)}", file=sys.stderr)
+    print(f"  (not in Verified):    {len(stray)}", file=sys.stderr)
+    print(f"Kept (filtered subset): {len(kept)}", file=sys.stderr)
+
+    if not (MIN_EXPECTED <= len(kept) <= MAX_EXPECTED):
+        print(f"WARNING: kept count {len(kept)} outside expected "
+              f"[{MIN_EXPECTED}, {MAX_EXPECTED}] range — verify the label set.",
+              file=sys.stderr)
+
+    if args.overlap_with.exists():
+        slice_ids = json.loads(args.overlap_with.read_text())
+        survivors = [t for t in slice_ids if t in set(kept)]
+        not_verified = [t for t in slice_ids if t not in verified]
+        print(f"\n{args.overlap_with.name}: {len(slice_ids)} tasks", file=sys.stderr)
+        print(f"  survive filter:       {len(survivors)}", file=sys.stderr)
+        print(f"  not in Verified:      {len(not_verified)}", file=sys.stderr)
+        header["overlap"] = {
+            "against": args.overlap_with.name,
+            "total": len(slice_ids),
+            "survivors": survivors,
+            "not_in_verified": not_verified,
+        }
+
+    if args.dry_run:
+        print("\n[dry-run] not writing output.", file=sys.stderr)
+        return 0
+
+    args.out.write_text(json.dumps({"_provenance": header, "instance_ids": kept}, indent=2) + "\n")
+    print(f"\nWrote {len(kept)} instances -> {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/agents/test_build_filtered_tasks.py
+++ b/bench/agents/test_build_filtered_tasks.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Offline unit tests for build_filtered_tasks.py.
+
+No network / no HuggingFace download: load_verified is monkeypatched to return a
+synthetic instance-id set, and --labels / --overlap-with are synthetic tmp files.
+Stdlib unittest only (no pytest / datasets dependency).
+
+    python -m unittest bench.agents.test_build_filtered_tasks   # from repo root
+    python bench/agents/test_build_filtered_tasks.py            # direct
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+_HERE = Path(__file__).resolve().parent
+_spec = importlib.util.spec_from_file_location(
+    "build_filtered_tasks", _HERE / "build_filtered_tasks.py"
+)
+bft = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bft)
+
+
+def _write(dir_: Path, name: str, obj) -> Path:
+    p = dir_ / name
+    p.write_text(json.dumps(obj))
+    return p
+
+
+class ParseExcludeTest(unittest.TestCase):
+    """All three label formats parse to the same exclude set."""
+
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.d = Path(self._tmp.name)
+        self.expected = {"a__x-1", "b__y-2", "c__z-3"}
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_flat_list(self):
+        p = _write(self.d, "flat.json", sorted(self.expected))
+        self.assertEqual(bft.parse_exclude(p), self.expected)
+
+    def test_id_reason_map(self):
+        p = _write(self.d, "map.json", {i: "solution_leakage" for i in self.expected})
+        self.assertEqual(bft.parse_exclude(p), self.expected)
+
+    def test_exclude_object(self):
+        p = _write(
+            self.d,
+            "obj.json",
+            {"exclude": sorted(self.expected), "source": "arXiv:2410.06992"},
+        )
+        self.assertEqual(bft.parse_exclude(p), self.expected)
+
+    def test_all_three_agree(self):
+        a = bft.parse_exclude(_write(self.d, "a.json", sorted(self.expected)))
+        b = bft.parse_exclude(
+            _write(self.d, "b.json", {i: "r" for i in self.expected})
+        )
+        c = bft.parse_exclude(
+            _write(self.d, "c.json", {"exclude": sorted(self.expected)})
+        )
+        self.assertEqual(a, b)
+        self.assertEqual(b, c)
+
+    def test_unrecognised_shape_raises(self):
+        p = _write(self.d, "bad.json", 42)
+        with self.assertRaises(ValueError):
+            bft.parse_exclude(p)
+
+
+class _RunMixin(unittest.TestCase):
+    """Runs main() with load_verified stubbed and captured std streams."""
+
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.d = Path(self._tmp.name)
+        self._orig_load = bft.load_verified
+
+    def tearDown(self):
+        bft.load_verified = self._orig_load
+        self._tmp.cleanup()
+
+    def run_main(self, verified: set[str], exclude, argv_extra=None, overlap=None):
+        bft.load_verified = lambda dataset, revision: set(verified)
+        labels = _write(self.d, "labels.json", exclude)
+        out = self.d / "tasks_filtered.json"
+        argv = ["--labels", str(labels), "--out", str(out)]
+        if overlap is not None:
+            ov = _write(self.d, "overlap.json", overlap)
+            argv += ["--overlap-with", str(ov)]
+        else:
+            # point at a nonexistent file so the real tasks_50.json is not read
+            argv += ["--overlap-with", str(self.d / "no_overlap.json")]
+        if argv_extra:
+            argv += argv_extra
+        so, se = io.StringIO(), io.StringIO()
+        with redirect_stdout(so), redirect_stderr(se):
+            rc = bft.main(argv)
+        return rc, so.getvalue(), se.getvalue(), out
+
+
+class IntersectionTest(_RunMixin):
+    def test_survivors_are_verified_minus_exclude(self):
+        verified = {f"p__r-{i}" for i in range(200)}
+        exclude = [f"p__r-{i}" for i in range(50)]  # first 50 excluded
+        rc, _out, _err, outpath = self.run_main(verified, exclude)
+        self.assertEqual(rc, 0)
+        written = json.loads(outpath.read_text())
+        kept = set(written["instance_ids"])
+        self.assertEqual(kept, verified - set(exclude))
+        # excluded ids are gone
+        self.assertTrue(kept.isdisjoint(set(exclude)))
+        # kept is sorted
+        self.assertEqual(written["instance_ids"], sorted(written["instance_ids"]))
+
+    def test_stray_labels_not_in_verified_dont_remove_anything(self):
+        verified = {f"p__r-{i}" for i in range(160)}
+        exclude = ["p__r-0", "ghost__x-999"]  # ghost not in verified
+        rc, _out, err, outpath = self.run_main(verified, exclude)
+        self.assertEqual(rc, 0)
+        kept = set(json.loads(outpath.read_text())["instance_ids"])
+        self.assertEqual(kept, verified - {"p__r-0"})
+        self.assertIn("not in Verified", err)
+
+    def test_dry_run_writes_nothing(self):
+        verified = {f"p__r-{i}" for i in range(200)}
+        rc, _out, err, outpath = self.run_main(
+            verified, ["p__r-0"], argv_extra=["--dry-run"]
+        )
+        self.assertEqual(rc, 0)
+        self.assertFalse(outpath.exists())
+        self.assertIn("dry-run", err)
+
+
+class RangeWarningTest(_RunMixin):
+    WARN = "WARNING:"
+
+    def _err_for(self, n_verified, n_exclude):
+        verified = {f"p__r-{i}" for i in range(n_verified)}
+        exclude = [f"p__r-{i}" for i in range(n_exclude)]
+        _rc, _out, err, _outpath = self.run_main(
+            verified, exclude, argv_extra=["--dry-run"]
+        )
+        return err
+
+    def test_warns_below_min(self):
+        # 149 survivors < 150
+        err = self._err_for(149, 0)
+        self.assertIn(self.WARN, err)
+
+    def test_warns_above_max(self):
+        # 301 survivors > 300
+        err = self._err_for(301, 0)
+        self.assertIn(self.WARN, err)
+
+    def test_no_warn_at_lower_bound(self):
+        err = self._err_for(150, 0)  # exactly 150
+        self.assertNotIn(self.WARN, err)
+
+    def test_no_warn_at_upper_bound(self):
+        err = self._err_for(300, 0)  # exactly 300
+        self.assertNotIn(self.WARN, err)
+
+    def test_no_warn_in_range(self):
+        err = self._err_for(250, 25)  # 225 survivors
+        self.assertNotIn(self.WARN, err)
+
+
+class ProvenanceHeaderTest(_RunMixin):
+    def test_header_has_required_keys_and_values(self):
+        verified = {f"p__r-{i}" for i in range(200)}
+        exclude = [f"p__r-{i}" for i in range(40)]  # 160 survive
+        labels = _write(self.d, "labels.json", exclude)
+        out = self.d / "tasks_filtered.json"
+        bft.load_verified = lambda dataset, revision: set(verified)
+        argv = [
+            "--labels", str(labels),
+            "--out", str(out),
+            "--labels-source", "arXiv:2410.06992 repl pkg, rev deadbeef",
+            "--dataset-revision", "abc123",
+            "--overlap-with", str(self.d / "none.json"),
+        ]
+        so, se = io.StringIO(), io.StringIO()
+        with redirect_stdout(so), redirect_stderr(se):
+            rc = bft.main(argv)
+        self.assertEqual(rc, 0)
+        h = json.loads(out.read_text())["_provenance"]
+        for key in (
+            "instance_filter", "generated_by", "verified_dataset",
+            "verified_dataset_revision", "verified_count",
+            "swebench_plus_source", "swebench_plus_ref",
+            "excluded_count", "kept_count",
+        ):
+            self.assertIn(key, h, f"missing provenance key: {key}")
+        self.assertEqual(h["instance_filter"], "swebench_plus_filtered")
+        self.assertEqual(h["generated_by"], "build_filtered_tasks.py")
+        self.assertEqual(h["verified_dataset"], bft.VERIFIED_DATASET)
+        self.assertEqual(h["verified_dataset_revision"], "abc123")
+        self.assertEqual(h["verified_count"], 200)
+        self.assertEqual(h["swebench_plus_source"], "arXiv:2410.06992 repl pkg, rev deadbeef")
+        self.assertEqual(h["swebench_plus_ref"], "arXiv:2410.06992")
+        # excluded_count counts only labels actually in Verified
+        self.assertEqual(h["excluded_count"], 40)
+        self.assertEqual(h["kept_count"], 160)
+        self.assertEqual(h["kept_count"], len(json.loads(out.read_text())["instance_ids"]))
+
+    def test_excluded_count_ignores_stray_labels(self):
+        verified = {f"p__r-{i}" for i in range(160)}
+        exclude = ["p__r-0", "p__r-1", "ghost__a-1", "ghost__b-2"]
+        _rc, _out, _err, outpath = self.run_main(verified, exclude)
+        h = json.loads(outpath.read_text())["_provenance"]
+        self.assertEqual(h["excluded_count"], 2)  # ghosts don't count
+        self.assertEqual(h["verified_dataset_revision"], "default")  # no --dataset-revision
+
+
+class OverlapTest(_RunMixin):
+    def test_overlap_survivors_and_not_in_verified(self):
+        verified = {f"p__r-{i}" for i in range(200)}
+        exclude = ["p__r-5", "p__r-6"]
+        # tasks_50-like slice: some survive, some excluded, some not in Verified at all
+        slice_ids = ["p__r-5", "p__r-10", "p__r-11", "ghost__x-1", "ghost__x-2"]
+        _rc, _out, _err, outpath = self.run_main(
+            verified, exclude, overlap=slice_ids
+        )
+        ov = json.loads(outpath.read_text())["_provenance"]["overlap"]
+        self.assertEqual(ov["total"], 5)
+        # p__r-5 excluded -> not a survivor; p__r-10, p__r-11 survive; ghosts not in verified
+        self.assertEqual(sorted(ov["survivors"]), ["p__r-10", "p__r-11"])
+        self.assertEqual(sorted(ov["not_in_verified"]), ["ghost__x-1", "ghost__x-2"])
+        self.assertEqual(ov["against"], "overlap.json")
+
+    def test_no_overlap_key_when_file_absent(self):
+        verified = {f"p__r-{i}" for i in range(160)}
+        _rc, _out, _err, outpath = self.run_main(verified, ["p__r-0"])
+        h = json.loads(outpath.read_text())["_provenance"]
+        self.assertNotIn("overlap", h)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `build_filtered_tasks.py`: rerunnable intersection script that filters SWE-bench Verified against SWE-Bench+ leakage/suspicious labels (arXiv:2410.06992)
- Produces `tasks_filtered.json` with provenance header (dataset revision, source ref, generated timestamp, overlap stats)
- Includes 17 offline unit tests validating label parsing (3 formats), intersection logic, range warnings, and provenance headers
- Updates README with honest documentation: labels must be supplied by maintainer (not committed), explains the 150–300 survivor range, and documents the always-separate reporting rule for `instance_filter`

## What shipped
The script is genuinely rerunnable and honest about data gaps:
- No machine-enumerable per-instance leakage label set exists in SWE-Bench+ paper artifacts, so `tasks_filtered.json` is NOT generated here
- README clearly states: maintainer must obtain labels from authors' released artifact, pin revision via `--labels-source`, then run the script
- Result: 24/50 instances from `tasks_50.json` are in Verified; those 24 can survive the filter (26 come from SWE-bench *full* split and cannot)
- Overlap report generated by script once label set is available

## Test plan
1. Run offline unit tests: `python3 -m unittest bench.agents.test_build_filtered_tasks -v` → must pass all 17 tests
2. Verify CLI works: `python3 bench/agents/build_filtered_tasks.py --help` → prints full usage + detailed docstring
3. Dry-run the script with synthetic labels:
   ```bash
   echo '["task1", "task2"]' > /tmp/labels.json
   python3 bench/agents/build_filtered_tasks.py \
     --labels /tmp/labels.json \
     --labels-source "test artifact" \
     --overlap-with bench/agents/tasks_50.json \
     --dry-run
   ```
   → should report counts and overlap without writing
4. Verify public-repo boundary: no competitor names, internal refs, or prose em-dashes in new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)