### PR TITLE
docs: terse-comment cleanup of #513 files (spelunk-oss^115)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -11,71 +11,40 @@ use crate::{
     storage::Database,
 };
 
-/// Hard ceiling on chunks per request — the server enforces 256 (returns 413 if
-/// exceeded), so both the user-supplied `--batch-size` and the calibrated batch
-/// size are clamped to this. The server's candle embedder (F2LLM-v2-330M) runs
-/// inference in padded sub-batches of EMBED_BATCH_SIZE=8, so e.g. 64 chunks = 8
-/// forward passes.
+/// Hard ceiling on chunks per request; the server returns 413 above this.
 const MAX_BATCH: usize = 256;
 
-/// Default ceiling on the calibrated batch size when the user has not set
-/// `--batch-size` (i.e. it is still 0): the server's own hard limit, so
-/// calibration is free to grow the batch as large as the measured throughput
-/// justifies. `--batch-size` exists to let a user *lower* this ceiling (e.g.
-/// memory-constrained hardware), not to hand-pick a fixed size (see
-/// `resolve_batch_ceiling`).
+/// Calibration ceiling when `--batch-size` is unset (0): the server's hard
+/// limit. `--batch-size` only lowers this ceiling, never picks a fixed size
+/// (see `resolve_batch_ceiling`).
 const DEFAULT_BATCH_CEILING: usize = MAX_BATCH;
 
-/// Size of the very first request: a single chunk. We deliberately do not
-/// guess a batch size before we have ANY timing data — a full batch's cold
-/// start (model load, first-request JIT, etc.) used to be exactly what made
-/// the old fixed-timeout approach unsafe on slow hardware. A batch of 1 gives
-/// an initial per-entry estimate almost immediately, and also makes the
-/// progress bar move right away (spelunk-oss^73) instead of only after a full
-/// batch round-trips.
+/// First request is a single chunk: yields an initial per-entry estimate almost
+/// immediately and gets the progress bar moving before any full batch lands.
 const CALIBRATION_BATCH_1: usize = 1;
 
-/// Size of the second request, used to refine the estimate from
-/// `CALIBRATION_BATCH_1` (which is dominated by one-off cold-start costs: model
-/// warm-up, first-connection overhead, etc.) before committing to a steady-
-/// state batch size. Only run when enough chunks remain (see
-/// `next_batch_size` / calibration bookkeeping in `run_embed_phase`).
+/// Second request: refines the estimate from `CALIBRATION_BATCH_1` (dominated by
+/// one-off cold-start) before committing to a steady-state size.
 const CALIBRATION_BATCH_2: usize = 4;
 
-/// Target wall-clock time we aim to keep each *steady-state* (post-calibration)
-/// batch under. Batch size is derived by dividing this budget by the measured
-/// per-entry rate: slow hardware (e.g. ~60 s/entry) gets a small batch (~4), fast
-/// hardware (e.g. ~1 s/entry) gets a large one (up to `MAX_BATCH`), per the
-/// founder's calibration approach for spelunk-oss^74/^71 — we time a couple of
-/// small batches up front and size subsequent ones from the observed rate,
-/// rather than always sending a fixed-size batch and reacting after the fact.
+/// Wall-clock time each steady-state batch aims to stay under; batch size is
+/// this budget divided by the measured per-entry rate.
 const TARGET_BATCH_SECONDS: u64 = 240;
 
-/// Floor for a calibrated per-request timeout. Even on very fast hardware we
-/// never drop below this, to absorb transient latency spikes (a slow DNS
-/// lookup, a GC pause on the server, etc.).
+/// Floor for a calibrated per-request timeout, to absorb transient latency spikes.
 const MIN_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Ceiling for a calibrated per-request timeout, so a pathologically slow
-/// sample can't derive an effectively unbounded deadline.
+/// Ceiling for a calibrated per-request timeout, so a pathologically slow sample
+/// can't derive an unbounded deadline.
 const MAX_REQUEST_TIMEOUT: Duration = Duration::from_secs(1800);
 
-/// Safety multiple applied to a batch's *expected* duration (at the current
-/// measured per-entry rate) when deriving that batch's request timeout: give
-/// it this much headroom over the estimate so normal jitter never trips it.
+/// Headroom multiple over a batch's expected duration when deriving its timeout.
 const TIMEOUT_SAFETY_FACTOR: u32 = 4;
 
-/// Resolve the effective ceiling the calibrated batch size may grow to, from
-/// the user-supplied `--batch-size` flag: 0 falls back to the default ceiling,
-/// and anything above the server ceiling is clamped to `MAX_BATCH`. Unlike the
-/// old fixed batch size, this is now only an upper bound — the actual
-/// per-request size is calibrated from measured throughput and may end up
-/// smaller (see `next_batch_size`).
-///
-/// `server_max_batch_chunks` (from `ServerLimits::max_batch_chunks`, when the
-/// server advertises it) additionally clamps the ceiling — a client should
-/// never plan around a batch count the specific server it's talking to won't
-/// even accept (`413`), independent of the client's own `MAX_BATCH` guess.
+/// Effective ceiling the calibrated batch size may grow to: `--batch-size`
+/// (0 → `DEFAULT_BATCH_CEILING`) clamped to `MAX_BATCH` and, when advertised,
+/// the server's own `max_batch_chunks` (413 above it). Only an upper bound —
+/// actual size is calibrated (see `next_batch_size`).
 fn resolve_batch_ceiling(requested: usize, server_max_batch_chunks: Option<usize>) -> usize {
     let ceiling = if requested == 0 {
         DEFAULT_BATCH_CEILING
@@ -88,40 +57,19 @@ fn resolve_batch_ceiling(requested: usize, server_max_batch_chunks: Option<usize
     }
 }
 
-/// Legacy per-request budget assumed when talking to a server that pre-dates
-/// the `/v1/health` `limits` field (spelunk-oss^71/^73/^74) — i.e. the old
-/// blanket `TimeoutLayer` budget with no `/index/embed` exemption. This is
-/// the exact version-skew case that produced the field failure this fix
-/// addresses: a CLI calibrating toward `TARGET_BATCH_SECONDS` (240s) talking
-/// to an old server that kills every request at 30s regardless.
+/// Per-request budget assumed for a server that pre-dates the `/v1/health`
+/// `limits` field: the old blanket 30s `TimeoutLayer` with no `/index/embed`
+/// exemption.
 const LEGACY_SERVER_REQUEST_BUDGET_SECS: u64 = 30;
 
-/// Fraction of the server's advertised (or assumed-legacy) per-request budget
-/// that a calibrated batch should target, leaving headroom for jitter/variance
-/// between the calibration sample and the batch actually sent — the server
-/// will 408 at the hard budget regardless of how well-intentioned the
-/// client's estimate was.
+/// Fraction of the server's per-request budget a calibrated batch targets,
+/// leaving headroom for jitter between the calibration sample and the batch sent.
 const SERVER_BUDGET_TARGET_FRACTION: f64 = 2.0 / 3.0;
 
-/// Resolve the effective target batch duration (seconds), clamped to fit
-/// comfortably inside the server's own advertised `/index/embed` request
-/// budget when known — this REPLACES the fixed `TARGET_BATCH_SECONDS` as the
-/// primary mechanism for staying under the server's actual budget (the
-/// 408-triggered shrink in `run_embed_phase` is the fallback, for a server
-/// that misreports or whose effective budget changes under load).
-///
-/// - Server advertises `limits` (current build, carries the
-///   `/index/embed`-specific exemption from this same fix): target is
-///   `TARGET_BATCH_SECONDS`, clamped down to `SERVER_BUDGET_TARGET_FRACTION ×
-///   embed_request_timeout_secs` if that's smaller (a self-hosted deployment
-///   could in principle configure a smaller budget than the CLI's default
-///   target).
-/// - Server does NOT advertise `limits` (pre-dates this fix, still enforces
-///   the old blanket 30s budget with no exemption): target is
-///   `SERVER_BUDGET_TARGET_FRACTION × LEGACY_SERVER_REQUEST_BUDGET_SECS` —
-///   the version-skew case (instruction 5 / founder directive): a new CLI
-///   talking to an old, long-running server must still make progress, just
-///   with smaller batches and (at the call site) a warning.
+/// Effective target batch duration (seconds), clamped to fit the server's
+/// advertised `/index/embed` budget. Absent `limits` (older server) falls back
+/// to `SERVER_BUDGET_TARGET_FRACTION × LEGACY_SERVER_REQUEST_BUDGET_SECS`. The
+/// 408-triggered shrink in `run_embed_phase` is the fallback.
 fn resolve_target_batch_seconds(server_limits: Option<ServerLimits>) -> u64 {
     let budget_secs = server_limits
         .map(|l| l.embed_request_timeout_secs)
@@ -130,36 +78,13 @@ fn resolve_target_batch_seconds(server_limits: Option<ServerLimits>) -> u64 {
     TARGET_BATCH_SECONDS.min(safe_budget.max(1))
 }
 
-/// Max multiple of the *previous* batch's size that the next calibrated batch
-/// is allowed to grow to in one step (spelunk-oss^71/^73/^74 field-failure
-/// follow-up, PR #513 review). Without this, a single fast sample right after
-/// a slow one could derive a batch many times larger than anything actually
-/// measured — e.g. observed in the field: calibration batch 2 (4 chunks)
-/// landing unusually fast produced a *raw* per-entry rate that alone implied a
-/// batch of 200, an ~50x jump from the 4-chunk sample that produced it, with
-/// no batch of intermediate size ever having been measured. Capping growth to
-/// `GROWTH_FACTOR`x per step means the size ramps up over a few batches
-/// instead of leaping straight to a value nothing has verified is safe.
+/// Max multiple of the previous batch's size the next calibrated batch may grow
+/// to in one step, so one fast sample can't leap to a size nothing has measured.
 const GROWTH_FACTOR: usize = 8;
 
-/// Choose the next steady-state batch size from the measured per-entry
-/// duration, so a batch takes roughly `target_seconds` wall-clock: slow
-/// hardware (large `per_entry`) gets a small batch, fast hardware gets a large
-/// one. Clamped to `[1, ceiling]` — `ceiling` is the smaller of `MAX_BATCH` (the
-/// server's hard 413 limit), the user's `--batch-size` (if they set one), and
-/// the server's own advertised `max_batch_chunks` (if known) — and
-/// additionally clamped to at most `GROWTH_FACTOR × previous_batch_size`,
-/// so one sample can never produce a many-times-larger leap in a single step
-/// (see `GROWTH_FACTOR`).
-///
-/// `target_seconds` is normally `TARGET_BATCH_SECONDS`, but is clamped down by
-/// `resolve_target_batch_seconds` to fit the server's advertised (or
-/// assumed-legacy) `/index/embed` request budget — see that function.
-///
-/// Examples from the calibration this replaces the old "time a fixed 64-batch"
-/// approach with: ~60 s/entry ⇒ batch 4; ~1 s/entry ⇒ batch up to
-/// `GROWTH_FACTOR × previous_batch_size` (not necessarily the full 256 ceiling
-/// — growth is capped per step, see `GROWTH_FACTOR`).
+/// Choose the next steady-state batch size so a batch takes ~`target_seconds` at
+/// the measured `per_entry` rate. Clamped to `[1, ceiling]` and to at most
+/// `GROWTH_FACTOR × previous_batch_size`.
 fn next_batch_size(
     per_entry: Duration,
     ceiling: usize,
@@ -185,67 +110,38 @@ fn next_batch_size(
     }
 }
 
-/// Derive the per-request timeout for a batch of `batch_size` entries from the
-/// current measured per-entry rate: `TIMEOUT_SAFETY_FACTOR ×` the batch's
-/// expected duration at that rate, clamped into
-/// `[MIN_REQUEST_TIMEOUT, MAX_REQUEST_TIMEOUT]`. Because batch size itself is
-/// derived from the same rate to target `TARGET_BATCH_SECONDS`, this timeout
-/// tracks the batch size rather than a single fixed deadline — a genuinely
-/// slow-but-progressing request is not killed mid-flight and its whole batch
-/// discarded (spelunk-oss^71).
+/// Per-request timeout for a batch: `TIMEOUT_SAFETY_FACTOR ×` its expected
+/// duration at `per_entry`, clamped to `[MIN_REQUEST_TIMEOUT, MAX_REQUEST_TIMEOUT]`.
 fn batch_timeout(per_entry: Duration, batch_size: usize) -> Duration {
     let expected = per_entry.saturating_mul(batch_size.max(1) as u32);
     let budget = expected.saturating_mul(TIMEOUT_SAFETY_FACTOR);
     budget.clamp(MIN_REQUEST_TIMEOUT, MAX_REQUEST_TIMEOUT)
 }
 
-/// Timeout used for the very first request (a single chunk), before we have
-/// any measurement of this machine's embedding speed at all. Pessimistic
-/// because it must also absorb one-off model cold-start.
+/// Timeout for the very first (single-chunk) request, before any rate is known.
+/// Pessimistic to absorb one-off model cold-start.
 const FIRST_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 
-/// Blend weight given to `CALIBRATION_BATCH_1`'s sample (a single chunk) the
-/// moment a second, larger sample arrives. Deliberately small: batch 1 exists
-/// only to get the progress bar moving and produce *some* number before batch
-/// 2 lands (spelunk-oss^73) — its 1-entry sample is dominated by one-off
-/// per-request overhead (connection setup, first-request scheduling, and on
-/// some hardware genuine model warm-up) that does not repeat on every
-/// subsequent batch, so it must not carry the same weight as a real,
-/// multi-entry measurement. A founder field report (2026-07-05, PR #513)
-/// showed a 50/50 blend of a cold ~25s batch-1 sample with a warm ~1.2s/entry
-/// batch-2 sample producing a ~13s/entry *displayed* rate while the batch-size
-/// decision (see `next_batch_size`) used a *different*, unblended sample —
-/// two disagreeing estimates from what should be one authoritative number.
-/// De-weighting the batch-1 sample here (instead of a straight 50/50) means
-/// the blended estimate — the single source both the batch-size/timeout
-/// decision AND the displayed rate now read from — converges to the real,
-/// measured rate almost immediately rather than staying skewed by a sample
-/// that was never representative of steady state.
+/// Weight given to `CALIBRATION_BATCH_1`'s 1-entry sample when the second sample
+/// arrives. Small: that sample is dominated by one-off per-request overhead that
+/// doesn't repeat, so it must not carry the weight of a real multi-entry
+/// measurement. Both the sizing decision and the displayed rate read the same
+/// blended estimate.
 const CALIBRATION_BATCH_1_WEIGHT: f64 = 0.1;
 
 /// Running estimate of this run's embedding throughput, refined after every
-/// batch so a rate that drifts mid-run (e.g. thermal throttling, another
-/// process contending for the GPU) is picked up rather than locked in from the
-/// first sample alone.
+/// batch so mid-run drift (thermal throttling, GPU contention) is picked up.
 ///
-/// This is the SINGLE authoritative rate source: `next_batch_size`,
-/// `batch_timeout`, and the progress-bar's displayed ETA (via `format_eta`,
-/// rendered into the status message — see `embed_progress_style`) all read
-/// `per_entry()` from the same `RateEstimate` instance, so they can never
-/// disagree the way the batch-size decision and the *displayed* rate
-/// diverged in the field (see `CALIBRATION_BATCH_1_WEIGHT`). This struct
-/// deliberately does NOT delegate to indicatif's own built-in `{eta}`
-/// estimator: that estimator infers rate purely from the timing of
-/// `bar.inc(1)` calls, which for this phase arrive in a burst right after
-/// each batch's response (see `format_eta`'s doc comment) — reliably wrong
-/// for bursty progress, hence this dedicated estimate.
+/// Single authoritative rate source: `next_batch_size`, `batch_timeout`, and the
+/// displayed ETA (`format_eta`) all read `per_entry()` from the same instance so
+/// they can't disagree. Deliberately not indicatif's `{eta}`, which infers rate
+/// from `bar.inc(1)` timing — wrong for this phase's bursty increments (see
+/// `format_eta`).
 struct RateEstimate {
-    /// Exponentially-weighted per-entry duration. `None` until the first batch
-    /// lands.
+    /// Exponentially-weighted per-entry duration. `None` until the first batch.
     per_entry: Option<Duration>,
-    /// Number of batches folded in so far, so `update` can tell "this is the
-    /// batch-1 cold sample being immediately superseded" (samples_seen == 1)
-    /// apart from every later, steady-state blend (50/50, same as before).
+    /// Batches folded in so far, so `update` can tell the batch-1 cold sample
+    /// (== 1) from later steady-state blends.
     samples_seen: u32,
 }
 
@@ -257,17 +153,10 @@ impl RateEstimate {
         }
     }
 
-    /// Fold in a newly-observed batch: `elapsed` wall-clock time for
-    /// `entries` chunks. The first observation seeds the estimate outright;
-    /// the second observation (superseding the batch-1 cold sample) blends
-    /// with only `CALIBRATION_BATCH_1_WEIGHT` given to that first sample
-    /// instead of an even split, since it is dominated by one-off overhead
-    /// that isn't representative of steady state (see
-    /// `CALIBRATION_BATCH_1_WEIGHT`). From the third observation onward,
-    /// later samples are blended 50/50 with the running estimate — recent
-    /// batches matter more than stale ones, so a hardware/network rate change
-    /// mid-run (thermal throttling, contention) is reflected within a couple
-    /// of batches instead of being permanently anchored to an early sample.
+    /// Fold in a batch: `elapsed` for `entries` chunks. First observation seeds
+    /// the estimate; the second de-weights the batch-1 cold sample
+    /// (`CALIBRATION_BATCH_1_WEIGHT`); from the third onward, a 50/50 EMA so
+    /// mid-run rate changes are reflected within a couple of batches.
     fn update(&mut self, elapsed: Duration, entries: usize) {
         if entries == 0 {
             return;
@@ -276,15 +165,13 @@ impl RateEstimate {
         self.per_entry = Some(match self.per_entry {
             None => sample,
             Some(prev) if self.samples_seen == 1 => {
-                // Superseding the batch-1 cold sample: give it only
-                // `CALIBRATION_BATCH_1_WEIGHT` instead of 50/50.
+                // Superseding the batch-1 cold sample: de-weight it.
                 let w = CALIBRATION_BATCH_1_WEIGHT;
                 let blended = prev.as_secs_f64() * w + sample.as_secs_f64() * (1.0 - w);
                 Duration::from_secs_f64(blended)
             }
             Some(prev) => {
-                // Steady-state blend: a simple 50/50 exponential moving
-                // average.
+                // Steady-state 50/50 EMA.
                 let blended = (prev.as_secs_f64() + sample.as_secs_f64()) / 2.0;
                 Duration::from_secs_f64(blended)
             }
@@ -298,29 +185,11 @@ impl RateEstimate {
     }
 }
 
-/// Progress style for the embed phase. This does NOT use indicatif's
-/// built-in `{eta}` token: embedding is bursty (a batch's `bar.inc(1)` calls
-/// all land together right after its HTTP response arrives, then there's a
-/// long silent gap while the next request is in flight, with no increments
-/// at all), and indicatif's smoothed rate estimator reads that silence as
-/// "rate ≈ 0" and extrapolates a wildly inflated ETA — this is exactly the
-/// founder-observed "ETA 153y" bug (spelunk-oss^74 follow-up, PR #513). A
-/// PREVIOUS version of this doc comment claimed indicatif's smoothing
-/// "washes out" the cold-start skew across batches; that assumption is false
-/// for burst-then-silence updates like this phase's.
-///
-/// Instead, the ETA is computed from `RateEstimate` — the same measured
-/// per-chunk wall-clock rate that already drives `next_batch_size` and
-/// `batch_timeout` (see that struct's doc comment) — via `format_eta`, and
-/// rendered into `{wide_msg}` by the call sites in `run_embed_phase`. Using
-/// one rate source for sizing, timeout, AND the displayed ETA means they can
-/// never disagree.
-///
-/// Starting calibration with a batch of 1 (rather than a full batch) means
-/// the first data point lands almost immediately, so the bar itself becomes
-/// visible right away instead of only after a full batch completes
-/// (spelunk-oss^73/^74). A steady tick keeps the spinner moving even while a
-/// request is in flight, so a slow batch never looks frozen.
+/// Progress style for the embed phase. Does NOT use indicatif's `{eta}`:
+/// embedding is bursty (a batch's `bar.inc(1)` calls land together, then a long
+/// silent gap), which indicatif reads as rate ≈ 0 and extrapolates absurd ETAs.
+/// The ETA is computed from `RateEstimate` via `format_eta` and rendered into
+/// `{wide_msg}` by `run_embed_phase` instead.
 fn embed_progress_style() -> ProgressStyle {
     ProgressStyle::with_template(
         "{spinner:.cyan} Embedding [{bar:38.cyan/blue}] {pos}/{len}  {wide_msg}",
@@ -329,28 +198,17 @@ fn embed_progress_style() -> ProgressStyle {
     .progress_chars("=>-")
 }
 
-/// Ceiling on the computed ETA duration: a single bad/degenerate sample (a
-/// huge `per_entry` from a pathological retry, or an early estimate skewed by
-/// cold-start) must never render an absurd value like "153y" — the exact
-/// founder-observed regression this fix addresses. Anything at or above this
-/// is displayed as `ETA >24h` instead of the literal computed duration.
+/// Ceiling on the displayed ETA: anything at or above shows `ETA >24h` rather
+/// than a literal (possibly absurd) computed duration.
 const ETA_DISPLAY_CAP: Duration = Duration::from_secs(24 * 60 * 60);
 
-/// Render the embed phase's displayed ETA from the measured `RateEstimate`
-/// (see that struct's doc comment) and the number of chunks remaining.
+/// Render the displayed ETA from the measured `RateEstimate` and chunks remaining.
 ///
-/// - `per_entry` is `None` before the first batch has landed (i.e. during
-///   calibration batch 1's in-flight request) — there is no measurement yet
-///   to derive anything from, so this shows a calibrating placeholder rather
-///   than guessing.
-/// - Otherwise the remaining wall-clock time is `per_entry * remaining`,
-///   computed with `f64` and clamped BEFORE converting back to a `Duration`
-///   (`per_entry.as_secs_f64() * remaining as f64` can overflow/produce `inf`
-///   for a pathological `per_entry`, e.g. a 408-derived sample folded in at
-///   `MAX_REQUEST_TIMEOUT`) — so a bad sample can only ever produce the
-///   `>24h` capped string, never a panic or a nonsense number of years.
-/// - The formatted duration is compact: sub-minute shows seconds, sub-hour
-///   shows minutes (+ seconds if any), and hours show hours + minutes.
+/// - `None` per_entry (pre-first-batch): a calibrating placeholder, not a guess.
+/// - Else `per_entry * remaining`, computed in f64 and clamped BEFORE converting
+///   back to `Duration` (a pathological `per_entry` can overflow/produce `inf`),
+///   so a bad sample yields the `>24h` string, never a panic.
+/// - Compact format: seconds / minutes(+seconds) / hours+minutes.
 fn format_eta(remaining: usize, per_entry: Option<Duration>) -> String {
     let Some(per_entry) = per_entry else {
         return "ETA calibrating…".to_string();
@@ -394,18 +252,10 @@ struct ReqChunk {
     content: String,
 }
 
-/// Report an unrecoverable embed-phase failure: abandon the progress bar with
-/// a summary, and print an actionable message to stderr. Does NOT return an
-/// `Err` — callers report the count embedded so far via `Ok(embedded)` (see
-/// `run_embed_phase`'s doc comment on why an `Err` here would be wrong).
-///
-/// The message names the server request budget and a possible server-version
-/// mismatch as likely causes when the error text itself doesn't already make
-/// that obvious (a 408/timeout error already says "request budget" — see
-/// `embed_one_batch`'s `EmbedBatchError::BudgetExceeded` construction — but a
-/// user may not connect that to "maybe my server is out of date", especially
-/// since a modern server importing this same fix should never actually reach
-/// this path for a reasonably-sized batch).
+/// Report an unrecoverable embed-phase failure: abandon the progress bar and
+/// print an actionable message to stderr (naming the server request budget and a
+/// possible server-version mismatch). Does NOT return `Err` — callers report the
+/// count embedded so far via `Ok(embedded)`.
 fn report_embed_failure(
     bar: &ProgressBar,
     embedded: u64,
@@ -454,28 +304,18 @@ pub(super) async fn run_embed_phase(
     db.ensure_embedding_model(spelunk_core::embeddings::MODEL_ID)?;
     let server_limits = tier.server_limits();
 
-    // Ceiling the calibrated batch size may grow to. Unlike the old scheme,
-    // this is no longer the size we always send — see `next_batch_size`. Also
-    // clamped to what the server itself advertises (`max_batch_chunks`), when
-    // known, so the client never plans around a batch count the specific
-    // server it's talking to won't accept.
+    // Ceiling the calibrated batch size may grow to (see `next_batch_size`),
+    // clamped to the server's advertised `max_batch_chunks` when known.
     let server_max_batch_chunks = server_limits.map(|l| l.max_batch_chunks);
     let ceiling = resolve_batch_ceiling(batch_size, server_max_batch_chunks);
 
-    // Target batch duration, clamped to fit the server's advertised (or
-    // assumed-legacy) `/index/embed` request budget — see
-    // `resolve_target_batch_seconds`. This is the PRIMARY mechanism for
-    // staying under the server's budget; the steady-state 408-triggered
-    // shrink below is the fallback for a server that misreports or changes
-    // its effective budget under load (spelunk-oss^71/^73/^74).
+    // Target batch duration, clamped to the server's advertised (or legacy)
+    // `/index/embed` budget — see `resolve_target_batch_seconds`. The 408
+    // shrink below is the fallback.
     let target_batch_seconds = resolve_target_batch_seconds(server_limits);
     if server_limits.is_none() {
-        // Version-skew notice: this server pre-dates the `/v1/health`
-        // `limits` field, so it may still enforce the old blanket 30s
-        // `/index/embed` budget with no exemption (the exact field failure
-        // this fix addresses). Calibrating toward a smaller target keeps the
-        // run working — just with smaller, more frequent batches — instead of
-        // repeatedly hitting 408 against an old server.
+        // Older server: no `limits` field, so it may still enforce the blanket
+        // 30s budget. Target smaller batches to keep the run working.
         eprintln!(
             "Note: spelunk-server at {server_url} did not report its /index/embed request \
              budget (older server build) — assuming a conservative {LEGACY_SERVER_REQUEST_BUDGET_SECS}s \
@@ -484,17 +324,14 @@ pub(super) async fn run_embed_phase(
         );
     }
 
-    // Use `resolve_project_id` so that loopback auto-discovered servers (where
-    // `cfg.project_id` may be absent) derive the id from the project root path,
-    // matching `Config::resolve_project_id` behaviour (see spelunk#307).
+    // Loopback auto-discovered servers may lack `cfg.project_id`; derive it from
+    // the project root, matching `Config::resolve_project_id`.
     let project_id_owned = cfg.resolve_project_id(project_root);
     let project_id = project_id_owned.as_str();
 
-    // No client-wide timeout: we apply a PER-REQUEST timeout below, derived
-    // from the measured rate once we have one (starting pessimistic for the
-    // very first, single-chunk request). A single fixed client deadline is
-    // what let a slow first batch expire with nothing persisted
-    // (spelunk-oss^71).
+    // No client-wide timeout: a PER-REQUEST timeout is applied below, derived
+    // from the measured rate (pessimistic for the first, single-chunk request).
+    // A single fixed deadline let a slow first batch expire with nothing saved.
     let client = reqwest::Client::builder()
         .build()
         .context("building HTTP client for embed phase")?;
@@ -508,11 +345,9 @@ pub(super) async fn run_embed_phase(
         ProgressBar::hidden()
     };
 
-    // Draw the bar immediately, before the first (small, fast) request even
-    // fires, so the embedding phase shows visible movement within ~1 s of
-    // parsing finishing instead of only after a full batch round-trip returns
-    // (spelunk-oss^73). The steady tick animates the spinner while a request
-    // is in flight so a single slow batch never looks frozen.
+    // Draw the bar before the first request fires so the phase shows movement
+    // immediately; the steady tick animates the spinner while a request is in
+    // flight so a slow batch never looks frozen.
     bar.set_message("calibrating batch size\u{2026}");
     bar.enable_steady_tick(std::time::Duration::from_millis(120));
     bar.tick();
@@ -523,9 +358,9 @@ pub(super) async fn run_embed_phase(
     let mut batch_num = 0u64;
     let mut previous_batch_size = 1usize;
     let remaining = chunk_ids_and_texts.len();
-    // Percent-encode the project_id path segment: slugs contain `/`
-    // (`local/<hex>`, `github.com/owner/repo`) which would otherwise split
-    // the segment and break axum routing → 404. See spelunk decision #106.
+    // Percent-encode the project_id segment: slugs contain `/`
+    // (`local/<hex>`, `github.com/owner/repo`) which would otherwise split the
+    // segment and break axum routing → 404.
     let url = format!(
         "{}/v1/projects/{}/index/embed",
         server_url.trim_end_matches('/'),
@@ -536,12 +371,8 @@ pub(super) async fn run_embed_phase(
         batch_num += 1;
         let left = remaining - cursor;
 
-        // Calibration phase: the first request is a single chunk, the second
-        // is a small 4-chunk sample (both clamped to what's actually left, for
-        // small indexes). Both exist purely to get real timing data before
-        // committing to a steady-state batch size, per the founder's feedback
-        // on spelunk-oss^71/^74 — we no longer time a full default-sized batch
-        // and adapt afterward.
+        // Calibration: first request 1 chunk, second 4 chunks (both clamped to
+        // what's left), to gather timing before committing to a steady-state size.
         let mut this_batch_size = match batch_num {
             1 => CALIBRATION_BATCH_1,
             2 => CALIBRATION_BATCH_2,
@@ -559,15 +390,9 @@ pub(super) async fn run_embed_phase(
         }
         .clamp(1, left);
 
-        // Retry loop for THIS batch: a 408/timeout ("budget exceeded") is
-        // treated as recoverable — either escalate patience (calibration
-        // batch 1 only, where we have no rate estimate yet to size a smaller
-        // request from) or shrink the batch and retry, rather than aborting
-        // the whole run at 0 embedded (spelunk-oss^71/^73/^74 field-failure
-        // follow-up). Any other failure (network error, 5xx, malformed
-        // response) still aborts immediately as before — shrinking/retrying
-        // is specifically a response to "the request was too big/slow for
-        // the budget", not a generic retry-everything policy.
+        // Retry loop for THIS batch: a 408/timeout is recoverable — escalate
+        // patience (calibration batch 1, no rate estimate yet) or shrink and
+        // retry, rather than aborting at 0 embedded. Any other failure aborts.
         let mut escalated_calibration_once = false;
         let bytes = 'retry: loop {
             let request_timeout = match rate.per_entry() {
@@ -576,12 +401,8 @@ pub(super) async fn run_embed_phase(
                 None => FIRST_REQUEST_TIMEOUT,
             };
 
-            // Show which chunks are in flight so a single slow request reads as
-            // progress against a known window, not a frozen bar (spelunk-oss^73).
-            // Prefix with the ETA derived from the measured `RateEstimate`
-            // (spelunk-oss^74 follow-up, PR #513) — NOT indicatif's built-in
-            // `{eta}` token, which misreads this phase's bursty increments as
-            // near-zero throughput (see `format_eta`'s doc comment).
+            // Show which chunks are in flight, prefixed with the `RateEstimate`
+            // ETA (not indicatif's `{eta}` — see `format_eta`).
             let eta_str = format_eta(total.saturating_sub(embedded) as usize, rate.per_entry());
             bar.set_message(format!(
                 "{eta_str}  \u{00b7}  sent {this_batch_size} chunk(s) ({embedded}/{total} done \
@@ -611,34 +432,18 @@ pub(super) async fn run_embed_phase(
 
             match outcome {
                 Ok(bytes) => {
-                    // Fold this batch's measured rate in and re-estimate:
-                    // later batches' sizes (and timeouts) track the current
-                    // rate rather than being fixed from a single early
-                    // sample, so a rate that drifts mid-run is picked up
-                    // within a couple of batches (spelunk-oss^71/^74). The
-                    // freshly-updated `rate` is also what the per-chunk
-                    // `bar.inc(1)` loop below re-derives the displayed ETA
-                    // from (via `format_eta`) — NOT indicatif's own `{eta}`
-                    // estimator, which reads this phase's bursty increments
-                    // (all landing at once, right here) as near-zero
-                    // throughput (spelunk-oss^74 follow-up, PR #513).
+                    // Fold this batch's rate in so later sizes/timeouts track
+                    // the current rate. Also what the `bar.inc(1)` loop below
+                    // reads for the displayed ETA (via `format_eta`).
                     rate.update(started.elapsed(), batch.len());
                     break 'retry bytes;
                 }
                 Err(EmbedBatchError::BudgetExceeded(e)) if this_batch_size == 1 => {
-                    // Can't shrink below 1 chunk. For calibration batch 1
-                    // specifically (no rate estimate yet), escalate patience
-                    // once (FIRST_REQUEST_TIMEOUT → MAX_REQUEST_TIMEOUT) —
-                    // this is the "retry the calibration batch once with
-                    // escalated patience" behaviour: a single chunk that took
-                    // >FIRST_REQUEST_TIMEOUT might still legitimately finish
-                    // given the full 1800s ceiling (e.g. genuine cold-start
-                    // cost on very slow hardware), and giving up at 0/total
-                    // embedded on the very first request is the worst
-                    // possible failure mode. Only escalate once; if it still
-                    // fails at the max budget, this really is unrecoverable
-                    // (or a persistently mis-configured/underpowered server)
-                    // and we must stop.
+                    // Can't shrink below 1 chunk. On calibration batch 1 (no
+                    // rate estimate yet), escalate patience once
+                    // (FIRST_REQUEST_TIMEOUT → MAX_REQUEST_TIMEOUT) before
+                    // giving up: a cold single chunk on slow hardware may still
+                    // finish given the full budget.
                     if !escalated_calibration_once && rate.per_entry().is_none() {
                         escalated_calibration_once = true;
                         eprintln!(
@@ -648,32 +453,21 @@ pub(super) async fn run_embed_phase(
                         );
                         continue 'retry;
                     }
-                    // A batch failing (even after the calibration escalation
-                    // above) must NOT abort the whole run with an `Err`:
-                    // embeddings already committed from prior batches stay in
-                    // the DB, and a re-run picks up the rest via the
-                    // missing-embedding backfill (spelunk-oss^72). Report and
-                    // return the count embedded so far — propagating an `Err`
-                    // here would unwind the command before `stats()` runs and
-                    // discard the visible progress (spelunk-oss^71).
+                    // Don't abort the whole run: prior batches stay committed
+                    // and a re-run backfills the rest. Return the count so far —
+                    // an `Err` would unwind before `stats()` and discard the
+                    // visible progress.
                     report_embed_failure(&bar, embedded, total, &server_url, e);
                     return Ok(embedded);
                 }
                 Err(EmbedBatchError::BudgetExceeded(e)) => {
-                    // Steady-state (or post-calibration) batch exceeded the
-                    // server's request budget: treat this as "the server's
-                    // effective budget is smaller than this batch", not as a
-                    // fatal error — shrink and retry rather than discarding
-                    // all subsequent progress. Halve (floor 1) and also fold
-                    // a pessimistic sample into the rate estimate so
-                    // subsequent `next_batch_size` calls don't immediately
-                    // re-derive the same too-large size.
+                    // Steady-state batch exceeded the server's budget: shrink
+                    // (halve, floor 1) and retry rather than discarding progress.
                     let shrunk = (this_batch_size / 2).max(1);
                     if shrunk == this_batch_size {
-                        // Already at the floor and still failing — no smaller
-                        // batch to try; this is the batch-of-1 branch above,
-                        // so unreachable in practice, but guards against an
-                        // infinite loop if reached some other way.
+                        // Already at the floor and still failing (the batch-of-1
+                        // branch above handles this; guards against an infinite
+                        // loop otherwise).
                         report_embed_failure(&bar, embedded, total, &server_url, e);
                         return Ok(embedded);
                     }
@@ -681,26 +475,17 @@ pub(super) async fn run_embed_phase(
                         "index/embed batch of {this_batch_size} chunks exceeded the server's \
                          request budget (408) — shrinking to {shrunk} chunk(s) and retrying: {e:#}",
                     );
-                    // A 408 tells us this batch's *expected* duration exceeded
-                    // the server's budget: fold in a pessimistic per-entry
-                    // sample (the request_timeout that just failed, spread
-                    // over the batch) so the rate estimate reflects "at least
-                    // this slow", pulling future `next_batch_size` calls down
-                    // rather than immediately re-deriving the same too-large
-                    // batch from a stale, too-optimistic estimate.
+                    // Fold in a pessimistic per-entry sample (the failed timeout
+                    // over the batch) so future `next_batch_size` calls don't
+                    // re-derive the same too-large batch.
                     rate.update(request_timeout, this_batch_size);
                     this_batch_size = shrunk;
                     continue 'retry;
                 }
                 Err(EmbedBatchError::Other(e)) => {
-                    // A batch failing for any other reason (connection reset,
-                    // non-408 non-2xx, malformed response, …) must NOT abort
-                    // the whole run: embeddings already committed from prior
-                    // batches stay in the DB, and a re-run picks up the rest
-                    // via the missing-embedding backfill (spelunk-oss^72).
-                    // Report and stop rather than propagating an Err that
-                    // would unwind the command before `stats()` and discard
-                    // the visible progress (spelunk-oss^71).
+                    // Any other failure: prior batches stay committed and a
+                    // re-run backfills the rest. Report and stop rather than
+                    // propagating an `Err` that would discard the visible progress.
                     report_embed_failure(&bar, embedded, total, &server_url, e);
                     return Ok(embedded);
                 }
@@ -717,12 +502,8 @@ pub(super) async fn run_embed_phase(
             db.insert_embedding(*row_id, &vector)?;
             embedded += 1;
             bar.inc(1);
-            // Refresh the displayed ETA from the just-updated `rate` as each
-            // chunk in this batch lands, so it visibly counts down through a
-            // batch rather than only updating once per request
-            // (spelunk-oss^74 follow-up, PR #513); recomputed fresh each time
-            // rather than cached, since `embedded`/`total.saturating_sub` and
-            // `rate` are cheap and this loop runs at most `MAX_BATCH` times.
+            // Refresh the displayed ETA from the updated `rate` as each chunk
+            // lands, so it counts down through a batch, not once per request.
             let eta_str = format_eta(total.saturating_sub(embedded) as usize, rate.per_entry());
             bar.set_message(format!("{eta_str}  \u{00b7}  {embedded}/{total} embedded"));
         }
@@ -736,29 +517,20 @@ pub(super) async fn run_embed_phase(
 }
 
 /// An `embed_one_batch` failure, distinguishing "the request budget was too
-/// small for this batch" (HTTP 408 from the server's `TimeoutLayer`, or a
-/// client-side `reqwest` timeout expiring first) from every other failure
-/// (connection refused, 5xx, malformed response, …). The distinction matters:
-/// a 408/timeout is actionable and often recoverable by shrinking the batch
-/// and/or escalating patience and retrying (see `run_embed_phase`'s
-/// calibration retry and steady-state shrink-on-408 handling); other failures
-/// are not something retrying the same batch smaller is expected to fix.
+/// small for this batch" (408, or a client-side timeout expiring first) from
+/// every other failure — only the former is worth shrinking and retrying (see
+/// `run_embed_phase`).
 enum EmbedBatchError {
-    /// Server returned `408 Request Timeout`, or the client-side `timeout`
-    /// passed to this call elapsed first (`reqwest::Error::is_timeout()`).
+    /// Server returned 408, or the client-side `timeout` elapsed first.
     BudgetExceeded(anyhow::Error),
-    /// Any other failure (network error, non-408 non-2xx status, malformed
-    /// response body, …).
+    /// Any other failure (network error, non-408 status, malformed body).
     Other(anyhow::Error),
 }
 
-/// Send one embed batch and return the raw little-endian f32 response bytes:
-/// one `EMBEDDING_DIM`-float vector per request chunk, in request order.
-///
-/// Applies a per-request `timeout` (see `batch_timeout`) and validates the
-/// response length before returning, so callers get a single fallible unit they
-/// can treat as all-or-nothing for that batch (spelunk-oss^71). Distinguishes
-/// a 408/timeout failure from every other kind — see [`EmbedBatchError`].
+/// Send one embed batch and return the raw little-endian f32 response bytes: one
+/// `EMBEDDING_DIM`-float vector per chunk, in request order. Applies a
+/// per-request `timeout` (see `batch_timeout`) and validates the response length.
+/// Distinguishes a 408/timeout from other failures — see [`EmbedBatchError`].
 async fn embed_one_batch(
     client: &reqwest::Client,
     url: &str,
@@ -854,10 +626,8 @@ mod tests {
 
     #[test]
     fn resolve_batch_ceiling_clamps_to_server_advertised_max() {
-        // A server that advertises a smaller max_batch_chunks than our own
-        // MAX_BATCH guess must win — the client should never plan around a
-        // batch count the specific server it's talking to won't accept
-        // (spelunk-oss^71/^73/^74, founder directive on server-limits surface).
+        // A server advertising a smaller max_batch_chunks than our MAX_BATCH
+        // guess must win — never plan around a count the server won't accept.
         assert_eq!(resolve_batch_ceiling(0, Some(32)), 32);
         assert_eq!(resolve_batch_ceiling(200, Some(32)), 32);
         // A server-advertised max ABOVE the user's/default ceiling doesn't
@@ -866,7 +636,6 @@ mod tests {
     }
 
     // ── resolve_target_batch_seconds: server-limits-aware target clamping ───
-    // (spelunk-oss^71/^73/^74, founder directive on version-skew handling)
 
     #[test]
     fn resolve_target_batch_seconds_uses_default_when_server_budget_is_generous() {
@@ -909,12 +678,10 @@ mod tests {
     }
 
     // ── next_batch_size: calibration-driven batch sizing ────────────────────
-    // (spelunk-oss^71/^74, founder review on PR #513)
 
     #[test]
     fn next_batch_size_shrinks_for_slow_hardware() {
-        // ~60 s/entry ⇒ a 4-min (240 s) budget fits ~4 entries per batch —
-        // this is the founder's own worked example from the PR review.
+        // ~60 s/entry ⇒ a 240 s budget fits ~4 entries per batch.
         // previous_batch_size=256 so the growth cap doesn't bind here.
         assert_eq!(
             next_batch_size(Duration::from_secs(60), 256, 256, TARGET_BATCH_SECONDS),
@@ -925,9 +692,7 @@ mod tests {
     #[test]
     fn next_batch_size_grows_for_fast_hardware_but_respects_growth_cap() {
         // ~1 s/entry ⇒ a 240 s budget fits 240 entries, but growth from a
-        // previous batch of 4 is capped to GROWTH_FACTOR (8) × 4 = 32 — this
-        // is the fix for the field failure where a single fast sample after a
-        // small calibration batch derived a ~50x-larger batch in one step.
+        // previous batch of 4 is capped to GROWTH_FACTOR (8) × 4 = 32.
         assert_eq!(
             next_batch_size(Duration::from_secs(1), 256, 4, TARGET_BATCH_SECONDS),
             32
@@ -948,10 +713,8 @@ mod tests {
 
     #[test]
     fn next_batch_size_clamps_to_ceiling() {
-        // A very fast rate would derive a batch far above the ceiling (e.g.
-        // the server's hard 256-chunk / 413 limit, or a user-supplied
-        // `--batch-size`); the ceiling wins even when the growth cap (from a
-        // large previous batch) would otherwise allow more.
+        // A very fast rate would derive a batch above the ceiling; the ceiling
+        // wins even when the growth cap would otherwise allow more.
         let t = next_batch_size(Duration::from_millis(1), 256, 256, TARGET_BATCH_SECONDS);
         assert_eq!(t, 256);
         let t = next_batch_size(Duration::from_millis(1), 32, 32, TARGET_BATCH_SECONDS);
@@ -987,7 +750,6 @@ mod tests {
     }
 
     // ── batch_timeout: derive a per-request deadline from the measured rate ──
-    // (spelunk-oss^71)
 
     #[test]
     fn batch_timeout_scales_with_expected_batch_duration() {
@@ -1019,7 +781,6 @@ mod tests {
     }
 
     // ── RateEstimate: continuously re-estimate the per-entry rate ───────────
-    // (spelunk-oss^74 — "keep re-estimating the rate as batches complete")
 
     #[test]
     fn rate_estimate_seeds_from_first_observation() {
@@ -1031,11 +792,9 @@ mod tests {
 
     #[test]
     fn rate_estimate_deweights_the_batch_1_cold_sample_on_second_observation() {
-        // First (calibration batch 1) sample: 1 entry in 10 s ⇒ 10 s/entry,
-        // skewed by one-off cold start. The second sample (calibration batch
-        // 2, at 1 s/entry) must dominate the blend — only
-        // CALIBRATION_BATCH_1_WEIGHT (0.1) of the cold sample survives, not an
-        // even 50/50 split.
+        // Batch 1: 1 entry in 10 s ⇒ 10 s/entry (cold). Batch 2 (1 s/entry) must
+        // dominate — only CALIBRATION_BATCH_1_WEIGHT (0.1) of the cold sample
+        // survives, not a 50/50 split.
         let mut r = RateEstimate::new();
         r.update(Duration::from_secs(10), 1);
         r.update(Duration::from_secs(4), 4); // 1 s/entry
@@ -1053,9 +812,8 @@ mod tests {
 
     #[test]
     fn rate_estimate_third_sample_onward_blends_50_50() {
-        // From the THIRD observation onward (i.e. once the batch-1 cold
-        // sample has already been superseded), later samples blend evenly
-        // with the running estimate — same behaviour as before this fix.
+        // From the third observation onward (batch-1 cold sample already
+        // superseded), later samples blend evenly with the running estimate.
         let mut r = RateEstimate::new();
         r.update(Duration::from_secs(10), 1); // batch 1 (cold): 10s/entry
         r.update(Duration::from_secs(4), 4); // batch 2: 1s/entry -> blended 1.9s/entry
@@ -1070,16 +828,10 @@ mod tests {
 
     #[test]
     fn rate_estimate_reproduces_field_failure_scenario_with_fix() {
-        // Reproduces the founder's field-report numbers (PR #513 review,
-        // 2026-07-05): calibration batch 1 (1 chunk) took ~25s (cold);
-        // calibration batch 2 (4 chunks) took ~4.8s (~1.2s/entry, warm).
-        // Pre-fix, a straight 50/50 blend gave ~13.1s/entry, but
-        // next_batch_size used a DIFFERENT (raw, unblended) sample and
-        // derived a batch of 200 — an inconsistency between the displayed
-        // rate and the batch-size decision, and a batch sized to run for
-        // ~240s against a 30s server budget. Post-fix, the single shared
-        // estimate (de-weighted + growth-capped) must derive something far
-        // smaller and internally consistent.
+        // Batch 1 (1 chunk) ~25s cold; batch 2 (4 chunks) ~4.8s (~1.2s/entry
+        // warm). The single shared estimate (de-weighted + growth-capped) must
+        // derive a small, internally consistent batch — not the unblended
+        // ~50x leap an earlier build produced.
         let mut r = RateEstimate::new();
         r.update(Duration::from_secs(25), 1); // batch 1: cold
         r.update(Duration::from_millis(4800), 4); // batch 2: 1.2s/entry warm
@@ -1089,9 +841,8 @@ mod tests {
             (per_entry.as_secs_f64() - 3.58).abs() < 1e-9,
             "expected 3.58s/entry, got {per_entry:?}"
         );
-        // The SAME estimate feeds next_batch_size (growth-capped from the
-        // previous batch of 4) — this must land far below the old field
-        // failure's 200-chunk leap.
+        // The same estimate feeds next_batch_size, growth-capped from the
+        // previous batch of 4.
         let batch_3_size = next_batch_size(per_entry, 256, 4, TARGET_BATCH_SECONDS);
         assert_eq!(
             batch_3_size, 32,
@@ -1099,11 +850,8 @@ mod tests {
              240/3.58≈67 the estimate alone would suggest, and nowhere near the field \
              failure's 200"
         );
-        // And the resulting batch's expected duration must be far below the
-        // field failure's ~240s (the old, un-capped 200-chunk batch's target
-        // duration) — this test uses the uncapped TARGET_BATCH_SECONDS
-        // directly (not `resolve_target_batch_seconds`, covered separately
-        // above) so the growth cap alone is what's under test here.
+        // The resulting batch's expected duration must stay well under ~240s;
+        // uses the uncapped TARGET_BATCH_SECONDS so the growth cap alone is under test.
         let expected_duration = per_entry.as_secs_f64() * batch_3_size as f64;
         assert!(
             expected_duration < 150.0,
@@ -1119,22 +867,16 @@ mod tests {
         assert!(r.per_entry().is_none());
     }
 
-    // ── embed_progress_style: the template (message-only ETA, no indicatif
-    //    `{eta}` token) must build ──────────────────────────────────────────
-    // (spelunk-oss^74)
+    // ── embed_progress_style: the message-only-ETA template must build ──────
 
     #[test]
     fn embed_progress_style_builds_without_indicatif_eta_token() {
-        // `embed_progress_style()` calls `ProgressStyle::with_template(..).unwrap()`.
-        // A malformed template (e.g. a typo'd token) would panic at that unwrap the
-        // first time the embed phase runs. Building it here proves the style is
-        // well-formed and wired up, and applying it to a bar exercises the same path
-        // the embed phase takes when it calls `bar.set_style(embed_progress_style())`.
+        // A malformed template would panic at the `.unwrap()` the first time the
+        // embed phase runs; building and applying it here proves it's well-formed.
         let style = embed_progress_style();
         let bar = ProgressBar::hidden();
         bar.set_style(style);
-        // Driving the bar the way the embed phase does (steady tick + per-chunk
-        // inc + message updates) must not panic.
+        // Driving the bar the way the embed phase does must not panic.
         bar.enable_steady_tick(Duration::from_millis(120));
         bar.set_length(10);
         bar.tick();
@@ -1143,9 +885,7 @@ mod tests {
         bar.finish_and_clear();
     }
 
-    // ── format_eta: display ETA derived from the measured RateEstimate, not
-    //    indicatif's bursty built-in estimator ───────────────────────────────
-    // (spelunk-oss^74 follow-up, PR #513 — founder-observed "ETA 153y" bug)
+    // ── format_eta: display ETA derived from the measured RateEstimate ──────
 
     #[test]
     fn format_eta_shows_calibrating_when_rate_unknown() {
@@ -1185,11 +925,8 @@ mod tests {
 
     #[test]
     fn format_eta_caps_pathologically_large_duration_instead_of_showing_absurd_value() {
-        // THE regression guard: this is the shape of the founder-observed
-        // "ETA 153y" bug. A pathological per_entry (e.g. folded in from a
-        // MAX_REQUEST_TIMEOUT-derived 408 sample) times a large remaining
-        // count must render the capped ">24h" string — never an overflowed,
-        // panicking, or absurdly large (years-scale) computed value.
+        // A pathological per_entry times a large remaining count must render the
+        // capped ">24h" string — never an overflowed, panicking, or years-scale value.
         let eta = format_eta(1_000_000, Some(Duration::from_secs(10_000_000)));
         assert_eq!(eta, "ETA >24h");
         assert!(
@@ -1200,9 +937,8 @@ mod tests {
 
     #[test]
     fn format_eta_caps_at_boundary_just_above_24h() {
-        // Exactly at/above the 24h cap must show the capped string, not a
-        // literal "24h00m" or similar — the cap is a hard ceiling on what's
-        // ever displayed, not just a guard against overflow.
+        // At/above the 24h cap must show the capped string, not a literal
+        // "24h00m" — the cap is a hard display ceiling, not just an overflow guard.
         let eta = format_eta(1, Some(Duration::from_secs(24 * 60 * 60 + 1)));
         assert_eq!(eta, "ETA >24h");
     }
@@ -1217,7 +953,7 @@ mod tests {
     }
 
     // ── run_embed_phase: a mid-run batch failure must not discard earlier,
-    //    already-committed embeddings (spelunk-oss^71) ─────────────────────────
+    //    already-committed embeddings ──────────────────────────────────────────
 
     use std::sync::OnceLock;
 
@@ -1291,8 +1027,8 @@ mod tests {
         server_tier_with_limits(url, None)
     }
 
-    /// Same as [`server_tier`], but with `server_limits` set — used by tests
-    /// that exercise the version-skew clamping (spelunk-oss^71/^73/^74).
+    /// Same as [`server_tier`], but with `server_limits` set — for tests that
+    /// exercise the version-skew clamping.
     fn server_tier_with_limits(url: String, server_limits: Option<ServerLimits>) -> Tier {
         Tier::Server {
             url,
@@ -1305,12 +1041,9 @@ mod tests {
 
     #[tokio::test]
     async fn batch_failure_keeps_prior_batches_and_stops_gracefully() {
-        // 6 chunks with a small ceiling so calibration quickly ramps toward a
-        // multi-chunk steady-state batch; the mock server's third response
-        // (whichever batch it lands on) fails with 500. The run must persist
-        // every chunk embedded before the failure, NOT error, and report only
-        // the successfully-embedded count — proving a mid-run failure never
-        // discards batches the server already computed (spelunk-oss^71).
+        // 6 chunks, small ceiling; the mock's third response fails with 500.
+        // The run must persist every chunk embedded before the failure, NOT
+        // error, and report only the successfully-embedded count.
         let mock = MockServer::start().await;
         // The first two requests (calibration: 1 chunk, then up to 4 chunks)
         // succeed; everything after that fails, so the run stops partway
@@ -1469,16 +1202,12 @@ mod tests {
         assert_eq!(embedded, 0);
     }
 
-    // ── 408/timeout retry-then-shrink behaviour (spelunk-oss^71/^73/^74,
-    //    PR #513 field-failure fix) ──────────────────────────────────────────
+    // ── 408/timeout retry-then-shrink behaviour ────────────────────────────
 
     #[tokio::test]
     async fn calibration_batch_1_408_is_retried_and_succeeds() {
-        // The very first request (calibration batch of 1) 408s once, then
-        // succeeds on retry. This must NOT be treated as a fatal failure at
-        // 0/total embedded — the whole point of the escalated-patience retry
-        // is that a single calibration request timing out must not kill the
-        // phase outright (the exact founder-reported field failure).
+        // The first request (calibration batch of 1) 408s once, then succeeds
+        // on retry — must not be fatal at 0/total embedded.
         let mock = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path_regex(r"^/v1/projects/.+/index/embed$"))

--- a/crates/spelunk-core/src/embeddings/mod.rs
+++ b/crates/spelunk-core/src/embeddings/mod.rs
@@ -10,29 +10,20 @@ pub use spelunk_embed::MODEL_ID;
 pub const EMBEDDING_DIM: usize = 896;
 
 /// Serialise a float vector to raw little-endian f32 bytes for a sqlite-vec
-/// `float[N]` column.
-///
-/// Used for the memory-note vector table (`note_embeddings`, `FLOAT[896]`),
-/// which stays full-precision: the table is small, so the int8 footprint win
-/// that justifies [`vec_to_int8_blob`] for the large chunk/snapshot index does
-/// not apply, and float keeps the memory search path free of the int8
-/// distance-rescale (`INT8_SCALE`). See `docs/architecture.md` ("Why two
+/// `float[N]` column. Used for the full-precision memory-note vector table
+/// (`note_embeddings`, `FLOAT[896]`). See `docs/architecture.md` ("Why two
 /// vector-storage formats").
 pub fn vec_to_blob(v: &[f32]) -> Vec<u8> {
     v.iter().flat_map(|f| f.to_le_bytes()).collect()
 }
 
 /// Quantise an L2-normalised float vector to `int8` bytes for a sqlite-vec
-/// `int8[N]` column. Embeddings produced by F2LLM are unit vectors (components
-/// in `[-1, 1]`), so each component maps to `round(x * 127)` clamped to
-/// `[-127, 127]`. This is 4× smaller than f32 storage; because the scaling is
-/// uniform, L2 distance ranking is preserved (a sqlite-vec int8 L2 distance is
-/// ~127× the corresponding f32 distance — callers rescale by `INT8_SCALE`).
-///
-/// Used only for the chunk/snapshot vector tables (`embeddings`,
-/// `snapshot_embeddings`); memory note vectors keep full-precision f32 storage
-/// via [`vec_to_blob`]. See `docs/architecture.md` ("Why two vector-storage
-/// formats") for why the split is deliberate.
+/// `int8[N]` column. F2LLM vectors are unit vectors, so each component maps to
+/// `round(x * 127)` clamped to `[-127, 127]` — 4× smaller than f32, and since
+/// the scaling is uniform L2 ranking is preserved (callers rescale by
+/// `INT8_SCALE`). Used only for the chunk/snapshot tables (`embeddings`,
+/// `snapshot_embeddings`). See `docs/architecture.md` ("Why two vector-storage
+/// formats").
 pub fn vec_to_int8_blob(v: &[f32]) -> Vec<u8> {
     v.iter()
         .map(|&x| ((x * 127.0).round().clamp(-127.0, 127.0) as i8) as u8)

--- a/crates/spelunk-embed/src/embedder_native.rs
+++ b/crates/spelunk-embed/src/embedder_native.rs
@@ -55,19 +55,10 @@ fn single_chunk_budget(total_ram_bytes: u64) -> u64 {
 }
 
 /// Derive the maximum single-chunk token count that keeps the attention scratch
-/// within `budget_bytes`.
-///
-/// In `forward_one` (batch = 1) the dominant allocation is the attention score
-/// tensor `[1, n_head, seq, seq]` in f32 — and the softmax produces a second
-/// tensor of the same shape — so peak scratch is bounded by
-/// `n_head × seq² × 4 bytes`. (Anchor: at seq = 40 960, 16 × 40960² × 4 ≈ 100
-/// GiB, matching the observed ~107 GB OOM on a full-length 40 k-token chunk.)
-///
-/// Solving `n_head × seq² × 4 ≤ budget` for `seq` gives the cap. We also clamp
-/// to `MAX_SEQ_LEN` (the model's position-embedding ceiling) so the result is
-/// never larger than the model can attend over anyway.
-///
-/// At 2 GiB → ~5 792 tokens; at 4 GiB → ~8 192 tokens.
+/// within `budget_bytes`. In `forward_one` (batch = 1) the dominant allocation
+/// is the attention score tensor `[1, n_head, seq, seq]` in f32, so peak scratch
+/// is `n_head × seq² × 4 bytes`. Solving for `seq` gives the cap, clamped to
+/// `MAX_SEQ_LEN`. At 2 GiB → ~5 792 tokens; at 4 GiB → ~8 192.
 fn derive_token_cap(budget_bytes: u64, n_head: usize) -> usize {
     let bytes_per_seq_sq = (n_head as u64) * 4;
     // seq <= sqrt(budget / (n_head * 4))
@@ -306,25 +297,22 @@ impl Qwen3EmbedWeights {
         Ok(self.final_norm.forward(&h)?)
     }
 
-    /// Padded batch forward pass: all sequences in `batch_ids` are right-padded
-    /// to the longest sequence in the batch.  Returns one L2-normalised
-    /// embedding vector per input sequence in the same order.
+    /// Padded batch forward pass: sequences right-padded to the longest in the
+    /// batch. Returns one L2-normalised embedding per input, in order.
     ///
-    /// On CPU, sequences are forwarded together as a single BLAS call (batch
-    /// dim > 1), amortising per-call overhead.  On Metal/GPU the sequential
-    /// path is used instead: Metal's buffer pool grows unboundedly with batched
-    /// inference because `(b × n_head × seq²)` attention tensors are never
-    /// compacted between forward passes, causing OOM for large codebases.
-    /// Sequential GPU inference was the pre-batching baseline and is still fast.
+    /// CPU forwards the batch as a single BLAS call (batch dim > 1). Metal/GPU
+    /// uses the sequential path instead: its buffer pool grows unboundedly with
+    /// batched inference because `(b × n_head × seq²)` attention tensors are
+    /// never compacted between passes → OOM.
     fn embed_batch(&self, batch_ids: &[&[u32]]) -> Result<Vec<Vec<f32>>> {
         let b = batch_ids.len();
         assert!(b > 0);
 
         let max_seq = batch_ids.iter().map(|ids| ids.len()).max().unwrap_or(0);
 
-        // Sequential path: single sequences, GPU/Metal devices (buffer pool grows
-        // unboundedly with batching), or long sequences where the attention tensor
-        // (b × n_head × max_seq²) would exceed BATCH_MAX_SEQ and cause OOM.
+        // Sequential path: single sequences, GPU/Metal (buffer pool grows
+        // unboundedly with batching), or sequences past BATCH_MAX_SEQ (batched
+        // attention tensor would OOM).
         if b == 1 || !matches!(self.device, Device::Cpu) || max_seq > BATCH_MAX_SEQ {
             let mut out = Vec::with_capacity(b);
             for ids in batch_ids {
@@ -413,12 +401,11 @@ impl Qwen3EmbedWeights {
         let k = rope(&k.contiguous()?, &cos, &sin)?;
 
         // Grouped query attention: expand K, V from n_kv_heads to n_heads.
-        // MUST repeat-interleave (each kv head duplicated n_rep times contiguously,
-        // [kv0,kv0,kv1,kv1,…]) so query head j attends through kv head j/n_rep —
-        // matching HF's repeat_kv. `Tensor::repeat` instead *tiles* the kv dim
-        // ([kv0,…,kvN, kv0,…,kvN]), silently pairing most query heads with the
-        // wrong K/V projection and collapsing retrieval quality (spelunk-oss#19).
-        // candle's repeat_kv returns the correct interleaved order, contiguous.
+        // MUST repeat-interleave (each kv head duplicated n_rep times
+        // contiguously, [kv0,kv0,kv1,kv1,…]) so query head j attends through kv
+        // head j/n_rep. `Tensor::repeat` instead *tiles* ([kv0,…,kvN,kv0,…,kvN]),
+        // silently pairing most query heads with the wrong K/V. `repeat_kv`
+        // returns the correct interleaved order, contiguous.
         let n_rep = self.n_head / self.n_kv_head;
         let k = repeat_kv(k, n_rep)?;
         let v = repeat_kv(v, n_rep)?;
@@ -494,23 +481,13 @@ fn causal_mask(seq: usize, dtype: DType, device: &Device) -> Result<Tensor> {
 
 impl NativeEmbedder {
     /// Load the F2LLM-v2-330M embedder from local files already on disk, with
-    /// **zero network access**.
+    /// zero network access — this crate carries no download dependency
+    /// (`spelunk-server` resolves the artifacts via Hugging Face Hub first).
     ///
-    /// This is the entry point for callers that fetch the model artifacts
-    /// themselves — this crate carries no download/fetch dependency of its own.
-    /// (`spelunk-server` resolves the artifacts via its own Hugging Face Hub
-    /// acquisition path and then calls this.) All three inputs must be present
-    /// locally:
-    ///
-    /// * `gguf_path` points at the Q8_0-quantized GGUF
-    ///   (`f2llm-v2-330m-q8_0.gguf`).
-    /// * `tokenizer_path` points at the model's `tokenizer.json`.
-    /// * `config_path` points at the model's `config.json` (a Qwen3 config).
-    ///
-    /// The GGUF, tokenizer, and config must all come from the same F2LLM-v2-330M
-    /// revision so the weight keys and tensor shapes line up. Uses Metal/GPU on
-    /// macOS when built with the `metal` cargo feature, CPU otherwise. No files
-    /// are downloaded, written, or deleted.
+    /// All three must be present locally and from the same model revision so the
+    /// weight keys and tensor shapes line up: `gguf_path` (Q8_0 GGUF),
+    /// `tokenizer_path` (`tokenizer.json`), `config_path` (Qwen3 `config.json`).
+    /// Uses Metal/GPU on macOS with the `metal` feature, CPU otherwise.
     pub fn load_from_path(
         gguf_path: &Path,
         tokenizer_path: &Path,
@@ -633,17 +610,12 @@ impl crate::EmbeddingBackend for NativeEmbedder {
                 .lock()
                 .map_err(|_| anyhow::anyhow!("native embedder lock poisoned"))?;
 
-            // 1. Tokenize all texts upfront.
-            //
-            // Cap each sequence to `effective_cap` tokens. `MAX_SEQ_LEN` is the
-            // model's position-embedding ceiling; `token_cap` is the smaller,
-            // memory-budget-derived bound that keeps the single-chunk attention
-            // scratch (`[1, n_head, seq, seq]` f32) within the RAM budget. A
-            // single ~40 k-token chunk (e.g. a lock/data/minified file) would
-            // otherwise allocate ~100 GB of attention scores and OOM/abort the
-            // whole index — so we *truncate* oversized chunks here, preserving
-            // the leading (partial) signal rather than aborting. (token_cap == 0
-            // in unit-test fixtures means "no extra cap".)
+            // 1. Tokenize all texts upfront, capping each to `effective_cap`.
+            // `token_cap` is the memory-budget-derived bound that keeps the
+            // single-chunk attention scratch (`[1, n_head, seq, seq]` f32) within
+            // RAM; a ~40 k-token chunk would otherwise allocate ~100 GB and OOM
+            // the whole index, so truncate (preserving the leading signal).
+            // (token_cap == 0 in unit-test fixtures means "no extra cap".)
             let effective_cap = if guard.token_cap == 0 {
                 MAX_SEQ_LEN
             } else {
@@ -732,19 +704,18 @@ mod tests {
         (0..n_head).map(|h| flat[h * per_head] as usize).collect()
     }
 
-    /// Regression test for spelunk-oss#19: grouped-query-attention K/V expansion
-    /// must **repeat-interleave** the kv-head dim (`[kv0,kv0,kv1,kv1,…]`) so query
-    /// head `j` attends through kv head `j / n_rep`. The original bug used
-    /// `Tensor::repeat`, which *tiles* (`[kv0..kvN, kv0..kvN]`) and silently paired
-    /// 15 of 16 query heads with the wrong K/V projection, collapsing retrieval.
-    /// This guards the `repeat_kv` call in `Qwen3EmbedWeights::attn`.
+    /// Grouped-query-attention K/V expansion must repeat-interleave the kv-head
+    /// dim (`[kv0,kv0,kv1,kv1,…]`) so query head `j` attends through kv head
+    /// `j / n_rep`. `Tensor::repeat` tiles instead (`[kv0..kvN, kv0..kvN]`),
+    /// silently pairing 15 of 16 query heads with the wrong K/V. Guards the
+    /// `repeat_kv` call in `Qwen3EmbedWeights::attn`.
     #[test]
     fn repeat_kv_interleaves_gqa_heads_not_tiles() {
         // F2LLM-v2-330M: 16 attention heads / 8 kv heads → n_rep = 2.
         let (n_kv, n_rep, seq, head_dim) = (8usize, 2usize, 3usize, 4usize);
         let kv = headed_kv(n_kv, seq, head_dim);
 
-        // Production path (the #19 fix).
+        // Production path.
         let expanded = repeat_kv(kv.clone(), n_rep).unwrap();
         assert_eq!(expanded.dims4().unwrap(), (1, n_kv * n_rep, seq, head_dim));
 
@@ -756,7 +727,7 @@ mod tests {
             "repeat_kv must repeat-interleave kv heads (spelunk-oss#19)"
         );
 
-        // The #19 bug: `Tensor::repeat` tiles instead — [kv0..kv7, kv0..kv7].
+        // Tiling bug: `Tensor::repeat` → [kv0..kv7, kv0..kv7].
         let tiled = kv.repeat(&[1, n_rep, 1, 1]).unwrap();
         let tiled_order: Vec<usize> = (0..n_kv).chain(0..n_kv).collect();
         assert_eq!(head_sources(&tiled), tiled_order);
@@ -782,7 +753,7 @@ mod tests {
         );
     }
 
-    // ── single-chunk memory-budget cap (spelunk-oss#17) ───────────────────────
+    // ── single-chunk memory-budget cap ────────────────────────────────────────
 
     /// Budget selection keys off total system RAM: 2 GiB at/below the 16 GiB
     /// threshold, 4 GiB above it.
@@ -822,10 +793,8 @@ mod tests {
         assert!(cap_4g > cap_2g);
     }
 
-    /// A 40 k-token chunk under the old (uncapped) path would allocate the
-    /// attention scratch that caused the ~107 GB OOM; the cap brings it to a
-    /// bounded size. Document the before/after scratch sizes here so the
-    /// regression is captured in code, not just the PR body.
+    /// A 40 k-token chunk uncapped would allocate ~100 GiB of attention scratch;
+    /// the cap brings it within budget.
     #[test]
     fn oversized_chunk_scratch_drops_below_budget() {
         let scratch = |seq: usize| (N_HEAD as u64) * (seq as u64) * (seq as u64) * 4;
@@ -869,16 +838,12 @@ mod tests {
 
     // ── L2 normalisation invariant ────────────────────────────────────────────
     //
-    // The public embedding contract is "896-dim, L2-normalised". The end-to-end
-    // proof of that runs through the ignored network tests in spelunk-server's
-    // `embed_hub`; these pin the normalisation step itself (the last thing each
-    // embedding passes through) without needing the model on disk, so a
-    // regression in `l2_normalise` is caught by the fast, offline suite too.
+    // Contract: "896-dim, L2-normalised". These pin the normalisation step
+    // without needing the model on disk; the end-to-end proof runs through the
+    // ignored network tests in spelunk-server's `embed_hub`.
 
-    /// A non-zero vector must come out with unit L2 norm, and its direction must
-    /// be preserved (each component scaled by the same factor). This is the
-    /// invariant the ignored `*_896_dim` / `embeddings_discriminate` tests assert
-    /// end-to-end (`norm ≈ 1.0`), pinned here directly on the normaliser.
+    /// A non-zero vector must come out with unit L2 norm and preserved direction
+    /// (each component scaled by the same factor).
     #[test]
     fn l2_normalise_yields_unit_norm_and_preserves_direction() {
         let original = [3.0f32, 0.0, 4.0]; // norm 5
@@ -896,10 +861,8 @@ mod tests {
         }
     }
 
-    /// The zero vector has no direction, so `l2_normalise` must leave it untouched
-    /// rather than divide by zero and produce NaNs. (A padded/empty forward pass
-    /// could in principle yield an all-zero hidden state; the normaliser must not
-    /// turn that into NaNs that would poison the int8 index.)
+    /// The zero vector must be left untouched, not divide-by-zero into NaNs that
+    /// would poison the int8 index.
     #[test]
     fn l2_normalise_leaves_zero_vector_finite() {
         let mut v = [0.0f32; 4];
@@ -910,10 +873,8 @@ mod tests {
         );
     }
 
-    /// The advertised embedding dimension is the F2LLM-v2-330M hidden size (896).
-    /// Pin the public `DIM` constant so an accidental change to the exported
-    /// contract (which the int8 vec0 index and every consumer depend on) fails a
-    /// cheap, offline test rather than only surfacing under the ignored model run.
+    /// Pin the public `DIM` constant (896, F2LLM-v2-330M hidden size) so an
+    /// accidental change to the exported contract fails a cheap offline test.
     #[test]
     fn dim_is_f2llm_hidden_size() {
         assert_eq!(
@@ -922,14 +883,8 @@ mod tests {
         );
     }
 
-    /// End-to-end semantic-discrimination check over the real model. Ignored by
-    /// default: it downloads ~650 MB of weights and runs inference. Run with
-    /// `cargo test -p spelunk-embed -- --ignored embeddings_discriminate`.
-    ///
     /// `load_from_path` must do no network access: with a missing GGUF it fails
-    /// fast on the local-file check rather than reaching out to the Hub. This is
-    /// the offline-load contract for callers that supply the model artifacts
-    /// themselves, and runs without downloading anything.
+    /// fast on the local-file check rather than reaching out to the Hub.
     #[test]
     fn load_from_path_missing_gguf_errors_without_network() {
         let dir = tempfile::tempdir().unwrap();
@@ -947,13 +902,9 @@ mod tests {
         );
     }
 
-    /// Stronger offline guarantee: even when the GGUF *exists* (so the fail-fast
-    /// existence check passes), `load_from_path` must resolve the tokenizer and
-    /// config from the local paths it was handed and error locally — never fall
-    /// back to a Hub download for a missing/invalid artifact. Here the GGUF is
-    /// present but the tokenizer file is absent, so the load must fail on the
-    /// local tokenizer read (`loading tokenizer from ...`), proving the code
-    /// past the existence guard also stays on disk. Runs with no network.
+    /// Stronger offline guarantee: even when the GGUF exists (existence check
+    /// passes), a missing tokenizer must fail on the local read, never a Hub
+    /// download — proving the code past the existence guard stays on disk.
     #[test]
     fn load_from_path_present_gguf_missing_tokenizer_errors_locally() {
         let dir = tempfile::tempdir().unwrap();
@@ -968,9 +919,7 @@ mod tests {
             Ok(_) => panic!("an empty GGUF with no tokenizer must be a load error"),
             Err(e) => format!("{e:#}"),
         };
-        // The error must name the local tokenizer path (a filesystem read),
-        // never a Hub URL / download. This is the regression guard against a
-        // future Hub fallback slipping into the post-existence-check path.
+        // The error must name the local tokenizer path, never a Hub URL/download.
         assert!(
             msg.contains("loading tokenizer from")
                 && msg.contains(&tokenizer.display().to_string()),
@@ -982,32 +931,21 @@ mod tests {
         );
     }
 
-    // End-to-end "load from a real local GGUF/tokenizer/config and embed"
-    // tests — including the `token_cap()` trait-method proof
-    // (`native_embedder_reports_its_token_cap`) — live in `spelunk-server`'s
-    // `embed_hub` module (ignored by default; it uses that crate's Hugging
-    // Face Hub path to prime the local cache artifacts this crate's
-    // `load_from_path` then reads with zero network access). This crate has
-    // no way to acquire those artifacts itself.
+    // End-to-end "load a real GGUF/tokenizer/config and embed" tests (including
+    // the `token_cap()` proof) live in spelunk-server's `embed_hub`, which can
+    // acquire the model artifacts this crate can't.
 
-    /// `token_cap()` (the `EmbeddingBackend` trait method `/v1/health`'s
-    /// `limits.embedder_token_cap` reads) must report the same value
-    /// `derive_token_cap`/`single_chunk_budget` compute for a given
-    /// budget/host-RAM pair — not `None` and not some other constant. This is
-    /// a pure-math check against the private helpers (no model load), so it
-    /// runs unconditionally; the live end-to-end proof against a real loaded
-    /// `NativeEmbedder` is `embed_hub::tests::native_embedder_reports_its_token_cap`
-    /// (ignored by default — downloads the model).
+    /// The `token_cap()` derivation (`derive_token_cap`/`single_chunk_budget`)
+    /// must be stable and non-degenerate for the host's budget. Pure-math check
+    /// against the private helpers; the live proof against a loaded embedder is
+    /// `embed_hub::tests::native_embedder_reports_its_token_cap`.
     #[test]
     fn token_cap_matches_derive_token_cap_for_host_budget() {
         let budget = single_chunk_budget(total_system_ram());
         let expected_cap = derive_token_cap(budget, N_HEAD);
 
-        // `EmbedderSlotInner`/`NativeEmbedder.inner.token_cap` (the field
-        // `token_cap()` reads) is set from exactly this derivation at load
-        // time (see `NativeEmbedder::from_files`/`load_from_path`) — assert
-        // the derivation itself is stable and non-degenerate rather than
-        // duplicating a full model load here.
+        // `token_cap` is set from this derivation at load time (see
+        // `from_files`); assert the derivation is stable rather than loading a model.
         assert!(expected_cap >= 1, "derived cap must be usable");
         assert!(
             expected_cap <= MAX_SEQ_LEN,

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -21,7 +21,7 @@ use utoipa::ToSchema;
 use super::auth::AuthContext;
 use super::{AppError, AppState, EmbedderState, ErrorBody};
 
-// ── Input validation caps (V1-SERVER-AUDIT §4 / spelunk-oss^60) ────────────────
+// ── Input validation caps ─────────────────────────────────────────────────────
 
 /// Max length (chars) for a memory entry's `title`.
 pub const MAX_TITLE_LEN: usize = 500;
@@ -88,12 +88,10 @@ fn validate_project_slug(slug: &str) -> Result<(), AppError> {
     Ok(())
 }
 
-/// Resolve the client's IP address for rate-limiting: prefer the leftmost
-/// `X-Forwarded-For` entry when present (the server is expected to sit behind
-/// a trusted proxy in shared/team deployments — see ADR-056 tenancy model),
-/// falling back to the TCP peer address from `ConnectInfo`. Returns a stable
-/// string key; when neither is available, falls back to a constant so all
-/// such requests share one bucket rather than bypassing rate limiting.
+/// Resolve the client's IP for rate-limiting: prefer the leftmost
+/// `X-Forwarded-For` entry (the server sits behind a trusted proxy in team
+/// deployments — see ADR-056), else the TCP peer. Falls back to a constant so
+/// keyless requests share one bucket rather than bypassing the limit.
 fn client_ip_key(headers: &HeaderMap, peer: Option<SocketAddr>) -> String {
     if let Some(xff) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) {
         let first = xff.split(',').next().unwrap_or("").trim();
@@ -108,11 +106,8 @@ fn client_ip_key(headers: &HeaderMap, peer: Option<SocketAddr>) -> String {
 }
 
 /// Test-only override for the generation budget `llm_generate_with_timeout`
-/// enforces. Production code always uses `super::REQUEST_TIMEOUT` (30s); this
-/// lets tests inject a millisecond-scale budget so a genuinely-hanging LLM
-/// backend can be proven cut off without the test itself waiting 30+ real
-/// seconds. `#[cfg(test)]`-gated: compiled out of (and inert in) the release
-/// binary. See `handlers::tests::explore_cuts_off_hanging_llm_backend`.
+/// enforces (production uses `super::REQUEST_TIMEOUT`). Lets tests inject a
+/// millisecond-scale budget. `#[cfg(test)]`-gated, inert in the release binary.
 #[cfg(test)]
 static GENERATION_TIMEOUT_OVERRIDE: std::sync::OnceLock<std::sync::Mutex<Option<Duration>>> =
     std::sync::OnceLock::new();
@@ -144,25 +139,14 @@ fn generation_timeout() -> Duration {
     super::REQUEST_TIMEOUT
 }
 
-/// Run an LLM backend's `generate` call with a wall-clock budget, so a
-/// hung/slow backend can't hold the spawned generation task (and the SSE
-/// connection + channel it feeds) open forever.
+/// Run an LLM backend's `generate` call with a wall-clock budget, so a hung/slow
+/// backend can't hold the spawned generation task (and the SSE connection it
+/// feeds) open forever.
 ///
-/// **Why this exists (spelunk-oss^60 follow-up):** `/explore` and
-/// `/llm/complete` construct their SSE `Response` and return it as soon as
-/// the stream is built, handing the actual generation off to a detached
-/// `tokio::spawn`. The handler `Future` that `TimeoutLayer` wraps therefore
-/// resolves immediately — the layer never sees the generation work at all, so
-/// the router-level 30s timeout does not bound these two endpoints the way it
-/// bounds every synchronous handler. This wraps the generation call itself
-/// with the same budget so a hung backend still can't hold the connection
-/// open indefinitely, closing that gap without changing the SSE framing.
-/// (Verified failing without this wrapper by
-/// `handlers::tests::normal_route_exceeding_timeout_returns_408`, which drove
-/// `/explore` against a backend that never returns. The wrapper's own
-/// effectiveness — that it actually cuts off a hung backend within budget —
-/// is proved directly by
-/// `handlers::tests::explore_cuts_off_hanging_llm_backend`.)
+/// `/explore` and `/llm/complete` return their SSE `Response` as soon as the
+/// stream is built and hand generation to a detached `tokio::spawn`, so the
+/// router-level `TimeoutLayer` never sees this work. This wraps the generation
+/// call with the same budget to close that gap without changing the SSE framing.
 async fn llm_generate_with_timeout(
     llm: Arc<dyn spelunk_core::llm::LlmBackend>,
     messages: Vec<spelunk_core::llm::Message>,
@@ -298,17 +282,11 @@ pub struct EmbedderStatus {
     pub detail: Option<String>,
 }
 
-/// Server-enforced operative limits relevant to sizing an `/index/embed`
-/// request, so a client can clamp its own batching to what this particular
-/// server build actually supports instead of assuming (spelunk-oss^71/^73/^74
-/// PR #513 field-failure follow-up).
+/// Server-enforced limits relevant to sizing an `/index/embed` request, so a
+/// client can clamp its batching to what this server build supports.
 ///
-/// Added alongside the `/index/embed`-specific request timeout (see
-/// `EMBED_REQUEST_TIMEOUT` in `lib.rs`): a CLI that calibrates a batch to run
-/// for `request_timeout_secs` and gets 408'd is a **version-skew** signal — an
-/// old server (pre-dating this field, so the whole `limits` object is absent)
-/// still enforces the old blanket 30s budget. Absent `limits` therefore means
-/// "assume the legacy 30s / no-embed-exemption profile", not "unlimited".
+/// Absent `limits` (an older server pre-dating this field) means "assume the
+/// legacy 30s / no-embed-exemption profile", not "unlimited".
 #[derive(Serialize, ToSchema)]
 pub struct ServerLimits {
     /// Wall-clock budget (seconds) this server allows a single `/index/embed`
@@ -322,13 +300,9 @@ pub struct ServerLimits {
     pub max_batch_chunks: usize,
     /// Per-chunk token truncation cap the embedder enforces, if known (native
     /// backend only — see `EmbeddingBackend::token_cap`). `null` when the
-    /// embedder isn't ready yet or doesn't expose one (e.g. an external
-    /// `--embedding-url` backend). Informational: a client can use it to avoid
-    /// assuming every chunk is small when estimating a batch's total token
-    /// volume, but the binding constraint in practice is wall-clock time, not
-    /// per-batch memory — sub-batches are already bounded independently of
-    /// total batch size (see `EMBED_BATCH_SIZE` / `BATCH_MAX_SEQ` in
-    /// `embedder_native.rs`).
+    /// embedder isn't ready or exposes none (e.g. an external `--embedding-url`).
+    /// Informational — the binding constraint in practice is wall-clock time,
+    /// not per-batch memory.
     pub embedder_token_cap: Option<usize>,
 }
 
@@ -1090,10 +1064,9 @@ pub async fn index_embed(
     }
 
     // Serialise as raw little-endian f32 bytes, one vector after another in
-    // request order. Avoids the per-element JSON float-array cost on both
-    // serialize (here) and parse (CLI); the client maps response[i] → request
-    // chunk[i] by position, so no chunk_id framing is needed.
-    // (Snowflake "byte serialization" optimisation.)
+    // request order. Avoids the per-element JSON float cost on both ends; the
+    // client maps response[i] → request chunk[i] by position, so no chunk_id
+    // framing is needed.
     let dim = vectors.first().map_or(0, Vec::len);
     let mut body_bytes = Vec::with_capacity(vectors.len() * dim * 4);
     for v in &vectors {
@@ -1114,7 +1087,7 @@ fn octet_stream(bytes: Vec<u8>) -> Response {
         .into_response()
 }
 
-// ── Code search (query embedding proxy, spelunk#322) ─────────────────────────
+// ── Code search (query embedding proxy) ───────────────────────────────────────
 
 /// Request body for `POST /v1/projects/{project_id}/search`.
 #[derive(Deserialize, ToSchema)]
@@ -1801,7 +1774,6 @@ mod tests {
             caps.iter().any(|c| c == "memory"),
             "capabilities must include 'memory'"
         );
-        // New fields from #321.
         let id = json["instance_id"]
             .as_str()
             .expect("instance_id must be a string");
@@ -1820,9 +1792,8 @@ mod tests {
             json!("disabled"),
             "embedder.state must be 'disabled' when no embedder is configured"
         );
-        // `limits` (spelunk-oss^71/^73/^74, PR #513): always present, even
-        // with no embedder — a client needs the request-timeout/batch-count
-        // limits before it can even ask whether an embedder is ready.
+        // `limits` is always present, even with no embedder — a client needs
+        // the request-timeout/batch-count limits before asking if one is ready.
         assert_eq!(
             json["limits"]["embed_request_timeout_secs"],
             json!(super::super::EMBED_REQUEST_TIMEOUT.as_secs()),
@@ -1999,7 +1970,7 @@ mod tests {
         );
     }
 
-    // ── Readiness / warm-up contract (oss^50) ────────────────────────────────
+    // ── Readiness / warm-up contract ─────────────────────────────────────────
 
     async fn get_health_json(app: axum::Router) -> Value {
         let req = Request::builder()
@@ -2163,7 +2134,7 @@ mod tests {
         );
     }
 
-    // ── Input-length caps (spelunk-oss^60 / V1-SERVER-AUDIT §4) ───────────────
+    // ── Input-length caps ────────────────────────────────────────────────────
 
     /// POST /v1/projects/{slug}/memory with a title over `MAX_TITLE_LEN` chars
     /// must be rejected with 400, not silently truncated or stored.
@@ -2282,7 +2253,7 @@ mod tests {
         );
     }
 
-    // ── /explore rate limiting (spelunk-oss^60) ────────────────────────────────
+    // ── /explore rate limiting ─────────────────────────────────────────────────
 
     /// An LLM backend that immediately closes the token channel — enough to
     /// exercise routing/rate-limiting without generating real content.
@@ -2336,10 +2307,8 @@ mod tests {
         app.clone().oneshot(req).await.unwrap().status()
     }
 
-    /// `/explore` must be rate-limited the same way `/llm/complete` is: once
-    /// the per-bucket budget is exhausted, further calls get 429, not a normal
-    /// (SSE 200) response. This closes the "unmetered token-burn proxy" hole
-    /// from V1-SERVER-AUDIT §4 — previously `/explore` had no rate check at all.
+    /// `/explore` must be rate-limited like `/llm/complete`: once the per-bucket
+    /// budget is exhausted, further calls get 429, not a normal (SSE 200) response.
     #[tokio::test]
     async fn explore_returns_429_past_rate_limit() {
         let app = make_app_with_llm_and_limit(2);
@@ -2358,8 +2327,8 @@ mod tests {
     }
 
     /// Two different client IPs (via `X-Forwarded-For`) must not share one
-    /// rate-limit bucket — each gets its own budget. Guards the "single shared
-    /// key = single global bucket" hole from V1-SERVER-AUDIT §4.
+    /// rate-limit bucket — each gets its own budget, so a shared key can't
+    /// collapse every caller onto one global bucket.
     #[tokio::test]
     async fn explore_rate_limit_keyed_per_client_ip() {
         let app = make_app_with_llm_and_limit(1);
@@ -2392,13 +2361,11 @@ mod tests {
         );
     }
 
-    // ── Exact-boundary input-cap tests (spelunk-oss^60 / V1-SERVER-AUDIT §4) ──
+    // ── Exact-boundary input-cap tests ───────────────────────────────────────
     //
-    // `add_note_within_caps_returns_201` (above) already checks a title at
-    // exactly MAX_TITLE_LEN. These fill the remaining boundary combinations:
-    // body at exactly the cap, and title/body one char *under* the cap (so we
-    // have off-by-one coverage on both sides of both fields, not just "way
-    // over" vs. "exactly at" for title alone).
+    // `add_note_within_caps_returns_201` already checks a title at exactly
+    // MAX_TITLE_LEN. These fill the remaining boundary combinations: body at the
+    // cap, and title/body one char under, for off-by-one coverage on both sides.
 
     /// A body at exactly `MAX_BODY_LEN` chars must be accepted (boundary,
     /// mirrors the existing exact-title-cap test).
@@ -2468,14 +2435,12 @@ mod tests {
         );
     }
 
-    // ── TimeoutLayer / SSE exemption (spelunk-oss^60) ──────────────────────────
+    // ── TimeoutLayer / SSE exemption ──────────────────────────────────────────
     //
-    // These bind the *real* router (via `router_with_timeout`, injecting a
-    // short millisecond-scale budget instead of the production 30s) to a real
-    // TCP listener and drive it with a real HTTP client, so we're proving
-    // actual wire behaviour — a connection that is genuinely held open past
-    // the timeout window — not just that `/memory/stream` lives in a
-    // sub-router without a `TimeoutLayer` attached.
+    // These bind the real router (via `router_with_timeout`, injecting a short
+    // millisecond-scale budget) to a real TCP listener and drive it with a real
+    // HTTP client, so they prove actual wire behaviour — a connection genuinely
+    // held open past the timeout window — not just router wiring.
 
     /// Bind a real router (with the given injected timeout) to an ephemeral
     /// TCP port and start serving it in the background. Returns the base URL
@@ -2570,20 +2535,13 @@ mod tests {
     }
 
     /// A normal (non-exempt, non-streaming) route whose handler outlives the
-    /// injected `TimeoutLayer` budget must be aborted with `408 Request
-    /// Timeout`. This is the control case proving the timeout layer is live
-    /// and actually enforced on the wire — not merely configured.
+    /// injected `TimeoutLayer` budget must be aborted with `408`. Control case
+    /// proving the layer is enforced on the wire, not merely configured.
     ///
-    /// Uses `add_note`, which synchronously awaits the DB lock and returns a
-    /// JSON `Response`, rather than `/explore`/`/llm/complete` — those two
-    /// construct their SSE `Response` and return immediately regardless of
-    /// how long generation takes, so `TimeoutLayer` structurally can't bound
-    /// them (see `llm_generate_with_timeout` in this module and its doc
-    /// comment on `REQUEST_TIMEOUT` in `lib.rs` for that separate gap and how
-    /// it's closed). `add_note` is representative of the synchronous handler
-    /// class the router-level `TimeoutLayer` is actually meant to protect: we
-    /// hold its DB mutex externally so `add_note`'s `state.db.lock().await`
-    /// legitimately blocks past the injected budget.
+    /// Uses `add_note` (a synchronous handler awaiting the DB lock) rather than
+    /// `/explore`/`/llm/complete`, which return their SSE `Response` immediately
+    /// and so can't be bound by `TimeoutLayer`. Its DB mutex is held externally
+    /// so `state.db.lock().await` blocks past the injected budget.
     #[tokio::test]
     async fn normal_route_exceeding_timeout_returns_408() {
         let request_timeout = std::time::Duration::from_millis(200);
@@ -2622,30 +2580,20 @@ mod tests {
         release_task.await.expect("release task panicked");
     }
 
-    // ── Generation-side timeout on `/explore` and `/llm/complete` (spelunk-oss^60,
-    //    QA follow-up) ──────────────────────────────────────────────────────────
+    // ── Generation-side timeout on `/explore` and `/llm/complete` ─────────────
     //
-    // `normal_route_exceeding_timeout_returns_408` above proves the *router's*
-    // `TimeoutLayer` doesn't (and structurally can't) bound `/explore` or
-    // `/llm/complete` — those handlers return their SSE `Response` immediately
-    // and hand generation to a detached `tokio::spawn`. This is the missing
-    // other half: proving `llm_generate_with_timeout` — the generation-side
-    // wrapper added to close that gap — actually cuts a hung backend off
-    // within budget, rather than just reading correct on inspection. Without
-    // this test, deleting the `tokio::time::timeout(...)` wrapper around
-    // `llm.generate(...)` in `llm_generate_with_timeout` would compile and
-    // pass every other test in this suite.
+    // `normal_route_exceeding_timeout_returns_408` proves the router's
+    // `TimeoutLayer` can't bound these two endpoints. This is the other half:
+    // proving `llm_generate_with_timeout` actually cuts a hung backend off
+    // within budget — without it, deleting the `tokio::time::timeout(...)`
+    // wrapper would compile and pass every other test.
 
-    /// An LLM backend whose `generate()` never returns and never sends a
-    /// token — models a genuinely hung inference backend (wedged HTTP call,
-    /// deadlocked model runtime, etc.), the case `llm_generate_with_timeout`
-    /// exists to bound. Awaits a `Notify` that the test never fires, rather
-    /// than e.g. `std::future::pending()`, purely so it's unmistakable in a
-    /// stack trace / debugger what's being awaited if this ever fails.
+    /// An LLM backend whose `generate()` never returns and never sends a token —
+    /// models a hung inference backend, the case `llm_generate_with_timeout`
+    /// exists to bound.
     struct HangingLlm {
-        /// Bumped once `generate()` is actually entered, so tests can assert
-        /// generation genuinely started (and wasn't e.g. skipped by a
-        /// short-circuit) before checking it gets cut off.
+        /// Bumped once `generate()` is entered, so tests can assert generation
+        /// genuinely started before checking it gets cut off.
         entered: Arc<std::sync::atomic::AtomicUsize>,
     }
 
@@ -2660,10 +2608,8 @@ mod tests {
         ) -> anyhow::Result<()> {
             self.entered
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            // Never returns, never sends anything, never drops `_tx` on its
-            // own — the only way this future completes is by being dropped
-            // from outside (i.e. by `tokio::time::timeout` in
-            // `llm_generate_with_timeout` firing).
+            // Never returns or drops `_tx` on its own — the only way it
+            // completes is by being dropped from outside (the timeout firing).
             std::future::pending::<()>().await;
             unreachable!("pending() never resolves");
         }
@@ -2671,37 +2617,24 @@ mod tests {
 
     /// `/explore` backed by a `HangingLlm` must still have its connection cut
     /// off within the generation budget — proving `llm_generate_with_timeout`
-    /// actually bounds a hung backend, not just that the code compiles.
+    /// bounds a hung backend, not just that the code compiles.
     ///
-    /// Without the `tokio::time::timeout` wrapper in `llm_generate_with_timeout`
-    /// (i.e. reverting to a bare `llm.generate(...).await`), this test hangs
-    /// until the outer `#[tokio::test]` runtime / CI timeout kills it — this
-    /// was confirmed manually while writing this test (temporarily replacing
-    /// the wrapped call with the bare `.await` reproduces exactly the "200
-    /// immediately, then the SSE stream never ends" symptom QA's review
-    /// flagged) and is *not* re-verified on every run, since a test that
-    /// hangs on regression instead of failing fast would be a worse failure
-    /// mode than the gap this closes.
+    /// GOTCHA: without the `tokio::time::timeout` wrapper this test hangs until
+    /// the CI timeout rather than failing fast — a worse failure mode, but
+    /// accepted since the alternative doesn't exercise the wrapper.
     #[tokio::test]
     async fn explore_cuts_off_hanging_llm_backend() {
-        // Millisecond-scale budget via the test-only override, so this test
-        // doesn't need to wait out the real 30s `REQUEST_TIMEOUT`. Global
-        // (process-wide) by construction, so this test must not run
-        // concurrently with anything else that spawns `llm_generate_with_timeout`
-        // under a *different* intended budget; `#[tokio::test]` gives each
-        // test its own runtime but they still share this process, so guard
-        // with a lock rather than relying on test-harness serialization.
+        // Millisecond-scale budget via the test-only override. The override is
+        // process-wide, so guard with a lock: this test must not run
+        // concurrently with anything else spawning `llm_generate_with_timeout`
+        // under a different budget.
         static OVERRIDE_GUARD: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
         let _guard = OVERRIDE_GUARD.lock().await;
 
         let generation_budget = std::time::Duration::from_millis(150);
         set_generation_timeout_override(generation_budget);
-        // Router-level TimeoutLayer is set generously long (well past the
-        // generation budget) so it's structurally impossible for it to be
-        // what cuts the connection off — isolates this test to proving the
-        // generation-side wrapper alone does the job, per
-        // `normal_route_exceeding_timeout_returns_408`'s finding that the
-        // router layer can't see this endpoint's spawned work at all.
+        // Router-level TimeoutLayer set generously long so it can't be what cuts
+        // the connection off — isolates the generation-side wrapper.
         let router_timeout = generation_budget * 20;
 
         let entered = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2725,12 +2658,9 @@ mod tests {
              TimeoutLayer can't bound this endpoint (see normal_route_exceeding_timeout_returns_408)"
         );
 
-        // Read the stream until it ends (or errors), bounded by a deadline
-        // well past the generation budget but far short of what "never cut
-        // off" (i.e. the pre-fix bug) would need — if the wrapper weren't
-        // doing its job, `stream.next()` would still be pending when this
-        // deadline hits and `tokio::time::timeout` below would fire instead
-        // of the stream ending on its own, which the assertion distinguishes.
+        // Read the stream until it ends, bounded by a deadline past the
+        // generation budget: if the wrapper weren't cutting the backend off,
+        // the stream would still be pending when this deadline fires.
         use futures_util::StreamExt;
         let mut stream = resp.bytes_stream();
         let overall_deadline = generation_budget * 10;
@@ -2846,15 +2776,12 @@ mod tests {
         }
     }
 
-    // ── TimeoutLayer / `/index/embed` exemption (spelunk-oss^71/^73/^74,
-    //    PR #513 field-failure follow-up) ───────────────────────────────────
+    // ── TimeoutLayer / `/index/embed` exemption ───────────────────────────────
     //
     // Same proof style as the `/memory/stream` exemption above: bind the real
-    // router with the general and embed timeouts injected *independently*
-    // (mirroring production's `REQUEST_TIMEOUT` vs `EMBED_REQUEST_TIMEOUT`
-    // split) and drive it with a real HTTP client, so we're proving actual
-    // wire behaviour rather than just that `/index/embed` lives in a
-    // sub-router with a different `TimeoutLayer` attached.
+    // router with the general and embed timeouts injected independently
+    // (mirroring the `REQUEST_TIMEOUT` vs `EMBED_REQUEST_TIMEOUT` split) and
+    // drive it with a real HTTP client.
 
     /// An embedder backend that sleeps for a fixed duration before returning a
     /// zero vector per input — models a slow (e.g. CPU-only, cold-cache, or
@@ -3000,42 +2927,27 @@ mod tests {
         release_task.await.expect("release task panicked");
     }
 
-    // ── ConcurrencyLimitLayer under concurrent load (spelunk-oss^60) ──────────
+    // ── ConcurrencyLimitLayer under concurrent load ───────────────────────────
 
-    /// Proves `tower::limit::ConcurrencyLimitLayer` itself backpressures
-    /// concurrent requests beyond its cap — i.e. the layer type used by
-    /// `router_with_limits`/`router` behaves as intended in this axum/tower
-    /// version, under real concurrent load (multiple in-flight requests
-    /// racing through `tower::limit`), not just "the layer is attached".
+    /// Proves `tower::limit::ConcurrencyLimitLayer` backpressures concurrent
+    /// requests beyond its cap under real concurrent load, not just that the
+    /// layer is attached.
     ///
-    /// This deliberately does **not** route through `/explore` or
-    /// `/llm/complete`: those handlers construct their `Response` and return
-    /// immediately (generation happens in a detached `tokio::spawn`), so the
-    /// concurrency permit — like the `TimeoutLayer` budget — is released as
-    /// soon as the SSE stream is constructed, not when the stream finishes.
-    /// A same-shaped test against `/explore` (verified while writing this)
-    /// shows all 5 concurrent requests admitted immediately regardless of the
-    /// cap, which is *not* a bug in `ConcurrencyLimitLayer` — it's that these
-    /// two SSE-streaming endpoints structurally sit outside what
-    /// `ConcurrencyLimitLayer` can bound, the same gap
-    /// `llm_generate_with_timeout` (see `lib.rs`) closes for `TimeoutLayer`.
-    /// `ConcurrencyLimitLayer` has no per-endpoint override to fix this the
-    /// same way; bounding concurrent *streaming sessions* (as opposed to
-    /// concurrent handler invocations) would need a dedicated semaphore held
-    /// for the stream's lifetime — filed as a follow-up, out of scope here.
+    /// Deliberately does NOT route through `/explore` or `/llm/complete`: those
+    /// release the concurrency permit as soon as the SSE stream is constructed
+    /// (generation is a detached `tokio::spawn`), so they sit outside what
+    /// `ConcurrencyLimitLayer` can bound — the same gap `llm_generate_with_timeout`
+    /// closes for `TimeoutLayer`.
     #[tokio::test]
     async fn concurrency_limit_layer_queues_requests_beyond_the_cap() {
         use axum::{Router, routing::get};
 
-        // A trivial handler that blocks until released, wrapped in the exact
-        // same `ConcurrencyLimitLayer` type used by `router`/`router_with_limits`.
+        // A trivial handler that blocks until released, wrapped in the same
+        // `ConcurrencyLimitLayer` type used by `router`.
         //
-        // Uses a `watch` channel (not `Notify`) as the gate: `Notify::notify_waiters`
-        // only wakes tasks *already* waiting at the moment it's called, so any
-        // handler invocation admitted *after* the gate is released would hang
-        // forever — exactly the requests queued behind the concurrency cap here.
-        // `watch` retains the last-sent value, so a late subscriber that calls
-        // `wait_for` after the release still observes it immediately.
+        // Uses a `watch` channel (not `Notify`) as the gate: `Notify` only wakes
+        // tasks already waiting when fired, so a handler admitted after release
+        // would hang; `watch` retains the value for late subscribers.
         let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
         let started = Arc::new(std::sync::atomic::AtomicUsize::new(0));
 

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -27,68 +27,40 @@ use auth::{AuthError, AuthProvider};
 use db::ServerDb;
 use rate_limiter::RateLimiter;
 
-/// Wall-clock budget for a single request before the server aborts it and
-/// returns `408 Request Timeout`. `/memory/stream` is exempt (long-lived SSE
-/// connection by design; see [`GLOBAL_CONCURRENCY_LIMIT`] for its own bound).
-/// `/index/embed` is also exempt — see [`EMBED_REQUEST_TIMEOUT`] — because a
-/// legitimate embed batch can genuinely run for minutes on slow hardware.
+/// Wall-clock budget for a single request before the server aborts it with
+/// `408`. `/memory/stream` (SSE) and `/index/embed` (see
+/// [`EMBED_REQUEST_TIMEOUT`]) are exempt.
 ///
-/// **Does not bound `/explore` or `/llm/complete`.** Both return their SSE
-/// `Response` as soon as the stream is constructed and hand the actual
-/// generation off to a detached `tokio::spawn` — the handler `Future` this
-/// layer wraps resolves immediately, well before the LLM backend finishes (or
-/// hangs). `TimeoutLayer` therefore can't see that work at all (proved by
-/// `handlers::tests::normal_route_exceeding_timeout_returns_408`, which fails
-/// against `/explore` without the generation-side timeout in
-/// `handlers::llm_generate_with_timeout`). Those two handlers bound the
-/// spawned generation directly with this same constant instead.
+/// Does NOT bound `/explore` or `/llm/complete`: both return their SSE
+/// `Response` immediately and run generation in a detached `tokio::spawn`, which
+/// this layer can't see. Those handlers bound the spawned generation directly
+/// with this same constant (see `handlers::llm_generate_with_timeout`).
 pub(crate) const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Wall-clock budget for a single `/index/embed` request before the server
-/// aborts it and returns `408 Request Timeout`. Deliberately much larger than
-/// [`REQUEST_TIMEOUT`] and sized to match the CLI's own `MAX_REQUEST_TIMEOUT`
-/// (`crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs`): the CLI calibrates
-/// batch size to target a ~240s round trip on the *measured* hardware, and
-/// clamps its own per-request timeout up to 1800s to absorb slow-hardware
-/// outliers. A 30s server-side budget made that calibration impossible to
-/// satisfy — any batch sized for a 240s target, or even a single oversized
-/// chunk on slow/CPU-only hardware, was killed by the router before the CLI's
-/// own (much longer) client-side timeout ever had a chance to apply. This is
-/// the fix for the field failure captured in the CHANGELOG entry for this
-/// change (408 on `index/embed` batch 1).
+/// Wall-clock budget for a single `/index/embed` request before `408`. Much
+/// larger than [`REQUEST_TIMEOUT`] and matched to the CLI's `MAX_REQUEST_TIMEOUT`:
+/// a legitimate embed batch can run for minutes on slow/CPU-only hardware, which
+/// a 30s budget would kill.
 ///
-/// This does **not** reopen the DoS gap `REQUEST_TIMEOUT` closes:
-/// `/index/embed` is still auth-gated (same `auth_middleware` as every other
-/// protected route) and still behind `ConcurrencyLimitLayer` and
-/// `RequestBodyLimitLayer`, so a hostile or misbehaving caller can hold open
-/// at most `GLOBAL_CONCURRENCY_LIMIT` embed requests, each bounded in size by
-/// `MAX_BATCH` (256 chunks) and `DEFAULT_BODY_LIMIT_BYTES` — not an unbounded
-/// number of unauthenticated, unbounded-duration connections. A slow legitimate
-/// batch and a held-open attack connection are indistinguishable to a generic
-/// wall-clock timeout; bounding the *count* and *size* of concurrent embed
-/// requests is what actually defends this endpoint, same as it always was.
+/// Not a DoS gap: `/index/embed` is still auth-gated and behind
+/// `ConcurrencyLimitLayer` + `RequestBodyLimitLayer`, so the count and size of
+/// concurrent embed requests stay bounded.
 pub(crate) const EMBED_REQUEST_TIMEOUT: Duration = Duration::from_secs(1800);
 
-/// Cap on the JSON request body size accepted by the general API surface.
-/// Generous enough for the largest legitimate payload (an `index/embed` batch
-/// of up to 256 chunks) while still bounding memory use per request.
-/// `title` (≤500) + `body` (≤50 000) caps are enforced in the handlers on top
-/// of this — this layer is the outer, cheap-to-check net.
+/// Cap on the JSON request body size. Generous enough for the largest legitimate
+/// payload (a 256-chunk `index/embed` batch); per-field caps (title/body) are
+/// enforced in the handlers on top of this.
 const DEFAULT_BODY_LIMIT_BYTES: usize = 2 * 1024 * 1024; // 2 MiB
 
-/// Global cap on requests being processed concurrently across the whole
-/// server. Bounds worst-case resource usage (including the SSE poll loop on
-/// `/memory/stream`, which otherwise has no other backpressure now that the
-/// single-mutex → read-pool refactor is out of scope for this change — see
-/// the follow-up note in the task).
+/// Global cap on requests processed concurrently across the whole server,
+/// including the `/memory/stream` SSE poll loop.
 const GLOBAL_CONCURRENCY_LIMIT: usize = 256;
 
 /// Readiness state of the server-side embedder.
 ///
-/// The native (in-process) embedder is loaded on a background task *after* the
-/// listener binds, so `/v1/health` is live immediately while the model is still
-/// warming up. This enum is the single source of truth for that readiness; the
-/// health body carries it and the embed endpoints branch on it.
+/// The native embedder loads on a background task after the listener binds, so
+/// `/v1/health` is live while the model warms up. Single source of truth for
+/// that readiness; the health body carries it and the embed endpoints branch on it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum EmbedderState {
@@ -333,35 +305,24 @@ impl utoipa::Modify for SecurityAddon {
 
 /// Build the axum router with all routes.
 ///
-/// Protective middleware (see V1-SERVER-AUDIT §4 / spelunk-oss^60):
-/// - `RequestBodyLimitLayer` + `ConcurrencyLimitLayer` apply to every route,
-///   including `/memory/stream` and `/index/embed`.
-/// - `TimeoutLayer` (30s) applies to everything **except** `/memory/stream`
-///   (long-lived SSE connection by design) and `/index/embed` (its own, much
-///   larger [`EMBED_REQUEST_TIMEOUT`] budget — see that constant's doc comment
-///   for why: a 30s budget cannot fit a legitimate embed batch on slow
-///   hardware, which is the root cause of the 408 this timeout split fixes).
-/// - Per-handler input caps (title/body/vector length, batch chunk count,
-///   etc.) are enforced in `handlers.rs`, not here.
+/// - `RequestBodyLimitLayer` + `ConcurrencyLimitLayer` apply to every route.
+/// - `TimeoutLayer` (30s) applies to everything except `/memory/stream` (SSE)
+///   and `/index/embed` (its own [`EMBED_REQUEST_TIMEOUT`]).
+/// - Per-handler input caps are enforced in `handlers.rs`.
 pub fn router(state: AppState) -> Router {
     router_with_timeouts(state, REQUEST_TIMEOUT, EMBED_REQUEST_TIMEOUT)
 }
 
-/// Same as [`router`], but with an injectable request timeout applied to both
-/// the general route group and `/index/embed`. Exists so tests can prove the
-/// `/memory/stream` timeout exemption against a short (millisecond-scale)
-/// budget instead of waiting out the real 30s [`REQUEST_TIMEOUT`] — see
-/// `handlers::tests::*timeout*`.
+/// Same as [`router`], but with an injectable request timeout for both the
+/// general route group and `/index/embed`. Lets tests exercise the timeout
+/// exemptions on a millisecond-scale budget.
 pub fn router_with_timeout(state: AppState, request_timeout: Duration) -> Router {
     router_with_timeouts(state, request_timeout, request_timeout)
 }
 
-/// Same as [`router`], but with the general-route timeout, the `/index/embed`
-/// timeout, and the global concurrency cap all injectable. Exists so tests can
-/// prove `/index/embed` survives past the general [`REQUEST_TIMEOUT`] budget
-/// (mirroring the `/memory/stream` SSE-exemption tests) without waiting out
-/// the real 1800s [`EMBED_REQUEST_TIMEOUT`] — see
-/// `handlers::tests::embed_survives_general_timeout_budget`.
+/// Same as [`router`], but with the general timeout, `/index/embed` timeout, and
+/// global concurrency cap all injectable. Lets tests prove `/index/embed`
+/// survives past the general budget without waiting out the real 1800s.
 pub fn router_with_timeouts(
     state: AppState,
     request_timeout: Duration,
@@ -375,11 +336,9 @@ pub fn router_with_timeouts(
     )
 }
 
-/// Same as [`router`], but with the request timeout, `/index/embed` timeout,
-/// and the global concurrency cap all injectable. Exists so tests can prove
-/// `ConcurrencyLimitLayer` actually backpressures concurrent requests using a
-/// small limit (e.g. 2) instead of needing 257 real concurrent connections to
-/// exercise the production [`GLOBAL_CONCURRENCY_LIMIT`].
+/// Same as [`router`], but with the request timeout, `/index/embed` timeout, and
+/// global concurrency cap all injectable. Lets tests exercise
+/// `ConcurrencyLimitLayer` backpressure with a small limit.
 pub fn router_with_limits(
     state: AppState,
     request_timeout: Duration,
@@ -399,10 +358,8 @@ pub fn router_with_limits(
         .layer(ConcurrencyLimitLayer::new(concurrency_limit));
 
     // `/index/embed` gets its own long-budget timeout instead of the general
-    // `REQUEST_TIMEOUT` (30s) — see [`EMBED_REQUEST_TIMEOUT`]. Auth,
-    // concurrency, and body-size limits are identical to `protected` below;
-    // only the wall-clock budget differs, same pattern as the `stream_route`
-    // carve-out above.
+    // `REQUEST_TIMEOUT` — see [`EMBED_REQUEST_TIMEOUT`]. Auth/concurrency/body
+    // limits match `protected` below.
     let embed_route = Router::new()
         .route(
             "/v1/projects/{project_id}/index/embed",
@@ -520,13 +477,10 @@ mod app_error_tests {
         assert!(body.contains("proj"));
     }
 
-    /// Any other error — even one whose `Display` text happens to contain the
-    /// words "mismatch" or "required" — must NEVER have its raw text reach the
-    /// client body. Only the fixed, generic "Internal server error" message is
-    /// allowed through for `AppError::Internal` errors that aren't the one
-    /// explicitly-typed, known-safe variant. This is the regression test for
-    /// the substring-sniffing leak: the old code matched on `msg.contains(...)`
-    /// and echoed the raw error string back to the client.
+    /// Any other error — even one whose text contains "mismatch"/"required" —
+    /// must NEVER have its raw text reach the client body; only the generic
+    /// "Internal server error" message is allowed through. Regression guard
+    /// against substring-sniffing the error message.
     #[tokio::test]
     async fn generic_internal_error_never_leaks_raw_text_even_with_trigger_words() {
         let secret_path = "/Users/johan/.ssh/id_ed25519";

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1408,7 +1408,7 @@
       },
       "EmbedderState": {
         "type": "string",
-        "description": "Readiness state of the server-side embedder.\n\nThe native (in-process) embedder is loaded on a background task *after* the\nlistener binds, so `/v1/health` is live immediately while the model is still\nwarming up. This enum is the single source of truth for that readiness; the\nhealth body carries it and the embed endpoints branch on it.",
+        "description": "Readiness state of the server-side embedder.\n\nThe native embedder loads on a background task after the listener binds, so\n`/v1/health` is live while the model warms up. Single source of truth for\nthat readiness; the health body carries it and the embed endpoints branch on it.",
         "enum": [
           "loading",
           "ready",
@@ -1709,7 +1709,7 @@
       },
       "ServerLimits": {
         "type": "object",
-        "description": "Server-enforced operative limits relevant to sizing an `/index/embed`\nrequest, so a client can clamp its own batching to what this particular\nserver build actually supports instead of assuming (spelunk-oss^71/^73/^74\nPR #513 field-failure follow-up).\n\nAdded alongside the `/index/embed`-specific request timeout (see\n`EMBED_REQUEST_TIMEOUT` in `lib.rs`): a CLI that calibrates a batch to run\nfor `request_timeout_secs` and gets 408'd is a **version-skew** signal — an\nold server (pre-dating this field, so the whole `limits` object is absent)\nstill enforces the old blanket 30s budget. Absent `limits` therefore means\n\"assume the legacy 30s / no-embed-exemption profile\", not \"unlimited\".",
+        "description": "Server-enforced limits relevant to sizing an `/index/embed` request, so a\nclient can clamp its batching to what this server build supports.\n\nAbsent `limits` (an older server pre-dating this field) means \"assume the\nlegacy 30s / no-embed-exemption profile\", not \"unlimited\".",
         "required": [
           "embed_request_timeout_secs",
           "max_batch_chunks"
@@ -1726,7 +1726,7 @@
               "integer",
               "null"
             ],
-            "description": "Per-chunk token truncation cap the embedder enforces, if known (native\nbackend only — see `EmbeddingBackend::token_cap`). `null` when the\nembedder isn't ready yet or doesn't expose one (e.g. an external\n`--embedding-url` backend). Informational: a client can use it to avoid\nassuming every chunk is small when estimating a batch's total token\nvolume, but the binding constraint in practice is wall-clock time, not\nper-batch memory — sub-batches are already bounded independently of\ntotal batch size (see `EMBED_BATCH_SIZE` / `BATCH_MAX_SEQ` in\n`embedder_native.rs`).",
+            "description": "Per-chunk token truncation cap the embedder enforces, if known (native\nbackend only — see `EmbeddingBackend::token_cap`). `null` when the\nembedder isn't ready or exposes none (e.g. an external `--embedding-url`).\nInformational — the binding constraint in practice is wall-clock time,\nnot per-batch memory.",
             "minimum": 0
           },
           "max_batch_chunks": {


### PR DESCRIPTION
Mechanical comment-terseness cleanup of the five files landed by #513, per the going-forward standard: a comment states only a constraint/invariant/gotcha the code can't show. Cut rationale, history, correctness arguments, and inline `oss^NN`/PR citations (those live in the commit/PR, not the source).

**Comments only — no code behavior change.** Every added/removed line in the `.rs` files is inside a `//`/`///` comment or blank.

Files:
- `crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs`
- `crates/spelunk-server/src/lib.rs`
- `crates/spelunk-server/src/handlers.rs`
- `crates/spelunk-embed/src/embedder_native.rs`
- `crates/spelunk-core/src/embeddings/mod.rs`

`docs/openapi.json` is an **auto-regenerated, description-only snapshot** — utoipa embeds `ToSchema` doc-comments as OpenAPI `description` strings, and the `write_openapi_snapshot` unit test rewrites the file on `cargo test`. The diff is description-text only (3 hunks), mirroring the trimmed doc-comments; no structural/field/type/enum/path change. Committed to keep the snapshot in sync.

## Test plan
All run with `SPELUNK_SECRET_STORE=file`:
- `git diff origin/main...HEAD -- '*.rs'` audited: every changed line is a comment or blank — no code, attributes, or string literals changed.
- `git diff origin/main...HEAD -- docs/openapi.json`: 3 hunks, all `description:` string values only.
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo build --no-default-features` (mandatory CI cell) — clean
- `cargo test` — all suites pass (0 failed), incl. `write_openapi_snapshot` (tree clean after run → snapshot in sync).