### PR TITLE
spelunk-embed: drop redundant embed-native feature gate (oss^103)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,12 @@ jobs:
             # `embed-native` path stays under test on at least one platform.
             test-flags: ""
           - os: macos-latest
-            # macOS drops `embed-native` to keep this leg fast: the candle
-            # native-embedder stack is heavy to compile and is already covered
-            # on the Linux leg. The embedder is EXPERIMENTAL / NOT RECOMMENDED.
+            # macOS drops the server's `embed-native` feature: this builds the
+            # external-endpoint-only server (no hf-hub download path, no candle
+            # in spelunk-server) and keeps that config under test. Note candle is
+            # now an unconditional dep of the spelunk-embed crate, so its native
+            # embedder still compiles here as a workspace member. The embedder is
+            # EXPERIMENTAL / NOT RECOMMENDED.
             test-flags: "--no-default-features"
           - os: windows-latest
             # Windows keeps default features: the embed-native default builds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,13 +230,17 @@ migrations/  (crates/spelunk-server/migrations/)
   server_002.sql — server memory FTS
 ```
 
-The native embedder engine lives in the `spelunk-embed` crate (below); the
-server depends on it and forwards its `embed-native` / `metal` cargo features.
+The native embedder engine lives in the `spelunk-embed` crate (below). The
+server's `embed-native` feature enables the optional `spelunk-embed` dep (and
+the server's own hf-hub download path); `metal` forwards to `spelunk-embed`'s
+`metal` feature. `spelunk-embed` depends on candle unconditionally — the crate
+is only worth depending on for its native embedder, so there is no feature to
+gate candle out. Its only remaining feature is `metal` (macOS GPU accel).
 
 ### spelunk-embed (`crates/spelunk-embed/src/`)
 
 ```
-lib.rs             — crate root; re-exports NativeEmbedder + DIM (gated by `embed-native`)
+lib.rs             — crate root; re-exports NativeEmbedder + DIM (candle is unconditional)
 embedder_native.rs — native embedder (F2LLM-v2-330M via candle, 896-dim, Metal/GPU on macOS).
                      NativeEmbedder::load_from_path(gguf, tokenizer, config) loads local files
                      already on disk with zero network access — the crate's only load entry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ pretty_assertions = "1"
 serial_test = "3"
 wiremock    = "0.6"
 dirs        = "6"
-# Native embedder stack (F2LLM-v2-330M via candle). Pulled in by the
-# `spelunk-embed` crate behind its `embed-native` feature; versions pinned here
-# so the candle trio stays on one runtime line.
+# Native embedder stack (F2LLM-v2-330M via candle). Depended on unconditionally
+# by the `spelunk-embed` crate; versions pinned here so the candle trio stays on
+# one runtime line.
 candle-core = "0.11.0"
 candle-nn   = "0.11.0"
 candle-transformers = "0.11.0"

--- a/crates/spelunk-embed/Cargo.toml
+++ b/crates/spelunk-embed/Cargo.toml
@@ -11,12 +11,6 @@ name = "spelunk_embed"
 path = "src/lib.rs"
 
 [features]
-default = ["embed-native"]
-# embed-native: bundle the F2LLM-v2-330M Qwen3 embedder via candle (CPU). No
-# download dependency here (no hf-hub) — this crate only loads from local
-# files (`load_from_path`); the Hugging Face Hub acquisition path lives in
-# spelunk-server's `embed_hub` module.
-embed-native = ["dep:candle-core", "dep:candle-nn", "dep:candle-transformers", "dep:tokenizers", "dep:thiserror"]
 # metal: enable Metal GPU acceleration on macOS. Add this when building the macOS binary.
 metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
 
@@ -26,11 +20,16 @@ async-trait = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-candle-core = { workspace = true, optional = true }
-candle-nn = { workspace = true, optional = true }
-candle-transformers = { workspace = true, optional = true }
-tokenizers = { workspace = true, optional = true }
-thiserror = { workspace = true, optional = true }
+# candle is an unconditional dep: depending on this crate at all means you want
+# its native embedder, so gating candle behind a feature bought nothing. This
+# crate still carries no download dep (no hf-hub) — it loads local files only
+# via `load_from_path`; the HF-Hub acquisition path lives in spelunk-server's
+# `embed_hub` module.
+candle-core = { workspace = true }
+candle-nn = { workspace = true }
+candle-transformers = { workspace = true }
+tokenizers = { workspace = true }
+thiserror = { workspace = true }
 
 # macOS-only: `hw.memsize` sysctl in `total_system_ram` (Linux reads
 # /proc/meminfo, no FFI). Not in [workspace.dependencies] since spelunk-embed

--- a/crates/spelunk-embed/src/lib.rs
+++ b/crates/spelunk-embed/src/lib.rs
@@ -16,10 +16,10 @@
 //!
 //! The result is a [`NativeEmbedder`], which implements the crate's own
 //! [`EmbeddingBackend`] trait (re-exported by spelunk-core at
-//! `spelunk_core::embeddings::EmbeddingBackend`). The trait compiles
-//! unconditionally so this crate is storage-free; only the candle engine is
-//! gated behind the `embed-native` cargo feature (on by default). Add the
-//! `metal` feature for Metal GPU acceleration on macOS.
+//! `spelunk_core::embeddings::EmbeddingBackend`). candle is an unconditional
+//! dependency: depending on this crate means you want its native embedder, so
+//! there is no feature gate to opt out of candle. Add the `metal` feature for
+//! Metal GPU acceleration on macOS.
 
 mod backend;
 pub use backend::EmbeddingBackend;
@@ -30,14 +30,8 @@ pub use backend::EmbeddingBackend;
 /// (different weights / vector space) does, which forces a re-index.
 pub const MODEL_ID: &str = "F2LLM-v2-330M@896";
 
-#[cfg(feature = "embed-native")]
 mod embedder_native;
-
-#[cfg(feature = "embed-native")]
 pub use embedder_native::{DIM, NativeEmbedder};
 
-#[cfg(feature = "embed-native")]
 mod error;
-
-#[cfg(feature = "embed-native")]
 pub use error::EmbedError;

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -20,15 +20,16 @@ default = ["embed-native"]
 # inference engine lives in the `spelunk-embed` crate (local-path load only);
 # this crate additionally owns the Hugging Face Hub acquisition path
 # (`embed_hub` module) that resolves the model artifacts before handing them
-# to `spelunk-embed`'s `load_from_path`. Forwards to `spelunk-embed`'s feature.
-embed-native = ["spelunk-embed/embed-native", "dep:candle-core", "dep:hf-hub", "dep:dirs"]
+# to `spelunk-embed`'s `load_from_path`. Enables the optional `spelunk-embed`
+# dep; disable this feature for an external-endpoint-only server (no candle).
+embed-native = ["dep:spelunk-embed", "dep:candle-core", "dep:hf-hub", "dep:dirs"]
 # metal: enable Metal GPU acceleration on macOS. Add this when building the
 # macOS binary. Forwards to `spelunk-embed`'s `metal` feature.
 metal = ["spelunk-embed/metal"]
 
 [dependencies]
 spelunk-core = { path = "../spelunk-core" }
-spelunk-embed = { path = "../spelunk-embed", default-features = false, optional = true }
+spelunk-embed = { path = "../spelunk-embed", optional = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## What

Per Johan's cloud-api #205 review: `spelunk-embed`'s `embed-native` feature gate was redundant. Depending on `spelunk-embed` without the feature yielded only the `EmbeddingBackend` trait (which `spelunk-core` already re-exports), so a candle-free dep on this crate was a noop. This drops that gate — **candle is now an unconditional dependency of `spelunk-embed`**.

- `spelunk-embed/Cargo.toml`: removed `default`/`embed-native` features; candle-core/nn/transformers, tokenizers, thiserror are now non-optional. Kept `metal` (a real macOS GPU-accel toggle, off by default).
- `spelunk-embed/src/lib.rs`: removed the four `#[cfg(feature = "embed-native")]` gates; `embedder_native` + `error` modules and `NativeEmbedder`/`DIM`/`EmbedError` re-exports are unconditional.
- `spelunk-server/Cargo.toml`: **kept** its own `embed-native` feature — it is *not* redundant (it gates the hf-hub download path via `embed_hub`, `dirs`, `candle-core`, and the external-endpoint-only server build). It now enables the optional `spelunk-embed` dep directly (`dep:spelunk-embed`) instead of forwarding to the removed `spelunk-embed/embed-native`.
- Comment updates: root `Cargo.toml`, CI macOS-leg comment, `CLAUDE.md` module map.

Server-side `#[cfg(feature = "embed-native")]` gates in `main.rs`/`lib.rs` are unchanged — the server feature stays real.

## `--no-default-features` semantics

The CI macOS leg runs `--no-default-features`. Its primary purpose — verifying the **external-endpoint-only server** (no candle in `spelunk-server`, no hf-hub) — still holds: `spelunk-server`'s feature is untouched. Consequence of making candle unconditional: the `spelunk-embed` crate now compiles candle even under `--no-default-features` (as a workspace member), so that leg no longer skips candle entirely. CI comment updated to reflect this. No CI matrix change.

## cloud-api impact (separate repo — not touched here)

cloud-api depends with `default-features = false, features = ["embed-native"]`. Once cloud-api bumps its git pin past this commit, that line will fail to resolve (the feature no longer exists). Follow-up needed there: simplify to a plain `spelunk-embed` dep. Flagged for a cloud-api task.

## Test plan

All run from the worktree with `SPELUNK_SECRET_STORE=file`:

- `cargo fmt --all -- --check` → clean
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo clippy --all-targets --features rich-formats -- -D warnings` → clean (mirrors CI Check&Lint)
- `cargo check --workspace --all-targets` (default) → ok
- `cargo check --workspace --all-targets --no-default-features` → ok (server drops candle; embed crate unchanged)
- `cargo test --workspace` → all pass
- `cargo test --workspace --no-default-features` → all pass, 0 failed
- `cargo audit` → only pre-existing allowed warnings (ttf-parser/lopdf via rich-formats); `Cargo.lock` unchanged (identical dependency graph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)