### PR TITLE
docs: show how to inspect spelunk's git notes with plain git

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -139,6 +139,17 @@ By default (`store_in_git_notes = true`) `memory add` also writes the entry to
 `refs/notes/spelunk` on `HEAD`, so memory travels with the code. Graceful no-op
 outside a git repo.
 
+To check those notes by hand with stock git, point it at the `spelunk` ref.
+Plain `git notes show` reads git's default `commits` ref and reports "no note
+found", which is a false negative:
+
+```bash
+git notes --ref=spelunk show HEAD    # notes on the current commit
+git notes --ref=spelunk list         # every commit carrying spelunk notes
+# equivalently
+GIT_NOTES_REF=refs/notes/spelunk git notes show HEAD
+```
+
 ### Query
 
 ```bash

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -179,6 +179,17 @@ spelunk memory search "why did we choose sqlite-vec"
 so decisions travel with the code through clone/fetch. It is a graceful no-op
 outside a git repository. Set `store_in_git_notes = false` to disable.
 
+To inspect that write-through by hand with stock git, name the `spelunk` ref.
+Plain `git notes show HEAD` reads git's default `commits` ref and reports "no
+note found", a false negative that makes it look like nothing was written:
+
+```bash
+git notes --ref=spelunk show HEAD    # notes on the current commit
+git notes --ref=spelunk list         # every commit carrying spelunk notes
+# equivalently
+GIT_NOTES_REF=refs/notes/spelunk git notes show HEAD
+```
+
 ## Automatic capture (no authoring tax)
 
 Recording decisions by hand is the part that never happens under deadline. The

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -10,6 +10,18 @@ database or server is required. (You can make git-notes the primary backend with
 are searchable by full text at all times; semantic search (by meaning) is
 available when a server is running — the local one is autostarted on demand.
 
+To verify that memory really travels with the repository, inspect the notes by
+hand with stock git. They live on the `spelunk` ref, so you must name it: plain
+`git notes show HEAD` reads git's default `commits` ref and reports "no note
+found" even when spelunk has written entries.
+
+```bash
+git notes --ref=spelunk show HEAD    # notes on the current commit
+git notes --ref=spelunk list         # every commit carrying spelunk notes
+# equivalently
+GIT_NOTES_REF=refs/notes/spelunk git notes show HEAD
+```
+
 Memory is scoped to a local project. Run `spelunk init` once per repository to
 create its `.spelunk/` store. In a directory with no local `.spelunk/`,
 `memory add/list/search` and `context` fail closed with a `no spelunk project


### PR DESCRIPTION
## Problem

`spelunk memory add` writes each entry through to git notes on the `refs/notes/spelunk` ref so decisions travel with the repo. But a user who tries to verify this with plain `git notes show HEAD` gets "no note found": stock git defaults to the `refs/notes/commits` ref and never looks at the spelunk ref. That false negative has made people think nothing was written.

## Fix

Document the correct incantation next to each existing git-notes write-through explanation, in `SKILL.md`, `docs/memory.md`, and `docs/agent-guide.md`. Each spot now shows `git notes --ref=spelunk show HEAD` / `list` and the equivalent `GIT_NOTES_REF=refs/notes/spelunk` form, so a skeptical user can verify the "memory travels with the repo" claim by hand. Docs-only change; no code or commands are altered.

## Test plan

- `git notes --ref=spelunk list` in a repo with spelunk history returns entries (160 here); plain `git notes list` returns none, confirming the ref mismatch the docs warn about.
- `git notes --ref=spelunk show HEAD` and the `GIT_NOTES_REF=refs/notes/spelunk git notes show HEAD` form both resolve against the spelunk ref.
- Diff is docs-only: touches only `SKILL.md`, `docs/agent-guide.md`, `docs/memory.md` (34 insertions, no deletions), no code or new subcommand.
- No em-dashes in added lines; all fenced code blocks balanced.
