### PR TITLE
docs(examples): Windows fleet-management MDM example (spelunk-oss^36)

### DIFF
--- a/examples/mdm/README.md
+++ b/examples/mdm/README.md
@@ -5,6 +5,11 @@ This directory shows how an administrator can deploy and pre-configure
 Management (MDM). It is example configuration and documentation only; nothing
 here changes how spelunk behaves at runtime.
 
+The shared config templates and this overview are cross-platform. The
+platform-specific server deployment lives in per-OS subdirectories: macOS in
+[`macos/`](macos/), Windows (Intune/GPO + Windows Service) in
+[`windows/`](windows/README.md).
+
 > These templates are community examples. Test them on a single device before
 > rolling out to a fleet, and adapt the paths, ports, and credentials to your
 > environment.
@@ -51,6 +56,7 @@ spelunk's own settings.
 | `spelunk-config.toml` | Example global config to push to `~/.config/spelunk/config.toml`. Every key is a real field read by `spelunk`. |
 | `spelunk.env.example` | Example managed environment (shared API key, server URL, fleet policy) to deliver via launchd, a profile script, or Group Policy. |
 | `macos/cloud.spelunk.server.mobileconfig` | macOS configuration profile that installs a managed `spelunk-server` LaunchDaemon on a shared or always-on host. |
+| `windows/` | Windows fleet guide: Intune/GPO config delivery + a PowerShell script that runs `spelunk-server` as a Windows Service. See [`windows/README.md`](windows/README.md). |
 
 ## Two deployment shapes
 
@@ -97,8 +103,10 @@ Steps:
 2. **Run the managed server.** On a macOS server host, install
    `macos/cloud.spelunk.server.mobileconfig` (it installs a system-scoped
    LaunchDaemon). On Linux, deploy the systemd unit from
-   `packaging/spelunk-server.service`. Set a real `SPELUNK_SERVER_KEY` on the
-   server.
+   `packaging/spelunk-server.service`. On Windows, run it as a Windows Service
+   with `windows/Install-SpelunkServerService.ps1` (see
+   [`windows/README.md`](windows/README.md)). Set a real `SPELUNK_SERVER_KEY` on
+   the server.
 3. **Pre-configure the laptops** so users do not have to. Push
    `spelunk-config.toml` to `~/.config/spelunk/config.toml` (server URL, project
    slug, sync mode) and deliver the shared `SPELUNK_SERVER_KEY` via the managed
@@ -123,8 +131,9 @@ Write `spelunk-config.toml` (edited for your environment) to each user's
   copies the file in for each managed user. Keep the file readable only by its
   owner if it contains anything sensitive (it should not; keep secrets in the
   environment).
-- **Windows:** the equivalent path resolves under the user profile; deploy the
-  file with a managed script or login script.
+- **Windows:** the same `~/.config` path resolves to
+  `%USERPROFILE%\.config\spelunk\config.toml` (not `%APPDATA%`); deploy the file
+  with a managed script or login script. See [`windows/README.md`](windows/README.md).
 
 A team-wide subset can instead live in a committed `.spelunk/config.toml` at the
 repository root (`server_url`, `project_id`), which needs no MDM at all. Use the
@@ -174,6 +183,8 @@ report that they are unavailable instead of starting anything.
 
 ## Further reading
 
+- [`windows/README.md`](windows/README.md) - the Windows fleet guide (Intune/GPO
+  config delivery + running `spelunk-server` as a Windows Service).
 - [Getting started](../../docs/getting-started.md) - install paths and the team
   setup walkthrough.
 - [Self-hosting](../../docs/self-hosting.md) - exposing `spelunk-server` to

--- a/examples/mdm/windows/Install-SpelunkServerService.ps1
+++ b/examples/mdm/windows/Install-SpelunkServerService.ps1
@@ -1,0 +1,85 @@
+<#
+.SYNOPSIS
+  Install a managed, shared spelunk-server as a Windows Service (NSSM-hosted).
+
+.DESCRIPTION
+  Windows counterpart to macos/cloud.spelunk.server.mobileconfig. Registers a
+  long-lived spelunk-server on an always-on host (a build host or team server)
+  so a Windows fleet can share memory.
+
+  spelunk-server.exe is a plain console program: it does NOT implement the
+  Windows Service Control Manager (SCM) dispatcher, so `sc.exe create` /
+  `New-Service` pointed straight at it will register but fail to start with
+  error 1053 ("did not respond in a timely fashion"). A wrapper that hosts the
+  console process as a service is required. This script uses NSSM
+  (https://nssm.cc). Alternatives that also work: WinSW (XML-configured
+  service shim) or a Task Scheduler task set to run at startup, whether or not a
+  user is logged on, with restart-on-failure. Pick one; don't stack them.
+
+  This binds loopback (127.0.0.1) only. spelunk-server refuses a non-loopback
+  plaintext bind unconditionally, so a team-reachable server is loopback + an
+  operator-owned TLS reverse proxy (IIS ARR, nginx, Caddy) on the same host.
+  Point laptops at the proxy's HTTPS URL, not at this port. See
+  ../../../docs/self-hosting.md and ../../../docs/adr/056-oss-server-tenancy-model.md.
+
+.NOTES
+  Run as Administrator. Verify NSSM argument names against your NSSM version;
+  they are stable but not guaranteed.
+#>
+[CmdletBinding()]
+param(
+    # spelunk-server.exe location. The install script places it in
+    # %LOCALAPPDATA%\Programs\spelunk for the running user; for a machine
+    # service, copy it somewhere machine-wide first (e.g. %ProgramData%).
+    [string]$BinaryPath = "$env:ProgramData\spelunk\spelunk-server.exe",
+
+    # nssm.exe location (install via Scoop/Chocolatey or download from nssm.cc).
+    [string]$NssmPath = "nssm.exe",
+
+    [string]$ServiceName = "spelunk-server",
+
+    # Loopback only; see .DESCRIPTION. Do not set 0.0.0.0 here.
+    [int]$Port = 7777,
+
+    # Persistent DB + logs for an always-on host.
+    [string]$DataDir = "$env:ProgramData\spelunk",
+
+    # Shared API key. REQUIRED for any server other teammates reach (via the
+    # TLS proxy). Prefer passing it out-of-band over hardcoding it here.
+    [Parameter(Mandatory = $true)]
+    [string]$ServerKey
+)
+
+$ErrorActionPreference = "Stop"
+
+$dbPath  = Join-Path $DataDir "spelunk.db"
+$logDir  = Join-Path $DataDir "logs"
+New-Item -ItemType Directory -Force -Path $DataDir, $logDir | Out-Null
+
+if (-not (Test-Path $BinaryPath)) {
+    throw "spelunk-server.exe not found at '$BinaryPath'. Deploy the binary first (see README.md)."
+}
+
+# Register the service. --host is omitted so the server keeps its loopback
+# default. --key-file is preferred over --key so the key is not visible in the
+# service's argument list; write it 0600-equivalent (Administrators/SYSTEM only).
+$keyFile = Join-Path $DataDir "server-key"
+Set-Content -Path $keyFile -Value $ServerKey -NoNewline
+icacls $keyFile /inheritance:r /grant:r "SYSTEM:(R)" "Administrators:(R)" | Out-Null
+
+$serverArgs = "--port $Port --db `"$dbPath`" --key-file `"$keyFile`""
+
+& $NssmPath install $ServiceName $BinaryPath
+& $NssmPath set $ServiceName AppParameters $serverArgs
+& $NssmPath set $ServiceName AppDirectory $DataDir
+& $NssmPath set $ServiceName AppStdout (Join-Path $logDir "spelunk-server.log")
+& $NssmPath set $ServiceName AppStderr (Join-Path $logDir "spelunk-server.err.log")
+& $NssmPath set $ServiceName Start SERVICE_AUTO_START
+# RUST_LOG controls server verbosity. Add SPELUNK_* policy vars here if you
+# prefer the service environment over machine environment variables.
+& $NssmPath set $ServiceName AppEnvironmentExtra "RUST_LOG=info"
+
+& $NssmPath start $ServiceName
+
+Write-Host "Installed and started service '$ServiceName' on 127.0.0.1:$Port."
+Write-Host "Verify: & '$BinaryPath' --health-check --port $Port"

--- a/examples/mdm/windows/README.md
+++ b/examples/mdm/windows/README.md
@@ -1,0 +1,146 @@
+# Windows fleet deployment for spelunk
+
+The Windows counterpart to the macOS example one directory up. It covers the two
+Windows-specific pieces of an MDM rollout: pushing spelunk's config/environment
+with Intune or Group Policy, and running a shared `spelunk-server` as a Windows
+Service. Read [`../README.md`](../README.md) first — the configuration surface,
+the two deployment shapes, and the trust model are the same on every platform;
+only the mechanics below differ.
+
+> Community examples. Test on one machine before a fleet rollout, and verify
+> every Intune/GPO payload in your own MDM console — the exact policy CSP and
+> ADMX shapes vary by console and are noted as "verify in console" below.
+
+## Windows paths
+
+spelunk reads the same TOML config and environment variables on Windows as
+elsewhere; only the paths differ.
+
+| What | Path |
+|------|------|
+| Global user config | `%USERPROFILE%\.config\spelunk\config.toml` |
+| Project config (in-repo) | `<repo>\.spelunk\config.toml` |
+| Stored credentials | Windows Credential Manager (default) |
+| Binaries (install script) | `%LOCALAPPDATA%\Programs\spelunk\` |
+| Shared-server data (this example) | `%ProgramData%\spelunk\` |
+
+Note the config path: spelunk uses `~/.config` on **every** platform, so on
+Windows that is `%USERPROFILE%\.config\spelunk\`, **not** `%APPDATA%` or
+`%LOCALAPPDATA%`. Push the shared [`../spelunk-config.toml`](../spelunk-config.toml)
+there; its keys are identical on Windows.
+
+## Shape A: managed laptops, no shared server
+
+Each laptop autostarts a local, loopback-bound `spelunk-server` on demand. There
+is nothing to provision. Two Windows-specific MDM tasks:
+
+1. **Install the binaries.** Deploy `spelunk.exe` and `spelunk-server.exe` to a
+   machine-wide directory on `PATH` (e.g. `%ProgramData%\spelunk\`), or run the
+   PowerShell install script (see [`../../../docs/getting-started.md`](../../../docs/getting-started.md))
+   as a managed script. A winget package is planned as the primary managed path;
+   until then, an Intune Win32 app or a script payload is the deployment vehicle.
+2. **Pre-approve the loopback firewall rule.** The first time the local server
+   binds its port, Windows Defender Firewall may prompt; if it is dismissed or
+   silently blocked, spelunk drops to text/AST search with a "no server
+   reachable" notice. Push an **inbound allow rule for `spelunk-server.exe`** so
+   no user prompt is needed. With Group Policy:
+
+   ```
+   Computer Configuration > Policies > Windows Settings > Security Settings >
+   Windows Defender Firewall with Advanced Security > Inbound Rules
+   ```
+
+   Create an inbound Program rule allowing `%ProgramData%\spelunk\spelunk-server.exe`.
+   Via Intune, the equivalent is an Endpoint security **Firewall** rule policy
+   (verify the rule fields in your console). Scope it as tightly as your policy
+   allows — the server binds loopback, so a local rule is sufficient.
+
+Optionally push fleet policy (e.g. `SPELUNK_NO_SERVER=1` on air-gapped
+machines) via the environment mechanism below.
+
+## Shape B: shared team memory server on a Windows host
+
+Run one long-lived `spelunk-server` and point every laptop at it.
+
+1. **Install the binaries** on the laptops (Shape A) and on the server host.
+   Copy `spelunk-server.exe` to a machine-wide location such as
+   `%ProgramData%\spelunk\`.
+2. **Run the server as a Windows Service.** Use
+   [`Install-SpelunkServerService.ps1`](Install-SpelunkServerService.ps1). It
+   registers `spelunk-server.exe` under NSSM (a service wrapper), binds loopback,
+   stores the DB and logs under `%ProgramData%\spelunk\`, and reads the API key
+   from a locked-down key file.
+
+   ```powershell
+   .\Install-SpelunkServerService.ps1 -ServerKey "replace-with-your-shared-api-key"
+   ```
+
+   `spelunk-server.exe` is a plain console program and does not speak the Windows
+   Service Control Manager protocol, so `sc.exe create` / `New-Service` pointed
+   directly at it will fail to start (error 1053). A wrapper is required; the
+   script uses NSSM, and WinSW or a startup Task Scheduler task work equally.
+3. **Terminate TLS in front of it.** `spelunk-server` refuses a non-loopback
+   plaintext bind with no override, so it is not reachable off-host by itself.
+   Put an operator-owned TLS reverse proxy (IIS with ARR, nginx, or Caddy) on the
+   same host, forwarding HTTPS to `127.0.0.1:7777`. This mirrors the bare-metal
+   shape in [`../../../docs/self-hosting.md`](../../../docs/self-hosting.md).
+4. **Pre-configure the laptops.** Push [`../spelunk-config.toml`](../spelunk-config.toml)
+   to each user's `%USERPROFILE%\.config\spelunk\config.toml` with `server_url`
+   set to the **proxy's HTTPS URL** (e.g. `https://spelunk.internal`), and deliver
+   the shared `SPELUNK_SERVER_KEY` via the environment mechanism below.
+
+## Pushing spelunk configuration on Windows
+
+### The config file
+
+Write your edited copy of `../spelunk-config.toml` to each user's
+`%USERPROFILE%\.config\spelunk\config.toml`. Deploy it with an Intune
+platform-script (PowerShell) payload or a GPO login/startup script that creates
+`%USERPROFILE%\.config\spelunk\` and copies the file in per user. A team-wide
+subset (`server_url`, `project_id`) can instead live in a committed
+`.spelunk\config.toml` at the repo root, needing no MDM at all.
+
+### The environment
+
+Deliver the variables from [`../spelunk.env.example`](../spelunk.env.example) as
+Windows environment variables. `SPELUNK_SERVER_KEY` is the one to prioritise: it
+carries the shared credential, overrides Credential Manager, and works on
+headless and freshly imaged machines with no interactive login.
+
+- **Machine-wide, per host:** `setx /M SPELUNK_SERVER_KEY "..."` from a managed
+  script (writes `HKLM\...\Environment`).
+- **Group Policy:** *Computer/User Configuration > Preferences > Windows
+  Settings > Environment*, one item per variable.
+- **Intune:** a platform script that sets the machine/user environment, or an
+  OMA-URI/settings-catalog environment payload (verify the exact setting in your
+  console).
+
+Do not set both `SPELUNK_SERVER_URL` and `SPELUNK_NO_SERVER=1` — the offline
+kill-switch overrides everything and disables the server entirely.
+
+## Verifying a rollout
+
+On a managed machine after deployment (PowerShell):
+
+```powershell
+spelunk --version            # binaries are on PATH
+spelunk status               # index + config health
+spelunk context              # confirms the configured server is reachable
+```
+
+On the server host, probe the service without curl/wget:
+
+```powershell
+& "$env:ProgramData\spelunk\spelunk-server.exe" --health-check --port 7777
+```
+
+## What is in this directory
+
+| File | Purpose |
+|------|---------|
+| `README.md` | This guide. |
+| `Install-SpelunkServerService.ps1` | Registers a loopback-bound `spelunk-server` as an NSSM-hosted Windows Service on a shared host. |
+
+Shared, cross-platform config templates live one level up:
+[`../spelunk-config.toml`](../spelunk-config.toml) and
+[`../spelunk.env.example`](../spelunk.env.example).


### PR DESCRIPTION
## What this adds

A Windows fleet-management MDM example under `examples/mdm/windows/`, paralleling the existing macOS example:

- **`windows/README.md`** — Intune/GPO config + environment delivery, Windows path table (`%USERPROFILE%\.config\spelunk\config.toml`, Credential Manager, `%ProgramData%\spelunk\`), Shape A (managed laptops, loopback autostart + Defender firewall pre-approval) and Shape B (shared server on a Windows host).
- **`windows/Install-SpelunkServerService.ps1`** — registers `spelunk-server.exe` as a Windows Service via NSSM, binds loopback, stores DB/logs under `%ProgramData%\spelunk\`, reads the API key from an ACL-locked key file.
- **`examples/mdm/README.md`** — cross-links the new per-OS subdir, corrects the Windows config path (was hand-waved), adds Windows to the shared-server deployment step and the file table.

## Design rationale

- **NSSM wrapper, not `sc.exe`/`New-Service`:** `spelunk-server.exe` is a plain console program with no Windows SCM dispatcher, so a direct service registration starts and then fails with error 1053. A wrapper (NSSM, WinSW, or a startup Task Scheduler task) is required; the script uses NSSM and documents the alternatives.
- **Loopback + TLS proxy:** `check_bind_safety` in `crates/spelunk-server/src/main.rs` refuses a non-loopback plaintext bind unconditionally. The service binds `127.0.0.1` only; a team-reachable server is loopback plus an operator-owned TLS reverse proxy (IIS ARR / nginx / Caddy), and laptops point at the proxy HTTPS URL. The script passes no `--host`, keeping the loopback default.
- **Key file over inline key:** `--key-file` is used (ACL: SYSTEM/Administrators read-only) so the shared key never lands in the service's argument list.

## Left as "verify in console"

The exact Intune policy CSP / ADMX / OMA-URI / settings-catalog shapes for firewall rules and environment payloads vary by MDM console, so the README phrases those as "verify in your console" rather than asserting a specific payload. GPO paths (which are stable) are given concretely.

## Note: pre-existing macOS bug (separately filed)

The existing `examples/mdm/macos/cloud.spelunk.server.mobileconfig` binds `--host 0.0.0.0` plaintext (LaunchDaemon `ProgramArguments`), which the current `check_bind_safety` would refuse to start. That is a pre-existing defect in the macOS example, filed separately; this PR does not touch it and the Windows example deliberately does not replicate the pattern.

## Test plan (QA — CLI-flag verification against source)

Docs/example only; no build. Every flag/env referenced was checked against the binary:

`spelunk-server` flags (`crates/spelunk-server/src/main.rs` `Args`): `--port` ✓ (default 7777), `--host` ✓ (default 127.0.0.1), `--db` ✓, `--key` ✓, `--key-file` ✓, `--health-check` ✓. No invented flags.

`spelunk` subcommands (`crates/spelunk-cli/src/main.rs`): `status` ✓ (`Command::Status`), `context` ✓ (`Command::Context`), `--version` ✓ (clap).

Env vars: `SPELUNK_SERVER_KEY` ✓, `SPELUNK_SERVER_URL` ✓, `SPELUNK_NO_SERVER` ✓ (`capability.rs`), `SPELUNK_MODE` ✓, `SPELUNK_PROJECT_ID` ✓, `SPELUNK_SECRET_STORE` ✓, `RUST_LOG` ✓ (EnvFilter).

- No `--embedding-model` / `SPELUNK_EMBEDDING_MODEL` reference (post-ADR-053): confirmed absent.
- Config path matches `crates/spelunk-core/src/config.rs` (`dirs::home_dir().join(".config")` on all platforms → `%USERPROFILE%\.config\spelunk\`, not `%APPDATA%`): confirmed.
- Bind/firewall consistent with `check_bind_safety` and `docs/server.md` Windows firewall section: confirmed (no `--host 0.0.0.0` plaintext).
- All referenced links resolve; OSS/public boundary clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
