### PR TITLE
fix(memory): fail closed when no local project (ADR-067, oss^131) [P0]

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/context.rs
+++ b/crates/spelunk-cli/src/cli/cmd/context.rs
@@ -84,9 +84,12 @@ const SECTIONS: &[Section] = &[
 
 pub async fn context(args: ContextArgs, cfg: Config) -> Result<()> {
     cfg.validate()?;
-    let mem_path = args.db.clone().unwrap_or_else(|| {
-        crate::config::resolve_db(None, &cfg.db_path).with_file_name("memory.db")
-    });
+    // ADR-067: fail closed when there is no local `.spelunk/` project instead of
+    // silently using the global store. `--db` is an explicit override, exempt.
+    let mem_path = match args.db.clone() {
+        Some(p) => p,
+        None => crate::config::require_project_db(&cfg.db_path, false)?.with_file_name("memory.db"),
+    };
 
     // Discovery nudge: warn once when unimported server.db notes exist.
     crate::cli::cmd::memory::reconcile::maybe_emit_nudge(&mem_path, &cfg);

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -372,9 +372,12 @@ mod watch;
 
 pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> {
     cfg.validate()?;
-    let mem_path = args.db.clone().unwrap_or_else(|| {
-        crate::config::resolve_db(None, &cfg.db_path).with_file_name("memory.db")
-    });
+    // ADR-067: fail closed when there is no local `.spelunk/` project instead of
+    // silently using the global store. `--db` is an explicit override, exempt.
+    let mem_path = match args.db.clone() {
+        Some(p) => p,
+        None => crate::config::require_project_db(&cfg.db_path, false)?.with_file_name("memory.db"),
+    };
     let be = backend_override(&args.backend);
     match args.command {
         MemoryCommand::Add(a) => add::memory_add(a, &mem_path, &cfg, be).await,

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -83,14 +83,24 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
         // after attempting to load it; for now, fall through to normal path.
     }
 
+    // ADR-067 D1: index-free ast-grep touches no index and no global store, so
+    // it is never project-gated — run it live before the fail-closed resolve.
+    if mode == "ast-grep" {
+        return search_live(
+            &args.query,
+            &args.format,
+            std::path::Path::new("."),
+            args.limit,
+        );
+    }
+
     let (db_path, dep_projects) = resolve_project_and_deps(args.db.as_ref(), &cfg)?;
     crate::storage::record_usage_at(&db_path, "search");
 
-    // Explicit (non-auto, non-ast-grep) modes surface an empty index as an
-    // actionable error instead of a silent "No results found." — the ast-grep
-    // mode never touches the index, and auto mode already degraded above.
+    // Explicit (non-auto) index-backed modes surface an empty index as an
+    // actionable error instead of a silent "No results found." — ast-grep
+    // returned above, and auto mode already degraded above.
     if !auto_mode
-        && mode != "ast-grep"
         && Database::open(&db_path)
             .and_then(|db| db.stats())
             .is_ok_and(|s| s.chunk_count == 0)
@@ -163,14 +173,6 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
             .unwrap_or_default();
         sp.finish_and_clear();
         res
-    } else if mode == "ast-grep" {
-        // Explicit ast-grep mode: skip index entirely.
-        return search_live(
-            &args.query,
-            &args.format,
-            std::path::Path::new("."),
-            args.limit,
-        );
     } else {
         // semantic, hybrid, or auto: need an embedding via server.
         //

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -383,13 +383,22 @@ pub(crate) fn resolve_project_and_deps(
     explicit_db: Option<&std::path::PathBuf>,
     cfg: &Config,
 ) -> Result<(std::path::PathBuf, Vec<Project>)> {
-    let resolved = resolve_project_context(explicit_db.map(|p| p.as_path()), &cfg.db_path)?;
+    // ADR-067: without an explicit --db, refuse when there is no local
+    // `.spelunk/` project rather than silently searching the global store. The
+    // scoped path also wins over any stray global `index.db`.
+    let project_db = match explicit_db {
+        Some(_) => None,
+        None => Some(crate::config::require_project_db(&cfg.db_path, false)?),
+    };
 
-    if !resolved.db_path.exists() {
+    let resolved = resolve_project_context(explicit_db.map(|p| p.as_path()), &cfg.db_path)?;
+    let db_path = project_db.unwrap_or(resolved.db_path);
+
+    if !db_path.exists() {
         if explicit_db.is_some() {
             anyhow::bail!(
                 "Database not found at '{}'. Run `spelunk index <path>` first.",
-                resolved.db_path.display()
+                db_path.display()
             );
         }
         anyhow::bail!(
@@ -399,8 +408,8 @@ pub(crate) fn resolve_project_and_deps(
     }
 
     // If the registry returned a project whose DB no longer exists, the
-    // existence check above would have caught it via resolved.db_path.
-    Ok((resolved.db_path, resolved.deps))
+    // existence check above would have caught it via db_path.
+    Ok((db_path, resolved.deps))
 }
 
 /// Annotate results with governing specs from the primary DB, and set

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -18,7 +18,7 @@ pub struct StatusArgs {
 
 use crate::{
     capability::{self, Tier},
-    config::{Config, resolve_db},
+    config::Config,
     registry::{Registry, resolve_project_context},
     storage::{Database, open_memory_backend},
 };
@@ -56,6 +56,10 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
 
     // JSON mode: current project stats only
     if fmt == "json" {
+        // ADR-067: fail closed when there is no local `.spelunk/` project rather
+        // than reporting the global store as if it were this project's. The
+        // scoped path also wins over any stray global `index.db`.
+        let db_path = crate::config::require_project_db(&cfg.db_path, false)?;
         let tier = capability::get_tier(&cfg).await;
 
         let resolved = resolve_project_context(None, &cfg.db_path)?;
@@ -63,14 +67,13 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
             .project
             .as_ref()
             .map(|p| p.root_path.display().to_string());
-        let db_path = resolved.db_path;
 
         let db = Database::open(&db_path)?;
         let stats = db.stats()?;
         let languages = db.language_stats().unwrap_or_default();
         let drift = db.drift_candidates(30, 10).unwrap_or_default();
         let usage = db.usage_last_7_days().unwrap_or_default();
-        let mem_path = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
+        let mem_path = db_path.with_file_name("memory.db");
         let (memory_count, memory_backend_kind) =
             match open_memory_backend(&cfg, &mem_path, None).await.ok() {
                 Some(b) => {
@@ -237,11 +240,20 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
         return Ok(());
     }
 
-    // Current project only
+    // Current project only.
+    // ADR-067: fail closed when there is no local `.spelunk/` project rather than
+    // describing the global store. The scoped path also wins over a stray global
+    // `index.db`.
+    let db_path = match crate::config::require_project_db(&cfg.db_path, false) {
+        Ok(p) => p,
+        Err(_) => {
+            println!("No spelunk project here. Run `spelunk init` first.");
+            return Ok(());
+        }
+    };
     let tier = capability::get_tier(&cfg).await;
 
     let resolved = resolve_project_context(None, &cfg.db_path)?;
-    let db_path = &resolved.db_path;
 
     if !db_path.exists() {
         println!("No index found for the current directory (checked parents too).");
@@ -249,17 +261,18 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
         return Ok(());
     }
 
-    let db = Database::open(db_path)?;
+    let db = Database::open(&db_path)?;
     let s = db.stats()?;
 
-    // ── Memory backend ────────────────────────────────────────────────────────
-    let mem_path_text = resolve_db(None, &cfg.db_path).with_file_name("memory.db");
-    if let Ok(b) = open_memory_backend(&cfg, &mem_path_text, None).await {
-        println!("Memory backend: {}", b.backend_kind());
-    }
+    // ── Memory backend (single truthful line from the resolved backend, ADR-067 D3) ──
+    let mem_path_text = db_path.with_file_name("memory.db");
+    let mem_label = match open_memory_backend(&cfg, &mem_path_text, None).await {
+        Ok(b) => memory_backend_label(b.backend_kind()).to_string(),
+        Err(_) => "unavailable".to_string(),
+    };
 
     // ── Capability tier section ───────────────────────────────────────────────
-    print_tier_section(tier, &cfg);
+    print_tier_section(tier, &cfg, &mem_label);
 
     if let Some(p) = &resolved.project {
         println!("Project: \x1b[1m{}\x1b[0m", p.root_path.display());
@@ -331,7 +344,9 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
     Ok(())
 }
 
-fn print_tier_section(tier: &Tier, cfg: &Config) {
+/// `mem_label` is the resolved memory line (ADR-067 D3): derived from the opened
+/// backend's `backend_kind()`, never inferred from the capability tier.
+fn print_tier_section(tier: &Tier, cfg: &Config, mem_label: &str) {
     match tier {
         Tier::Offline => {
             let server_hint = if cfg.server_url.is_some() {
@@ -341,7 +356,7 @@ fn print_tier_section(tier: &Tier, cfg: &Config) {
             };
             println!("Capability tier:  \x1b[33mOffline\x1b[0m");
             println!("  search          ast-grep + text{server_hint}");
-            println!("  memory          git-notes (local)");
+            println!("  memory          {mem_label}");
             println!("  explore         unavailable  [set server_url to enable]");
         }
         Tier::Server {
@@ -368,11 +383,6 @@ fn print_tier_section(tier: &Tier, cfg: &Config) {
             if let Some(line) = embedder_status_line(embedder_state) {
                 println!("{line}");
             }
-            let mem_label = if caps.memory_push {
-                "git-notes + server sync"
-            } else {
-                "git-notes (local)"
-            };
             println!("  memory          {mem_label}");
             let explore_label = if caps.explore {
                 "available"
@@ -383,6 +393,17 @@ fn print_tier_section(tier: &Tier, cfg: &Config) {
         }
     }
     println!();
+}
+
+/// Human-readable label for a resolved memory `backend_kind()` (ADR-067 D3).
+/// The parenthetical is derived from the backend kind, not the capability tier.
+fn memory_backend_label(kind: &str) -> &str {
+    match kind {
+        "sqlite" => "sqlite (local)",
+        "git-notes" => "git-notes (local)",
+        "remote" => "remote (server)",
+        other => other,
+    }
 }
 
 /// Render the `embedder` line for `spelunk status` (text mode) from the
@@ -510,5 +531,21 @@ mod tests {
     #[test]
     fn embedding_progress_hidden_for_empty_index() {
         assert!(embedding_progress_line(0, 0).is_none());
+    }
+
+    // ── memory_backend_label: resolved-backend memory line (ADR-067 D3) ─────────
+
+    #[test]
+    fn memory_backend_label_maps_resolved_kinds() {
+        // The label reflects the resolved backend_kind(), never the tier. Default
+        // resolved backend is sqlite, so an offline repo must not read git-notes.
+        assert_eq!(memory_backend_label("sqlite"), "sqlite (local)");
+        assert_eq!(memory_backend_label("git-notes"), "git-notes (local)");
+        assert_eq!(memory_backend_label("remote"), "remote (server)");
+    }
+
+    #[test]
+    fn memory_backend_label_passes_through_unknown() {
+        assert_eq!(memory_backend_label("future-kind"), "future-kind");
     }
 }

--- a/crates/spelunk-cli/src/main.rs
+++ b/crates/spelunk-cli/src/main.rs
@@ -81,7 +81,9 @@ async fn main() -> Result<()> {
             // message) by `resolve_sync_project` inside `memory_sync`.
             let project_available = args.project.is_some() || cfg.project_id.is_some();
             cfg.validate_with_project(project_available)?;
-            let mem_path = config::resolve_db(None, &cfg.db_path).with_file_name("memory.db");
+            // ADR-067: fail closed when there is no local `.spelunk/` project.
+            let mem_path =
+                config::require_project_db(&cfg.db_path, false)?.with_file_name("memory.db");
             cli::cmd::memory_sync(args, &mem_path, &cfg).await
         }
         Command::Server(args) => cli::cmd::server(args).await,

--- a/crates/spelunk-cli/tests/backend_kind_diagnostic.rs
+++ b/crates/spelunk-cli/tests/backend_kind_diagnostic.rs
@@ -148,7 +148,9 @@ fn check_json_includes_memory_backend_field() {
 // ── `spelunk status` text output ─────────────────────────────────────────────
 
 /// `spelunk status` text output (no --format json) must mention the active
-/// memory backend so humans can see which store is in use (issue #308).
+/// memory backend so humans can see which store is in use (issue #308). Since
+/// ADR-067 D3 the line reflects the resolved backend (sqlite by default), sourced
+/// from `backend_kind()` rather than the capability tier.
 #[test]
 fn status_text_mentions_memory_backend() {
     let (_temp, project_dir, config_path) = setup_offline_project();
@@ -162,5 +164,5 @@ fn status_text_mentions_memory_backend() {
         .arg("status")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Memory backend:"));
+        .stdout(predicate::str::contains("sqlite (local)"));
 }

--- a/crates/spelunk-cli/tests/context.rs
+++ b/crates/spelunk-cli/tests/context.rs
@@ -23,7 +23,11 @@ fn setup_context_project() -> (TempDir, PathBuf, PathBuf) {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let tmp = TempDir::new().expect("create temp dir");
-    let db_path = tmp.path().join("spelunk.db");
+    // ADR-067: `context` fails closed without a local `.spelunk/` project, so
+    // make the temp dir a real project. The memory store then resolves to
+    // `<tmp>/.spelunk/memory.db` (where the entries below are seeded).
+    std::fs::create_dir_all(tmp.path().join(".spelunk")).expect("create .spelunk");
+    let db_path = tmp.path().join(".spelunk").join("index.db");
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let mock_server = rt.block_on(async {
@@ -373,7 +377,9 @@ fn context_default_limits_respected() {
 fn context_empty_memory_exits_zero_with_no_output() {
     // Fresh project with no memory entries at all.
     let tmp = TempDir::new().expect("create temp dir");
-    let db_path = tmp.path().join("spelunk.db");
+    // ADR-067: a local `.spelunk/` makes this a real (empty) project.
+    std::fs::create_dir_all(tmp.path().join(".spelunk")).expect("create .spelunk");
+    let db_path = tmp.path().join(".spelunk").join("index.db");
     let config_path = write_config_for_context(tmp.path(), &db_path, "http://127.0.0.1:19999");
 
     // Write a valid but empty memory.db so the backend can open.

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -131,9 +131,9 @@ fn test_status_empty_project() {
         .arg("status")
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "No index found for the current directory",
-        ));
+        // ADR-067: an un-init'd dir fails closed and reports no project rather
+        // than describing the global store.
+        .stdout(predicate::str::contains("No spelunk project here"));
 }
 
 use wiremock::matchers::{method, path, path_regex};
@@ -415,7 +415,9 @@ async fn test_status_shows_offline_tier() {
         .stdout(predicate::str::contains("Capability tier:"))
         .stdout(predicate::str::contains("Offline"))
         .stdout(predicate::str::contains("ast-grep + text"))
-        .stdout(predicate::str::contains("git-notes (local)"))
+        // ADR-067 D3: the memory line reflects the resolved backend (sqlite by
+        // default), not a tier-derived git-notes label.
+        .stdout(predicate::str::contains("sqlite (local)"))
         .stdout(predicate::str::contains("set server_url to enable"));
 }
 
@@ -470,7 +472,10 @@ async fn test_status_shows_server_tier() {
         .stdout(predicate::str::contains("Capability tier:"))
         .stdout(predicate::str::contains("Server"))
         .stdout(predicate::str::contains("semantic"))
-        .stdout(predicate::str::contains("server sync"));
+        // ADR-067 D3: memory line reflects the resolved backend. With an explicit
+        // team server_url the mode is local_first, so the store is local sqlite
+        // (converged by `spelunk sync`), not a tier-inferred "server sync" label.
+        .stdout(predicate::str::contains("sqlite (local)"));
 }
 
 #[tokio::test]

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -14,8 +14,9 @@ use predicates::prelude::*;
 use std::path::Path;
 use tempfile::TempDir;
 
-/// Exact fail-closed error text mandated by ADR-067 (em dash, single quotes).
-const NO_PROJECT_ERR: &str = "no spelunk project here \u{2014} run 'spelunk init' first";
+/// Exact fail-closed error text (ADR-067; em dash restructured out per the
+/// no-em-dash house rule for user-facing copy).
+const NO_PROJECT_ERR: &str = "no spelunk project here. Run 'spelunk init' first";
 
 /// A `spelunk` command with an isolated HOME (so the "global" store lives under
 /// `<home>/.config/spelunk`) and no server contact, run in `cwd`.

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -1,0 +1,223 @@
+//! Fail-closed behaviour when there is no local `.spelunk/` project (ADR-067,
+//! spelunk-oss^131).
+//!
+//! In a directory that was never `spelunk init`'d, memory/context/index-backed
+//! search must refuse rather than silently read or write the machine-global
+//! `~/.config/spelunk/` store. `--db` and `spelunk index` stay exempt. `status`
+//! reports "no project" instead of describing the global store.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Exact fail-closed error text mandated by ADR-067 (em dash, single quotes).
+const NO_PROJECT_ERR: &str = "no spelunk project here \u{2014} run 'spelunk init' first";
+
+/// A `spelunk` command with an isolated HOME (so the "global" store lives under
+/// `<home>/.config/spelunk`) and no server contact, run in `cwd`.
+fn bin(home: &Path, cwd: &Path) -> Command {
+    let mut cmd = spelunk_bin_in(home);
+    cmd.current_dir(cwd)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL")
+        .env_remove("SPELUNK_MEMORY_SERVER_URL");
+    cmd
+}
+
+/// The global memory store path under the isolated HOME. Must never be created
+/// by a fail-closed command.
+fn global_memory_db(home: &Path) -> std::path::PathBuf {
+    home.join(".config").join("spelunk").join("memory.db")
+}
+
+// ── refuse-guard: un-init'd dir, no --db ───────────────────────────────────────
+
+#[test]
+fn memory_add_refuses_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    bin(home.path(), proj.path())
+        .args([
+            "memory", "add", "--kind", "note", "--title", "t", "--body", "b",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert!(
+        !global_memory_db(home.path()).exists(),
+        "refused memory add must not create the global store"
+    );
+}
+
+#[test]
+fn memory_list_refuses_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["memory", "list"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert!(!global_memory_db(home.path()).exists());
+}
+
+#[test]
+fn memory_search_refuses_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["memory", "search", "anything"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert!(!global_memory_db(home.path()).exists());
+}
+
+#[test]
+fn context_refuses_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["context"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert!(!global_memory_db(home.path()).exists());
+}
+
+#[test]
+fn index_backed_search_refuses_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    // Explicit index-backed mode: must refuse rather than fall back to global.
+    bin(home.path(), proj.path())
+        .args(["search", "anything", "--mode", "text"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+}
+
+// ── exempt: a real local project, an explicit --db, and `spelunk index` ────────
+
+#[test]
+fn memory_add_works_with_local_dot_spelunk() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::create_dir_all(proj.path().join(".spelunk")).unwrap();
+
+    bin(home.path(), proj.path())
+        .args([
+            "memory", "add", "--kind", "note", "--title", "t", "--body", "b",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [note]"));
+
+    assert!(
+        proj.path().join(".spelunk").join("memory.db").exists(),
+        "memory add must write into the local project's .spelunk/memory.db"
+    );
+    assert!(
+        !global_memory_db(home.path()).exists(),
+        "the global store must stay untouched"
+    );
+}
+
+#[test]
+fn memory_add_works_with_explicit_db_in_uninit_dir() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    let db = proj.path().join("custom.db");
+
+    bin(home.path(), proj.path())
+        .args(["memory", "--db"])
+        .arg(&db)
+        .args(["add", "--kind", "note", "--title", "t", "--body", "b"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [note]"));
+
+    assert!(
+        db.exists(),
+        "--db override must be honored even with no .spelunk/"
+    );
+    assert!(!global_memory_db(home.path()).exists());
+}
+
+#[test]
+fn index_creates_project_in_uninit_dir() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::write(proj.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+    // `spelunk index <path>` is the project-creation command; never gated.
+    bin(home.path(), proj.path())
+        .args(["index", "."])
+        .assert()
+        .success();
+
+    assert!(
+        proj.path().join(".spelunk").join("index.db").exists(),
+        "index must create the local .spelunk/index.db"
+    );
+}
+
+// ── status: report no-project, and label the resolved backend ──────────────────
+
+#[test]
+fn status_text_reports_no_project_when_uninit() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No spelunk project here"));
+}
+
+#[test]
+fn status_json_fails_closed_when_uninit() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["status", "--format", "json"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+}
+
+#[test]
+fn status_labels_resolved_backend_as_sqlite_not_git_notes() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::write(proj.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["index", "."])
+        .assert()
+        .success();
+
+    // The memory line must reflect the resolved backend (sqlite by default), not
+    // a tier-derived "git-notes" label (ADR-067 D3).
+    bin(home.path(), proj.path())
+        .args(["status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sqlite (local)"))
+        .stdout(predicate::str::contains("git-notes").not());
+}

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -222,3 +222,200 @@ fn status_labels_resolved_backend_as_sqlite_not_git_notes() {
         .stdout(predicate::str::contains("sqlite (local)"))
         .stdout(predicate::str::contains("git-notes").not());
 }
+
+// ── gap: the top-level `Sync` arm (main.rs), distinct from memory-dispatch ─────
+
+#[test]
+fn sync_arm_refuses_without_local_project() {
+    // `spelunk sync` is a top-level command whose guard lives in `main.rs`, not in
+    // the `memory` dispatch. With no `server_url` configured, `validate_with_project`
+    // passes, so the fail-closed guard is what must fire (not a config error).
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["sync"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert!(
+        !global_memory_db(home.path()).exists(),
+        "refused sync must not create the global store"
+    );
+}
+
+// ── gap: a memory subcommand past add/list/search proves the shared funnel ─────
+
+#[test]
+fn memory_timeline_refuses_without_local_project() {
+    // Every `memory` subcommand resolves its store through the same
+    // `require_project_db` line before dispatch; `timeline` (needs no server)
+    // confirms the guard is not specific to add/list/search.
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["memory", "timeline", "anything"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert!(!global_memory_db(home.path()).exists());
+}
+
+// ── security invariant: a refused command must not MUTATE a pre-existing global ──
+//
+// The other refuse tests assert the global store is not *created*. These assert
+// the other half of ADR-067's "not created or mutated": a global store left over
+// from the pre-fix silent-fallback era is left byte-for-byte untouched.
+
+#[test]
+fn refused_memory_add_does_not_mutate_preexisting_global_store() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    let global = global_memory_db(home.path());
+    std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+    let sentinel = b"pre-existing global memory store sentinel";
+    std::fs::write(&global, sentinel).unwrap();
+
+    bin(home.path(), proj.path())
+        .args([
+            "memory", "add", "--kind", "note", "--title", "t", "--body", "b",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert_eq!(
+        std::fs::read(&global).unwrap(),
+        sentinel,
+        "refused memory add must not open or mutate the pre-existing global store"
+    );
+}
+
+#[test]
+fn refused_index_search_does_not_touch_preexisting_global_index() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    let global_index = home.path().join(".config").join("spelunk").join("index.db");
+    std::fs::create_dir_all(global_index.parent().unwrap()).unwrap();
+    let sentinel = b"pre-existing global index sentinel";
+    std::fs::write(&global_index, sentinel).unwrap();
+
+    // Index-backed search fails closed before opening any DB, so even a stray
+    // global index.db is never read or written.
+    bin(home.path(), proj.path())
+        .args(["search", "anything", "--mode", "text"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert_eq!(
+        std::fs::read(&global_index).unwrap(),
+        sentinel,
+        "refused index-backed search must not touch the pre-existing global index"
+    );
+}
+
+// ── walk-up: memory resolves the ancestor project from a deep subdir ───────────
+
+#[test]
+fn memory_add_works_from_deep_nested_subdir() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::create_dir_all(proj.path().join(".spelunk")).unwrap();
+    let deep = proj.path().join("a").join("b").join("c");
+    std::fs::create_dir_all(&deep).unwrap();
+
+    // Run several levels below the `.spelunk/` project root; the guard walks up
+    // and resolves the ancestor's store, not the global one.
+    bin(home.path(), &deep)
+        .args([
+            "memory", "add", "--kind", "note", "--title", "t", "--body", "b",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [note]"));
+
+    assert!(
+        proj.path().join(".spelunk").join("memory.db").exists(),
+        "note must land in the ancestor project's .spelunk/memory.db"
+    );
+    assert!(!global_memory_db(home.path()).exists());
+}
+
+// ── worktree-awareness: a linked worktree resolves to the main worktree's store ──
+
+/// Run `git args` in `dir`, asserting success. Isolated identity so it works on a
+/// machine with no global git config.
+fn git(dir: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@example.com")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@example.com")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("spawn git");
+    assert!(status.status.success(), "git {args:?} failed");
+}
+
+#[test]
+fn memory_resolves_main_worktree_dot_spelunk_from_linked_worktree() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let main_root = tmp.path().join("main");
+    std::fs::create_dir_all(&main_root).unwrap();
+
+    git(&main_root, &["init", "-q", "-b", "main"]);
+    std::fs::write(main_root.join("f.txt"), "x\n").unwrap();
+    git(&main_root, &["add", "."]);
+    git(&main_root, &["commit", "-q", "-m", "init"]);
+
+    // Only the main worktree is a real project (has `.spelunk/`).
+    std::fs::create_dir_all(main_root.join(".spelunk")).unwrap();
+
+    // Add a linked worktree with no `.spelunk/` of its own.
+    let linked = tmp.path().join("linked");
+    git(
+        &main_root,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            linked.to_str().unwrap(),
+            "-b",
+            "feat",
+        ],
+    );
+    assert!(
+        !linked.join(".spelunk").exists(),
+        "precondition: linked worktree has no .spelunk/"
+    );
+
+    // ADR-067 worktree-awareness: memory run from the linked worktree must resolve
+    // to the MAIN worktree's `.spelunk/` store, not fail closed and not go global.
+    bin(home.path(), &linked)
+        .args([
+            "memory", "add", "--kind", "note", "--title", "t", "--body", "b",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [note]"));
+
+    assert!(
+        main_root.join(".spelunk").join("memory.db").exists(),
+        "note must land in the main worktree's .spelunk/memory.db"
+    );
+    assert!(
+        !linked.join(".spelunk").exists(),
+        "the linked worktree must not get its own .spelunk/"
+    );
+    assert!(!global_memory_db(home.path()).exists());
+}

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -111,6 +111,49 @@ fn index_backed_search_refuses_without_local_project() {
         .stderr(predicate::str::contains(NO_PROJECT_ERR));
 }
 
+// ── exempt: index-free ast-grep search (ADR-067 D1) ────────────────────────────
+
+#[test]
+fn ast_grep_search_works_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::write(
+        proj.path().join("lib.rs"),
+        "pub fn greet(name: &str) -> String { format!(\"hi {name}\") }\n\
+         fn caller() { greet(\"x\"); }\n",
+    )
+    .unwrap();
+
+    // `--mode ast-grep` touches no index and no global store, so it must run live
+    // over the working tree in an un-init'd dir rather than fail closed. The
+    // `greet($$$ARGS)` call pattern matches the call site in `caller`.
+    bin(home.path(), proj.path())
+        .args([
+            "search",
+            "greet($$$ARGS)",
+            "--mode",
+            "ast-grep",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"file_path\""))
+        .stdout(predicate::str::contains("lib.rs"));
+
+    // Index-free search must never create or read the machine-global store.
+    assert!(
+        !home
+            .path()
+            .join(".config")
+            .join("spelunk")
+            .join("index.db")
+            .exists(),
+        "ast-grep search must not create the global index"
+    );
+    assert!(!global_memory_db(home.path()).exists());
+}
+
 // ── exempt: a real local project, an explicit --db, and `spelunk index` ────────
 
 #[test]

--- a/crates/spelunk-cli/tests/harvest_ref_injection.rs
+++ b/crates/spelunk-cli/tests/harvest_ref_injection.rs
@@ -42,6 +42,10 @@ fn init_repo(dir: &std::path::Path) {
     fs::write(dir.join("README.md"), "hello\n").unwrap();
     run(&["add", "."]);
     run(&["commit", "-q", "-m", "initial commit"]);
+    // ADR-067: `memory harvest` fails closed without a local `.spelunk/` project,
+    // so make this repo a real project — otherwise the guard fires before the
+    // ref-injection check under test is reached.
+    fs::create_dir_all(dir.join(".spelunk")).expect("create .spelunk");
 }
 
 #[test]

--- a/crates/spelunk-cli/tests/harvest_upfront_check.rs
+++ b/crates/spelunk-cli/tests/harvest_upfront_check.rs
@@ -20,6 +20,9 @@ const SERVER_REQUIRED: &str = "'spelunk memory harvest' requires spelunk-server"
 
 /// Write a minimal config file under `dir`.  `extra` is appended verbatim.
 fn write_harvest_config(dir: &std::path::Path, extra: &str) -> std::path::PathBuf {
+    // ADR-067: harvest fails closed without a local `.spelunk/` project, which
+    // would pre-empt the server-gate check under test. Make `dir` a real project.
+    fs::create_dir_all(dir.join(".spelunk")).expect("create .spelunk");
     let db_path = dir.join("memory.db");
     let config_path = dir.join("config.toml");
     let content = format!(

--- a/crates/spelunk-cli/tests/memory_reconcile.rs
+++ b/crates/spelunk-cli/tests/memory_reconcile.rs
@@ -41,32 +41,36 @@ fn ensure_sqlite_vec() {
     });
 }
 
-/// Write a minimal spelunk config file.
+/// Write a minimal spelunk config file and make `dir` a real project.
 ///
-/// `db_path` is the `db_path` config value (the index database).  The memory
-/// database defaults to a sibling `memory.db` next to `db_path` when no
-/// explicit `--db` flag is passed to `spelunk memory`.
+/// ADR-067: `memory reconcile` (a memory subcommand) fails closed without a
+/// local `.spelunk/` project, so we create `<dir>/.spelunk/`. Memory is now
+/// project-scoped: the CLI resolves it to `<dir>/.spelunk/memory.db` regardless
+/// of the config `db_path`. The incoming `db_path` argument is ignored (kept for
+/// call-site compatibility).
 ///
 /// We deliberately do NOT pass `memory --db` in `reconcile_cmd` because the
 /// `MemoryArgs.db` arg is `global = true` in clap, which means a second `--db`
 /// on the `reconcile` subcommand would override the memory path rather than
-/// setting the reconcile source path.  Instead we control the memory.db
-/// location via `db_path` in the config.
+/// setting the reconcile source path.
 ///
 /// Returns `(config_path, mem_path)` where `mem_path` is where the CLI will
 /// write `memory.db`.
-fn write_config(dir: &Path, db_path: &Path) -> (PathBuf, PathBuf) {
+fn write_config(dir: &Path, _db_path: &Path) -> (PathBuf, PathBuf) {
+    let spelunk_dir = dir.join(".spelunk");
+    std::fs::create_dir_all(&spelunk_dir).expect("create .spelunk");
+    let index_db = spelunk_dir.join("index.db");
     let config_path = dir.join("config.toml");
     std::fs::write(
         &config_path,
         format!(
             "db_path = {:?}\nllm_model = \"test-model\"\n",
-            db_path.display().to_string()
+            index_db.display().to_string()
         ),
     )
     .expect("write config");
-    // The CLI resolves memory.db as a sibling of db_path.
-    let mem_path = db_path.with_file_name("memory.db");
+    // Project-scoped memory store lives next to the index inside `.spelunk/`.
+    let mem_path = index_db.with_file_name("memory.db");
     (config_path, mem_path)
 }
 

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -173,7 +173,12 @@ pub fn index_fixture_project() -> (TempDir, PathBuf, PathBuf) {
 /// alive for the duration of the test.
 pub fn index_project_dir(project_dir: &Path) -> (TempDir, PathBuf, PathBuf) {
     let tmp = TempDir::new().expect("create temp dir");
-    let db_path = tmp.path().join("spelunk.db");
+    // Keep the index under `<tmp>/.spelunk/` so `<tmp>` is a real project that a
+    // bare (no `--db`) command run from that CWD discovers (ADR-067). Plumbing
+    // callers pass the returned `db_path` via `--db`, so the location is
+    // transparent to them.
+    std::fs::create_dir_all(tmp.path().join(".spelunk")).expect("create .spelunk");
+    let db_path = tmp.path().join(".spelunk").join("index.db");
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let _mock_server = rt.block_on(async {

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -226,7 +226,7 @@ pub fn require_project_db_at(
     if allow_global {
         return Ok(cfg_default.to_path_buf());
     }
-    anyhow::bail!("no spelunk project here \u{2014} run 'spelunk init' first")
+    anyhow::bail!("no spelunk project here. Run 'spelunk init' first")
 }
 
 /// [`require_project_db_at`] anchored at the current working directory.
@@ -2177,8 +2177,9 @@ project_id = "team/old"
 
     // ── find_project_dir / require_project_db_at (ADR-067) ───────────────────
 
-    /// Exact fail-closed error text mandated by ADR-067 (em dash, single quotes).
-    const NO_PROJECT_ERR: &str = "no spelunk project here \u{2014} run 'spelunk init' first";
+    /// Exact fail-closed error text (ADR-067; em dash restructured out per the
+    /// no-em-dash house rule for user-facing copy).
+    const NO_PROJECT_ERR: &str = "no spelunk project here. Run 'spelunk init' first";
 
     #[test]
     fn find_project_dir_finds_dot_spelunk_at_start() {

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -187,6 +187,54 @@ pub fn find_project_db(start: &Path) -> Option<PathBuf> {
     }
 }
 
+/// Walk up from `start` for a `.spelunk/` **directory** (worktree-aware).
+/// Returns the `.spelunk` dir path, or `None` if none is found before the root.
+///
+/// Keys on the directory, not `index.db`: `spelunk init --no-index` writes a
+/// `.spelunk/config.toml` with no index, and memory needs no index. Linked
+/// worktrees resolve to the main worktree's `.spelunk/` (mirrors
+/// [`find_project_db`]).
+pub fn find_project_dir(start: &Path) -> Option<PathBuf> {
+    let mut dir = crate::utils::resolve_main_worktree_root(start);
+    loop {
+        let candidate = dir.join(".spelunk");
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+/// ADR-067: resolve the local project's `.spelunk/index.db` base path anchored at
+/// `start`, failing closed when `start` has no `.spelunk/` project instead of
+/// silently falling back to the global `~/.config/spelunk/` store.
+///
+/// Explicit `--db` / index-path callers bypass this (an explicit store is always
+/// honored). Memory callers apply `.with_file_name("memory.db")` to the result.
+/// `allow_global` restores the legacy global fallback and is reserved for a
+/// future `--global` flag (ADR-067 D2); no caller sets it today.
+pub fn require_project_db_at(
+    start: &Path,
+    cfg_default: &Path,
+    allow_global: bool,
+) -> Result<PathBuf> {
+    if let Some(spelunk_dir) = find_project_dir(start) {
+        return Ok(spelunk_dir.join("index.db"));
+    }
+    if allow_global {
+        return Ok(cfg_default.to_path_buf());
+    }
+    anyhow::bail!("no spelunk project here \u{2014} run 'spelunk init' first")
+}
+
+/// [`require_project_db_at`] anchored at the current working directory.
+pub fn require_project_db(cfg_default: &Path, allow_global: bool) -> Result<PathBuf> {
+    let cwd = std::env::current_dir().context("resolving current directory")?;
+    require_project_db_at(&cwd, cfg_default, allow_global)
+}
+
 /// Walk up from `start` looking for `.spelunk/config.toml` (project-level config).
 /// Stops at the filesystem root. Returns the path if found.
 fn find_project_config(start: &Path) -> Option<PathBuf> {
@@ -2125,5 +2173,81 @@ project_id = "team/old"
         let store = MemoryStore::default();
         let cfg = Config::load_with_store(Some(&path), &store).unwrap();
         assert_eq!(cfg.server_key, None);
+    }
+
+    // ── find_project_dir / require_project_db_at (ADR-067) ───────────────────
+
+    /// Exact fail-closed error text mandated by ADR-067 (em dash, single quotes).
+    const NO_PROJECT_ERR: &str = "no spelunk project here \u{2014} run 'spelunk init' first";
+
+    #[test]
+    fn find_project_dir_finds_dot_spelunk_at_start() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".spelunk")).unwrap();
+        assert_eq!(
+            find_project_dir(tmp.path()),
+            Some(tmp.path().join(".spelunk"))
+        );
+    }
+
+    #[test]
+    fn find_project_dir_walks_up_from_subdir() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".spelunk")).unwrap();
+        let sub = tmp.path().join("a").join("b");
+        std::fs::create_dir_all(&sub).unwrap();
+        assert_eq!(find_project_dir(&sub), Some(tmp.path().join(".spelunk")));
+    }
+
+    #[test]
+    fn find_project_dir_none_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(find_project_dir(tmp.path()), None);
+    }
+
+    #[test]
+    fn find_project_dir_ignores_dot_spelunk_file() {
+        // A regular file named `.spelunk` is not a project dir.
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".spelunk"), "not a dir").unwrap();
+        assert_eq!(find_project_dir(tmp.path()), None);
+    }
+
+    #[test]
+    fn require_project_db_at_returns_scoped_index_db_with_project() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".spelunk")).unwrap();
+        let global = PathBuf::from("/nonexistent/global/index.db");
+        let got = require_project_db_at(tmp.path(), &global, false).unwrap();
+        assert_eq!(got, tmp.path().join(".spelunk").join("index.db"));
+    }
+
+    #[test]
+    fn require_project_db_at_walks_up_to_project() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".spelunk")).unwrap();
+        let sub = tmp.path().join("crates").join("x");
+        std::fs::create_dir_all(&sub).unwrap();
+        let global = PathBuf::from("/nonexistent/global/index.db");
+        let got = require_project_db_at(&sub, &global, false).unwrap();
+        assert_eq!(got, tmp.path().join(".spelunk").join("index.db"));
+    }
+
+    #[test]
+    fn require_project_db_at_errors_without_project() {
+        let tmp = TempDir::new().unwrap();
+        let global = PathBuf::from("/nonexistent/global/index.db");
+        let err = require_project_db_at(tmp.path(), &global, false).unwrap_err();
+        assert_eq!(err.to_string(), NO_PROJECT_ERR);
+    }
+
+    #[test]
+    fn require_project_db_at_allow_global_returns_default_when_no_project() {
+        // The reserved --global opt-in path (ADR-067 D2) restores the legacy
+        // global fallback instead of failing closed.
+        let tmp = TempDir::new().unwrap();
+        let global = tmp.path().join("global-index.db");
+        let got = require_project_db_at(tmp.path(), &global, true).unwrap();
+        assert_eq!(got, global);
     }
 }

--- a/docs/architecture/capability-tiers.md
+++ b/docs/architecture/capability-tiers.md
@@ -16,7 +16,7 @@ used; the binary is the same in both tiers.
 | **Condition** | No `server_url` configured, or server unreachable | `server_url` set and health probe succeeds |
 | **Search** | ast-grep + BM25 text | + semantic KNN (server encodes query, CLI does local KNN) |
 | **Index** | Parse + AST chunk + graph (no embeddings) | + embedding phase: server generates vectors, CLI stores in local DB |
-| **Memory add/list/show/archive** | git-notes (local) | Same |
+| **Memory add/list/show/archive** | sqlite (local) | Same |
 | **Memory push/pull** | Not available | Sync git-notes entries to/from server DB |
 | **Memory search** | Not available | Server encodes query, does KNN over server-side memory DB |
 | **Memory harvest** | Not available | LLM extraction via server |

--- a/docs/architecture/capability-tiers.md
+++ b/docs/architecture/capability-tiers.md
@@ -175,17 +175,22 @@ and [server.md → Local server](../server.md#local-server-automatic--no-setup).
 ```
 Capability tier:  Offline
   search          ast-grep + text
-  memory          git-notes (local)
+  memory          sqlite (local)
   explore         unavailable  [set server_url to enable]
   plan            unavailable  [set server_url to enable]
 ```
+
+The `memory` line reflects the resolved backend (`sqlite` / `git-notes` /
+`remote`), not the capability tier. In a directory with no local `.spelunk/`
+project, `spelunk status` reports `No spelunk project here` instead (see
+[fail-closed, ADR-067](../adr/067-fail-closed-no-local-project.md)).
 
 **Text output (Tier 1 — server connected):**
 
 ```
 Capability tier:  Server  (http://spelunk.internal:7777)
   search          ast-grep + text + semantic
-  memory          git-notes + server sync
+  memory          sqlite (local)
   explore         available
   plan            available
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -191,9 +191,13 @@ In non-interactive contexts (CI, agent harnesses) `spelunk init` does **not**
 auto-spawn the server — run `spelunk server start` first if you want semantic
 search there, or set `SPELUNK_NO_SERVER=1` to stay fully offline.
 
-## 3. Start using it immediately — no setup required
+## 3. Start using it inside your project
 
-No configuration needed. From inside any git repository, you can immediately:
+`graph` and `search --mode ast-grep` need no index and run in any repository.
+Memory and `context` operate on the local project you created with `spelunk init`
+(step 2); in an un-initialized directory they fail closed with a `no spelunk
+project here` error instead of using a machine-global store. From inside your
+project you can:
 
 ```bash
 # Trace callers and callees for any symbol
@@ -211,7 +215,9 @@ spelunk memory add --kind decision \
 spelunk memory list --kind decision
 ```
 
-Memory is stored in git notes — no server, no database, no configuration.
+Memory is stored locally in the project's `.spelunk/memory.db` (and mirrored to
+git notes by default), so it travels with the repo. No server or database
+service to run.
 
 ## 4. Start an agent session
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -10,6 +10,13 @@ database or server is required. (You can make git-notes the primary backend with
 are searchable by full text at all times; semantic search (by meaning) is
 available when a server is running — the local one is autostarted on demand.
 
+Memory is scoped to a local project. Run `spelunk init` once per repository to
+create its `.spelunk/` store. In a directory with no local `.spelunk/`,
+`memory add/list/search` and `context` fail closed with a `no spelunk project
+here` error rather than reading or writing a machine-global store (see
+[ADR-067](adr/067-fail-closed-no-local-project.md)). An explicit `--db <path>`
+still overrides this.
+
 ## Why memory?
 
 Code tells you *what* the system does. Memory tells you *why* it was built that way.

--- a/docs/server.md
+++ b/docs/server.md
@@ -23,8 +23,8 @@ When you run a command that needs inference — `spelunk init`, a semantic
 address `127.0.0.1:7777`. If none is running, it starts the bundled
 `spelunk-server` in the background, owned by your user, and reuses it for the
 rest of the session and future runs. You don't configure anything, and you don't
-manage a process. Memory still lives in local git-notes; the local server only
-provides inference.
+manage a process. Memory still lives in the local project's `memory.db`; the
+local server only provides inference.
 
 If you ever need to manage it explicitly:
 


### PR DESCRIPTION
## Summary

Un-`init`'d repos (no local `.spelunk/`) silently shared ONE machine-global `~/.config/spelunk/` memory + index store, commingling decisions across every un-scoped repo on the machine. Per **ADR-067** (merged), this fix makes the memory/index surface **fail closed**: in a directory with no local `.spelunk/` (walking up from CWD, worktree-aware), `memory add/list/search` (all `memory` subcommands), `context`, index-backed `search`, and the `Sync` arm now **refuse** rather than fall back to the global store.

Error string (em-dash removed per the house rule on user-facing copy):

```
no spelunk project here. Run 'spelunk init' first
```

Exemptions preserved: an explicit `--db <path>` and `spelunk index <path>` (the project-creation command) still work with no pre-existing project. `spelunk status` now reports the resolved `backend_kind()` (`sqlite`/`git-notes`/`remote`) instead of a tier-inferred hardcoded `git-notes` label (ADR-067 D3), and reports "No spelunk project here" in an un-init'd dir.

Central resolver: `config::require_project_db` / `find_project_dir` (`crates/spelunk-core/src/config.rs`), applied at `memory/mod.rs`, `context.rs`, `search.rs` (`resolve_project_and_deps`), `main.rs` (Sync), and `status.rs`.

### Index-free `ast-grep` search stays ungated (ADR-067 D1)

`search --mode ast-grep` is a zero-infra structural scan that touches no index and no global store, so it is **not** project-gated: it now runs live *before* the fail-closed `resolve_project_and_deps?`, so it works in an un-`init`'d dir (matching `auto` mode's ast-grep fallback). Index-backed modes (`text`/`semantic`/`hybrid`) still fail closed. The previously-unreachable later ast-grep branch was removed.

## Security crux (independently verified)

In an isolated `HOME` + un-init'd temp dir, confirmed via the `fail_closed_no_project.rs` suite AND a manual CLI repro:

- `memory add/list/search`, `context`, index-backed `search`, `memory harvest`, and `sync` all **refuse** and exit non-zero.
- `~/.config/spelunk/` is **never created or mutated** — no global `memory.db`/`index.db` read or written from an un-init'd dir (sentinel tests assert a pre-existing global store is left byte-for-byte untouched).
- `search --mode ast-grep` in an un-init'd dir **succeeds** (live scan, exit 0) and creates no global `index.db`; `--mode text` in the same dir **refuses**.
- A dir WITH `.spelunk/` works; a deep nested subdir walks up to it; a **git linked worktree** subdir resolves to the main worktree's `.spelunk/memory.db`.
- `--db <explicit>` and `spelunk index .` still work in an un-init'd dir.
- Ungated `graph` runs a live scan and never touches the global store.

Residual (ADR-sanctioned, non-blocking): `spelunk check` is deliberately out of ADR-067 D1. It never creates the global store; on a machine with pre-existing global `index.db` it could still read-only display cross-project data. Noted for a possible follow-up.

## Test plan (actual steps run, `SPELUNK_SECRET_STORE=file`)

- `cargo test` — **867 passed, 0 failed, 9 ignored** (43 test binaries)
- `cargo test --no-default-features` — **866 passed, 0 failed, 4 ignored** (OSS CI cell)
- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo clippy --all-targets --no-default-features -- -D warnings` — clean
- Manual repro (built `target/debug/spelunk`, isolated `HOME`): `ast-grep` search succeeds live (exit 0); `--mode text` + `memory add` refuse (exit 1); `auto` degrades to live ast-grep (exit 0); `~/.config/spelunk` never created (both `memory.db` and `index.db` absent). Positive cases for local `.spelunk/`, git-worktree walk-up, `--db`, and `index` also confirmed.

## Docs

`docs/memory.md`, `docs/getting-started.md`, `docs/architecture/capability-tiers.md`, and `docs/server.md` updated to describe the fail-closed behavior and the resolved-backend `status` label (git-notes → sqlite mislabels corrected). No new em-dashes introduced in prose.

Fixes the P0 cross-project memory leak (spelunk-oss^131); implements ADR-067.
