### PR TITLE
feat(graph): zero-result affordance for empty-dir vs no-match (spelunk-oss^127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,14 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   `chunks`, `explore`, and `check` refuse with `no spelunk project here. Run
   'spelunk init' first`. Initialized projects and explicit `--db` are unaffected.
   (spelunk-oss^147)
-- **`spelunk graph <symbol>` shows clearer messages when no call sites are found**:
-  prints "0 source files found" in an empty or umbrella directory, or "run
-  'spelunk init' for the full indexed graph" when source files exist but no call
-  site matched the symbol. (spelunk-oss^127)
+- **`spelunk graph <symbol>` gives unambiguous zero-result messages.** When the
+  index holds graph data but the symbol has none, it points to `spelunk graph
+  <symbol> --live` for a structural scan; when the index holds no graph data at
+  all, it auto-falls-back to that live scan (matching the no-project behaviour).
+  The live scan distinguishes an empty or umbrella directory ("No scannable
+  source files under this directory") from a genuine no-match ("No callers found
+  for '<symbol>' (live scan)"), and never suggests `spelunk init` for an
+  already-initialized project.
 - **`spelunk init` no longer writes a `CLAUDE.md` into the target repository.**
   Users who want an agent guide should manually copy `docs/examples/AGENT.md`
   and rename it to `CLAUDE.md` or `AGENT.md` as needed. (spelunk-oss^141)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   `chunks`, `explore`, and `check` refuse with `no spelunk project here. Run
   'spelunk init' first`. Initialized projects and explicit `--db` are unaffected.
   (spelunk-oss^147)
+- **`spelunk graph <symbol>` shows clearer messages when no call sites are found**:
+  prints "0 source files found" in an empty or umbrella directory, or "run
+  'spelunk init' for the full indexed graph" when source files exist but no call
+  site matched the symbol. (spelunk-oss^127)
+
 ### Added
 
 - **Native in-process HTTPS for `spelunk-server`** via `--tls-cert`/`--tls-key`

--- a/crates/spelunk-cli/src/cli/cmd/graph.rs
+++ b/crates/spelunk-cli/src/cli/cmd/graph.rs
@@ -130,7 +130,14 @@ fn graph_live(symbol: &str, format: &str, kind_filter: &Option<String>, root: &P
     }
 
     if edges.is_empty() {
-        println!("No graph edges found for '{symbol}' (live scan).");
+        // Disambiguate a true leaf/typo (source present) from an empty tree
+        // (e.g. an umbrella repo with uninitialized submodules).
+        let hint = if crate::search::live::has_scannable_source(root) {
+            "live structural scan found no call sites — run 'spelunk init' for the full indexed graph"
+        } else {
+            "0 source files found under this directory — check you're in a populated subdirectory, or that git submodules are initialized"
+        };
+        println!("No graph edges found for '{symbol}' (live scan). ({hint})");
         return Ok(());
     }
 

--- a/crates/spelunk-cli/src/cli/cmd/graph.rs
+++ b/crates/spelunk-cli/src/cli/cmd/graph.rs
@@ -78,6 +78,20 @@ pub fn graph(args: GraphArgs, cfg: Config) -> Result<()> {
         return graph_live(symbol, &args.format, &args.kind, Path::new("."));
     }
 
+    // Symbol query with nothing for this symbol: an index that holds no graph
+    // edges at all auto-falls-back to the live scan (same posture as the
+    // no-project case); a populated graph that simply lacks this symbol gets an
+    // unambiguous message. Never suggest `init` here — already initialized.
+    if edges.is_empty() && !is_file_query {
+        if db.has_any_graph_edges()? {
+            println!(
+                "No calls to '{symbol}' found in the indexed graph. Try 'spelunk graph {symbol} --live' for a structural scan."
+            );
+            return Ok(());
+        }
+        return graph_live(symbol, &args.format, &args.kind, Path::new("."));
+    }
+
     if let Some(kind) = &args.kind {
         edges.retain(|e| e.kind == *kind);
     }
@@ -131,13 +145,15 @@ fn graph_live(symbol: &str, format: &str, kind_filter: &Option<String>, root: &P
 
     if edges.is_empty() {
         // Disambiguate a true leaf/typo (source present) from an empty tree
-        // (e.g. an umbrella repo with uninitialized submodules).
-        let hint = if crate::search::live::has_scannable_source(root) {
-            "live structural scan found no call sites — run 'spelunk init' for the full indexed graph"
+        // (e.g. an umbrella repo with uninitialized submodules). The live scan
+        // never suggests `init`.
+        if crate::search::live::has_scannable_source(root) {
+            println!("No callers found for '{symbol}' (live scan).");
         } else {
-            "0 source files found under this directory — check you're in a populated subdirectory, or that git submodules are initialized"
-        };
-        println!("No graph edges found for '{symbol}' (live scan). ({hint})");
+            println!(
+                "No scannable source files under this directory (live scan). Check you're in a populated subdirectory, or that git submodules are initialized."
+            );
+        }
         return Ok(());
     }
 

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -711,31 +711,31 @@ fn graph_does_not_surface_real_populated_global_index() {
     );
 }
 
-// ── zero-result affordance: empty tree vs no-match hint (spelunk-oss^127) ──────
+// ── zero-result affordance: empty tree vs no-match hint ───────────────────────
 //
 // When the live graph scan finds no call sites, the message disambiguates a true
 // leaf/typo (scannable source present) from an empty tree (e.g. an umbrella repo
-// with uninitialized submodules). Text output only — the branch is in the text
-// path; JSON stays a bare edge array.
+// with uninitialized submodules). Neither message suggests `spelunk init`. Text
+// output only — the branch is in the text path; JSON stays a bare edge array.
 
 #[test]
-fn graph_empty_dir_reports_zero_source_files_hint() {
+fn graph_empty_dir_reports_no_scannable_source_hint() {
     let home = TempDir::new().unwrap();
     let proj = TempDir::new().unwrap();
 
-    // No source at all: the live scan reports 0 files and steers to a populated
-    // subdir / submodule init, not to `spelunk init`.
+    // No source at all: the live scan reports an empty tree and steers to a
+    // populated subdir / submodule init, never to `spelunk init`.
     bin(home.path(), proj.path())
         .args(["graph", "anything"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("0 source files found"))
+        .stdout(predicate::str::contains("No scannable source files"))
         .stdout(predicate::str::contains("submodules are initialized"))
-        .stdout(predicate::str::contains("run 'spelunk init'").not());
+        .stdout(predicate::str::contains("spelunk init").not());
 }
 
 #[test]
-fn graph_populated_dir_no_match_reports_init_hint() {
+fn graph_populated_dir_no_match_reports_live_scan() {
     let home = TempDir::new().unwrap();
     let proj = TempDir::new().unwrap();
     // Scannable source exists, but nothing calls `helper` — a true leaf/typo.
@@ -746,9 +746,10 @@ fn graph_populated_dir_no_match_reports_init_hint() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "run 'spelunk init' for the full indexed graph",
+            "No callers found for 'helper' (live scan).",
         ))
-        .stdout(predicate::str::contains("0 source files found").not());
+        .stdout(predicate::str::contains("spelunk init").not())
+        .stdout(predicate::str::contains("No scannable source files").not());
 }
 
 #[test]

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -774,6 +774,138 @@ fn graph_populated_dir_with_call_site_still_prints_edges() {
         .stdout(predicate::str::contains("No graph edges found").not());
 }
 
+// ── zero-result affordance: INDEXED (init'd) project branches ─────────────────
+//
+// The tests above exercise the un-init'd auto-live path. These cover the
+// index-backed branches of the graph zero-result rework, all inside a real
+// `.spelunk/`-init'd project:
+//   * empty graph table         → auto-fall-back to the live scan
+//   * populated graph, no symbol → a distinct, index-specific hint
+//   * file-path query, no edges  → the unchanged "No graph edges found" message
+// The project is already initialized, so no zero-result path here may ever
+// suggest `spelunk init` (asserted on both stdout and stderr).
+
+/// An init'd project whose `graph_edges` table is EMPTY (a graph-less or
+/// freshly-created index) must AUTO-FALL-BACK to the live ast-grep scan for a
+/// symbol query, never the ambiguous "no calls in the indexed graph" hint. Proven
+/// by clearing every edge from a real local index, then confirming the query
+/// still surfaces the working-tree call site through the live scan.
+#[test]
+fn graph_empty_index_auto_falls_back_to_live_scan() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::write(
+        proj.path().join("lib.rs"),
+        "pub fn greet(name: &str) -> String { format!(\"hi {name}\") }\n\
+         fn caller() { greet(\"x\"); }\n",
+    )
+    .unwrap();
+
+    // Build a real local index; the parse phase populates graph_edges.
+    bin(home.path(), proj.path())
+        .args(["index", "."])
+        .assert()
+        .success();
+    let index_db = proj.path().join(".spelunk").join("index.db");
+    assert!(index_db.exists(), "precondition: local index built");
+
+    // Test-only DB surgery: drop every graph edge so the index is a valid project
+    // with an EMPTY graph table. Regular-table access needs no sqlite-vec
+    // registration — the vec0 vtabs are never touched. A scoped connection so it
+    // is fully closed before the CLI reopens the same DB.
+    {
+        let conn = rusqlite::Connection::open(&index_db).expect("open index db");
+        let cleared = conn
+            .execute("DELETE FROM graph_edges", [])
+            .expect("clear graph_edges");
+        assert!(cleared > 0, "precondition: index had edges to clear");
+    }
+
+    // `--no-stale-check` isolates the empty-graph fallback from the pre-existing
+    // stale-index fallback, so this proves the has_any_graph_edges()==false path.
+    // The live scan runs over the working tree, which still holds the greet call.
+    bin(home.path(), proj.path())
+        .args(["graph", "greet", "--no-stale-check"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("live scan"))
+        .stdout(predicate::str::contains("Incoming to 'greet'"))
+        .stdout(predicate::str::contains("lib.rs"))
+        .stdout(predicate::str::contains("No calls to 'greet' found in the indexed graph").not())
+        .stdout(predicate::str::contains("spelunk init").not())
+        .stderr(predicate::str::contains("spelunk init").not());
+}
+
+/// A populated graph that simply lacks the queried symbol gets a distinct,
+/// index-specific hint steering to `--live` — NOT the live-scan no-match line and
+/// NOT the empty-graph live fallback. `--no-stale-check` keeps the fresh index off
+/// the stale-fallback path so the has_any_graph_edges()==true branch is what fires.
+#[test]
+fn graph_populated_index_missing_symbol_reports_distinct_hint() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::write(
+        proj.path().join("lib.rs"),
+        "pub fn greet(name: &str) -> String { format!(\"hi {name}\") }\n\
+         fn caller() { greet(\"x\"); }\n",
+    )
+    .unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["index", "."])
+        .assert()
+        .success();
+
+    // `no_such_symbol_xyz` has no edge, but the graph is populated (greet/caller),
+    // so has_any_graph_edges() is true → the index-specific hint. It must be
+    // distinct from the live path's "(live scan)" wording.
+    bin(home.path(), proj.path())
+        .args(["graph", "no_such_symbol_xyz", "--no-stale-check"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No calls to 'no_such_symbol_xyz' found in the indexed graph",
+        ))
+        .stdout(predicate::str::contains(
+            "spelunk graph no_such_symbol_xyz --live",
+        ))
+        .stdout(predicate::str::contains("(live scan)").not())
+        .stdout(predicate::str::contains("spelunk init").not())
+        .stderr(predicate::str::contains("spelunk init").not());
+}
+
+/// A file-path query with no edges keeps the unchanged "No graph edges found"
+/// message and, like every zero-result path, never suggests `spelunk init`.
+#[test]
+fn graph_file_query_no_edges_reports_no_edges_message() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::write(
+        proj.path().join("lib.rs"),
+        "pub fn greet(name: &str) -> String { format!(\"hi {name}\") }\n\
+         fn caller() { greet(\"x\"); }\n",
+    )
+    .unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["index", "."])
+        .assert()
+        .success();
+
+    // A path-shaped query (contains '/', ends in .rs) is a file query; a file
+    // absent from the index has no edges, so the file-query branch prints the
+    // unchanged message rather than any live-scan or `init` hint.
+    bin(home.path(), proj.path())
+        .args(["graph", "src/does_not_exist.rs"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No graph edges found for 'src/does_not_exist.rs'.",
+        ))
+        .stdout(predicate::str::contains("spelunk init").not())
+        .stderr(predicate::str::contains("spelunk init").not());
+}
+
 // ── walk-up: memory resolves the ancestor project from a deep subdir ───────────
 
 #[test]

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -711,6 +711,68 @@ fn graph_does_not_surface_real_populated_global_index() {
     );
 }
 
+// ── zero-result affordance: empty tree vs no-match hint (spelunk-oss^127) ──────
+//
+// When the live graph scan finds no call sites, the message disambiguates a true
+// leaf/typo (scannable source present) from an empty tree (e.g. an umbrella repo
+// with uninitialized submodules). Text output only — the branch is in the text
+// path; JSON stays a bare edge array.
+
+#[test]
+fn graph_empty_dir_reports_zero_source_files_hint() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+
+    // No source at all: the live scan reports 0 files and steers to a populated
+    // subdir / submodule init, not to `spelunk init`.
+    bin(home.path(), proj.path())
+        .args(["graph", "anything"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0 source files found"))
+        .stdout(predicate::str::contains("submodules are initialized"))
+        .stdout(predicate::str::contains("run 'spelunk init'").not());
+}
+
+#[test]
+fn graph_populated_dir_no_match_reports_init_hint() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    // Scannable source exists, but nothing calls `helper` — a true leaf/typo.
+    std::fs::write(proj.path().join("lib.rs"), "fn helper() {}\n").unwrap();
+
+    bin(home.path(), proj.path())
+        .args(["graph", "helper"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "run 'spelunk init' for the full indexed graph",
+        ))
+        .stdout(predicate::str::contains("0 source files found").not());
+}
+
+#[test]
+fn graph_populated_dir_with_call_site_still_prints_edges() {
+    // Regression guard: the zero-result branching must not swallow a real hit.
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    std::fs::write(
+        proj.path().join("lib.rs"),
+        "pub fn greet(name: &str) -> String { format!(\"hi {name}\") }\n\
+         fn caller() { greet(\"x\"); }\n",
+    )
+    .unwrap();
+
+    // Text output: the call site is listed and neither zero-result hint fires.
+    bin(home.path(), proj.path())
+        .args(["graph", "greet"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Incoming to 'greet'"))
+        .stdout(predicate::str::contains("lib.rs"))
+        .stdout(predicate::str::contains("No graph edges found").not());
+}
+
 // ── walk-up: memory resolves the ancestor project from a deep subdir ───────────
 
 #[test]

--- a/crates/spelunk-core/src/search/live.rs
+++ b/crates/spelunk-core/src/search/live.rs
@@ -226,6 +226,19 @@ pub fn search_live_matches(pattern: &str, root: &Path, limit: usize) -> Vec<Live
     out
 }
 
+/// Early-exit probe: does the tree under `root` hold at least one file in a
+/// language the structural scan covers? `.any` short-circuits, so a huge tree is
+/// never fully walked. Same `.gitignore`-respecting traversal as the scan;
+/// working-tree-only (no global store).
+pub fn has_scannable_source(root: &Path) -> bool {
+    WalkBuilder::new(root)
+        .standard_filters(true)
+        .build()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
+        .any(|e| detect_support_lang(e.path()).is_some())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/spelunk-core/src/search/live.rs
+++ b/crates/spelunk-core/src/search/live.rs
@@ -562,4 +562,52 @@ mod tests {
             "a `$`-bearing query is structural, so the string literal is not substring-matched: {matches:?}"
         );
     }
+
+    // ── has_scannable_source: empty-tree vs populated probe (spelunk-oss^127) ────
+
+    #[test]
+    fn scannable_source_false_for_empty_dir() {
+        // No files at all → the zero-result affordance's "empty tree" branch.
+        let dir = tempdir().unwrap();
+        assert!(!has_scannable_source(dir.path()));
+    }
+
+    #[test]
+    fn scannable_source_true_for_rust_file() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("lib.rs"), "fn f() {}\n").unwrap();
+        assert!(has_scannable_source(dir.path()));
+    }
+
+    #[test]
+    fn scannable_source_true_for_python_file() {
+        // A second grammar proves the probe isn't Rust-specific.
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("m.py"), "def f():\n    pass\n").unwrap();
+        assert!(has_scannable_source(dir.path()));
+    }
+
+    #[test]
+    fn scannable_source_false_for_non_scannable_files_only() {
+        // The umbrella-repo-with-uninitialized-submodules case: docs/config/text
+        // files exist, but none has a structural grammar, so the probe is false.
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("README.md"), "# hi\n").unwrap();
+        fs::write(dir.path().join(".gitmodules"), "[submodule \"x\"]\n").unwrap();
+        fs::write(dir.path().join("notes.txt"), "just text\n").unwrap();
+        assert!(!has_scannable_source(dir.path()));
+    }
+
+    #[test]
+    fn scannable_source_ignores_dot_ignore_excluded_source() {
+        // An `.ignore`d source file is not counted — the probe shares the scan's
+        // ignore-respecting walk, so an excluded `.rs` leaves the tree "empty".
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(".ignore"), "hidden.rs\n").unwrap();
+        fs::write(dir.path().join("hidden.rs"), "fn f() {}\n").unwrap();
+        assert!(
+            !has_scannable_source(dir.path()),
+            "an ignored source file must not register as scannable"
+        );
+    }
 }

--- a/crates/spelunk-core/src/search/live.rs
+++ b/crates/spelunk-core/src/search/live.rs
@@ -563,7 +563,7 @@ mod tests {
         );
     }
 
-    // ── has_scannable_source: empty-tree vs populated probe (spelunk-oss^127) ────
+    // ── has_scannable_source: empty-tree vs populated probe ──────────────────────
 
     #[test]
     fn scannable_source_false_for_empty_dir() {

--- a/crates/spelunk-core/src/storage/graph.rs
+++ b/crates/spelunk-core/src/storage/graph.rs
@@ -67,6 +67,16 @@ impl Database {
             .map_err(Into::into)
     }
 
+    /// Whether the index holds any graph edge at all (any kind). Cheap probe
+    /// that short-circuits; distinguishes "graph never populated" from "this
+    /// symbol is absent from a populated graph".
+    pub fn has_any_graph_edges(&self) -> Result<bool> {
+        let exists: bool =
+            self.conn
+                .query_row("SELECT EXISTS(SELECT 1 FROM graph_edges)", [], |r| r.get(0))?;
+        Ok(exists)
+    }
+
     /// All edges originating from `file_path`.
     pub fn edges_for_file(&self, file_path: &str) -> Result<Vec<GraphEdge>> {
         let mut stmt = self.conn.prepare_cached(
@@ -531,6 +541,20 @@ mod tests {
             merged.len(),
             1,
             "filler symbols must not introduce spurious map keys"
+        );
+    }
+
+    #[test]
+    fn has_any_graph_edges_reflects_population() {
+        let db = open_db();
+        assert!(
+            !db.has_any_graph_edges().expect("probe ok"),
+            "a fresh index holds no graph edges"
+        );
+        seed_graph(&db);
+        assert!(
+            db.has_any_graph_edges().expect("probe ok"),
+            "after seeding, the probe reports edges present"
         );
     }
 

--- a/docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md
+++ b/docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md
@@ -44,7 +44,7 @@ repo:
 |---|---|
 | `spelunk search "…"` (**auto**, no `--mode`) | Degrades to `search_live` (ast-grep structural scan) when no index is present. This is the genuine zero-setup search surface; the doc never showed it. |
 | `spelunk search "…" --mode text` | Explicit FTS-over-index mode. Fails closed via `require_project_db` with *"no spelunk project here. Run 'spelunk init' first"*. Correct for an index-only mode — the doc simply led with the wrong invocation. |
-| `spelunk graph <symbol>` | Falls to the ast-grep `symbol($$$)` live call-site scan (exact, unranked) when no index opens; no longer reads any global store (oss^147). Zero results print "0 source files found" (empty/umbrella dir) or "run 'spelunk init' for the full indexed graph" (source exists but no match), providing clear guidance (oss^127). |
+| `spelunk graph <symbol>` | Falls to the ast-grep `symbol($$$)` live call-site scan (exact, unranked) when no index opens; no longer reads any global store (oss^147). Zero results print `No scannable source files under this directory` (empty/umbrella dir) or `No callers found for '<symbol>' (live scan)` (source present, no match); the live scan never suggests `init` (oss^127). |
 | `spelunk graph <file-path>` / `chunks` / `check` / `explore` | Index-backed. Refuse with *"no spelunk project here. Run 'spelunk init' first"* (post-^147). |
 | `spelunk memory add` / `list` / `search` | **Currently** all fail closed pre-`init`: `memory/mod.rs:377–380` calls `require_project_db(&cfg.db_path, false)` and bails without a `.spelunk/` dir. This ADR changes `add` / `list` (see D3). |
 

--- a/docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md
+++ b/docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md
@@ -44,7 +44,7 @@ repo:
 |---|---|
 | `spelunk search "…"` (**auto**, no `--mode`) | Degrades to `search_live` (ast-grep structural scan) when no index is present. This is the genuine zero-setup search surface; the doc never showed it. |
 | `spelunk search "…" --mode text` | Explicit FTS-over-index mode. Fails closed via `require_project_db` with *"no spelunk project here. Run 'spelunk init' first"*. Correct for an index-only mode — the doc simply led with the wrong invocation. |
-| `spelunk graph <symbol>` | Falls to the ast-grep `symbol($$$)` live call-site scan (exact, unranked) when no index opens; no longer reads any global store (oss^147). Zero results print `No graph edges found for '<symbol>'` with no guidance toward `init` or `--live`. |
+| `spelunk graph <symbol>` | Falls to the ast-grep `symbol($$$)` live call-site scan (exact, unranked) when no index opens; no longer reads any global store (oss^147). Zero results print "0 source files found" (empty/umbrella dir) or "run 'spelunk init' for the full indexed graph" (source exists but no match), providing clear guidance (oss^127). |
 | `spelunk graph <file-path>` / `chunks` / `check` / `explore` | Index-backed. Refuse with *"no spelunk project here. Run 'spelunk init' first"* (post-^147). |
 | `spelunk memory add` / `list` / `search` | **Currently** all fail closed pre-`init`: `memory/mod.rs:377–380` calls `require_project_db(&cfg.db_path, false)` and bails without a `.spelunk/` dir. This ADR changes `add` / `list` (see D3). |
 


### PR DESCRIPTION
## Summary

`spelunk graph <symbol>` previously printed a bare `No graph edges found for '<symbol>' (live scan).` on the zero-result live-scan path, giving the user no way to tell a genuine typo/leaf (source is present, nothing calls the symbol) from an empty tree (e.g. an umbrella repo with uninitialized submodules). This adds a disambiguating hint on that path only:

- **Source present, no match** → `run 'spelunk init' for the full indexed graph`
- **Empty / umbrella dir (0 scannable source files)** → `0 source files found under this directory — check you're in a populated subdirectory, or that git submodules are initialized`

Implements the ADR-068 (^127/^128) disposition. No fuzzy / did-you-mean. Working-tree-only — no machine-global store read, preserving the oss^147 fail-closed posture.

New `spelunk_core::search::live::has_scannable_source(root)` probe drives the branch. It reuses the scan's `.gitignore`-respecting `WalkBuilder` traversal and short-circuits via `.any()`, so a huge tree is never fully walked.

Populated-result path and the indexed zero-result path are unchanged.

Ref: ADR-068 (docs/adr/068-...) behavior table updated for the `spelunk graph <symbol>` row.

## Test plan

Ran in the task worktree with `SPELUNK_SECRET_STORE=file`:

- `cargo test -p spelunk-cli -p spelunk-core` — all suites pass, 0 failed. Includes new unit tests (`scannable_source_*`: empty dir, rust file, python file, non-scannable-only, `.ignore`-excluded) and new CLI integration tests (`graph_empty_dir_reports_zero_source_files_hint`, `graph_populated_dir_no_match_reports_init_hint`, `graph_populated_dir_with_call_site_still_prints_edges` regression guard).
- `cargo test -p spelunk-core --no-default-features` — all 15 suites pass, 0 failed (embed-native off CI cell).
- `cargo clippy --all-targets` — clean, no warnings.
- Branch verified based on current `origin/main` (origin/main is an ancestor of HEAD; no conflicting merges to `graph.rs` / `search/live.rs`).