### PR TITLE
fix(cli): context --budget keeps durable memory ahead of questions (spelunk-oss^149)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/context.rs
+++ b/crates/spelunk-cli/src/cli/cmd/context.rs
@@ -117,8 +117,15 @@ fn cap_sections(sections: &mut [(String, Vec<Note>)], limit_override: Option<usi
     }
 }
 
-/// Greedily drop notes then conventions (in output order) that don't fit
-/// `budget`, mirroring `search --budget`. Returns the tokens actually packed.
+/// Order in which sections compete for `--budget`: durable "why"
+/// (decision, requirement) survives first, ephemeral `question` drops first.
+/// Display/emission order is independent of this (see `SECTIONS`).
+const PACK_PRIORITY: &[&str] = &["decision", "requirement", "handoff", "question"];
+
+/// Greedily drop notes then conventions that don't fit `budget`. Notes are
+/// packed in `PACK_PRIORITY` order so durable memory wins a tight budget, but
+/// the `sections` Vec is not reordered: display order stays as assembled.
+/// Returns the tokens actually packed. Conventions pack after all sections.
 fn apply_budget(
     sections: &mut [(String, Vec<Note>)],
     conventions: &mut Vec<crate::conventions::ConventionRecord>,
@@ -133,7 +140,17 @@ fn apply_budget(
             false
         }
     };
-    for (_, notes) in sections.iter_mut() {
+    // Pack by priority, then any kind not in the priority list in existing
+    // order (defensive: no such kind today). `sections` is never reordered.
+    for kind in PACK_PRIORITY {
+        if let Some((_, notes)) = sections.iter_mut().find(|(k, _)| k == kind) {
+            notes.retain(|n| fits(note_tokens(n)));
+        }
+    }
+    for (kind, notes) in sections.iter_mut() {
+        if PACK_PRIORITY.contains(&kind.as_str()) {
+            continue;
+        }
         notes.retain(|n| fits(note_tokens(n)));
     }
     conventions.retain(|c| {
@@ -551,10 +568,11 @@ mod tests {
     }
 
     #[test]
-    fn budget_packs_sections_in_output_order_and_can_starve_a_later_section() {
-        // Budget is spent across sections in their fixed output order, so a
-        // budget-hungry earlier section starves a later one. Section slots and
-        // their order stay stable (a section can end up empty, not removed).
+    fn budget_packs_by_priority_not_display_order() {
+        // Budget is spent in PACK_PRIORITY order, not display order: `decision`
+        // outranks `handoff`, so under a tight budget the decision survives even
+        // though handoff is emitted first. Section slots and their display order
+        // stay stable (a starved section ends up empty, not removed).
         let big = "x".repeat(800); // title(1)+body(200) = 201 tokens
         let small = "x".repeat(400); // title(1)+body(100) = 101 tokens
         let mut sections = vec![
@@ -565,18 +583,90 @@ mod tests {
             ),
         ];
         let mut conv: Vec<ConventionRecord> = vec![];
-        // Budget fits exactly the first section's note, leaving nothing for the
-        // second — proving spend follows output order and can starve a later one.
+        // 201-token budget: decision (101) packs first and fits; handoff (201)
+        // no longer fits the 100 that remain — reversed vs a display-order pass.
         let used = apply_budget(&mut sections, &mut conv, 201);
         assert_eq!(sections.len(), 2, "section slots and order are preserved");
         assert_eq!(sections[0].0, "handoff");
-        assert_eq!(sections[0].1.len(), 1, "earlier section packed first");
-        assert_eq!(sections[1].0, "decision");
         assert!(
-            sections[1].1.is_empty(),
-            "later section starved once budget is exhausted"
+            sections[0].1.is_empty(),
+            "handoff starved despite being displayed first"
         );
-        assert_eq!(used, 201);
+        assert_eq!(sections[1].0, "decision");
+        assert_eq!(sections[1].1.len(), 1, "higher-priority decision survives");
+        assert_eq!(used, 101);
+    }
+
+    #[test]
+    fn budget_prioritizes_durable_over_questions() {
+        // Ticket ^149: under a tight budget, durable decision/requirement notes
+        // must survive while ephemeral questions drop first, regardless of the
+        // fact that `question` is displayed before decision/requirement.
+        let body = "x".repeat(400); // title(1)+body(100) = 101 tokens each
+        let mut sections = vec![
+            ("handoff".to_string(), vec![note(0, "handoff", "ti", &body)]),
+            (
+                "question".to_string(),
+                vec![
+                    note(1, "question", "ti", &body),
+                    note(2, "question", "ti", &body),
+                    note(3, "question", "ti", &body),
+                ],
+            ),
+            (
+                "decision".to_string(),
+                vec![
+                    note(4, "decision", "ti", &body),
+                    note(5, "decision", "ti", &body),
+                ],
+            ),
+            (
+                "requirement".to_string(),
+                vec![
+                    note(6, "requirement", "ti", &body),
+                    note(7, "requirement", "ti", &body),
+                ],
+            ),
+        ];
+        let mut conv: Vec<ConventionRecord> = vec![];
+        // 505 tokens = 2 decisions + 2 requirements + 1 handoff (5 * 101). All
+        // durable notes plus handoff fit; the 3 questions are dropped first.
+        let used = apply_budget(&mut sections, &mut conv, 505);
+        // Emission order is unchanged.
+        let kinds: Vec<&str> = sections.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(kinds, ["handoff", "question", "decision", "requirement"]);
+        assert_eq!(sections[0].1.len(), 1, "handoff kept (outranks question)");
+        assert!(sections[1].1.is_empty(), "questions dropped first");
+        assert_eq!(sections[2].1.len(), 2, "every decision survives");
+        assert_eq!(sections[3].1.len(), 2, "every requirement survives");
+        assert_eq!(used, 505);
+    }
+
+    #[test]
+    fn budget_preserves_display_order_of_sections() {
+        // The retain pass reorders nothing: whatever budget survivors remain,
+        // the sections Vec keeps its assembled display order.
+        let body = "x".repeat(400);
+        let mut sections = vec![
+            ("handoff".to_string(), vec![note(0, "handoff", "ti", &body)]),
+            (
+                "question".to_string(),
+                vec![note(1, "question", "ti", &body)],
+            ),
+            (
+                "decision".to_string(),
+                vec![note(2, "decision", "ti", &body)],
+            ),
+            (
+                "requirement".to_string(),
+                vec![note(3, "requirement", "ti", &body)],
+            ),
+        ];
+        let mut conv: Vec<ConventionRecord> = vec![];
+        // A budget that only fits some notes still must not shuffle the Vec.
+        apply_budget(&mut sections, &mut conv, 150);
+        let kinds: Vec<&str> = sections.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(kinds, ["handoff", "question", "decision", "requirement"]);
     }
 
     #[test]

--- a/crates/spelunk-cli/tests/context.rs
+++ b/crates/spelunk-cli/tests/context.rs
@@ -152,6 +152,113 @@ fn context_cmd(_db_path: &Path, config_path: &Path) -> Command {
     cmd
 }
 
+/// Seed a fresh project with fixed-size notes so `--budget` token math is
+/// deterministic (chars/4 heuristic): each note is a 4-char title (1 token) +
+/// 400-char body (100 tokens) = 101 tokens. 1 handoff, 3 questions, 2
+/// decisions, 2 requirements. Returns `(TempDir, config_path)`.
+fn setup_budget_project() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("create temp dir");
+    std::fs::create_dir_all(tmp.path().join(".spelunk")).expect("create .spelunk");
+    let db_path = tmp.path().join(".spelunk").join("index.db");
+    // No embed server needed: memory add stores without a vector when no server
+    // is configured, which is irrelevant to budget packing.
+    let config_path = write_config_for_context(tmp.path(), &db_path, "http://127.0.0.1:19999");
+    let mem_path = db_path.with_file_name("memory.db");
+
+    let body = "x".repeat(400); // 100 tokens; 4-char title => 101 tokens/note
+    let entries: &[(&str, &str)] = &[
+        ("handoff", "hnd0"),
+        ("question", "qst0"),
+        ("question", "qst1"),
+        ("question", "qst2"),
+        ("decision", "dec0"),
+        ("decision", "dec1"),
+        ("requirement", "req0"),
+        ("requirement", "req1"),
+    ];
+    for (kind, title) in entries {
+        spelunk_bin()
+            .arg("--config")
+            .arg(&config_path)
+            .arg("memory")
+            .arg("--db")
+            .arg(&mem_path)
+            .arg("add")
+            .arg("--kind")
+            .arg(kind)
+            .arg("--title")
+            .arg(title)
+            .arg("--body")
+            .arg(&body)
+            .assert()
+            .success();
+    }
+    (tmp, config_path)
+}
+
+// ── budget: durable priority end-to-end (spelunk-oss^149) ─────────────────────
+
+#[test]
+fn context_budget_keeps_durable_drops_questions_e2e() {
+    // Drives the real `spelunk context --budget` CLI path. A 505-token budget
+    // fits every decision+requirement+handoff (5 * 101) with nothing left for
+    // the 3 questions, so questions must drop first while durable notes survive
+    // — regardless of question being displayed before decision/requirement.
+    let (_tmp, config_path) = setup_budget_project();
+
+    let mut cmd = spelunk_bin();
+    if let Some(dir) = config_path.parent() {
+        cmd.current_dir(dir);
+    }
+    let output = cmd
+        .arg("--config")
+        .arg(&config_path)
+        .arg("context")
+        .arg("--budget")
+        .arg("505")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+    let obj: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let parsed = obj["sections"].as_array().expect("sections array");
+
+    // Display order is unchanged by budget packing.
+    let kinds: Vec<&str> = parsed.iter().map(|s| s[0].as_str().unwrap()).collect();
+    assert_eq!(
+        kinds,
+        ["handoff", "question", "decision", "requirement"],
+        "section display order must stay handoff -> question -> decision -> requirement"
+    );
+
+    let len_of = |kind: &str| -> usize {
+        parsed
+            .iter()
+            .find(|s| s[0].as_str() == Some(kind))
+            .and_then(|s| s[1].as_array())
+            .map(|n| n.len())
+            .unwrap_or(0)
+    };
+    assert_eq!(len_of("decision"), 2, "every durable decision survives");
+    assert_eq!(
+        len_of("requirement"),
+        2,
+        "every durable requirement survives"
+    );
+    assert_eq!(len_of("handoff"), 1, "handoff outranks question, survives");
+    assert_eq!(len_of("question"), 0, "ephemeral questions drop first");
+
+    // Budget accounting is reported and never exceeds the cap.
+    assert_eq!(obj["token_budget"].as_u64(), Some(505));
+    assert_eq!(obj["tokens_used"].as_u64(), Some(505));
+    assert_eq!(obj["tokens_remaining"].as_u64(), Some(0));
+}
+
 // ── happy path: default text output ───────────────────────────────────────────
 
 #[test]

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -93,7 +93,7 @@ Flags:
 - `--kind decision` — narrow to one section
 - `--path src/auth` — filter by file path tag
 - `--limit N` – entries per section (defaults: handoff=3, question=10, decision=10, requirement=10); mutually exclusive with `--budget`
-- `--budget N` (alias `--max-tokens`) – cap total output at N tokens; mutually exclusive with `--limit`
+- `--budget N` (alias `--max-tokens`) – cap total output at N tokens; mutually exclusive with `--limit`. Under a tight budget, durable decisions and requirements are kept ahead of open questions.
 - `--no-conventions` — skip the extracted-conventions section
 
 `spelunk context` also surfaces a **conventions** section: coding conventions

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -255,6 +255,10 @@ spelunk context [options]
 | `--no-conventions` | false | Skip the conventions section |
 | `--local-only` | false | Skip cross-project dep pass; query only the primary project's memory |
 
+Under a tight `--budget`, durable memory (decisions and requirements) is kept
+ahead of ephemeral open questions when trimming to fit; the section display
+order is unchanged.
+
 When projects are linked with `spelunk link`, `context` also surfaces `locked`
 or `cross-project`-tagged `decision` and `requirement` entries from linked
 projects' memory stores, each labelled with its source project. Pass


### PR DESCRIPTION
## Summary

`spelunk context --budget` previously packed sections in display order (`handoff → question → decision → requirement`), mirroring `search --budget`. Under a tight budget, ephemeral session-local `question` entries were packed before durable `decision`/`requirement` entries and could starve them out. That inverts what `context` exists to surface: the durable "why" at session start.

Unlike `search` (which relevance-sorts before packing, so emission-order packing keeps the best hits), `context` emits sections in a fixed reading order that happens to place the most ephemeral kind second. So it needs an explicit pack priority.

This change (spelunk-oss^149, architect Option (a)) decouples budget drop-priority from display order in `apply_budget`:

- Adds `PACK_PRIORITY = ["decision", "requirement", "handoff", "question"]`. The greedy retain/drop pass iterates buckets in this order, so durable memory wins a tight budget and questions drop first.
- The `sections` Vec is never reordered: `iter_mut().find()` mutates buckets in place, so JSON `sections` and text output still render in display order `handoff → question → decision → requirement`.
- Conventions still pack after all sections; `budget - remaining` token accounting is unchanged; no behaviour change when `--budget` is absent (`apply_budget` is only invoked via `args.budget.map(...)`).

### Pack-priority rationale

`decision` and `requirement` are the durable, cross-project "why" that `context` exists to surface, so they win the budget. `handoff` is session continuity (few, small, default cap 3) so it outranks `question`. `question` is the session-local open-noise kind called out in the ticket, so it is dropped first under pressure. Display/reading order is deliberately independent of this and stays unchanged in every format.

## Test plan

Independently reviewed the diff and ran the full local gate matrix in the task worktree (`SPELUNK_SECRET_STORE=file`):

- `cargo fmt --all --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo clippy --no-default-features --all-targets -- -D warnings` — clean (CI `--no-default-features` matrix cell).
- `cargo test -p spelunk-cli` — all bins pass, 0 failed (3 pre-existing server-gated ignores).

Verified the specific coverage:

- `budget_packs_by_priority_not_display_order` (rewritten): 201-token budget, `decision` (101) survives while displayed-first `handoff` (201) is starved; `used == 101`.
- `budget_prioritizes_durable_over_questions` (unit): display order `[handoff, question×3, decision×2, requirement×2]` at 101 tokens each; a 505-token budget keeps 2 decisions + 2 requirements + 1 handoff and drops all 3 questions; emission order preserved; `used == 505`.
- `budget_preserves_display_order_of_sections` (unit): after `apply_budget`, the sections Vec kinds are still `handoff, question, decision, requirement`.
- `context_budget_keeps_durable_drops_questions_e2e` (e2e): drives the real `spelunk context --budget 505 --format json` binary against a freshly-seeded project; asserts through parsed JSON that display order is unchanged, decision=2/requirement=2/handoff=1 survive, question=0, and `token_budget=505 / tokens_used=505 / tokens_remaining=0`. This is real token-weighted starvation, not a tautology.

Also confirmed by review: token accounting uses a single shared `remaining` accumulator (`FnMut`), so no double-count across the priority passes and conventions; and the no-`--budget` path is untouched.

Staleness: branch base `8aed06382` equals freshly-fetched `origin/main` HEAD — no rebase needed.

Ref: spelunk-oss^149
