### PR TITLE
refactor(cli): remove unreachable server_url branch from inference-required message (spelunk-oss^148)

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -617,30 +617,17 @@ fn current_uid() -> Option<u32> {
 /// Guidance for an *inference*-backed feature (semantic `memory search`,
 /// `memory timeline`, `memory harvest`) that has no reachable server.
 ///
-/// These features only need inference (query embedding / LLM extraction), which
-/// a zero-config local server satisfies — so the remedy depends on state:
-///   - `server_url` unset → no server is configured; point at the local
-///     auto-server. Never mention `server_url` (that is team-memory setup, a
-///     heavier and unrelated fix).
-///   - `server_url` set but unreachable → the configured team server is down;
-///     surface the URL so the user knows what to check.
-///
-/// This is deliberately NOT `require_tier1`'s message: `memory push/pull/watch`
-/// and `sync` genuinely require an explicit team `server_url`, so for those the
-/// `server_url` advice is correct.
-pub fn inference_server_required_message(feature: &str, server_url: Option<&str>) -> String {
-    match server_url {
-        None => format!(
-            "'spelunk {feature}' requires spelunk-server.\n\
-             Run `spelunk server start` to enable this feature."
-        ),
-        Some(url) => format!(
-            "'spelunk {feature}' requires spelunk-server.\n\
-             The configured server_url ({url}) is unreachable. Start it and retry, or \
-             remove server_url from ~/.config/spelunk/config.toml to use a local server \
-             (`spelunk server start`)."
-        ),
-    }
+/// Emitted at client construction, where reachability is unknown: when
+/// `server_url` is set, construction always succeeds, so this message only ever
+/// fires with `server_url` unset. It therefore carries no configured-server
+/// hint; a team-server-unreachable hint, if ever wanted, must be produced at the
+/// inference call site where the connection failure is observed. `server_url`
+/// advice stays `require_tier1`'s job for the genuinely team-only features.
+pub fn inference_server_required_message(feature: &str) -> String {
+    format!(
+        "'spelunk {feature}' requires spelunk-server.\n\
+         Run `spelunk server start` to enable this feature."
+    )
 }
 
 /// Return `Ok(())` if the tier is `Server`, otherwise return an `anyhow::Error`
@@ -923,7 +910,7 @@ mod tests {
     /// and must NOT mention `server_url` (the misleading team-infra advice).
     #[test]
     fn inference_msg_no_server_url_points_at_local_start_only() {
-        let msg = inference_server_required_message("memory search", None);
+        let msg = inference_server_required_message("memory search");
         assert!(msg.contains("'spelunk memory search' requires spelunk-server"));
         assert!(
             msg.contains("spelunk server start"),
@@ -935,22 +922,11 @@ mod tests {
         );
     }
 
-    /// A team `server_url` IS configured but unreachable: mentioning it is now
-    /// legitimate, and the message still offers the local fallback.
-    #[test]
-    fn inference_msg_configured_server_url_mentions_it() {
-        let msg =
-            inference_server_required_message("memory search", Some("https://team.example:7777"));
-        assert!(msg.contains("server_url"));
-        assert!(msg.contains("https://team.example:7777"));
-        assert!(msg.contains("spelunk server start"));
-    }
-
     /// Feature name is interpolated (harvest reuses this via
     /// `harvest_requires_server`, preserving its Tier-0 substring contract).
     #[test]
     fn inference_msg_interpolates_feature_and_keeps_harvest_substring() {
-        let msg = inference_server_required_message("memory harvest", None);
+        let msg = inference_server_required_message("memory harvest");
         assert!(msg.contains("'spelunk memory harvest' requires spelunk-server"));
     }
 

--- a/crates/spelunk-cli/src/cli/cmd/helpers.rs
+++ b/crates/spelunk-cli/src/cli/cmd/helpers.rs
@@ -33,8 +33,7 @@ pub(crate) fn require_server_client(cfg: &Config, feature: &str) -> Result<Serve
     // for an auto-discovered loopback and `Some` only for an explicit team URL.
     ServerInferenceClient::from_config(cfg).ok_or_else(|| {
         anyhow::anyhow!(crate::capability::inference_server_required_message(
-            feature,
-            cfg.server_url.as_deref()
+            feature
         ))
     })
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -59,10 +59,9 @@ pub(super) async fn memory_harvest(
     let cfg = &eff_cfg;
 
     // Tier-0: harvest requires server inference (#259 locked-feature error).
-    // Pass the configured team `server_url` (usually `None` here) so the guidance
-    // points at the local auto-server rather than team setup (oss^133).
+    // Guidance points at the local auto-server, never team `server_url` setup (oss^133).
     if cfg.resolve_inference_url().is_none() {
-        return Err(harvest_requires_server(cfg.server_url.as_deref()));
+        return Err(harvest_requires_server());
     }
 
     if args.detach {
@@ -193,8 +192,7 @@ async fn memory_harvest_git(
         }
     });
 
-    let server = ServerInferenceClient::from_config(cfg)
-        .ok_or_else(|| harvest_requires_server(cfg.server_url.as_deref()))?;
+    let server = ServerInferenceClient::from_config(cfg).ok_or_else(harvest_requires_server)?;
 
     let mut stored = 0usize;
     let mut dedup_skipped = 0usize;
@@ -579,8 +577,7 @@ async fn memory_harvest_failures(
         }
     });
 
-    let server = ServerInferenceClient::from_config(cfg)
-        .ok_or_else(|| harvest_requires_server(cfg.server_url.as_deref()))?;
+    let server = ServerInferenceClient::from_config(cfg).ok_or_else(harvest_requires_server)?;
 
     let mut stored = 0usize;
     let mut dedup_skipped = 0usize;

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
@@ -46,8 +46,7 @@ pub(super) async fn harvest_claude_code(
     backend_override: Option<&str>,
 ) -> Result<()> {
     // Tier-0 gate: harvest requires server inference.
-    let server = ServerInferenceClient::from_config(cfg)
-        .ok_or_else(|| harvest_requires_server(cfg.server_url.as_deref()))?;
+    let server = ServerInferenceClient::from_config(cfg).ok_or_else(harvest_requires_server)?;
 
     // 1. Require explicit confirmation.
     if !args.confirm {

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -600,13 +600,11 @@ fn server_inference_error(endpoint: &str, status: reqwest::StatusCode, body: &st
 
 /// Return the locked-feature error when harvest is attempted without a server.
 ///
-/// Harvest needs inference only, so a local `spelunk server start` suffices;
-/// pass the configured team `server_url` (or `None`) so the message points at
-/// the right fix (oss^133). See `capability::inference_server_required_message`.
-pub fn harvest_requires_server(server_url: Option<&str>) -> anyhow::Error {
+/// Harvest needs inference only, so a local `spelunk server start` suffices.
+/// See `capability::inference_server_required_message`.
+pub fn harvest_requires_server() -> anyhow::Error {
     anyhow::anyhow!(crate::capability::inference_server_required_message(
-        "memory harvest",
-        server_url
+        "memory harvest"
     ))
 }
 


### PR DESCRIPTION
## Summary

Removes the structurally-unreachable `Some(url)` arm of `inference_server_required_message` (`capability.rs`) and its now-unused `server_url` parameter, then updates the callers. No behaviour or docs change: the emitted text is byte-for-byte the surviving `None`-branch message.

### Why the branch was dead

`inference_server_required_message` fires only through `require_server_client` (`helpers.rs`), which emits it when `ServerInferenceClient::from_config(cfg)` is `None`. `from_config` returns `None` only when `cfg.resolve_inference_url()` is `None`, and `resolve_inference_url() = inference_url.or(server_url)` is `None` only when `server_url` is also `None`. So whenever the message fired, `server_url` was provably `None` and the `Some(url)` arm could never execute.

The mismatch is structural: the message is built at client construction time, where reachability is unknown and a set `server_url` always makes construction succeed. A configured-but-unreachable team server is only observable at the inference call site (embed/LLM POST), which already returns a real connection error naming the URL, so no user is misled. Wiring a softer hint there is a separate, properly-scoped follow-up (see spelunk-oss^148 description); this PR is the dead-code cleanup only.

### Changes

- `capability.rs`: drop the `match` / `Some(url)` arm and the `server_url` param; replace the doc-comment to state the construction-time constraint.
- `helpers.rs` `require_server_client`: call the single-arg signature.
- `server_client.rs` `harvest_requires_server`: drop its pass-through `server_url` param (it always forwarded `"memory harvest"` unchanged); update its 4 call sites in `harvest.rs` / `harvest_claude.rs`.
- Tests: delete `inference_msg_configured_server_url_mentions_it` (pinned the dead branch); update the two surviving message tests to the single-arg signature. Their contract (names the feature, points at `spelunk server start`, never mentions `server_url`) is unchanged.

`require_tier1` is untouched; it legitimately mentions `server_url` for the genuinely team-only features (`memory push/pull/watch`, `sync`).

## Test plan

Ran on branch, base `8aed06382` (== origin/main, no drift), `SPELUNK_SECRET_STORE=file`:

- `cargo fmt --all --check` -> clean
- `cargo clippy --all-targets -- -D warnings` -> clean
- `cargo clippy --no-default-features --all-targets -- -D warnings` -> clean
- `cargo test -p spelunk-cli` -> all suites pass, 0 failed
- End-to-end regression guards green: `inference_server_message` (3 tests, drives the real CLI incl. the configured-but-unreachable and no-`server_url` scenarios) and `harvest_upfront_check` (5 tests)

Refs: spelunk-oss^148
