### PR TITLE
refactor(config)!: remove deprecated memory_server_url/memory_server_key aliases (oss^144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Removed
+
+- **Deprecated `memory_server_url` / `memory_server_key` config keys (and the
+  `SPELUNK_MEMORY_SERVER_URL` env var).** These were backward-compat aliases for
+  `server_url` / `server_key`; use those (and `SPELUNK_SERVER_URL`) instead. An
+  old config that still carries the deprecated keys continues to load, but the
+  keys are now silently ignored rather than mapped. (spelunk-oss^144)
+
 ## [0.9.3] — 2026-07-08
 
 ### Removed

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -24,8 +24,7 @@ fn bin(home: &Path, cwd: &Path) -> Command {
     let mut cmd = spelunk_bin_in(home);
     cmd.current_dir(cwd)
         .env("SPELUNK_NO_SERVER", "1")
-        .env_remove("SPELUNK_SERVER_URL")
-        .env_remove("SPELUNK_MEMORY_SERVER_URL");
+        .env_remove("SPELUNK_SERVER_URL");
     cmd
 }
 

--- a/crates/spelunk-cli/tests/harvest_ref_injection.rs
+++ b/crates/spelunk-cli/tests/harvest_ref_injection.rs
@@ -69,7 +69,6 @@ fn harvest_rejects_option_like_branch_and_does_not_touch_victim_file() {
     let mut cmd = spelunk_bin();
     cmd.current_dir(temp.path())
         .env_remove("SPELUNK_SERVER_URL")
-        .env_remove("SPELUNK_MEMORY_SERVER_URL")
         .env_remove("SPELUNK_LLM_URL")
         .arg("--config")
         .arg(&config_path)
@@ -105,7 +104,6 @@ fn harvest_rejects_option_like_git_range() {
     let mut cmd = spelunk_bin();
     cmd.current_dir(temp.path())
         .env_remove("SPELUNK_SERVER_URL")
-        .env_remove("SPELUNK_MEMORY_SERVER_URL")
         .env_remove("SPELUNK_LLM_URL")
         .arg("--config")
         .arg(&config_path)
@@ -136,7 +134,6 @@ fn harvest_rejects_short_option_like_branch() {
     let mut cmd = spelunk_bin();
     cmd.current_dir(temp.path())
         .env_remove("SPELUNK_SERVER_URL")
-        .env_remove("SPELUNK_MEMORY_SERVER_URL")
         .env_remove("SPELUNK_LLM_URL")
         .arg("--config")
         .arg(&config_path)
@@ -164,7 +161,6 @@ fn harvest_rejects_bare_double_dash_branch() {
     let mut cmd = spelunk_bin();
     cmd.current_dir(temp.path())
         .env_remove("SPELUNK_SERVER_URL")
-        .env_remove("SPELUNK_MEMORY_SERVER_URL")
         .env_remove("SPELUNK_LLM_URL")
         .arg("--config")
         .arg(&config_path)
@@ -203,7 +199,6 @@ fn harvest_rejects_option_like_branch_with_shell_metacharacters() {
     let mut cmd = spelunk_bin();
     cmd.current_dir(temp.path())
         .env_remove("SPELUNK_SERVER_URL")
-        .env_remove("SPELUNK_MEMORY_SERVER_URL")
         .env_remove("SPELUNK_LLM_URL")
         .arg("--config")
         .arg(&config_path)

--- a/crates/spelunk-cli/tests/harvest_upfront_check.rs
+++ b/crates/spelunk-cli/tests/harvest_upfront_check.rs
@@ -38,7 +38,6 @@ fn harvest_cmd(config_path: &std::path::Path, dir: &std::path::Path) -> Command 
     let mut cmd = spelunk_bin();
     cmd.current_dir(dir)
         .env_remove("SPELUNK_SERVER_URL")
-        .env_remove("SPELUNK_MEMORY_SERVER_URL")
         .env_remove("SPELUNK_LLM_URL")
         // Disable loopback auto-discovery so the server gate fires before the
         // git-log step even when a local spelunk-server happens to be running.

--- a/crates/spelunk-cli/tests/memory_add_secret_gate.rs
+++ b/crates/spelunk-cli/tests/memory_add_secret_gate.rs
@@ -44,7 +44,6 @@ fn memory_add_cmd(dir: &Path, cfg: &Path, mem_db: &Path) -> Command {
     cmd.current_dir(dir)
         // Avoid picking up any server config from the real user environment.
         .env_remove("SPELUNK_SERVER_URL")
-        .env_remove("SPELUNK_MEMORY_SERVER_URL")
         .arg("--config")
         .arg(cfg)
         .arg("memory")

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -259,10 +259,6 @@ struct ProjectConfig {
     /// Shared API key — acceptable if the server is behind a VPN/firewall.
     /// For secrets, prefer `SPELUNK_SERVER_KEY` env var instead.
     server_key: Option<String>,
-    /// Deprecated alias for server_url.
-    memory_server_url: Option<String>,
-    /// Deprecated alias for server_key.
-    memory_server_key: Option<String>,
     project_id: Option<String>,
 }
 
@@ -302,8 +298,7 @@ pub struct Config {
     /// When set, the CLI operates in Tier 1 (server-connected) mode, enabling
     /// semantic search, embedding, and explore.
     /// Set in `.spelunk/config.toml` (project-level) or via `SPELUNK_SERVER_URL`.
-    /// The old `memory_server_url` TOML key is accepted as a backward-compat alias.
-    #[serde(default, alias = "memory_server_url")]
+    #[serde(default)]
     pub server_url: Option<String>,
 
     /// Bearer token for cloud/spelunk-server auth — the single token every auth
@@ -311,8 +306,7 @@ pub struct Config {
     /// Set in `~/.config/spelunk/config.toml` (personal), written by
     /// `spelunk login`, or overridden via `SPELUNK_SERVER_KEY`.
     /// Do NOT commit this to `.spelunk/config.toml`.
-    /// The old `memory_server_key` TOML key is accepted as a backward-compat alias.
-    #[serde(default, alias = "memory_server_key")]
+    #[serde(default)]
     pub server_key: Option<String>,
 
     /// Project slug for the spelunk-server (e.g. `acme/my-app`).
@@ -494,11 +488,10 @@ impl Config {
             let proj: ProjectConfig =
                 toml::from_str(&raw).context("parsing .spelunk/config.toml")?;
 
-            // Prefer new name; fall back to deprecated alias.
-            if let Some(v) = proj.server_url.or(proj.memory_server_url) {
+            if let Some(v) = proj.server_url {
                 cfg.server_url = Some(v);
             }
-            if let Some(v) = proj.server_key.or(proj.memory_server_key) {
+            if let Some(v) = proj.server_key {
                 project_server_key = Some(v.clone());
                 cfg.server_key = Some(v);
             }
@@ -537,11 +530,6 @@ impl Config {
 
         // ── 3. Environment variable overrides ────────────────────────────────
         if let Ok(v) = std::env::var("SPELUNK_SERVER_URL") {
-            cfg.server_url = Some(v);
-        } else if let Ok(v) = std::env::var("SPELUNK_MEMORY_SERVER_URL") {
-            tracing::warn!(
-                "SPELUNK_MEMORY_SERVER_URL is deprecated; use SPELUNK_SERVER_URL instead"
-            );
             cfg.server_url = Some(v);
         }
         let env_server_key = std::env::var("SPELUNK_SERVER_KEY").ok();
@@ -999,7 +987,6 @@ mod tests {
     fn clear_spelunk_env() {
         unsafe {
             std::env::remove_var("SPELUNK_SERVER_URL");
-            std::env::remove_var("SPELUNK_MEMORY_SERVER_URL");
             std::env::remove_var("SPELUNK_SERVER_KEY");
             std::env::remove_var("SPELUNK_PROJECT_ID");
             std::env::remove_var("SPELUNK_MODE");
@@ -1165,11 +1152,13 @@ specs_dir = "docs/specs"
         assert_eq!(cfg.mode, Some(SyncMode::LocalFirst));
     }
 
-    // ── serde alias: memory_server_url → server_url ─────────────────────────
+    // ── breaking change: the deprecated memory_server_* keys are gone ───────
 
     #[test]
     #[serial_test::serial]
-    fn memory_server_url_alias_loads_as_server_url() {
+    fn deprecated_memory_server_keys_are_ignored() {
+        // The old aliases were removed pre-1.0: these keys no longer populate
+        // server_url/server_key and are silently dropped as unknown.
         clear_spelunk_env();
         let tmp = TempDir::new().unwrap();
         let config_path = tmp.path().join("config.toml");
@@ -1177,28 +1166,6 @@ specs_dir = "docs/specs"
             &config_path,
             r#"
 memory_server_url = "http://old.example.com:7777"
-project_id = "my-proj"
-"#,
-        )
-        .unwrap();
-
-        let cfg = load_hermetic(&config_path).unwrap();
-        assert_eq!(
-            cfg.server_url,
-            Some("http://old.example.com:7777".to_string())
-        );
-        assert_eq!(cfg.project_id, Some("my-proj".to_string()));
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn memory_server_key_alias_loads_as_server_key() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-        std::fs::write(
-            &config_path,
-            r#"
 memory_server_key = "secret-token"
 project_id = "my-proj"
 "#,
@@ -1206,7 +1173,9 @@ project_id = "my-proj"
         .unwrap();
 
         let cfg = load_hermetic(&config_path).unwrap();
-        assert_eq!(cfg.server_key, Some("secret-token".to_string()));
+        assert_eq!(cfg.server_url, None);
+        assert_eq!(cfg.server_key, None);
+        assert_eq!(cfg.project_id, Some("my-proj".to_string()));
     }
 
     #[test]
@@ -1657,44 +1626,6 @@ project_id = "my-proj"
         assert_eq!(cfg.project_id, Some("env-proj".to_string()));
     }
 
-    #[test]
-    #[serial_test::serial]
-    fn env_memory_server_url_deprecated_fallback() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-        std::fs::write(&config_path, "").unwrap();
-
-        // Only set the deprecated var; SPELUNK_SERVER_URL must be absent.
-        unsafe {
-            std::env::set_var("SPELUNK_MEMORY_SERVER_URL", "http://old.example.com:7777");
-        }
-        let cfg = load_hermetic(&config_path).unwrap();
-        assert_eq!(
-            cfg.server_url,
-            Some("http://old.example.com:7777".to_string())
-        );
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn env_spelunk_server_url_precedence_over_memory_fallback() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let config_path = tmp.path().join("config.toml");
-        std::fs::write(&config_path, "").unwrap();
-
-        unsafe {
-            std::env::set_var("SPELUNK_SERVER_URL", "http://new.example.com:7777");
-            std::env::set_var("SPELUNK_MEMORY_SERVER_URL", "http://old.example.com:7777");
-        }
-        let cfg = load_hermetic(&config_path).unwrap();
-        assert_eq!(
-            cfg.server_url,
-            Some("http://new.example.com:7777".to_string())
-        );
-    }
-
     // ── .spelunk/config.toml project-level merge ─────────────────────────────
 
     #[test]
@@ -1871,7 +1802,8 @@ project_id = "team/proj"
 
     #[test]
     #[serial_test::serial]
-    fn project_level_config_accepts_memory_server_url_alias() {
+    fn project_level_config_ignores_deprecated_memory_server_url() {
+        // Breaking change: the removed alias no longer resolves in project config.
         clear_spelunk_env();
         let tmp = TempDir::new().unwrap();
         let proj_dir = tmp.path().join("project");
@@ -1892,10 +1824,7 @@ project_id = "team/old"
         std::env::set_current_dir(&proj_dir).unwrap();
 
         let cfg = load_hermetic(&global_config).unwrap();
-        assert_eq!(
-            cfg.server_url,
-            Some("http://old.example.com:7777".to_string())
-        );
+        assert_eq!(cfg.server_url, None);
         assert_eq!(cfg.project_id, Some("team/old".to_string()));
 
         if let Some(d) = original_cwd {

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -1180,6 +1180,33 @@ project_id = "my-proj"
 
     #[test]
     #[serial_test::serial]
+    fn mixed_config_live_key_wins_over_deprecated() {
+        // Both the live key and its removed alias present: the live key resolves
+        // and the deprecated key is silently dropped (no error, no override).
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+server_url = "http://new.example.com:7777"
+memory_server_url = "http://old.example.com:7777"
+server_key = "new-token"
+memory_server_key = "old-token"
+"#,
+        )
+        .unwrap();
+
+        let cfg = load_hermetic(&config_path).unwrap();
+        assert_eq!(
+            cfg.server_url,
+            Some("http://new.example.com:7777".to_string())
+        );
+        assert_eq!(cfg.server_key, Some("new-token".to_string()));
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn loads_without_any_server_config() {
         clear_spelunk_env();
         let tmp = TempDir::new().unwrap();
@@ -1626,6 +1653,27 @@ project_id = "my-proj"
         assert_eq!(cfg.project_id, Some("env-proj".to_string()));
     }
 
+    #[test]
+    #[serial_test::serial]
+    fn env_spelunk_memory_server_url_is_ignored() {
+        // Breaking change: the deprecated SPELUNK_MEMORY_SERVER_URL env fallback
+        // was removed. Setting it alone must NOT populate server_url. (Not in
+        // clear_spelunk_env's unset list since nothing reads it — clean up here.)
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "").unwrap();
+
+        unsafe {
+            std::env::set_var("SPELUNK_MEMORY_SERVER_URL", "http://old.example.com:7777");
+        }
+        let cfg = load_hermetic(&config_path).unwrap();
+        unsafe {
+            std::env::remove_var("SPELUNK_MEMORY_SERVER_URL");
+        }
+        assert_eq!(cfg.server_url, None);
+    }
+
     // ── .spelunk/config.toml project-level merge ─────────────────────────────
 
     #[test]
@@ -1826,6 +1874,43 @@ project_id = "team/old"
         let cfg = load_hermetic(&global_config).unwrap();
         assert_eq!(cfg.server_url, None);
         assert_eq!(cfg.project_id, Some("team/old".to_string()));
+
+        if let Some(d) = original_cwd {
+            std::env::set_current_dir(d).unwrap();
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn project_level_config_live_key_wins_over_deprecated() {
+        // Mixed project config: the live server_url resolves and the removed
+        // alias is dropped (no error, no override).
+        clear_spelunk_env();
+        let tmp = TempDir::new().unwrap();
+        let proj_dir = tmp.path().join("project");
+        let spelunk_dir = proj_dir.join(".spelunk");
+        std::fs::create_dir_all(&spelunk_dir).unwrap();
+        std::fs::write(
+            spelunk_dir.join("config.toml"),
+            r#"server_url = "http://new.example.com:7777"
+memory_server_url = "http://old.example.com:7777"
+project_id = "team/new"
+"#,
+        )
+        .unwrap();
+
+        let global_config = tmp.path().join("global.toml");
+        std::fs::write(&global_config, "").unwrap();
+
+        let original_cwd = std::env::current_dir().ok();
+        std::env::set_current_dir(&proj_dir).unwrap();
+
+        let cfg = load_hermetic(&global_config).unwrap();
+        assert_eq!(
+            cfg.server_url,
+            Some("http://new.example.com:7777".to_string())
+        );
+        assert_eq!(cfg.project_id, Some("team/new".to_string()));
 
         if let Some(d) = original_cwd {
             std::env::set_current_dir(d).unwrap();

--- a/docs/architecture/capability-tiers.md
+++ b/docs/architecture/capability-tiers.md
@@ -35,10 +35,7 @@ configuration.** All inference routes through `spelunk-server`.
 ### New unified field: `server_url`
 
 Add `server_url` to `Config` as the single entry point for all server-mediated
-features. The existing `memory_server_url` field is a backward-compat alias:
-if `server_url` is absent and `memory_server_url` is present, treat
-`memory_server_url` as the `server_url` value. Log a deprecation warning
-once.
+features.
 
 ```toml
 # ~/.config/spelunk/config.toml  (personal — never commit)
@@ -61,14 +58,13 @@ Environment variable overrides:
 
 | Field | Env var |
 |---|---|
-| `server_url` | `SPELUNK_SERVER_URL` (also `SPELUNK_MEMORY_SERVER_URL` as alias) |
+| `server_url` | `SPELUNK_SERVER_URL` |
 | `server_key` | `SPELUNK_SERVER_KEY` |
 | `project_id` | `SPELUNK_PROJECT_ID` |
 
 ### Validation
 
-`server_url` present without `project_id` → hard error at load time (same as
-current `memory_server_url` validation).
+`server_url` present without `project_id` → hard error at load time.
 
 ---
 
@@ -319,8 +315,7 @@ request.
 
 ## Definition of done
 
-- [ ] `Config` gains `server_url` / `server_key` fields; `memory_server_url`
-  aliased with deprecation warning
+- [ ] `Config` gains `server_url` / `server_key` fields
 - [ ] Capability probe implemented and cached per-process
 - [ ] `spelunk status` shows capability tier section
 - [ ] `spelunk check` shows server reachability line when `server_url` is set

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -456,9 +456,6 @@ an owner-only `~/.config/spelunk/secrets.toml`. For the full credential-storage
 rules and the `SPELUNK_SECRET_STORE` override, see the
 [Commands reference](commands.md#spelunk-login).
 
-> The older `memory_server_url` / `memory_server_key` keys are still accepted as
-> deprecated aliases for `server_url` / `server_key`.
-
 `project_id` stays a human-readable slug. If the server routes projects by an
 internal UUID (as a team/cloud memory server does), the CLI resolves the slug
 for you on first use and caches the result locally, so no manual UUID lookup is

--- a/docs/server.md
+++ b/docs/server.md
@@ -165,9 +165,6 @@ Personal config (`~/.config/spelunk/config.toml` — never commit):
 server_key = "your-shared-api-key"
 ```
 
-> The legacy `memory_server_url` / `memory_server_key` keys remain accepted as
-> deprecated aliases for `server_url` / `server_key`.
-
 `project_id` is a human-readable slug. If the server routes projects by an
 internal UUID (as a team/cloud memory server does), the CLI resolves the slug to
 that UUID automatically on first use and caches it in


### PR DESCRIPTION
## What

Removes the deprecated `memory_server_url` / `memory_server_key` config keys and
the `SPELUNK_MEMORY_SERVER_URL` env var - the pre-1.0 backward-compat aliases for
`server_url` / `server_key` / `SPELUNK_SERVER_URL`.

- Drops the `memory_server_*` fields from `ProjectConfig`.
- Drops the serde `alias("memory_server_*")` attributes on `Config::server_url` /
  `server_key`.
- Drops the `.or(proj.memory_server_*)` project-level fallbacks and the
  `SPELUNK_MEMORY_SERVER_URL` env fallback in `config.rs`.
- Strips alias mentions from `getting-started.md`, `server.md`,
  `capability-tiers.md`; adds a CHANGELOG breaking-change entry.

## Breaking change

The deprecated keys are now **silently ignored**, not an error. `Config` carries
no `deny_unknown_fields`, so an old `config.toml` (global or `.spelunk/`) that
still lists `memory_server_url` / `memory_server_key` continues to parse - those
keys simply no longer populate `server_url` / `server_key`. Users on the old keys
must migrate to `server_url` / `server_key` / `SPELUNK_SERVER_URL`. Mixed
old+new config: the live key wins, the deprecated key is dropped.

CHANGELOG: entry added under `[Unreleased] > Removed`.

## Test plan

`export SPELUNK_SECRET_STORE=file`, run in the worktree:

- `cargo test -p spelunk-core` - 237 lib + all integration suites green.
- `cargo test -p spelunk-core --no-default-features` - identical, green.
- `cargo test -p spelunk-cli` on the 4 touched integration files
  (`fail_closed_no_project`, `harvest_ref_injection`, `harvest_upfront_check`,
  `memory_add_secret_gate`) - 30 tests green.
- New/updated breaking-change tests, all green:
  `deprecated_memory_server_keys_are_ignored`,
  `mixed_config_live_key_wins_over_deprecated`,
  `env_spelunk_memory_server_url_is_ignored`,
  `project_level_config_ignores_deprecated_memory_server_url`,
  `project_level_config_live_key_wins_over_deprecated`.
- Live `server_url` resolution still covered: `env_spelunk_server_url_overrides_config`,
  `project_level_config_merges_server_url`, plus the validate/resolve_mode suites.
- `cargo fmt --all --check` clean; `cargo clippy --all-targets -- -D warnings` clean.

Closes spelunk-oss^144.
