### PR TITLE
ci: fix nextest install on macOS (taiki-e/install-action) [spelunk-oss^117]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,9 @@ jobs:
         run: npm install --global @ast-grep/cli
 
       - name: Install cargo-nextest
-        run: cargo install cargo-nextest --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
 
       - name: Run tests
         run: cargo nextest run ${{ matrix.test-flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,11 +113,10 @@ jobs:
       - name: Install ast-grep
         run: npm install --global @ast-grep/cli
 
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-
       - name: Install cargo-nextest
-        run: cargo binstall cargo-nextest --secure --no-confirm
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
 
       - name: Run tests
         run: cargo nextest run ${{ matrix.test-flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,7 @@ jobs:
         run: npm install --global @ast-grep/cli
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
+        run: cargo install cargo-nextest --locked
 
       - name: Run tests
         run: cargo nextest run ${{ matrix.test-flags }}


### PR DESCRIPTION
## Problem

The `Test (macos-latest, --no-default-features)` CI cell fails at the **Install cargo-nextest** step (not in any test), blocking merges on #541/#542/#543/#544 and main. Fallout from today's nextest migration.

## Root cause

`.github/workflows/ci.yml` installed nextest via `cargo binstall cargo-nextest --secure --no-confirm`. On macOS the prebuilt fetch didn't land and binstall fell back to a **source** `cargo install cargo-nextest`, which hard-errors: nextest's `locked-tripwire` dep has a `compile_error!` requiring `--locked` (`Nextest does not support being installed without --locked`). The source fallback can never succeed.

## Fix

Replace the `Install cargo-binstall` + `Install cargo-nextest` steps with nextest's own recommended installer, `taiki-e/install-action@v2`, which fetches the prebuilt binary with no source-compile fallback path:

```yaml
- name: Install cargo-nextest
  uses: taiki-e/install-action@v2
  with:
    tool: cargo-nextest
```

`cargo binstall` had no other consumer in ci.yml (grep-confirmed), so the now-unused `Install cargo-binstall` step is dropped. Pure workflow change, no Rust code.

## Test plan

- CI on this PR must show the `Test (macos-latest, --no-default-features)` cell green.
- Confirm the other Test cells (ubuntu, windows) still install + run nextest fine.

Closes spelunk-oss^117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)