### PR TITLE
ci: drop unused ast-grep install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-v2-
 
-      - name: Install ast-grep
-        run: npm install --global @ast-grep/cli
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
## Summary
- Remove the `npm install --global @ast-grep/cli` step from the `test` job. Structural search runs in-process via the `ast-grep-core`/`ast-grep-language` Rust crates (`crates/spelunk-core/src/search/live.rs`); nothing in CI shells out to the `ast-grep` npm CLI.

## Test plan
- [ ] CI passes on this PR (test job matrix still green without the npm install)