### PR TITLE
docs(config): drop nonexistent "plan" from server_url Tier 1 doc

### DIFF
--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -268,7 +268,7 @@ pub struct Config {
     // ── spelunk-server (optional) ─────────────────────────────────────────────
     /// URL of the spelunk-server instance, e.g. `http://spelunk.internal:7777`.
     /// When set, the CLI operates in Tier 1 (server-connected) mode, enabling
-    /// semantic search, embedding, explore, and plan features.
+    /// semantic search, embedding, and explore.
     /// Set in `.spelunk/config.toml` (project-level) or via `SPELUNK_SERVER_URL`.
     /// The old `memory_server_url` TOML key is accepted as a backward-compat alias.
     #[serde(default, alias = "memory_server_url")]


### PR DESCRIPTION
Follow-up to #532 / `spelunk-oss^109`. The `server_url` field doc comment in `crates/spelunk-core/src/config.rs` still advertised a "plan" capability in its Tier 1 list, but there is no `plan` / `plan create` variant in the CLI `Command` enum, so that entry was purely stale. This drops it, leaving the three real Tier 1 capabilities: `enabling semantic search, embedding, and explore.` Doc-comment only, one line, no behaviour change. (The separate `plans_dir` config field is out of scope here – its removal is owned by the still-open #532.)

## Test plan
- `git diff origin/main --stat` and `git diff origin/main -- crates/spelunk-core/src/config.rs`: confirmed the diff is exactly the one doc-comment line and nothing else.
- Grepped the CLI `Command` enum (`crates/spelunk-cli/src/cli/mod.rs`): no `plan` / `plan create` variant; `Search`, `Index` (embedding), and `Explore` are all present, so the three retained capabilities are real.
- `grep -rn "plan features" crates/`: zero matches after the change.
- `git merge-base --is-ancestor origin/main HEAD`: `origin/main` is an ancestor of branch HEAD (no staleness).
- `cargo fmt --check` clean; `cargo check -p spelunk-core` finished successfully (`SPELUNK_SECRET_STORE=file`).
- A `///` doc-comment change cannot alter codegen or feature-gating, so it is inert across the CI feature matrix (`--no-default-features`, multi-OS); a full matrix run is disproportionate for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)