### PR TITLE
docs: retire the reverse-proxy team-server model for native HTTPS (ADR-066)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,11 +62,10 @@ services:
       SPELUNK_SERVER_KEY: ${SPELUNK_SERVER_KEY:?set SPELUNK_SERVER_KEY for a team server}
       SPELUNK_SERVER_TLS_CERT: /tls/cert
       SPELUNK_SERVER_TLS_KEY: /tls/key
-    healthcheck:
-      test: ["CMD", "/usr/local/bin/spelunk-server", "--health-check"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
+    # No container healthcheck here: the binary's built-in `--health-check` probe
+    # speaks plaintext HTTP only, so it cannot validate this in-process TLS
+    # listener (it would report unhealthy forever). Health-check the published
+    # https:// endpoint from outside the container instead.
 
 volumes:
   spelunk-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,27 @@
-# spelunk-server — minimal LOCAL SCAFFOLD (server + persistent volume)
+# spelunk-server – two shapes in one file.
 #
-# This is not a networked or team-serving deployment. spelunk-server binds
-# 127.0.0.1 inside its own container's network namespace (the image's own
-# default — see Dockerfile) and refuses to bind a non-loopback address over
-# plaintext HTTP, unconditionally, keyed or not (see
-# docs/server.md#non-loopback-plaintext-binds-are-refused-no-override). No
-# port is published here, so the server is not reachable from the host or a
-# sibling container — only from inside this same network namespace, e.g. a
-# separate container started with `--network container:spelunk-server`
-# (the runtime image itself has no curl/wget to test from a bare
-# `docker compose exec` shell — see docs/server.md#docker-local-scaffold-only).
+#   spelunk-server (default) – a minimal LOCAL SCAFFOLD. It binds 127.0.0.1
+#     inside the container's own network namespace and publishes no port, so it
+#     is reachable only from inside that namespace (e.g. a sidecar started with
+#     `--network container:spelunk-server`; the runtime image has no curl/wget to
+#     test from a bare `docker compose exec` shell). Use it to poke at the API
+#     locally. See docs/server.md#docker-a-team-server-or-a-local-scaffold.
+#     Start with:  SPELUNK_SERVER_KEY=your-key docker compose up -d
 #
-# For a team-reachable deployment, run the binary bare-metal under systemd
-# instead, with your own TLS terminator in front of the same loopback bind on
-# that host — see docs/self-hosting.md. That is the recommended path.
+#   team-server (profile) – a TEAM-REACHABLE deployment. spelunk-server binds a
+#     routable interface and terminates HTTPS in-process (ADR-066): it serves TLS
+#     itself with an operator-provided PEM cert + key, with nothing in front of
+#     it. A non-loopback bind is refused unless BOTH the TLS cert/key AND an API
+#     key are set (see
+#     docs/server.md#non-loopback-plaintext-binds-are-refused-no-override).
+#     Bring your own certificate (internal CA / certbot / cloud); the server does
+#     not renew it, so you do. Start with:
+#       SPELUNK_SERVER_KEY=your-key \
+#       SPELUNK_TLS_CERT=/etc/spelunk/tls-cert SPELUNK_TLS_KEY=/etc/spelunk/tls-key \
+#       docker compose --profile team-server up -d
 #
-# Usage:
-#   SPELUNK_SERVER_KEY=your-key docker compose up -d
+# The bare-metal/systemd path in docs/self-hosting.md is the same shape without a
+# container, and is the recommended single-host deployment.
 
 services:
   spelunk-server:
@@ -30,6 +35,34 @@ services:
     healthcheck:
       # Self-probe: the runtime image ships no curl/wget, so the binary hits its
       # own /v1/health and exits 0/non-0. Pass --port here too if you change it.
+      test: ["CMD", "/usr/local/bin/spelunk-server", "--health-check"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Team-reachable: routable TLS bind, cert + key mounted, port published.
+  # Only started with `--profile team-server`.
+  team-server:
+    build: .
+    image: spelunk-server:latest
+    profiles: ["team-server"]
+    restart: unless-stopped
+    command: ["--host", "0.0.0.0", "--port", "7777"]
+    ports:
+      # Publish the container's routable TLS port on the host's 443.
+      - "443:7777"
+    volumes:
+      - spelunk-data:/data
+      # Operator-provided PEM. The cert chain is public; the key is a secret,
+      # so keep the source file 0600 root-owned on the host.
+      - ${SPELUNK_TLS_CERT:-/etc/spelunk/tls-cert}:/tls/cert:ro
+      - ${SPELUNK_TLS_KEY:-/etc/spelunk/tls-key}:/tls/key:ro
+    environment:
+      # A routable bind is refused without a key; set a real one.
+      SPELUNK_SERVER_KEY: ${SPELUNK_SERVER_KEY:?set SPELUNK_SERVER_KEY for a team server}
+      SPELUNK_SERVER_TLS_CERT: /tls/cert
+      SPELUNK_SERVER_TLS_KEY: /tls/key
+    healthcheck:
       test: ["CMD", "/usr/local/bin/spelunk-server", "--health-check"]
       interval: 30s
       timeout: 5s

--- a/docs/adr/056-oss-server-tenancy-model.md
+++ b/docs/adr/056-oss-server-tenancy-model.md
@@ -3,6 +3,16 @@
 **Date:** 2026-07-02
 **Deciders:** founder (Johan), architect
 
+> **Clarification (2026-07-12, transport mechanism only, tenancy unchanged):**
+> This ADR's requirement that a non-loopback deployment use TLS "with no
+> override" still holds, but the *mechanism* has changed. Where the text below
+> implies TLS is terminated by a component in front of the server, read it as
+> terminated **by the server itself**: [ADR-066](066-native-tls-in-spelunk-server.md)
+> gives `spelunk-server` in-process HTTPS (`--tls-cert`/`--tls-key`), so a
+> non-loopback bind is now refused unless **both** TLS and a key are set, with
+> nothing in front of it. The tenancy model here (single trust domain, shared key
+> as the only boundary) is orthogonal to transport and is unchanged.
+
 ## Context
 
 `spelunk-server` is an HTTP listener (axum) that can hold a team's memory when a

--- a/docs/adr/058-team-server-bare-metal-deployment.md
+++ b/docs/adr/058-team-server-bare-metal-deployment.md
@@ -367,3 +367,18 @@ Both open questions raised in review are resolved above (§2/§3): the binary
 reads the systemd credential directly (with `SPELUNK_SERVER_KEY` kept as a
 supported alternative), and a `DynamicUser=` variant will ship alongside the
 static-user default unit.
+
+---
+
+> **Correction (2026-07-12, transport topology, supersedes the
+> same-host-terminator reasoning):** In addition to the Non-goal reversal noted
+> at the top and in Non-goals, the recommended *topology* described in this ADR
+> is superseded by [ADR-066](066-native-tls-in-spelunk-server.md). Wherever this
+> ADR recommends the server bind loopback with a **same-host TLS terminator in
+> front** (Decision and Security implications), the shipped model instead has the
+> server bind a **routable interface and terminate HTTPS itself**
+> (`--tls-cert`/`--tls-key`), with nothing in front of it. The plaintext-off-host
+> refusal is unchanged and now bimodal: a non-loopback bind is allowed only with
+> both TLS and a key. The systemd unit, dedicated user, credential handling
+> (extended to the TLS private key), and sandboxing from this ADR remain in
+> force; only the "put a terminator in front" shape is retired.

--- a/docs/remote-agents.md
+++ b/docs/remote-agents.md
@@ -30,18 +30,20 @@ A containerized agent needs three things: an env var pointing its CLI at a
 `spelunk-server`, a bind-mount of the repo, and a bind-mount of your spelunk
 config so it resolves the same project.
 
-The one detail that trips people up is **which URL** the container uses. A
+The one detail that trips people up is **which URL** the container uses. A local
 `spelunk-server` binds the host's loopback (`127.0.0.1`), and a container's
 network namespace cannot reach the host's loopback by any portable means — so
-the reliable answer is to point the container at the server's **TLS endpoint**,
-the same `https://` URL any other client uses, not at a Docker bridge address.
+the reliable answer is to point the container at the team server's **HTTPS
+endpoint**, the same `https://` URL any other client uses, not at a Docker bridge
+address.
 
-### Recommended: point at the operator's TLS endpoint (portable)
+### Recommended: point at the server's HTTPS endpoint (portable)
 
-Stand up the team server the [Self-hosting](self-hosting.md) way — bare-metal on
-loopback with a same-host TLS terminator — and point the container at its
-`https://` hostname. This works identically on Docker Desktop and native Linux,
-because it's a routable HTTPS URL, not a host-loopback address:
+Stand up the team server the [Self-hosting](self-hosting.md) way (a routable
+bind with `--tls-cert`/`--tls-key` and a key, where the server terminates HTTPS
+itself) and point the container at its `https://` hostname. This works
+identically on Docker Desktop and native Linux, because it's a routable HTTPS
+URL, not a host-loopback address:
 
 ```bash
 docker run --rm -it \
@@ -53,8 +55,8 @@ docker run --rm -it \
   your-agent-image
 ```
 
-- `SPELUNK_SERVER_URL` points the in-container CLI at the operator's TLS
-  terminator, which forwards to the loopback-bound server on the host.
+- `SPELUNK_SERVER_URL` points the in-container CLI at the team server's own
+  HTTPS endpoint, which the server serves directly.
 - `SPELUNK_SERVER_KEY` is the shared API key (required — a networked server is
   always keyed; see [Self-hosting](self-hosting.md)).
 - `-v "$PWD":/work` bind-mounts the repository so file paths recorded in memory
@@ -71,8 +73,8 @@ spelunk check                 # should report the server reachable over TLS
 spelunk search "auth tokens"  # semantic search via the server
 ```
 
-The **server side** of this — the loopback bind, the systemd unit, and the TLS
-terminator — is the bare-metal path in [Self-hosting](self-hosting.md).
+The **server side** of this (the routable TLS bind and the systemd unit) is the
+bare-metal path in [Self-hosting](self-hosting.md).
 
 ### Docker Desktop convenience (solo, non-portable)
 
@@ -100,15 +102,17 @@ host-loopback-bound server from a container:
 
 - The default bridge gateway (`172.17.0.1`) and
   `--add-host=host.docker.internal:host-gateway` both resolve to the host's
-  **routable** interface, not its loopback — so a server bound to `127.0.0.1` is
-  not listening where the container can reach it.
-- Binding the server to the bridge address instead is a **non-loopback plaintext
-  bind, which `spelunk-server` refuses unconditionally** — there is no override.
+  **routable** interface, not its loopback, so a local server bound to
+  `127.0.0.1` is not listening where the container can reach it.
+- Binding the server to the bridge address over plaintext instead is a
+  **non-loopback plaintext bind, which `spelunk-server` refuses
+  unconditionally**: there is no override. A routable bind is only allowed with
+  `--tls-cert`/`--tls-key` and a key, i.e. the HTTPS endpoint below.
 
-So on native Linux there is no bridge shortcut: use the recommended TLS-endpoint
-path above. Terminating TLS on the host (per [Self-hosting](self-hosting.md)) is
-what makes the server reachable from a container, and it does so the same way on
-every platform.
+So on native Linux there is no bridge shortcut: use the recommended HTTPS-endpoint
+path above. The team server's own routable TLS listener (per
+[Self-hosting](self-hosting.md)) is what makes it reachable from a container, and
+it does so the same way on every platform.
 
 ### Notes
 

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -1,7 +1,7 @@
 # spelunk Threat Model
 
 **Method:** Lightweight threat modeling (STRIDE-informed)  
-**Last reviewed:** July 2026 (egress model corrected to the server-owned embedding path, ADR-002; `api_base_url` retired)  
+**Last reviewed:** July 2026 (transport model updated to native in-process HTTPS, ADR-066; egress model corrected to the server-owned embedding path, ADR-002; `api_base_url` retired)  
 **Reviewed by:** Architect  
 **Next review:** v1.0 release or after any new network-facing feature
 
@@ -23,8 +23,8 @@ spelunk has two distinct operational modes with different attack surfaces:
 
 ### Mode B — spelunk-server
 An axum HTTP API (`src/server/`) that exposes memory CRUD and semantic search over the network:
-- Binds to a configurable port; intended for shared team use
-- Bearer token authentication (`--key` / `SPELUNK_SERVER_KEY`). Unauthenticated is permitted **only on a loopback bind**; a non-loopback bind without a key is refused at startup (see "Key difference" below)
+- Binds to a configurable interface/port; intended for shared team use. Loopback binds serve plaintext HTTP; a non-loopback bind serves HTTPS in-process (ADR-066) via `--tls-cert`/`--tls-key`
+- Bearer token authentication (`--key` / `SPELUNK_SERVER_KEY`). Unauthenticated is permitted **only on a loopback bind**; a non-loopback bind is refused unless **both** TLS and a key are set (see "Key difference" below)
 - Accepts pre-computed embedding vectors from clients (clients embed locally, server stores and searches)
 - Serves multiple projects via project_id routing
 - Exposes: `POST /v1/projects/{id}/memory`, `POST /v1/projects/{id}/memory/search`, DELETE, archive, supersede
@@ -128,12 +128,23 @@ Client (spelunk CLI / any HTTP client)
 ```
 
 **Key difference from Mode A:** In server mode, memory content is accessible to anyone
-who can reach the server's port. To prevent an open, unauthenticated server on a
-shared network, `spelunk-server` **refuses to start** when `--host` is a non-loopback
-address (`0.0.0.0`, a LAN/public IP) and no `--key` / `SPELUNK_SERVER_KEY` is set. A
-keyless server can therefore only bind loopback (`127.0.0.1`), where it is reachable
-by local processes but not by other machines. (A blank/whitespace key — e.g.
-docker-compose's `${SPELUNK_SERVER_KEY:-}` default — is treated as no key.)
+who can reach the server's port. The bind guard (`check_bind_safety`) encodes the
+local/remote boundary directly (ADR-066 §4):
+
+| Bind | TLS configured | Key set | Result |
+|---|---|---|---|
+| loopback | any | any | allow (local plaintext HTTP, no key needed) |
+| non-loopback | no | any | refuse (no plaintext off-host, keyed or not) |
+| non-loopback | yes | no | refuse (remote requires an API key) |
+| non-loopback | yes | yes | allow (remote HTTPS, key required) |
+
+So a non-loopback bind is allowed **only** when the server terminates HTTPS
+itself (`--tls-cert`/`--tls-key`) **and** an API key is set: this keeps the bearer
+key off the wire in cleartext and prevents an open, unauthenticated server. A
+keyless or plaintext server can therefore only bind loopback (`127.0.0.1`), where
+it is reachable by local processes but not by other machines. (A blank or
+whitespace key, e.g. docker-compose's `${SPELUNK_SERVER_KEY:-}` default, is
+treated as no key.)
 
 ### Tenancy boundary: single trust domain (ADR-056)
 
@@ -155,9 +166,10 @@ the tenancy boundary. This is a deliberate design decision recorded in
   intended behaviour under this model, not a vulnerability. A future ADR that
   introduces a scoped-key and ACL model would supersede this decision.
 
-**Transport (ADR-056 addendum):** the server serves plaintext HTTP only on a
-loopback bind. A shared, non-loopback deployment terminates TLS in a front proxy
-so the shared key never crosses the network in cleartext. `/v1/health` is
+**Transport (ADR-056 addendum, updated by ADR-066):** the server serves plaintext
+HTTP only on a loopback bind. A shared, non-loopback deployment terminates TLS
+**in-process** (`--tls-cert`/`--tls-key`, ADR-066) so the shared key never crosses
+the network in cleartext, with nothing in front of the server. `/v1/health` is
 unauthenticated (no bearer required or sent).
 
 ---
@@ -195,7 +207,7 @@ unauthenticated (no bearer required or sent).
 | **Source code sent off-machine for embedding** | A | Medium | **High** | The default loopback server embeds natively on-machine, so nothing leaves. Egress requires an explicit remote team `server_url` (chunk text crosses to the team server) or a server whose operator set an external `--embedding-url` (server forwards post-secret-scan chunks to a third party). Both are explicit operator choices; users must be informed via docs. |
 | **Memory notes / code context sent off-machine for LLM** | A | Low | **High** | `spelunk explore` and `memory harvest` send memory content + code context to `spelunk-server`. On the default loopback server the LLM runs on-machine; egress requires a remote team `server_url` or a server-side `--llm-url` shim. |
 | Server memory accessible without auth | B | Medium | High | No `--key` / `SPELUNK_SERVER_KEY` by default; any process that can reach the port reads all notes |
-| Server bound to 0.0.0.0 exposes data on LAN/internet | B | Medium | High | **Enforced:** a non-loopback bind requires a key — `spelunk-server` refuses to start on `0.0.0.0`/LAN/public addresses without `--key` / `SPELUNK_SERVER_KEY`; loopback (`127.0.0.1`) is the default (spelunk-oss^52 / PR #490) |
+| Server bound to 0.0.0.0 exposes data on LAN/internet | B | Medium | High | **Enforced:** a non-loopback bind requires **both** TLS and a key: `spelunk-server` refuses to start on `0.0.0.0`/LAN/public addresses unless `--tls-cert`/`--tls-key` and `--key` / `SPELUNK_SERVER_KEY` are set (ADR-066 §4); plaintext off-host is refused with no override; loopback (`127.0.0.1`) is the default (spelunk-oss^52 / PR #490) |
 | Indexed content contains credentials missed by scanner | A | Medium | Medium | Pattern gaps tracked in #138 |
 | CLI bearer credential (`server_key`) readable as plaintext at rest (e.g. user syncs `~/.config` into a dotfiles repo or backup) | A | Medium | High | The `server_key` is stored in the OS keychain (macOS Keychain / Linux Secret Service / Windows Credential Manager), not in `config.toml`; a legacy plaintext key is migrated out and stripped on next run. Headless fallback is an owner-only (`0600`) `secrets.toml`; `SPELUNK_SERVER_KEY` is the CI escape hatch. The credential is never logged. |
 | `spelunk memory add`/edit interactive `$EDITOR` draft written to a predictable temp path, enabling symlink/TOCTOU clobber and a world-readable info-leak window | A | Low | Medium | **Fixed (spelunk-oss^62):** the draft is created via `tempfile::Builder` (unpredictable name, `O_EXCL`, mode `0600` on unix) instead of a PID-derived path in `std::env::temp_dir()`. The `NamedTempFile` handle is kept open across the `$EDITOR`/`$VISUAL` spawn and the body is read back by seeking the retained handle (not by re-opening the path), so a symlink swapped in at the draft's path during the edit window is not followed. |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,26 +1,25 @@
 # Self-hosting spelunk-server (R3)
 
 This is the **recommended way to run a shared team `spelunk-server`**: the binary
-bare-metal on a host under systemd, bound to loopback, with an operator-owned TLS
-terminator on the same host in front of it. It is the one mechanically-correct
-shape for a team-reachable instance — Docker cannot host it (a container's
-loopback is unreachable from the host or sibling containers; see
-[Server setup → Docker: local scaffold only](server.md#docker-local-scaffold-only)).
+on a host under systemd, bound to a routable interface, terminating HTTPS itself
+with a certificate and key you provide. `spelunk-server` serves TLS in-process
+(ADR-066), so there is nothing in front of it: no separate terminator to install,
+own, or keep current. A container is an equally valid vehicle for the same shape
+(see [Server setup → Docker](server.md#docker-a-team-server-or-a-local-scaffold)).
 
-If you operate your own `spelunk-server` and want remote agents — on a VM, a k8s
-pod, or a teammate's laptop across a VPN — to reach it, you are in the
+If you operate your own `spelunk-server` and want remote agents – on a VM, a k8s
+pod, or a teammate's laptop across a VPN – to reach it, you are in the
 **self-hosted remote (R3)** shape. R3 is just [R1](remote-agents.md) over a
 network: the same CLI, the same env vars, the same API. The only thing the
-network adds is that **TLS becomes mandatory.**
+network adds is that **TLS becomes mandatory**, and the server provides it.
 
-`spelunk-server` terminates plain HTTP. Do **not** expose it directly on a
-public or shared-network interface. Put a TLS-terminating reverse proxy in front
-of it and keep the server itself bound to loopback.
+`spelunk-server` speaks plain HTTP on loopback and HTTPS off it. A non-loopback
+bind is refused unless you pass both TLS flags **and** an API key, so there is no
+way to accidentally expose it in cleartext.
 
-> **Trust model.** Everything on the other side of that proxy — every holder of
-> the shared `SPELUNK_SERVER_KEY` — is a full administrator of every project on
-> this server instance; there is no per-project access control. See
-> [Trust model](server.md#trust-model) and
+> **Trust model.** Everything that holds the shared `SPELUNK_SERVER_KEY` is a
+> full administrator of every project on this server instance; there is no
+> per-project access control. See [Trust model](server.md#trust-model) and
 > [ADR-056](adr/056-oss-server-tenancy-model.md) before sharing a key with more
 > than one mutually-trusting group. If you need isolation between teams, run
 > separate server instances (separate keys), not one shared instance.
@@ -29,103 +28,92 @@ of it and keep the server itself bound to loopback.
 > retrieval* server so remote agents can use it as a peer. It is not an agent
 > runtime.
 
-## 1. Run spelunk-server on loopback
+## 1. Bring your own certificate
 
-Keep the server bound to `127.0.0.1` so the only way in is through the proxy:
+`spelunk-server` loads an operator-provided PEM certificate chain and private
+key. It does **not** obtain or renew certificates itself (no ACME/Let's Encrypt
+automation): you bring a certificate from wherever you already get one, and you
+renew it. A certificate with no renewal will eventually expire and the server
+will stop answering, so treat renewal as part of running the service.
 
-```bash
-spelunk-server --port 7777 --host 127.0.0.1
-```
+Any of these are fine:
 
-Always start the server with an API key so the exposed endpoint requires auth:
+- an internal CA your fleet already trusts,
+- `certbot` (or another ACME client) run out-of-band to produce the PEM files,
+- a cloud-issued certificate.
 
-```bash
-SPELUNK_SERVER_KEY=$(openssl rand -hex 32) spelunk-server --port 7777 --host 127.0.0.1
-```
+You need two files:
 
-## 2. Terminate TLS with a reverse proxy (operator-owned)
+- a **certificate chain** (leaf plus any intermediates), PEM, which is public, and
+- a **private key**, PEM, which is a high-value secret: keep it `0600` and
+  root-owned, and never place it in an environment variable.
 
-The proxy configs below are **operator-owned reference examples**, not shipped
-configuration — spelunk ships no `Caddyfile` or `nginx.conf`. The TLS terminator
-is yours to own and keep current; pick whichever proxy you already run. Both
-examples terminate TLS and forward to the loopback server on the same host.
+## 2. Run spelunk-server with a routable TLS bind
 
-### 2a. Caddy (automatic TLS)
-
-Caddy fetches and renews a Let's Encrypt certificate automatically. A whole
-`Caddyfile` for this is two lines:
-
-```caddyfile
-spelunk.example.com {
-    reverse_proxy 127.0.0.1:7777
-}
-```
+Bind a routable interface and pass the cert, the key, and an API key. The server
+terminates HTTPS itself:
 
 ```bash
-caddy run --config /etc/caddy/Caddyfile
+SPELUNK_SERVER_KEY=$(openssl rand -hex 32) \
+spelunk-server \
+  --host 0.0.0.0 --port 7777 \
+  --tls-cert /etc/spelunk/tls-cert \
+  --tls-key  /etc/spelunk/tls-key
 ```
 
-That's it — `https://spelunk.example.com` now terminates TLS and forwards to the
-loopback server.
+- `--host 0.0.0.0` (or a specific routable IP) makes the server reachable
+  off-host. Loopback (`127.0.0.1`, the default) stays plain-HTTP local-only.
+- `--tls-cert` / `--tls-key` are the PEM certificate chain and private key. Both
+  or neither: setting one without the other is a startup error. They can also be
+  supplied as `SPELUNK_SERVER_TLS_CERT` / `SPELUNK_SERVER_TLS_KEY`.
+- An API key is required for any non-loopback bind (`--key` / `--key-file` /
+  `SPELUNK_SERVER_KEY`). A routable bind with TLS but no key is refused, as is a
+  routable bind with no TLS.
 
-### 2b. nginx
-
-If you already run nginx, terminate TLS there (certificate via certbot or your
-own CA) and proxy to loopback:
-
-```nginx
-server {
-    listen 443 ssl;
-    server_name spelunk.example.com;
-
-    ssl_certificate     /etc/letsencrypt/live/spelunk.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/spelunk.example.com/privkey.pem;
-
-    location / {
-        proxy_pass         http://127.0.0.1:7777;
-        proxy_http_version 1.1;
-        proxy_set_header   Host $host;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
-
-        # The memory stream is server-sent events — don't buffer it.
-        proxy_set_header   Connection '';
-        proxy_buffering    off;
-        proxy_read_timeout 1h;
-    }
-}
-```
-
-The `proxy_buffering off` / long read-timeout block matters: the `spelunk memory`
-stream endpoint uses [server-sent events](architecture/server-api.md), and
-default nginx buffering would stall it.
+That is the whole exposure story: `https://<host>:7777` now answers, the bearer
+key is required, and the connection is encrypted by the server with nothing in
+front of it. The bind flags are distinct from the API-key flags on purpose:
+`--tls-key` is the TLS private key, `--key`/`--key-file` is the bearer API key,
+two different secrets.
 
 ## 3. Run it under systemd
 
 Spelunk ships a first-party unit for the team server:
 [`packaging/spelunk-server-team.service`](../packaging/spelunk-server-team.service).
-It runs the server as a dedicated unprivileged `spelunk` user, supplies the API
-key as a **systemd credential** rather than an environment line, and applies
-standard sandboxing. (This is the deployed team-server unit — distinct from the
+It runs the server as a dedicated unprivileged `spelunk` user, binds a routable
+interface with TLS, supplies **both** the API key and the TLS private key as
+**systemd credentials** rather than environment lines, and applies standard
+sandboxing. (This is the deployed team-server unit, distinct from the
 per-developer local-inference user unit, `packaging/spelunk-server.service`.)
 
-### Provision the key and data dir
+### Provision the key, the certificate, and the data dir
 
-The key is supplied through systemd's `LoadCredential=`, which reads a
-`root:root 0600` file and exposes it to the process at
-`$CREDENTIALS_DIRECTORY/server-key` — the binary reads it from there directly.
-This keeps the key out of `systemctl show` / `/proc/<pid>/environ`, where an
-`Environment=SPELUNK_SERVER_KEY=…` line would leak it to any local user.
+Two secrets go through systemd's `LoadCredential=`, which reads a `root:root
+0600` file and exposes it to the process under `$CREDENTIALS_DIRECTORY` (kept out
+of `systemctl show` / `/proc/<pid>/environ`, where an `Environment=` line would
+leak it to any local user):
+
+- `server-key` – the bearer API key, read automatically from
+  `$CREDENTIALS_DIRECTORY/server-key`.
+- `tls-key` – the TLS private key, passed to `--tls-key` via `%d`
+  (`%d` = `$CREDENTIALS_DIRECTORY`).
+
+The **certificate chain** is public, so it stays a plain readable path (add it to
+`ReadOnlyPaths=` if `ProtectSystem=strict` hides it):
 
 ```bash
 # Dedicated user + data dir
 sudo useradd --system --home-dir /var/lib/spelunk --shell /usr/sbin/nologin spelunk
 sudo install -d -o spelunk -g spelunk -m 0750 /var/lib/spelunk
 
-# The key, as a root-only 0600 file
+# The bearer key, as a root-only 0600 file
 sudo install -d -m 0755 /etc/spelunk
 openssl rand -hex 32 | sudo tee /etc/spelunk/server-key >/dev/null
 sudo chmod 0600 /etc/spelunk/server-key
+
+# Bring your own TLS cert chain + private key
+sudo install -m 0644 fullchain.pem /etc/spelunk/tls-cert   # public chain
+sudo install -m 0600 privkey.pem   /etc/spelunk/tls-key    # root:root, private
 
 # Install and start the unit
 sudo install -m 0644 packaging/spelunk-server-team.service \
@@ -135,76 +123,57 @@ sudo systemctl enable --now spelunk-server
 sudo systemctl status spelunk-server
 ```
 
-The shipped unit:
+The shipped unit's `ExecStart` is:
 
 ```ini
-# /etc/systemd/system/spelunk-server.service
-[Unit]
-Description=spelunk-server (team memory)
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=simple
-User=spelunk
-Group=spelunk
-
-# Key as a systemd credential, exposed at $CREDENTIALS_DIRECTORY/server-key
-# and read there by the binary — not a world-readable Environment= line.
-LoadCredential=server-key:/etc/spelunk/server-key
 ExecStart=/usr/local/bin/spelunk-server \
-  --host 127.0.0.1 --port 7777 \
-  --db /var/lib/spelunk/spelunk.db
-Restart=on-failure
-RestartSec=5
-
-# Hardening — the server needs only its data dir and loopback.
-NoNewPrivileges=true
-ProtectSystem=strict
-ProtectHome=true
-PrivateTmp=true
-ReadWritePaths=/var/lib/spelunk
-ProtectKernelTunables=true
-ProtectKernelModules=true
-ProtectControlGroups=true
-RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
-RestrictNamespaces=true
-RestrictRealtime=true
-RestrictSUIDSGID=true
-LockPersonality=true
-SystemCallArchitectures=native
-
-[Install]
-WantedBy=multi-user.target
+  --host 0.0.0.0 --port 7777 \
+  --db /var/lib/spelunk/spelunk.db \
+  --tls-cert /etc/spelunk/tls-cert \
+  --tls-key %d/tls-key
 ```
+
+with both secrets loaded as credentials:
+
+```ini
+LoadCredential=server-key:/etc/spelunk/server-key
+LoadCredential=tls-key:/etc/spelunk/tls-key
+```
+
+The full unit (dedicated user, hardening directives, and all) is in the repo at
+[`packaging/spelunk-server-team.service`](../packaging/spelunk-server-team.service);
+install it verbatim as above.
 
 > `MemoryDenyWriteExecute=true` is a further hardening step, but the native
 > embedder mmaps model weights and some backends (CUDA/BLAS) may need
-> writable-executable pages — validate it against your embedder backend before
+> writable-executable pages: validate it against your embedder backend before
 > enabling. The shipped unit leaves it commented.
 
 **Key sources.** The credential file is preferred under systemd, but it is not
-the only supported source — `SPELUNK_SERVER_KEY` remains a fully-supported
-equal alternative (e.g. an `EnvironmentFile=` pointing at a `0600` root-owned
-file, or set by tooling that runs the binary outside systemd). Resolution
-precedence is `--key` → `--key-file` → `SPELUNK_SERVER_KEY` →
-`$CREDENTIALS_DIRECTORY/server-key`. To rotate the key, replace
-`/etc/spelunk/server-key`, `sudo systemctl restart spelunk-server`, and
-redistribute it to clients.
+the only supported source: `SPELUNK_SERVER_KEY` remains a fully-supported equal
+alternative (e.g. an `EnvironmentFile=` pointing at a `0600` root-owned file, or
+set by tooling that runs the binary outside systemd). Resolution precedence is
+`--key` → `--key-file` → `SPELUNK_SERVER_KEY` → `$CREDENTIALS_DIRECTORY/server-key`.
+To rotate the bearer key, replace `/etc/spelunk/server-key`, `sudo systemctl
+restart spelunk-server`, and redistribute it to clients. To renew the
+certificate, replace `/etc/spelunk/tls-cert` (and `/etc/spelunk/tls-key` if the
+key changed) and restart the service.
 
 ### Alternative: `DynamicUser=`
 
 If you'd rather not manage a static user and data dir, use the
 [`DynamicUser=` variant](../packaging/spelunk-server-team-dynamicuser.service):
 systemd allocates a per-boot UID and creates `/var/lib/spelunk` via
-`StateDirectory=`, chowned to that UID — no `useradd`, no manual `install -d`.
-Install it in place of the static-user unit (the key/`/etc/spelunk` provisioning
-above still applies):
+`StateDirectory=`, chowned to that UID, so there is no `useradd` and no manual
+`install -d`. Install it in place of the static-user unit; the key, certificate,
+and `/etc/spelunk` provisioning above still applies:
 
 ```bash
 sudo install -d -m 0755 /etc/spelunk
 openssl rand -hex 32 | sudo tee /etc/spelunk/server-key >/dev/null
 sudo chmod 0600 /etc/spelunk/server-key
+sudo install -m 0644 fullchain.pem /etc/spelunk/tls-cert
+sudo install -m 0600 privkey.pem   /etc/spelunk/tls-key
 sudo install -m 0644 packaging/spelunk-server-team-dynamicuser.service \
      /etc/systemd/system/spelunk-server.service
 sudo systemctl daemon-reload
@@ -218,7 +187,7 @@ you want a stable owner for backup/inspection or a stable `started_by` UID.
 ## 4. Point a remote agent at it
 
 On the remote host (or in its container), the configuration is identical to
-[R1](remote-agents.md) — only the URL and the mandatory key change:
+[R1](remote-agents.md); only the URL and the mandatory key change:
 
 ```bash
 export SPELUNK_SERVER_URL=https://spelunk.example.com
@@ -228,12 +197,13 @@ spelunk check                 # should report the server reachable over TLS
 spelunk search "auth tokens"
 ```
 
-The agent's network path to `spelunk.example.com` is yours to provide — a VPN,
-Tailscale, or a public DNS record. Spelunk does not tunnel traffic; it just
-needs the URL to resolve and the TLS proxy to answer.
+The `https://` URL points straight at the server's own TLS listener. The agent's
+network path to `spelunk.example.com` is yours to provide: a VPN, Tailscale, or a
+public DNS record. Spelunk does not tunnel traffic; it just needs the URL to
+resolve and the server to answer.
 
 ## Related
 
-- [Remote agents](remote-agents.md) — the R1 local-Docker path
-- [Server setup](server.md) — Docker, keys, client config, API reference
-- [Server API](architecture/server-api.md) — the HTTP + SSE surface behind the proxy
+- [Remote agents](remote-agents.md) – the R1 local-Docker path
+- [Server setup](server.md) – Docker, keys, client config, API reference
+- [Server API](architecture/server-api.md) – the HTTP + SSE surface the server exposes

--- a/docs/server.md
+++ b/docs/server.md
@@ -63,83 +63,72 @@ service so a team can sync memory. This is distinct from the local-auto server
 above: it's long-lived, reachable over the network, and protected by an API key.
 
 **Recommended: bare-metal + systemd.** Run the binary directly on a host under
-systemd, bound to loopback, with an operator-owned TLS terminator
-(nginx/Caddy/…) in front of that same loopback bind on the same host. This is
-the one mechanically-correct shape for a team-reachable server, because the
-server binds `127.0.0.1` unconditionally (see
+systemd, bound to a routable interface (`--host 0.0.0.0`) with a certificate and
+key (`--tls-cert`/`--tls-key`) and an API key. `spelunk-server` terminates HTTPS
+itself (ADR-066), so nothing sits in front of it. Off-host reachability is the
+server's own TLS listener, not a separate component. A non-loopback bind is
+refused unless both TLS and a key are set (see
 [Non-loopback plaintext binds are refused](#non-loopback-plaintext-binds-are-refused-no-override)
-below) and refuses to serve plaintext off-host — so reaching it from another
-machine needs a same-host terminator in front of that loopback bind. Docker
-cannot host this: a container's own loopback lives in its private network
-namespace and isn't reachable from the host or sibling containers by any of the
-usual means (bridge port-publish, Docker Desktop host-mode, container-to-container
-DNS all fail to reach it).
+below), so there is no way to expose it in cleartext.
+
+**Docker is an equally valid vehicle for the same shape.** With in-process TLS
+the container binds its routable interface directly and `-p 443:7777` publishes a
+working `https://` endpoint; see [Docker](#docker-a-team-server-or-a-local-scaffold)
+below.
 
 **[Self-hosting](self-hosting.md) is the full team-server guide** — it walks
-through the loopback bind, the first-party `spelunk-server.service` systemd unit
-(hardened, key supplied as a systemd credential), and the Caddy/nginx reference
-examples. Start there. The rest of this page covers client configuration, the
-trust model, and the CLI/flag reference that path relies on.
+through the routable TLS bind, bringing your own certificate, and the first-party
+`spelunk-server-team.service` systemd unit (hardened, both the API key and the
+TLS private key supplied as systemd credentials). Start there. The rest of this
+page covers client configuration, the trust model, and the CLI/flag reference
+that path relies on.
 
-## Docker: local scaffold only
+## Docker: a team server or a local scaffold
 
-`docker-compose.yml` in this repo is a **minimal local scaffold**: it builds
-the image and runs `spelunk-server` with a persistent named volume for the
-SQLite database. It is **not** a networked or team-serving recipe — the
-container binds `127.0.0.1` *inside its own network namespace* (the image's
-own default; see the Dockerfile), and nothing in the compose file publishes a
-port out of that namespace, so the server is not reachable from the host or
-from sibling containers. Use it to run the server process locally (e.g. to
-poke at the API by hand); for anything a team or a remote machine needs to
-reach, use the bare-metal/systemd path in [Self-hosting](self-hosting.md)
-instead.
+With in-process TLS, a container is a real team-server vehicle. Bind the
+container's routable interface, mount a certificate and key, publish the port,
+and set an API key:
 
 ```bash
-# Clone and build
 git clone https://github.com/spelunk-cloud/spelunk
 cd spelunk
 
-# Generate a key (optional for a purely local scaffold, but matches the
-# real deployment's shape if you're using this to test client config)
 export SPELUNK_SERVER_KEY=$(openssl rand -hex 32)
 
-# Start
-SPELUNK_SERVER_KEY=$SPELUNK_SERVER_KEY docker compose up -d
+# Team server: routable TLS bind, cert + key mounted, port published.
+docker run --rm -d --name spelunk-server \
+  -p 443:7777 \
+  -v spelunk-data:/data \
+  -v /etc/spelunk/tls-cert:/tls/cert:ro \
+  -v /etc/spelunk/tls-key:/tls/key:ro \
+  -e SPELUNK_SERVER_KEY \
+  -e SPELUNK_SERVER_TLS_CERT=/tls/cert \
+  -e SPELUNK_SERVER_TLS_KEY=/tls/key \
+  spelunk-server --host 0.0.0.0 --port 7777
 ```
 
-Because the container's loopback isn't reachable from outside its own
-network namespace, the only way to talk to this instance is from **inside
-that same namespace** — there is no host-reachable port to point a client
-at. The runtime image is a minimal Debian base with no `curl`/`wget`
-installed, so the practical way to reach it is a separate container that
-shares the same network namespace:
+`https://<host>` now answers, keyed, with the container serving TLS itself. The
+`team-server` profile in [`docker-compose.yml`](../docker-compose.yml) wires the
+same thing up declaratively.
+
+`docker-compose.yml`'s **default** service is still a **local scaffold**: it
+builds the image and runs `spelunk-server` on loopback with a persistent named
+volume and no published port, for poking at the API by hand. That default binds
+`127.0.0.1` inside the container's own network namespace, so it is reachable only
+from inside that namespace (e.g. a sidecar started with `--network
+container:spelunk-server`). The runtime image is a minimal Debian base with no
+`curl`/`wget`, so the practical way to reach the scaffold is a sidecar:
 
 ```bash
 docker run --rm --network container:spelunk-server curlimages/curl \
   curl http://127.0.0.1:7777/v1/health
 ```
 
-If you want other **sibling containers** (not sharing the exact namespace) to
-reach a spelunk-server on the same Docker network — e.g. a containerized
-agent, see [Remote agents](remote-agents.md) — run it on a user-defined
-bridge network instead of via compose:
-
-```bash
-docker network create spelunk-dev
-docker run --rm -d --name spelunk-server --network spelunk-dev \
-  -v spelunk-data:/data spelunk-server
-# other containers on `spelunk-dev` reach it at http://spelunk-server:7777
-```
-
-This works because Docker's embedded DNS resolves the container's *address on
-the bridge network*, not its loopback — the request never needs to cross into
-the container's private loopback namespace. A bare
-`docker run -p 7777:7777 ...` of this image, by contrast, will **not** make it
-reachable from the host: `-p` forwards host traffic to the container's
-network interface, not into its private loopback, so nothing published from
-the host ever reaches a loopback-only bind. There is no Docker Compose
-recipe in this repo for host- or off-host-reachable serving — use
-bare-metal/systemd (see [Self-hosting](self-hosting.md)) for that.
+To make it team-reachable, give it a routable TLS bind as shown above (the
+`team-server` compose profile does this); a bare `docker run -p 7777:7777 ...` of
+the loopback scaffold will **not** be reachable, because `-p` forwards host
+traffic to the container's routable interface, not into its private loopback, so
+nothing published reaches a loopback-only bind.
 
 ## Client configuration
 
@@ -154,9 +143,10 @@ project_id = "my-awesome-app"
 > **`server_url` must be `https://` unless it points at loopback**
 > (`127.0.0.1` / `::1` / `localhost`). The CLI attaches your bearer token to
 > requests built from this URL, so a non-loopback `http://` config is rejected
-> at startup with no override — see [Self-hosting](self-hosting.md) for how to
-> put TLS in front of a deployed server. Loopback `http://` (e.g. while
-> developing against a server on your own machine) is fine.
+> at startup with no override. A deployed server serves that `https://` itself
+> (see [Self-hosting](self-hosting.md)), so this is satisfied by pointing at its
+> TLS endpoint. Loopback `http://` (e.g. while developing against a server on
+> your own machine) is fine.
 
 Personal config (`~/.config/spelunk/config.toml` — never commit):
 
@@ -269,17 +259,16 @@ environment:
 ## Production deployment
 
 **Bare-metal / systemd is the recommended way to run a team-reachable
-`spelunk-server`.** The server itself binds loopback only; running it directly
-on the host (rather than in a container) means the operator's own TLS
-terminator — nginx, Caddy, whatever's already on the box — can sit in front of
-that same loopback bind on the same host and actually be reachable off-host.
-See [Self-hosting](self-hosting.md) for the systemd unit and reverse-proxy
-recipes.
+`spelunk-server`.** The server binds a routable interface and terminates HTTPS
+itself with `--tls-cert`/`--tls-key` and an API key, so it is reachable off-host
+with nothing in front of it. See [Self-hosting](self-hosting.md) for the systemd
+unit and the bring-your-own-certificate steps.
 
-`docker-compose.yml` (see [Docker: local scaffold only](#docker-local-scaffold-only) above)
-is a local scaffold for running the server process itself — useful for local
-development or testing — not a substitute for the bare-metal path when the
-server needs to be reachable by a team or over a network.
+A container works equally well for a team server now that the bind is routable
+TLS (see [Docker](#docker-a-team-server-or-a-local-scaffold) above). The
+`docker-compose.yml` **default** service remains a loopback-only local scaffold,
+useful for local development or testing; its `team-server` profile is the
+routable-TLS shape.
 
 Key considerations for any deployment:
 - Putting the server behind a VPN or private subnet is still good
@@ -310,11 +299,17 @@ cargo build --release --bin spelunk-server
 
 | Flag | Env | Default | Purpose |
 |---|---|---|---|
-| `--host` | (none) | `127.0.0.1` | Interface to bind. Non-loopback needs a key and TLS in front (see below). |
+| `--host` | (none) | `127.0.0.1` | Interface to bind. Non-loopback needs both a key and TLS (`--tls-cert`/`--tls-key`); see below. |
 | `--port` | (none) | `7777` | Port to bind. |
 | `--key` | (none) | unset | Shared bearer API key, passed inline. Visible in the process table — prefer `--key-file` or `SPELUNK_SERVER_KEY`. Leave every key source unset only for a loopback dev server. |
 | `--key-file` | (none) | unset | Read the key from a file (whole contents, trimmed). First-class alternative to `SPELUNK_SERVER_KEY`, not a fallback. |
 | (none) | `SPELUNK_SERVER_KEY` | unset | Read the key from the environment. Fully supported alongside `--key-file`. |
+| `--tls-cert` | `SPELUNK_SERVER_TLS_CERT` | unset | PEM certificate chain (leaf + intermediates) for in-process HTTPS. The chain is public. Set with `--tls-key` (both or neither). Distinct from `--key`/`--key-file`. |
+| `--tls-key` | `SPELUNK_SERVER_TLS_KEY` | unset | PEM private key matching `--tls-cert`. A high-value secret: supply via a systemd credential or a `0600` root-owned file, never an `Environment=` line. Set with `--tls-cert`. |
+
+The certificate is bring-your-own PEM (an internal CA, `certbot`, or a
+cloud-issued cert). `spelunk-server` does not obtain or renew it (no ACME); the
+operator renews it. See [Self-hosting](self-hosting.md).
 
 The key is resolved from, in precedence order: `--key` → `--key-file` →
 `SPELUNK_SERVER_KEY` → a systemd `LoadCredential=server-key` (read automatically
@@ -345,13 +340,21 @@ overridden. The resolved value and its source are logged at startup
 whether or not a key is set, and there is no opt-out. With no key that would be
 an open, unauthenticated server; with a key the bearer `SPELUNK_SERVER_KEY`
 would travel across the network in cleartext. The refusal names the
-interface/port and points back at this guidance.
+interface/port and points at `--tls-cert`/`--tls-key`.
 
-The supported posture is to bind loopback and terminate TLS in a front proxy
-(see [Self-hosting](self-hosting.md)). If you need a process outside the host
-— including a container — to reach the server, put a reverse proxy (nginx,
-Caddy, Traefik) in front of the loopback bind and terminate TLS there; don't
-bind the server itself to a routable interface over plaintext.
+The rule the server enforces at startup is exactly the local/remote boundary:
+
+| Bind | TLS configured | Key set | Result |
+|---|---|---|---|
+| loopback | any | any | allow (local HTTP, no key needed) |
+| non-loopback | no | any | refuse (no plaintext off-host, keyed or not) |
+| non-loopback | yes | no | refuse (remote requires an API key) |
+| non-loopback | yes | yes | allow (the remote HTTPS path) |
+
+So the supported way to reach the server from another machine (including a
+container) is a routable bind with `--tls-cert`/`--tls-key` and a key, where the
+server terminates HTTPS itself (see [Self-hosting](self-hosting.md)). Plaintext
+off-host stays refused with no override.
 
 ## API reference
 

--- a/examples/mdm/README.md
+++ b/examples/mdm/README.md
@@ -100,13 +100,16 @@ Steps:
 
 1. **Install the binaries** on the laptops (as in Shape A) and on the host that
    will run the shared server.
-2. **Run the managed server.** On a macOS server host, install
-   `macos/cloud.spelunk.server.mobileconfig` (it installs a system-scoped
-   LaunchDaemon). On Linux, deploy the systemd unit from
-   `packaging/spelunk-server.service`. On Windows, run it as a Windows Service
-   with `windows/Install-SpelunkServerService.ps1` (see
-   [`windows/README.md`](windows/README.md)). Set a real `SPELUNK_SERVER_KEY` on
-   the server.
+2. **Run the managed server.** A team-reachable server binds a routable
+   interface and terminates HTTPS in-process (ADR-066): bring your own PEM
+   certificate and private key, and set a real `SPELUNK_SERVER_KEY`. On a macOS
+   server host, install `macos/cloud.spelunk.server.mobileconfig` (it installs a
+   system-scoped LaunchDaemon). On Linux, deploy the team systemd unit from
+   `packaging/spelunk-server-team.service` (see
+   [Self-hosting](../../docs/self-hosting.md)); `packaging/spelunk-server.service`
+   is the per-developer local-inference unit, not the team server. On Windows,
+   run it as a Windows Service with `windows/Install-SpelunkServerService.ps1`
+   (see [`windows/README.md`](windows/README.md)).
 3. **Pre-configure the laptops** so users do not have to. Push
    `spelunk-config.toml` to `~/.config/spelunk/config.toml` (server URL, project
    slug, sync mode) and deliver the shared `SPELUNK_SERVER_KEY` via the managed

--- a/examples/mdm/macos/cloud.spelunk.server.mobileconfig
+++ b/examples/mdm/macos/cloud.spelunk.server.mobileconfig
@@ -20,11 +20,14 @@
   see ../README.md ("Pushing spelunk configuration").
 
   REACHING IT OFF-HOST
-  This job binds loopback (--host 127.0.0.1) only, and this profile is scoped
-  to local, on-host use. spelunk-server refuses a non-loopback plaintext bind
-  with no override, so do NOT change --host to 0.0.0.0 (the daemon would fail
-  to start). This profile does not expose the server to other machines;
-  reaching it off-host is a separate deployment decision, out of scope here.
+  This job binds a routable interface (--host 0.0.0.0) and serves HTTPS
+  in-process: spelunk-server terminates TLS itself (ADR-066), with nothing in
+  front of it. A non-loopback bind is refused unless BOTH the TLS cert/key
+  (--tls-cert/--tls-key) AND an API key (SPELUNK_SERVER_KEY) are set, so a
+  team-reachable server carries all three. Bring your own PEM certificate
+  (internal CA, certbot, or a cloud-issued cert); spelunk-server does not renew
+  it, so the operator does. For a purely on-host server instead, set
+  --host 127.0.0.1 and drop the --tls-* args (loopback plaintext, no key needed).
 
   BEFORE YOU DEPLOY
   1. Regenerate every PayloadUUID below (`uuidgen`) so this profile does not
@@ -32,7 +35,10 @@
   2. Set PayloadOrganization to your organization name.
   3. Confirm the binary path matches where your fleet installs spelunk-server
      (the install script places it in /usr/local/bin when run as root).
-  4. Adjust the --port, --db path, and SPELUNK_SERVER_KEY to suit your
+  4. Install your PEM cert chain at /etc/spelunk/tls-cert (public, 0644) and the
+     private key at /etc/spelunk/tls-key (root-only, 0600), or edit the paths
+     below to match your host.
+  5. Adjust the --port, --db path, and SPELUNK_SERVER_KEY to suit your
      deployment. For a shared server, ALWAYS set an API key (see README).
 -->
 <plist version="1.0">
@@ -89,16 +95,27 @@
 									<!-- Path the install script uses when run as root. -->
 									<string>/usr/local/bin/spelunk-server</string>
 									<!--
-									  Loopback bind only. spelunk-server refuses a non-loopback
-									  plaintext bind (no override); see the header note.
+									  Routable bind + in-process HTTPS. A non-loopback bind is
+									  refused unless the --tls-* args below AND an API key are
+									  set; see the header note. For on-host-only use, set
+									  127.0.0.1 and remove the --tls-cert/--tls-key args.
 									-->
 									<string>--host</string>
-									<string>127.0.0.1</string>
+									<string>0.0.0.0</string>
 									<string>--port</string>
 									<string>7777</string>
 									<!-- Persistent DB path for a shared/always-on host. -->
 									<string>--db</string>
 									<string>/var/lib/spelunk/spelunk.db</string>
+									<!--
+									  Operator-provided PEM. The cert chain is public (0644);
+									  the private key is root-only (0600). Bring your own
+									  (internal CA / certbot / cloud); the server does not renew.
+									-->
+									<string>--tls-cert</string>
+									<string>/etc/spelunk/tls-cert</string>
+									<string>--tls-key</string>
+									<string>/etc/spelunk/tls-key</string>
 								</array>
 								<key>EnvironmentVariables</key>
 								<dict>

--- a/examples/mdm/macos/cloud.spelunk.server.mobileconfig
+++ b/examples/mdm/macos/cloud.spelunk.server.mobileconfig
@@ -120,10 +120,11 @@
 								<key>EnvironmentVariables</key>
 								<dict>
 									<!--
-									  Set a real API key for any shared server.
-									  An unset key leaves the server unauthenticated
-									  (dev only). You can also inject it out-of-band
-									  rather than committing it into the profile.
+									  Set a real API key. This job binds a routable
+									  interface, so an unset key makes spelunk-server
+									  refuse to start (a non-loopback bind requires
+									  both TLS and a key). You can also inject it
+									  out-of-band rather than committing it here.
 									-->
 									<key>SPELUNK_SERVER_KEY</key>
 									<string>replace-with-your-shared-api-key</string>

--- a/examples/mdm/windows/Install-SpelunkServerService.ps1
+++ b/examples/mdm/windows/Install-SpelunkServerService.ps1
@@ -16,11 +16,13 @@
   service shim) or a Task Scheduler task set to run at startup, whether or not a
   user is logged on, with restart-on-failure. Pick one; don't stack them.
 
-  This binds loopback (127.0.0.1) only. spelunk-server refuses a non-loopback
-  plaintext bind unconditionally, so this service is not reachable off-host by
-  itself. Exposing it to other machines is a separate deployment decision, out
-  of scope for this script. See ../../../docs/adr/056-oss-server-tenancy-model.md
-  for the trust model once you have a reachability plan.
+  For a team-reachable server, pass -BindHost 0.0.0.0 with -TlsCert and -TlsKey:
+  spelunk-server terminates HTTPS in-process (ADR-066), so nothing sits in front
+  of it. A non-loopback bind is refused unless BOTH the TLS cert/key AND an API
+  key are set. Bring your own PEM certificate (internal CA / certbot / cloud);
+  the server does not renew it. With no -TlsCert/-TlsKey the service stays on the
+  loopback (127.0.0.1) default, reachable on-host only. See
+  ../../../docs/adr/056-oss-server-tenancy-model.md for the trust model.
 
 .NOTES
   Run as Administrator. Verify NSSM argument names against your NSSM version;
@@ -38,8 +40,17 @@ param(
 
     [string]$ServiceName = "spelunk-server",
 
-    # Loopback only; see .DESCRIPTION. Do not set 0.0.0.0 here.
+    # Interface to bind. Loopback (default) is on-host only. For a
+    # team-reachable server pass 0.0.0.0 together with -TlsCert and -TlsKey.
+    [string]$BindHost = "127.0.0.1",
+
     [int]$Port = 7777,
+
+    # Operator-provided PEM cert chain (public) and private key. Both or neither.
+    # Required for a routable (-BindHost 0.0.0.0) bind; leave empty for loopback.
+    # Bring your own (internal CA / certbot / cloud); the server does not renew.
+    [string]$TlsCert = "",
+    [string]$TlsKey  = "",
 
     # Persistent DB + logs for an always-on host.
     [string]$DataDir = "$env:ProgramData\spelunk",
@@ -60,14 +71,26 @@ if (-not (Test-Path $BinaryPath)) {
     throw "spelunk-server.exe not found at '$BinaryPath'. Deploy the binary first (see README.md)."
 }
 
-# Register the service. --host is omitted so the server keeps its loopback
-# default. --key-file is preferred over --key so the key is not visible in the
-# service's argument list; write it 0600-equivalent (Administrators/SYSTEM only).
+# TLS args are all-or-nothing, and a routable bind requires them.
+if ([bool]$TlsCert -ne [bool]$TlsKey) {
+    throw "Set both -TlsCert and -TlsKey, or neither."
+}
+$tlsEnabled = [bool]$TlsCert
+if ($BindHost -ne "127.0.0.1" -and $BindHost -ne "::1" -and $BindHost -ne "localhost" -and -not $tlsEnabled) {
+    throw "A non-loopback -BindHost requires -TlsCert and -TlsKey (spelunk-server refuses a plaintext off-host bind)."
+}
+
+# --key-file is preferred over --key so the key is not visible in the service's
+# argument list; write it 0600-equivalent (Administrators/SYSTEM only).
 $keyFile = Join-Path $DataDir "server-key"
 Set-Content -Path $keyFile -Value $ServerKey -NoNewline
 icacls $keyFile /inheritance:r /grant:r "SYSTEM:(R)" "Administrators:(R)" | Out-Null
 
-$serverArgs = "--port $Port --db `"$dbPath`" --key-file `"$keyFile`""
+$serverArgs = "--host $BindHost --port $Port --db `"$dbPath`" --key-file `"$keyFile`""
+if ($tlsEnabled) {
+    # The private key must be a locked-down file (SYSTEM/Administrators only).
+    $serverArgs += " --tls-cert `"$TlsCert`" --tls-key `"$TlsKey`""
+}
 
 & $NssmPath install $ServiceName $BinaryPath
 & $NssmPath set $ServiceName AppParameters $serverArgs
@@ -81,5 +104,6 @@ $serverArgs = "--port $Port --db `"$dbPath`" --key-file `"$keyFile`""
 
 & $NssmPath start $ServiceName
 
-Write-Host "Installed and started service '$ServiceName' on 127.0.0.1:$Port."
+$scheme = if ($tlsEnabled) { "https" } else { "http" }
+Write-Host "Installed and started service '$ServiceName' on ${scheme}://${BindHost}:$Port."
 Write-Host "Verify: & '$BinaryPath' --health-check --port $Port"

--- a/examples/mdm/windows/README.md
+++ b/examples/mdm/windows/README.md
@@ -67,26 +67,38 @@ Run one long-lived `spelunk-server` and point every laptop at it.
    `%ProgramData%\spelunk\`.
 2. **Run the server as a Windows Service.** Use
    [`Install-SpelunkServerService.ps1`](Install-SpelunkServerService.ps1). It
-   registers `spelunk-server.exe` under NSSM (a service wrapper), binds loopback,
-   stores the DB and logs under `%ProgramData%\spelunk\`, and reads the API key
-   from a locked-down key file.
+   registers `spelunk-server.exe` under NSSM (a service wrapper), stores the DB
+   and logs under `%ProgramData%\spelunk\`, and reads the API key from a
+   locked-down key file. For a team-reachable server, pass `-BindHost 0.0.0.0`
+   with your PEM certificate and private key so the server terminates HTTPS
+   in-process (ADR-066), with nothing in front of it:
 
    ```powershell
-   .\Install-SpelunkServerService.ps1 -ServerKey "replace-with-your-shared-api-key"
+   .\Install-SpelunkServerService.ps1 `
+     -ServerKey "replace-with-your-shared-api-key" `
+     -BindHost 0.0.0.0 `
+     -TlsCert "C:\ProgramData\spelunk\tls-cert.pem" `
+     -TlsKey  "C:\ProgramData\spelunk\tls-key.pem"
    ```
+
+   Bring your own certificate (an internal CA, `certbot`, or a cloud-issued
+   cert); `spelunk-server` does not renew it, so the operator does. Omit the
+   `-BindHost`/`-TlsCert`/`-TlsKey` args for an on-host-only server that keeps the
+   loopback default.
 
    `spelunk-server.exe` is a plain console program and does not speak the Windows
    Service Control Manager protocol, so `sc.exe create` / `New-Service` pointed
    directly at it will fail to start (error 1053). A wrapper is required; the
    script uses NSSM, and WinSW or a startup Task Scheduler task work equally.
-3. **This installs a loopback-only server.** `spelunk-server` refuses a
-   non-loopback plaintext bind with no override, so the service from step 2 is
-   not reachable off-host by itself. Exposing it to other machines is a
-   separate deployment decision, out of scope for this script and README.
+3. **A non-loopback bind needs both TLS and a key.** `spelunk-server` refuses a
+   non-loopback plaintext bind with no override, so a routable `-BindHost`
+   requires `-TlsCert`/`-TlsKey` and the API key (the script enforces this). Lock
+   the private key file down to SYSTEM/Administrators only. Loopback with no TLS
+   stays on-host only.
 4. **Pre-configure the laptops.** Push [`../spelunk-config.toml`](../spelunk-config.toml)
    to each user's `%USERPROFILE%\.config\spelunk\config.toml` with `server_url`
-   set to wherever your own deployment makes the server reachable, and deliver
-   the shared `SPELUNK_SERVER_KEY` via the environment mechanism below.
+   set to the server's `https://` endpoint, and deliver the shared
+   `SPELUNK_SERVER_KEY` via the environment mechanism below.
 
 ## Pushing spelunk configuration on Windows
 


### PR DESCRIPTION
## What changed

Retires the reverse-proxy team-server model from the deployment docs. `spelunk-server` now terminates HTTPS in-process (ADR-066), so the docs, MDM examples, and Compose file teach the server's own `--tls-cert`/`--tls-key` HTTPS with an API key, bound to a routable interface. No separate TLS terminator to install, own, or keep current.

- **docs/self-hosting.md, docs/server.md, docs/remote-agents.md, docs/security/THREAT-MODEL.md** restructured to the native-HTTPS shape: the recommended remote recipe is `--host 0.0.0.0 --tls-cert … --tls-key …` plus a bearer key, and the bind-safety policy table matches the shipped binary's 4-row rule (loopback allowed; non-loopback refused unless both TLS and a key are set).
- **examples/mdm/** (macOS `.mobileconfig`, Windows install script + READMEs) updated to provision the routable TLS bind directly.
- **docker-compose.yml** teaches the same native-TLS shape and fixes the team-server HTTPS healthcheck.
- **docs/adr/056, docs/adr/058** get append-only corrections noting the topology is superseded by ADR-066; the systemd unit, dedicated user, credential handling, and sandboxing remain in force. Only the "put a terminator in front" shape is retired.

## Test plan

- Proxy-grep over the diff (`reverse proxy|caddy|nginx|terminator|proxy_pass`): every remaining hit is prose retiring the proxy shape, not recommending it.
- `docker-compose.yml` parses under a YAML loader; `examples/mdm/macos/cloud.spelunk.server.mobileconfig` passes `plutil -lint`.
- Documented bind-safety table cross-checked against the shipped `spelunk-server` bind logic (the 4-row loopback/TLS/key policy) and matches exactly.
- ADR-056/058 changes confirmed append-only (no body deletions); no em-dashes on added lines.
- Rebased onto latest `main`; diff touches only deployment docs, MDM examples, `docker-compose.yml`, and the two ADR appends.
