### PR TITLE
fix(server): bound candle CPU threads so embeds don't starve request serving (oss^97)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5214,6 +5214,7 @@ dependencies = [
  "dirs",
  "futures-util",
  "hf-hub",
+ "num_cpus",
  "pretty_assertions",
  "regex",
  "reqwest",

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -51,6 +51,10 @@ clap = { version = "4", features = ["derive", "env"] }
 regex = { version = "1", default-features = false, features = ["std"] }
 blake3 = "1"
 constant_time_eq = "0.5"
+# Physical core count for the embed CPU-thread budget (main.rs). Not gated by
+# embed-native: the budget is resolved before the runtime starts regardless of
+# feature set. Pinned here since no other crate uses it directly.
+num_cpus = "1"
 # Hugging Face Hub acquisition path for the bundled native embedder
 # (`embed_hub` module) — the only place in the workspace that depends on
 # `hf-hub`. Gated behind `embed-native` so a build without that feature

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -94,8 +94,30 @@ struct Args {
     print_openapi: bool,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    // Bound candle's CPU threads BEFORE the runtime / first candle op: candle
+    // reads RAYON_NUM_THREADS live for gemm and caches its private rayon pool in
+    // a OnceLock on first use, so the env must be set while still single-threaded
+    // (set_var is unsafe in edition 2024 for that reason). Setting only an
+    // already-unset var keeps a user's RAYON_NUM_THREADS authoritative.
+    let budget = resolve_embed_thread_budget();
+    unsafe {
+        if std::env::var_os("RAYON_NUM_THREADS").is_none() {
+            std::env::set_var("RAYON_NUM_THREADS", budget.threads.to_string());
+        }
+        if std::env::var_os("CANDLE_NUM_THREADS").is_none() {
+            std::env::set_var("CANDLE_NUM_THREADS", budget.threads.to_string());
+        }
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime")?
+        .block_on(run(budget))
+}
+
+async fn run(budget: ThreadBudget) -> Result<()> {
     // Register sqlite-vec extension for every connection in this process.
     #[allow(clippy::missing_transmute_annotations)]
     unsafe {
@@ -108,6 +130,12 @@ async fn main() -> Result<()> {
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .with(fmt::layer())
         .init();
+
+    tracing::info!(
+        threads = budget.threads,
+        source = budget.source,
+        "embed CPU thread budget resolved"
+    );
 
     let args = Args::parse();
 
@@ -306,6 +334,52 @@ async fn main() -> Result<()> {
     .await?;
 
     Ok(())
+}
+
+// ── Embed CPU thread budget ───────────────────────────────────────────────────
+
+/// Resolved candle CPU-thread budget plus the source it came from, for the
+/// startup log line.
+struct ThreadBudget {
+    threads: usize,
+    source: &'static str,
+}
+
+/// CPU threads candle may use for a forward pass, so a running embed leaves
+/// cores free to serve requests. Precedence: `SPELUNK_EMBED_THREADS` > an
+/// already-set `RAYON_NUM_THREADS` > `max(1, physical - 2)`. A zero or
+/// unparseable override is `None`/`Some(0)` here and falls through.
+fn embed_thread_budget(
+    physical: usize,
+    rayon_override: Option<usize>,
+    spelunk_override: Option<usize>,
+) -> usize {
+    if let Some(n) = spelunk_override.filter(|&n| n > 0) {
+        return n;
+    }
+    if let Some(n) = rayon_override.filter(|&n| n > 0) {
+        return n;
+    }
+    physical.saturating_sub(2).max(1)
+}
+
+/// Read the physical core count and env overrides, then resolve the budget and
+/// which source won (for the startup log).
+fn resolve_embed_thread_budget() -> ThreadBudget {
+    fn env_threads(key: &str) -> Option<usize> {
+        std::env::var(key).ok().and_then(|v| v.trim().parse().ok())
+    }
+    let rayon = env_threads("RAYON_NUM_THREADS");
+    let spelunk = env_threads("SPELUNK_EMBED_THREADS");
+    let threads = embed_thread_budget(num_cpus::get_physical(), rayon, spelunk);
+    let source = if spelunk.filter(|&n| n > 0).is_some() {
+        "SPELUNK_EMBED_THREADS"
+    } else if rayon.filter(|&n| n > 0).is_some() {
+        "RAYON_NUM_THREADS"
+    } else {
+        "default"
+    };
+    ThreadBudget { threads, source }
 }
 
 // ── Bind-safety guard ─────────────────────────────────────────────────────────
@@ -935,5 +1009,51 @@ mod arg_tests {
             args.key_file.as_deref(),
             Some(std::path::Path::new("/etc/spelunk/server-key"))
         );
+    }
+}
+
+// ── Embed CPU thread budget ──────────────────────────────────────────────────
+
+#[cfg(test)]
+mod thread_budget_tests {
+    use super::embed_thread_budget;
+
+    /// No overrides: reserve 2 cores for the async runtime + OS.
+    #[test]
+    fn default_reserves_two_cores() {
+        assert_eq!(embed_thread_budget(10, None, None), 8);
+        assert_eq!(embed_thread_budget(4, None, None), 2);
+    }
+
+    /// Tiny hosts must never yield 0 threads.
+    #[test]
+    fn tiny_hosts_clamp_to_one() {
+        assert_eq!(embed_thread_budget(1, None, None), 1);
+        assert_eq!(embed_thread_budget(2, None, None), 1);
+        assert_eq!(embed_thread_budget(3, None, None), 1);
+    }
+
+    /// `SPELUNK_EMBED_THREADS` wins over both the default and a set
+    /// `RAYON_NUM_THREADS`.
+    #[test]
+    fn spelunk_override_wins() {
+        assert_eq!(embed_thread_budget(10, None, Some(3)), 3);
+        assert_eq!(embed_thread_budget(10, Some(6), Some(3)), 3);
+    }
+
+    /// A user-set `RAYON_NUM_THREADS` is respected when there is no spelunk
+    /// override — don't override CI / power users.
+    #[test]
+    fn rayon_override_respected_without_spelunk() {
+        assert_eq!(embed_thread_budget(10, Some(4), None), 4);
+    }
+
+    /// Zero (and, upstream, unparseable) overrides are ignored and fall through
+    /// to the next source.
+    #[test]
+    fn zero_overrides_fall_through() {
+        assert_eq!(embed_thread_budget(10, Some(0), Some(0)), 8);
+        assert_eq!(embed_thread_budget(10, Some(0), None), 8);
+        assert_eq!(embed_thread_budget(10, Some(4), Some(0)), 4);
     }
 }

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -126,6 +126,15 @@ async fn run(budget: ThreadBudget) -> Result<()> {
         )));
     }
 
+    // Parse args and handle --print-openapi before any subscriber/log init, so
+    // the emitted document is pure JSON on stdout (CI diffs it byte-for-byte).
+    let args = Args::parse();
+
+    if args.print_openapi {
+        println!("{}", ApiDoc::openapi().to_pretty_json()?);
+        return Ok(());
+    }
+
     tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .with(fmt::layer())
@@ -136,13 +145,6 @@ async fn run(budget: ThreadBudget) -> Result<()> {
         source = budget.source,
         "embed CPU thread budget resolved"
     );
-
-    let args = Args::parse();
-
-    if args.print_openapi {
-        println!("{}", ApiDoc::openapi().to_pretty_json()?);
-        return Ok(());
-    }
 
     // Resolve the API key from --key / --key-file / SPELUNK_SERVER_KEY /
     // systemd LoadCredential (see resolve_api_key for precedence). A blank

--- a/docs/server.md
+++ b/docs/server.md
@@ -321,6 +321,22 @@ source is ignored and falls through to the next. Under systemd the credential
 path is preferred — it keeps the key out of the world-readable process
 environment; see [Self-hosting](self-hosting.md).
 
+### Embedding CPU thread budget
+
+On a CPU-only host the bundled native embedder (candle) would otherwise fan a
+single embed batch across every core, briefly starving the server's own request
+handling (`/v1/health` can go unresponsive during a large index). To leave
+headroom, the server caps candle's thread count at startup.
+
+| Env | Default | Purpose |
+|---|---|---|
+| `SPELUNK_EMBED_THREADS` | `max(1, physical cores − 2)` | CPU threads the native embedder may use. Reserves ~2 cores for request serving. |
+
+Precedence: `SPELUNK_EMBED_THREADS` > an already-set `RAYON_NUM_THREADS` >
+the bounded default. A pre-set `RAYON_NUM_THREADS` is respected and never
+overridden. The resolved value and its source are logged at startup
+(`embed CPU thread budget resolved`). GPU (Metal/CUDA) builds are unaffected.
+
 ### Non-loopback plaintext binds are refused, no override
 
 `spelunk-server` refuses to bind a non-loopback address over plaintext HTTP,


### PR DESCRIPTION
## What & why

On a CPU-only host the bundled native candle embedder sized its gemm/rayon parallelism from the physical core count, so a single embed batch fanned across **every** core and briefly starved the server's own request handling (`/v1/health` unresponsive during a large index). Embed work is already serialized (mutex) and off-reactor (`spawn_blocking`); the missing piece was CPU fairness. This caps candle's thread count at startup, before the runtime / first candle op.

Implements spelunk-oss^97 (architect-refined spec) verbatim. No new pool/semaphore, no `config.toml`, no ADR.

## Changes

- `crates/spelunk-server/src/main.rs`: rename `async fn main` → `run`; add a thin `fn main()` that resolves the budget and sets `RAYON_NUM_THREADS` + `CANDLE_NUM_THREADS` **iff unset**, while still single-threaded, then builds the tokio runtime and `block_on(run())`. candle reads `RAYON_NUM_THREADS` live and caches its rayon pool in a `OnceLock` on first use, so the env must be set before the first candle op; `set_var` is `unsafe` in edition 2024 for that reason.
- Pure, unit-tested `embed_thread_budget(physical, rayon_override, spelunk_override) -> usize`. Precedence: `SPELUNK_EMBED_THREADS` > an already-set `RAYON_NUM_THREADS` > `max(1, physical − 2)`. A user-set `RAYON_NUM_THREADS` is respected. Zero/unparseable overrides fall through.
- Startup `tracing::info!` records the resolved budget **and** its source (`default` / `RAYON_NUM_THREADS` / `SPELUNK_EMBED_THREADS`).
- `num_cpus` added as a direct dep (already in the lockfile via candle; needed non-gated since `main()` runs under `--no-default-features` too).
- Docs: `SPELUNK_EMBED_THREADS` documented in `docs/server.md`.

GPU (Metal/CUDA) paths are unaffected — the bound is CPU-only.

## Test plan

All run with `SPELUNK_SECRET_STORE=file`.

- `cargo fmt --check` → clean (also enforced by pre-commit hook).
- `cargo clippy -p spelunk-server --all-targets -- -D warnings` → clean.
- `cargo clippy -p spelunk-server --no-default-features --all-targets -- -D warnings` → clean.
- `cargo test -p spelunk-server` → 25 unit (incl. 5 new `thread_budget_tests`) + 12 integration, all pass.
- `cargo test -p spelunk-server --no-default-features` → 25 unit + 12 integration, all pass.
- New `thread_budget_tests` cover: default `max(1, physical−2)` (10→8, 4→2); tiny hosts 1/2/3 cores → 1; `SPELUNK_EMBED_THREADS` beats default and rayon; `RAYON_NUM_THREADS` respected without spelunk override; zero overrides fall through.
- `cargo audit` → no new advisories (pre-existing allowlisted ttf-parser warning only).

The behavioral core-starvation check (large embed batch no longer pegs all cores, `/v1/health` stays responsive) is manual/local — no prod hardware in CI, per the spec. The CI-gated parts are the unit-tested helper and "env set before first candle op".

🤖 Generated with [Claude Code](https://claude.com/claude-code)