### PR TITLE
fix(context): compact default limits + --budget token cap + cap cross-project appends (oss^143)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This project is indexed with spelunk. Use it — don't just use Read/Grep/Glob.
 
 **At the start of every session:**
 ```bash
-spelunk context                                   # pull prior decisions, handoffs, questions, requirements
+spelunk context                                   # pull prior decisions, handoffs, questions, requirements (compact by default; --budget <N> caps output tokens)
 spelunk check                                     # verify index is fresh (only if indexed)
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -235,7 +235,7 @@ AGENT=true spelunk context --kind decision
 AGENT=true spelunk check
 ```
 
-`spelunk context` replaces the multi-command sequence. It retrieves handoffs, open questions, decisions, and requirements in one call.
+`spelunk context` replaces the multi-command sequence. It retrieves handoffs, open questions, decisions, and requirements in one call. The default output is compact; pass `--budget <N>` (alias `--max-tokens`) to cap total output at N tokens.
 
 **Understanding code:**
 1. `AGENT=true spelunk search "<topic>" --mode text` — full-text search, no server needed

--- a/crates/spelunk-cli/src/cli/cmd/context.rs
+++ b/crates/spelunk-cli/src/cli/cmd/context.rs
@@ -36,9 +36,19 @@ pub struct ContextArgs {
     #[arg(short, long, value_name = "KIND")]
     pub kind: Option<String>,
 
-    /// Maximum entries per section (defaults: handoff=3, question=500, decision=10, requirement=500)
-    #[arg(short, long, value_name = "N")]
+    /// Maximum entries per section (defaults: handoff=3, question=10, decision=10, requirement=10)
+    #[arg(short, long, value_name = "N", conflicts_with = "budget")]
     pub limit: Option<usize>,
+
+    /// Cap total output to this many tokens (safety net independent of entry
+    /// count; mirrors `search --budget`). Mutually exclusive with --limit.
+    #[arg(
+        long,
+        visible_alias = "max-tokens",
+        value_name = "N",
+        conflicts_with = "limit"
+    )]
+    pub budget: Option<usize>,
 
     /// Only show entries tagged with this file or directory path
     #[arg(long, value_name = "PATH")]
@@ -59,7 +69,8 @@ pub struct ContextArgs {
 
 struct Section {
     kind: &'static str,
-    /// Fetch this many entries before optional path post-filter; 500 is the NoteStore hard-cap.
+    /// Fetch this many entries before optional path post-filter. `context` runs
+    /// every session/compaction, so defaults stay small — use `--limit` to widen.
     default_limit: usize,
 }
 
@@ -70,7 +81,7 @@ const SECTIONS: &[Section] = &[
     },
     Section {
         kind: "question",
-        default_limit: 500,
+        default_limit: 10,
     },
     Section {
         kind: "decision",
@@ -78,9 +89,61 @@ const SECTIONS: &[Section] = &[
     },
     Section {
         kind: "requirement",
-        default_limit: 500,
+        default_limit: 10,
     },
 ];
+
+/// Effective per-section entry cap for `kind` given an optional `--limit` override.
+fn section_limit(kind: &str, limit_override: Option<usize>) -> usize {
+    let default = SECTIONS
+        .iter()
+        .find(|s| s.kind == kind)
+        .map(|s| s.default_limit)
+        .unwrap_or(DEFAULT_UNKNOWN_KIND_LIMIT);
+    limit_override.unwrap_or(default)
+}
+
+/// Token weight of a note for `--budget` packing (title + body).
+fn note_tokens(n: &Note) -> usize {
+    crate::search::tokens::estimate_tokens(&n.title)
+        + crate::search::tokens::estimate_tokens(&n.body)
+}
+
+/// Truncate each section (local + appended dep notes) to its effective
+/// per-section limit, so cross-project appends can't exceed --limit / defaults.
+fn cap_sections(sections: &mut [(String, Vec<Note>)], limit_override: Option<usize>) {
+    for (kind, notes) in sections.iter_mut() {
+        notes.truncate(section_limit(kind, limit_override));
+    }
+}
+
+/// Greedily drop notes then conventions (in output order) that don't fit
+/// `budget`, mirroring `search --budget`. Returns the tokens actually packed.
+fn apply_budget(
+    sections: &mut [(String, Vec<Note>)],
+    conventions: &mut Vec<crate::conventions::ConventionRecord>,
+    budget: usize,
+) -> usize {
+    let mut remaining = budget;
+    let mut fits = |tc: usize| {
+        if tc <= remaining {
+            remaining -= tc;
+            true
+        } else {
+            false
+        }
+    };
+    for (_, notes) in sections.iter_mut() {
+        notes.retain(|n| fits(note_tokens(n)));
+    }
+    conventions.retain(|c| {
+        fits(
+            crate::search::tokens::estimate_tokens(&c.category)
+                + crate::search::tokens::estimate_tokens(&c.description),
+        )
+    });
+    budget - remaining
+}
 
 pub async fn context(args: ContextArgs, cfg: Config) -> Result<()> {
     cfg.validate()?;
@@ -145,20 +208,33 @@ pub async fn context(args: ContextArgs, cfg: Config) -> Result<()> {
         }
     }
 
+    // Cap each section (incl. cross-project appends) to its per-section limit.
+    cap_sections(&mut sections, args.limit);
+
     // Load conventions from the index DB (best-effort; skip if unavailable).
-    let conventions: Vec<crate::conventions::ConventionRecord> =
+    let mut conventions: Vec<crate::conventions::ConventionRecord> =
         if !args.no_conventions && args.kind.is_none() {
             load_conventions(args.index_db.as_deref(), &cfg)
         } else {
             vec![]
         };
 
+    // Token-budget safety net: pack output to fit --budget (mirrors search).
+    let budget_used = args
+        .budget
+        .map(|b| apply_budget(&mut sections, &mut conventions, b));
+
     match crate::utils::effective_format(&args.format) {
         "json" => {
-            let output = serde_json::json!({
+            let mut output = serde_json::json!({
                 "sections": sections,
                 "conventions": conventions,
             });
+            if let (Some(budget), Some(used)) = (args.budget, budget_used) {
+                output["token_budget"] = budget.into();
+                output["tokens_used"] = used.into();
+                output["tokens_remaining"] = (budget - used).into();
+            }
             println!("{output}");
         }
         _ => {
@@ -173,6 +249,9 @@ pub async fn context(args: ContextArgs, cfg: Config) -> Result<()> {
             }
             if !conventions.is_empty() {
                 print_conventions_section(&conventions);
+            }
+            if let (Some(budget), Some(used)) = (args.budget, budget_used) {
+                println!("tokens used: {used}/{budget}");
             }
         }
     }
@@ -211,16 +290,11 @@ async fn collect_sections(
     let mut result = Vec::new();
 
     let sections: Vec<(&str, usize)> = if let Some(k) = kind_filter {
-        let default_limit = SECTIONS
-            .iter()
-            .find(|s| s.kind == k)
-            .map(|s| s.default_limit)
-            .unwrap_or(DEFAULT_UNKNOWN_KIND_LIMIT);
-        vec![(k, limit_override.unwrap_or(default_limit))]
+        vec![(k, section_limit(k, limit_override))]
     } else {
         SECTIONS
             .iter()
-            .map(|s| (s.kind, limit_override.unwrap_or(s.default_limit)))
+            .map(|s| (s.kind, section_limit(s.kind, limit_override)))
             .collect()
     };
 
@@ -267,5 +341,108 @@ fn print_conventions_section(records: &[crate::conventions::ConventionRecord]) {
             );
         }
         println!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conventions::ConventionRecord;
+
+    fn note(id: i64, kind: &str, title: &str, body: &str) -> Note {
+        Note {
+            id,
+            kind: kind.to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+            tags: vec![],
+            linked_files: vec![],
+            created_at: 0,
+            status: "active".to_string(),
+            superseded_by: None,
+            source_ref: None,
+            valid_at: None,
+            invalid_at: None,
+            distance: None,
+            score: None,
+            source_project: None,
+            source_project_path: None,
+            remote_id: None,
+        }
+    }
+
+    #[test]
+    fn default_limits_are_small_for_every_section() {
+        // Regression for spelunk-oss^143: question/requirement were 500.
+        assert_eq!(section_limit("handoff", None), 3);
+        assert_eq!(section_limit("question", None), 10);
+        assert_eq!(section_limit("decision", None), 10);
+        assert_eq!(section_limit("requirement", None), 10);
+        // Unknown kind falls back to the shared default.
+        assert_eq!(section_limit("mystery", None), DEFAULT_UNKNOWN_KIND_LIMIT);
+    }
+
+    #[test]
+    fn explicit_limit_override_wins() {
+        assert_eq!(section_limit("question", Some(42)), 42);
+        assert_eq!(section_limit("mystery", Some(1)), 1);
+    }
+
+    #[test]
+    fn cap_sections_bounds_cross_project_appends() {
+        // A section holding local + appended dep notes past its limit is trimmed
+        // to the per-section default, keeping the earliest (local) entries.
+        let mut sections = vec![(
+            "decision".to_string(),
+            (0..25).map(|i| note(i, "decision", "t", "b")).collect(),
+        )];
+        cap_sections(&mut sections, None);
+        assert_eq!(sections[0].1.len(), 10);
+        assert_eq!(sections[0].1.first().unwrap().id, 0);
+    }
+
+    #[test]
+    fn budget_truncates_output_to_fit() {
+        // Each note ~ title+body tokens; a tight budget keeps only the earliest.
+        let body = "x".repeat(400); // ~100 tokens
+        let mut sections = vec![(
+            "decision".to_string(),
+            (0..5).map(|i| note(i, "decision", "ti", &body)).collect(),
+        )];
+        let mut conv: Vec<ConventionRecord> = vec![];
+        let used = apply_budget(&mut sections, &mut conv, 250);
+        // 250-token budget fits 2 notes (~101 each), not the 3rd.
+        assert_eq!(sections[0].1.len(), 2);
+        assert!(used <= 250);
+        assert!(used > 0);
+    }
+
+    #[test]
+    fn budget_zero_drops_everything() {
+        let mut sections = vec![(
+            "decision".to_string(),
+            vec![note(0, "decision", "t", "body")],
+        )];
+        let mut conv: Vec<ConventionRecord> = vec![];
+        let used = apply_budget(&mut sections, &mut conv, 0);
+        assert!(sections[0].1.is_empty());
+        assert_eq!(used, 0);
+    }
+
+    #[test]
+    fn budget_also_bounds_conventions() {
+        let mut sections: Vec<(String, Vec<Note>)> = vec![];
+        let mut conv: Vec<ConventionRecord> = (0..5)
+            .map(|_| ConventionRecord {
+                language: "rust".to_string(),
+                category: "naming".to_string(),
+                description: "x".repeat(400),
+                confidence: 0.9,
+                evidence_count: 5,
+                extracted_at: 0,
+            })
+            .collect();
+        apply_budget(&mut sections, &mut conv, 250);
+        assert!(conv.len() < 5);
     }
 }

--- a/crates/spelunk-cli/src/cli/cmd/context.rs
+++ b/crates/spelunk-cli/src/cli/cmd/context.rs
@@ -348,6 +348,7 @@ fn print_conventions_section(records: &[crate::conventions::ConventionRecord]) {
 mod tests {
     use super::*;
     use crate::conventions::ConventionRecord;
+    use clap::Parser;
 
     fn note(id: i64, kind: &str, title: &str, body: &str) -> Note {
         Note {
@@ -444,5 +445,166 @@ mod tests {
             .collect();
         apply_budget(&mut sections, &mut conv, 250);
         assert!(conv.len() < 5);
+    }
+
+    // ── Coverage pass (spelunk-oss^143 Test Engineer) ────────────────────────
+
+    /// Minimal parser so we can exercise `ContextArgs` clap parsing (incl. the
+    /// declared `conflicts_with`) without pulling in the whole top-level `Cli`.
+    #[derive(clap::Parser, Debug)]
+    struct TestCli {
+        #[command(flatten)]
+        ctx: ContextArgs,
+    }
+
+    #[test]
+    fn limit_and_budget_conflict_is_enforced_at_arg_level() {
+        // Declared `conflicts_with` must actually reject both together, not just
+        // be present in the attribute.
+        assert!(
+            TestCli::try_parse_from(["spelunk", "--limit", "5", "--budget", "100"]).is_err(),
+            "--limit + --budget must be rejected"
+        );
+        // Each alone parses and lands in the right field.
+        let l = TestCli::try_parse_from(["spelunk", "--limit", "5"]).expect("limit alone parses");
+        assert_eq!(l.ctx.limit, Some(5));
+        assert_eq!(l.ctx.budget, None);
+        let b =
+            TestCli::try_parse_from(["spelunk", "--budget", "100"]).expect("budget alone parses");
+        assert_eq!(b.ctx.budget, Some(100));
+        assert_eq!(b.ctx.limit, None);
+    }
+
+    #[test]
+    fn max_tokens_alias_maps_to_budget_and_still_conflicts_with_limit() {
+        let a = TestCli::try_parse_from(["spelunk", "--max-tokens", "100"]).expect("alias parses");
+        assert_eq!(a.ctx.budget, Some(100));
+        assert!(
+            TestCli::try_parse_from(["spelunk", "--limit", "5", "--max-tokens", "100"]).is_err(),
+            "alias must inherit the conflict with --limit"
+        );
+    }
+
+    #[test]
+    fn budget_exact_fit_keeps_all_and_uses_full_budget() {
+        // 3 notes of ~101 tokens each; budget == exact total keeps all 3, and an
+        // entry sitting exactly at the remaining budget is kept (tc <= remaining).
+        let body = "x".repeat(400); // 100 tokens; title "ti" -> 1 => 101 each
+        let mut sections = vec![(
+            "decision".to_string(),
+            (0..3).map(|i| note(i, "decision", "ti", &body)).collect(),
+        )];
+        let mut conv: Vec<ConventionRecord> = vec![];
+        let used = apply_budget(&mut sections, &mut conv, 303);
+        assert_eq!(sections[0].1.len(), 3, "exact-fit budget keeps every entry");
+        assert_eq!(used, 303, "tokens_used equals the full budget at exact fit");
+    }
+
+    #[test]
+    fn budget_larger_than_content_keeps_everything_with_correct_used() {
+        let body = "x".repeat(400); // 101 tokens each
+        let mut sections = vec![(
+            "decision".to_string(),
+            (0..3).map(|i| note(i, "decision", "ti", &body)).collect(),
+        )];
+        let mut conv: Vec<ConventionRecord> = vec![];
+        let used = apply_budget(&mut sections, &mut conv, 100_000);
+        assert_eq!(sections[0].1.len(), 3, "generous budget emits everything");
+        assert_eq!(used, 303, "used is the true sum, not the budget");
+        assert!(used <= 100_000, "used never exceeds the budget");
+        // Mirrors the caller's `tokens_remaining = budget - used`: non-negative.
+        assert_eq!(100_000 - used, 99_697);
+    }
+
+    #[test]
+    fn budget_first_and_only_entry_exceeding_emits_nothing() {
+        let body = "x".repeat(800); // 200 tokens
+        let mut sections = vec![(
+            "decision".to_string(),
+            vec![note(0, "decision", "ti", &body)],
+        )];
+        let mut conv: Vec<ConventionRecord> = vec![];
+        let used = apply_budget(&mut sections, &mut conv, 150);
+        assert!(sections[0].1.is_empty(), "an entry over budget is dropped");
+        assert_eq!(used, 0, "nothing packed => zero used, never underflows");
+    }
+
+    #[test]
+    fn budget_greedy_skips_oversized_then_packs_later_smaller() {
+        // Documents the greedy-by-fit (non-strict-prefix) semantics that mirror
+        // `search --budget`: an oversized head entry is skipped but a later
+        // smaller one can still be packed. Relative order of survivors is kept.
+        let big = "x".repeat(800); // 200 tokens, id 0
+        let small = "x".repeat(400); // 101 tokens, id 1
+        let mut sections = vec![(
+            "decision".to_string(),
+            vec![
+                note(0, "decision", "ti", &big),
+                note(1, "decision", "ti", &small),
+            ],
+        )];
+        let mut conv: Vec<ConventionRecord> = vec![];
+        let used = apply_budget(&mut sections, &mut conv, 150);
+        assert_eq!(sections[0].1.len(), 1);
+        assert_eq!(sections[0].1[0].id, 1, "the smaller later entry survives");
+        assert_eq!(used, 101);
+    }
+
+    #[test]
+    fn budget_packs_sections_in_output_order_and_can_starve_a_later_section() {
+        // Budget is spent across sections in their fixed output order, so a
+        // budget-hungry earlier section starves a later one. Section slots and
+        // their order stay stable (a section can end up empty, not removed).
+        let big = "x".repeat(800); // title(1)+body(200) = 201 tokens
+        let small = "x".repeat(400); // title(1)+body(100) = 101 tokens
+        let mut sections = vec![
+            ("handoff".to_string(), vec![note(0, "handoff", "ti", &big)]),
+            (
+                "decision".to_string(),
+                vec![note(1, "decision", "ti", &small)],
+            ),
+        ];
+        let mut conv: Vec<ConventionRecord> = vec![];
+        // Budget fits exactly the first section's note, leaving nothing for the
+        // second — proving spend follows output order and can starve a later one.
+        let used = apply_budget(&mut sections, &mut conv, 201);
+        assert_eq!(sections.len(), 2, "section slots and order are preserved");
+        assert_eq!(sections[0].0, "handoff");
+        assert_eq!(sections[0].1.len(), 1, "earlier section packed first");
+        assert_eq!(sections[1].0, "decision");
+        assert!(
+            sections[1].1.is_empty(),
+            "later section starved once budget is exhausted"
+        );
+        assert_eq!(used, 201);
+    }
+
+    #[test]
+    fn cap_keeps_locals_and_trims_dep_overflow() {
+        // Post-append order in production is locals-first then dep appends
+        // (context.rs collects locals, then pushes dep notes). cap_sections
+        // truncate() therefore keeps every local before any dep note.
+        let mut notes: Vec<Note> = (0..8).map(|i| note(i, "decision", "local", "b")).collect();
+        notes.extend((100..108).map(|i| note(i, "decision", "dep", "b")));
+        let mut sections = vec![("decision".to_string(), notes)];
+        cap_sections(&mut sections, None); // decision default = 10
+        let kept = &sections[0].1;
+        assert_eq!(kept.len(), 10);
+        // All 8 locals survive...
+        for (idx, expected) in (0..8).enumerate() {
+            assert_eq!(kept[idx].id, expected, "local {expected} must survive");
+        }
+        // ...and only the first two dep notes (the overflow tail is trimmed).
+        assert_eq!(kept[8].id, 100);
+        assert_eq!(kept[9].id, 101);
+    }
+
+    #[test]
+    fn note_tokens_handles_empty_and_huge_bodies() {
+        // estimate_tokens floors at 1, so an empty note weighs title(1)+body(1).
+        assert_eq!(note_tokens(&note(0, "decision", "", "")), 2);
+        // Huge body: 4000 chars -> 1000 tokens, plus 1 for the 1-char title.
+        let huge = note(1, "decision", "t", &"x".repeat(4000));
+        assert_eq!(note_tokens(&huge), 1001);
     }
 }

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -92,7 +92,8 @@ Flags:
 - `--format json` — machine-readable output
 - `--kind decision` — narrow to one section
 - `--path src/auth` — filter by file path tag
-- `--limit N` — entries per section (defaults: handoff=3, decision=10, question/requirement=500)
+- `--limit N` – entries per section (defaults: handoff=3, question=10, decision=10, requirement=10); mutually exclusive with `--budget`
+- `--budget N` (alias `--max-tokens`) – cap total output at N tokens; mutually exclusive with `--limit`
 - `--no-conventions` — skip the extracted-conventions section
 
 `spelunk context` also surfaces a **conventions** section: coding conventions
@@ -569,6 +570,7 @@ spelunk plumbing read-memory --kind decision --limit 5 | jq '{id, title}'
 ```bash
 # Session start — all work out of the box
 spelunk context                                              # pull all prior context
+spelunk context --budget 4000                               # cap total output at ~4000 tokens
 AGENT=true spelunk context --format json                    # machine-readable
 
 # Before writing code — retrieve context, reason yourself

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -240,7 +240,8 @@ spelunk context [options]
 | `--index-db <path>` | auto | Index DB used to load the conventions section |
 | `--backend sqlite\|git-notes` | sqlite | Memory storage backend |
 | `-k, --kind <kind>` | — | Filter to a single kind instead of the multi-section view |
-| `-l, --limit <n>` | per-section | Max entries per section (handoff=3, decision=10, question/requirement=500) |
+| `-l, --limit <n>` | per-section | Max entries per section (handoff=3, question=10, decision=10, requirement=10); mutually exclusive with `--budget` |
+| `--budget <n>` (alias `--max-tokens`) | unlimited | Cap total output to this many tokens; mutually exclusive with `--limit` |
 | `--path <path>` | — | Only show entries tagged with this file/directory |
 | `--format text\|json` | text | Output format |
 | `--no-conventions` | false | Skip the conventions section |
@@ -257,6 +258,7 @@ projects' memory stores, each labelled with its source project. Pass
 spelunk context
 spelunk context --kind decision
 spelunk context --local-only      # primary project only, no dep pass
+spelunk context --budget 4000     # cap total output at ~4000 tokens
 AGENT=true spelunk context        # JSON for machine processing
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -234,6 +234,10 @@ spelunk context --kind decision
 AGENT=true spelunk context
 ```
 
+The default output is compact (a few recent entries per section). Pass
+`--budget <N>` (alias `--max-tokens`) to cap total output at N tokens, or
+`--limit <N>` to widen the per-section count.
+
 ## 5. Set up automatic memory harvesting (optional)
 
 Install a git post-commit hook so `spelunk` automatically extracts memories from commit messages:


### PR DESCRIPTION
## Problem

`spelunk context` runs at every session start and every compaction, but its
`question` and `requirement` sections defaulted to `--limit 500` each. With a
busy project that meant a worst-case ~1013 entries dumped into the model's
context on every single call (500 questions + 500 requirements + 10 decisions +
3 handoffs), swamping the very window the command is meant to prime.

## Fix

- **Compact defaults.** `question` and `requirement` default_limit 500 -> 10
  (handoff stays 3, decision stays 10). `--limit N` still widens any section.
- **`--budget N` (alias `--max-tokens`) token cap.** A safety net independent of
  entry count that greedily packs output to fit N tokens, mirroring
  `search --budget` (uses `spelunk_core::search::tokens::estimate_tokens`).
  Emits `token_budget` / `tokens_used` / `tokens_remaining` in JSON and a
  `tokens used: U/N` line in text mode.
- **`--budget` and `--limit` are mutually exclusive**, enforced at the clap arg
  level (`conflicts_with`), not just declared.
- **Cross-project appends are bounded.** `cap_sections()` truncates each section
  (locals + ADR-003 dep appends) to its effective per-section limit *before* the
  budget pass, so a linked project can no longer blow past `--limit`/defaults.
  Order is cap-then-budget; locals are kept ahead of dep appends.
- `tokens_remaining` cannot underflow (`used = budget - remaining`, remaining
  only decreases, so `used <= budget` always).

## Test matrix

Package-scoped, `SPELUNK_SECRET_STORE=file`:

| Gate | Result |
| --- | --- |
| `cargo test -p spelunk-cli` | 429 passed, 0 failed |
| `cargo test -p spelunk-cli --no-default-features` | 429 passed, 0 failed |
| `cargo fmt --all --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |

New unit tests cover: small defaults per section, `--limit` override, arg-level
`--limit`/`--budget` conflict (real `try_parse_from`, both directions incl. the
`--max-tokens` alias), budget boundary cases (zero, exact fit, oversized-head
skip-then-pack, generous budget, cross-section starvation in output order), and
`cap_sections` keeping locals ahead of trimmed dep overflow.

## Docs

`docs/commands.md`, `docs/agent-guide.md`, `docs/getting-started.md`, `SKILL.md`,
`CLAUDE.md` updated for the new defaults and the `--budget` row/examples.

## Test plan (live repro, isolated HOME + seeded project)

Seeded 25 decisions / 25 questions / 25 requirements into an isolated project, then:

- `spelunk context` -> 10 per section (question/decision/requirement), not 25/500.
- `spelunk context --budget 50` -> truncates to a few entries, prints
  `tokens used: 50/50`; JSON carries `token_budget/tokens_used/tokens_remaining`
  with `used <= budget` and `remaining == budget - used`.
- `spelunk context --budget 0` -> nothing emitted, used 0, no underflow.
- `spelunk context --budget 100000` -> everything kept, `tokens_used` is the true
  sum (610), `tokens_remaining` stays non-negative.
- `spelunk context --limit 3` -> 3 per section (override honored).
- `spelunk context --limit 5 --budget 100` -> rejected at parse (exit 2).

## Follow-up

`spelunk-oss^149` tracks a known design nuance: the budget packs sections in
their fixed output order, so `question` entries can consume budget before
`decision`/`requirement`. This is intentional (mirrors `search --budget`) and is
not a correctness bug (no crash, no negative tokens) - filed for a later
priority-aware packing pass.
