### PR TITLE
CLI: default init project slug to derive_project_id (oss^121, ADR-063 §4)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -10,6 +10,12 @@ pub struct InitArgs {
     /// Skip the initial index run
     #[arg(long)]
     pub no_index: bool,
+
+    /// Explicit project slug, written to `.spelunk/config.toml`. Overrides the
+    /// git-derived default; use it for projects without a git remote. Ignored
+    /// when a `project_id` is already set in config.
+    #[arg(long)]
+    pub name: Option<String>,
 }
 
 use crate::{capability, config::Config, registry::Registry, storage::Database};
@@ -29,25 +35,43 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
         }
     };
 
-    let project_name = project_root
+    // Directory basename — a cosmetic title only (used for the CLAUDE.md heading).
+    let dir_name = project_root
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| project_root.to_string_lossy().into_owned());
 
     let spelunk_dir = project_root.join(".spelunk");
     let db_path = spelunk_dir.join("index.db");
+    let config_path = spelunk_dir.join("config.toml");
 
     // Ignore machine-specific SQLite (index.db/memory.db + their -wal/-shm
     // sidecars); config.toml and cloud-project-id.lock are committed, so must
     // not be listed here. Idempotent: never clobbers a pre-existing file.
     write_spelunk_gitignore(&spelunk_dir);
 
+    // Project slug: explicit --name, else derived (`host/owner/repo` when a git
+    // remote exists, else `local/<blake3-hex>`). Written to config.toml, never
+    // overwriting an existing project_id (no retroactive rename).
+    let desired_slug = args
+        .name
+        .clone()
+        .unwrap_or_else(|| spelunk_core::config::derive_project_id(&project_root));
+    let (project_slug, wrote_slug) =
+        match spelunk_core::config::write_project_slug(&config_path, &desired_slug) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Warning: could not write project slug to config: {e}");
+                (desired_slug.clone(), false)
+            }
+        };
+
     // ── 2. Check if already initialised ──────────────────────────────────────
     let already_exists = db_path.exists();
     if already_exists {
         println!(
             "Note: spelunk is already initialised for '{}' (DB exists at {}).",
-            project_name,
+            project_slug,
             db_path.display()
         );
         println!("Re-running init is safe — it will update the registry and optionally re-index.");
@@ -159,7 +183,7 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
              spelunk memory add --kind handoff --title \"Handoff: <summary>\" --body \"done, next, open\"\n\
              spelunk index .               # re-index after any commits\n\
              ```\n",
-            name = project_name
+            name = dir_name
         );
         if let Err(e) = std::fs::write(&claude_md_path, claude_md) {
             eprintln!("Warning: could not write CLAUDE.md: {e}");
@@ -199,10 +223,23 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
 
     // ── 8. Print success summary ──────────────────────────────────────────────
     println!();
-    println!("spelunk initialised for {}", project_name);
+    println!("spelunk initialised for {}", project_slug);
     println!();
     println!("  Index:   {} files, {} chunks", file_count, chunk_count);
     println!("  DB:      {}", db_path.display());
+    if wrote_slug {
+        println!(
+            "  Project: {}  (written to {})",
+            project_slug,
+            config_path.display()
+        );
+    } else {
+        println!(
+            "  Project: {}  (from {})",
+            project_slug,
+            config_path.display()
+        );
+    }
     println!("  Hook:    {}", hook_status);
     if let Some(line) = server_line {
         println!("  Server:  {line}");

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -737,6 +737,32 @@ pub fn remove_auth_tokens_from(config_path: &Path) -> Result<()> {
     write_config_secure(config_path, &serialised)
 }
 
+/// Write `slug` as `project_id` to a project-level `.spelunk/config.toml`,
+/// creating the file (and parent dir) if absent. Other keys are preserved.
+///
+/// Returns `(effective_slug, wrote)`: if the file already sets `project_id`,
+/// it is left untouched — `wrote` is `false` and the existing value is returned
+/// (no retroactive rename). This is a committed, shared file, so it is written
+/// with normal permissions (unlike the secret-bearing personal config).
+pub fn write_project_slug(config_path: &Path, slug: &str) -> Result<(String, bool)> {
+    let mut doc = read_config_table(config_path)?;
+    if let Some(existing) = doc.get("project_id").and_then(|v| v.as_str()) {
+        return Ok((existing.to_string(), false));
+    }
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating config dir {}", parent.display()))?;
+    }
+    doc.insert(
+        "project_id".to_string(),
+        toml::Value::String(slug.to_string()),
+    );
+    let serialised = toml::to_string_pretty(&doc).context("serialising config.toml")?;
+    std::fs::write(config_path, serialised)
+        .with_context(|| format!("writing {}", config_path.display()))?;
+    Ok((slug.to_string(), true))
+}
+
 /// Parse the config file into a `toml::Table`, returning an empty table when the
 /// file does not exist.
 fn read_config_table(config_path: &Path) -> Result<toml::Table> {
@@ -867,6 +893,58 @@ mod tests {
     /// never touch the host keychain or `~/.config/spelunk/secrets.toml`.
     fn load_hermetic(path: &Path) -> Result<Config> {
         Config::load_with_store(Some(path), &MemoryStore::default())
+    }
+
+    #[test]
+    fn write_project_slug_creates_file_and_reports_written() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join(".spelunk").join("config.toml");
+
+        let (slug, wrote) = write_project_slug(&cfg, "github.com/acme/app").unwrap();
+        assert_eq!(slug, "github.com/acme/app");
+        assert!(wrote);
+
+        let raw = std::fs::read_to_string(&cfg).unwrap();
+        assert!(
+            raw.contains("project_id = \"github.com/acme/app\""),
+            "{raw}"
+        );
+    }
+
+    #[test]
+    fn write_project_slug_preserves_existing_and_does_not_rename() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        std::fs::write(
+            &cfg,
+            "server_url = \"http://team:7777\"\nproject_id = \"old/slug\"\n",
+        )
+        .unwrap();
+
+        let (slug, wrote) = write_project_slug(&cfg, "local/deadbeef").unwrap();
+        assert_eq!(slug, "old/slug");
+        assert!(!wrote);
+
+        let raw = std::fs::read_to_string(&cfg).unwrap();
+        assert!(raw.contains("project_id = \"old/slug\""), "{raw}");
+        assert!(raw.contains("server_url"), "other keys preserved: {raw}");
+    }
+
+    #[test]
+    fn write_project_slug_adds_key_preserving_other_keys() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        std::fs::write(&cfg, "server_url = \"http://team:7777\"\n").unwrap();
+
+        let (_, wrote) = write_project_slug(&cfg, "github.com/acme/app").unwrap();
+        assert!(wrote);
+
+        let raw = std::fs::read_to_string(&cfg).unwrap();
+        assert!(
+            raw.contains("project_id = \"github.com/acme/app\""),
+            "{raw}"
+        );
+        assert!(raw.contains("server_url"), "existing key preserved: {raw}");
     }
 
     /// Unset all spelunk-related env vars to prevent cross-test contamination.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,13 +26,23 @@ spelunk init [options]
 |------|---------|-------------|
 | `--hook` | false | Also install the post-commit git hook |
 | `--no-index` | false | Skip the initial index run |
+| `--name <slug>` | derived | Explicit project slug. Overrides the git-derived default; use it for projects without a git remote. |
+
+`init` writes the project slug to `.spelunk/config.toml` (committed, so the whole
+team shares one identity). The slug defaults to the git-derived value:
+`host/owner/repo` when an `origin` remote exists, else `local/<blake3-hex>` of the
+canonical path. Pass `--name` to set an explicit slug for a repo without a remote
+or to choose your own. An existing `project_id` in config is never rewritten, so
+re-running `init` (or running it after a rename) does not change an established
+slug.
 
 **Example:**
 
 ```bash
 cd /path/to/project
 spelunk init
-spelunk init --hook        # also wire up auto-index/harvest on commit
+spelunk init --hook            # also wire up auto-index/harvest on commit
+spelunk init --name acme/tools # explicit slug (e.g. no git remote)
 ```
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -161,10 +161,15 @@ spelunk search "where do we validate auth tokens"
 ```
 
 `init` also writes `.spelunk/.gitignore` so the machine-specific SQLite
-(`index.db*`, `memory.db*`) stays out of version control. It leaves
-`.spelunk/config.toml` and `.spelunk/cloud-project-id.lock` tracked, since those
-are meant to be committed and shared. An existing `.spelunk/.gitignore` is never
-overwritten, so re-running `init` is safe.
+(`index.db*`, `memory.db*`) stays out of version control, and records the
+project slug as `project_id` in `.spelunk/config.toml`. The slug defaults to the
+git-derived identity (`host/owner/repo` when an `origin` remote exists, else
+`local/<blake3-hex>` of the path); pass `spelunk init --name <slug>` to set an
+explicit one for a repo without a remote. Both `.spelunk/config.toml` and
+`.spelunk/cloud-project-id.lock` stay tracked, since they are meant to be
+committed and shared, so the whole team resolves to one project identity. An
+existing `project_id` or `.spelunk/.gitignore` is never overwritten, so
+re-running `init` is safe.
 
 No config file, no Docker, no external embedder. The server bundles a native
 embedding model (codefuse-ai/F2LLM-v2-330M, 896-dim, GPU-accelerated on macOS
@@ -345,10 +350,11 @@ This:
 
 Output:
 ```
-spelunk initialised for my-project
+spelunk initialised for github.com/acme/my-project
 
   Index:   142 files, 1 840 chunks
   DB:      ~/.local/share/spelunk/my-project.db
+  Project: github.com/acme/my-project  (written to .spelunk/config.toml)
   Embeddings: 1 840 vectors
 ```
 


### PR DESCRIPTION
Implements ADR-063 §4 (spelunk-oss^121): `spelunk init` now defaults the project slug to the git-derived identity and persists it to `.spelunk/config.toml`.

## What changed
- `init` defaults the slug to `derive_project_id` — `host/owner/repo` when an `origin` remote exists, else `local/<blake3-hex>` of the canonical path.
- New `--name <slug>` flag sets an explicit slug for projects without a git remote (or to choose your own).
- The slug is written as `project_id` to `.spelunk/config.toml` at init. New `spelunk_core::config::write_project_slug` preserves any other keys and, critically, never rewrites an existing `project_id` (no retroactive rename); it returns `(effective_slug, wrote)` so the summary reports "written to" vs "from".
- Success summary and the "already initialised" note now show the resolved slug; the directory basename is retained only for the CLAUDE.md heading.
- Docs (`commands.md`, `getting-started.md`) updated for the new default and `--name`.

## Test plan
Ran the full spelunk-oss CI matrix in a fresh worktree (SPELUNK_SECRET_STORE=file, shared CARGO_TARGET_DIR):

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean, no warnings.
- `cargo test` (default features) — all green (incl. 3 new `write_project_slug` unit tests: create+report-written, preserve-existing-no-rename, add-key-preserving-others).
- `cargo test --no-default-features` — all green (exit 0 on clean run).

Behavior spot-check with the built `spelunk` binary:
- Git repo with `origin=https://github.com/acme/widget.git` → `spelunk init --no-index` wrote `project_id = "github.com/acme/widget"` and printed "written to …/.spelunk/config.toml".
- Non-repo dir with `--name acme/tools` → wrote `project_id = "acme/tools"`.
- Non-repo dir without `--name` → wrote `project_id = "local/<blake3-hex>"` fallback.
- Idempotency: a repo already carrying `project_id = "first/slug"`, re-`init`ed with `--name second/slug`, kept `first/slug` unchanged and reported "(from …)" — confirms no retroactive rename.

Refs spelunk-oss^121, ADR-063 §4.
