### PR TITLE
fix(cli): don't read the global index from an un-init'd dir (graph/chunks/explore/check)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`graph`, `chunks`, `explore`, and `check` no longer read the machine-global
+  index (`~/.config/spelunk/index.db`) from an un-`init`'d directory**, extending
+  the ADR-067 fail-closed posture to these read-only display commands (previously
+  they resolved via the legacy `open_project_db` fallback and could surface
+  cross-project data from the global store). In an uninitialized directory,
+  `graph <symbol>` now degrades to a live ast-grep scan; `graph <file-path>`,
+  `chunks`, `explore`, and `check` refuse with `no spelunk project here. Run
+  'spelunk init' first`. Initialized projects and explicit `--db` are unaffected.
+  (spelunk-oss^147)
+
 ### Removed
 
 - **Deprecated `memory_server_url` / `memory_server_key` config keys (and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ spelunk check                                     # verify index is fresh (only 
 
 **Before reading any file, search first:**
 ```bash
-spelunk graph <symbol>                            # trace callers/callees (always works)
+spelunk graph <symbol>                            # trace callers/callees (works live even without an index)
 spelunk search "<topic>" --mode text              # full-text search (always works)
 spelunk search "<topic>"                          # semantic search (if indexed + server running)
 ```
@@ -45,7 +45,7 @@ Full reference: `SKILL.md` and `docs/agent-guide.md`.
 
 `spelunk` is a Rust CLI and context retrieval engine for AI agents.
 
-**Built-in (zero infrastructure):** git-notes memory, full-text search, code graph (AST + call edges), tree-sitter chunking. Works immediately with no setup.
+**Built-in (no inference server or cloud dependency):** git-notes memory, full-text search, code graph (AST + call edges), tree-sitter chunking. Full-text search and `spelunk graph <symbol>` run live even in an uninitialized directory; the index-backed paths (`chunks`, `check`, memory, and `graph` on a file path) need `spelunk init` first.
 
 **Semantic search via spelunk-server:** from v0.9.0 the default UX runs a local `spelunk-server` (auto-bound on `127.0.0.1`). The server bundles a native embedder (codefuse-ai/F2LLM-v2-330M, 896-dim, candle runtime, Metal/GPU on macOS) — no external embedding endpoint required. Semantic search, `spelunk explore`, `spelunk memory harvest`, and LLM summaries all route through the server's inference endpoints; the CLI talks to it via `server_client.rs`. Manage the daemon with `spelunk server start|stop|status|logs`. This **auto-discovered loopback server is an inference backend only** — it embeds queries and runs LLM calls, but it is **never** a memory store. A project's memory always lives in its local `memory.db`; the loopback server holds no authoritative memory.
 

--- a/crates/spelunk-cli/src/cli/cmd/check.rs
+++ b/crates/spelunk-cli/src/cli/cmd/check.rs
@@ -23,13 +23,18 @@ pub struct CheckArgs {
 
 use crate::{
     capability,
-    config::{Config, resolve_db},
+    config::{Config, require_project_db},
     storage::{Database, open_memory_backend},
     utils::{format_age, worktree_modified_files},
 };
 
 pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
-    let db_path = resolve_db(args.db.as_deref(), &cfg.db_path);
+    // ADR-067: fail closed in an un-init'd dir rather than checking the
+    // machine-global index.db. Explicit `--db` bypasses the project gate.
+    let db_path = match args.db.as_deref() {
+        Some(p) => p.to_path_buf(),
+        None => require_project_db(&cfg.db_path, false)?,
+    };
     if !db_path.exists() {
         anyhow::bail!(
             "No index found (checked current directory and parents).\n\
@@ -91,7 +96,7 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                     .unwrap_or(serde_json::Value::Null),
             ),
         };
-        let mem_path = resolve_db(args.db.as_deref(), &cfg.db_path).with_file_name("memory.db");
+        let mem_path = db_path.with_file_name("memory.db");
         let memory_backend_kind = open_memory_backend(&cfg, &mem_path, None)
             .await
             .ok()
@@ -158,7 +163,7 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
 
     // Show active intent entries (text mode only; silently skip if memory unavailable).
     if effective == "text" || effective == "porcelain" {
-        let mem_path = resolve_db(args.db.as_deref(), &cfg.db_path).with_file_name("memory.db");
+        let mem_path = db_path.with_file_name("memory.db");
         if let Ok(backend) = open_memory_backend(&cfg, &mem_path, None).await
             && let Ok(intents) = backend.list(Some("intent"), 20, false, None).await
             && !intents.is_empty()

--- a/crates/spelunk-cli/src/cli/cmd/explore.rs
+++ b/crates/spelunk-cli/src/cli/cmd/explore.rs
@@ -41,10 +41,14 @@ use crate::{
 };
 
 pub async fn explore(args: ExploreArgs, cfg: Config) -> Result<()> {
+    // ADR-067: gate on a local project first (fail-closed, no global fallback) so
+    // an un-init'd dir refuses before any server probe, and explore never reads
+    // the machine-global index.db.
+    let (db_path, _db) = open_project_db(args.db.as_deref(), &cfg.db_path)?;
+
     let tier = capability::get_tier(&cfg).await;
     capability::require_tier1("explore", tier, cfg.server_url.as_deref())?;
 
-    let (db_path, _db) = open_project_db(args.db.as_deref(), &cfg.db_path)?;
     maybe_warn_stale(&db_path);
     crate::storage::record_usage_at(&db_path, "explore");
 

--- a/crates/spelunk-cli/src/cli/cmd/graph.rs
+++ b/crates/spelunk-cli/src/cli/cmd/graph.rs
@@ -49,9 +49,13 @@ pub fn graph(args: GraphArgs, cfg: Config) -> Result<()> {
         return graph_live(symbol, &args.format, &args.kind, Path::new("."));
     }
 
+    // ADR-067: resolves fail-closed (no global fallback) via open_project_db.
     let db_result = open_project_db(args.db.as_deref(), &cfg.db_path);
 
-    // No index present — fall back to ast-grep for symbol queries.
+    // No local project or no index — run the live ast-grep graph for symbol
+    // queries (mirrors search's auto/live posture) rather than reading the
+    // machine-global store. File queries need the index, so they propagate the
+    // refuse error below.
     if db_result.is_err() && !is_file_query {
         return graph_live(symbol, &args.format, &args.kind, Path::new("."));
     }

--- a/crates/spelunk-cli/src/cli/cmd/helpers.rs
+++ b/crates/spelunk-cli/src/cli/cmd/helpers.rs
@@ -1,19 +1,25 @@
 use anyhow::{Context, Result};
 
 use crate::{
-    config::{Config, resolve_db},
+    config::{Config, require_project_db},
     embeddings::vec_to_blob,
     server_client::ServerInferenceClient,
     storage::Database,
 };
 
-/// Resolve the DB path via `resolve_db`, error if not found, open and return
-/// both the path and the opened database.
+/// ADR-067: resolve the project's `index.db` fail-closed via
+/// [`require_project_db`] (no machine-global fallback), error if it does not
+/// exist, then open it. An explicit `--db` bypasses the project gate. In an
+/// un-`init`'d dir this refuses with the ADR-067 message instead of reading the
+/// global `~/.config/spelunk/index.db`.
 pub(crate) fn open_project_db(
     db: Option<&std::path::Path>,
     cfg_path: &std::path::Path,
 ) -> Result<(std::path::PathBuf, Database)> {
-    let db_path = resolve_db(db, cfg_path);
+    let db_path = match db {
+        Some(p) => p.to_path_buf(),
+        None => require_project_db(cfg_path, false)?,
+    };
     if !db_path.exists() {
         anyhow::bail!(
             "No index found (checked current directory and parents).\n\

--- a/crates/spelunk-cli/src/cli/cmd/misc.rs
+++ b/crates/spelunk-cli/src/cli/cmd/misc.rs
@@ -30,6 +30,8 @@ pub fn languages() -> Result<()> {
 }
 
 pub fn chunks(args: ChunksArgs, cfg: Config) -> Result<()> {
+    // ADR-067: chunks needs the index and has no live mode, so an un-init'd dir
+    // refuses via open_project_db rather than reading the global store.
     let (_db_path, db) = open_project_db(args.db.as_deref(), &cfg.db_path)?;
     // Stored paths use forward slashes; normalize the query arg so a Windows
     // caller passing `src\lib.rs` matches the indexed `src/lib.rs`.

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -34,6 +34,12 @@ fn global_memory_db(home: &Path) -> std::path::PathBuf {
     home.join(".config").join("spelunk").join("memory.db")
 }
 
+/// The global index store path under the isolated HOME. Display commands must
+/// never read or create it from an un-init'd dir (ADR-067, spelunk-oss^147).
+fn global_index_db(home: &Path) -> std::path::PathBuf {
+    home.join(".config").join("spelunk").join("index.db")
+}
+
 // ── refuse-guard: un-init'd dir, no --db ───────────────────────────────────────
 
 #[test]
@@ -424,6 +430,147 @@ fn refused_index_search_does_not_touch_preexisting_global_index() {
         std::fs::read(&global_index).unwrap(),
         sentinel,
         "refused index-backed search must not touch the pre-existing global index"
+    );
+}
+
+// ── display commands: graph / chunks / explore / check (spelunk-oss^147) ───────
+//
+// These read-only commands previously resolved their DB via the legacy
+// `open_project_db`/`resolve_db` path, which fell back to the machine-global
+// `index.db` in an un-init'd dir and displayed cross-project data. They now share
+// ADR-067's fail-closed resolver: refuse (or run live) instead of reading global.
+
+#[test]
+fn graph_runs_live_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::write(
+        proj.path().join("lib.rs"),
+        "pub fn greet(name: &str) -> String { format!(\"hi {name}\") }\n\
+         fn caller() { greet(\"x\"); }\n",
+    )
+    .unwrap();
+
+    // A symbol query in an un-init'd dir must degrade to the live ast-grep graph
+    // (mirroring search), matching the `greet(...)` call site in `caller`, not
+    // read the machine-global index.
+    bin(home.path(), proj.path())
+        .args(["graph", "greet", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lib.rs"))
+        .stdout(predicate::str::contains("calls"));
+
+    assert!(
+        !global_index_db(home.path()).exists(),
+        "live graph must not create the global index"
+    );
+}
+
+#[test]
+fn graph_does_not_read_preexisting_global_index() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::write(
+        proj.path().join("lib.rs"),
+        "pub fn greet(name: &str) -> String { format!(\"hi {name}\") }\n\
+         fn caller() { greet(\"x\"); }\n",
+    )
+    .unwrap();
+
+    let global = global_index_db(home.path());
+    std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+    let sentinel = b"pre-existing global index sentinel";
+    std::fs::write(&global, sentinel).unwrap();
+
+    // The symbol query runs live and must leave the stray global index untouched
+    // rather than opening it (the pre-fix bug displayed its cross-project edges).
+    bin(home.path(), proj.path())
+        .args(["graph", "greet", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lib.rs"));
+
+    assert_eq!(
+        std::fs::read(&global).unwrap(),
+        sentinel,
+        "live graph must not open or mutate the pre-existing global index"
+    );
+}
+
+#[test]
+fn graph_file_query_refuses_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    // A file-path query needs the index and has no live mode, so it must refuse
+    // rather than fall back to the global store.
+    bin(home.path(), proj.path())
+        .args(["graph", "src/lib.rs"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+}
+
+#[test]
+fn chunks_refuses_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    let global = global_index_db(home.path());
+    std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+    let sentinel = b"pre-existing global index sentinel";
+    std::fs::write(&global, sentinel).unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["chunks", "src/lib.rs"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert_eq!(
+        std::fs::read(&global).unwrap(),
+        sentinel,
+        "refused chunks must not open or mutate the pre-existing global index"
+    );
+}
+
+#[test]
+fn explore_refuses_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    // The project gate fires before any server probe, so an un-init'd dir refuses
+    // with the ADR-067 message rather than reading the global index.
+    bin(home.path(), proj.path())
+        .args(["explore", "how does auth work"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert!(!global_index_db(home.path()).exists());
+}
+
+#[test]
+fn check_refuses_without_local_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    let global = global_index_db(home.path());
+    std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+    let sentinel = b"pre-existing global index sentinel";
+    std::fs::write(&global, sentinel).unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["check"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert_eq!(
+        std::fs::read(&global).unwrap(),
+        sentinel,
+        "refused check must not open or mutate the pre-existing global index"
     );
 }
 

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -503,6 +503,11 @@ fn graph_file_query_refuses_without_local_project() {
     let home = TempDir::new().unwrap();
     let proj = TempDir::new().unwrap();
 
+    let global = global_index_db(home.path());
+    std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+    let sentinel = b"pre-existing global index sentinel";
+    std::fs::write(&global, sentinel).unwrap();
+
     // A file-path query needs the index and has no live mode, so it must refuse
     // rather than fall back to the global store.
     bin(home.path(), proj.path())
@@ -510,6 +515,12 @@ fn graph_file_query_refuses_without_local_project() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(NO_PROJECT_ERR));
+
+    assert_eq!(
+        std::fs::read(&global).unwrap(),
+        sentinel,
+        "refused graph file-query must not open or mutate the pre-existing global index"
+    );
 }
 
 #[test]
@@ -540,6 +551,11 @@ fn explore_refuses_without_local_project() {
     let home = TempDir::new().unwrap();
     let proj = TempDir::new().unwrap();
 
+    let global = global_index_db(home.path());
+    std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+    let sentinel = b"pre-existing global index sentinel";
+    std::fs::write(&global, sentinel).unwrap();
+
     // The project gate fires before any server probe, so an un-init'd dir refuses
     // with the ADR-067 message rather than reading the global index.
     bin(home.path(), proj.path())
@@ -548,7 +564,11 @@ fn explore_refuses_without_local_project() {
         .failure()
         .stderr(predicate::str::contains(NO_PROJECT_ERR));
 
-    assert!(!global_index_db(home.path()).exists());
+    assert_eq!(
+        std::fs::read(&global).unwrap(),
+        sentinel,
+        "refused explore must not open or mutate the pre-existing global index"
+    );
 }
 
 #[test]
@@ -571,6 +591,123 @@ fn check_refuses_without_local_project() {
         std::fs::read(&global).unwrap(),
         sentinel,
         "refused check must not open or mutate the pre-existing global index"
+    );
+}
+
+// ── happy path: an init'd project still resolves graph/chunks/check locally ────
+//
+// The fail-closed rework must not break the normal case: with a real local
+// `.spelunk/index.db`, the display commands resolve LOCAL (not global) and work.
+// A stray global index is left in place to prove they read local, not global.
+
+#[test]
+fn display_commands_resolve_local_index_in_initd_project() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::write(
+        proj.path().join("lib.rs"),
+        "pub fn local_target() -> u32 { 7 }\n\
+         fn local_caller() { let _ = local_target(); }\n",
+    )
+    .unwrap();
+
+    // A stray machine-global index that must never be consulted by the local
+    // happy path (garbage bytes: if any command opened it as SQLite it would err).
+    let global = global_index_db(home.path());
+    std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+    let sentinel = b"stray global index sentinel";
+    std::fs::write(&global, sentinel).unwrap();
+
+    // Create the local project.
+    bin(home.path(), proj.path())
+        .args(["index", "."])
+        .assert()
+        .success();
+    assert!(proj.path().join(".spelunk").join("index.db").exists());
+
+    // graph: index-backed symbol query resolves the LOCAL index and shows the edge.
+    bin(home.path(), proj.path())
+        .args(["graph", "local_target", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lib.rs"))
+        .stdout(predicate::str::contains("local_target"));
+
+    // chunks: resolves the LOCAL index and returns this file's chunks.
+    bin(home.path(), proj.path())
+        .args(["chunks", "lib.rs", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("local_target"));
+
+    // check: resolves the LOCAL index and reports on it rather than refusing.
+    bin(home.path(), proj.path())
+        .args(["check"])
+        .assert()
+        .success();
+
+    assert_eq!(
+        std::fs::read(&global).unwrap(),
+        sentinel,
+        "init'd-project display commands must resolve local and never touch the global store"
+    );
+}
+
+// ── strongest isolation assertion: a REAL populated global is never surfaced ───
+//
+// The refuse tests above use garbage-byte sentinels (which prove the file is not
+// opened). graph is the one display command with a live fallback, so it is the
+// only place a resolver regression could actually *print* cross-project data.
+// This uses a genuine populated global index and asserts its data never appears.
+
+#[test]
+fn graph_does_not_surface_real_populated_global_index() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+
+    // Build a real index elsewhere, then copy it into the machine-global location
+    // so the global store holds genuine graph edges for `global_only_symbol`.
+    let global_src = tmp.path().join("global_src");
+    std::fs::create_dir_all(&global_src).unwrap();
+    std::fs::write(
+        global_src.join("secret_global_file.rs"),
+        "pub fn global_only_symbol() -> u32 { 1 }\n\
+         fn global_only_caller() { let _ = global_only_symbol(); }\n",
+    )
+    .unwrap();
+    bin(home.path(), &global_src)
+        .args(["index", "."])
+        .assert()
+        .success();
+    let real_global_index = global_src.join(".spelunk").join("index.db");
+    assert!(
+        real_global_index.exists(),
+        "precondition: real global index built"
+    );
+
+    let global = global_index_db(home.path());
+    std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+    std::fs::copy(&real_global_index, &global).unwrap();
+    let before = std::fs::read(&global).unwrap();
+
+    // A sibling (not ancestor) un-init'd dir with no source defining the symbol.
+    // If graph regressed to reading the global store it would print
+    // `global_only_caller` / `secret_global_file`; the fail-closed live scan over
+    // this empty dir must not.
+    let proj = tmp.path().join("uninit");
+    std::fs::create_dir_all(&proj).unwrap();
+
+    bin(home.path(), &proj)
+        .args(["graph", "global_only_symbol", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("global_only_caller").not())
+        .stdout(predicate::str::contains("secret_global_file").not());
+
+    assert_eq!(
+        std::fs::read(&global).unwrap(),
+        before,
+        "graph in an un-init'd dir must not open the real populated global index"
     );
 }
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -145,7 +145,7 @@ AGENT=true spelunk explore "where is the embedding model loaded?" --max-steps 3
 ## After making changes
 
 ```bash
-# Confirm call sites still match using the code graph (always works)
+# Confirm call sites still match using the code graph (symbol queries work live even without an index)
 spelunk graph validate_token --kind calls
 
 # If the project is indexed: re-index changed files (incremental, blake3-gated)


### PR DESCRIPTION
## Problem

ADR-067 made spelunk fail closed against the machine-global index (`~/.config/spelunk/index.db`) so an un-`init`'d directory refuses rather than silently reading or writing a machine-global store, but four read-only display commands were missed. `graph`, `chunks`, `explore`, and `check` still resolved their DB through the legacy `open_project_db` / `resolve_db` fallback, so in an uninitialized directory they opened the machine-global `index.db` and could surface another project's data (a read-only cross-project exposure).

## Fix

Route these commands through ADR-067's fail-closed resolver:

- `open_project_db` (shared by `graph`, `chunks`, `explore`) now resolves via `require_project_db(cfg, false)` instead of `resolve_db`, so there is no global fallback.
- `check` resolves its DB path the same way inline.
- `graph <symbol>` degrades to a live ast-grep scan in an un-`init`'d dir (mirroring `search`'s auto/live posture); `graph <file-path>`, `chunks`, `explore`, and `check` need the index and so refuse with `no spelunk project here. Run 'spelunk init' first`.
- An explicit `--db` still bypasses the project gate (defaults to `None`; only an explicit value is honored). Initialized projects resolve their local `.spelunk/index.db` exactly as before.

Docs (`CLAUDE.md`, `docs/agent-guide.md`) and the CHANGELOG are reconciled with the shipped behavior: `graph <symbol>` works live even without an index, while the index-backed paths need `spelunk init` first.

## Test plan

New isolation coverage in `crates/spelunk-cli/tests/fail_closed_no_project.rs`, run against a pre-existing populated global `index.db` under an isolated HOME:

- `graph <symbol>` runs live and its output never contains the global store's symbols; the real populated global index is left byte-for-byte unchanged.
- `graph <file-path>`, `chunks`, `explore`, and `check` each refuse in an un-`init`'d dir and leave a stray global index untouched.
- Happy path: an `init`'d project resolves its LOCAL index for `graph` / `chunks` / `check` while a stray global index is never consulted.

Full gate, both feature sets:

- `cargo test` and `cargo test --no-default-features` (`fail_closed_no_project`: 27 passed on both)
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings` and `--no-default-features` (both clean)

Refs ADR-067.
