### PR TITLE
ADR-066: native TLS for spelunk-server team mode (spelunk-oss^137)

### DIFF
--- a/docs/adr/056-oss-server-tenancy-model.md
+++ b/docs/adr/056-oss-server-tenancy-model.md
@@ -132,3 +132,12 @@ the primary mitigation. The consequences for the threat model:
   server-audit checklist items that assume per-project or per-principal scoping
   are reframed as not applicable by design under this ADR, rather than as
   unmet requirements.
+
+> **Clarification (2026-07-10, see [ADR-066](066-server-native-tls-team-mode.md)):**
+> the tenancy model above (single trust domain, shared key is the boundary) is
+> unchanged. What changes is *how* a non-loopback keyed bind stops sending the
+> key in cleartext: `spelunk-server` gains native TLS termination (Team mode),
+> rather than relying solely on an operator's own reverse proxy. The passage
+> above stating "the server restricts plaintext HTTP to loopback and
+> unconditionally requires TLS for any non-loopback deployment" now means TLS
+> can be satisfied in-process, not only via an external terminator.

--- a/docs/adr/058-team-server-bare-metal-deployment.md
+++ b/docs/adr/058-team-server-bare-metal-deployment.md
@@ -359,3 +359,20 @@ Both open questions raised in review are resolved above (§2/§3): the binary
 reads the systemd credential directly (with `SPELUNK_SERVER_KEY` kept as a
 supported alternative), and a `DynamicUser=` variant will ship alongside the
 static-user default unit.
+
+> **Superseded in part (2026-07-10, see [ADR-066](066-server-native-tls-team-mode.md)):**
+> founder directive reversed the "Recommended topology" (§1) and the "Native
+> TLS in `spelunk-server`" Non-goal above. `spelunk-server` now terminates TLS
+> natively; a non-loopback bind requires an in-process TLS cert/key **and** a
+> key, and that — not a same-host operator-owned reverse proxy — is the
+> recommended (and only first-party-documented) team-server shape going
+> forward. The bare-metal + operator-terminator pattern this ADR designed
+> remains valid as an alternative for an operator who prefers to run
+> `spelunk-server` in **Local** (loopback) mode behind TLS infrastructure they
+> already operate — it is no longer the only supported path. The tenancy
+> model (§"Interaction" and all cross-references to ADR-056) is unaffected.
+> The systemd packaging, credential provisioning (§2/§3), and the
+> Docker-cannot-host-networked-serving analysis are unaffected by this ADR in
+> the loopback case, but that Docker analysis no longer applies to a
+> container run in Team mode (native TLS + `0.0.0.0`) — see ADR-066's
+> Consequences.

--- a/docs/adr/066-server-native-tls-team-mode.md
+++ b/docs/adr/066-server-native-tls-team-mode.md
@@ -1,0 +1,196 @@
+# ADR-066: Native TLS in `spelunk-server` — Team mode requires HTTPS + key, Local mode stays HTTP + loopback
+
+**Date:** 2026-07-10
+**Deciders:** founder (Johan), architect
+**Trigger:** founder directive overriding the team-server deployment story in
+[ADR-056](056-oss-server-tenancy-model.md) and [ADR-058](058-team-server-bare-metal-deployment.md).
+ADR-058 explicitly deferred native TLS as a Non-goal, "its own ADR if ever
+pursued" — this is that ADR. It supersedes ADR-058's bare-metal +
+operator-owned-reverse-proxy recommendation as *the* team-server path.
+
+---
+
+## Context
+
+`check_bind_safety` (`crates/spelunk-server/src/main.rs`) governs what hosts
+`spelunk-server` may bind to. Today:
+
+- A loopback bind (`127.0.0.1`, `::1`, `localhost`) is always allowed, keyed or
+  not.
+- A non-loopback bind (`0.0.0.0`, a routable address) is refused
+  **unconditionally** — keyless (an open, unauthenticated server) and keyed
+  alike (the bearer `SPELUNK_SERVER_KEY` would cross the network in
+  cleartext). There is no override.
+
+ADR-058 designed around that refusal: it recommends running `spelunk-server`
+on loopback with an operator-owned TLS terminator (nginx, Caddy) on the same
+host, and explicitly puts native TLS in the binary out of scope ("Non-goals:
+Native TLS in `spelunk-server`... would be its own ADR if ever pursued").
+
+The founder has now decided the opposite: the binary itself should terminate
+TLS, and that is the only supported team-server shape — no external reverse
+proxy.
+
+Verified before writing this ADR: `crates/spelunk-server` has **no TLS support
+today** — no `rustls`, `native-tls`, or `axum-server` dependency anywhere in
+the crate or its `Cargo.toml`. `axum = "0.8"` is the web framework
+(`crates/spelunk-server/Cargo.toml:44`); `axum-server` 0.7's `rustls` feature
+targets axum 0.8, so this is an additive dependency, not a framework
+migration. `clap` is already built with the `env` feature
+(`crates/spelunk-server/Cargo.toml:51`), which the existing `--key`/
+`SPELUNK_SERVER_KEY` pattern already relies on.
+
+## Decision
+
+**Two supported bind modes. Strictly bimodal — no partial states.**
+
+| Mode | Host | Transport | API key |
+|---|---|---|---|
+| **Local** | `127.0.0.1` (loopback) | HTTP | optional (authless allowed) |
+| **Team** | `0.0.0.0` / a specific non-loopback interface | HTTPS (native, in-process) | **required** |
+
+A non-loopback bind must have **both** a TLS cert/key configured **and** an
+API key set. Missing either is refused — there is still no partial or
+opt-out state; a keyed-but-plaintext or TLS-but-keyless non-loopback bind
+remains invalid, same as today, just for a different reason (incompleteness
+of Team mode rather than an unconditional ban).
+
+### 1. Configuration surface
+
+New flags, mirroring the existing `--key` / `--key-file` / `SPELUNK_SERVER_KEY`
+pattern:
+
+- `--tls-cert <path>` / `SPELUNK_TLS_CERT` — path to a PEM certificate
+  (full chain).
+- `--tls-key <path>` / `SPELUNK_TLS_KEY` — path to the matching PEM private
+  key.
+
+Both must be set together (one without the other is a startup config error,
+independent of `check_bind_safety`'s host check). No built-in ACME/Let's
+Encrypt client in this ADR — the operator supplies a certificate however they
+already obtain one (Let's Encrypt via certbot, internal CA, self-signed for a
+closed network). An in-process ACME client is a possible future ADR if
+operator demand appears; it is not designed here.
+
+### 2. TLS termination
+
+`axum-server` with its `rustls` feature serves the existing `axum::Router` via
+`axum_server::bind_rustls` when TLS is configured, in place of the current
+`axum::serve` + `tokio::net::TcpListener` path. Local mode (no TLS
+configured) keeps the existing plain-HTTP serve path unchanged — this is
+additive, not a rewrite of the request-handling stack.
+
+No hot-reload of the certificate in v1: rotating a cert means replacing the
+files and restarting the process, the same operational model as rotating
+`SPELUNK_SERVER_KEY` today (ADR-058 §3).
+
+### 3. Revised `check_bind_safety` policy
+
+Replaces the unconditional non-loopback refusal:
+
+- **Loopback** (`host_is_loopback(host)`): always allowed, exactly as today —
+  key optional, TLS irrelevant (a TLS cert may be configured on a loopback
+  bind without complaint, but nothing requires it).
+- **Non-loopback**: allowed **only** when both a key is set and a TLS
+  cert/key pair is configured. Otherwise refuse, with a message naming
+  *specifically* what's missing — three distinct cases, not one generic
+  error, so an operator isn't left guessing:
+  - no key, no TLS configured → refuse, name both.
+  - key set, no TLS configured → refuse, name missing TLS cert/key.
+  - TLS configured, no key set → refuse, name missing key.
+
+### 4. `warn_single_trust_domain` becomes reachable again
+
+[ADR-056](056-oss-server-tenancy-model.md)'s single-trust-domain startup
+notice (`warn_single_trust_domain` / `should_warn_single_trust_domain` in
+`main.rs`) fires on a non-loopback + keyed bind. Under today's unconditional
+refusal that state is unreachable at runtime — the process exits before
+getting there. Under this ADR, a non-loopback + keyed bind is exactly Team
+mode, so the warning is live again, unchanged in content: every keyholder is
+still a full administrator of every project on the instance (ADR-056 is not
+revisited by this ADR).
+
+### 5. Docs restructure (executed post-approval, as impl — not in this ADR)
+
+- **`docs/self-hosting.md`** — lead with native TLS as the Team-mode path:
+  generate/obtain a cert, pass `--tls-cert`/`--tls-key` alongside
+  `--host 0.0.0.0` and a key, done. The bare-metal + operator-owned
+  reverse-proxy recipe from ADR-058 is **not deleted** — an operator who
+  already terminates TLS in front of everything on a host may still run
+  `spelunk-server` in **Local mode** behind their own proxy (the proxy's
+  existence doesn't touch `spelunk-server`'s own bind, which stays loopback).
+  It is demoted from *the* recommended path to *an* alternative for operators
+  who prefer centralizing TLS in infrastructure they already run.
+- **`docs/server.md`** — document the two modes as a table (as above), the
+  new flags/env vars, and the three refusal messages.
+- **`Dockerfile` / `docker-compose.yml`** — ADR-058 §"Why Docker cannot host
+  the networked serving path" concluded Docker can't host a team server
+  because a container's loopback + a same-host proxy don't compose. Native
+  TLS **removes that constraint**: a container can bind `0.0.0.0` directly
+  with a mounted cert/key and a published port, and now correctly serves
+  HTTPS from inside the container's own network namespace. Revisit the
+  Docker "local scaffold only" framing as a follow-up task — it is no longer
+  categorically true, though not designed in detail here.
+- **ADR-056, ADR-058** — append a dated *Superseded-in-part* blockquote each
+  (ADR bodies are immutable) pointing at this ADR: ADR-058's "Recommended
+  topology" (§1) and its "Native TLS" Non-goal are both superseded; ADR-056's
+  tenancy model (single trust domain, shared key is the boundary) is
+  unchanged and not superseded.
+
+## Rationale
+
+| Option | Considered | Rejected because |
+|---|---|---|
+| **Native TLS in `spelunk-server`; strict Local/Team bimodal split (chosen)** | ✅ | Founder directive: a team server is `spelunk-server` itself on `0.0.0.0` over HTTPS with a key — no separate process to stand up, own, and keep patched. Also incidentally un-blocks Docker as a viable team-server host (ADR-058's Docker rejection was specifically about the loopback+proxy shape). |
+| Keep ADR-058's bare-metal + operator-TLS-terminator as the only path | ✅ | This is the status quo being overridden. Requires every operator to stand up and maintain a second process (nginx/Caddy) just to run a team server; rejected by founder as unnecessary given `axum-server`+`rustls` makes native termination straightforward. |
+| Relax `check_bind_safety` to allow a keyed non-loopback plaintext bind (no TLS at all) | ✅ | This is exactly the hole the original unconditional refusal exists to close — the bearer key would cross the network in cleartext. Never on the table; TLS is mandatory for Team mode, not optional. |
+| Built-in ACME (Let's Encrypt) client in this ADR | ✅ | Real future value, but a separable concern (renewal scheduling, HTTP-01/DNS-01 challenge handling, rate limits) that would bloat this decision. Operator-supplied cert/key files ship first; ACME is a candidate follow-up ADR if demand appears. |
+
+## Consequences
+
+- **Easier:** a team server is one binary, one process, cert files, a key,
+  and `--host 0.0.0.0` — no reverse proxy to install, configure, or keep
+  patched. Docker becomes a legitimate team-server host again (tracked as a
+  follow-up, not designed here).
+- **Harder / by design:** `spelunk-server` now owns certificate lifecycle
+  (the operator still renews and replaces the files; the server does not
+  fetch or renew certs itself in v1). No hot-reload — rotating a cert or key
+  requires a restart, same operational shape as rotating
+  `SPELUNK_SERVER_KEY`.
+- **New in-process attack surface:** `rustls` is now linked into the server
+  binary. This is accepted — `rustls` is a memory-safe, widely-audited TLS
+  implementation, and the alternative (every operator hand-rolling a
+  same-host proxy) does not reduce real-world attack surface, it just moves
+  it to code we don't control.
+- **Follow-on implementation work (tracked as its own task, not this ADR):**
+  - Add `axum-server` (`rustls` feature) to `crates/spelunk-server/Cargo.toml`;
+    wire `--tls-cert`/`--tls-key`/`SPELUNK_TLS_CERT`/`SPELUNK_TLS_KEY` into
+    `main.rs`; switch to `axum_server::bind_rustls` when both are present.
+  - Rewrite `check_bind_safety` per §3 above, with three distinct error
+    messages.
+  - Re-verify `warn_single_trust_domain` fires correctly now that its
+    firing condition is reachable again.
+  - Execute the §5 docs restructure (`self-hosting.md`, `server.md`,
+    Dockerfile/compose framing) and the ADR-056/058 superseding blockquotes.
+  - Re-open [spelunk-oss^122](https://agentic-os.johan-0e7.workers.dev/t/spelunk-oss/122)
+    once this ADR and its implementation land — that task's docs
+    reconciliation needs to be redone against the Team-mode model, not the
+    superseded loopback+proxy one.
+- **Revisit if:** operator demand appears for automatic certificate
+  provisioning (ACME) — a future ADR, not blocking this one.
+
+## Security implications
+
+- Directly closes the concern the original `check_bind_safety` refusal names:
+  a non-loopback keyed bind can no longer send the bearer key in cleartext,
+  because Team mode requires TLS to be configured before the bind is
+  permitted at all. There is no state where a key is set on a non-loopback
+  interface without TLS also being active.
+- Certificate and key file handling should follow the same guidance as the
+  existing `--key-file`: restrictive permissions (`0600`), not committed to
+  version control, rotated on suspected exposure.
+- No change to [ADR-056](056-oss-server-tenancy-model.md)'s tenancy model —
+  the shared key remains the single trust-domain boundary; TLS protects the
+  key in transit, it does not add per-project authorization.
+- `rustls` (not OpenSSL) is the specified library — memory-safe, no
+  C TLS stack in the dependency tree.


### PR DESCRIPTION
## Summary

Founder directive overrides the team-server story in ADR-058: a team server
is `spelunk-server` itself terminating HTTPS on `0.0.0.0` (or a specific
non-loopback interface) with an API key - not loopback + an operator-owned
reverse proxy. This ADR records that decision.

## Decision (design only - no code in this PR)

Strictly bimodal bind policy, no partial states:

| Mode | Host | Transport | API key |
|---|---|---|---|
| Local | `127.0.0.1` | HTTP | optional |
| Team | `0.0.0.0` / interface | HTTPS (native) | required |

- New `--tls-cert`/`--tls-key` flags + `SPELUNK_TLS_CERT`/`SPELUNK_TLS_KEY` env,
  mirroring the existing `--key`/`SPELUNK_SERVER_KEY` pattern.
- `axum-server` + `rustls` feature for in-process TLS termination (axum 0.8
  compatible, additive dependency - verified no TLS support exists in the
  crate today).
- `check_bind_safety` policy: non-loopback requires **both** TLS configured
  and a key set; three distinct refusal messages for which is missing.
- `warn_single_trust_domain` (ADR-056) becomes reachable again - it was dead
  code under the prior unconditional-refusal policy.

## Changes

- **`docs/adr/066-server-native-tls-team-mode.md`** (new) - the ADR.
- **`docs/adr/058-team-server-bare-metal-deployment.md`** - dated
  *Superseded in part* blockquote appended (body untouched): its
  "Recommended topology" and "Native TLS" Non-goal are superseded. The
  bare-metal + operator-proxy pattern remains valid as an alternative for
  Local-mode-behind-your-own-infra operators, just not the only path.
- **`docs/adr/056-oss-server-tenancy-model.md`** - dated *Clarification*
  blockquote appended: tenancy model unchanged, only *how* TLS is achieved
  changes.

## Relationship to spelunk-oss^122

^122 (reconcile bind-safety docs with `check_bind_safety`'s behavior) is
blocked pending this ADR - it was scoped against the now-superseded
loopback+proxy-only policy and needs to be redone once this lands. PR #561
(the docs-only fix under the old policy) is also on hold.

## Follow-on implementation (separate task, not this PR)

- Wire `axum-server`/`rustls` + new flags into `crates/spelunk-server/src/main.rs`.
- Rewrite `check_bind_safety` per the ADR's §3.
- Docs restructure: `self-hosting.md`, `server.md`, Dockerfile/compose framing
  (native TLS reopens Docker as a viable team-server host - ADR-058's
  Docker rejection was specifically about the loopback+proxy shape).
- Re-open spelunk-oss^122 against the new model.

## Test plan

- Docs-only change (ADR + two append-only blockquotes). Verified all
  cross-links (`066-...`, `056-...`, `058-...`) resolve to existing files.
- Confirmed ADR-056/058 bodies unchanged above the appended blockquotes
  (immutable-history convention).
- `cargo fmt --check` + `cargo clippy` passed via pre-commit hook (workspace
  unaffected - no `.rs` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)