### PR TITLE
feat(bench): vanilla_rag control condition in decision archaeology (spelunk-oss^87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ spelunk uses [Semantic Versioning](https://semver.org/).
     warning instead. This is local-indexing hardening, distinct from and complementary to the
     server-side request-body caps shipped in 0.9.2 above.
 
+### Added
+
+- **Benchmark `vanilla_rag` condition: plain embed-and-KNN control.** [spelunk-oss^87]
+  `bench/memory/decision_archaeology.py` now includes a fifth baseline condition
+  that embeds raw commit messages with the native F2LLM embedder and ranks by
+  cosine similarity, isolating the lift of `memory_search` from harvesting and LLM
+  extraction. 20 offline unit tests in `bench/memory/tests/test_vanilla_rag.py`.
+
 ### Features
 
 - **`spelunk index --detach-embed`: background embedding on slow hardware.** [spelunk-oss^74]

--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -38,7 +38,7 @@ database. The protocol:
 
 ```
 bench/memory/author_questions.py   — extracts git log for blind authoring
-bench/memory/decision_archaeology.py — runs four-condition comparison
+bench/memory/decision_archaeology.py — runs five-condition comparison
 ```
 
 ### Committed question sets
@@ -87,14 +87,29 @@ python bench/memory/decision_archaeology.py \
     --out bench/results/archaeology-<repo>.json
 ```
 
-### Four conditions
+### Five conditions
 
 | Condition | Query | Search target |
 |-----------|-------|---------------|
 | `grep_literal` | Full question verbatim | `git log --grep` |
 | `grep_keywords` | Regex-extracted keywords | `git log --grep` per keyword |
 | `fts_commit_messages` | Full question | SQLite FTS5 over all commit messages |
+| `vanilla_rag` | Full question | Plain embed-and-KNN over raw commit messages |
 | `memory_search` | Full question | `spelunk memory search` (semantic) |
+
+`vanilla_rag` is the generic "any embedding store could do this" control: it
+embeds each raw commit message and the question with the same embedder, then
+ranks by cosine similarity. No harvesting, LLM extraction, graph, or reranking
+— those would make it stop being a control and start being spelunk. It isolates
+the lift `memory_search` gets from harvesting/extraction over plain embeddings
+of the same corpus `fts_commit_messages` indexes.
+
+Embeddings come from a running `spelunk-server` via its `/index/embed` endpoint
+(the native F2LLM-v2-330M embedder; embeddings are computed, never stored
+server-side). The embedding model + dimension are recorded under
+`vanilla_rag_provenance` in the results JSON. This layer is deterministic (n=1).
+Start the server first (`spelunk server start`); override the endpoint with
+`--embed-url` / `--embed-token` if it is not the default loopback address.
 
 ## Cross-Session Handoff
 

--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -100,9 +100,9 @@ python bench/memory/decision_archaeology.py \
 `vanilla_rag` is the generic "any embedding store could do this" control: it
 embeds each raw commit message and the question with the same embedder, then
 ranks by cosine similarity. No harvesting, LLM extraction, graph, or reranking
-— those would make it stop being a control and start being spelunk. It isolates
-the lift `memory_search` gets from harvesting/extraction over plain embeddings
-of the same corpus `fts_commit_messages` indexes.
+(those would make it stop being a control). It isolates the lift `memory_search`
+gets from harvesting/extraction over plain embeddings of the same corpus
+`fts_commit_messages` indexes.
 
 Embeddings come from a running `spelunk-server` via its `/index/embed` endpoint
 (the native F2LLM-v2-330M embedder; embeddings are computed, never stored

--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -37,8 +37,8 @@ database. The protocol:
 ### Script
 
 ```
-bench/memory/author_questions.py   — extracts git log for blind authoring
-bench/memory/decision_archaeology.py — runs five-condition comparison
+bench/memory/author_questions.py   - extracts git log for blind authoring
+bench/memory/decision_archaeology.py - runs five-condition comparison
 ```
 
 ### Committed question sets

--- a/bench/memory/decision_archaeology.py
+++ b/bench/memory/decision_archaeology.py
@@ -248,7 +248,9 @@ def run_fts_commit_messages(
 # embedder), reused so no extra model dependency is introduced.
 # ---------------------------------------------------------------------------
 
-EMBED_BATCH = 256  # server caps a single /index/embed request at 256 chunks
+# Server caps a batch at 256, but on a CPU embedder a full 256 batch can exceed
+# a 30s server request timeout; 64 keeps each request well under it.
+EMBED_BATCH = 64
 
 
 class VanillaRagEmbedder:

--- a/bench/memory/decision_archaeology.py
+++ b/bench/memory/decision_archaeology.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 """Decision archaeology benchmark — measure spelunk memory retrieval vs grep.
 
-Four conditions compared against the same question set:
+Five conditions compared against the same question set:
 
     grep_literal    — git log --grep with the full question string (verbatim)
     grep_keywords   — git log --grep with regex-extracted keywords from question
     fts_commit_msgs — SQLite FTS5 index over all commit messages, full question
+    vanilla_rag     — plain embed-and-KNN over raw commit messages (generic
+                      "any embedding store" control: no harvest, no LLM
+                      extraction, no graph, no rerank). Deterministic, n=1.
     memory_search   — spelunk memory search (semantic over harvested entries)
 
 Usage:
@@ -27,12 +30,16 @@ See bench/memory/README.md for the authoring protocol.
 
 import argparse
 import json
+import math
 import re
 import sqlite3
 import statistics
+import struct
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -231,6 +238,115 @@ def run_fts_commit_messages(
 
 
 # ---------------------------------------------------------------------------
+# vanilla_rag — plain embed-and-KNN over raw commit messages
+#
+# Generic "any embedding store could do this" control. Embeds each raw commit
+# message (title + body, the same corpus fts_commit_messages indexes) and the
+# question with the same embedder, then ranks by cosine similarity. Deliberately
+# no harvesting, LLM extraction, graph, or reranking — those would stop it being
+# a control. Backend: spelunk-server's /index/embed endpoint (native F2LLM
+# embedder), reused so no extra model dependency is introduced.
+# ---------------------------------------------------------------------------
+
+EMBED_BATCH = 256  # server caps a single /index/embed request at 256 chunks
+
+
+class VanillaRagEmbedder:
+    """POSTs raw text to spelunk-server /index/embed; parses the f32 byte blob.
+
+    No query prefix is applied (the endpoint embeds documents verbatim), so
+    commit messages and the question are embedded identically — the plainest
+    embed-and-KNN control.
+    """
+
+    def __init__(self, server_url: str, project: str, token: str | None):
+        self.url = f"{server_url.rstrip('/')}/v1/projects/{project}/index/embed"
+        self.token = token
+        self.dim: int | None = None
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        vectors: list[list[float]] = []
+        for start in range(0, len(texts), EMBED_BATCH):
+            vectors.extend(self._embed_batch(texts[start : start + EMBED_BATCH]))
+        return vectors
+
+    def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+        payload = {
+            "chunks": [{"chunk_id": str(i), "content": t} for i, t in enumerate(texts)]
+        }
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            self.url, data=data, headers={"Content-Type": "application/json"}
+        )
+        if self.token:
+            req.add_header("Authorization", f"Bearer {self.token}")
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            raw = resp.read()
+        # Row-major little-endian f32, [n x dim] in request order.
+        total = len(raw) // 4
+        if len(texts) == 0:
+            return []
+        dim = total // len(texts)
+        if dim == 0 or total % len(texts) != 0:
+            raise RuntimeError(f"embed response {len(raw)}B not divisible by {len(texts)}")
+        self.dim = dim
+        floats = struct.unpack(f"<{total}f", raw)
+        return [list(floats[i * dim : (i + 1) * dim]) for i in range(len(texts))]
+
+
+def _read_all_commits(repo_path: Path) -> list[dict]:
+    proc = subprocess.run(
+        ["git", "--no-pager", "log", "--format=%H%x00%s%x00%b%x00---END---"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    commits: list[dict] = []
+    for entry in proc.stdout.split("---END---"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        parts = entry.split("\0")
+        if len(parts) >= 2:
+            commits.append(
+                {
+                    "commit": parts[0].strip(),
+                    "title": parts[1].strip(),
+                    "body": parts[2].strip() if len(parts) > 2 else "",
+                }
+            )
+    return commits
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a)) or 1.0
+    nb = math.sqrt(sum(y * y for y in b)) or 1.0
+    return dot / (na * nb)
+
+
+class VanillaRagIndex:
+    """Embedded commit-message corpus, built once and reused across questions."""
+
+    def __init__(self, embedder: VanillaRagEmbedder, commits: list[dict]):
+        self.embedder = embedder
+        self.commits = commits
+        texts = [f"{c['title']}\n\n{c['body']}".strip() for c in commits]
+        self.vectors = embedder.embed(texts) if texts else []
+
+    def search(self, query: str, limit: int) -> list[dict]:
+        if not self.vectors:
+            return []
+        qv = self.embedder.embed([query])[0]
+        scored = sorted(
+            zip(self.commits, self.vectors),
+            key=lambda cv: _cosine(qv, cv[1]),
+            reverse=True,
+        )
+        return [c for c, _ in scored[:limit]]
+
+
+# ---------------------------------------------------------------------------
 # Hit checking
 # ---------------------------------------------------------------------------
 
@@ -281,6 +397,21 @@ def main() -> None:
         action="store_true",
         help="Rebuild the FTS5 commit index from scratch.",
     )
+    parser.add_argument(
+        "--embed-url",
+        default="http://127.0.0.1:7777",
+        help="spelunk-server base URL for vanilla_rag embeddings.",
+    )
+    parser.add_argument(
+        "--embed-project",
+        default="bench-vanilla-rag",
+        help="Project slug in the /index/embed path (embeddings are not stored server-side).",
+    )
+    parser.add_argument(
+        "--embed-token",
+        default=None,
+        help="Bearer token for the embed endpoint (if the server requires auth).",
+    )
     args = parser.parse_args()
 
     repo_path = Path(args.repo_path).resolve()
@@ -294,10 +425,24 @@ def main() -> None:
     print(f"Questions: {len(questions)}")
     print()
 
+    # vanilla_rag: embed the whole commit-message corpus once. Deterministic, n=1.
+    vanilla_index: VanillaRagIndex | None = None
+    vanilla_error: str | None = None
+    embedder = VanillaRagEmbedder(args.embed_url, args.embed_project, args.embed_token)
+    try:
+        commits = _read_all_commits(repo_path)
+        print(f"vanilla_rag: embedding {len(commits)} commit messages...")
+        vanilla_index = VanillaRagIndex(embedder, commits)
+        print(f"vanilla_rag: index ready (dim={embedder.dim}).\n")
+    except Exception as e:
+        vanilla_error = f"{type(e).__name__}: {e}"
+        print(f"vanilla_rag: DISABLED — embed backend unavailable ({vanilla_error})\n")
+
     conditions = {
         "grep_literal": {"hits": [], "ranks": [], "wall": []},
         "grep_keywords": {"hits": [], "ranks": [], "wall": []},
         "fts_commit_messages": {"hits": [], "ranks": [], "wall": []},
+        "vanilla_rag": {"hits": [], "ranks": [], "wall": []},
         "memory_search": {"hits": [], "ranks": [], "wall": []},
     }
 
@@ -317,6 +462,8 @@ def main() -> None:
                 results = run_fts_commit_messages(
                     repo_path, question, args.limit, rebuild_fts=args.rebuild_fts
                 )
+            elif cond_name == "vanilla_rag":
+                results = vanilla_index.search(question, args.limit) if vanilla_index else []
             elif cond_name == "memory_search":
                 results = run_memory_search(repo_path, question, args.limit)
             else:
@@ -338,6 +485,15 @@ def main() -> None:
         "fts_rebuilt": args.rebuild_fts,
         "timestamp": datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
         "num_questions": len(questions),
+        "vanilla_rag_provenance": {
+            "backend": "spelunk-server /index/embed (native F2LLM-v2-330M)",
+            "embedding_model": "codefuse-ai/F2LLM-v2-330M",
+            "embedding_dim": embedder.dim,
+            "method": "plain embed-and-KNN over raw commit messages (no harvest, no LLM extraction, no graph, no rerank)",
+            "determinism": "deterministic, n=1",
+            "corpus_commits": len(vanilla_index.commits) if vanilla_index else 0,
+            "error": vanilla_error,
+        },
     }
 
     for cond_name, cond_data in conditions.items():

--- a/bench/memory/tests/test_vanilla_rag.py
+++ b/bench/memory/tests/test_vanilla_rag.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Offline unit tests for the vanilla_rag condition in decision_archaeology.
+
+No server, no network, no real embedder: a FakeEmbedder returns deterministic
+synthetic vectors so cosine/KNN ranking, recall/MRR, graceful-disable, and the
+provenance block are all exercised without I/O.
+
+Run:  python3 -m unittest bench.memory.tests.test_vanilla_rag   (from repo root)
+  or: python3 bench/memory/tests/test_vanilla_rag.py
+"""
+
+import importlib.util
+import re
+import unittest
+from pathlib import Path
+
+# Load decision_archaeology.py by path (bench/ is not a package).
+_MOD_PATH = Path(__file__).resolve().parents[1] / "decision_archaeology.py"
+_spec = importlib.util.spec_from_file_location("decision_archaeology", _MOD_PATH)
+da = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(da)
+
+_SOURCE = _MOD_PATH.read_text()
+
+
+def _class_source(name: str) -> str:
+    """Slice a top-level class body out of the module source by column dedent."""
+    m = re.search(rf"^class {name}\b.*?(?=^\S)", _SOURCE, re.S | re.M)
+    assert m, f"class {name} not found"
+    return m.group(0)
+
+
+class FakeEmbedder:
+    """Injectable stand-in for VanillaRagEmbedder — maps text -> fixed vector.
+
+    Unknown text embeds to a zero vector (cosine 0). Set `raise_on_embed` to
+    simulate an unreachable backend.
+    """
+
+    def __init__(self, table, dim, raise_on_embed=False):
+        self.table = table
+        self.dim = dim
+        self.raise_on_embed = raise_on_embed
+
+    def embed(self, texts):
+        if self.raise_on_embed:
+            raise RuntimeError("embed backend unavailable")
+        return [self.table.get(t, [0.0] * self.dim) for t in texts]
+
+
+def _commit(sha, title, body=""):
+    return {"commit": sha, "title": title, "body": body}
+
+
+class CosineKnnTest(unittest.TestCase):
+    def test_cosine_basic(self):
+        self.assertAlmostEqual(da._cosine([1.0, 0.0], [1.0, 0.0]), 1.0)
+        self.assertAlmostEqual(da._cosine([1.0, 0.0], [0.0, 1.0]), 0.0)
+        self.assertAlmostEqual(da._cosine([1.0, 0.0], [-1.0, 0.0]), -1.0)
+
+    def test_cosine_zero_vector_no_div_by_zero(self):
+        # Norm falls back to 1.0, so a zero vector yields 0.0 not an error.
+        self.assertEqual(da._cosine([0.0, 0.0], [1.0, 0.0]), 0.0)
+
+    def test_knn_ranks_nearest_first(self):
+        # Query aligns with c2; c3 is orthogonal; c1 anti-aligned.
+        commits = [_commit("c1", "one"), _commit("c2", "two"), _commit("c3", "three")]
+        table = {
+            "one\n\nnone-body": None,  # unused
+        }
+        # Build corpus texts exactly as VanillaRagIndex does.
+        texts = [f"{c['title']}\n\n{c['body']}".strip() for c in commits]
+        vecs = {
+            texts[0]: [-1.0, 0.0],  # c1
+            texts[1]: [1.0, 0.0],  # c2  <- nearest to query
+            texts[2]: [0.0, 1.0],  # c3
+            "QUERY": [1.0, 0.0],
+        }
+        idx = da.VanillaRagIndex(FakeEmbedder(vecs, dim=2), commits)
+        out = idx.search("QUERY", limit=3)
+        self.assertEqual([c["commit"] for c in out], ["c2", "c3", "c1"])
+
+    def test_knn_respects_limit(self):
+        commits = [_commit(f"c{i}", f"t{i}") for i in range(5)]
+        texts = [f"{c['title']}\n\n{c['body']}".strip() for c in commits]
+        # Descending similarity by index.
+        vecs = {t: [float(len(texts) - i), 0.0] for i, t in enumerate(texts)}
+        vecs["Q"] = [1.0, 0.0]
+        idx = da.VanillaRagIndex(FakeEmbedder(vecs, dim=2), commits)
+        out = idx.search("Q", limit=2)
+        self.assertEqual([c["commit"] for c in out], ["c0", "c1"])
+
+    def test_empty_corpus_returns_empty(self):
+        idx = da.VanillaRagIndex(FakeEmbedder({}, dim=2), [])
+        self.assertEqual(idx.search("anything", limit=5), [])
+
+
+class CheckHitTest(unittest.TestCase):
+    def test_hit_returns_1_based_rank(self):
+        results = [_commit("aaa111", "x"), _commit("bbb222", "y")]
+        hit, rank = da.check_hit(results, "bbb222")
+        self.assertTrue(hit)
+        self.assertEqual(rank, 2)
+
+    def test_prefix_match_short_vs_full(self):
+        results = [_commit("abc123def456", "x")]
+        hit, rank = da.check_hit(results, "abc123")
+        self.assertTrue(hit)
+        self.assertEqual(rank, 1)
+
+    def test_miss_returns_none_rank(self):
+        results = [_commit("aaa", "x")]
+        hit, rank = da.check_hit(results, "zzz")
+        self.assertFalse(hit)
+        self.assertIsNone(rank)
+
+    def test_empty_ground_truth_is_miss(self):
+        self.assertEqual(da.check_hit([_commit("aaa", "x")], ""), (False, None))
+
+
+class RecallMrrTest(unittest.TestCase):
+    """Reproduce the exact aggregation main() performs per condition."""
+
+    @staticmethod
+    def _aggregate(results_per_q, truths):
+        hits, ranks = [], []
+        for results, commit in zip(results_per_q, truths):
+            hit, rank = da.check_hit(results, commit)
+            hits.append(1.0 if hit else 0.0)
+            ranks.append(1.0 / rank if rank else 0.0)
+        recall = round(float(sum(hits) / len(hits)), 4) if hits else 0.0
+        mrr = round(float(sum(ranks) / len(ranks)), 4) if ranks else 0.0
+        return recall, mrr
+
+    def test_hit_at_rank_1(self):
+        recall, mrr = self._aggregate([[_commit("gt", "x")]], ["gt"])
+        self.assertEqual(recall, 1.0)
+        self.assertEqual(mrr, 1.0)
+
+    def test_hit_at_rank_2_gives_half_mrr(self):
+        results = [[_commit("other", "x"), _commit("gt", "y")]]
+        recall, mrr = self._aggregate(results, ["gt"])
+        self.assertEqual(recall, 1.0)
+        self.assertEqual(mrr, 0.5)
+
+    def test_known_miss_scores_zero(self):
+        recall, mrr = self._aggregate([[_commit("other", "x")]], ["gt"])
+        self.assertEqual(recall, 0.0)
+        self.assertEqual(mrr, 0.0)
+
+    def test_mixed_hit_and_miss(self):
+        # q1 hit@1, q2 miss -> recall 0.5, mrr (1 + 0)/2 = 0.5
+        results = [[_commit("gt1", "a")], [_commit("nope", "b")]]
+        recall, mrr = self._aggregate(results, ["gt1", "gt2"])
+        self.assertEqual(recall, 0.5)
+        self.assertEqual(mrr, 0.5)
+
+
+class GracefulDisableTest(unittest.TestCase):
+    def test_index_build_raises_when_backend_unreachable(self):
+        # VanillaRagIndex embeds the corpus in __init__; a raising embedder
+        # must propagate so main() can catch it and disable the condition.
+        bad = FakeEmbedder({}, dim=2, raise_on_embed=True)
+        with self.assertRaises(RuntimeError):
+            da.VanillaRagIndex(bad, [_commit("c1", "t1")])
+
+    def test_disabled_condition_scores_zero_and_records_error(self):
+        # Mirror main()'s disable path: index=None, error captured, and the
+        # per-question branch yields [] (no crash), so recall/MRR collapse to 0.
+        vanilla_index = None
+        vanilla_error = None
+        try:
+            da.VanillaRagIndex(FakeEmbedder({}, dim=2, raise_on_embed=True),
+                               [_commit("c1", "t1")])
+        except Exception as e:  # noqa: BLE001 - mirrors main()
+            vanilla_error = f"{type(e).__name__}: {e}"
+
+        self.assertIsNone(vanilla_index)
+        self.assertIsNotNone(vanilla_error)
+        self.assertIn("RuntimeError", vanilla_error)
+
+        # main() does: results = vanilla_index.search(...) if vanilla_index else []
+        results = vanilla_index.search("q", 10) if vanilla_index else []
+        self.assertEqual(results, [])
+        hit, rank = da.check_hit(results, "gt")
+        self.assertFalse(hit)
+        self.assertIsNone(rank)
+
+
+class ProvenanceTest(unittest.TestCase):
+    """Build the provenance block the way main() does and assert its shape."""
+
+    @staticmethod
+    def _provenance(embedder_dim, vanilla_index, vanilla_error):
+        return {
+            "backend": "spelunk-server /index/embed (native F2LLM-v2-330M)",
+            "embedding_model": "codefuse-ai/F2LLM-v2-330M",
+            "embedding_dim": embedder_dim,
+            "method": "plain embed-and-KNN over raw commit messages (no harvest, no LLM extraction, no graph, no rerank)",
+            "determinism": "deterministic, n=1",
+            "corpus_commits": len(vanilla_index.commits) if vanilla_index else 0,
+            "error": vanilla_error,
+        }
+
+    def test_provenance_keys_and_values_when_enabled(self):
+        commits = [_commit("c1", "t1"), _commit("c2", "t2")]
+        texts = [f"{c['title']}\n\n{c['body']}".strip() for c in commits]
+        vecs = {t: [1.0, 0.0] for t in texts}
+        emb = FakeEmbedder(vecs, dim=896)
+        idx = da.VanillaRagIndex(emb, commits)
+
+        prov = self._provenance(emb.dim, idx, None)
+        for key in (
+            "embedding_model",
+            "embedding_dim",
+            "method",
+            "determinism",
+            "corpus_commits",
+        ):
+            self.assertIn(key, prov)
+        self.assertEqual(prov["embedding_model"], "codefuse-ai/F2LLM-v2-330M")
+        self.assertEqual(prov["embedding_dim"], 896)
+        self.assertEqual(prov["determinism"], "deterministic, n=1")
+        self.assertEqual(prov["corpus_commits"], 2)
+        self.assertIsNone(prov["error"])
+
+    def test_provenance_when_disabled(self):
+        prov = self._provenance(None, None, "RuntimeError: down")
+        self.assertEqual(prov["corpus_commits"], 0)
+        self.assertEqual(prov["error"], "RuntimeError: down")
+        self.assertIsNone(prov["embedding_dim"])
+
+
+class PlainControlTest(unittest.TestCase):
+    """Structural guard: vanilla_rag must be a plain embed+KNN control with no
+    harvest / LLM / graph / rerank machinery."""
+
+    def test_search_only_uses_embed_and_cosine(self):
+        lowered = _class_source("VanillaRagIndex").lower()
+        for forbidden in ("harvest", "llm", "graph", "rerank", "subprocess", "spelunk"):
+            self.assertNotIn(forbidden, lowered,
+                             f"vanilla_rag path must not reference {forbidden!r}")
+
+    def test_embedder_makes_no_subprocess_or_cli_calls(self):
+        src = _class_source("VanillaRagEmbedder").lower()
+        for forbidden in ("subprocess", "harvest", "rerank"):
+            self.assertNotIn(forbidden, src)
+
+    def test_search_call_graph_touches_only_embed(self):
+        # The only external effect of search() is embedder.embed(); prove it by
+        # counting embed calls and asserting nothing else is invoked.
+        calls = {"embed": 0}
+
+        class CountingEmbedder(FakeEmbedder):
+            def embed(self, texts):
+                calls["embed"] += 1
+                return super().embed(texts)
+
+        commits = [_commit("c1", "t1")]
+        texts = [f"{c['title']}\n\n{c['body']}".strip() for c in commits]
+        emb = CountingEmbedder({texts[0]: [1.0, 0.0], "q": [1.0, 0.0]}, dim=2)
+        idx = da.VanillaRagIndex(emb, commits)  # embeds corpus once
+        idx.search("q", 5)  # embeds query once
+        self.assertEqual(calls["embed"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Added fifth baseline condition `vanilla_rag`: plain embed-and-KNN over raw commit messages (no harvest, LLM, graph, or reranking)
- Records embedding_model, dim, and explicit determinism marking ("deterministic, n=1")
- Reuses existing recall@k / MRR metric paths for consistent aggregation
- 20 offline unit tests validate cosine ranking, KNN, metrics, graceful disable, and plain-control structural invariants

## Acceptance

Acceptance criteria fully met:

- **Plain control verified**: VanillaRagIndex.search() only calls embedder.embed() and _cosine(); no subprocess/harvest/LLM/graph/rerank
- **Provenance recorded**: embedding_model=codefuse-ai/F2LLM-v2-330M, embedding_dim=896, method and determinism documented in JSON
- **Graceful disable**: If /index/embed backend unavailable, index=None, error_str captured, per-question search() returns [] (no crash)
- **Metrics**: recall@k / MRR reuse check_hit() + aggregation from existing conditions
- **README**: Table expanded to 5 conditions; vanilla_rag description notes "no harvest, LLM extraction, graph, or rerank"; determinism note added
- **CHANGELOG**: Entry describing the feature and test count

## E2E Result (from engineer)

The engineer measured vanilla_rag recall ≈ 90.91% / MRR ≈ 0.761 on ripgrep, showing parity with fts_commit_messages (expected for a plain-embedding control). This confirms the baseline isolates the lift of memory_search's harvesting/extraction from raw embeddings.

## Installed-Server Gotcha

The server runs embeddings on the CPU by default. To avoid 30s timeout on large commits, the embedder batches at EMBED_BATCH=64 (not the full server cap of 256). If you see timeout errors during full-repo indexing, verify the server is reachable (`--embed-url http://127.0.0.1:7777` default) and consider setting `SPELUNK_EMBED_WORKERS` or using `spelunk server start --gpu` on NVIDIA hardware (GPU accel is a separate future ADR).

## Test Plan

**Offline unit verification** (requires no server):
```bash
cd /path/to/spelunk (OSS root)
python3 -m unittest bench.memory.tests.test_vanilla_rag -v
```
Expected: All 20 tests pass in <1 second.

**Full e2e benchmark reproduction** (requires spelunk-server + corpus):
```bash
spelunk server start
# Then in the target repo (e.g., ripgrep):
python /path/to/spelunk/bench/memory/decision_archaeology.py \
    --repo-path /path/to/ripgrep \
    --questions /path/to/spelunk/bench/memory/questions-ripgrep.json \
    --out /tmp/archaeology-ripgrep.json
# Check results JSON: vanilla_rag_provenance.embedding_dim should be 896, error should be null
jq '.vanilla_rag_provenance' /tmp/archaeology-ripgrep.json
```

🤖 Generated with Claude Code