### PR TITLE
chore: release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.3] — 2026-07-08
+
 ### Removed
 
 - **`spelunk search --as-of <sha>` (snapshot-based temporal search).** The snapshot
@@ -20,6 +22,11 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   continues to work unchanged. Note: `spelunk memory list/search --as-of <date>` for
   point-in-time memory archaeology remains available and unaffected. (#517,
   spelunk-oss^67)
+- **Retired the `api_base_url` client egress path and pruned the remaining dead
+  config keys** (`plans_dir`, `specs_dir`, `batch_size`, …) from the config surface
+  and the shipped `examples/mdm/spelunk-config.toml`. Existing config files that
+  still carry these keys continue to parse unchanged (forward-compat locked by a
+  regression test). (#532, #551, spelunk-oss^109/^118)
 
 ### Security
 
@@ -77,6 +84,14 @@ spelunk uses [Semantic Versioning](https://semver.org/).
     format could still be read fully into memory first. Oversized files are now skipped with a
     warning instead. This is local-indexing hardening, distinct from and complementary to the
     server-side request-body caps shipped in 0.9.2 above.
+- **`CloudSyncClient` refuses to attach a bearer token to a non-HTTPS `server_url`
+  at construction.** A team `server_url` set to plaintext `http://` no longer sends
+  the bearer `SPELUNK_SERVER_KEY` in cleartext — the client fails fast at
+  construction, closing the CLI-side gap adjacent to the server bind-safety work
+  above. (#549, spelunk-oss^78)
+- **`add_note` now audit-logs notes rejected by injection-pattern detection**, so a
+  rejected write leaves a trail instead of failing silently.
+- **Bumped `crossbeam-epoch` to 0.9.20** for RUSTSEC-2026-0204. (#535)
 
 ### Added
 
@@ -100,9 +115,27 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 - **Embedding progress bar displayed immediately during indexing.** [spelunk-oss^73]
   The ETA-aware embedding progress bar now appears as soon as the embed phase begins, instead of
   waiting for the first batch to complete.
+- **`spelunk-server --health-check`: a self-contained container health probe.** [spelunk-oss^99]
+  It probes the server's own `/v1/health` on the configured `--host`/`--port` and exits `0`
+  (live) or non-zero, so a container `HEALTHCHECK` needs no `curl`/`wget` in the runtime image.
+- **First-party systemd units + credential-based API keys for the team server.** `spelunk-server`
+  can now read its shared API key from `--key-file` or a systemd `LoadCredential` credential — a
+  first-class alternative to `SPELUNK_SERVER_KEY` that keeps the key out of the process table —
+  and the repo ships packaged systemd units for running the bare-metal team server.
 
 ### Fixes
 
+- **`spelunk-server` bounds candle's CPU embedding threads so embeds no longer starve request
+  serving.** [spelunk-oss^97] On CPU-only hosts a single embed batch previously fanned candle's
+  gemm across every core, pinning the machine and briefly hanging `/v1/health`. The server now
+  caps the embedder's CPU thread budget to `max(1, cores − 2)` by default (override with
+  `SPELUNK_EMBED_THREADS`, or a pre-set `RAYON_NUM_THREADS`), leaving headroom to keep serving
+  requests during indexing.
+- **The chunker caps oversized semantic and Markdown chunks** so a single very large unit no
+  longer stalls the embed phase. [spelunk-oss^114]
+- **`spelunk init` writes `.spelunk/.gitignore`** so machine-specific SQLite files aren't
+  accidentally committed.
+- **The CLI no longer surfaces a phantom `plan` capability** it never implemented. (#540)
 - **`spelunk index` no longer loses computed embeddings when a batch times out on slow hardware.**
   [spelunk-oss^71] The embed phase now calibrates against real timing before committing to a
   batch size: it sends a 1-chunk request, then a 4-chunk request, and derives the per-request

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5135,7 +5135,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-embed"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-embed/Cargo.toml
+++ b/crates/spelunk-embed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-embed"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 description = "Native F2LLM-v2-330M embedder (candle) for spelunk"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"


### PR DESCRIPTION
## Release v0.9.3

Version bump plus changelog roll for the next 0.9 patch release.

### Changes
- Bumped all four workspace crates 0.9.2 -> 0.9.3 (`spelunk-cli`, `spelunk-core`, `spelunk-embed`, `spelunk-server`) and `Cargo.lock`.
- Rolled `CHANGELOG.md` `[Unreleased]` into `[0.9.3] — 2026-07-08`, leaving a fresh empty `[Unreleased]`.
- Reconciled the changelog against everything merged since v0.9.2. The earlier wave already had `[Unreleased]` entries; I added the ones the most recent merges never wrote:
  - **Security:** `CloudSyncClient` non-HTTPS bearer guard (#549, oss^78); `add_note` rejection audit-logging; `crossbeam-epoch` RUSTSEC-2026-0204 (#535).
  - **Features:** `spelunk-server --health-check` (#541, oss^99); systemd units and `--key-file` / credential-based API keys.
  - **Fixes:** candle CPU thread cap / `SPELUNK_EMBED_THREADS` (#548, oss^97); oversized-chunk cap (#543, oss^114); `.spelunk/.gitignore` on `init`; phantom `plan` capability removed (#540).
  - **Removed:** `api_base_url` egress path and remaining dead config keys (#532, #551, oss^109/^118).

Please sanity-check the wording on the entries I curated from the merge log.

### Validation
- `cargo check --workspace` compiles clean at 0.9.3.
- All four crate `Cargo.toml` files and the `Cargo.lock` workspace entries read `0.9.3`.
- Changelog renders with a `[0.9.3]` section and an empty `[Unreleased]`; the version-heading dash matches the existing em-dash style.

### Releasing (post-merge)
This PR is the version bump only. Per `docs/RELEASING.md`, the release is triggered by pushing the tag after merge (`git tag v0.9.3 && git push origin v0.9.3`), which runs `.github/workflows/release.yml`: multi-platform binaries, the `.deb`, a GitHub Release with auto-generated notes, and the Homebrew formula update. I did not tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
