### PR TITLE
fix(cli): stop surfacing the phantom `plan` capability

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -134,6 +134,10 @@ pub struct Capabilities {
     pub memory_search: bool,
     pub memory_harvest: bool,
     pub explore: bool,
+    /// Reserved (ADR-002 `/plan`): parsed from server caps but hidden from all
+    /// user-facing output until a `spelunk plan` command ships.
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
     pub plan: bool,
 }
 

--- a/crates/spelunk-cli/src/cli/cmd/check.rs
+++ b/crates/spelunk-cli/src/cli/cmd/check.rs
@@ -137,7 +137,6 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                     let features: Vec<&str> = [
                         caps.search_semantic.then_some("semantic search"),
                         caps.explore.then_some("explore"),
-                        caps.plan.then_some("plan"),
                     ]
                     .into_iter()
                     .flatten()

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -343,7 +343,6 @@ fn print_tier_section(tier: &Tier, cfg: &Config) {
             println!("  search          ast-grep + text{server_hint}");
             println!("  memory          git-notes (local)");
             println!("  explore         unavailable  [set server_url to enable]");
-            println!("  plan            unavailable  [set server_url to enable]");
         }
         Tier::Server {
             url,
@@ -381,12 +380,6 @@ fn print_tier_section(tier: &Tier, cfg: &Config) {
                 "unavailable"
             };
             println!("  explore         {explore_label}");
-            let plan_label = if caps.plan {
-                "available"
-            } else {
-                "unavailable"
-            };
-            println!("  plan            {plan_label}");
         }
     }
     println!();

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -536,7 +536,10 @@ async fn test_status_json_includes_tier_fields() {
     assert!(body["capabilities"].is_object());
     assert!(body["capabilities"]["search_semantic"].as_bool().unwrap());
     assert!(body["capabilities"]["index_embed"].as_bool().unwrap());
-    assert!(body["capabilities"]["plan"].as_bool().unwrap());
+    // `plan` is a reserved protocol field (ADR-002) with no `spelunk plan`
+    // command yet: even though this mock server advertises "plan", it must
+    // never surface in user-facing status JSON.
+    assert!(body["capabilities"]["plan"].is_null());
     assert!(!body["capabilities"]["explore"].as_bool().unwrap());
 }
 


### PR DESCRIPTION
## What

The `plan` capability is wired through the CLI capability layer, but there is
no `spelunk plan` command and the server never advertises a `plan` capability,
so it surfaced to users as an always-"unavailable" phantom feature in
`spelunk status` and `spelunk check`.

This suppresses `plan` from every user-facing surface while keeping the
protocol plumbing intact.

## Decision: suppress, do not remove

ADR-002 (Accepted) reserves `/plan` as a server-owned SSE route for a future
command, so `Capabilities.plan` and its `from_server_caps` parsing are a
legitimate protocol reservation, not dead code. Removing them would contradict
an accepted architecture decision. So:

- Removed from user-facing output:
  - `status` text tier section (offline and server branches)
  - `status --format json` capabilities object (via `#[serde(skip_serializing)]`)
  - `check` server feature list
- Kept as reserved protocol:
  - `Capabilities.plan` field and its `from_server_caps` / `legacy_memory_only`
    / `all` parsing, marked `#[serde(skip_serializing)]` and
    `#[allow(dead_code)]`

This closes the code side of the code/docs gap opened by the
`capability-tiers.md` rewrite (spelunk-oss^12). No docs are touched here.

## Test plan

- `cargo fmt --all -- --check` clean.
- `cargo clippy --all-targets --features rich-formats -- -D warnings` clean
  (confirms the reserved field does not trip the never-read lint).
- `SPELUNK_SECRET_STORE=file cargo nextest run -p spelunk-cli`: 382 passed,
  0 failed.
- `SPELUNK_SECRET_STORE=file cargo nextest run --no-default-features`: 796
  passed, 0 failed (the macOS CI matrix cell, `embed-native` off).
- Updated `test_status_json_includes_tier_fields` so it now asserts `plan` is
  absent from status JSON even when the mock server advertises it, locking in
  that the reserved field stays hidden.

No server routes or utoipa annotations changed, so `docs/openapi.json` is
unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
