### PR TITLE
feat(server): native in-process HTTPS (--tls-cert/--tls-key) per ADR-066

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Native in-process HTTPS for `spelunk-server`** via `--tls-cert`/`--tls-key`
+  (env `SPELUNK_SERVER_TLS_CERT`/`SPELUNK_SERVER_TLS_KEY`), both-or-neither. The
+  server terminates TLS itself, so a team/remote deployment is a routable
+  `--host` plus the TLS flags and an API key, with nothing in front. A
+  non-loopback bind is now allowed only with both TLS and an API key set;
+  loopback binds are unchanged. (ADR-066, spelunk-oss^151)
+
 ### Removed
 
 - **Deprecated `memory_server_url` / `memory_server_key` config keys (and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1710,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -5207,6 +5239,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "axum-server",
  "blake3",
  "candle-core",
  "clap",
@@ -5219,6 +5252,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ thiserror   = "2"
 rusqlite    = { version = "0.40", features = ["bundled"] }
 sqlite-vec  = "0.1"
 reqwest     = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+# In-process HTTPS for spelunk-server (ADR-066). `tls-rustls-no-provider` avoids
+# rustls' default aws-lc-rs provider (needs cmake/C/NASM); ring is installed at
+# startup instead — already the resolved provider via reqwest/hf-hub.
+axum-server = { version = "0.8", default-features = false, features = ["tls-rustls-no-provider"] }
 uuid        = { version = "1", features = ["v4", "v7", "serde"] }
 tempfile    = "3"
 pretty_assertions = "1"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -42,6 +42,11 @@ sqlite-vec = { workspace = true }
 uuid = { workspace = true }
 reqwest = { workspace = true }
 axum = { version = "0.8", features = ["macros"] }
+axum-server = { workspace = true }
+# In-process TLS (ADR-066): needed only to install the `ring` CryptoProvider as
+# the process default at startup. default-features off keeps aws-lc-rs out of
+# the tree; `ring`/`tls12` match rustls' resolved provider and TLS 1.2+ policy.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 tower = { version = "0.5", features = ["util", "limit"] }
 tower-http = { version = "0.7", features = ["auth", "timeout", "limit"] }
 async-stream = "0.3"

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -1,6 +1,7 @@
 use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Result};
+use axum_server::tls_rustls::RustlsConfig;
 use clap::Parser;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
@@ -29,10 +30,11 @@ struct Args {
     #[arg(long, default_value = "7777")]
     port: u16,
 
-    /// Host/address to bind. Defaults to loopback (`127.0.0.1`) — the safe,
-    /// firewall-exempt posture for a local server. Pass `--host 0.0.0.0`
-    /// explicitly to expose the server on all interfaces (e.g. a shared/team
-    /// server or the container image, which sets this in its entrypoint).
+    /// Host/address to bind. Defaults to loopback (`127.0.0.1`): a local
+    /// plaintext-HTTP server, no API key required. To serve a team/remote
+    /// server, bind a routable address (e.g. `--host 0.0.0.0`) together with
+    /// `--tls-cert`/`--tls-key` and an API key — the server terminates HTTPS
+    /// itself. A non-loopback bind is refused unless both TLS and a key are set.
     #[arg(long, default_value = "127.0.0.1")]
     host: String,
 
@@ -55,6 +57,19 @@ struct Args {
     /// flag. Read failure is fatal.
     #[arg(long, value_name = "PATH")]
     key_file: Option<PathBuf>,
+
+    /// PEM certificate chain (leaf + intermediates) for in-process HTTPS. Set
+    /// with `--tls-key` (both or neither). Distinct from `--key`/`--key-file`,
+    /// which are the bearer API key — a different secret. The certificate chain
+    /// is public; a routable bind needs this plus `--tls-key` and an API key.
+    #[arg(long, env = "SPELUNK_SERVER_TLS_CERT", value_name = "PATH")]
+    tls_cert: Option<PathBuf>,
+
+    /// PEM private key matching `--tls-cert`. Set with `--tls-cert` (both or
+    /// neither). A high-value secret: supply via a systemd credential or a
+    /// `0600` root-owned file, never an `Environment=` line.
+    #[arg(long, env = "SPELUNK_SERVER_TLS_KEY", value_name = "PATH")]
+    tls_key: Option<PathBuf>,
 
     /// Embedding dimension expected from clients (must match the team's model).
     /// Default: 896 (F2LLM-v2-330M).
@@ -181,11 +196,13 @@ async fn run(budget: ThreadBudget) -> Result<()> {
         credentials_dir.as_deref(),
     )?;
 
-    // Bind-safety: refuse to expose the server off-host over plaintext HTTP,
-    // whether that would leak an open (keyless) endpoint or the bearer key in
-    // cleartext (keyed). Fail fast, before touching the DB or warming the
-    // embedder. This refusal is unconditional — there is no opt-out.
-    check_bind_safety(&args.host, args.port, api_key.is_some())?;
+    // TLS flags are all-or-nothing (ADR-066 §2).
+    let tls_enabled = resolve_tls_enabled(args.tls_cert.is_some(), args.tls_key.is_some())?;
+
+    // Bind-safety (ADR-066 §4): loopback binds are always allowed; a non-loopback
+    // bind is refused unless BOTH in-process TLS and an API key are configured.
+    // Fail fast, before touching the DB or warming the embedder.
+    check_bind_safety(&args.host, args.port, api_key.is_some(), tls_enabled)?;
 
     let db = ServerDb::open(&args.db, args.embedding_dim, NATIVE_MODEL_ID)
         .with_context(|| format!("opening server db at {}", args.db.display()))?;
@@ -305,10 +322,43 @@ async fn run(budget: ThreadBudget) -> Result<()> {
         .parse()
         .context("parsing bind address")?;
 
+    // Load TLS material before binding so a bad cert/key fails fast. Install
+    // `ring` as the process crypto provider (NOT rustls' default aws-lc-rs,
+    // which needs a cmake/C/NASM build toolchain); ignore the error if another
+    // component already installed one.
+    let tls_config = if tls_enabled {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let cert = args.tls_cert.as_deref().expect("tls_enabled ⇒ cert set");
+        let key = args.tls_key.as_deref().expect("tls_enabled ⇒ key set");
+        let config = RustlsConfig::from_pem_file(cert, key)
+            .await
+            .with_context(|| {
+                format!(
+                    "loading TLS cert {} / key {}",
+                    cert.display(),
+                    key.display()
+                )
+            })?;
+        Some(config)
+    } else {
+        None
+    };
+
     // Bind first: `/v1/health` must be reachable the instant the port is bound,
-    // *before* the (potentially multi-minute, ~339 MB) native model download.
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    tracing::info!("spelunk-server listening on http://{addr}");
+    // *before* the (potentially multi-minute, ~339 MB) native model download. A
+    // std listener backs both serve paths (plaintext axum, TLS axum-server), so
+    // the single bind-before-warm point is preserved either way.
+    let listener = std::net::TcpListener::bind(addr).with_context(|| format!("binding {addr}"))?;
+    // Both serve paths register the fd with tokio, which rejects a blocking fd.
+    listener
+        .set_nonblocking(true)
+        .context("setting listener non-blocking")?;
+    let scheme = if tls_config.is_some() {
+        "https"
+    } else {
+        "http"
+    };
+    tracing::info!("spelunk-server listening on {scheme}://{addr}");
 
     // Load the native embedder on a background task now that health is live.
     // `embed_hub::load_from_hub()` is blocking/CPU-heavy, so run it on the blocking
@@ -346,11 +396,22 @@ async fn run(budget: ThreadBudget) -> Result<()> {
     #[cfg(not(feature = "embed-native"))]
     let _ = (load_native, &embedder_slot);
 
-    axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .await?;
+    let make_service = app.into_make_service_with_connect_info::<SocketAddr>();
+    match tls_config {
+        // axum-server accepts the pre-bound std listener (bind-before-warm kept).
+        Some(config) => {
+            axum_server::from_tcp_rustls(listener, config)
+                .context("adopting std listener for TLS")?
+                .serve(make_service)
+                .await?;
+        }
+        // Plaintext loopback path, unchanged.
+        None => {
+            let listener =
+                tokio::net::TcpListener::from_std(listener).context("adopting std listener")?;
+            axum::serve(listener, make_service).await?;
+        }
+    }
 
     Ok(())
 }
@@ -498,43 +559,69 @@ fn resolve_api_key(
     Ok(None)
 }
 
-/// Refuse to expose the server off-host over plaintext HTTP. Binding to any
-/// non-loopback address makes the endpoint reachable from other machines, and
-/// the server only ever speaks plaintext HTTP. Two cases are refused,
-/// unconditionally:
+/// `--tls-cert`/`--tls-key` are all-or-nothing (ADR-066 §2): a cert chain needs
+/// its matching private key. Returns whether in-process TLS is enabled, or errs
+/// when exactly one of the two is set.
+fn resolve_tls_enabled(cert_set: bool, key_set: bool) -> Result<bool> {
+    match (cert_set, key_set) {
+        (true, true) => Ok(true),
+        (false, false) => Ok(false),
+        (true, false) => {
+            anyhow::bail!(
+                "--tls-cert was set without --tls-key: a certificate chain needs its matching private key."
+            )
+        }
+        (false, true) => {
+            anyhow::bail!(
+                "--tls-key was set without --tls-cert: a private key needs its matching certificate chain."
+            )
+        }
+    }
+}
+
+/// TLS-aware bind-safety guard (ADR-066 §4). Encodes "local = HTTP no key,
+/// remote = HTTPS + key":
 ///
-/// - **keyless** non-loopback bind: an open, unauthenticated server; and
-/// - **keyed** non-loopback bind: the bearer `SPELUNK_SERVER_KEY` would cross
-///   the network in cleartext.
+/// | Bind | TLS | Key | Result |
+/// |---|---|---|---|
+/// | loopback | any | any | allow |
+/// | non-loopback | no | any | refuse (no plaintext off-host) |
+/// | non-loopback | yes | no | refuse (remote requires an API key) |
+/// | non-loopback | yes | yes | allow (the remote HTTPS path) |
 ///
-/// This matches the ADR-056 transport guardrail: plaintext HTTP is
-/// loopback-only. Loopback binds (the default) are always allowed. There is
-/// no opt-out. The refusal names the interface and port being refused.
-fn check_bind_safety(host: &str, port: u16, key_is_set: bool) -> Result<()> {
+/// Loopback binds are always allowed (unreachable off-host). Plaintext off-host
+/// stays refused with no opt-out. The refusal names the interface/port and
+/// points the operator at `--tls-cert`/`--tls-key`.
+fn check_bind_safety(host: &str, port: u16, key_is_set: bool, tls_is_set: bool) -> Result<()> {
     if host_is_loopback(host) {
         return Ok(());
     }
 
-    if !key_is_set {
-        // Keyless off-host bind: an open, unauthenticated server.
+    if !tls_is_set {
+        // Non-loopback plaintext, keyed or not: an open server, or the bearer
+        // key crossing the wire in cleartext. Refused unconditionally.
         anyhow::bail!(
-            "Refusing to bind to non-loopback address '{host}:{port}' without \
-             authentication.\n\
-             A server reachable from other machines must require an API key. Either:\n  \
-             • set --key / SPELUNK_SERVER_KEY to expose it on {host}:{port}, or\n  \
+            "Refusing to bind to non-loopback address '{host}:{port}' over plaintext HTTP.\n\
+             A server reachable from other machines must terminate TLS in-process. Either:\n  \
+             • pass --tls-cert <pem> --tls-key <pem> and an API key \
+             (--key / --key-file / SPELUNK_SERVER_KEY) to serve HTTPS on {host}:{port}, or\n  \
+             • bind to loopback (the default --host 127.0.0.1) for local-only plaintext use."
+        );
+    }
+
+    if !key_is_set {
+        // TLS is configured but no bearer key: a remote HTTPS server must
+        // authenticate its callers.
+        anyhow::bail!(
+            "Refusing to bind to non-loopback address '{host}:{port}' with TLS but no API key.\n\
+             A remote HTTPS server must require an API key so callers are authenticated. Either:\n  \
+             • set --key / --key-file / SPELUNK_SERVER_KEY, or\n  \
              • bind to loopback (the default --host 127.0.0.1) for local-only use."
         );
     }
 
-    // Keyed off-host bind over plaintext HTTP: the bearer key would cross the
-    // network in cleartext. Refused unconditionally — there is no opt-out.
-    anyhow::bail!(
-        "Refusing to bind to non-loopback address '{host}:{port}' over plaintext HTTP: \
-         the bearer SPELUNK_SERVER_KEY would cross the network in cleartext.\n\
-         A shared server must not send its key in the clear. Bind to loopback \
-         (the default --host 127.0.0.1) instead.\n\
-         See docs/adr/056-oss-server-tenancy-model.md."
-    );
+    // Non-loopback + TLS + key: the remote HTTPS path (ADR-066 §4). Allowed.
+    Ok(())
 }
 
 /// Whether a keyed, non-loopback bind is a shared/team server that should get
@@ -845,61 +932,125 @@ mod arg_tests {
         }
     }
 
-    /// Loopback binds never require a key (local-only, unreachable off-host).
+    // ── ADR-066 §4: TLS-aware bind-safety table ─────────────────────────────
+    //
+    // | Bind | TLS | Key | Result |
+    // | loopback     | any | any | allow |
+    // | non-loopback | no  | any | refuse |
+    // | non-loopback | yes | no  | refuse |
+    // | non-loopback | yes | yes | allow  |
+
+    /// Row 1: a loopback bind is allowed for every TLS/key combination
+    /// (unreachable off-host, so local plaintext with no key is fine).
     #[test]
-    fn loopback_without_key_is_allowed() {
+    fn loopback_is_allowed_for_every_combination() {
         for h in ["127.0.0.1", "::1", "localhost"] {
-            assert!(
-                super::check_bind_safety(h, 7777, false).is_ok(),
-                "{h} without a key should be allowed"
-            );
-            assert!(
-                super::check_bind_safety(h, 7777, true).is_ok(),
-                "{h} with a key should be allowed on loopback"
-            );
+            for tls in [false, true] {
+                for key in [false, true] {
+                    assert!(
+                        super::check_bind_safety(h, 7777, key, tls).is_ok(),
+                        "loopback {h} (tls={tls}, key={key}) should be allowed"
+                    );
+                }
+            }
         }
     }
 
-    /// A non-loopback bind without a key is refused — no open, unauthenticated
-    /// server reachable from other machines.
+    /// Row 2: a non-loopback bind with no TLS is refused whether keyed or not —
+    /// no plaintext off-host, keyed (key in cleartext) or keyless (open server).
     #[test]
-    fn non_loopback_without_key_is_refused() {
-        for h in ["0.0.0.0", "::", "192.168.1.10"] {
-            assert!(
-                super::check_bind_safety(h, 7777, false).is_err(),
-                "{h} without a key must be refused"
-            );
-        }
-    }
-
-    /// A keyed non-loopback *plaintext* bind is refused unconditionally: the
-    /// bearer key would cross the network in cleartext (ADR-056 transport
-    /// guardrail). There is no opt-out. The error names the interface/port
-    /// and points at the ADR-056 guidance doc.
-    #[test]
-    fn non_loopback_with_key_plaintext_is_refused_unconditionally() {
+    fn non_loopback_without_tls_is_refused() {
         for h in ["0.0.0.0", "::", "192.168.1.10", "example.com"] {
-            let err = super::check_bind_safety(h, 7777, true)
-                .expect_err(&format!("{h} with a key over plaintext must be refused"));
+            for key in [false, true] {
+                let err = super::check_bind_safety(h, 7777, key, false)
+                    .expect_err(&format!("{h} (tls=false, key={key}) must be refused"));
+                let msg = format!("{err}");
+                assert!(
+                    msg.contains(h) && msg.contains("7777"),
+                    "error must name the interface and port '{h}:7777': {msg}"
+                );
+                assert!(
+                    msg.contains("--tls-cert") && msg.contains("--tls-key"),
+                    "refusal must offer the --tls-cert/--tls-key remedy, not a proxy: {msg}"
+                );
+            }
+        }
+    }
+
+    /// Row 3: a non-loopback TLS bind with no API key is refused — a remote
+    /// HTTPS server must authenticate its callers.
+    #[test]
+    fn non_loopback_tls_without_key_is_refused() {
+        for h in ["0.0.0.0", "::", "192.168.1.10", "example.com"] {
+            let err = super::check_bind_safety(h, 7777, false, true)
+                .expect_err(&format!("{h} (tls=true, key=false) must be refused"));
             let msg = format!("{err}");
             assert!(
                 msg.contains(h) && msg.contains("7777"),
                 "error must name the interface and port '{h}:7777': {msg}"
             );
             assert!(
-                msg.contains("cleartext"),
-                "error must mention cleartext exposure: {msg}"
-            );
-            assert!(
-                msg.contains("loopback"),
-                "error must point at binding to loopback instead: {msg}"
-            );
-            assert!(
-                msg.contains("docs/adr/056-oss-server-tenancy-model.md"),
-                "error must point at the ADR-056 guidance doc so the operator \
-                 can find the loopback-only policy: {msg}"
+                msg.contains("API key"),
+                "refusal must say a remote server requires an API key: {msg}"
             );
         }
+    }
+
+    /// Row 4: the new remote path — a non-loopback bind with BOTH TLS and a key
+    /// is allowed.
+    #[test]
+    fn non_loopback_tls_with_key_is_allowed() {
+        for h in ["0.0.0.0", "::", "192.168.1.10", "example.com"] {
+            assert!(
+                super::check_bind_safety(h, 7777, true, true).is_ok(),
+                "{h} (tls=true, key=true) is the remote HTTPS path and must be allowed"
+            );
+        }
+    }
+
+    // ── ADR-066 §2: --tls-cert / --tls-key are all-or-nothing ────────────────
+
+    /// Both unset → TLS disabled; both set → TLS enabled.
+    #[test]
+    fn tls_both_or_neither_resolves() {
+        assert!(!super::resolve_tls_enabled(false, false).unwrap());
+        assert!(super::resolve_tls_enabled(true, true).unwrap());
+    }
+
+    /// Exactly one set is a fatal configuration error, and the message names the
+    /// missing flag.
+    #[test]
+    fn tls_exactly_one_set_is_error() {
+        let err = super::resolve_tls_enabled(true, false).unwrap_err();
+        assert!(
+            format!("{err}").contains("--tls-key"),
+            "cert-only error must name the missing --tls-key: {err}"
+        );
+        let err = super::resolve_tls_enabled(false, true).unwrap_err();
+        assert!(
+            format!("{err}").contains("--tls-cert"),
+            "key-only error must name the missing --tls-cert: {err}"
+        );
+    }
+
+    /// The TLS flags parse as paths and read their env vars.
+    #[test]
+    fn tls_flags_parse() {
+        let args = Args::parse_from([
+            "spelunk-server",
+            "--tls-cert",
+            "/etc/spelunk/tls-cert",
+            "--tls-key",
+            "/etc/spelunk/tls-key",
+        ]);
+        assert_eq!(
+            args.tls_cert.as_deref(),
+            Some(std::path::Path::new("/etc/spelunk/tls-cert"))
+        );
+        assert_eq!(
+            args.tls_key.as_deref(),
+            Some(std::path::Path::new("/etc/spelunk/tls-key"))
+        );
     }
 
     /// A blank/whitespace key (incl. clap's `Some("")` for a set-but-empty

--- a/crates/spelunk-server/tests/tls_serve.rs
+++ b/crates/spelunk-server/tests/tls_serve.rs
@@ -1,0 +1,152 @@
+//! Integration test for the ADR-066 in-process HTTPS serve path.
+//!
+//! Unlike `integration_server.rs` (router-level oneshot, no socket), this test
+//! exercises the *real* TLS transport: it binds a std `TcpListener`, adopts it
+//! with `axum_server::from_tcp_rustls` exactly as `main::run` does, and drives a
+//! full HTTPS request to `/v1/health` over the loopback socket.
+//!
+//! The self-signed cert/key are generated at test time into a tempdir via
+//! `openssl` and never committed. If `openssl` is not on PATH the TLS body is
+//! skipped (the machine can't mint a cert), so CI images without openssl don't
+//! hard-fail.
+
+mod common;
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::process::Command;
+
+use axum_server::tls_rustls::RustlsConfig;
+use serial_test::serial;
+use spelunk_server::router;
+
+/// Mint a throwaway self-signed leaf (CN=localhost, SAN IP 127.0.0.1) into
+/// `dir`, returning `(cert_pem, key_pem)` paths. Returns `None` when `openssl`
+/// is absent so the caller can skip rather than fail.
+fn make_self_signed(dir: &Path) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+    let cert = dir.join("cert.pem");
+    let key = dir.join("key.pem");
+    let out = Command::new("openssl")
+        .args([
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-days",
+            "1",
+            "-subj",
+            "/CN=localhost",
+            "-addext",
+            "subjectAltName=IP:127.0.0.1,DNS:localhost",
+            "-keyout",
+        ])
+        .arg(&key)
+        .arg("-out")
+        .arg(&cert)
+        .output();
+    match out {
+        Ok(o) if o.status.success() => Some((cert, key)),
+        Ok(o) => panic!(
+            "openssl failed to generate a self-signed cert: {}",
+            String::from_utf8_lossy(&o.stderr)
+        ),
+        // openssl not installed → skip.
+        Err(_) => None,
+    }
+}
+
+/// The full remote path end to end: bind a std listener, adopt it for TLS via
+/// the same `from_tcp_rustls` call `main::run` uses, and confirm a client gets a
+/// 200 from `/v1/health` over real HTTPS.
+///
+/// This is also the bind-before-warm guarantee for the TLS branch: the socket is
+/// bound (and made non-blocking) *before* `from_tcp_rustls` adopts it, so health
+/// is served off the pre-bound fd — the same single bind point the plaintext
+/// path uses, and the point at which `main::run` would have already returned
+/// from `TcpListener::bind` before warming the embedder.
+#[tokio::test]
+#[serial]
+async fn health_over_real_https() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let Some((cert, key)) = make_self_signed(dir.path()) else {
+        eprintln!("SKIP health_over_real_https: openssl not found on PATH");
+        return;
+    };
+
+    // Install `ring` as the process crypto provider (mirrors `main::run`); the
+    // reqwest client below also resolves against this process default. Ignore
+    // the error if another test already installed one.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let state = common::make_test_state(4, None);
+    let app = router(state);
+
+    // Bind first, exactly like `main::run`: a std listener, made non-blocking so
+    // tokio/axum-server can adopt the fd.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    listener.set_nonblocking(true).expect("non-blocking");
+    let addr = listener.local_addr().expect("local_addr");
+
+    let config = RustlsConfig::from_pem_file(&cert, &key)
+        .await
+        .expect("load self-signed TLS material");
+
+    // Serve on the pre-bound listener via the production TLS branch.
+    let server = tokio::spawn(async move {
+        axum_server::from_tcp_rustls(listener, config)
+            .expect("adopt std listener for TLS")
+            .serve(app.into_make_service_with_connect_info::<SocketAddr>())
+            .await
+    });
+
+    // Client trusts any cert (self-signed) but still performs a real TLS
+    // handshake — a plaintext server would be rejected here.
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .expect("reqwest client");
+
+    let url = format!("https://{addr}/v1/health");
+    // Small retry loop: the spawned server may not have entered `accept` yet.
+    let mut last_err = None;
+    let mut status = None;
+    for _ in 0..50 {
+        match client.get(&url).send().await {
+            Ok(resp) => {
+                status = Some(resp.status());
+                break;
+            }
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        }
+    }
+
+    server.abort();
+
+    let status = status.unwrap_or_else(|| {
+        panic!("no HTTPS response from {url}: {last_err:?}");
+    });
+    assert_eq!(
+        status,
+        reqwest::StatusCode::OK,
+        "GET {url} over HTTPS must return 200"
+    );
+}
+
+/// Fail-fast on bad TLS material: `main::run` loads the cert/key *before* binding
+/// so a bad cert is a startup error, never a half-up server. A non-existent cert
+/// path must therefore make `RustlsConfig::from_pem_file` err.
+#[tokio::test]
+async fn tls_config_missing_cert_fails_fast() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing_cert = dir.path().join("nope-cert.pem");
+    let missing_key = dir.path().join("nope-key.pem");
+    let res = RustlsConfig::from_pem_file(&missing_cert, &missing_key).await;
+    assert!(
+        res.is_err(),
+        "loading a non-existent cert/key must fail fast, not silently succeed"
+    );
+}

--- a/packaging/spelunk-server-team-dynamicuser.service
+++ b/packaging/spelunk-server-team-dynamicuser.service
@@ -6,6 +6,9 @@
 # no manual `install -d` for the data dir. Choose this when you prefer
 # systemd-managed identity/ownership over a fixed-owner data dir.
 #
+# The server terminates HTTPS in-process (ADR-066): a routable bind, TLS served
+# by the server itself, API key required, nothing in front.
+#
 # Trade-off: the data dir owner changes across boots, so out-of-band backup
 # tooling must not assume a fixed UID. If you need a stable owner for backup /
 # inspection or a stable started_by UID, use the static-user default
@@ -15,6 +18,9 @@
 #   sudo install -d -m 0755 /etc/spelunk
 #   openssl rand -hex 32 | sudo tee /etc/spelunk/server-key >/dev/null
 #   sudo chmod 0600 /etc/spelunk/server-key   # root:root
+#   # Bring your own TLS cert chain + private key (internal CA, certbot, cloud):
+#   sudo install -m 0644 fullchain.pem /etc/spelunk/tls-cert   # public chain
+#   sudo install -m 0600 privkey.pem   /etc/spelunk/tls-key    # root:root, private
 #   sudo install -m 0644 packaging/spelunk-server-team-dynamicuser.service \
 #        /etc/systemd/system/spelunk-server.service
 #   sudo systemctl daemon-reload
@@ -34,16 +40,22 @@ Type=simple
 DynamicUser=yes
 StateDirectory=spelunk
 
-# See the static-user unit for why the key is a credential, not Environment=.
+# See the static-user unit for why both secrets are credentials, not Environment=.
+# server-key (bearer API key) is auto-read from $CREDENTIALS_DIRECTORY; tls-key
+# (TLS private key) is passed to --tls-key via %d (= $CREDENTIALS_DIRECTORY). The
+# certificate chain is public and stays a plain readable path.
 LoadCredential=server-key:/etc/spelunk/server-key
+LoadCredential=tls-key:/etc/spelunk/tls-key
 ExecStart=/usr/local/bin/spelunk-server \
-  --host 127.0.0.1 --port 7777 \
-  --db /var/lib/spelunk/spelunk.db
+  --host 0.0.0.0 --port 7777 \
+  --db /var/lib/spelunk/spelunk.db \
+  --tls-cert /etc/spelunk/tls-cert \
+  --tls-key %d/tls-key
 
 Restart=on-failure
 RestartSec=5
 
-# Hardening — the server needs only its state dir (StateDirectory=) and loopback.
+# Hardening — the server needs its state dir (StateDirectory=) and a routable socket.
 # DynamicUser=yes already implies ProtectSystem=strict, ProtectHome=read-only,
 # PrivateTmp, and RemoveIPC; the directives below narrow it further.
 NoNewPrivileges=true

--- a/packaging/spelunk-server-team.service
+++ b/packaging/spelunk-server-team.service
@@ -4,9 +4,9 @@
 # memory store), NOT the local per-developer inference server — for that see the
 # user unit `spelunk-server.service` in this directory. Do not confuse the two.
 #
-# The server binds loopback only and terminates plaintext HTTP; a shared
-# deployment puts an operator-owned TLS terminator (nginx/Caddy/…) on the SAME
-# host in front of this loopback bind. See docs/self-hosting.md.
+# The server terminates HTTPS in-process (ADR-066): it binds a routable address
+# and serves TLS itself, with the shared API key required. Nothing sits in front
+# of it. See docs/self-hosting.md.
 #
 # Install:
 #   sudo useradd --system --home-dir /var/lib/spelunk --shell /usr/sbin/nologin spelunk
@@ -14,6 +14,9 @@
 #   sudo install -d -m 0755 /etc/spelunk
 #   openssl rand -hex 32 | sudo tee /etc/spelunk/server-key >/dev/null
 #   sudo chmod 0600 /etc/spelunk/server-key   # root:root
+#   # Bring your own TLS cert chain + private key (internal CA, certbot, cloud):
+#   sudo install -m 0644 fullchain.pem /etc/spelunk/tls-cert   # public chain
+#   sudo install -m 0600 privkey.pem   /etc/spelunk/tls-key    # root:root, private
 #   sudo install -m 0644 packaging/spelunk-server-team.service \
 #        /etc/systemd/system/spelunk-server.service
 #   sudo systemctl daemon-reload
@@ -36,21 +39,30 @@ Type=simple
 User=spelunk
 Group=spelunk
 
-# Key supplied as a systemd credential, not an Environment= line (which is
-# world-readable via `systemctl show` / /proc). The 0600 root-only source file
-# is exposed at $CREDENTIALS_DIRECTORY/server-key, readable only by this unit;
-# the binary reads it from there automatically. SPELUNK_SERVER_KEY as an
-# Environment=/EnvironmentFile= value is equally supported for operators who
-# prefer it (use a 0600 root-owned EnvironmentFile, never an inline Environment=).
+# Two secrets, both as systemd credentials rather than Environment= lines (which
+# are world-readable via `systemctl show` / /proc):
+#   • server-key — the bearer API key, exposed at $CREDENTIALS_DIRECTORY/server-key
+#     and read automatically by the binary.
+#   • tls-key    — the TLS private key, exposed at $CREDENTIALS_DIRECTORY/tls-key
+#     and passed to --tls-key below (%d = $CREDENTIALS_DIRECTORY).
+# Both source files are 0600 root-only; systemd reads them as root before the
+# sandbox applies. SPELUNK_SERVER_KEY as an Environment=/EnvironmentFile= value is
+# equally supported for the bearer key (use a 0600 root-owned EnvironmentFile,
+# never an inline Environment=).
 LoadCredential=server-key:/etc/spelunk/server-key
+LoadCredential=tls-key:/etc/spelunk/tls-key
+# The TLS certificate chain is public; it stays a plain readable path (readable
+# under ProtectSystem=strict, which makes /etc read-only, not hidden).
 ExecStart=/usr/local/bin/spelunk-server \
-  --host 127.0.0.1 --port 7777 \
-  --db /var/lib/spelunk/spelunk.db
+  --host 0.0.0.0 --port 7777 \
+  --db /var/lib/spelunk/spelunk.db \
+  --tls-cert /etc/spelunk/tls-cert \
+  --tls-key %d/tls-key
 
 Restart=on-failure
 RestartSec=5
 
-# Hardening — the server needs only its data dir and loopback.
+# Hardening — the server needs its data dir and a routable socket.
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true


### PR DESCRIPTION
Adds native, in-process HTTPS to `spelunk-server` per ADR-066, so a team/remote
deployment terminates TLS itself with nothing in front of it.

## What it adds

- **`--tls-cert` / `--tls-key`** (env `SPELUNK_SERVER_TLS_CERT` /
  `SPELUNK_SERVER_TLS_KEY`): a PEM certificate chain and matching private key for
  in-process HTTPS, served via `axum-server` + `rustls`. The flags are
  both-or-neither, and are distinct from the bearer API key (`--key` /
  `--key-file` / `SPELUNK_SERVER_KEY`).
- **`ring` crypto provider** installed at startup (rustls' default aws-lc-rs is
  kept out of the tree, avoiding a cmake/C/NASM build toolchain); `ring` is
  already the resolved provider via reqwest/hf-hub.
- **TLS-aware bind-safety table**: loopback binds are always allowed; a
  non-loopback bind is refused unless BOTH in-process TLS and an API key are
  set. Refusals name the interface/port and point the operator at
  `--tls-cert` / `--tls-key`. Plaintext off-host stays refused with no opt-out.

  | Bind | TLS | Key | Result |
  |---|---|---|---|
  | loopback | any | any | allow |
  | non-loopback | no | any | refuse (no plaintext off-host) |
  | non-loopback | yes | no | refuse (remote requires an API key) |
  | non-loopback | yes | yes | allow (remote HTTPS path) |

- **Bind-before-warm preserved**: a std listener is bound (and made
  non-blocking) before the ~339 MB embedder warm-up, backing both the plaintext
  (`axum::serve`) and TLS (`axum_server::from_tcp_rustls`) serve paths, so
  `/v1/health` is reachable the instant the port is bound. A bad cert/key fails
  fast at load time, before binding.
- **systemd units** (`spelunk-server-team.service`,
  `spelunk-server-team-dynamicuser.service`): the TLS private key is supplied as
  a systemd credential (`LoadCredential=tls-key`, passed via `%d/tls-key`), never
  an `Environment=` line; the public certificate chain stays a plain readable
  path. Units now bind a routable address and serve HTTPS in-process.

## Test plan

- **Bind-safety table unit tests** (`crates/spelunk-server/src/main.rs`
  `arg_tests`): one test per row of the table above, plus the all-or-nothing
  `--tls-cert`/`--tls-key` resolution (both set, neither set, and each set alone
  erroring with the missing flag named) and flag/env parsing. All pass.
- **Live-HTTPS integration test** (`crates/spelunk-server/tests/tls_serve.rs`
  `health_over_real_https`): mints a throwaway self-signed cert with `openssl`,
  binds a std listener, adopts it with the same `from_tcp_rustls` call
  production uses, and drives a real HTTPS request to `/v1/health`, asserting
  200 over a genuine TLS handshake. A companion test asserts a missing cert
  path fails fast. Both pass (openssl present).
- **Full gate, both feature sets**: `cargo test -p spelunk-server` and
  `cargo test -p spelunk-server --no-default-features` green; `cargo fmt
  --check` clean; `cargo clippy -p spelunk-server --all-targets -- -D warnings`
  clean on default AND `--no-default-features`. Full `cargo test --workspace`
  green.
- **Provider check**: `cargo tree -i aws-lc-sys` returns no match; `ring` is the
  sole TLS provider.

See `docs/adr/066-*` for the design rationale.
