### PR TITLE
fix(init): stop writing an uninvited CLAUDE.md into the user's repo (spelunk-oss^141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   `chunks`, `explore`, and `check` refuse with `no spelunk project here. Run
   'spelunk init' first`. Initialized projects and explicit `--db` are unaffected.
   (spelunk-oss^147)
+- **`spelunk init` no longer writes a `CLAUDE.md` into the target repository.**
+  Users who want an agent guide should manually copy `docs/examples/AGENT.md`
+  and rename it to `CLAUDE.md` or `AGENT.md` as needed. (spelunk-oss^141)
+
 ### Added
 
 - **Native in-process HTTPS for `spelunk-server`** via `--tls-cert`/`--tls-key`

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -35,12 +35,6 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
         }
     };
 
-    // Directory basename — a cosmetic title only (used for the CLAUDE.md heading).
-    let dir_name = project_root
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| project_root.to_string_lossy().into_owned());
-
     let spelunk_dir = project_root.join(".spelunk");
     let db_path = spelunk_dir.join("index.db");
     let config_path = spelunk_dir.join("config.toml");
@@ -145,54 +139,7 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
         }
     };
 
-    // ── 6. Write CLAUDE.md if missing ─────────────────────────────────────────
-    let claude_md_path = project_root.join("CLAUDE.md");
-    if !claude_md_path.exists() {
-        let claude_md = format!(
-            "# CLAUDE.md — {name}\n\
-             \n\
-             Developer guide for AI agents working on this codebase.\n\
-             \n\
-             ---\n\
-             \n\
-             ## Agent workflow\n\
-             \n\
-             This project is indexed with spelunk. Use it — don't just use Read/Grep/Glob.\n\
-             \n\
-             **At the start of every session:**\n\
-             ```bash\n\
-             spelunk check                 # verify index is fresh\n\
-             spelunk context               # review handoffs, open questions, decisions, requirements\n\
-             ```\n\
-             \n\
-             **Before reading any file, search first:**\n\
-             ```bash\n\
-             spelunk search \"<topic>\"      # find relevant chunks by meaning\n\
-             spelunk graph <symbol>        # trace callers/callees when needed\n\
-             ```\n\
-             \n\
-             **Store decisions as you make them:**\n\
-             ```bash\n\
-             spelunk memory add --kind decision --title \"...\" --body \"why, alternatives, tradeoffs\"\n\
-             spelunk memory add --kind requirement --title \"...\"\n\
-             spelunk memory add --kind note --title \"...\"      # surprising/non-obvious facts\n\
-             ```\n\
-             \n\
-             **At the end of every session:**\n\
-             ```bash\n\
-             spelunk memory add --kind handoff --title \"Handoff: <summary>\" --body \"done, next, open\"\n\
-             spelunk index .               # re-index after any commits\n\
-             ```\n",
-            name = dir_name
-        );
-        if let Err(e) = std::fs::write(&claude_md_path, claude_md) {
-            eprintln!("Warning: could not write CLAUDE.md: {e}");
-        } else {
-            println!("  CLAUDE.md written to {}", claude_md_path.display());
-        }
-    }
-
-    // ── 7. Auto-spawn server (TTY only) or probe for a running server ─────────
+    // ── 6. Auto-spawn server (TTY only) or probe for a running server ─────────
     //
     // Interactive (stdin is a TTY): attempt to start the server so semantic
     // search works immediately. Non-interactive (CI / hook): probe only —
@@ -221,7 +168,7 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
         }
     };
 
-    // ── 8. Print success summary ──────────────────────────────────────────────
+    // ── 7. Print success summary ──────────────────────────────────────────────
     println!();
     println!("spelunk initialised for {}", project_slug);
     println!();

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -1138,6 +1138,81 @@ fn test_init_non_tty_prints_skip_notice() {
         ));
 }
 
+/// Init a git repo at `dir` with a committer identity so `spelunk init` finds a
+/// project root. (spelunk#141 init tests only need the repo, not any commits.)
+fn git_init_repo(dir: &std::path::Path) {
+    for args in [
+        &["init", "-q"][..],
+        &["config", "user.email", "test@test.com"][..],
+        &["config", "user.name", "Test"][..],
+    ] {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("git setup");
+    }
+}
+
+/// spelunk-oss^141: `spelunk init` must NOT create an uninvited `CLAUDE.md` in
+/// the user's repo, and must not claim to have written one.
+#[test]
+fn test_init_does_not_write_claude_md() {
+    let tmp = tempdir().unwrap();
+    git_init_repo(tmp.path());
+
+    let config_path = tmp.path().join("config.toml");
+    fs::write(&config_path, "").unwrap();
+
+    spelunk_bin()
+        .current_dir(tmp.path())
+        .env("HOME", tmp.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&config_path)
+        .args(["init", "--no-index"])
+        .assert()
+        .success()
+        // The uninvited-write log line must be gone.
+        .stdout(predicate::str::contains("CLAUDE.md written").not());
+
+    assert!(
+        !tmp.path().join("CLAUDE.md").exists(),
+        "init must not create a CLAUDE.md in the project root"
+    );
+}
+
+/// spelunk-oss^141: a pre-existing `CLAUDE.md` must be left byte-for-byte
+/// untouched — init must never overwrite a user's own file.
+#[test]
+fn test_init_leaves_existing_claude_md_untouched() {
+    let tmp = tempdir().unwrap();
+    git_init_repo(tmp.path());
+
+    let claude_md = tmp.path().join("CLAUDE.md");
+    let sentinel = b"# my own CLAUDE.md\n\ndo not touch\n";
+    fs::write(&claude_md, sentinel).unwrap();
+
+    let config_path = tmp.path().join("config.toml");
+    fs::write(&config_path, "").unwrap();
+
+    spelunk_bin()
+        .current_dir(tmp.path())
+        .env("HOME", tmp.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&config_path)
+        .args(["init", "--no-index"])
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read(&claude_md).unwrap(),
+        sentinel,
+        "init must not modify a pre-existing CLAUDE.md"
+    );
+}
+
 // ── memory commands against an auto-discovered (loopback) server ─────────────
 //
 // ADR-004 (unified memory storage): `.spelunk/memory.db` is the single


### PR DESCRIPTION
## What

`spelunk init` no longer writes a `CLAUDE.md` into the target repository, and no longer prints the `CLAUDE.md written to ...` line. The removal deletes the write block (former step 6) plus the now-unused `dir_name` variable that only fed the CLAUDE.md heading; comment step numbering is renumbered accordingly.

Per the founder constraint, **no replacement auto-write mechanism and no always-on flag were added** — init simply stops creating the file. Its other outputs (`.spelunk/config.toml`, `.spelunk/.gitignore`, index, hook install, server probe/spawn, success summary) are untouched.

Users who want an agent guide are directed (CHANGELOG) to manually copy the existing `docs/examples/AGENT.md` and rename it to `CLAUDE.md`/`AGENT.md`.

## Pre-existing-file safety

A pre-existing `CLAUDE.md` in the repo is left byte-for-byte unchanged — init never touches the user's own file. Covered by a dedicated test.

## Test plan

Ran in the task worktree with `SPELUNK_SECRET_STORE=file`:

- `cargo test -p spelunk-cli` — all green, including the two new e2e tests:
  - `test_init_does_not_write_claude_md` — asserts no `CLAUDE.md` is created and stdout does not contain "CLAUDE.md written"
  - `test_init_leaves_existing_claude_md_untouched` — writes a sentinel `CLAUDE.md`, runs init, asserts the bytes are unchanged
- `cargo test -p spelunk-cli --no-default-features` — all green (CI embed-native-off cell)
- `cargo clippy --all-targets` — zero warnings/errors
- Verified branch is based on current `origin/main` (no conflicting `init.rs` merges since fork) and `git diff origin/main...HEAD` is scoped to the removal + tests + CHANGELOG.

spelunk-oss^141