### PR TITLE
docs: reconcile non-loopback plaintext bind refusal (oss^122)

### DIFF
--- a/docs/adr/056-oss-server-tenancy-model.md
+++ b/docs/adr/056-oss-server-tenancy-model.md
@@ -3,6 +3,19 @@
 **Date:** 2026-07-02
 **Deciders:** founder (Johan), architect
 
+> **Clarification (2026-07-10, spelunk-oss^122):** The Context below refers to
+> `--host 0.0.0.0` with a shared key as the then-documented multi-developer
+> setup. That describes the pre-hardening state the security review examined, not
+> a supported posture today. The shipped binary refuses **any** non-loopback
+> plaintext bind unconditionally, keyless *and* keyed alike, with no override,
+> exactly as this ADR's own Decision and Consequences already require
+> (`check_bind_safety` in `crates/spelunk-server/src/main.rs`). A shared
+> deployment binds loopback and terminates TLS in an operator-owned front proxy
+> ([ADR-058](058-team-server-bare-metal-deployment.md)). The authoritative
+> operator-facing wording lives in [`server.md`](../server.md) and
+> [`THREAT-MODEL.md`](../security/THREAT-MODEL.md). This note clarifies the
+> historical Context; it does not change the decision.
+
 ## Context
 
 `spelunk-server` is an HTTP listener (axum) that can hold a team's memory when a

--- a/docs/adr/058-team-server-bare-metal-deployment.md
+++ b/docs/adr/058-team-server-bare-metal-deployment.md
@@ -12,6 +12,21 @@ Docker quick-start that publishes a port nothing can reach, and no first-class
 answer to "how do I actually stand up a shared team server?" This ADR records
 the founder's answer.
 
+> **Correction (2026-07-10, spelunk-oss^122):** Several passages below, namely
+> Context "What the server does and does not do about transport", Decision §1,
+> and Security implications, describe the keyed non-loopback plaintext bind as
+> "permitted by the binary" or a bind the binary "still allows" / "still
+> permits", framed as a footgun to steer operators away from. That is stale
+> relative to shipped code and contradicts this ADR's own Trigger note above:
+> `check_bind_safety` (`crates/spelunk-server/src/main.rs`) refuses **every**
+> non-loopback plaintext bind unconditionally, keyless *and* keyed alike, with no
+> override. There is no keyed-LAN-plaintext bind to warn about; the only off-host
+> path is a loopback bind behind an operator-owned TLS terminator, which is the
+> topology this ADR recommends. Read every "permitted/allowed/permits" phrasing
+> below as "refused." The reconciled operator-facing wording is in
+> [`server.md`](../server.md) and
+> [`THREAT-MODEL.md`](../security/THREAT-MODEL.md).
+
 ---
 
 ## Context

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -128,12 +128,17 @@ Client (spelunk CLI / any HTTP client)
 ```
 
 **Key difference from Mode A:** In server mode, memory content is accessible to anyone
-who can reach the server's port. To prevent an open, unauthenticated server on a
-shared network, `spelunk-server` **refuses to start** when `--host` is a non-loopback
-address (`0.0.0.0`, a LAN/public IP) and no `--key` / `SPELUNK_SERVER_KEY` is set. A
-keyless server can therefore only bind loopback (`127.0.0.1`), where it is reachable
-by local processes but not by other machines. (A blank/whitespace key — e.g.
-docker-compose's `${SPELUNK_SERVER_KEY:-}` default — is treated as no key.)
+who can reach the server's port. `spelunk-server` **refuses to start** on any
+non-loopback plaintext bind (`--host 0.0.0.0`, a LAN/public IP), and this refusal is
+**unconditional**: it applies whether or not a `--key` / `SPELUNK_SERVER_KEY` is set,
+with no override. A keyless non-loopback bind would be an open, unauthenticated server;
+a keyed one would send the bearer key across the network in cleartext. Plaintext HTTP
+is therefore loopback-only (`127.0.0.1`), reachable by local processes but not by other
+machines. (A blank or whitespace key, such as docker-compose's `${SPELUNK_SERVER_KEY:-}`
+default, is treated as no key.) A shared, off-host deployment binds `spelunk-server`
+to loopback and puts an operator-owned TLS terminator in front, so the shared key never
+crosses the network in cleartext (see
+[ADR-058](../adr/058-team-server-bare-metal-deployment.md)).
 
 ### Tenancy boundary: single trust domain (ADR-056)
 
@@ -195,7 +200,7 @@ unauthenticated (no bearer required or sent).
 | **Source code sent off-machine for embedding** | A | Medium | **High** | The default loopback server embeds natively on-machine, so nothing leaves. Egress requires an explicit remote team `server_url` (chunk text crosses to the team server) or a server whose operator set an external `--embedding-url` (server forwards post-secret-scan chunks to a third party). Both are explicit operator choices; users must be informed via docs. |
 | **Memory notes / code context sent off-machine for LLM** | A | Low | **High** | `spelunk explore` and `memory harvest` send memory content + code context to `spelunk-server`. On the default loopback server the LLM runs on-machine; egress requires a remote team `server_url` or a server-side `--llm-url` shim. |
 | Server memory accessible without auth | B | Medium | High | No `--key` / `SPELUNK_SERVER_KEY` by default; any process that can reach the port reads all notes |
-| Server bound to 0.0.0.0 exposes data on LAN/internet | B | Medium | High | **Enforced:** a non-loopback bind requires a key — `spelunk-server` refuses to start on `0.0.0.0`/LAN/public addresses without `--key` / `SPELUNK_SERVER_KEY`; loopback (`127.0.0.1`) is the default (spelunk-oss^52 / PR #490) |
+| Server bound to 0.0.0.0 exposes data on LAN/internet | B | Medium | High | **Enforced:** `spelunk-server` refuses to start on any non-loopback plaintext bind (`0.0.0.0`/LAN/public). The refusal is unconditional, covering both the keyless case (an open, unauthenticated server) and the keyed case (the bearer key would cross the network in cleartext), with no override. Plaintext HTTP is loopback-only (`127.0.0.1`, the default); an off-host deployment terminates TLS in an operator-owned front proxy (spelunk-oss^52 / PR #490; see [ADR-058](../adr/058-team-server-bare-metal-deployment.md)) |
 | Indexed content contains credentials missed by scanner | A | Medium | Medium | Pattern gaps tracked in #138 |
 | CLI bearer credential (`server_key`) readable as plaintext at rest (e.g. user syncs `~/.config` into a dotfiles repo or backup) | A | Medium | High | The `server_key` is stored in the OS keychain (macOS Keychain / Linux Secret Service / Windows Credential Manager), not in `config.toml`; a legacy plaintext key is migrated out and stripped on next run. Headless fallback is an owner-only (`0600`) `secrets.toml`; `SPELUNK_SERVER_KEY` is the CI escape hatch. The credential is never logged. |
 | `spelunk memory add`/edit interactive `$EDITOR` draft written to a predictable temp path, enabling symlink/TOCTOU clobber and a world-readable info-leak window | A | Low | Medium | **Fixed (spelunk-oss^62):** the draft is created via `tempfile::Builder` (unpredictable name, `O_EXCL`, mode `0600` on unix) instead of a PID-derived path in `std::env::temp_dir()`. The `NamedTempFile` handle is kept open across the `$EDITOR`/`$VISUAL` spawn and the body is read back by seeking the retained handle (not by re-opening the path), so a symlink swapped in at the draft's path during the edit window is not followed. |

--- a/docs/server.md
+++ b/docs/server.md
@@ -234,10 +234,11 @@ says so explicitly so no one has to infer it from behaviour.
   instances** — each with its own key and its own database — not by relying on
   project slugs within one instance. Two groups that must not see each other's
   memory run two servers.
-- The server enforces this at startup: binding to a non-loopback address with
-  a key configured (a shared/team deployment) logs a prominent warning
-  restating exactly this — every keyholder is a full administrator of every
-  project on the instance.
+- The server enforces the transport half of this at startup: it refuses any
+  non-loopback plaintext bind outright, keyed or keyless (see below), so a
+  shared/team deployment binds loopback behind an operator-owned TLS proxy. On
+  such an instance every keyholder is a full administrator of every project,
+  because the shared key is the only boundary.
 - If you need per-project or per-user access control within a single
   instance, this server does not provide it (and is not planned to for
   v1.0 — see ADR-056's "Revisit if" clause). The managed cloud product
@@ -313,7 +314,7 @@ cargo build --release --bin spelunk-server
 
 | Flag | Env | Default | Purpose |
 |---|---|---|---|
-| `--host` | (none) | `127.0.0.1` | Interface to bind. Non-loopback needs a key and TLS in front (see below). |
+| `--host` | (none) | `127.0.0.1` | Interface to bind. Non-loopback plaintext binds are refused, keyed or not (see below); a shared deployment binds loopback behind a TLS proxy. |
 | `--port` | (none) | `7777` | Port to bind. |
 | `--key` | (none) | unset | Shared bearer API key, passed inline. Visible in the process table — prefer `--key-file` or `SPELUNK_SERVER_KEY`. Leave every key source unset only for a loopback dev server. |
 | `--key-file` | (none) | unset | Read the key from a file (whole contents, trimmed). First-class alternative to `SPELUNK_SERVER_KEY`, not a fallback. |


### PR DESCRIPTION
## Summary

Docs and binary disagreed about non-loopback plaintext binds. `check_bind_safety`
(`crates/spelunk-server/src/main.rs`) refuses **every** non-loopback plaintext bind
unconditionally, keyless and keyed alike, with no override. Several docs still framed
the refusal as keyless-only, or described a keyed LAN bind as a permitted (if
discouraged) deployment. This reconciles the docs to the shipped code (policy: the
code is correct; it ratifies the pre-v1.0 security posture that a cleartext bearer key
over the network is deliberately refused).

## Changes (docs only)

- **`docs/security/THREAT-MODEL.md`** — rewrote the Mode B "key difference" paragraph
  and the E-table `0.0.0.0` row to state the unconditional refusal (keyless *and* keyed),
  pointing at the loopback + operator-TLS-proxy topology as the only off-host path.
- **`docs/server.md`** — fixed the tenancy startup-enforcement bullet and the `--host`
  flag-table row, both of which implied a keyed non-loopback bind was a valid deployment.
  (The dedicated "Non-loopback plaintext binds are refused" section was already correct.)
- **`docs/adr/056`** — appended a dated *Clarification* blockquote. Its Decision and
  Consequences already state the unconditional refusal; the note flags that the
  Context's `--host 0.0.0.0` + shared-key mention is pre-hardening history.
- **`docs/adr/058`** — appended a dated *Correction* blockquote. Its body called the
  keyed non-loopback bind "permitted by the binary" (contradicting its own Trigger
  note); the blockquote directs readers to read those "permitted/allowed" passages as
  "refused." ADR bodies left unchanged (immutable history).

No code changes; no ADR bodies rewritten.

## Follow-ups noted (not in this PR)

- `crates/spelunk-server/src/main.rs` lines ~32-35: the `--host` doc-comment still
  suggests `--host 0.0.0.0` for a shared/team server, which the binary refuses.
- The single-trust-domain startup warning (`warn_single_trust_domain`) is now
  effectively unreachable: it runs only after `check_bind_safety` and requires a
  non-loopback host, but every non-loopback bind is refused first, so it never fires
  for the recommended loopback+key deployment.

## Test plan

- Docs-only change. Verified all internal relative links resolve
  (`../adr/058-...`, `../server.md`, `../security/THREAT-MODEL.md`).
- Confirmed no em-dashes in added prose (public repo copy rule).
- Pre-commit `cargo fmt --check` + `cargo clippy` passed (workspace unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)