### PR TITLE
feat(core): bound oversized chunks with MAX_CHUNK_TOKENS cap (spelunk-oss^114)

### DIFF
--- a/crates/spelunk-core/src/indexer/chunker.rs
+++ b/crates/spelunk-core/src/indexer/chunker.rs
@@ -72,6 +72,11 @@ impl Chunk {
     }
 }
 
+/// Soft ceiling for one chunk (tokens, chars/4 estimate). Oversized leaves are
+/// re-windowed and oversized containers suppressed in favour of their children.
+/// Distinct from the embedder's hard `token_cap` OOM guard.
+pub const MAX_CHUNK_TOKENS: usize = 2048;
+
 /// Split `source` into chunks using a sliding window (fallback for
 /// languages without a tree-sitter grammar or for files that failed parsing).
 pub fn sliding_window(

--- a/crates/spelunk-core/src/indexer/parser/text.rs
+++ b/crates/spelunk-core/src/indexer/parser/text.rs
@@ -1,4 +1,5 @@
-use super::super::chunker::{Chunk, ChunkKind, sliding_window};
+use super::super::chunker::{Chunk, ChunkKind, MAX_CHUNK_TOKENS, sliding_window};
+use crate::search::tokens::estimate_tokens;
 
 /// Parse a `.ipynb` notebook into per-cell chunks.
 ///
@@ -109,6 +110,16 @@ pub(super) fn parse_markdown(source: &str, file_path: &str) -> Vec<Chunk> {
                  chunks: &mut Vec<Chunk>| {
         let content = lines[start..end].join("\n");
         if content.trim().is_empty() {
+            return;
+        }
+        if estimate_tokens(&content) > MAX_CHUNK_TOKENS {
+            // Section start is 0-based line index `start`; sub-chunk lines are
+            // 1-based within the section, so `start` is the correct offset.
+            for mut sub in sliding_window(&content, file_path, "markdown", 120, 15) {
+                sub.start_line += start;
+                sub.end_line += start;
+                chunks.push(sub);
+            }
             return;
         }
         chunks.push(Chunk {

--- a/crates/spelunk-core/src/indexer/parser/ts_walker.rs
+++ b/crates/spelunk-core/src/indexer/parser/ts_walker.rs
@@ -1,5 +1,6 @@
-use super::super::chunker::{Chunk, ChunkKind};
+use super::super::chunker::{Chunk, ChunkKind, MAX_CHUNK_TOKENS, sliding_window};
 use crate::error::IndexError;
+use crate::search::tokens::estimate_tokens;
 use anyhow::Result;
 
 pub(super) fn ts_language(name: &str) -> Result<tree_sitter::Language> {
@@ -271,12 +272,47 @@ fn walk_node_inner(
             _ => parent_scope.map(str::to_owned),
         };
 
+        let start_row = node.start_position().row;
+        let is_container = matches!(
+            spec.chunk_kind,
+            ChunkKind::Module
+                | ChunkKind::Impl
+                | ChunkKind::Class
+                | ChunkKind::Trait
+                | ChunkKind::Interface
+        );
+
+        if estimate_tokens(&content) > MAX_CHUNK_TOKENS {
+            if is_container {
+                // Suppress the container's own chunk; its children already carry
+                // fine-grained chunks framed by parent_scope. Re-window only if the
+                // container matched no children.
+                let before = out.len();
+                for i in 0..node.child_count() {
+                    if let Some(child) = node.child(i as u32) {
+                        walk_node_inner(child, ctx, scope_label.as_deref(), out, depth + 1);
+                    }
+                }
+                if out.len() == before {
+                    push_windowed(&content, ctx, start_row, out);
+                }
+            } else {
+                push_windowed(&content, ctx, start_row, out);
+                for i in 0..node.child_count() {
+                    if let Some(child) = node.child(i as u32) {
+                        walk_node_inner(child, ctx, scope_label.as_deref(), out, depth + 1);
+                    }
+                }
+            }
+            return;
+        }
+
         out.push(Chunk {
             file_path: ctx.file_path.to_owned(),
             language: ctx.language.to_owned(),
             kind: spec.chunk_kind.clone(),
             name,
-            start_line: node.start_position().row + 1,
+            start_line: start_row + 1,
             end_line: node.end_position().row + 1,
             content,
             docstring,
@@ -297,6 +333,16 @@ fn walk_node_inner(
                 walk_node_inner(child, ctx, parent_scope, out, depth + 1);
             }
         }
+    }
+}
+
+/// Re-window an oversized node's text into sliding-window sub-chunks, offsetting
+/// each sub-chunk's line span by the node's 0-based `start_row`.
+fn push_windowed(content: &str, ctx: &WalkCtx<'_>, start_row: usize, out: &mut Vec<Chunk>) {
+    for mut sub in sliding_window(content, ctx.file_path, ctx.language, 120, 15) {
+        sub.start_line += start_row;
+        sub.end_line += start_row;
+        out.push(sub);
     }
 }
 

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -1,6 +1,8 @@
 //! Unit tests for the chunker module (no I/O, no SQLite).
 
-use spelunk_core::indexer::{Chunk, ChunkKind};
+use spelunk_core::indexer::chunker::MAX_CHUNK_TOKENS;
+use spelunk_core::indexer::{Chunk, ChunkKind, SourceParser};
+use spelunk_core::search::tokens::estimate_tokens;
 
 // ── sliding_window ───────────────────────────────────────────────────────────
 
@@ -81,4 +83,83 @@ fn embedding_text_prepends_docstring() {
         c.embedding_text(),
         "title: foo | text: /// Does foo.\nfn foo() {}"
     );
+}
+
+// ── MAX_CHUNK_TOKENS ceiling (oss^114) ───────────────────────────────────────
+
+/// A Rust function with `body_lines` short statements, guaranteed short enough
+/// per line that any 120-line window stays under the cap.
+fn big_rust_fn(name: &str, body_lines: usize) -> String {
+    let mut s = format!("fn {name}() {{\n");
+    for i in 0..body_lines {
+        s.push_str(&format!("    let v{i} = {i};\n"));
+    }
+    s.push_str("}\n");
+    s
+}
+
+#[test]
+fn oversized_leaf_splits_into_capped_subchunks() {
+    // 600 short lines ≈ 2.4k tokens for the function — over the cap.
+    let src = big_rust_fn("huge", 600);
+    assert!(
+        estimate_tokens(&src) > MAX_CHUNK_TOKENS,
+        "fixture must exceed cap"
+    );
+
+    let chunks = SourceParser::parse(&src, "huge.rs", "rust").unwrap();
+
+    // No single whole-function chunk survives; it is re-windowed.
+    assert!(
+        chunks.len() > 1,
+        "oversized leaf should split into >1 chunk"
+    );
+    assert!(
+        chunks.iter().all(|c| matches!(c.kind, ChunkKind::Verbatim)),
+        "re-windowed sub-chunks are Verbatim"
+    );
+    for c in &chunks {
+        assert!(
+            estimate_tokens(&c.content) <= MAX_CHUNK_TOKENS,
+            "sub-chunk {}-{} over cap: {} tok",
+            c.start_line,
+            c.end_line,
+            estimate_tokens(&c.content)
+        );
+    }
+    // Line offset preserved: the function starts at file line 1.
+    assert_eq!(chunks[0].start_line, 1);
+}
+
+#[test]
+fn oversized_container_suppresses_own_chunk_keeps_children() {
+    // A module whose whole text is over the cap, but each child fn is under it.
+    let mut src = String::from("mod tests {\n");
+    for i in 0..5 {
+        src.push_str(&big_rust_fn(&format!("f{i}"), 120));
+    }
+    src.push_str("}\n");
+    assert!(
+        estimate_tokens(&src) > MAX_CHUNK_TOKENS,
+        "module fixture must exceed cap"
+    );
+
+    let chunks = SourceParser::parse(&src, "container.rs", "rust").unwrap();
+
+    // Container's own Module chunk is suppressed.
+    assert!(
+        !chunks.iter().any(|c| matches!(c.kind, ChunkKind::Module)),
+        "oversized container must not emit its own chunk"
+    );
+    // But per-fn child chunks are still emitted, each under the cap.
+    let fns: Vec<&Chunk> = chunks
+        .iter()
+        .filter(|c| matches!(c.kind, ChunkKind::Function))
+        .collect();
+    assert_eq!(fns.len(), 5, "each child function should yield a chunk");
+    for c in &fns {
+        assert!(estimate_tokens(&c.content) <= MAX_CHUNK_TOKENS);
+    }
+    let names: Vec<&str> = fns.iter().filter_map(|c| c.name.as_deref()).collect();
+    assert!(names.contains(&"f0") && names.contains(&"f4"));
 }


### PR DESCRIPTION
Split from spelunk-oss^100 Part A. Bounds oversized chunks at creation time with a soft `MAX_CHUNK_TOKENS = 2048` ceiling in spelunk-core, eliminating the "embed phase looks frozen for tens of seconds on one chunk" stall during `spelunk index` (an O(seq²) forward pass on a chunk near the embedder's ~5792-tok OOM `token_cap`).

## What changed
- **`chunker.rs`**: new `pub const MAX_CHUNK_TOKENS: usize = 2048` (soft ceiling; the embedder's `token_cap` stays the hard OOM guard). Measured via `search::tokens::estimate_tokens` (chars/4, same as stored `token_count`).
- **`parser/ts_walker.rs`**: oversized **leaf** nodes (Function/Method/Struct/Enum/Constant/TypeAlias/Rule) re-window into `sliding_window(…,120,15)` sub-chunks, line-offset by the node's start row; still recurse into children. Oversized **container** nodes (Module/Impl/Class/Trait/Interface) suppress their own chunk and rely on child chunks (framed by `parent_scope`); a container that matched no children falls back to leaf re-window so no content is dropped.
- **`parser/text.rs`**: oversized markdown/MDX sections re-window instead of emitting one `Section` chunk.
- **`tests/unit_chunker.rs`**: `oversized_leaf_splits_into_capped_subchunks` + `oversized_container_suppresses_own_chunk_keeps_children`.

## Re-index required
This changes chunk boundaries, so existing indexes must be re-indexed to pick up the new chunking. **No DB schema or migration change.**

## Test plan (QA-run, `SPELUNK_SECRET_STORE=file`)
- `cargo fmt --check` — clean.
- `cargo test` (full workspace) — all binaries pass, incl. the 2 new tests.
- `cargo build --no-default-features` (CI matrix cell) — OK.
- `cargo clippy --all-targets -- -D warnings` — clean.
- **Container suppression**: `spelunk plumbing parse-file crates/spelunk-server/src/handlers.rs` → max chunk **17033 → 1120 tok**, zero chunks over 2048, no `module` chunk remains (the `#[cfg(test)] mod tests` monster is gone), per-test-fn + small impl/struct children intact.
- **Leaf re-window**: `harvest_claude.rs::harvest_claude_code` (was 3627 tok) → 4 `Verbatim` sub-chunks, each ≤ cap (1000/1006/1196/794), correct line offsets (start line 42) and 15-line overlap; no oversized function chunk remains.
- Spot-checks: `server/db.rs` max 1429 tok, `index/embed_phase.rs` max 1622 tok — under cap, none over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
