### PR TITLE
Guard CloudSyncClient::new transport scheme when bearer present (spelunk-oss^78)

### DIFF
--- a/crates/spelunk-core/src/storage/remote/sync.rs
+++ b/crates/spelunk-core/src/storage/remote/sync.rs
@@ -113,6 +113,12 @@ impl CloudSyncClient {
     /// (a UUID for cloud-api, or a slug for an OSS spelunk-server); it is
     /// percent-encoded into a single path segment either way.
     pub fn new(base_url: &str, project_id: &str, api_key: Option<&str>) -> Result<Self> {
+        // Fail closed before building the client: a bearer must never travel over
+        // plaintext http to a non-loopback host (spelunk-oss^63). Keyless
+        // loopback-dev construction is unaffected — nothing to leak.
+        if api_key.is_some() {
+            crate::config::validate_transport_url(base_url).map_err(anyhow::Error::msg)?;
+        }
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()
@@ -379,6 +385,32 @@ mod tests {
         let client = CloudSyncClient::new(&server.uri(), "acme/new-app", None).unwrap();
         let res = client.push_batch(vec![item("e1")]).await.unwrap();
         assert_eq!(res.created, 1);
+    }
+
+    // ── transport-scheme guard at construction (spelunk-oss^78) ──────────────
+    // A bearer must never travel over plaintext http to a non-loopback host;
+    // keyless construction is unaffected. Mirrors config::validate_transport_url_*.
+
+    #[test]
+    fn new_with_key_rejects_non_loopback_http() {
+        let err = match CloudSyncClient::new("http://team-server:7777", "proj", Some("secret")) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("expected non-loopback plaintext http to be rejected"),
+        };
+        assert!(err.contains("plaintext http"), "err: {err}");
+    }
+
+    #[test]
+    fn new_with_key_accepts_https_and_loopback_http() {
+        assert!(CloudSyncClient::new("https://team-server:7777", "proj", Some("secret")).is_ok());
+        assert!(CloudSyncClient::new("http://127.0.0.1:7777", "proj", Some("secret")).is_ok());
+        assert!(CloudSyncClient::new("http://localhost:7777", "proj", Some("secret")).is_ok());
+    }
+
+    #[test]
+    fn new_keyless_construction_unaffected_by_transport() {
+        // No bearer to leak, so even a non-loopback plaintext dev server is fine.
+        assert!(CloudSyncClient::new("http://team-server:7777", "proj", None).is_ok());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
`CloudSyncClient::new` (`crates/spelunk-core/src/storage/remote/sync.rs`) built a client that sends `Authorization: Bearer` to `base_url` without validating the transport scheme at construction. A misconfigured non-loopback plaintext `http://` URL could leak the token in the clear.

Fix: call the existing `config::validate_transport_url` and **fail closed** at construction, but only when an `api_key` is present. Keyless loopback-dev construction is unaffected (nothing to leak), matching the intent of the guard (spelunk-oss^63/^76).

### Why this is the right choke point
- `push.rs` / `sync.rs` build `CloudSyncClient` from **raw** `cfg.server_url` with no upstream validation — this was the un-guarded production path.
- `RemoteMemoryBackend` is already guarded at `storage/mod.rs:109`; the CLI `since`/`watch` direct-bearer paths receive an already-validated URL via `Tier::Server` (guarded at `capability.rs:439`). No change needed there.

### Test plan
Run from the worktree with `export SPELUNK_SECRET_STORE=file`:
- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo test` — green (exit 0)
- `cargo test --no-default-features` — green (exit 0)
- New unit tests (mirror `config::validate_transport_url_*`), all pass:
  - `new_with_key_rejects_non_loopback_http`
  - `new_with_key_accepts_https_and_loopback_http`
  - `new_keyless_construction_unaffected_by_transport`

Closes spelunk-oss^78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)