### PR TITLE
Add Scoop managed-install channel for Windows

### DIFF
--- a/.github/scripts/update-scoop-manifest.js
+++ b/.github/scripts/update-scoop-manifest.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+//
+// Regenerates bucket/spelunk.json from a template.
+//
+// The manifest is always written from scratch. Given a version and the Windows
+// x86_64 release-asset sha256 digest, this script produces the exact file
+// contents and writes them out.
+//
+// Invoked by the update-scoop-manifest job in .github/workflows/release.yml on
+// every stable tag push, which then commits the result back to the bucket in
+// this repo.
+//
+// Usage:
+//   node update-scoop-manifest.js \
+//     --version 0.8.1 \
+//     --sha-x86_64-windows <hex> \
+//     [--out bucket/spelunk.json]
+//
+// --sha-x86_64-windows may also be supplied via SHA_X86_64_WINDOWS, and
+// --version via VERSION. Flags win when both are present.
+//
+// Only Node.js builtins are used (fs, path) — no extra npm dependencies.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    args[key] = value;
+    i++;
+  }
+  return args;
+}
+
+function requireValue(name, ...sources) {
+  for (const source of sources) {
+    if (source !== undefined && source !== null && source !== "") {
+      return source;
+    }
+  }
+  throw new Error(
+    `Missing required value: ${name} (pass it as a flag or environment variable)`
+  );
+}
+
+function assertSha256(name, value) {
+  if (!/^[0-9a-f]{64}$/i.test(value)) {
+    throw new Error(
+      `Invalid sha256 for ${name}: "${value}" (expected 64 hex characters)`
+    );
+  }
+  return value.toLowerCase();
+}
+
+function buildManifest({ version, shaX86_64Windows }) {
+  const base = "https://github.com/spelunk-cloud/spelunk";
+  const manifest = {
+    version,
+    description:
+      "Code intelligence for AI agents - persistent memory, code graph, search",
+    homepage: base,
+    license: "MIT",
+    architecture: {
+      "64bit": {
+        url: `${base}/releases/download/v${version}/spelunk-v${version}-x86_64-pc-windows-msvc.zip`,
+        hash: shaX86_64Windows,
+      },
+    },
+    bin: ["spelunk.exe", "spelunk-server.exe"],
+    checkver: {
+      github: base,
+    },
+    autoupdate: {
+      architecture: {
+        "64bit": {
+          url: `${base}/releases/download/v$version/spelunk-v$version-x86_64-pc-windows-msvc.zip`,
+        },
+      },
+    },
+  };
+  return JSON.stringify(manifest, null, 2) + "\n";
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const env = process.env;
+
+  const rawVersion = requireValue("--version", args.version, env.VERSION);
+  // The manifest `version` field never carries the leading "v"; the URL
+  // templates add it back ("v${version}" / "v$version").
+  const version = rawVersion.replace(/^v/, "");
+
+  const shaX86_64Windows = assertSha256(
+    "x86_64-pc-windows-msvc",
+    requireValue(
+      "--sha-x86_64-windows",
+      args["sha-x86_64-windows"],
+      env.SHA_X86_64_WINDOWS
+    )
+  );
+
+  const outPath = path.resolve(
+    requireValue("--out", args.out, "bucket/spelunk.json")
+  );
+
+  const manifest = buildManifest({ version, shaX86_64Windows });
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, manifest, "utf8");
+  process.stdout.write(`Wrote ${outPath}\n`);
+  process.stdout.write(manifest);
+}
+
+main();

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,3 +310,57 @@ jobs:
           git add Formula/spelunk.rb
           git commit -m "spelunk ${{ github.ref_name }}"
           git push origin main
+
+  update-scoop-manifest:
+    name: Update Scoop bucket (bucket/spelunk.json)
+    needs: release
+    # Skip pre-release tags (rc/beta/alpha) — the bucket only tracks stable releases.
+    if: ${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      # Commit lands on main, not the tag ref.
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Read Windows sha256 digest from the GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.ref_name }}"
+          VER="${VERSION#v}"
+          ASSET="spelunk-${VERSION}-x86_64-pc-windows-msvc.zip"
+          # The release asset's `digest` field is "sha256:<hex>".
+          SHA_X86_64_WINDOWS="$(gh release view "${VERSION}" --json assets \
+            --jq ".assets[] | select(.name == \"${ASSET}\") | .digest" \
+            | sed 's/^sha256://')"
+          echo "SHA_X86_64_WINDOWS=${SHA_X86_64_WINDOWS}" >> "$GITHUB_ENV"
+          echo "VER=${VER}"                               >> "$GITHUB_ENV"
+
+      - name: Regenerate bucket/spelunk.json
+        run: |
+          node .github/scripts/update-scoop-manifest.js \
+            --version "$VER" \
+            --sha-x86_64-windows "$SHA_X86_64_WINDOWS" \
+            --out bucket/spelunk.json
+
+          cat bucket/spelunk.json
+
+      - name: Commit and push bucket/spelunk.json
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- bucket/spelunk.json; then
+            echo "No changes to bucket/spelunk.json — skipping push."
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/spelunk.json
+          git commit -m "scoop: spelunk ${{ github.ref_name }}"
+          git push origin main

--- a/bucket/spelunk.json
+++ b/bucket/spelunk.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.9.3",
+  "description": "Code intelligence for AI agents - persistent memory, code graph, search",
+  "homepage": "https://github.com/spelunk-cloud/spelunk",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/spelunk-cloud/spelunk/releases/download/v0.9.3/spelunk-v0.9.3-x86_64-pc-windows-msvc.zip",
+      "hash": "9c1691dc700c67af0c63ba0c61b20c1f51e02bdb80da07ae3c24fea04d7a0161"
+    }
+  },
+  "bin": [
+    "spelunk.exe",
+    "spelunk-server.exe"
+  ],
+  "checkver": {
+    "github": "https://github.com/spelunk-cloud/spelunk"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/spelunk-cloud/spelunk/releases/download/v$version/spelunk-v$version-x86_64-pc-windows-msvc.zip"
+      }
+    }
+  }
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,18 @@ Preview what it would do without writing anything:
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/spelunk-cloud/spelunk/refs/heads/main/install.ps1))) -DryRun
 ```
 
+#### Scoop
+
+The repo doubles as a [Scoop](https://scoop.sh) bucket, so `scoop` installs and
+updates `spelunk.exe` and `spelunk-server.exe` from the release `.zip` and keeps
+them current with `scoop update`:
+
+```powershell
+scoop bucket add spelunk https://github.com/spelunk-cloud/spelunk
+scoop install spelunk
+spelunk --version
+```
+
 #### Manual `.zip` download
 
 Download the `.zip` for your platform from the
@@ -45,11 +57,9 @@ archive is named `spelunk-<version>-x86_64-pc-windows-msvc.zip`. Extract it and
 place `spelunk.exe` and `spelunk-server.exe` anywhere on your `PATH`
 (e.g. `C:\Users\<you>\bin\`).
 
-> **Windows package managers (winget, Scoop):** a winget manifest is planned as
-> the primary managed install path for Windows; submission is pending a decision
-> on which managed channel to support. Follow the
-> [releases page](https://github.com/spelunk-cloud/spelunk/releases) or the
-> repo for updates.
+> **winget:** deferred, available on request. Track the
+> [releases page](https://github.com/spelunk-cloud/spelunk/releases) or the repo
+> for updates.
 
 ---
 


### PR DESCRIPTION
## What changed

Adds a **Scoop** managed-install path for the Windows x86_64 CLI.

- **`bucket/spelunk.json`** — Scoop manifest for the release `.zip`: `version`, `architecture.64bit` (`url` + `hash`), `bin` (`spelunk.exe`, `spelunk-server.exe`), plus `checkver` (GitHub releases) and `autoupdate` blocks. Users run `scoop bucket add spelunk https://github.com/spelunk-cloud/spelunk` then `scoop install spelunk`.
- **`.github/scripts/update-scoop-manifest.js`** — regenerates the manifest from a template given a version + Windows sha256, mirroring `update-homebrew-formula.js` (deterministic, idempotent, validates the sha256, Node builtins only).
- **`.github/workflows/release.yml`** — new `update-scoop-manifest` job: on a stable tag it reads the Windows asset's `digest` from the release, regenerates `bucket/spelunk.json`, and commits it back to `main` (skips prerelease tags; no-ops when unchanged), mirroring the Homebrew auto-bump.
- **`docs/getting-started.md`** — Windows section gains the Scoop path; winget noted as deferred / on request.

## Bucket approach decision

The manifest is served **as a Scoop bucket from this repo** (`bucket/spelunk.json`) rather than submitted to `ScoopInstaller/Extras`. A self-hosted bucket ships on our own release cadence with no external-PR review latency, and the auto-bump job keeps it current on every stable tag. winget is deferred (external manifest repo has the same slow-review problem, and needs additional accounts).

## Test plan

Verified on macOS (Scoop itself can't run here; real `scoop install` is the remaining Windows smoke):

- **Manifest is well-formed + schema-conformant** — valid JSON; all required fields present with correct types (`architecture.64bit.url`/`hash`, `bin` array, `checkver.github`, `autoupdate` with a `$version` template).
- **URL pattern matches the real release asset** — downloaded `spelunk-v0.9.3-x86_64-pc-windows-msvc.zip` from the templated URL successfully; its contents are exactly `spelunk.exe` + `spelunk-server.exe` (matching `bin`).
- **Hash / auto-bump logic proven** — the release API `digest` field (`sha256:9c1691…0161`) equals the locally computed `shasum -a 256` of the downloaded asset, confirming the workflow's digest-reading substitution produces the correct `hash`.
- **Generator is idempotent** — re-running produces a byte-identical file (no-op commit); invalid sha256 is rejected.
- **`cargo fmt --check` + `cargo clippy`** — pass (pre-commit hook).

### Remaining (needs a real Windows box)
- `scoop bucket add` + `scoop install spelunk` end-to-end, and `scoop update` after a subsequent release, to confirm `checkver`/`autoupdate` resolve against a new tag.

/cc QA — needs review.