### PR TITLE
fix(server): self-contained --health-check probe for docker-compose healthcheck (spelunk-oss^99)

### DIFF
--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -92,6 +92,13 @@ struct Args {
     /// Print the OpenAPI spec as JSON and exit (for Postman / Newman import).
     #[arg(long)]
     print_openapi: bool,
+
+    /// Probe this server's own `/v1/health` on the configured `--host`/`--port`,
+    /// then exit 0 if live or non-zero otherwise. Self-contained container
+    /// HEALTHCHECK that needs no curl/wget in the runtime image. A wildcard
+    /// `--host` is probed over loopback.
+    #[arg(long)]
+    health_check: bool,
 }
 
 #[tokio::main]
@@ -114,6 +121,10 @@ async fn main() -> Result<()> {
     if args.print_openapi {
         println!("{}", ApiDoc::openapi().to_pretty_json()?);
         return Ok(());
+    }
+
+    if args.health_check {
+        return run_health_check(&args.host, args.port).await;
     }
 
     // Resolve the API key from --key / --key-file / SPELUNK_SERVER_KEY /
@@ -452,6 +463,51 @@ fn warn_single_trust_domain(host: &str, key_is_set: bool) {
              teams or projects. See docs/adr/056-oss-server-tenancy-model.md."
         );
     }
+}
+
+// ── Self-contained health probe ───────────────────────────────────────────────
+
+/// Host to aim the health probe at. A wildcard bind (`0.0.0.0` / `::` / empty)
+/// is not itself connectable, so probe over loopback; any other host is probed
+/// as-is.
+fn health_probe_host(host: &str) -> &str {
+    match host.trim() {
+        "0.0.0.0" | "" => "127.0.0.1",
+        "::" => "::1",
+        h => h,
+    }
+}
+
+/// Build the `/v1/health` URL for the probe, bracketing IPv6 literals.
+fn health_probe_url(host: &str, port: u16) -> String {
+    let h = health_probe_host(host);
+    if h.contains(':') {
+        format!("http://[{h}]:{port}/v1/health")
+    } else {
+        format!("http://{h}:{port}/v1/health")
+    }
+}
+
+/// Probe `/v1/health` and return `Ok` iff the server answers `2xx`. Backs the
+/// container HEALTHCHECK so the runtime image needs no curl/wget; a non-`Ok`
+/// return propagates to a non-zero process exit.
+async fn run_health_check(host: &str, port: u16) -> Result<()> {
+    let url = health_probe_url(host, port);
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(4))
+        .build()
+        .context("building health-check HTTP client")?;
+    let status = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("health probe request to {url} failed"))?
+        .status();
+    anyhow::ensure!(
+        status.is_success(),
+        "health probe to {url} returned HTTP {status}"
+    );
+    Ok(())
 }
 
 // ── Effective UID helper ──────────────────────────────────────────────────────
@@ -935,5 +991,73 @@ mod arg_tests {
             args.key_file.as_deref(),
             Some(std::path::Path::new("/etc/spelunk/server-key"))
         );
+    }
+
+    // ── Self-contained health probe ──────────────────────────────────────────
+
+    /// Wildcard binds are probed over loopback (a wildcard is not itself
+    /// connectable); a concrete host is probed as-is. IPv6 literals are
+    /// bracketed in the URL.
+    #[test]
+    fn health_probe_url_maps_wildcard_and_brackets_ipv6() {
+        assert_eq!(
+            super::health_probe_url("127.0.0.1", 7777),
+            "http://127.0.0.1:7777/v1/health"
+        );
+        assert_eq!(
+            super::health_probe_url("0.0.0.0", 7777),
+            "http://127.0.0.1:7777/v1/health"
+        );
+        assert_eq!(
+            super::health_probe_url("", 7777),
+            "http://127.0.0.1:7777/v1/health"
+        );
+        assert_eq!(
+            super::health_probe_url("::", 9000),
+            "http://[::1]:9000/v1/health"
+        );
+        assert_eq!(
+            super::health_probe_url("::1", 9000),
+            "http://[::1]:9000/v1/health"
+        );
+        assert_eq!(
+            super::health_probe_url("example.com", 8080),
+            "http://example.com:8080/v1/health"
+        );
+    }
+
+    /// The probe returns `Ok` when `/v1/health` answers `2xx`.
+    #[tokio::test]
+    async fn health_probe_ok_on_2xx() {
+        use axum::{Router, routing::get};
+        let app = Router::new().route("/v1/health", get(|| async { "ok" }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        assert!(super::run_health_check("127.0.0.1", port).await.is_ok());
+    }
+
+    /// A non-`2xx` response is a failed probe (non-zero exit).
+    #[tokio::test]
+    async fn health_probe_err_on_5xx() {
+        use axum::{Router, http::StatusCode, routing::get};
+        let app = Router::new().route(
+            "/v1/health",
+            get(|| async { StatusCode::SERVICE_UNAVAILABLE }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        assert!(super::run_health_check("127.0.0.1", port).await.is_err());
+    }
+
+    /// No listener → the probe fails (connection refused), not hangs.
+    #[tokio::test]
+    async fn health_probe_err_when_unreachable() {
+        // Bind then drop to claim a definitely-free port.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        assert!(super::run_health_check("127.0.0.1", port).await.is_err());
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,9 @@ services:
     environment:
       SPELUNK_SERVER_KEY: ${SPELUNK_SERVER_KEY:-}
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:7777/v1/health"]
+      # Self-probe: the runtime image ships no curl/wget, so the binary hits its
+      # own /v1/health and exits 0/non-0. Pass --port here too if you change it.
+      test: ["CMD", "/usr/local/bin/spelunk-server", "--health-check"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## What

The `docker-compose.yml` HEALTHCHECK ran `wget -qO- http://127.0.0.1:7777/v1/health`, but the runtime image (`debian:trixie-slim` base) ships neither `wget` nor `curl`, so the healthcheck always reported unhealthy. Pre-existing on `main` (predates #516), spotted by QA during #516, filed as fast-follow (spelunk-oss^99).

Implements option (b) from the task: a self-contained probe with no extra image deps.

- `crates/spelunk-server/src/main.rs`: new `--health-check` flag. The binary hits its own `/v1/health` on the configured `--host`/`--port` via `reqwest` (4s timeout), exits `0` on `2xx` and non-zero otherwise. A wildcard bind (`0.0.0.0`/`::`/empty) is probed over loopback; IPv6 literals are bracketed in the URL.
- `docker-compose.yml`: HEALTHCHECK is now `["CMD", "/usr/local/bin/spelunk-server", "--health-check"]` (the binary path the image installs). No runtime image change needed.

Defaults line up: the container runs the server with `--host 127.0.0.1` (Dockerfile CMD) on the default port `7777`, and the healthcheck invokes `--health-check` with the same defaults, so the probe targets exactly the address the server binds.

Docs (`docs/server.md` / `docs/self-hosting.md`) are intentionally untouched — owned by the parallel ADR-058 docs restructure (spelunk-oss^101).

## Test plan

Verified in the task worktree with `SPELUNK_SECRET_STORE=file`:

- `cargo test -p spelunk-server` → 16 unit + 12 integration tests pass, including new coverage: `health_probe_url_maps_wildcard_and_brackets_ipv6` (wildcard→loopback + IPv6 bracketing) and three `#[tokio::test]`s driving `run_health_check` against a live axum `/v1/health` — `2xx`→Ok, `5xx`→Err, unreachable→Err.
- `cargo build --no-default-features` (CI no-default-features cell) → clean.
- `cargo clippy --all-targets -- -D warnings` (whole workspace) → clean, exit 0.
- Branch staleness: `git merge-base --is-ancestor origin/main HEAD` confirms the branch is on top of current `origin/main` (single commit, no conflicting drift).
- Reviewed the exit-code contract in source: `main() -> Result<()>` maps `Err` to a non-zero process exit; `run_health_check` returns `Ok` only on `status.is_success()`.
- Confirmed `/usr/local/bin/spelunk-server` is the install path (`Dockerfile` `COPY --from=builder … /usr/local/bin/spelunk-server`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)