### PR TITLE
Wire dead_code allows into real call sites (or drop them)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5193,6 +5193,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
+ "thiserror 2.0.18",
  "tokenizers 0.23.1",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_json  = "1"
 tokio       = { version = "1", features = ["full"] }
 tracing     = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+thiserror   = "2"
 rusqlite    = { version = "0.40", features = ["bundled"] }
 sqlite-vec  = "0.1"
 reqwest     = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }

--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -169,7 +169,7 @@ impl Capabilities {
     }
 
     /// Full set for a fully-featured server.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn all() -> Self {
         Self {
             search_semantic: true,
@@ -197,7 +197,6 @@ pub enum Tier {
         /// `false` when it was set explicitly via config / env var.
         /// Used to annotate UX output (e.g. `(local, auto)` in `spelunk status`).
         /// Consumed by `is_auto_discovered()` and sub-issue #324 UX wiring.
-        #[allow(dead_code)]
         auto_discovered: bool,
         /// Server-side embedder readiness, mirrored from the `/v1/health`
         /// `embedder.state` field (spelunk-oss^50). `Unknown` when the field is
@@ -222,7 +221,7 @@ impl Tier {
 
     // Used by check.rs / status.rs via pattern matching on the enum variant;
     // also consumed by sub-issues #323/#324 UX wiring.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn server_url(&self) -> Option<&str> {
         match self {
             Tier::Server { url, .. } => Some(url),
@@ -230,7 +229,6 @@ impl Tier {
         }
     }
 
-    #[allow(dead_code)]
     pub fn caps(&self) -> Option<&Capabilities> {
         match self {
             Tier::Server { caps, .. } => Some(caps),
@@ -265,7 +263,7 @@ impl Tier {
     /// Returns `true` when the server URL was discovered automatically via
     /// the loopback probe rather than set explicitly in config or environment.
     /// Used by `spelunk status` (sub-issue #324) to annotate the URL with `(local, auto)`.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn is_auto_discovered(&self) -> bool {
         matches!(
             self,

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -64,8 +64,14 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
     // ast-grep — mirroring the `graph --live` pattern.
     if auto_mode {
         let db_result = resolve_project_and_deps(args.db.as_ref(), &cfg);
-        if db_result.is_err() {
-            // No index found — fall back to ast-grep silently.
+        let is_empty = db_result
+            .as_ref()
+            .ok()
+            .and_then(|(db_path, _)| Database::open(db_path).and_then(|db| db.stats()).ok())
+            .is_some_and(|s| s.chunk_count == 0);
+        if db_result.is_err() || is_empty {
+            // No index found (or the index has zero chunks) — fall back to
+            // ast-grep silently, mirroring the missing-index case.
             return search_live(
                 &args.query,
                 &args.format,
@@ -79,6 +85,18 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
 
     let (db_path, dep_projects) = resolve_project_and_deps(args.db.as_ref(), &cfg)?;
     crate::storage::record_usage_at(&db_path, "search");
+
+    // Explicit (non-auto, non-ast-grep) modes surface an empty index as an
+    // actionable error instead of a silent "No results found." — the ast-grep
+    // mode never touches the index, and auto mode already degraded above.
+    if !auto_mode
+        && mode != "ast-grep"
+        && Database::open(&db_path)
+            .and_then(|db| db.stats())
+            .is_ok_and(|s| s.chunk_count == 0)
+    {
+        return Err(crate::error::SearchError::EmptyIndex.into());
+    }
 
     // Honor the capability tier: when the server was auto-discovered via the
     // loopback probe, `cfg.server_url` is unset; fill it in from the tier so

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -179,8 +179,8 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
         if args.list {
             // Brief table: one line per project
             println!(
-                "{:<6}  {:<8}  {:<10}  Root",
-                "Files", "Chunks", "Embeddings"
+                "{:<6}  {:<8}  {:<10}  {:<10}  Root",
+                "Files", "Chunks", "Embeddings", "Registered"
             );
             println!("{}", "─".repeat(70));
             for p in &projects {
@@ -194,10 +194,11 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
                     " [missing]"
                 };
                 println!(
-                    "{:<6}  {:<8}  {:<10}  {}{}",
+                    "{:<6}  {:<8}  {:<10}  {:<10}  {}{}",
                     files,
                     chunks,
                     embeddings,
+                    format_age(p.registered_at),
                     p.root_path.display(),
                     exists
                 );
@@ -210,6 +211,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
                     println!("  \x1b[31m[root path missing from disk]\x1b[0m");
                 }
                 println!("  DB: {}", p.db_path.display());
+                println!("  Registered: {}", format_age(p.registered_at));
                 match Database::open(&p.db_path).and_then(|db| db.stats()) {
                     Ok(s) => {
                         println!(

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -27,7 +27,7 @@ tracing-subscriber = { workspace = true }
 rusqlite = { workspace = true }
 sqlite-vec = { workspace = true }
 reqwest = { workspace = true }
-thiserror = "2"
+thiserror = { workspace = true }
 percent-encoding = "2.3"
 keyring = { workspace = true }
 

--- a/crates/spelunk-core/src/embeddings/mod.rs
+++ b/crates/spelunk-core/src/embeddings/mod.rs
@@ -41,7 +41,6 @@ pub fn vec_to_int8_blob(v: &[f32]) -> Vec<u8> {
 pub const INT8_SCALE: f32 = 127.0;
 
 /// Deserialise raw little-endian bytes back to a float vector.
-#[allow(dead_code)]
 pub fn blob_to_vec(b: &[u8]) -> Vec<f32> {
     b.chunks_exact(4)
         .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))

--- a/crates/spelunk-core/src/error.rs
+++ b/crates/spelunk-core/src/error.rs
@@ -1,7 +1,6 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-#[allow(dead_code)]
 pub enum IndexError {
     #[error("unsupported language: {0}")]
     UnsupportedLanguage(String),
@@ -14,20 +13,6 @@ pub enum IndexError {
 }
 
 #[derive(Error, Debug)]
-#[allow(dead_code)]
-pub enum EmbeddingError {
-    #[error("model not loaded")]
-    ModelNotLoaded,
-
-    #[error("tokenization failed: {0}")]
-    Tokenization(String),
-
-    #[error("inference failed: {0}")]
-    Inference(String),
-}
-
-#[derive(Error, Debug)]
-#[allow(dead_code)]
 pub enum SearchError {
     #[error("index is empty — run `spelunk index <path>` first")]
     EmptyIndex,

--- a/crates/spelunk-core/src/indexer/chunker.rs
+++ b/crates/spelunk-core/src/indexer/chunker.rs
@@ -36,9 +36,7 @@ impl std::fmt::Display for ChunkKind {
 /// A single unit of source code to be embedded and stored.
 #[derive(Debug, Clone)]
 pub struct Chunk {
-    #[allow(dead_code)]
     pub file_path: String,
-    #[allow(dead_code)]
     pub language: String,
     pub kind: ChunkKind,
     /// Symbol name, if the node has one (e.g. function or struct name).

--- a/crates/spelunk-core/src/indexer/graph/mod.rs
+++ b/crates/spelunk-core/src/indexer/graph/mod.rs
@@ -43,7 +43,6 @@ impl std::fmt::Display for EdgeKind {
 }
 
 impl EdgeKind {
-    #[allow(dead_code)]
     pub fn parse(s: &str) -> Self {
         match s {
             "calls" => Self::Calls,

--- a/crates/spelunk-core/src/indexer/parser/ts_walker.rs
+++ b/crates/spelunk-core/src/indexer/parser/ts_walker.rs
@@ -1,5 +1,6 @@
 use super::super::chunker::{Chunk, ChunkKind};
-use anyhow::{Result, bail};
+use crate::error::IndexError;
+use anyhow::Result;
 
 pub(super) fn ts_language(name: &str) -> Result<tree_sitter::Language> {
     use ast_grep_language::{LanguageExt, SupportLang};
@@ -31,7 +32,7 @@ pub(super) fn ts_language(name: &str) -> Result<tree_sitter::Language> {
         "swift" => SupportLang::Swift,
         "sql" => return Ok(tree_sitter_sequel::LANGUAGE.into()),
         "proto" => return Ok(tree_sitter_proto::LANGUAGE.into()),
-        other => bail!("unsupported language: {other}"),
+        other => return Err(IndexError::UnsupportedLanguage(other.to_string()).into()),
     };
     Ok(support.get_ts_language())
 }

--- a/crates/spelunk-core/src/registry.rs
+++ b/crates/spelunk-core/src/registry.rs
@@ -21,7 +21,6 @@ pub struct Project {
     pub id: i64,
     pub root_path: PathBuf,
     pub db_path: PathBuf,
-    #[allow(dead_code)]
     pub registered_at: i64,
 }
 

--- a/crates/spelunk-core/src/storage/graph.rs
+++ b/crates/spelunk-core/src/storage/graph.rs
@@ -13,11 +13,15 @@ pub struct GraphEdge {
 }
 
 fn row_to_edge(row: &rusqlite::Row<'_>) -> rusqlite::Result<GraphEdge> {
+    // Round-trip the stored `kind` through `EdgeKind::parse` so a row written
+    // by an older/foreign schema variant with an unrecognised kind string
+    // normalises to a known value instead of propagating an arbitrary string.
+    let kind: String = row.get(3)?;
     Ok(GraphEdge {
         source_file: row.get(0)?,
         source_name: row.get(1)?,
         target_name: row.get(2)?,
-        kind: row.get(3)?,
+        kind: crate::indexer::graph::EdgeKind::parse(&kind).to_string(),
         line: row.get::<_, i64>(4)? as usize,
     })
 }

--- a/crates/spelunk-embed/Cargo.toml
+++ b/crates/spelunk-embed/Cargo.toml
@@ -16,7 +16,7 @@ default = ["embed-native"]
 # download dependency here (no hf-hub) — this crate only loads from local
 # files (`load_from_path`); the Hugging Face Hub acquisition path lives in
 # spelunk-server's `embed_hub` module.
-embed-native = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers"]
+embed-native = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers", "dep:thiserror"]
 # metal: enable Metal GPU acceleration on macOS. Add this when building the macOS binary.
 metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
 
@@ -30,6 +30,7 @@ candle-core = { workspace = true, optional = true }
 candle-nn = { workspace = true, optional = true }
 candle-transformers = { workspace = true, optional = true }
 tokenizers = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
 
 # macOS-only: `hw.memsize` sysctl in `total_system_ram` (Linux reads
 # /proc/meminfo, no FFI). Not in [workspace.dependencies] since spelunk-embed

--- a/crates/spelunk-embed/src/backend.rs
+++ b/crates/spelunk-embed/src/backend.rs
@@ -12,7 +12,6 @@ pub trait EmbeddingBackend: Send + Sync {
     async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>>;
 
     /// Dimensionality of the output vectors.
-    #[allow(dead_code)]
     fn dimension(&self) -> usize;
 
     /// Per-chunk token truncation cap this backend enforces before embedding a

--- a/crates/spelunk-embed/src/embedder_native.rs
+++ b/crates/spelunk-embed/src/embedder_native.rs
@@ -9,6 +9,8 @@ use candle_transformers::models::qwen3::Config as Qwen3Config;
 use candle_transformers::utils::repeat_kv;
 use tokenizers::Tokenizer;
 
+use crate::error::EmbedError;
+
 /// Embedding dimension produced by F2LLM-v2-330M (hidden_size = 896).
 pub const DIM: usize = 896;
 
@@ -652,7 +654,7 @@ impl crate::EmbeddingBackend for NativeEmbedder {
                 let encoding = guard
                     .tokenizer
                     .encode(text.as_str(), true) // add_special_tokens=true → appends EOS
-                    .map_err(|e| anyhow::anyhow!("tokenization failed: {e}"))?;
+                    .map_err(|e| EmbedError::Tokenization(e.to_string()))?;
                 let full_len = encoding.get_ids().len();
                 let ids: Vec<u32> = encoding
                     .get_ids()
@@ -680,7 +682,10 @@ impl crate::EmbeddingBackend for NativeEmbedder {
             for sub_batch in indexed.chunks(EMBED_BATCH_SIZE) {
                 let batch_ids: Vec<&[u32]> =
                     sub_batch.iter().map(|(_, ids)| ids.as_slice()).collect();
-                let vecs = guard.weights.embed_batch(&batch_ids)?;
+                let vecs = guard
+                    .weights
+                    .embed_batch(&batch_ids)
+                    .map_err(|e| EmbedError::Inference(e.to_string()))?;
                 for ((orig_idx, _), vec) in sub_batch.iter().zip(vecs) {
                     results[*orig_idx] = vec;
                 }

--- a/crates/spelunk-embed/src/error.rs
+++ b/crates/spelunk-embed/src/error.rs
@@ -1,0 +1,14 @@
+use thiserror::Error;
+
+/// Errors raised by the native candle embedding engine
+/// ([`crate::embedder_native`]). Kept distinct from a bare `anyhow::Error` so
+/// a caller (e.g. `spelunk-server`'s HTTP handlers) can match on the failure
+/// kind instead of string-matching a message.
+#[derive(Error, Debug)]
+pub enum EmbedError {
+    #[error("tokenization failed: {0}")]
+    Tokenization(String),
+
+    #[error("inference failed: {0}")]
+    Inference(String),
+}

--- a/crates/spelunk-embed/src/lib.rs
+++ b/crates/spelunk-embed/src/lib.rs
@@ -29,3 +29,9 @@ mod embedder_native;
 
 #[cfg(feature = "embed-native")]
 pub use embedder_native::{DIM, NativeEmbedder};
+
+#[cfg(feature = "embed-native")]
+mod error;
+
+#[cfg(feature = "embed-native")]
+pub use error::EmbedError;


### PR DESCRIPTION
## Summary
Audited every `#[allow(dead_code)]` across the workspace. Each was either removed, converted to `#[cfg(test)]` (genuinely test-only API surface), or wired into a real call site:

- **`IndexError::UnsupportedLanguage`** now returned from `ts_walker`'s language dispatch instead of a plain `anyhow::bail!`.
- **`EmbeddingError` → `EmbedError`**, moved from `spelunk-core` into `spelunk-embed` (`Tokenization`/`Inference` only — `ModelNotLoaded` dropped since `spelunk-embed` has no "unloaded" state, and `spelunk-server`'s `AppError::EmbedderWarmingUp` already covers that case more precisely). `spelunk-embed` intentionally doesn't depend on `spelunk-core`, so the error type has to live where the failures actually occur.
- **`SearchError::EmptyIndex`** wired into `spelunk search`: auto mode now falls back to ast-grep (like a missing index) when the index has zero chunks; explicit `text`/`semantic`/`hybrid` modes return `EmptyIndex` instead of silently printing "No results found."
- **`Registry::Project.registered_at`** surfaced in `spelunk status --all` and `--list`.
- **`EdgeKind::parse`** now normalises `graph_edges.kind` read back from SQL.
- **`capability.rs`** test-only accessors (`Capabilities::all`, `Tier::server_url`, `Tier::is_auto_discovered`) switched from `#[allow(dead_code)]` to `#[cfg(test)]`.
- `thiserror` promoted to `[workspace.dependencies]` now that two crates depend on it.

Left `Registry::projects_depending_on()` untouched (still unused, no clean call site yet).

## Test plan
- [x] `cargo build --workspace --all-targets` — clean, no warnings
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo test --workspace` — all tests pass, including existing `test_search_*` e2e tests exercising the fallback paths touched here

🤖 Generated with [Claude Code](https://claude.com/claude-code)