### PR TITLE
fix(cli): point solo users at 'spelunk server start', not team server_url, when semantic inference needs a server (oss^133)

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -614,6 +614,35 @@ fn current_uid() -> Option<u32> {
     }
 }
 
+/// Guidance for an *inference*-backed feature (semantic `memory search`,
+/// `memory timeline`, `memory harvest`) that has no reachable server.
+///
+/// These features only need inference (query embedding / LLM extraction), which
+/// a zero-config local server satisfies — so the remedy depends on state:
+///   - `server_url` unset → no server is configured; point at the local
+///     auto-server. Never mention `server_url` (that is team-memory setup, a
+///     heavier and unrelated fix).
+///   - `server_url` set but unreachable → the configured team server is down;
+///     surface the URL so the user knows what to check.
+///
+/// This is deliberately NOT `require_tier1`'s message: `memory push/pull/watch`
+/// and `sync` genuinely require an explicit team `server_url`, so for those the
+/// `server_url` advice is correct.
+pub fn inference_server_required_message(feature: &str, server_url: Option<&str>) -> String {
+    match server_url {
+        None => format!(
+            "'spelunk {feature}' requires spelunk-server.\n\
+             Run `spelunk server start` to enable this feature."
+        ),
+        Some(url) => format!(
+            "'spelunk {feature}' requires spelunk-server.\n\
+             The configured server_url ({url}) is unreachable. Start it and retry, or \
+             remove server_url from ~/.config/spelunk/config.toml to use a local server \
+             (`spelunk server start`)."
+        ),
+    }
+}
+
 /// Return `Ok(())` if the tier is `Server`, otherwise return an `anyhow::Error`
 /// with the standard locked-feature message format.
 ///
@@ -885,6 +914,44 @@ mod tests {
         let eff = Tier::Offline.effective_config(&cfg, std::path::Path::new("/tmp/proj"));
         assert_eq!(eff.server_url, None);
         assert_eq!(eff.inference_url, None);
+    }
+
+    // ── inference_server_required_message (oss^133) ──────────────────────────
+
+    /// No server reachable AND no `server_url` configured (solo user, no local
+    /// server running): the message must point at the zero-setup local server
+    /// and must NOT mention `server_url` (the misleading team-infra advice).
+    #[test]
+    fn inference_msg_no_server_url_points_at_local_start_only() {
+        let msg = inference_server_required_message("memory search", None);
+        assert!(msg.contains("'spelunk memory search' requires spelunk-server"));
+        assert!(
+            msg.contains("spelunk server start"),
+            "must point at the local auto-server: {msg}"
+        );
+        assert!(
+            !msg.contains("server_url"),
+            "must NOT mention server_url when none is configured: {msg}"
+        );
+    }
+
+    /// A team `server_url` IS configured but unreachable: mentioning it is now
+    /// legitimate, and the message still offers the local fallback.
+    #[test]
+    fn inference_msg_configured_server_url_mentions_it() {
+        let msg =
+            inference_server_required_message("memory search", Some("https://team.example:7777"));
+        assert!(msg.contains("server_url"));
+        assert!(msg.contains("https://team.example:7777"));
+        assert!(msg.contains("spelunk server start"));
+    }
+
+    /// Feature name is interpolated (harvest reuses this via
+    /// `harvest_requires_server`, preserving its Tier-0 substring contract).
+    #[test]
+    fn inference_msg_interpolates_feature_and_keeps_harvest_substring() {
+        let msg = inference_server_required_message("memory harvest", None);
+        assert!(msg.contains("'spelunk memory harvest' requires spelunk-server"));
     }
 
     // ── require_tier1 ────────────────────────────────────────────────────────

--- a/crates/spelunk-cli/src/cli/cmd/helpers.rs
+++ b/crates/spelunk-cli/src/cli/cmd/helpers.rs
@@ -27,11 +27,15 @@ pub(crate) fn open_project_db(
 /// Build a `ServerInferenceClient` from config, returning an error if
 /// `server_url` is not configured.
 pub(crate) fn require_server_client(cfg: &Config, feature: &str) -> Result<ServerInferenceClient> {
+    // Inference-only feature: a local `spelunk server start` is enough, so the
+    // guidance must not tell a solo user to configure a team `server_url`
+    // (oss^133). `cfg.server_url` here is the effective config, so it is `None`
+    // for an auto-discovered loopback and `Some` only for an explicit team URL.
     ServerInferenceClient::from_config(cfg).ok_or_else(|| {
-        anyhow::anyhow!(
-            "'spelunk {feature}' requires spelunk-server.\n\
-             Set server_url in ~/.config/spelunk/config.toml to enable this feature."
-        )
+        anyhow::anyhow!(crate::capability::inference_server_required_message(
+            feature,
+            cfg.server_url.as_deref()
+        ))
     })
 }
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -59,8 +59,10 @@ pub(super) async fn memory_harvest(
     let cfg = &eff_cfg;
 
     // Tier-0: harvest requires server inference (#259 locked-feature error).
+    // Pass the configured team `server_url` (usually `None` here) so the guidance
+    // points at the local auto-server rather than team setup (oss^133).
     if cfg.resolve_inference_url().is_none() {
-        return Err(harvest_requires_server(None));
+        return Err(harvest_requires_server(cfg.server_url.as_deref()));
     }
 
     if args.detach {
@@ -192,7 +194,7 @@ async fn memory_harvest_git(
     });
 
     let server = ServerInferenceClient::from_config(cfg)
-        .ok_or_else(|| harvest_requires_server(cfg.resolve_inference_url()))?;
+        .ok_or_else(|| harvest_requires_server(cfg.server_url.as_deref()))?;
 
     let mut stored = 0usize;
     let mut dedup_skipped = 0usize;
@@ -578,7 +580,7 @@ async fn memory_harvest_failures(
     });
 
     let server = ServerInferenceClient::from_config(cfg)
-        .ok_or_else(|| harvest_requires_server(cfg.resolve_inference_url()))?;
+        .ok_or_else(|| harvest_requires_server(cfg.server_url.as_deref()))?;
 
     let mut stored = 0usize;
     let mut dedup_skipped = 0usize;

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
@@ -47,7 +47,7 @@ pub(super) async fn harvest_claude_code(
 ) -> Result<()> {
     // Tier-0 gate: harvest requires server inference.
     let server = ServerInferenceClient::from_config(cfg)
-        .ok_or_else(|| harvest_requires_server(cfg.resolve_inference_url()))?;
+        .ok_or_else(|| harvest_requires_server(cfg.server_url.as_deref()))?;
 
     // 1. Require explicit confirmation.
     if !args.confirm {

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -444,12 +444,19 @@ impl ServerInferenceClient {
 
         // Response is raw little-endian f32 bytes (one vector, `dim` floats).
         let url = self.embed_url();
-        let bytes = self
+        let resp = self
             .send_authed(|| self.client.post(&url).json(&body))
             .await
-            .context("POST /index/embed (query vector)")?
-            .error_for_status()
-            .context("spelunk-server returned an error for /index/embed")?
+            .context("POST /index/embed (query vector)")?;
+        // Surface the server's structured reason (e.g. embedder still loading /
+        // failed to load) instead of a bare "HTTP status 503" so a memory search
+        // against a warming-up local server gets actionable guidance (oss^133).
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("{}", server_inference_error("/index/embed", status, &text));
+        }
+        let bytes = resp
             .bytes()
             .await
             .context("reading /index/embed response")?;
@@ -562,17 +569,45 @@ impl spelunk_core::llm::LlmBackend for ServerLlmAdapter {
     }
 }
 
+/// Format a non-2xx spelunk-server inference response into an actionable error.
+///
+/// The server returns a `{ error, state, detail }` JSON body for an unready
+/// embedder (state `loading`/`unavailable`). `reqwest::error_for_status` throws
+/// that body away and yields a bare "HTTP status 503", so we parse it here and
+/// append a next-step hint (oss^133).
+fn server_inference_error(endpoint: &str, status: reqwest::StatusCode, body: &str) -> String {
+    let parsed: Option<serde_json::Value> = serde_json::from_str(body).ok();
+    let field = |k: &str| {
+        parsed
+            .as_ref()
+            .and_then(|v| v.get(k))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+    };
+    let reason = field("detail").or_else(|| field("error"));
+    let hint = match field("state") {
+        Some("loading") => " Retry shortly (`spelunk server status`).",
+        Some("unavailable") => " See `spelunk server logs`.",
+        _ => "",
+    };
+    match reason {
+        Some(reason) => format!("spelunk-server {endpoint} returned {status}: {reason}.{hint}"),
+        None => format!("spelunk-server {endpoint} returned {status}.{hint}"),
+    }
+}
+
 // ── Tier-0 error helper ───────────────────────────────────────────────────────
 
-/// Return the standard locked-feature error when harvest is attempted without a server.
+/// Return the locked-feature error when harvest is attempted without a server.
+///
+/// Harvest needs inference only, so a local `spelunk server start` suffices;
+/// pass the configured team `server_url` (or `None`) so the message points at
+/// the right fix (oss^133). See `capability::inference_server_required_message`.
 pub fn harvest_requires_server(server_url: Option<&str>) -> anyhow::Error {
-    let tried = server_url
-        .map(|u| format!("\n       (Tried: {u} — unreachable)"))
-        .unwrap_or_default();
-    anyhow::anyhow!(
-        "'spelunk memory harvest' requires spelunk-server.\n\
-         Set server_url in ~/.config/spelunk/config.toml to enable this feature.{tried}"
-    )
+    anyhow::anyhow!(crate::capability::inference_server_required_message(
+        "memory harvest",
+        server_url
+    ))
 }
 
 #[cfg(test)]
@@ -993,6 +1028,82 @@ mod tests {
             ServerInferenceClient::from_config(&cfg).is_some(),
             "https:// inference URL (any host) must be accepted"
         );
+    }
+
+    // ── server_inference_error (oss^133 bare-503 surfacing) ──────────────────
+
+    #[test]
+    fn inference_error_surfaces_loading_detail_and_retry_hint() {
+        let body = serde_json::json!({
+            "error": "embedder warming up, retry shortly",
+            "state": "loading",
+            "detail": "downloading model (42%)",
+        })
+        .to_string();
+        let msg = server_inference_error(
+            "/index/embed",
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            &body,
+        );
+        assert!(msg.contains("downloading model (42%)"), "got: {msg}");
+        assert!(msg.contains("spelunk server status"), "got: {msg}");
+        // The bare status is no longer the whole story.
+        assert!(msg.contains("503"), "got: {msg}");
+    }
+
+    #[test]
+    fn inference_error_surfaces_unavailable_points_at_logs() {
+        let body = serde_json::json!({
+            "error": "embedder unavailable",
+            "state": "unavailable",
+            "detail": "OOM loading GGUF",
+        })
+        .to_string();
+        let msg = server_inference_error(
+            "/index/embed",
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            &body,
+        );
+        assert!(msg.contains("OOM loading GGUF"), "got: {msg}");
+        assert!(msg.contains("spelunk server logs"), "got: {msg}");
+    }
+
+    #[test]
+    fn inference_error_falls_back_when_body_not_json() {
+        // A non-JSON body (proxy error page, empty) still yields a clean line.
+        let msg = server_inference_error(
+            "/index/embed",
+            reqwest::StatusCode::BAD_GATEWAY,
+            "<html>502</html>",
+        );
+        assert!(msg.contains("/index/embed"), "got: {msg}");
+        assert!(msg.contains("502"), "got: {msg}");
+    }
+
+    /// End-to-end: a 503 from `/index/embed` must surface the server's `detail`
+    /// (not a bare "HTTP status 503") when embedding a query vector.
+    #[tokio::test]
+    async fn embed_text_surfaces_server_detail_on_503() {
+        let inference = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/index/embed"))
+            .respond_with(ResponseTemplate::new(503).set_body_json(serde_json::json!({
+                "error": "embedder warming up, retry shortly",
+                "state": "loading",
+                "detail": "loading F2LLM weights",
+            })))
+            .mount(&inference)
+            .await;
+
+        let client =
+            ServerInferenceClient::for_test(&inference.uri(), "proj", Some("sk".into()), None);
+        let err = client
+            .embed_text("hello")
+            .await
+            .expect_err("503 must surface as an error");
+        let msg = err.to_string();
+        assert!(msg.contains("loading F2LLM weights"), "got: {msg}");
+        assert!(msg.contains("spelunk server status"), "got: {msg}");
     }
 
     /// `/v1/health`-style probes aside, inference requests built via

--- a/crates/spelunk-cli/tests/harvest_upfront_check.rs
+++ b/crates/spelunk-cli/tests/harvest_upfront_check.rs
@@ -60,7 +60,11 @@ fn harvest_fails_with_actionable_error_when_no_server_and_no_model() {
     harvest_cmd(&config_path, temp.path())
         .assert()
         .failure()
-        .stderr(predicate::str::contains(SERVER_REQUIRED));
+        .stderr(predicate::str::contains(SERVER_REQUIRED))
+        // oss^133: with no `server_url` the guidance must point at the local
+        // server and must NOT tell a solo user to configure a team `server_url`.
+        .stderr(predicate::str::contains("spelunk server start"))
+        .stderr(predicate::str::contains("server_url").not());
 }
 
 // ── (b) server_url set → gate passes (fails later for another reason) ─────────

--- a/crates/spelunk-cli/tests/inference_server_message.rs
+++ b/crates/spelunk-cli/tests/inference_server_message.rs
@@ -1,0 +1,196 @@
+//! End-to-end coverage for the inference-server-required guidance (oss^133).
+//!
+//! The bug: inference-only commands (`memory search --mode semantic|hybrid`,
+//! `memory timeline`, `plumbing embed`) told a solo user with no server to set a
+//! team `server_url` — when all they needed was `spelunk server start`. The fix
+//! routes every such caller's *effective* `server_url` (which is `None` for a
+//! solo/no-server user, never the auto-discovered loopback URL) into
+//! `capability::inference_server_required_message`, whose no-`server_url` branch
+//! must point at the local server and must NOT mention `server_url`.
+//!
+//! The engineer's unit tests pin the pure function and `embed_text` body
+//! surfacing. These tests close the highest-value gap: a real CLI invocation, so
+//! a caller that passed the *wrong* argument (e.g. the loopback inference URL, or
+//! a hard-coded `None` that suppresses a legitimately-configured URL) would be
+//! caught — a pure-fn test cannot see the wiring.
+//!
+//! All cases drive the no-`server_url` branch, because that is the branch the
+//! bug regressed and the only branch these callers can reach: each gates on
+//! `from_config` / `resolve_inference_url()` being `None`, which is only true
+//! when `server_url` is also `None` (`resolve_inference_url` falls back to
+//! `server_url`). See the report accompanying this change for the reachability
+//! analysis of the `Some(url)` branch.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
+use predicates::prelude::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
+
+/// The substring that reintroducing the bug would add back to the message. Its
+/// ABSENCE is the core regression guard: the no-server message must never tell a
+/// solo user to configure `server_url`.
+const REGRESSION_SUBSTR: &str = "server_url";
+
+/// Write a minimal config with NO `server_url` (solo / no-server user).
+fn write_no_server_config(dir: &Path) -> PathBuf {
+    let db_path = dir.join("index.db");
+    let config_path = dir.join("config.toml");
+    fs::write(
+        &config_path,
+        format!("db_path = {db_path:?}\nembedding_model = \"test-model\"\n"),
+    )
+    .expect("write config.toml");
+    config_path
+}
+
+/// Shared assertion: the no-server message points at the local server and never
+/// mentions `server_url`.
+fn assert_local_start_no_server_url(stderr: &str) {
+    assert!(
+        stderr.contains("requires spelunk-server"),
+        "must state the feature requires the server; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("spelunk server start"),
+        "must point at the local auto-server; got: {stderr}"
+    );
+    assert!(
+        !stderr.contains(REGRESSION_SUBSTR),
+        "no-server message must NOT mention `server_url` (oss^133 regression); got: {stderr}"
+    );
+}
+
+/// `memory search --mode semantic` with no server: the exact bug report.
+#[test]
+fn memory_search_semantic_no_server_points_at_local_start() {
+    let temp = tempdir().unwrap();
+    let config_path = write_no_server_config(temp.path());
+    let mem_db = temp.path().join("memory.db");
+
+    let assert = spelunk_bin()
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(temp.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_db)
+        .args(["search", "--mode", "semantic", "why did we pick candle"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+    assert_local_start_no_server_url(&stderr);
+    assert!(
+        stderr.contains("memory search"),
+        "message must name the invoked feature; got: {stderr}"
+    );
+}
+
+/// `memory search --mode hybrid` (the default mode) also embeds the query, so it
+/// flows through the same gate and must produce the same guidance.
+#[test]
+fn memory_search_hybrid_no_server_points_at_local_start() {
+    let temp = tempdir().unwrap();
+    let config_path = write_no_server_config(temp.path());
+    let mem_db = temp.path().join("memory.db");
+
+    let assert = spelunk_bin()
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(temp.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_db)
+        .args(["search", "--mode", "hybrid", "anything"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+    assert_local_start_no_server_url(&stderr);
+}
+
+/// `memory timeline` is a distinct caller of `require_server_client` (it reaches
+/// the gate before opening the memory backend), so cover it independently: a
+/// wiring regression there would not be caught by the search tests.
+#[test]
+fn memory_timeline_no_server_points_at_local_start() {
+    let temp = tempdir().unwrap();
+    let config_path = write_no_server_config(temp.path());
+    let mem_db = temp.path().join("memory.db");
+
+    let assert = spelunk_bin()
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(temp.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_db)
+        .args(["timeline", "some topic"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+    assert_local_start_no_server_url(&stderr);
+    assert!(
+        stderr.contains("memory timeline"),
+        "message must name the invoked feature; got: {stderr}"
+    );
+}
+
+/// `plumbing embed` is the low-level embedding path (a third `require_server_client`
+/// caller). It reads stdin; with no server the gate fires before any line is read.
+#[test]
+fn plumbing_embed_no_server_points_at_local_start() {
+    let temp = tempdir().unwrap();
+    let config_path = write_no_server_config(temp.path());
+    let db = temp.path().join("index.db");
+
+    let assert = spelunk_bin()
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(temp.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("plumbing")
+        .arg("--db")
+        .arg(&db)
+        .arg("embed")
+        .write_stdin("some text\n")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+    assert_local_start_no_server_url(&stderr);
+    assert!(
+        stderr.contains("plumbing embed"),
+        "message must name the invoked feature; got: {stderr}"
+    );
+}
+
+/// Guard the `predicates` negative-match idiom used elsewhere is not silently
+/// vacuous: the positive substring must actually be present (not merely "absent
+/// `server_url`" passing because the command produced no output at all).
+#[test]
+fn memory_search_semantic_message_is_nonempty() {
+    let temp = tempdir().unwrap();
+    let config_path = write_no_server_config(temp.path());
+    let mem_db = temp.path().join("memory.db");
+
+    spelunk_bin()
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(temp.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_db)
+        .args(["search", "--mode", "semantic", "q"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("spelunk server start"));
+}

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -399,20 +399,30 @@ fn require_embedder(
         return Ok(backend);
     }
     match state.embedder.state() {
-        EmbedderState::Loading => Err(AppError::EmbedderWarmingUp {
-            terminal: false,
-            detail: state
+        EmbedderState::Loading => {
+            let detail = state
                 .embedder
                 .detail()
-                .unwrap_or_else(|| "embedder warming up, retry shortly".to_string()),
-        }),
-        EmbedderState::Unavailable => Err(AppError::EmbedderWarmingUp {
-            terminal: true,
-            detail: state
+                .unwrap_or_else(|| "embedder warming up, retry shortly".to_string());
+            // Log the real cause: a 503 here is the model still loading, not a
+            // generic outage. Keeps the transient case out of error logs.
+            tracing::debug!(%detail, "embed request rejected: embedder still loading");
+            Err(AppError::EmbedderWarmingUp {
+                terminal: false,
+                detail,
+            })
+        }
+        EmbedderState::Unavailable => {
+            let detail = state
                 .embedder
                 .detail()
-                .unwrap_or_else(|| "embedder failed to load".to_string()),
-        }),
+                .unwrap_or_else(|| "embedder failed to load".to_string());
+            tracing::warn!(%detail, "embed request rejected: embedder unavailable (load failed)");
+            Err(AppError::EmbedderWarmingUp {
+                terminal: true,
+                detail,
+            })
+        }
         // Disabled (or the improbable ready-but-no-backend race) → permanent 400.
         EmbedderState::Disabled | EmbedderState::Ready => {
             Err(AppError::BadRequest(disabled_msg.to_string()))


### PR DESCRIPTION
## The bug (oss^133)

Inference-only commands (`memory search --mode semantic|hybrid`, `memory timeline`, `search`, `plumbing embed`, `memory harvest`/`harvest_claude`) told a **solo** user with no server to *"Set server_url in ~/.config/spelunk/config.toml"*. That is misleading: those features only need inference, which a zero-config local server (`spelunk server start`) satisfies. `server_url` is the **team-memory** setup — a heavier, unrelated fix. A solo user was pointed at the wrong remedy.

## The fix

New `capability::inference_server_required_message(feature, server_url)` branches on the *effective* config's `server_url`:

- **`None`** (no server configured — the solo case): `Run `spelunk server start` to enable this feature.` — never mentions `server_url`.
- **`Some(url)`** (a team `server_url` is configured but unreachable): names the URL and offers the local fallback.

`require_server_client` (`helpers.rs`) and the harvest gates (`server_client.rs::harvest_requires_server`, `harvest.rs`, `harvest_claude.rs`) now route their effective `server_url` into it. Team-only commands (`memory push/pull/sync/watch`, `explore`) are **unchanged** — they still go through `require_tier1`, whose `server_url` guidance is correct for them.

## 503-premise correction (not a status remap)

`embed_text` previously threw away the server's structured `{ error, state, detail }` body via `reqwest::error_for_status()`, surfacing a bare "HTTP status 503". The real cause of that 503 is the **embedder still warming up** (downloading/loading the F2LLM model), not an unindexed project — so the fix surfaces the server's `detail` plus a next-step hint (`spelunk server status` / `spelunk server logs`). No status code is remapped; every non-2xx is reported with its actual status and the parsed reason (non-JSON bodies fall back cleanly). Server-side, `require_embedder` now logs the real cause (`debug` for loading, `warn` for load-failure) so a transient warmup stays out of error logs.

## Accepted limitation

The `Some(url)` branch is currently unreachable from callers (each gates on `from_config`/`resolve_inference_url()` being `None`, which implies `server_url` is also `None`). This is a latent-correct branch, filed as a follow-up (oss^148); it is **not** a regression and the primary solo case is fully correct.

## Test plan

Live repro in an isolated HOME with a real `.spelunk/` project (`spelunk init`), `SPELUNK_NO_SERVER=1`:

- `spelunk memory search "…" --mode semantic` → `'spelunk memory search' requires spelunk-server. Run `spelunk server start`…` — **no** `server_url`. ✅
- `spelunk memory timeline "…"` → same local-start guidance. ✅
- `spelunk sync` / `spelunk memory push` → still `Set server_url in ~/.config/spelunk/config.toml` (team path unchanged). ✅

Test matrix (`SPELUNK_SECRET_STORE=file`):

- `cargo test` → **851 passed, 0 failed, 9 ignored**
- `cargo test --no-default-features` → **850 passed, 0 failed, 4 ignored**
- `cargo fmt --all --check` → clean
- `cargo clippy --all-targets -- -D warnings` → clean

New e2e coverage (`tests/inference_server_message.rs`, 5 tests) drives real CLI invocations for every no-server caller and asserts the message points at `spelunk server start` and never contains `server_url`. Verified non-vacuous by mutation: reverting the message to the old text fails all 5 e2e tests plus the strengthened `harvest_upfront_check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
