### PR TITLE
feat(server): ADR-058 bare-metal team server — --key-file/systemd-credential + units + docs (closes spelunk-oss^70)

### DIFF
--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -40,9 +40,21 @@ struct Args {
     #[arg(long, default_value = "spelunk.db")]
     db: PathBuf,
 
-    /// Shared API key (Bearer token). Leave unset to disable auth (dev only).
-    #[arg(long, env = "SPELUNK_SERVER_KEY")]
+    /// Shared API key (Bearer token) passed inline. Visible in the process
+    /// table and `systemctl show`, so prefer --key-file or SPELUNK_SERVER_KEY
+    /// for real deployments. Leave all key sources unset to disable auth
+    /// (loopback dev only). Overrides every other key source.
+    #[arg(long)]
     key: Option<String>,
+
+    /// Read the shared API key from a file (its whole trimmed contents). A
+    /// first-class alternative to SPELUNK_SERVER_KEY, not a fallback: point it
+    /// at a `0600` file, or at `$CREDENTIALS_DIRECTORY/server-key` when run
+    /// under systemd `LoadCredential=`. When run under systemd, a
+    /// `server-key` credential is picked up automatically even without this
+    /// flag. Read failure is fatal.
+    #[arg(long, value_name = "PATH")]
+    key_file: Option<PathBuf>,
 
     /// Embedding dimension expected from clients (must match the team's model).
     /// Default: 896 (F2LLM-v2-330M).
@@ -104,11 +116,19 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Normalise the API key: treat a blank/whitespace value as "no key". This
-    // matters because clap reads a *set-but-empty* env var as `Some("")` — e.g.
-    // docker-compose's `SPELUNK_SERVER_KEY=${SPELUNK_SERVER_KEY:-}` default —
-    // which must count as unauthenticated, not as a (broken, empty-token) key.
-    let api_key = normalize_api_key(args.key.as_deref());
+    // Resolve the API key from --key / --key-file / SPELUNK_SERVER_KEY /
+    // systemd LoadCredential (see resolve_api_key for precedence). A blank
+    // value from any source counts as "no key" — a set-but-empty
+    // `SPELUNK_SERVER_KEY` (docker-compose's `${SPELUNK_SERVER_KEY:-}` default)
+    // must read as unauthenticated, not as a broken empty-token key.
+    let env_key = std::env::var("SPELUNK_SERVER_KEY").ok();
+    let credentials_dir = std::env::var_os("CREDENTIALS_DIRECTORY").map(PathBuf::from);
+    let api_key = resolve_api_key(
+        args.key.as_deref(),
+        args.key_file.as_deref(),
+        env_key.as_deref(),
+        credentials_dir.as_deref(),
+    )?;
 
     // Bind-safety: refuse to expose the server off-host over plaintext HTTP,
     // whether that would leak an open (keyless) endpoint or the bearer key in
@@ -129,7 +149,7 @@ async fn main() -> Result<()> {
     if api_key.is_none() {
         tracing::warn!(
             "No API key configured — server is running without authentication. \
-             Set --key or SPELUNK_SERVER_KEY for production use."
+             Set --key-file, SPELUNK_SERVER_KEY, or --key for production use."
         );
     }
 
@@ -305,14 +325,69 @@ fn host_is_loopback(host: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Normalise a configured API key: a blank/whitespace value (including the
-/// `Some("")` that clap yields for a set-but-empty `SPELUNK_SERVER_KEY`) becomes
+/// Normalise a configured API key: a blank/whitespace value (e.g. a
+/// set-but-empty `SPELUNK_SERVER_KEY`, or an empty credential file) becomes
 /// `None`, so "empty key" is treated as "no key" everywhere — both by the
 /// bind-safety guard and by the auth provider.
 fn normalize_api_key(key: Option<&str>) -> Option<String> {
     key.map(str::trim)
         .filter(|k| !k.is_empty())
         .map(str::to_owned)
+}
+
+/// Filename systemd exposes for `LoadCredential=server-key:...` under
+/// `$CREDENTIALS_DIRECTORY`.
+const SERVER_KEY_CREDENTIAL: &str = "server-key";
+
+/// Resolve the shared API key from all supported sources, in precedence order
+/// (a blank value at any level is ignored and falls through to the next):
+///
+/// 1. `--key <value>` — inline flag (most explicit).
+/// 2. `--key-file <path>` — explicit file; a read failure is fatal.
+/// 3. `SPELUNK_SERVER_KEY` — environment variable.
+/// 4. `$CREDENTIALS_DIRECTORY/server-key` — systemd `LoadCredential=`, used
+///    automatically when the credential is present.
+///
+/// The credential file (3/4) and the env var are equal first-class sources, not
+/// fallbacks: a systemd deployment sets only the credential and gets it; an
+/// operator outside systemd sets only the env var and gets it.
+fn resolve_api_key(
+    key: Option<&str>,
+    key_file: Option<&std::path::Path>,
+    env_key: Option<&str>,
+    credentials_dir: Option<&std::path::Path>,
+) -> Result<Option<String>> {
+    if let Some(k) = normalize_api_key(key) {
+        return Ok(Some(k));
+    }
+    if let Some(path) = key_file {
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("reading --key-file {}", path.display()))?;
+        if let Some(k) = normalize_api_key(Some(&raw)) {
+            return Ok(Some(k));
+        }
+    }
+    if let Some(k) = normalize_api_key(env_key) {
+        return Ok(Some(k));
+    }
+    if let Some(dir) = credentials_dir {
+        let path = dir.join(SERVER_KEY_CREDENTIAL);
+        match std::fs::read_to_string(&path) {
+            Ok(raw) => {
+                if let Some(k) = normalize_api_key(Some(&raw)) {
+                    return Ok(Some(k));
+                }
+            }
+            // A credentials dir without our credential is normal (systemd may
+            // be exporting other credentials); only a real read error is fatal.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(anyhow::Error::new(e)
+                    .context(format!("reading systemd credential {}", path.display())));
+            }
+        }
+    }
+    Ok(None)
 }
 
 /// Refuse to expose the server off-host over plaintext HTTP. Binding to any
@@ -736,5 +811,129 @@ mod arg_tests {
     #[test]
     fn trust_domain_warning_suppressed_without_key() {
         assert!(!super::should_warn_single_trust_domain("0.0.0.0", false));
+    }
+
+    // ── API key resolution (--key / --key-file / env / systemd credential) ──
+
+    use std::io::Write as _;
+
+    /// Write `contents` to a fresh file in `dir` and return its path.
+    fn write_key_file(dir: &tempfile::TempDir, name: &str, contents: &str) -> std::path::PathBuf {
+        let path = dir.path().join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    /// `--key-file` reads the whole file, trimmed — the systemd credential /
+    /// `0600`-file path is a first-class source, not a shim.
+    #[test]
+    fn key_file_is_read_and_trimmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_key_file(&dir, "server-key", "  file-secret\n");
+        let key = super::resolve_api_key(None, Some(&path), None, None).unwrap();
+        assert_eq!(key.as_deref(), Some("file-secret"));
+    }
+
+    /// systemd `LoadCredential=server-key` exposes `$CREDENTIALS_DIRECTORY/server-key`;
+    /// the binary picks it up automatically with no flag.
+    #[test]
+    fn systemd_credential_dir_is_read() {
+        let dir = tempfile::tempdir().unwrap();
+        write_key_file(&dir, "server-key", "cred-secret\n");
+        let key = super::resolve_api_key(None, None, None, Some(dir.path())).unwrap();
+        assert_eq!(key.as_deref(), Some("cred-secret"));
+    }
+
+    /// Precedence: inline `--key` > `--key-file` > `SPELUNK_SERVER_KEY` >
+    /// systemd credential. Each non-blank source wins over the ones below it.
+    #[test]
+    fn key_source_precedence() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = write_key_file(&dir, "kf", "from-file");
+        write_key_file(&dir, "server-key", "from-cred");
+
+        // Inline --key beats everything.
+        assert_eq!(
+            super::resolve_api_key(
+                Some("inline"),
+                Some(&file),
+                Some("from-env"),
+                Some(dir.path())
+            )
+            .unwrap()
+            .as_deref(),
+            Some("inline")
+        );
+        // --key-file beats env + credential.
+        assert_eq!(
+            super::resolve_api_key(None, Some(&file), Some("from-env"), Some(dir.path()))
+                .unwrap()
+                .as_deref(),
+            Some("from-file")
+        );
+        // env beats the systemd credential.
+        assert_eq!(
+            super::resolve_api_key(None, None, Some("from-env"), Some(dir.path()))
+                .unwrap()
+                .as_deref(),
+            Some("from-env")
+        );
+        // credential is the last resort.
+        assert_eq!(
+            super::resolve_api_key(None, None, None, Some(dir.path()))
+                .unwrap()
+                .as_deref(),
+            Some("from-cred")
+        );
+    }
+
+    /// A blank source is ignored and resolution falls through to the next one —
+    /// e.g. a set-but-empty `SPELUNK_SERVER_KEY` must not mask a real credential.
+    #[test]
+    fn blank_source_falls_through() {
+        let dir = tempfile::tempdir().unwrap();
+        write_key_file(&dir, "server-key", "cred-secret");
+        let key = super::resolve_api_key(Some("   "), None, Some(""), Some(dir.path())).unwrap();
+        assert_eq!(key.as_deref(), Some("cred-secret"));
+    }
+
+    /// No source set at all → unauthenticated (loopback dev server).
+    #[test]
+    fn no_key_source_resolves_to_none() {
+        assert_eq!(
+            super::resolve_api_key(None, None, None, None).unwrap(),
+            None
+        );
+    }
+
+    /// A credentials dir without our `server-key` file is not an error — systemd
+    /// may export other credentials.
+    #[test]
+    fn credentials_dir_without_server_key_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            super::resolve_api_key(None, None, None, Some(dir.path())).unwrap(),
+            None
+        );
+    }
+
+    /// An explicit `--key-file` that cannot be read is a fatal error — the
+    /// operator asked for that file, so a missing/unreadable one must not
+    /// silently degrade to no-auth.
+    #[test]
+    fn missing_key_file_is_fatal() {
+        let path = std::path::Path::new("/nonexistent/spelunk/server-key");
+        assert!(super::resolve_api_key(None, Some(path), None, None).is_err());
+    }
+
+    /// `--key-file` parses as a path arg.
+    #[test]
+    fn key_file_flag_parses() {
+        let args = Args::parse_from(["spelunk-server", "--key-file", "/etc/spelunk/server-key"]);
+        assert_eq!(
+            args.key_file.as_deref(),
+            Some(std::path::Path::new("/etc/spelunk/server-key"))
+        );
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@
 # sibling container — only from inside this same network namespace, e.g. a
 # separate container started with `--network container:spelunk-server`
 # (the runtime image itself has no curl/wget to test from a bare
-# `docker compose exec` shell — see docs/server.md#quick-start-docker).
+# `docker compose exec` shell — see docs/server.md#docker-local-scaffold-only).
 #
 # For a team-reachable deployment, run the binary bare-metal under systemd
 # instead, with your own TLS terminator in front of the same loopback bind on

--- a/docs/remote-agents.md
+++ b/docs/remote-agents.md
@@ -16,7 +16,7 @@ The shapes we distinguish:
 | Shape | Where the agent runs | `SPELUNK_SERVER_URL` |
 |---|---|---|
 | Local (R0) | Your workstation | `http://127.0.0.1:7777` (auto) |
-| **Local Docker (R1)** | A container on your machine | `http://host.docker.internal:7777` |
+| **Local Docker (R1)** | A container on your machine | `https://spelunk.your-domain` (portable) — or `http://host.docker.internal:7777` on Docker Desktop only |
 | Cloud-managed (R2) | A cloud workspace (e.g. Background Agents) | `https://api.spelunk.cloud` |
 | Self-hosted remote (R3) | Your own VM / pod | `https://spelunk.your-domain` — see [Self-hosting](self-hosting.md) |
 
@@ -26,18 +26,60 @@ documented separately when it ships. R3 (self-hosted over the network) is
 
 ## R1 — an agent in a local Docker container
 
-The whole story is three things: an env var pointing the container's CLI at the
-host's server, a bind-mount of the repo, and a bind-mount of your spelunk config
-so the container knows which project it's talking to.
+A containerized agent needs three things: an env var pointing its CLI at a
+`spelunk-server`, a bind-mount of the repo, and a bind-mount of your spelunk
+config so it resolves the same project.
 
-The local `spelunk-server` runs on the **host** (it is autostarted for you on
-first use — see [Getting started](getting-started.md)). The container reaches it
-across the Docker network.
+The one detail that trips people up is **which URL** the container uses. A
+`spelunk-server` binds the host's loopback (`127.0.0.1`), and a container's
+network namespace cannot reach the host's loopback by any portable means — so
+the reliable answer is to point the container at the server's **TLS endpoint**,
+the same `https://` URL any other client uses, not at a Docker bridge address.
 
-### macOS / Windows (Docker Desktop)
+### Recommended: point at the operator's TLS endpoint (portable)
 
-Docker Desktop exposes the host on the special DNS name
-`host.docker.internal`:
+Stand up the team server the [Self-hosting](self-hosting.md) way — bare-metal on
+loopback with a same-host TLS terminator — and point the container at its
+`https://` hostname. This works identically on Docker Desktop and native Linux,
+because it's a routable HTTPS URL, not a host-loopback address:
+
+```bash
+docker run --rm -it \
+  -e SPELUNK_SERVER_URL=https://spelunk.example.com \
+  -e SPELUNK_SERVER_KEY=your-shared-api-key \
+  -v "$PWD":/work \
+  -v "$HOME/.config/spelunk":/root/.config/spelunk \
+  -w /work \
+  your-agent-image
+```
+
+- `SPELUNK_SERVER_URL` points the in-container CLI at the operator's TLS
+  terminator, which forwards to the loopback-bound server on the host.
+- `SPELUNK_SERVER_KEY` is the shared API key (required — a networked server is
+  always keyed; see [Self-hosting](self-hosting.md)).
+- `-v "$PWD":/work` bind-mounts the repository so file paths recorded in memory
+  entries mean the same thing inside the container and on the host.
+- `-v "$HOME/.config/spelunk":/root/.config/spelunk` bind-mounts your spelunk
+  config so the container CLI resolves the same project. (Adjust the in-container
+  path if your agent image runs as a non-root user — match its `$HOME`.)
+- `-w /work` runs the agent in the mounted repo.
+
+Inside the container, the CLI behaves exactly as it would on the host:
+
+```bash
+spelunk check                 # should report the server reachable over TLS
+spelunk search "auth tokens"  # semantic search via the server
+```
+
+The **server side** of this — the loopback bind, the systemd unit, and the TLS
+terminator — is the bare-metal path in [Self-hosting](self-hosting.md).
+
+### Docker Desktop convenience (solo, non-portable)
+
+If you're a solo developer with only the auto-started local loopback server (no
+team server) and you're on **Docker Desktop** (macOS/Windows), Docker Desktop
+special-cases the DNS name `host.docker.internal` to reach the host's loopback,
+so you can skip the TLS endpoint and point straight at the host server:
 
 ```bash
 docker run --rm -it \
@@ -48,70 +90,28 @@ docker run --rm -it \
   your-agent-image
 ```
 
-- `SPELUNK_SERVER_URL` points the in-container CLI at the server running on your
-  host's loopback `:7777`.
-- `-v "$PWD":/work` bind-mounts the repository so file paths recorded in memory
-  entries mean the same thing inside the container and on the host.
-- `-v "$HOME/.config/spelunk":/root/.config/spelunk` bind-mounts your spelunk
-  config so the container CLI resolves the same project. (Adjust the in-container
-  path if your agent image runs as a non-root user — match its `$HOME`.)
-- `-w /work` runs the agent in the mounted repo.
+This is a **Docker Desktop-only** convenience. It does not work on native Linux
+Docker (see below), so don't bake it into anything you also run on Linux.
 
-If your host server requires authentication, also pass the key:
+### Native Linux: no loopback shortcut
 
-```bash
-  -e SPELUNK_SERVER_KEY=your-shared-api-key \
-```
+Plain Linux Docker (not Docker Desktop) has **no** way to reach a
+host-loopback-bound server from a container:
 
-Inside the container, the CLI now behaves exactly as it would on the host:
+- The default bridge gateway (`172.17.0.1`) and
+  `--add-host=host.docker.internal:host-gateway` both resolve to the host's
+  **routable** interface, not its loopback — so a server bound to `127.0.0.1` is
+  not listening where the container can reach it.
+- Binding the server to the bridge address instead is a **non-loopback plaintext
+  bind, which `spelunk-server` refuses unconditionally** — there is no override.
 
-```bash
-spelunk check                 # should report the server is reachable
-spelunk search "auth tokens"  # semantic search via the host server
-```
-
-### Linux (default Docker bridge)
-
-Plain Linux Docker (not Docker Desktop) usually has no `host.docker.internal`.
-The host is reachable on the default bridge gateway, normally `172.17.0.1`:
-
-```bash
-docker run --rm -it \
-  -e SPELUNK_SERVER_URL=http://172.17.0.1:7777 \
-  -v "$PWD":/work \
-  -v "$HOME/.config/spelunk":/root/.config/spelunk \
-  -w /work \
-  your-agent-image
-```
-
-If your daemon uses a custom bridge subnet, find the gateway with:
-
-```bash
-docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}'
-```
-
-<!-- TODO: confirm with Implementer — newer Docker Engine supports
-     `--add-host=host.docker.internal:host-gateway` on Linux, which lets the
-     macOS recipe work unchanged. Confirm the minimum Docker Engine version we
-     want to recommend before promoting that form over the 172.17.0.1 fallback. -->
+So on native Linux there is no bridge shortcut: use the recommended TLS-endpoint
+path above. Terminating TLS on the host (per [Self-hosting](self-hosting.md)) is
+what makes the server reachable from a container, and it does so the same way on
+every platform.
 
 ### Notes
 
-- **Bind the server only to loopback.** The host server listens on
-  `127.0.0.1:7777`; the Docker bridge can reach it without exposing it to your
-  LAN. Do not bind the OSS server to a public interface in plain HTTP — for
-  remote access over a network, terminate TLS in front of it (see
-  [Self-hosting](self-hosting.md)).
-- **If a Linux container needs to reach the bridge gateway (`172.17.0.1`)
-  instead of loopback**, binding the server to that address is a non-loopback
-  plaintext bind, which `spelunk-server` refuses unconditionally — there is no
-  override. On
-  Docker Desktop the `host.docker.internal` recipe reaches a loopback-bound
-  server directly.
 - **Project identity.** Bind-mounting `~/.config/spelunk/` is the simplest way
   to share project identity. Alternatively set `SPELUNK_PROJECT_ID` explicitly
   in the container's environment.
-
-<!-- TODO: confirm with Implementer — confirm whether `spelunk check` already
-     suggests `host.docker.internal` in its unreachable-server error message
-     (scope doc §3.2 calls for this hint). -->

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,5 +1,12 @@
 # Self-hosting spelunk-server (R3)
 
+This is the **recommended way to run a shared team `spelunk-server`**: the binary
+bare-metal on a host under systemd, bound to loopback, with an operator-owned TLS
+terminator on the same host in front of it. It is the one mechanically-correct
+shape for a team-reachable instance — Docker cannot host it (a container's
+loopback is unreachable from the host or sibling containers; see
+[Server setup → Docker: local scaffold only](server.md#docker-local-scaffold-only)).
+
 If you operate your own `spelunk-server` and want remote agents — on a VM, a k8s
 pod, or a teammate's laptop across a VPN — to reach it, you are in the
 **self-hosted remote (R3)** shape. R3 is just [R1](remote-agents.md) over a
@@ -36,7 +43,14 @@ Always start the server with an API key so the exposed endpoint requires auth:
 SPELUNK_SERVER_KEY=$(openssl rand -hex 32) spelunk-server --port 7777 --host 127.0.0.1
 ```
 
-## 2a. Reverse proxy — Caddy (automatic TLS)
+## 2. Terminate TLS with a reverse proxy (operator-owned)
+
+The proxy configs below are **operator-owned reference examples**, not shipped
+configuration — spelunk ships no `Caddyfile` or `nginx.conf`. The TLS terminator
+is yours to own and keep current; pick whichever proxy you already run. Both
+examples terminate TLS and forward to the loopback server on the same host.
+
+### 2a. Caddy (automatic TLS)
 
 Caddy fetches and renews a Let's Encrypt certificate automatically. A whole
 `Caddyfile` for this is two lines:
@@ -54,7 +68,7 @@ caddy run --config /etc/caddy/Caddyfile
 That's it — `https://spelunk.example.com` now terminates TLS and forwards to the
 loopback server.
 
-## 2b. Reverse proxy — nginx
+### 2b. nginx
 
 If you already run nginx, terminate TLS there (certificate via certbot or your
 own CA) and proxy to loopback:
@@ -88,39 +102,118 @@ default nginx buffering would stall it.
 
 ## 3. Run it under systemd
 
-A unit to keep the server running on boot, bound to loopback:
+Spelunk ships a first-party unit for the team server:
+[`packaging/spelunk-server-team.service`](../packaging/spelunk-server-team.service).
+It runs the server as a dedicated unprivileged `spelunk` user, supplies the API
+key as a **systemd credential** rather than an environment line, and applies
+standard sandboxing. (This is the deployed team-server unit — distinct from the
+per-developer local-inference user unit, `packaging/spelunk-server.service`.)
+
+### Provision the key and data dir
+
+The key is supplied through systemd's `LoadCredential=`, which reads a
+`root:root 0600` file and exposes it to the process at
+`$CREDENTIALS_DIRECTORY/server-key` — the binary reads it from there directly.
+This keeps the key out of `systemctl show` / `/proc/<pid>/environ`, where an
+`Environment=SPELUNK_SERVER_KEY=…` line would leak it to any local user.
+
+```bash
+# Dedicated user + data dir
+sudo useradd --system --home-dir /var/lib/spelunk --shell /usr/sbin/nologin spelunk
+sudo install -d -o spelunk -g spelunk -m 0750 /var/lib/spelunk
+
+# The key, as a root-only 0600 file
+sudo install -d -m 0755 /etc/spelunk
+openssl rand -hex 32 | sudo tee /etc/spelunk/server-key >/dev/null
+sudo chmod 0600 /etc/spelunk/server-key
+
+# Install and start the unit
+sudo install -m 0644 packaging/spelunk-server-team.service \
+     /etc/systemd/system/spelunk-server.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now spelunk-server
+sudo systemctl status spelunk-server
+```
+
+The shipped unit:
 
 ```ini
 # /etc/systemd/system/spelunk-server.service
 [Unit]
-Description=spelunk-server
+Description=spelunk-server (team memory)
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
 User=spelunk
-Environment=SPELUNK_SERVER_KEY=your-shared-api-key
-ExecStart=/usr/local/bin/spelunk-server --port 7777 --host 127.0.0.1 --db /var/lib/spelunk/spelunk.db
+Group=spelunk
+
+# Key as a systemd credential, exposed at $CREDENTIALS_DIRECTORY/server-key
+# and read there by the binary — not a world-readable Environment= line.
+LoadCredential=server-key:/etc/spelunk/server-key
+ExecStart=/usr/local/bin/spelunk-server \
+  --host 127.0.0.1 --port 7777 \
+  --db /var/lib/spelunk/spelunk.db
 Restart=on-failure
 RestartSec=5
 
-# Hardening — the server only needs its data dir and loopback.
+# Hardening — the server needs only its data dir and loopback.
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
 ReadWritePaths=/var/lib/spelunk
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=multi-user.target
 ```
 
+> `MemoryDenyWriteExecute=true` is a further hardening step, but the native
+> embedder mmaps model weights and some backends (CUDA/BLAS) may need
+> writable-executable pages — validate it against your embedder backend before
+> enabling. The shipped unit leaves it commented.
+
+**Key sources.** The credential file is preferred under systemd, but it is not
+the only supported source — `SPELUNK_SERVER_KEY` remains a fully-supported
+equal alternative (e.g. an `EnvironmentFile=` pointing at a `0600` root-owned
+file, or set by tooling that runs the binary outside systemd). Resolution
+precedence is `--key` → `--key-file` → `SPELUNK_SERVER_KEY` →
+`$CREDENTIALS_DIRECTORY/server-key`. To rotate the key, replace
+`/etc/spelunk/server-key`, `sudo systemctl restart spelunk-server`, and
+redistribute it to clients.
+
+### Alternative: `DynamicUser=`
+
+If you'd rather not manage a static user and data dir, use the
+[`DynamicUser=` variant](../packaging/spelunk-server-team-dynamicuser.service):
+systemd allocates a per-boot UID and creates `/var/lib/spelunk` via
+`StateDirectory=`, chowned to that UID — no `useradd`, no manual `install -d`.
+Install it in place of the static-user unit (the key/`/etc/spelunk` provisioning
+above still applies):
+
 ```bash
+sudo install -d -m 0755 /etc/spelunk
+openssl rand -hex 32 | sudo tee /etc/spelunk/server-key >/dev/null
+sudo chmod 0600 /etc/spelunk/server-key
+sudo install -m 0644 packaging/spelunk-server-team-dynamicuser.service \
+     /etc/systemd/system/spelunk-server.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now spelunk-server
-sudo systemctl status spelunk-server
 ```
+
+The trade-off: the data dir's owner changes across boots, so any out-of-band
+backup tooling must not assume a fixed UID. Prefer the static-user default when
+you want a stable owner for backup/inspection or a stable `started_by` UID.
 
 ## 4. Point a remote agent at it
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -36,7 +36,7 @@ spelunk server logs      # tail the local server's logs
 ```
 
 To opt out entirely and keep spelunk fully offline, set `SPELUNK_NO_SERVER=1`
-(see [Server mode vs no-server mode](getting-started.md#server-mode-vs-no-server-mode)).
+(see [Capability tiers](getting-started.md#capability-tiers-where-inference-and-memory-live)).
 With it set, spelunk never autostarts a server and inference-only features exit
 with a clear message instead.
 
@@ -62,21 +62,26 @@ The rest of this page covers running `spelunk-server` as a **deployed, shared**
 service so a team can sync memory. This is distinct from the local-auto server
 above: it's long-lived, reachable over the network, and protected by an API key.
 
-**Recommended: bare-metal / systemd.** The server binds `127.0.0.1`
-unconditionally (see [Non-loopback plaintext binds are refused](#non-loopback-plaintext-binds-are-refused-no-override)
-below) and refuses to serve plaintext off-host. Reaching it from another
-machine therefore needs a TLS terminator on the **same host**, in front of
-that loopback bind — which is straightforward with a bare-metal/systemd
-install, and awkward with Docker, since a container's own loopback lives in
-its private network namespace and isn't reachable from the host or sibling
-containers by any of the usual means (bridge port-publish, Docker Desktop
-host-mode, container-to-container DNS all fail to reach it). See
-[Self-hosting](self-hosting.md) for the systemd unit plus Caddy/nginx
-recipes — that's the recommended path for a team-reachable instance. (A
-fuller from-scratch team-deployment guide is tracked as follow-up work; this
-page and Self-hosting are the current source of truth in the meantime.)
+**Recommended: bare-metal + systemd.** Run the binary directly on a host under
+systemd, bound to loopback, with an operator-owned TLS terminator
+(nginx/Caddy/…) in front of that same loopback bind on the same host. This is
+the one mechanically-correct shape for a team-reachable server, because the
+server binds `127.0.0.1` unconditionally (see
+[Non-loopback plaintext binds are refused](#non-loopback-plaintext-binds-are-refused-no-override)
+below) and refuses to serve plaintext off-host — so reaching it from another
+machine needs a same-host terminator in front of that loopback bind. Docker
+cannot host this: a container's own loopback lives in its private network
+namespace and isn't reachable from the host or sibling containers by any of the
+usual means (bridge port-publish, Docker Desktop host-mode, container-to-container
+DNS all fail to reach it).
 
-## Quick start (Docker)
+**[Self-hosting](self-hosting.md) is the full team-server guide** — it walks
+through the loopback bind, the first-party `spelunk-server.service` systemd unit
+(hardened, key supplied as a systemd credential), and the Caddy/nginx reference
+examples. Start there. The rest of this page covers client configuration, the
+trust model, and the CLI/flag reference that path relies on.
+
+## Docker: local scaffold only
 
 `docker-compose.yml` in this repo is a **minimal local scaffold**: it builds
 the image and runs `spelunk-server` with a persistent named volume for the
@@ -269,7 +274,7 @@ that same loopback bind on the same host and actually be reachable off-host.
 See [Self-hosting](self-hosting.md) for the systemd unit and reverse-proxy
 recipes.
 
-`docker-compose.yml` (see [Quick start (Docker)](#quick-start-docker) above)
+`docker-compose.yml` (see [Docker: local scaffold only](#docker-local-scaffold-only) above)
 is a local scaffold for running the server process itself — useful for local
 development or testing — not a substitute for the bare-metal path when the
 server needs to be reachable by a team or over a network.
@@ -305,7 +310,16 @@ cargo build --release --bin spelunk-server
 |---|---|---|---|
 | `--host` | (none) | `127.0.0.1` | Interface to bind. Non-loopback needs a key and TLS in front (see below). |
 | `--port` | (none) | `7777` | Port to bind. |
-| `--key` | `SPELUNK_SERVER_KEY` | unset | Shared bearer API key. Leave unset only for a loopback dev server. |
+| `--key` | (none) | unset | Shared bearer API key, passed inline. Visible in the process table — prefer `--key-file` or `SPELUNK_SERVER_KEY`. Leave every key source unset only for a loopback dev server. |
+| `--key-file` | (none) | unset | Read the key from a file (whole contents, trimmed). First-class alternative to `SPELUNK_SERVER_KEY`, not a fallback. |
+| (none) | `SPELUNK_SERVER_KEY` | unset | Read the key from the environment. Fully supported alongside `--key-file`. |
+
+The key is resolved from, in precedence order: `--key` → `--key-file` →
+`SPELUNK_SERVER_KEY` → a systemd `LoadCredential=server-key` (read automatically
+from `$CREDENTIALS_DIRECTORY/server-key` when present). A blank value from any
+source is ignored and falls through to the next. Under systemd the credential
+path is preferred — it keeps the key out of the world-readable process
+environment; see [Self-hosting](self-hosting.md).
 
 ### Non-loopback plaintext binds are refused, no override
 

--- a/packaging/spelunk-server-team-dynamicuser.service
+++ b/packaging/spelunk-server-team-dynamicuser.service
@@ -1,0 +1,63 @@
+# spelunk-server — TEAM MEMORY server, DynamicUser= variant (alternative)
+#
+# Same deployment as spelunk-server-team.service, but systemd manages the
+# identity and the state dir: a per-boot UID (DynamicUser=) plus a
+# StateDirectory= that systemd creates and chowns to that UID. No `useradd` and
+# no manual `install -d` for the data dir. Choose this when you prefer
+# systemd-managed identity/ownership over a fixed-owner data dir.
+#
+# Trade-off: the data dir owner changes across boots, so out-of-band backup
+# tooling must not assume a fixed UID. If you need a stable owner for backup /
+# inspection or a stable started_by UID, use the static-user default
+# (spelunk-server-team.service) instead.
+#
+# Install:
+#   sudo install -d -m 0755 /etc/spelunk
+#   openssl rand -hex 32 | sudo tee /etc/spelunk/server-key >/dev/null
+#   sudo chmod 0600 /etc/spelunk/server-key   # root:root
+#   sudo install -m 0644 packaging/spelunk-server-team-dynamicuser.service \
+#        /etc/systemd/system/spelunk-server.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now spelunk-server
+
+[Unit]
+Description=spelunk-server (team memory)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+# systemd allocates a transient, unprivileged UID per boot and creates
+# /var/lib/spelunk (StateDirectory=), chowned to that UID, exposed as
+# $STATE_DIRECTORY. No static user or manual data-dir provisioning needed.
+DynamicUser=yes
+StateDirectory=spelunk
+
+# See the static-user unit for why the key is a credential, not Environment=.
+LoadCredential=server-key:/etc/spelunk/server-key
+ExecStart=/usr/local/bin/spelunk-server \
+  --host 127.0.0.1 --port 7777 \
+  --db /var/lib/spelunk/spelunk.db
+
+Restart=on-failure
+RestartSec=5
+
+# Hardening — the server needs only its state dir (StateDirectory=) and loopback.
+# DynamicUser=yes already implies ProtectSystem=strict, ProtectHome=read-only,
+# PrivateTmp, and RemoveIPC; the directives below narrow it further.
+NoNewPrivileges=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+SystemCallArchitectures=native
+# See the static-user unit before enabling MemoryDenyWriteExecute=.
+# MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/spelunk-server-team.service
+++ b/packaging/spelunk-server-team.service
@@ -1,0 +1,74 @@
+# spelunk-server — TEAM MEMORY server, static-user system unit (recommended)
+#
+# This is the first-party unit for a deployed, shared spelunk-server (a team
+# memory store), NOT the local per-developer inference server — for that see the
+# user unit `spelunk-server.service` in this directory. Do not confuse the two.
+#
+# The server binds loopback only and terminates plaintext HTTP; a shared
+# deployment puts an operator-owned TLS terminator (nginx/Caddy/…) on the SAME
+# host in front of this loopback bind. See docs/self-hosting.md.
+#
+# Install:
+#   sudo useradd --system --home-dir /var/lib/spelunk --shell /usr/sbin/nologin spelunk
+#   sudo install -d -o spelunk -g spelunk -m 0750 /var/lib/spelunk
+#   sudo install -d -m 0755 /etc/spelunk
+#   openssl rand -hex 32 | sudo tee /etc/spelunk/server-key >/dev/null
+#   sudo chmod 0600 /etc/spelunk/server-key   # root:root
+#   sudo install -m 0644 packaging/spelunk-server-team.service \
+#        /etc/systemd/system/spelunk-server.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now spelunk-server
+#
+# A DynamicUser= variant (no manual user/dir setup) is in
+# spelunk-server-team-dynamicuser.service.
+
+[Unit]
+Description=spelunk-server (team memory)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+# Dedicated, unprivileged identity. A static user (rather than DynamicUser=)
+# keeps a fixed owner on the persistent SQLite data dir for operator
+# backup/inspection and a stable started_by UID.
+User=spelunk
+Group=spelunk
+
+# Key supplied as a systemd credential, not an Environment= line (which is
+# world-readable via `systemctl show` / /proc). The 0600 root-only source file
+# is exposed at $CREDENTIALS_DIRECTORY/server-key, readable only by this unit;
+# the binary reads it from there automatically. SPELUNK_SERVER_KEY as an
+# Environment=/EnvironmentFile= value is equally supported for operators who
+# prefer it (use a 0600 root-owned EnvironmentFile, never an inline Environment=).
+LoadCredential=server-key:/etc/spelunk/server-key
+ExecStart=/usr/local/bin/spelunk-server \
+  --host 127.0.0.1 --port 7777 \
+  --db /var/lib/spelunk/spelunk.db
+
+Restart=on-failure
+RestartSec=5
+
+# Hardening — the server needs only its data dir and loopback.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/spelunk
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+SystemCallArchitectures=native
+# MemoryDenyWriteExecute=true blocks W+X mappings. The native embedder mmaps
+# model weights and, on CUDA/BLAS backends, may need writable-executable pages;
+# validate against your embedder backend before enabling.
+# MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Implements ADR-058 (accepted, PR #521): a first-party bare-metal team-server path — file/systemd-credential key resolution, hardened systemd units, and a docs restructure that elevates bare-metal to recommended and reframes Docker as a local-only scaffold. **Closes spelunk-oss^70** (remote-agents R1 rework).

## What changed

**Server key resolution (`crates/spelunk-server/src/main.rs`)**
- New `--key-file <PATH>` flag and a `resolve_api_key()` with precedence `--key` > `--key-file` > `SPELUNK_SERVER_KEY` > `$CREDENTIALS_DIRECTORY/server-key` (systemd `LoadCredential`, auto-detected).
- `--key-file` and the env var are equal first-class sources, not fallbacks. A blank value at any level falls through to the next; an explicit `--key-file` read error is **fatal** (no silent fail-open to no-auth); a missing systemd credential is tolerated while a real read error is fatal.
- Dropped clap's `env=` from `--key` so env precedence is explicit and testable. 9 new unit tests (each source, precedence, blank fall-through, fatal missing file, flag parse).

**Packaging**
- `packaging/spelunk-server-team.service` — static `spelunk` user default, `LoadCredential=server-key`, full sandboxing.
- `packaging/spelunk-server-team-dynamicuser.service` — `DynamicUser=yes` + `StateDirectory=spelunk` variant.
- Existing per-developer `packaging/spelunk-server.service` untouched. No proxy config shipped. `MemoryDenyWriteExecute=` shipped commented with an embedder-mmap rationale.

**Docs**
- `docs/server.md` / `docs/self-hosting.md`: bare-metal + systemd elevated to recommended; Docker reframed as "local scaffold only"; the first-party unit + credential provisioning + DynamicUser alternative documented; Caddy/nginx marked operator-owned reference examples.
- `docs/remote-agents.md`: R1 reworked from raw `host.docker.internal:7777` to the operator-TLS-endpoint model (portable across Docker Desktop and native Linux); Docker Desktop shortcut kept as a labeled convenience with the native-Linux caveat spelled out. **Closes oss^70.**
- Stale anchor fixes in `server.md` + `docker-compose.yml` after the heading renames.

## Test plan (steps QA ran, `SPELUNK_SECRET_STORE=file` throughout)
- `cargo test -p spelunk-server` → bin **20 passed**, integration **12 passed**, 0 failed (incl. the new key-resolution tests: precedence, blank fall-through, fatal `--key-file`, systemd auto-detect, flag parse).
- `cargo build --no-default-features` (mandatory CI cell) → clean.
- `cargo clippy --all-targets -- -D warnings` → clean.
- `cargo fmt --check` → clean.
- Branch staleness: rebased state confirmed on top of `origin/main` (@ #540), 0 commits behind.
- Anchor integrity: grepped repo — no dangling `quick-start-docker` / `server-mode-vs-no-server-mode` / `2a-reverse-proxy` references; new targets `#docker-local-scaffold-only` and `#capability-tiers-where-inference-and-memory-live` exist.
- Key-resolution correctness reviewed: explicit `--key-file` read error is fatal (propagated via `?`), systemd `NotFound` tolerated but real read error fatal — no fail-open on the auth key.

Closes spelunk-oss^70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
