### PR TITLE
Lock forward-compat for pruned config keys; drop stale batch_size example (oss^95)

### DIFF
--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -1010,6 +1010,35 @@ mod tests {
         assert_eq!(cfg.mode, Some(SyncMode::LocalFirst));
     }
 
+    #[test]
+    #[serial_test::serial]
+    fn config_with_pruned_keys_still_parses() {
+        // Guards the forward-compat contract for pre-0.9 config.toml files:
+        // `Config` carries no `deny_unknown_fields`, so keys pruned as dead
+        // (batch_size, models_dir, api_base_url, plans_dir, specs_dir) are
+        // ignored rather than rejected. Adding `deny_unknown_fields` would
+        // break every existing user config, so this must stay green.
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+mode = "local_first"
+batch_size = 32
+models_dir = "/opt/models"
+api_base_url = "http://inference.internal:1234"
+plans_dir = "docs/plans"
+specs_dir = "docs/specs"
+"#,
+        )
+        .unwrap();
+
+        let cfg = load_hermetic(&config_path).unwrap();
+        // Live keys still resolve; the removed keys are simply dropped.
+        assert_eq!(cfg.mode, Some(SyncMode::LocalFirst));
+    }
+
     // ── serde alias: memory_server_url → server_url ─────────────────────────
 
     #[test]

--- a/examples/mdm/spelunk-config.toml
+++ b/examples/mdm/spelunk-config.toml
@@ -40,7 +40,6 @@ mode = "local_first"
 # api_base_url    = "http://inference.internal:1234"
 # embedding_model = "text-embedding-embeddinggemma-300m-qat"
 # llm_model       = "google/gemma-3n-e4b"
-# batch_size      = 32
 
 # --- Optional: directory conventions -----------------------------------------
 # Where `spelunk plan create` and spec discovery look (relative to project root).


### PR DESCRIPTION
## Summary

spelunk-oss^95 asked to remove the dead `Config::batch_size` field / `default_batch_size()` and the stale `batch_size = 32` config example, while keeping config parsing backward-compatible.

Investigation found the two named deliverables were **already merged**:
- `Config::batch_size`, `default_batch_size()`, and its serde plumbing were removed in #532 (`2a3217052`, "Prune 5 dead config keys"), which also established that serde ignores unknown keys so pre-0.9 `config.toml` files still parse.
- `docs/getting-started.md` no longer shows a `batch_size = 32` config example (removed in the oss^12 docs rewrite `7cfdf4976`); it only references the live `--batch-size` CLI flag, which is out of scope and untouched.

Residual, genuinely-missing work this PR lands:
- **Regression guard** (`crates/spelunk-core/src/config.rs`): a test proving a `config.toml` carrying the pruned keys (`batch_size`, `models_dir`, `api_base_url`, `plans_dir`, `specs_dir`) still loads. This locks the forward-compat contract the task called for — anyone adding `#[serde(deny_unknown_fields)]` would break every existing user config, and this test now fails loudly if they try.
- **Stale example cleanup** (`examples/mdm/spelunk-config.toml`): removed the last `# batch_size = 32` line.

The live CLI `--batch-size` flag (calibration ceiling, PR #513) and the historical `docs/adr/052-*.md` are untouched per scope.

Note: the MDM example still advertises three other keys pruned by #532 (`api_base_url`, `plans_dir`, `specs_dir`) in comments; left for a separate follow-up to keep this task scoped to `batch_size`.

## Test plan

All run with `export SPELUNK_SECRET_STORE=file`.

- `cargo fmt --check` -> clean (FMT OK)
- `cargo clippy --workspace --all-targets -- -D warnings` -> Finished, no warnings
- `cargo test --workspace` -> all suites `ok`, 0 failed (new `config::tests::config_with_pruned_keys_still_parses` passes)
- `cargo test --workspace --no-default-features` -> all suites `ok`, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)