### PR TITLE
Prune 5 dead config keys; re-document embedding_model/llm_model; correct THREAT-MODEL egress path (oss^109)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -158,8 +158,8 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
         //
         // Use the dedicated POST /v1/projects/{id}/search endpoint (#322) when a
         // server is reachable — it applies the code-retrieval prefix server-side
-        // and returns the query vector for CLI-side KNN.  This eliminates the
-        // need for a local api_base_url / embedder in Tier-1 mode.
+        // and returns the query vector for CLI-side KNN.  The server owns the
+        // embedder; the CLI never embeds locally in Tier-1 mode.
         let client_result = require_server_client(&cfg, "search");
 
         // Map auto/hybrid/semantic → server-side mode string.

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -239,31 +239,15 @@ pub struct Config {
     #[serde(default = "Config::default_db_path")]
     pub db_path: PathBuf,
 
-    /// Directory where model weights are cached (used by backend-metal)
-    #[serde(default = "Config::default_models_dir")]
-    pub models_dir: PathBuf,
-
-    /// Model ID for embeddings.
-    /// LM Studio: the model's API key shown in the LM Studio UI
-    ///   (e.g. `text-embedding-embeddinggemma-300m-qat`).
-    /// Metal: HuggingFace repo ID (e.g. `google/embeddinggemma-300m`).
+    /// Display label for the `model:` field of `plumbing embed` JSONL output only.
+    /// The effective embedding model is owned by spelunk-server, not this key.
     #[serde(default = "Config::default_embedding_model")]
     pub embedding_model: String,
 
-    /// Model ID for the LLM used by `ask`, `memory harvest`, and `plan create`.
-    /// LM Studio: the model's API key (e.g. `google/gemma-3n-e4b`).
+    /// Chat model id, resolved by spelunk-server, for `ask` and `memory harvest`.
     /// When unset, commands that require a chat model are unavailable.
     #[serde(default)]
     pub llm_model: Option<String>,
-
-    /// Default embedding batch size
-    #[serde(default = "Config::default_batch_size")]
-    pub batch_size: usize,
-
-    /// Base URL for the OpenAI-compatible API server (e.g. LM Studio, Ollama, vLLM).
-    /// Default: `http://127.0.0.1:1234`
-    #[serde(default = "Config::default_api_base_url", alias = "lmstudio_base_url")]
-    pub api_base_url: String,
 
     // ── spelunk-server (optional) ─────────────────────────────────────────────
     /// URL of the spelunk-server instance, e.g. `http://spelunk.internal:7777`.
@@ -310,18 +294,6 @@ pub struct Config {
     /// never diverts memory CRUD away from the project's local `memory.db`.
     #[serde(skip)]
     pub inference_url: Option<String>,
-
-    // ── Directory conventions ─────────────────────────────────────────────────
-    /// Directory (relative to project root) where `spelunk plan create` writes plan files.
-    /// Default: `docs/plans`
-    #[serde(default = "Config::default_plans_dir")]
-    pub plans_dir: PathBuf,
-
-    /// Directory (relative to project root) where spec markdown files are discovered
-    /// during `spelunk index` and where `spelunk spec` looks for spec files.
-    /// Default: `docs/specs`
-    #[serde(default = "Config::default_specs_dir")]
-    pub specs_dir: PathBuf,
 
     /// Context-window size (tokens) of the LLM used for `memory harvest` and `ask`.
     /// spelunk uses this to split harvest batches that would overflow the model's window.
@@ -394,23 +366,8 @@ impl Config {
     fn default_db_path() -> PathBuf {
         spelunk_config_dir().join("index.db")
     }
-    fn default_models_dir() -> PathBuf {
-        spelunk_config_dir().join("models")
-    }
     fn default_embedding_model() -> String {
-        "text-embedding-embeddinggemma-300m-qat".to_string()
-    }
-    fn default_api_base_url() -> String {
-        "http://127.0.0.1:1234".to_string()
-    }
-    fn default_batch_size() -> usize {
-        32
-    }
-    fn default_plans_dir() -> PathBuf {
-        PathBuf::from("docs/plans")
-    }
-    fn default_specs_dir() -> PathBuf {
-        PathBuf::from("docs/specs")
+        "f2llm-v2-330m".to_string()
     }
     fn default_llm_context_length() -> usize {
         8192
@@ -424,18 +381,13 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             db_path: Self::default_db_path(),
-            models_dir: Self::default_models_dir(),
             embedding_model: Self::default_embedding_model(),
             llm_model: None,
-            batch_size: Self::default_batch_size(),
-            api_base_url: Self::default_api_base_url(),
             server_url: None,
             server_key: None,
             project_id: None,
             mode: None,
             inference_url: None,
-            plans_dir: Self::default_plans_dir(),
-            specs_dir: Self::default_specs_dir(),
             llm_context_length: Self::default_llm_context_length(),
             store_in_git_notes: Self::default_store_in_git_notes(),
             auth: None,

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -60,8 +60,9 @@ struct Args {
     #[arg(long, env = "SPELUNK_EMBEDDING_URL")]
     embedding_url: Option<String>,
 
-    /// Embedding model name to pass to the embedding server (e.g.
-    /// `text-embedding-embeddinggemma-300m-qat`). Overrides `SPELUNK_EMBEDDING_MODEL`.
+    /// Embedding model name to pass to the external `--embedding-url` server (e.g.
+    /// `f2llm-v2-330m`). Ignored by the bundled native embedder. Overrides
+    /// `SPELUNK_EMBEDDING_MODEL`.
     #[arg(long, env = "SPELUNK_EMBEDDING_MODEL", default_value = "")]
     embedding_model: String,
 

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -1,7 +1,7 @@
 # spelunk Threat Model
 
 **Method:** Lightweight threat modeling (STRIDE-informed)  
-**Last reviewed:** July 2026 (server reconciliation: ADR-056 single-trust-domain tenancy)  
+**Last reviewed:** July 2026 (egress model corrected to the server-owned embedding path, ADR-002; `api_base_url` retired)  
 **Reviewed by:** Architect  
 **Next review:** v1.0 release or after any new network-facing feature
 
@@ -13,9 +13,9 @@ spelunk has two distinct operational modes with different attack surfaces:
 
 ### Mode A — Local CLI (default)
 1. Walks source trees, parses files with tree-sitter, stores chunks in SQLite
-2. Embeds chunks by calling an OpenAI-compatible HTTP endpoint (`api_base_url`, default `http://127.0.0.1:1234`)
+2. Embeds chunks by sending chunk text to a `spelunk-server` over HTTP (ADR-002; the CLI never embeds in-process). The default auto-discovered loopback server embeds natively in-process (bundled F2LLM), so chunk text does **not** leave the machine.
 3. Runs KNN search over stored embeddings via sqlite-vec
-4. Optionally sends context + a user question to an LLM endpoint (`llm_model` / same base URL)
+4. Optionally sends context + a user question to the same `spelunk-server`'s LLM endpoint
 5. Maintains a `memory.db` of structured notes with semantic search. **`memory.db` is the single authoritative memory store at the CLI tier** (ADR-004). All `spelunk memory` operations (add, list, search, timeline, harvest) read from and write to `memory.db`.
 6. **When `store_in_git_notes = true` (the default):** each `spelunk memory add` also appends the note as a JSON line to `refs/notes/spelunk` on HEAD (PR #339). Git notes in this namespace travel with the repository on `git push` and are available to anyone who clones the repo — see [git-notes memory](#git-notes-memory-prref-notespelunk) below.
 
@@ -30,10 +30,21 @@ An axum HTTP API (`src/server/`) that exposes memory CRUD and semantic search ov
 - Exposes: `POST /v1/projects/{id}/memory`, `POST /v1/projects/{id}/memory/search`, DELETE, archive, supersede
 
 ### Backend configurability
-Both the embedding endpoint and LLM endpoint are configurable via `api_base_url` in
-`~/.config/spelunk/config.toml`. **This is not restricted to localhost.** Users may
-configure third-party cloud services (OpenAI, Anthropic, Cohere, etc.), which changes
-the data-egress threat profile significantly.
+All inference goes through `spelunk-server` (ADR-002); the CLI has no direct
+embedding/LLM endpoint of its own. Egress off the local machine happens in two
+cases, both of which change the data-egress threat profile:
+
+- **Explicit team `server_url`** in config points the CLI at a remote
+  `spelunk-server`. Chunk text and query text then cross the network to that
+  server (which may itself embed natively or proxy to a third party).
+- **Server-side external shim:** a `spelunk-server` operator may set
+  `--embedding-url` / `--llm-url` (`SPELUNK_EMBEDDING_URL` / `SPELUNK_LLM_URL`)
+  so the server forwards to a third-party OpenAI-compatible service (OpenAI,
+  Anthropic, Cohere, etc.) instead of embedding natively. This is configured on
+  the server, not by the client.
+
+The default auto-discovered loopback server embeds natively in-process with no
+external egress.
 
 ---
 
@@ -63,13 +74,15 @@ User filesystem
   │
   ├─ spelunk index ─► [secret scanner] ─► SQLite index.db (chunks + vectors)
   │                                              │
-  │                                              └─► embed via HTTP ─► api_base_url
-  │                                                   (local OR third-party cloud)
+  │                                              └─► embed chunk text via HTTP ─► spelunk-server
+  │                                                   (loopback: native, on-machine;
+  │                                                    team server_url: leaves the machine)
   ├─ spelunk ask/search
-  │     ├─► embed query via HTTP ─► api_base_url
-  │     │    (source code chunks + user query leave the machine if api_base_url is remote)
-  │     ├─► KNN search ─► index.db
-  │     └─► LLM prompt ─► api_base_url
+  │     ├─► embed query text via HTTP ─► spelunk-server
+  │     │    (chunk + query text leave the machine only if server_url is a remote
+  │     │     team server, or that server proxies to a third-party --embedding-url)
+  │     ├─► KNN search ─► index.db  (always local sqlite-vec)
+  │     └─► LLM prompt ─► spelunk-server
   │           └─ context: code chunks + spec files + memory notes
   │
   ├─ spelunk memory add ─► memory.db (SQLite, local)  ← single canonical store (ADR-004)
@@ -156,7 +169,7 @@ unauthenticated (no bearer required or sent).
 | Threat | Mode | Likelihood | Impact | Mitigation |
 |--------|------|-----------|--------|-----------|
 | Client impersonates a legitimate spelunk user to the server | B | Medium | High | Bearer token auth — but **optional**; server runs unauthenticated by default. Operators must explicitly pass `--key` / `SPELUNK_SERVER_KEY`. |
-| Attacker spoofs the embedding/LLM backend to return adversarial responses | A | Low | Medium | No server certificate validation is documented; if `api_base_url` is remote and HTTP (not HTTPS), responses can be intercepted. Recommend HTTPS for any non-localhost backend. |
+| Attacker spoofs the embedding/LLM backend to return adversarial responses | A | Low | Medium | The loopback server is on-machine, so this only applies when a remote team `server_url` (or a server's external `--embedding-url`/`--llm-url`) is used over plaintext HTTP. `validate_transport_url` rejects a non-loopback `http://` `server_url` (loopback-only plaintext; https required otherwise), so a remote backend must be HTTPS. |
 
 ### T — Tampering
 
@@ -179,8 +192,8 @@ unauthenticated (no bearer required or sent).
 | Threat | Mode | Likelihood | Impact | Mitigation |
 |--------|------|-----------|--------|-----------|
 | Credentials in source code indexed into vector DB | A | Medium | High | `secrets.rs` scanner drops matching chunks before storage; `.env*`/`*.pem`/`*.key` files excluded |
-| **Source code sent to third-party embedding service** | A | **High** | **High** | **No mitigation in spelunk itself.** If `api_base_url` points to a cloud service, every indexed chunk (post-secret-scan) is transmitted. Users must be informed via docs. |
-| **Memory notes sent to third-party LLM** | A | **Medium** | **High** | **No mitigation in spelunk itself.** `spelunk ask` and `memory harvest` send memory content + code context to the configured LLM endpoint. |
+| **Source code sent off-machine for embedding** | A | Medium | **High** | The default loopback server embeds natively on-machine, so nothing leaves. Egress requires an explicit remote team `server_url` (chunk text crosses to the team server) or a server whose operator set an external `--embedding-url` (server forwards post-secret-scan chunks to a third party). Both are explicit operator choices; users must be informed via docs. |
+| **Memory notes / code context sent off-machine for LLM** | A | Low | **High** | `spelunk ask` and `memory harvest` send memory content + code context to `spelunk-server`. On the default loopback server the LLM runs on-machine; egress requires a remote team `server_url` or a server-side `--llm-url` shim. |
 | Server memory accessible without auth | B | Medium | High | No `--key` / `SPELUNK_SERVER_KEY` by default; any process that can reach the port reads all notes |
 | Server bound to 0.0.0.0 exposes data on LAN/internet | B | Medium | High | **Enforced:** a non-loopback bind requires a key — `spelunk-server` refuses to start on `0.0.0.0`/LAN/public addresses without `--key` / `SPELUNK_SERVER_KEY`; loopback (`127.0.0.1`) is the default (spelunk-oss^52 / PR #490) |
 | Indexed content contains credentials missed by scanner | A | Medium | Medium | Pattern gaps tracked in #138 |
@@ -322,9 +335,12 @@ pushed with notes, the credential is exfiltrated.
 
 ## Third-Party Backend Risk (all modes)
 
-This section is elevated because the original model assumed local-only backends.
+The default backend is on-machine (loopback `spelunk-server`, native F2LLM
+embedder), so by default no code or memory content leaves the machine. This
+section covers the two paths that reach a third party.
 
-**When `api_base_url` is a third-party service (e.g. `https://api.openai.com`):**
+**When a remote team `server_url` is set, or a `spelunk-server` operator has set
+an external `--embedding-url` / `--llm-url` shim (e.g. `https://api.openai.com`):**
 
 | Data sent | Trigger | Risk |
 |-----------|---------|------|
@@ -335,10 +351,10 @@ This section is elevated because the original model assumed local-only backends.
 
 **Mitigations (documentation, not code):**
 - Document the data-egress implications prominently in `docs/getting-started.md` and the `config.toml` comments
-- Recommend users set `api_base_url = "http://127.0.0.1:1234"` (local model) in the default config
+- The default (no `server_url`, auto loopback server, native embedder) keeps all code and memory on-machine; reaching a third party is an explicit operator choice
 - Secret scanning reduces but does not eliminate the risk — it only drops chunks matching known credential patterns
 
-**Recommended future control:** Add a `data_classification = "local-only"` config flag that refuses to connect to non-loopback addresses, with an explicit opt-in override.
+**Recommended future control:** Add a `data_classification = "local-only"` config flag that refuses to configure a non-loopback `server_url`, with an explicit opt-in override.
 
 ---
 
@@ -359,5 +375,5 @@ From this threat model, the following requirements are binding:
 4. **Atomic transactions for memory state transitions** — `supersede()` and `insert_with_supersession()` (issue #136).
 5. **CI must gate on `cargo audit` and `cargo deny`.**
 6. **spelunk-server documentation must warn** that the server is unauthenticated by default and should only be exposed beyond localhost when `--key` / `SPELUNK_SERVER_KEY` is set.
-7. **Config documentation must warn** that setting `api_base_url` to a non-local address transmits source code and memory content to that endpoint.
+7. **Config documentation must warn** that setting a remote team `server_url` (or running a `spelunk-server` with an external `--embedding-url` / `--llm-url` shim) transmits source code and memory content off the machine.
 8. **Secret scanner must run on the git-notes write-through path.** `add.rs` must call `contains_secret(body)` (and optionally `contains_secret(title)`) before calling `append_to_git_notes()`. If a match is found, the git-notes write must be skipped (with a `tracing::warn!`) and the primary SQLite write must still succeed. This closes the gap identified in the [git-notes memory](#git-notes-memory-prref-notespelunk) section above. **This is a binding requirement for any release with `store_in_git_notes = true` as the default.**


### PR DESCRIPTION
## Summary

Pre-v1-freeze config hygiene (spelunk-oss^109, P2). Config keys are a forever-contract, so this prunes dead ones and re-documents live-but-stale ones before the freeze. No behaviour change: every pruned key was inert (zero readers), and the two re-documented keys keep their runtime effect.

**Pruned 5 dead `Config` keys** (field + `default_*` fn + `Default`-impl line each), all verified to have zero non-test readers:
- `models_dir`, `api_base_url`, `plans_dir`, `specs_dir`
- `batch_size` (the `Config` field only). The CLI `IndexArgs.batch_size` and `summary_batch_size` are separate fields and are untouched, so `--batch-size` still works.

**Re-documented 2 live keys:**
- `embedding_model` — sole reader is `plumbing embed` where it is a cosmetic `model:` output label; the effective model is server-owned. Doc reworded; stale default `text-embedding-embeddinggemma-300m-qat` changed to `f2llm-v2-330m`.
- `llm_model` — reworded to "chat model id, resolved by spelunk-server"; dropped the older LM-Studio framing.

**Coupled doc fixes riding the same PR:**
- `spelunk-server/src/main.rs` — `--embedding-model` arg doc: dropped stale embeddinggemma example, clarified it applies to the external `--embedding-url` server and is ignored by the bundled native embedder.
- `spelunk-cli/.../search.rs` — fixed a comment that referenced the removed `api_base_url`.
- `docs/security/THREAT-MODEL.md` — see Security doc note below.

## Back-compat

`Config` has no `#[serde(deny_unknown_fields)]`, so an old `config.toml` still carrying any pruned key parses fine (serde ignores unknown keys). Retained back-compat aliases on live keys (`memory_server_url` → `server_url`, `memory_server_key` → `server_key`) are untouched. The only removed alias, `lmstudio_base_url`, belonged to the pruned `api_base_url` field, which had no runtime effect.

## Security doc

Pruning `api_base_url` invalidated the THREAT-MODEL egress narrative, which described code leaving the machine via that key. The data-flow is re-described against the actual current path (verified in code): all inference routes through `spelunk-server` (ADR-002) and the CLI has no in-process embedder (`spelunk-cli` does not depend on `spelunk-embed`). The default auto-discovered loopback server embeds natively on-machine with no egress. Off-machine egress requires an explicit remote team `server_url` or a server-side `--embedding-url` / `--llm-url` shim. The Spoofing-row mitigation now cites the real `validate_transport_url` control (rejects non-loopback plaintext `http://`). Only the stale config key was removed from the narrative; no real security control was weakened or dropped.

## Test plan

Run in the worktree with `export SPELUNK_SECRET_STORE=file`:
- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — clean, no warnings
- `cargo test` — all pass, 0 failed across every binary (config unit tests 21/21; server integration 12/12)
- `cargo audit` — exit 0 (only pre-existing allowed unmaintained-transitive warnings; this change adds no deps)
- `grep -rn '<key>' crates/*/src` for each pruned key — zero non-test readers
- `grep -iE 'api_base_url|:1234|lm.?studio' docs/security/THREAT-MODEL.md` — no stale live references remain (only the changelog line noting the key was retired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
