### PR TITLE
index.db schema versioning (user_version) + embedding-model provenance (^107, ^108)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -449,6 +449,9 @@ pub(super) async fn run_embed_phase(
         Tier::Server { url, .. } => (url.clone(), cfg.server_key.clone()),
         Tier::Offline => return Ok(0),
     };
+    // Refuse to append vectors from a different model into an existing index;
+    // stamps provenance on a fresh/legacy DB.
+    db.ensure_embedding_model(spelunk_core::embeddings::MODEL_ID)?;
     let server_limits = tier.server_limits();
 
     // Ceiling the calibrated batch size may grow to. Unlike the old scheme,

--- a/crates/spelunk-core/migrations/022_index_meta.sql
+++ b/crates/spelunk-core/migrations/022_index_meta.sql
@@ -1,0 +1,7 @@
+-- Key-value metadata for the local index.db.
+-- Records embedding provenance (embedding_model, embedding_dim) so a
+-- same-dim successor model cannot silently corrupt the KNN space.
+CREATE TABLE IF NOT EXISTS index_meta (
+    key   TEXT NOT NULL PRIMARY KEY,
+    value TEXT NOT NULL
+);

--- a/crates/spelunk-core/src/embeddings/mod.rs
+++ b/crates/spelunk-core/src/embeddings/mod.rs
@@ -2,6 +2,10 @@
 /// that crate stays storage-free); re-exported here at the historical path.
 pub use spelunk_embed::EmbeddingBackend;
 
+/// Stable provenance id for the native embedding model. Single source of truth
+/// is `spelunk_embed::MODEL_ID`; re-exported here so server and CLI share it.
+pub use spelunk_embed::MODEL_ID;
+
 /// The embedding vector dimension produced by the default native model (F2LLM-v2-330M, 896-dim).
 pub const EMBEDDING_DIM: usize = 896;
 

--- a/crates/spelunk-core/src/storage/db.rs
+++ b/crates/spelunk-core/src/storage/db.rs
@@ -8,6 +8,15 @@ pub struct Database {
     pub(super) conn: Connection,
 }
 
+/// Latest local schema version. Append-only: never renumber an existing step.
+/// The runner in `Database::open` gates each migration on this via
+/// `PRAGMA user_version`; steps are numbered in the order they run (the field
+/// order), not filename order.
+pub(super) const CURRENT_SCHEMA_VERSION: i32 = 14;
+
+/// One entry in the migration runner: (target version, migration body).
+type MigrationStep = (i32, fn(&Database) -> Result<()>);
+
 impl Database {
     /// Open (or create) the database at `path` and run all migrations.
     ///
@@ -25,20 +34,145 @@ impl Database {
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
 
         let db = Self { conn };
-        db.migrate()?;
-        db.apply_vector_migration()?;
-        db.apply_graph_migration()?;
-        db.apply_spec_migration()?;
-        db.apply_fts_migration()?;
-        db.apply_token_count_migration()?;
-        db.apply_graph_rank_migration()?;
-        db.apply_summary_migration()?;
-        db.apply_usage_migration()?;
-        db.apply_compound_graph_idx_migration()?;
-        db.apply_conventions_migration()?;
-        db.apply_dim_upgrade_migration()?;
-        db.apply_drop_snapshots_migration()?;
+        db.run_migrations()?;
         Ok(db)
+    }
+
+    /// Forward-only migration runner gated on `PRAGMA user_version`.
+    ///
+    /// A `user_version=0` DB is either brand-new (no user tables) or a
+    /// pre-`user_version` field DB. New DBs run every step from 1. Field DBs
+    /// have their true version inferred from table shapes / the
+    /// `schema_int8_embeddings` marker, stamped, and only later steps run —
+    /// blindly re-running all steps would drive the guarded 008–010 ALTERs
+    /// through their `duplicate column name` branch needlessly. Each step is
+    /// idempotent, so a conservative (one-low) inference stays safe.
+    fn run_migrations(&self) -> Result<()> {
+        let mut version: i32 = self
+            .conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .context("reading user_version")?;
+
+        if version == 0 && !self.is_fresh_db()? {
+            version = self.infer_legacy_version()?;
+        }
+
+        // Each entry: (target_version, migration body). Ordered by call order.
+        // Append new steps at the end; never renumber.
+        let steps: &[MigrationStep] = &[
+            (1, Self::migrate),
+            (2, Self::apply_vector_migration),
+            (3, Self::apply_graph_migration),
+            (4, Self::apply_spec_migration),
+            (5, Self::apply_fts_migration),
+            (6, Self::apply_token_count_migration),
+            (7, Self::apply_graph_rank_migration),
+            (8, Self::apply_summary_migration),
+            (9, Self::apply_usage_migration),
+            (10, Self::apply_compound_graph_idx_migration),
+            (11, Self::apply_conventions_migration),
+            (12, Self::apply_dim_upgrade_migration),
+            (13, Self::apply_drop_snapshots_migration),
+            (14, Self::apply_index_meta_migration),
+        ];
+        debug_assert_eq!(
+            steps.last().map(|(v, _)| *v),
+            Some(CURRENT_SCHEMA_VERSION),
+            "steps table must end at CURRENT_SCHEMA_VERSION"
+        );
+
+        for (target, body) in steps {
+            if *target > version {
+                body(self)?;
+            }
+        }
+        // user_version is a header i32; the value is a code-controlled constant.
+        self.conn
+            .execute_batch(&format!("PRAGMA user_version = {CURRENT_SCHEMA_VERSION}"))
+            .context("stamping user_version")?;
+        Ok(())
+    }
+
+    /// True when the file has no user tables — a freshly created DB that must
+    /// run every migration from step 1.
+    fn is_fresh_db(&self) -> Result<bool> {
+        let n: i64 = self
+            .conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+                 WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+                [],
+                |r| r.get(0),
+            )
+            .context("counting user tables")?;
+        Ok(n == 0)
+    }
+
+    /// Infer the schema version of a pre-`user_version` field DB from its table
+    /// shapes. Walks the ladder top-down; the first unmet predicate fixes the
+    /// version. A conservative (one-low) result is safe: the re-run step is a
+    /// no-op guard that then advances the version.
+    fn infer_legacy_version(&self) -> Result<i32> {
+        let has_table = |name: &str| -> Result<bool> {
+            Ok(self
+                .conn
+                .query_row(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+                    rusqlite::params![name],
+                    |_| Ok(()),
+                )
+                .optional()
+                .context("probing table")?
+                .is_some())
+        };
+        let has_index = |name: &str| -> Result<bool> {
+            Ok(self
+                .conn
+                .query_row(
+                    "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?1",
+                    rusqlite::params![name],
+                    |_| Ok(()),
+                )
+                .optional()
+                .context("probing index")?
+                .is_some())
+        };
+        let chunks_has_column = |col: &str| -> Result<bool> {
+            let mut stmt = self.conn.prepare("PRAGMA table_info(chunks)")?;
+            let mut rows = stmt.query([])?;
+            while let Some(row) = rows.next()? {
+                if row.get::<_, String>(1)? == col {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        };
+
+        let ladder: [(i32, bool); 14] = [
+            (1, has_table("chunks")?),
+            (2, has_table("embeddings")?),
+            (3, has_table("graph_edges")?),
+            (4, has_table("specs")?),
+            (5, has_table("chunks_fts")?),
+            (6, chunks_has_column("token_count")?),
+            (7, chunks_has_column("graph_rank")?),
+            (8, chunks_has_column("summary")?),
+            (9, has_table("usage")?),
+            (10, has_index("graph_edges_source_name_kind")?),
+            (11, has_table("conventions")?),
+            (12, has_table("schema_int8_embeddings")?),
+            (13, !has_table("snapshots")?),
+            (14, has_table("index_meta")?),
+        ];
+        // Highest version whose predicate and all lower ones hold.
+        let mut version = 0;
+        for (v, satisfied) in ladder {
+            if !satisfied {
+                break;
+            }
+            version = v;
+        }
+        Ok(version)
     }
 
     fn migrate(&self) -> Result<()> {
@@ -88,27 +222,44 @@ impl Database {
         Ok(())
     }
 
-    /// Add token_count column to chunks table. Idempotent (column has DEFAULT 0).
+    /// Add token_count column to chunks table.
+    /// `ALTER TABLE` has no `IF NOT EXISTS`; only the already-applied error is
+    /// tolerated so a genuine failure propagates out of `Database::open`.
     pub fn apply_token_count_migration(&self) -> Result<()> {
-        let _ = self
+        match self
             .conn
-            .execute_batch(include_str!("../../migrations/008_token_counts.sql"));
+            .execute_batch(include_str!("../../migrations/008_token_counts.sql"))
+        {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => return Err(e).context("running token_count migration"),
+        }
         Ok(())
     }
 
-    /// Add graph_rank column to chunks table. Idempotent (column has DEFAULT 0.0).
+    /// Add graph_rank column to chunks table.
     pub fn apply_graph_rank_migration(&self) -> Result<()> {
-        let _ = self
+        match self
             .conn
-            .execute_batch(include_str!("../../migrations/009_graph_rank.sql"));
+            .execute_batch(include_str!("../../migrations/009_graph_rank.sql"))
+        {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => return Err(e).context("running graph_rank migration"),
+        }
         Ok(())
     }
 
-    /// Add summary column to chunks table. Idempotent.
+    /// Add summary column to chunks table.
     pub fn apply_summary_migration(&self) -> Result<()> {
-        let _ = self
+        match self
             .conn
-            .execute_batch(include_str!("../../migrations/010_summaries.sql"));
+            .execute_batch(include_str!("../../migrations/010_summaries.sql"))
+        {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => return Err(e).context("running summary migration"),
+        }
         Ok(())
     }
 
@@ -208,6 +359,51 @@ impl Database {
         Ok(())
     }
 
+    /// Create the index_meta KV table (embedding provenance). Idempotent.
+    pub fn apply_index_meta_migration(&self) -> Result<()> {
+        self.conn
+            .execute_batch(include_str!("../../migrations/022_index_meta.sql"))
+            .context("running index_meta migration")?;
+        Ok(())
+    }
+
+    /// Read the recorded embedding model id, or `None` if never stamped (a DB
+    /// predating provenance, treated as "matches anything" until first write).
+    pub fn embedding_model(&self) -> Result<Option<String>> {
+        self.conn
+            .query_row(
+                "SELECT value FROM index_meta WHERE key = 'embedding_model'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .context("reading embedding_model")
+    }
+
+    /// Assert the current model matches this DB's provenance before writing
+    /// embeddings, stamping it on a fresh/legacy DB. A recorded id that differs
+    /// is a hard error: mixing two model ids in one KNN space is corruption.
+    pub fn ensure_embedding_model(&self, model_id: &str) -> Result<()> {
+        match self.embedding_model()? {
+            Some(recorded) if recorded == model_id => Ok(()),
+            Some(recorded) => anyhow::bail!(
+                "index was built with embedding model '{recorded}' but this build uses \
+                 '{model_id}'. Vectors from two models must not share one search index. \
+                 Re-index from scratch: `spelunk index . --force` (or delete .spelunk/index.db)."
+            ),
+            None => {
+                self.conn
+                    .execute(
+                        "INSERT OR REPLACE INTO index_meta (key, value) \
+                         VALUES ('embedding_model', ?1), ('embedding_dim', ?2)",
+                        rusqlite::params![model_id, crate::embeddings::EMBEDDING_DIM.to_string()],
+                    )
+                    .context("stamping embedding provenance")?;
+                Ok(())
+            }
+        }
+    }
+
     /// Insert or replace an embedding for a chunk.
     ///
     /// Takes the raw float vector; it is int8-quantised here for the
@@ -232,5 +428,152 @@ impl Database {
             rusqlite::params![file_id],
         )?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CURRENT_SCHEMA_VERSION, Database};
+    use rusqlite::Connection;
+    use std::sync::OnceLock;
+
+    fn register_sqlite_vec() {
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            #[allow(clippy::missing_transmute_annotations)]
+            unsafe {
+                rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                    sqlite_vec::sqlite3_vec_init as *const (),
+                )));
+            }
+        });
+    }
+
+    fn user_version(conn: &Connection) -> i32 {
+        conn.query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    /// A freshly created DB runs every migration and ends stamped at the latest
+    /// version.
+    #[test]
+    fn fresh_db_stamps_current_version() {
+        register_sqlite_vec();
+        let db = Database::open(std::path::Path::new(":memory:")).expect("open fresh");
+        assert_eq!(user_version(&db.conn), CURRENT_SCHEMA_VERSION);
+    }
+
+    /// Opening an already-migrated DB a second time is a clean no-op that keeps
+    /// the version.
+    #[test]
+    fn reopen_is_idempotent() {
+        register_sqlite_vec();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let db = Database::open(tmp.path()).expect("first open");
+        drop(db);
+        let db = Database::open(tmp.path()).expect("second open");
+        assert_eq!(user_version(&db.conn), CURRENT_SCHEMA_VERSION);
+    }
+
+    /// A DB built by the previous binary reports `user_version = 0` but has all
+    /// tables. It must be inferred at the latest version, stamped, and re-run
+    /// zero erroring migration bodies.
+    #[test]
+    fn legacy_fully_migrated_db_is_inferred_and_stamped() {
+        register_sqlite_vec();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        {
+            let db = Database::open(tmp.path()).expect("build via runner");
+            // Simulate a pre-user_version binary: reset the header stamp.
+            db.conn
+                .execute_batch("PRAGMA user_version = 0")
+                .expect("reset version");
+        }
+        let db = Database::open(tmp.path()).expect("reopen legacy");
+        assert_eq!(
+            user_version(&db.conn),
+            CURRENT_SCHEMA_VERSION,
+            "a fully-migrated legacy DB must be inferred at the latest version"
+        );
+    }
+
+    /// A partially-migrated legacy DB (chunks without `summary`, no index_meta,
+    /// version 0) is inferred at 7 and only the later steps run to reach the
+    /// latest version.
+    #[test]
+    fn partially_migrated_legacy_db_is_inferred_then_completed() {
+        register_sqlite_vec();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        {
+            // Build a real DB, then strip it back to a version-7 shape: drop the
+            // later columns/tables so inference lands at 7.
+            let db = Database::open(tmp.path()).expect("build");
+            db.conn
+                .execute_batch(
+                    "ALTER TABLE chunks DROP COLUMN summary; \
+                     DROP TABLE IF EXISTS usage; \
+                     DROP INDEX IF EXISTS graph_edges_source_name_kind; \
+                     DROP TABLE IF EXISTS conventions; \
+                     DROP TABLE IF EXISTS schema_int8_embeddings; \
+                     DROP TABLE IF EXISTS index_meta; \
+                     PRAGMA user_version = 0;",
+                )
+                .expect("strip to v7 shape");
+            assert!(super::Database::infer_legacy_version(&db).unwrap() == 7);
+        }
+        let db = Database::open(tmp.path()).expect("reopen partial");
+        assert_eq!(user_version(&db.conn), CURRENT_SCHEMA_VERSION);
+        // The later step (index_meta) actually ran.
+        assert!(db.embedding_model().unwrap().is_none());
+        db.ensure_embedding_model("m").unwrap();
+        assert_eq!(db.embedding_model().unwrap().as_deref(), Some("m"));
+    }
+
+    /// A genuine failure in the guarded 008–010 ALTERs (not a duplicate column)
+    /// propagates out rather than being swallowed. We exercise the guard by
+    /// dropping the whole `chunks` table so the ALTER fails with "no such
+    /// table", which must surface as an `Err`.
+    #[test]
+    fn token_count_migration_propagates_non_duplicate_error() {
+        register_sqlite_vec();
+        let conn = Connection::open_in_memory().unwrap();
+        let db = Database { conn };
+        // No `chunks` table exists → the ALTER fails with "no such table".
+        let err = db
+            .apply_token_count_migration()
+            .expect_err("missing chunks table must surface as an error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no such table") || msg.contains("token_count migration"),
+            "a real migration failure must propagate, got: {msg}"
+        );
+    }
+
+    /// Model provenance round-trips through index_meta, and a mismatch is a hard
+    /// error while an absent model is backfilled.
+    #[test]
+    fn embedding_model_stamp_reject_and_backfill() {
+        register_sqlite_vec();
+        let db = Database::open(std::path::Path::new(":memory:")).expect("open");
+        // Absent → backfilled (no error).
+        assert!(db.embedding_model().unwrap().is_none());
+        db.ensure_embedding_model("F2LLM-v2-330M@896")
+            .expect("first stamp");
+        assert_eq!(
+            db.embedding_model().unwrap().as_deref(),
+            Some("F2LLM-v2-330M@896")
+        );
+        // Same model → no-op.
+        db.ensure_embedding_model("F2LLM-v2-330M@896")
+            .expect("same model is fine");
+        // Different model → hard error instructing a re-index.
+        let err = db
+            .ensure_embedding_model("some-other-model@896")
+            .expect_err("model mismatch must be a hard error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.to_lowercase().contains("re-index"),
+            "message must instruct re-index: {msg}"
+        );
     }
 }

--- a/crates/spelunk-embed/src/lib.rs
+++ b/crates/spelunk-embed/src/lib.rs
@@ -24,6 +24,12 @@
 mod backend;
 pub use backend::EmbeddingBackend;
 
+/// Stable provenance id for the native embedding model, `<repo-shortname>@<dim>`.
+/// Exact-match token: never parse it. Requantization or a hardware-portability
+/// rebuild of the same model must NOT change this — only a genuine model swap
+/// (different weights / vector space) does, which forces a re-index.
+pub const MODEL_ID: &str = "F2LLM-v2-330M@896";
+
 #[cfg(feature = "embed-native")]
 mod embedder_native;
 

--- a/crates/spelunk-server/migrations/server_005.sql
+++ b/crates/spelunk-server/migrations/server_005.sql
@@ -1,0 +1,5 @@
+-- spelunk-server migration 005
+-- Record the embedding model id per project (provenance), not just the dim.
+-- A same-dim successor model must be a detectable, deliberate re-index rather
+-- than a silent KNN corruption. NULL = legacy/unknown, lazy-stamped on first write.
+ALTER TABLE projects ADD COLUMN embedding_model TEXT;

--- a/crates/spelunk-server/src/db.rs
+++ b/crates/spelunk-server/src/db.rs
@@ -30,10 +30,38 @@ impl std::fmt::Display for DimensionMismatch {
 
 impl std::error::Error for DimensionMismatch {}
 
+/// Typed error for an embedding-model mismatch on a project — a same-dim
+/// successor model that would silently corrupt the KNN space. Distinct from
+/// `anyhow::Error` so the HTTP layer maps it to a 400 without message sniffing,
+/// exactly as [`DimensionMismatch`] does (`AppError::Internal` in `lib.rs`).
+#[derive(Debug)]
+pub struct ModelMismatch {
+    pub slug: String,
+    pub expected: String,
+    pub got: String,
+}
+
+impl std::fmt::Display for ModelMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "embedding model mismatch for project '{}': server expects '{}', got '{}'. \
+             All clients on the same project must use the same embedding model; \
+             a model change requires a deliberate re-index.",
+            self.slug, self.expected, self.got
+        )
+    }
+}
+
+impl std::error::Error for ModelMismatch {}
+
 /// Shared state for all DB operations on the server.
 pub struct ServerDb {
     pub conn: Connection,
     pub embedding_dim: usize,
+    /// Provenance id of the model this server embeds with; stamped onto and
+    /// validated against each project alongside `embedding_dim`.
+    pub embedding_model: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
@@ -41,6 +69,9 @@ pub struct Project {
     pub id: i64,
     pub slug: String,
     pub embedding_dim: usize,
+    /// Embedding model provenance id; None on a legacy project not yet stamped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embedding_model: Option<String>,
     /// Unix timestamp of project creation.
     pub created_at: i64,
 }
@@ -66,7 +97,11 @@ pub struct ServerNote {
 }
 
 impl ServerDb {
-    pub fn open(path: &std::path::Path, embedding_dim: usize) -> Result<Self> {
+    pub fn open(
+        path: &std::path::Path,
+        embedding_dim: usize,
+        embedding_model: &str,
+    ) -> Result<Self> {
         let conn = Connection::open(path)
             .with_context(|| format!("opening server db at {}", path.display()))?;
         // WAL mode for concurrent readers.
@@ -74,6 +109,7 @@ impl ServerDb {
         let db = Self {
             conn,
             embedding_dim,
+            embedding_model: embedding_model.to_string(),
         };
         db.migrate()?;
         Ok(db)
@@ -99,6 +135,16 @@ impl ServerDb {
         self.conn
             .execute_batch(include_str!("../migrations/server_003.sql"))
             .context("server migration 003")?;
+        // Migration 005: embedding_model column. `ALTER TABLE` has no
+        // `IF NOT EXISTS`; tolerate only the already-applied error.
+        match self
+            .conn
+            .execute_batch(include_str!("../migrations/server_005.sql"))
+        {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => return Err(e).context("server migration 005"),
+        }
         Ok(())
     }
 
@@ -131,13 +177,19 @@ impl ServerDb {
     // ── Projects ──────────────────────────────────────────────────────────────
 
     /// Get or auto-create a project by slug. On first write, records the
-    /// embedding dimension for subsequent validation.
-    pub fn upsert_project(&self, slug: &str, incoming_dim: usize) -> Result<Project> {
+    /// embedding dimension and model for subsequent validation. `incoming_model`
+    /// is the provenance id of the model producing this write's vectors.
+    pub fn upsert_project(
+        &self,
+        slug: &str,
+        incoming_dim: usize,
+        incoming_model: &str,
+    ) -> Result<Project> {
         // Check if project exists.
         let existing: Option<Project> = self
             .conn
             .query_row(
-                "SELECT id, slug, embedding_dim, created_at FROM projects WHERE slug = ?1",
+                "SELECT id, slug, embedding_dim, embedding_model, created_at FROM projects WHERE slug = ?1",
                 rusqlite::params![slug],
                 row_to_project,
             )
@@ -154,6 +206,17 @@ impl ServerDb {
                 }
                 .into());
             }
+            // Validate model if already set; NULL = legacy, lazy-stamped below.
+            if let Some(recorded) = &p.embedding_model
+                && recorded != incoming_model
+            {
+                return Err(ModelMismatch {
+                    slug: slug.to_string(),
+                    expected: recorded.clone(),
+                    got: incoming_model.to_string(),
+                }
+                .into());
+            }
             // Set dimension on first note.
             if p.embedding_dim == 0 {
                 self.conn.execute(
@@ -162,18 +225,27 @@ impl ServerDb {
                 )?;
                 p.embedding_dim = incoming_dim;
             }
+            // Stamp model on first write (legacy/unstamped project).
+            if p.embedding_model.is_none() {
+                self.conn.execute(
+                    "UPDATE projects SET embedding_model = ?1 WHERE id = ?2",
+                    rusqlite::params![incoming_model, p.id],
+                )?;
+                p.embedding_model = Some(incoming_model.to_string());
+            }
             Ok(p)
         } else {
             // Auto-create.
             self.conn.execute(
-                "INSERT INTO projects (slug, embedding_dim) VALUES (?1, ?2)",
-                rusqlite::params![slug, incoming_dim as i64],
+                "INSERT INTO projects (slug, embedding_dim, embedding_model) VALUES (?1, ?2, ?3)",
+                rusqlite::params![slug, incoming_dim as i64, incoming_model],
             )?;
             let id = self.conn.last_insert_rowid();
             Ok(Project {
                 id,
                 slug: slug.to_string(),
                 embedding_dim: incoming_dim,
+                embedding_model: Some(incoming_model.to_string()),
                 created_at: now_unix(),
             })
         }
@@ -182,7 +254,7 @@ impl ServerDb {
     pub fn get_project(&self, slug: &str) -> Result<Option<Project>> {
         self.conn
             .query_row(
-                "SELECT id, slug, embedding_dim, created_at FROM projects WHERE slug = ?1",
+                "SELECT id, slug, embedding_dim, embedding_model, created_at FROM projects WHERE slug = ?1",
                 rusqlite::params![slug],
                 row_to_project,
             )
@@ -193,7 +265,7 @@ impl ServerDb {
     pub fn list_projects(&self) -> Result<Vec<Project>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT id, slug, embedding_dim, created_at FROM projects ORDER BY slug")?;
+            .prepare("SELECT id, slug, embedding_dim, embedding_model, created_at FROM projects ORDER BY slug")?;
         let projects = stmt
             .query_map([], row_to_project)?
             .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -496,7 +568,8 @@ fn row_to_project(row: &rusqlite::Row<'_>) -> rusqlite::Result<Project> {
         id: row.get(0)?,
         slug: row.get(1)?,
         embedding_dim: row.get::<_, i64>(2)? as usize,
-        created_at: row.get(3)?,
+        embedding_model: row.get(3)?,
+        created_at: row.get(4)?,
     })
 }
 
@@ -602,7 +675,7 @@ mod tests {
         // End-to-end through the public method against a real (in-memory) DB:
         // the persisted v7 UUID is returned verbatim and is stable across calls.
         register_sqlite_vec();
-        let db = ServerDb::open(std::path::Path::new(":memory:"), 768)
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 768, "test-model")
             .expect("open in-memory server db");
 
         let id1 = db.get_or_create_instance_id().expect("first instance_id");
@@ -615,5 +688,44 @@ mod tests {
         // INSERT OR IGNORE keeps the original id, so the whole value is stable.
         let id2 = db.get_or_create_instance_id().expect("second instance_id");
         assert_eq!(id1, id2, "instance_id must be stable across calls");
+    }
+
+    /// A same-dim write with a different model id returns the typed
+    /// `ModelMismatch`, which the HTTP layer maps to a 400 (see `lib.rs`).
+    #[test]
+    fn upsert_project_model_mismatch_is_typed_error() {
+        register_sqlite_vec();
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "model-a")
+            .expect("open in-memory server db");
+        db.upsert_project("proj", 4, "model-a")
+            .expect("first upsert stamps model");
+        let err = db
+            .upsert_project("proj", 4, "model-b")
+            .expect_err("same dim, different model must error");
+        let mismatch = err
+            .downcast_ref::<ModelMismatch>()
+            .expect("error must be the typed ModelMismatch");
+        assert_eq!(mismatch.expected, "model-a");
+        assert_eq!(mismatch.got, "model-b");
+    }
+
+    /// A legacy project row with NULL `embedding_model` is lazy-stamped on the
+    /// next write rather than rejected.
+    #[test]
+    fn upsert_project_null_model_is_lazy_stamped() {
+        register_sqlite_vec();
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "model-a")
+            .expect("open in-memory server db");
+        // Simulate a legacy row created before the embedding_model column.
+        db.conn
+            .execute(
+                "INSERT INTO projects (slug, embedding_dim, embedding_model) VALUES ('legacy', 4, NULL)",
+                [],
+            )
+            .expect("seed legacy project");
+        let p = db
+            .upsert_project("legacy", 4, "model-a")
+            .expect("null model lazy-stamps without rejecting");
+        assert_eq!(p.embedding_model.as_deref(), Some("model-a"));
     }
 }

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -559,7 +559,8 @@ pub async fn add_note(
     let dim = embedding.map(|v| v.len()).unwrap_or(0);
 
     let db = state.db.lock().await;
-    let project = db.upsert_project(&project_id, dim)?;
+    let model = db.embedding_model.clone();
+    let project = db.upsert_project(&project_id, dim, &model)?;
 
     let id = db.add_note(
         project.id,
@@ -1580,7 +1581,7 @@ mod tests {
     fn make_app(conflict_threshold: f32) -> (axum::Router, i32) {
         register_sqlite_vec();
         let dim: usize = 4;
-        let db = ServerDb::open(std::path::Path::new(":memory:"), dim)
+        let db = ServerDb::open(std::path::Path::new(":memory:"), dim, "test-model")
             .expect("failed to open in-memory server db");
         let instance_id = db.get_or_create_instance_id().expect("instance_id in test");
         let state = AppState {
@@ -1749,7 +1750,7 @@ mod tests {
     /// Build an app with the given embedder slot (dim used only to size the DB).
     fn make_app_with_slot(dim: usize, embedder: super::super::EmbedderSlot) -> axum::Router {
         register_sqlite_vec();
-        let db = ServerDb::open(std::path::Path::new(":memory:"), dim)
+        let db = ServerDb::open(std::path::Path::new(":memory:"), dim, "test-model")
             .expect("failed to open in-memory server db");
         let instance_id = db.get_or_create_instance_id().expect("instance_id in test");
         let state = AppState {
@@ -2230,11 +2231,12 @@ mod tests {
     #[test]
     fn upsert_project_dimension_mismatch_is_typed_error() {
         register_sqlite_vec();
-        let db =
-            ServerDb::open(std::path::Path::new(":memory:"), 4).expect("open in-memory server db");
-        db.upsert_project("proj", 4).expect("first upsert sets dim");
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "test-model")
+            .expect("open in-memory server db");
+        db.upsert_project("proj", 4, "test-model")
+            .expect("first upsert sets dim");
         let err = db
-            .upsert_project("proj", 7)
+            .upsert_project("proj", 7, "test-model")
             .expect_err("second upsert with different dim must error");
         let mismatch = err
             .downcast_ref::<super::super::db::DimensionMismatch>()
@@ -2303,7 +2305,7 @@ mod tests {
     /// exercising `/explore` and `/llm/complete` rate limiting.
     fn make_app_with_llm_and_limit(max_requests: u32) -> axum::Router {
         register_sqlite_vec();
-        let db = ServerDb::open(std::path::Path::new(":memory:"), 4)
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "test-model")
             .expect("failed to open in-memory server db");
         let instance_id = db.get_or_create_instance_id().expect("instance_id in test");
         let state = AppState {
@@ -2484,12 +2486,12 @@ mod tests {
         request_timeout: std::time::Duration,
     ) -> (String, Arc<tokio::sync::Mutex<ServerDb>>) {
         register_sqlite_vec();
-        let db = ServerDb::open(std::path::Path::new(":memory:"), 4)
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "test-model")
             .expect("failed to open in-memory server db");
         let instance_id = db.get_or_create_instance_id().expect("instance_id in test");
         // Create the project up front so `/memory/stream` (which 404s on an
         // unknown project) has something valid to stream from.
-        db.upsert_project("timeout-test", 4)
+        db.upsert_project("timeout-test", 4, "test-model")
             .expect("create test project");
         let db = Arc::new(tokio::sync::Mutex::new(db));
         let state = AppState {
@@ -2533,10 +2535,10 @@ mod tests {
         embed_request_timeout: std::time::Duration,
     ) -> (String, Arc<tokio::sync::Mutex<ServerDb>>) {
         register_sqlite_vec();
-        let db = ServerDb::open(std::path::Path::new(":memory:"), 4)
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "test-model")
             .expect("failed to open in-memory server db");
         let instance_id = db.get_or_create_instance_id().expect("instance_id in test");
-        db.upsert_project("timeout-test", 4)
+        db.upsert_project("timeout-test", 4, "test-model")
             .expect("create test project");
         let db = Arc::new(tokio::sync::Mutex::new(db));
         let state = AppState {

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -681,6 +681,12 @@ impl IntoResponse for AppError {
                         Json(ErrorBody::new("bad_request", &mismatch.to_string())),
                     )
                         .into_response()
+                } else if let Some(mismatch) = e.downcast_ref::<crate::db::ModelMismatch>() {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorBody::new("bad_request", &mismatch.to_string())),
+                    )
+                        .into_response()
                 } else {
                     tracing::error!("internal error: {e:#}");
                     (

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -12,6 +12,7 @@ use utoipa::OpenApi;
 
 #[cfg(feature = "embed-native")]
 use spelunk_embed::DIM as NATIVE_EMBED_DIM;
+use spelunk_embed::MODEL_ID as NATIVE_MODEL_ID;
 #[cfg(feature = "embed-native")]
 use spelunk_server::embed_hub;
 
@@ -113,7 +114,7 @@ async fn main() -> Result<()> {
     // embedder. This refusal is unconditional — there is no opt-out.
     check_bind_safety(&args.host, args.port, api_key.is_some())?;
 
-    let db = ServerDb::open(&args.db, args.embedding_dim)
+    let db = ServerDb::open(&args.db, args.embedding_dim, NATIVE_MODEL_ID)
         .with_context(|| format!("opening server db at {}", args.db.display()))?;
 
     let instance_id = db

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -12,7 +12,8 @@ use utoipa::OpenApi;
 
 #[cfg(feature = "embed-native")]
 use spelunk_embed::DIM as NATIVE_EMBED_DIM;
-use spelunk_embed::MODEL_ID as NATIVE_MODEL_ID;
+// Via spelunk-core (always linked); spelunk_embed is only present under embed-native.
+use spelunk_core::embeddings::MODEL_ID as NATIVE_MODEL_ID;
 #[cfg(feature = "embed-native")]
 use spelunk_server::embed_hub;
 

--- a/crates/spelunk-server/tests/common/mod.rs
+++ b/crates/spelunk-server/tests/common/mod.rs
@@ -40,7 +40,7 @@ pub fn open_test_db() -> spelunk_core::storage::Database {
 /// Calls `register_sqlite_vec()` automatically.
 pub fn open_test_server_db(dim: usize) -> spelunk_server::db::ServerDb {
     register_sqlite_vec();
-    spelunk_server::db::ServerDb::open(std::path::Path::new(":memory:"), dim)
+    spelunk_server::db::ServerDb::open(std::path::Path::new(":memory:"), dim, "test-model")
         .expect("failed to open in-memory server database")
 }
 

--- a/crates/spelunk-server/tests/integration_server.rs
+++ b/crates/spelunk-server/tests/integration_server.rs
@@ -325,7 +325,8 @@ async fn since_endpoint_returns_entries_after_timestamp() {
     common::register_sqlite_vec();
 
     // Build a DB and insert two notes with known timestamps.
-    let db = ServerDb::open(std::path::Path::new(":memory:"), 4).expect("open in-memory server db");
+    let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "test-model")
+        .expect("open in-memory server db");
 
     // Insert a project manually so we control created_at timing.
     db.conn

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1650,6 +1650,13 @@
             "type": "integer",
             "minimum": 0
           },
+          "embedding_model": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Embedding model provenance id; None on a legacy project not yet stamped."
+          },
           "id": {
             "type": "integer",
             "format": "int64"


### PR DESCRIPTION
## Summary

Two P1 v1-freeze fixes for the local `index.db` and server, on one branch (they both extend the local migration path and share `storage/db.rs`).

### spelunk-oss^107 – unified `index.db` schema versioning via `PRAGMA user_version`

`Database::open` previously ran a fixed list of `apply_*` migrations with no schema-version record, and migrations 008-010 swallowed all errors with `let _ = execute_batch(...)`, making a genuine failure indistinguishable from an already-applied one.

- `Database::open` now runs a single `run_migrations()` gated on `PRAGMA user_version`. Steps run only when their target version is greater than the recorded version, then `CURRENT_SCHEMA_VERSION` (14) is stamped.
- Steps are numbered in the **actual historical `open` call order** (append-only, never renumbered): 1 base, 2 vectors, 3 graph, 4 specs, 5 fts, 6 token_count, 7 graph_rank, 8 summary, 9 usage, 10 compound_graph_idx, 11 conventions, 12 dim_upgrade, 13 drop_snapshots, 14 index_meta. A `debug_assert` locks the table's last entry to `CURRENT_SCHEMA_VERSION`.
- **Fleet stamping:** a `user_version = 0` DB with user tables is a pre-versioning field DB. `infer_legacy_version()` walks a top-down predicate ladder (table / index / column probes, the `schema_int8_embeddings` marker, and `snapshots`-absent), takes the highest satisfied version, stamps it, and runs only later steps. A brand-new DB (no user tables) runs every step from 1. Each ladder predicate maps to exactly the effect its own migration produces, so the inference is monotonic and a conservative one-low result stays safe (every step is idempotent or guarded).
- **008-010 no longer swallow errors:** the `let _ =` is replaced with the memory.db-style guard that tolerates only `duplicate column name` and propagates every other error out of `Database::open`.
- The `schema_int8_embeddings` / `schema_v896_note_embeddings` markers are untouched.

### spelunk-oss^108 – embedding-model provenance (not just dimension)

Provenance recorded the vector dimension but not the model, so a same-dim successor model could silently mix incompatible vectors into one KNN space. This is the OSS-side implementation of ADR-053's already-approved "Vector versioning" prerequisite (no new ADR).

- `spelunk_embed::MODEL_ID = "F2LLM-v2-330M@896"` is an unconditional `const` (not gated behind `embed-native`), re-exported at `spelunk_core::embeddings::MODEL_ID`. Single source of truth; server and CLI both consume it. It is a stable human-readable token, not a weight hash (a requantization or hardware-portability rebuild of the same model must not force a spurious re-index).
- **Server:** new `projects.embedding_model TEXT` column (`server_005.sql`, nullable). `upsert_project` validates it alongside the dimension: a same-dim different-model write returns a typed `ModelMismatch` (sibling to `DimensionMismatch`), mapped to a 400 in `AppError::into_response` via `downcast_ref` (no message sniffing). A NULL/legacy stored model lazy-stamps on first write instead of rejecting.
- **Local:** new `index_meta(key, value)` KV table (`022_index_meta.sql`, `user_version` step 14). `ensure_embedding_model()` hard-errors on a mismatch with an actionable re-index instruction, and backfills provenance when absent. It is called in `run_embed_phase` before any vector is written, so a mismatched index never receives mixed vectors.
- `docs/openapi.json` regenerated for the new `Project.embedding_model` wire field.

## Merge order

PR #531 introduces `server_004.sql` and edits the same `db.rs::migrate()` region. Merge #531 first; this branch then resolves via `git merge origin/main` (merge commit, no force-push). The server applies all migrations unconditionally and idempotently on each open, so merge order carries no data-safety risk; the only interaction is a textual conflict in `migrate()`. This branch's server migration is deliberately numbered `server_005.sql` (004 reserved for #531); resolving the conflict means keeping both `execute_batch` calls in order (`server_004` then `server_005`).

## Test plan

Ran in the worktree with `SPELUNK_SECRET_STORE=file`:

- `cargo fmt --check` clean.
- `cargo clippy --all-targets` 0 warnings.
- `cargo test --workspace` 96 passed, 0 failed (5 pre-existing ignored native-model tests).

New tests exercised:

- **^107:** fresh DB stamps version 14; reopen is an idempotent no-op; a fully-migrated legacy DB (`user_version` reset to 0) is inferred and stamped to 14; a partially-migrated DB stripped to a v7 shape is inferred at 7 then completed; a genuine non-`duplicate column name` failure (`no such table`) propagates out of `Database::open`.
- **^108:** local model round-trip, hard-error on mismatch, and backfill-when-absent; server `upsert_project` model mismatch is the typed `ModelMismatch`; server NULL-model lazy-stamp.

## Backward compatibility

- Existing field `index.db` files (all migrations applied, `user_version = 0`) are inferred at the latest version, stamped to 14, and re-run zero erroring migration bodies; a second open is a clean no-op.
- Existing server DBs with a NULL `embedding_model` and existing local DBs with no recorded model are stamped to the current constant on first touch and match thereafter.
- No change to the vector storage format, the 896 dimension, the int8 rebuild, or the memory.db 896 upgrade.

Closes spelunk-oss^107 and spelunk-oss^108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
