### PR TITLE
feat(server): fix the embedding model, drop the --embedding-model override (spelunk-oss^119)

### DIFF
--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -69,16 +69,20 @@ struct Args {
 
     /// Base URL of an OpenAI-compatible embedding server for server-side embedding
     /// (e.g. `http://127.0.0.1:1234`). Overrides `SPELUNK_EMBEDDING_URL`.
-    /// When set, entries posted without a pre-computed `embedding` field are embedded
-    /// by the server before storage.
+    /// Relocates *where* embeddings are computed only; the model stays fixed to
+    /// F2LLM-v2-330M@896 — the endpoint must serve that model. When set, entries
+    /// posted without a pre-computed `embedding` field are embedded by the server
+    /// before storage.
     #[arg(long, env = "SPELUNK_EMBEDDING_URL")]
     embedding_url: Option<String>,
 
-    /// Embedding model name to pass to the external `--embedding-url` server (e.g.
-    /// `f2llm-v2-330m`). Ignored by the bundled native embedder. Overrides
-    /// `SPELUNK_EMBEDDING_MODEL`.
-    #[arg(long, env = "SPELUNK_EMBEDDING_MODEL", default_value = "")]
-    embedding_model: String,
+    /// Deprecated and ignored. The embedding model is fixed to F2LLM-v2-330M@896
+    /// product-wide (ADR-053); a mismatched model silently corrupts the shared
+    /// vector space (ADR-010). Retained hidden only so a legacy
+    /// `SPELUNK_EMBEDDING_MODEL` / `--embedding-model` warns and is ignored
+    /// instead of hard-failing an old deployment on upgrade. Never selects a model.
+    #[arg(long, env = "SPELUNK_EMBEDDING_MODEL", hide = true)]
+    embedding_model: Option<String>,
 
     /// Base URL of an OpenAI-compatible chat completions server for LLM features
     /// (`/explore`). Overrides `SPELUNK_LLM_URL`.
@@ -157,6 +161,12 @@ async fn run(budget: ThreadBudget) -> Result<()> {
         "embed CPU thread budget resolved"
     );
 
+    // Legacy embedding-model override is ignored, not honoured (the model is
+    // fixed product-wide). Warn instead of hard-failing an old deployment.
+    if let Some(msg) = legacy_embedding_model_warning(args.embedding_model.as_deref()) {
+        tracing::warn!("{msg}");
+    }
+
     // Resolve the API key from --key / --key-file / SPELUNK_SERVER_KEY /
     // systemd LoadCredential (see resolve_api_key for precedence). A blank
     // value from any source counts as "no key" — a set-but-empty
@@ -219,12 +229,8 @@ async fn run(budget: ThreadBudget) -> Result<()> {
     // model download. When no embedder is configured at all, the slot is
     // `disabled` (embed endpoints return a permanent 400).
     let (embedder, load_native): (EmbedderSlot, bool) = if let Some(base_url) = args.embedding_url {
-        let model = if args.embedding_model.is_empty() {
-            "default".to_string()
-        } else {
-            args.embedding_model.clone()
-        };
-        tracing::info!("server-side embedding enabled: {base_url} model={model}");
+        // Model is fixed product-wide; the URL relocates compute only.
+        tracing::info!("server-side embedding enabled: {base_url} model={NATIVE_MODEL_ID}");
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(60))
             .build()
@@ -233,7 +239,7 @@ async fn run(budget: ThreadBudget) -> Result<()> {
             Arc::new(ServerEmbedder {
                 client,
                 base_url,
-                model,
+                model: NATIVE_MODEL_ID.to_string(),
             });
         (EmbedderSlot::ready(backend), false)
     } else {
@@ -393,6 +399,21 @@ fn resolve_embed_thread_budget() -> ThreadBudget {
         "default"
     };
     ThreadBudget { threads, source }
+}
+
+// ── Legacy embedding-model override ───────────────────────────────────────────
+
+/// Warning to emit when a legacy `SPELUNK_EMBEDDING_MODEL` / `--embedding-model`
+/// is set. The embedding model is fixed to `NATIVE_MODEL_ID` product-wide
+/// (ADR-053) and can no longer be selected; a non-blank value is ignored, not
+/// honoured. Returns `None` when unset/blank so upgrades stay quiet.
+fn legacy_embedding_model_warning(model: Option<&str>) -> Option<String> {
+    let value = model.map(str::trim).filter(|m| !m.is_empty())?;
+    Some(format!(
+        "Ignoring embedding model override '{value}': the embedding model is fixed to \
+         {NATIVE_MODEL_ID} product-wide and can no longer be selected. Remove \
+         SPELUNK_EMBEDDING_MODEL / --embedding-model."
+    ))
 }
 
 // ── Bind-safety guard ─────────────────────────────────────────────────────────
@@ -1067,6 +1088,42 @@ mod arg_tests {
             args.key_file.as_deref(),
             Some(std::path::Path::new("/etc/spelunk/server-key"))
         );
+    }
+
+    // ── Legacy embedding-model override ──────────────────────────────────────
+
+    /// A legacy `--embedding-model` / `SPELUNK_EMBEDDING_MODEL` still parses
+    /// (hidden, not removed) so an old deployment doesn't hard-fail clap on
+    /// upgrade — but it never selects a model.
+    #[test]
+    fn legacy_embedding_model_flag_still_parses() {
+        let args = Args::parse_from(["spelunk-server", "--embedding-model", "some-model"]);
+        assert_eq!(args.embedding_model.as_deref(), Some("some-model"));
+    }
+
+    /// A set (non-blank) legacy value yields a visible warning that names the
+    /// value and the fixed model, and tells the operator to remove it.
+    #[test]
+    fn legacy_embedding_model_value_warns() {
+        let msg = super::legacy_embedding_model_warning(Some("gemma-300m"))
+            .expect("a non-blank legacy value must warn");
+        assert!(msg.contains("gemma-300m"), "warning names the value: {msg}");
+        assert!(
+            msg.contains(super::NATIVE_MODEL_ID),
+            "warning names the fixed model: {msg}"
+        );
+        assert!(
+            msg.contains("SPELUNK_EMBEDDING_MODEL"),
+            "warning tells the operator which key to remove: {msg}"
+        );
+    }
+
+    /// Unset or blank → no warning, so a clean upgrade stays quiet.
+    #[test]
+    fn legacy_embedding_model_unset_or_blank_is_silent() {
+        assert!(super::legacy_embedding_model_warning(None).is_none());
+        assert!(super::legacy_embedding_model_warning(Some("")).is_none());
+        assert!(super::legacy_embedding_model_warning(Some("   ")).is_none());
     }
 
     // ── Self-contained health probe ──────────────────────────────────────────

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -264,16 +264,17 @@ For how discovery works and how to point the CLI at a remote server, see
 
 By default the bundled `spelunk-server` provides embeddings (native, via the
 candle-served F2LLM-v2-330M model) and — when a chat model is configured — LLM
-inference. If you'd rather have it call your own OpenAI-compatible endpoint
-(e.g. LM Studio on port `1234`, Ollama on `11434`, or a vLLM proxy) instead of
-the native embedder, configure **the server** — this is not a CLI
-`config.toml` key. `spelunk-server` reads these environment variables (each has
-an equivalent flag):
+inference. The embedding **model is fixed** to F2LLM-v2-330M (896-dim) product-wide
+and can no longer be selected: a mismatched embedding model silently corrupts
+semantic search. You *can* relocate **where** embeddings are computed — point the
+server at your own OpenAI-compatible endpoint that serves that same model (e.g. a
+shared GPU host) — but the model itself stays fixed. Configure **the server** —
+this is not a CLI `config.toml` key. `spelunk-server` reads these environment
+variables (each has an equivalent flag):
 
 | Variable | Flag | Purpose |
 |---|---|---|
-| `SPELUNK_EMBEDDING_URL` | `--embedding-url` | Base URL of an OpenAI-compatible embedding endpoint. When set, the server embeds through it instead of the native model. |
-| `SPELUNK_EMBEDDING_MODEL` | `--embedding-model` | Model id to send to that endpoint (must match what it serves). |
+| `SPELUNK_EMBEDDING_URL` | `--embedding-url` | Base URL of an OpenAI-compatible embedding endpoint serving F2LLM-v2-330M. When set, the server embeds through it instead of computing embeddings itself. |
 | `SPELUNK_LLM_URL` | `--llm-url` | Base URL of an OpenAI-compatible chat-completions endpoint for LLM features (`explore`, summaries, `memory harvest`). |
 | `SPELUNK_LLM_MODEL` | `--llm-model` | Chat model id to send to that endpoint. |
 
@@ -283,7 +284,6 @@ daemon that is already running keeps its old configuration until restarted:
 
 ```bash
 export SPELUNK_EMBEDDING_URL="http://127.0.0.1:1234"
-export SPELUNK_EMBEDDING_MODEL="your-endpoint-model-id"
 # optional, for LLM features (explore, summaries, harvest):
 export SPELUNK_LLM_URL="http://127.0.0.1:1234"
 export SPELUNK_LLM_MODEL="your-chat-model-id"
@@ -292,20 +292,22 @@ spelunk server stop     # if one is already running
 spelunk server start    # starts with the endpoint configured above
 ```
 
-Or, if you run `spelunk-server` yourself, pass the flags directly:
+Or, if you run `spelunk-server` yourself, pass the flag directly:
 
 ```bash
-spelunk-server --embedding-url http://127.0.0.1:1234 \
-               --embedding-model your-endpoint-model-id
+spelunk-server --embedding-url http://127.0.0.1:1234
 ```
 
-A non-native embedder almost certainly produces a different vector dimension
-than the native model's 896. Set `--embedding-dim` to match your endpoint and
-start from a fresh index — the server records the dimension on the first write
-and rejects later writes that disagree (see
-[Embedding dimension](server.md#embedding-dimension)). Even when the dimension
-matches, re-embedding an existing index through the new endpoint needs a full
-re-index (`spelunk index --force`), since unchanged files are otherwise skipped.
+There is no embedding-model flag: `spelunk` always computes 896-dim
+F2LLM-v2-330M vectors, and your endpoint must serve that model. (A legacy
+`SPELUNK_EMBEDDING_MODEL` / `--embedding-model` is ignored, with a startup
+warning, rather than honoured.) `--embedding-dim` still exists so an endpoint
+whose vectors differ in dimension can be matched, but changing it means you are
+running a different model at your own risk — the server records the dimension on
+the first write and rejects later writes that disagree (see
+[Embedding dimension](server.md#embedding-dimension)). Re-embedding an existing
+index through a new endpoint needs a full re-index (`spelunk index --force`),
+since unchanged files are otherwise skipped.
 
 Tune the per-request embedding batch ceiling at index time with
 `spelunk index --batch-size <n>` if a slow or memory-constrained endpoint

--- a/docs/server.md
+++ b/docs/server.md
@@ -245,13 +245,18 @@ says so explicitly so no one has to infer it from behaviour.
 
 ## Embedding dimension
 
-All clients writing to the same project must use the same embedding model.
-The server records the embedding dimension on the first write and rejects
-subsequent writes with a different dimension.
+All clients writing to the same project must use the same embedding model. The
+embedding model is fixed product-wide to codefuse-ai/F2LLM-v2-330M (896-dim) and
+cannot be selected — a mismatched model silently corrupts semantic search. The
+server records the embedding dimension on the first write and rejects subsequent
+writes with a different dimension.
 
 Default: 896 dimensions (codefuse-ai/F2LLM-v2-330M, the bundled native embedder).
 
-If your team uses a different model, configure the server at startup:
+`--embedding-dim` sets the dimension the server enforces. Change it only to match
+an external endpoint whose vectors differ in size — doing so means you are
+running a different model at your own risk (the one-model-per-vector-space
+invariant no longer holds), not a supported way to swap embedding models:
 
 ```bash
 docker compose run spelunk-server --embedding-dim 1024


### PR DESCRIPTION
## Scope (spelunk-oss^119)

Per Johan on PR #546 — "embedding models should no longer be possible to override" — this fixes the embedding model product-wide and removes the ability to select a different one on `spelunk-server`.

- `--embedding-model` / `SPELUNK_EMBEDDING_MODEL` no longer selects a model. The external `--embedding-url` path now sends the fixed `NATIVE_MODEL_ID` (F2LLM-v2-330M@896, from `spelunk_core::embeddings::MODEL_ID`) on the wire, never a user string.
- `--embedding-url` is retained as **endpoint relocation only** — it moves *where* embeddings are computed; the endpoint must serve the fixed model.
- `--embedding-dim` and all LLM overrides (`--llm-url` / `--llm-model` / `SPELUNK_LLM_*`) are untouched.
- Docs (`getting-started.md` advanced inference section, `server.md` embedding-dimension section) no longer advertise a model override and state the model is fixed.

## Legacy behaviour: warn, don't hard-fail (deliberate)

The `embedding_model` arg is kept **hidden** (`hide = true`) rather than deleted from clap. A full clap removal would make an old fleet that still sets `SPELUNK_EMBEDDING_MODEL` / passes `--embedding-model` **hard-fail on startup** after upgrade. Instead a non-blank legacy value is ignored and emits a visible `tracing::warn!` that names the ignored value, the fixed model, and the env key to remove. Unset/blank stays silent so clean upgrades are quiet.

## Deferred

Removing the external-embedding (`--embedding-url`) path **entirely** was explicitly deferred as a larger decision (adjacent to the cloud-side embedder work) — not in scope here. This PR keeps that path, only fixing the model it uses.

## Test plan

Both CI feature cells run in the task worktree (`SPELUNK_SECRET_STORE=file`):

- `cargo test -p spelunk-server` → 32 unit + 12 integration + 0 doc, **0 failed**
- `cargo test -p spelunk-server --no-default-features` → all green, **0 failed**; the 3 new `legacy_embedding_model_{flag_still_parses,value_warns,unset_or_blank_is_silent}` tests pass in both cells
- `cargo fmt --all --check` → clean
- `cargo clippy -p spelunk-server --all-targets -- -D warnings` → clean
- `cargo clippy -p spelunk-server --no-default-features --all-targets -- -D warnings` → clean

Verified the core guarantee by grep: the only consumers of the CLI/env `embedding_model` value are the legacy-warning function and its parse test; `ServerEmbedder` sends `NATIVE_MODEL_ID` in the `/v1/embeddings` request body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
