### PR TITLE
docs(mdm): drop #532-pruned dead config keys from spelunk-config.toml example (oss^118)

### DIFF
--- a/examples/mdm/spelunk-config.toml
+++ b/examples/mdm/spelunk-config.toml
@@ -37,15 +37,8 @@ mode = "local_first"
 # By default spelunk-server bundles a native embedder, so most fleets leave
 # these unset. Set them only if you run a shared OpenAI-compatible endpoint
 # (LM Studio, Ollama, vLLM, ...) for embeddings/LLM.
-# api_base_url    = "http://inference.internal:1234"
 # embedding_model = "text-embedding-embeddinggemma-300m-qat"
 # llm_model       = "google/gemma-3n-e4b"
-# batch_size      = 32
-
-# --- Optional: directory conventions -----------------------------------------
-# Where `spelunk plan create` and spec discovery look (relative to project root).
-# plans_dir = "docs/plans"
-# specs_dir = "docs/specs"
 
 # --- Optional: git-notes memory ----------------------------------------------
 # `spelunk memory add` also appends entries to refs/notes/spelunk by default.


### PR DESCRIPTION
Removes commented example lines for four keys that are no longer `Config` fields from the MDM server-config example, so it only advertises keys `Config::load` actually reads. Follow-up to #532 (which pruned the fields); `batch_size` also confirmed dead in oss^95/#547.

Keys removed (verified dead as config keys): `api_base_url`, `plans_dir`, `specs_dir`, `batch_size`. Comment-only change to `examples/mdm/spelunk-config.toml`; `Config` has no `deny_unknown_fields`, so nothing parses these anyway.

## Test plan
- `git grep -nE 'api_base_url|plans_dir|specs_dir|batch_size' crates/` — no live `Config` reader; only test-config strings, comments, and the unrelated CLI `IndexArgs`/harvest `batch_size`. Cross-checked `Config` fields in `crates/spelunk-core/src/config.rs` — none of the four is present.
- `git grep -nE 'api_base_url|plans_dir|specs_dir|batch_size' examples/` — no other example files affected.
- `SPELUNK_SECRET_STORE=file cargo check -p spelunk-core` — passes.