### PR TITLE
feat(memory): git-notes fallback for add/list before init (ADR-068 D3, spelunk-oss^154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   (spelunk-oss^147)
 ### Added
 
+- **`memory add` and `memory list` fall back to git-notes before `init`** when
+  inside a git repository, so you can record and list decisions without running
+  `spelunk init`. Entries are stored in `refs/notes/spelunk` on the repository's
+  HEAD, giving you a persistent memory store that travels with the code—locally.
+  `memory search` remains gated to initialized projects. (ADR-068, spelunk-oss^154)
 - **Native in-process HTTPS for `spelunk-server`** via `--tls-cert`/`--tls-key`
   (env `SPELUNK_SERVER_TLS_CERT`/`SPELUNK_SERVER_TLS_KEY`), both-or-neither. The
   server terminates TLS itself, so a team/remote deployment is a routable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,13 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **`memory add` and `memory list` fall back to git-notes before `init`** when
-  inside a git repository, so you can record and list decisions without running
-  `spelunk init`. Entries are stored in `refs/notes/spelunk` on the repository's
-  HEAD, giving you a persistent memory store that travels with the code—locally.
-  `memory search` remains gated to initialized projects. (ADR-068, spelunk-oss^154)
+- **`memory add` and `memory list` work before `init`** when inside a git
+  repository, so you can record and list decisions without running `spelunk init`
+  first. Pre-`init` entries ride the same git-notes write-through that already
+  runs after `init`, landing in `refs/notes/spelunk` on HEAD with an identical
+  record shape; there is no local SQLite store until you `spelunk init`. The
+  notes stay on the local machine unless you push the ref. `memory search`
+  remains gated to initialized projects. (ADR-068)
 - **Native in-process HTTPS for `spelunk-server`** via `--tls-cert`/`--tls-key`
   (env `SPELUNK_SERVER_TLS_CERT`/`SPELUNK_SERVER_TLS_KEY`), both-or-neither. The
   server terminates TLS itself, so a team/remote deployment is a routable

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -22,7 +22,15 @@ pub(super) async fn memory_add(
     // Build an effective config that routes inference to the discovered server
     // while leaving `server_url` unset, so `open_memory_backend` still writes the
     // note to the project's local `memory.db` (the single canonical store).
-    let project_root = mem_path.parent().unwrap_or(mem_path);
+    // On the git-notes path `mem_path` is a placeholder; the project is the git
+    // repo at CWD, so derive the inference project id from there instead.
+    let cwd;
+    let project_root: &std::path::Path = if backend_override == Some("git-notes") {
+        cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        &cwd
+    } else {
+        mem_path.parent().unwrap_or(mem_path)
+    };
     let tier = capability::get_tier(cfg).await;
     let eff_cfg = tier.effective_config(cfg, project_root);
     let cfg = &eff_cfg;
@@ -97,7 +105,10 @@ pub(super) async fn memory_add(
         .await?;
 
     // ── Git-notes write-through (best-effort, non-fatal) ─────────────────────
-    if cfg.store_in_git_notes {
+    // Skip when git-notes is already the primary store (explicit `--backend
+    // git-notes` or the ADR-068 D3 pre-init fallback): the backend just wrote
+    // this record to `refs/notes/spelunk`, so a write-through would duplicate it.
+    if cfg.store_in_git_notes && backend_override != Some("git-notes") {
         let record = NoteRecord {
             schema_version: 1,
             id,

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -6,7 +6,9 @@ use crate::{
     config::Config,
     indexer::secrets::contains_secret,
     server_client::ServerInferenceClient,
-    storage::{NoteInput, NoteRecord, append_to_git_notes, now_secs, open_memory_backend},
+    storage::{
+        NoteInput, NoteRecord, append_to_git_notes, now_millis, now_secs, open_memory_backend,
+    },
 };
 
 pub(super) async fn memory_add(
@@ -14,6 +16,7 @@ pub(super) async fn memory_add(
     mem_path: &std::path::Path,
     cfg: &Config,
     backend_override: Option<&str>,
+    pre_init_notes: bool,
 ) -> Result<()> {
     // Honor the auto-discovered server tier (ADR-004): loopback auto-discovery
     // sets the capability tier without populating `cfg.server_url`, so without
@@ -22,10 +25,12 @@ pub(super) async fn memory_add(
     // Build an effective config that routes inference to the discovered server
     // while leaving `server_url` unset, so `open_memory_backend` still writes the
     // note to the project's local `memory.db` (the single canonical store).
-    // On the git-notes path `mem_path` is a placeholder; the project is the git
+    // On the git-notes paths `mem_path` is a placeholder (explicit `--backend
+    // git-notes` or the ADR-068 D3 pre-init carrier); the project is the git
     // repo at CWD, so derive the inference project id from there instead.
     let cwd;
-    let project_root: &std::path::Path = if backend_override == Some("git-notes") {
+    let placeholder_path = pre_init_notes || backend_override == Some("git-notes");
+    let project_root: &std::path::Path = if placeholder_path {
         cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
         &cwd
     } else {
@@ -82,33 +87,52 @@ pub(super) async fn memory_add(
         );
     }
 
-    let embed_text = format!("title: {title} | text: {body}");
-    let embedding = try_embed_via_server(cfg, &embed_text).await;
+    // Pre-init carrier entries carry no vector (git notes hold none), and
+    // semantic `memory search` stays gated until the project is indexed and the
+    // carrier hydrates the index (ADR-068 D3/D4).
+    let embedding = if pre_init_notes {
+        None
+    } else {
+        let embed_text = format!("title: {title} | text: {body}");
+        try_embed_via_server(cfg, &embed_text).await
+    };
 
     let valid_at = args
         .valid_at
         .and_then(|s| super::parse_as_of(Some(&s)).ok().flatten());
 
-    let backend = open_memory_backend(cfg, mem_path, backend_override).await?;
-    let id = backend
-        .add(NoteInput {
-            kind: args.kind.clone(),
-            title: title.clone(),
-            body: body.clone(),
-            tags: tags.clone(),
-            linked_files: files.clone(),
-            embedding,
-            source_ref: None,
-            valid_at,
-            supersedes: args.supersedes,
-        })
-        .await?;
+    // Primary store (ADR-004): the local SQLite `memory.db`, an explicit team
+    // server, or (with `--backend git-notes`) git notes itself. Pre-init there
+    // is no primary; the write-through carrier below is the sole writer, so mint
+    // an id the same way the backends do (`now_millis`).
+    let id = if pre_init_notes {
+        now_millis()
+    } else {
+        let backend = open_memory_backend(cfg, mem_path, backend_override).await?;
+        backend
+            .add(NoteInput {
+                kind: args.kind.clone(),
+                title: title.clone(),
+                body: body.clone(),
+                tags: tags.clone(),
+                linked_files: files.clone(),
+                embedding,
+                source_ref: None,
+                valid_at,
+                supersedes: args.supersedes,
+            })
+            .await?
+    };
 
-    // ── Git-notes write-through (best-effort, non-fatal) ─────────────────────
-    // Skip when git-notes is already the primary store (explicit `--backend
-    // git-notes` or the ADR-068 D3 pre-init fallback): the backend just wrote
-    // this record to `refs/notes/spelunk`, so a write-through would duplicate it.
-    if cfg.store_in_git_notes && backend_override != Some("git-notes") {
+    // ── Git-notes write-through carrier ──────────────────────────────────────
+    // The single write path to `refs/notes/spelunk` both pre- and post-`init`,
+    // so every note carries an identical record shape. Suppressed only when git
+    // notes is already the primary store (explicit `--backend git-notes`), to
+    // avoid a double write. Post-`init` it is best-effort (SQLite already holds
+    // the entry); pre-`init` it is the sole store, so a failed carry is fatal.
+    let write_through =
+        pre_init_notes || (cfg.store_in_git_notes && backend_override != Some("git-notes"));
+    if write_through {
         let record = NoteRecord {
             schema_version: 1,
             id,
@@ -128,8 +152,14 @@ pub(super) async fn memory_add(
         };
         // Use process CWD (None) — the CLI is always run from the project root.
         // Secret scan already ran above; no second check needed here.
-        if let Err(e) = append_to_git_notes(None, &record).await {
-            tracing::warn!("git-notes write-through failed (non-fatal): {e}");
+        match append_to_git_notes(None, &record).await {
+            Ok(()) => {}
+            Err(e) if pre_init_notes => {
+                return Err(e.context(
+                    "recording memory entry to git notes (no local project store to fall back on)",
+                ));
+            }
+            Err(e) => tracing::warn!("git-notes write-through failed (non-fatal): {e}"),
         }
     }
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/list.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/list.rs
@@ -9,19 +9,25 @@ pub(super) async fn memory_list(
     mem_path: &std::path::Path,
     cfg: &Config,
     backend_override: Option<&str>,
+    pre_init_notes: bool,
 ) -> Result<()> {
-    // git-notes is a self-contained store of record (explicit `--backend
-    // git-notes` or the ADR-068 D3 pre-init fallback): `mem_path` is a
-    // placeholder, so skip the SQLite-oriented nudge and cross-project pass,
-    // which would otherwise open the local/global SQLite store.
-    let git_notes = backend_override == Some("git-notes");
+    // Read from git notes when it's the explicit backend (`--backend git-notes`)
+    // or the ADR-068 D3 pre-init carrier: `mem_path` is a placeholder in both, so
+    // skip the SQLite-oriented nudge and cross-project pass (they'd open the
+    // local/global SQLite store) and route the read to `refs/notes/spelunk`.
+    let git_notes = pre_init_notes || backend_override == Some("git-notes");
+    let effective_override = if git_notes {
+        Some("git-notes")
+    } else {
+        backend_override
+    };
 
     // Discovery nudge: warn once when unimported server.db notes exist.
     if !git_notes {
         super::reconcile::maybe_emit_nudge(mem_path, cfg);
     }
 
-    let backend = open_memory_backend(cfg, mem_path, backend_override).await?;
+    let backend = open_memory_backend(cfg, mem_path, effective_override).await?;
     let as_of = parse_as_of(args.as_of.as_deref())?;
     let mut notes = if let Some(ref sha_prefix) = args.source_ref {
         backend

--- a/crates/spelunk-cli/src/cli/cmd/memory/list.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/list.rs
@@ -10,8 +10,16 @@ pub(super) async fn memory_list(
     cfg: &Config,
     backend_override: Option<&str>,
 ) -> Result<()> {
+    // git-notes is a self-contained store of record (explicit `--backend
+    // git-notes` or the ADR-068 D3 pre-init fallback): `mem_path` is a
+    // placeholder, so skip the SQLite-oriented nudge and cross-project pass,
+    // which would otherwise open the local/global SQLite store.
+    let git_notes = backend_override == Some("git-notes");
+
     // Discovery nudge: warn once when unimported server.db notes exist.
-    super::reconcile::maybe_emit_nudge(mem_path, cfg);
+    if !git_notes {
+        super::reconcile::maybe_emit_nudge(mem_path, cfg);
+    }
 
     let backend = open_memory_backend(cfg, mem_path, backend_override).await?;
     let as_of = parse_as_of(args.as_of.as_deref())?;
@@ -30,7 +38,7 @@ pub(super) async fn memory_list(
     // The dep pass is skipped when --source-ref is given (commit-specific queries
     // are inherently local) or when --archived is set (archived entries are
     // project-local housekeeping noise, not cross-cutting signals).
-    if !args.local_only && args.source_ref.is_none() && !args.archived {
+    if !args.local_only && args.source_ref.is_none() && !args.archived && !git_notes {
         let index_db_path = crate::config::resolve_db(None, &cfg.db_path);
         let mut seen: std::collections::HashSet<(String, i64)> = Default::default();
         // Seed seen set from local results so local entries don't collide with

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -372,26 +372,18 @@ mod watch;
 
 pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> {
     cfg.validate()?;
-    let mut be = backend_override(&args.backend);
-    // ADR-067: fail closed when there is no local `.spelunk/` project instead of
-    // silently using the global store. `--db` is an explicit override, exempt.
-    // ADR-068 D3 narrows this for `add`/`list` only: with no project DB but inside
-    // a git repo they fall back to git-notes; `resolve_add_list_store` may flip
-    // `be` to git-notes and returns a placeholder path the callers never open.
-    let mem_path = if matches!(args.command, MemoryCommand::Add(_) | MemoryCommand::List(_)) {
-        resolve_add_list_store(&args, &cfg, &mut be).await?
-    } else {
-        match args.db.clone() {
-            Some(p) => p,
-            None => {
-                crate::config::require_project_db(&cfg.db_path, false)?.with_file_name("memory.db")
-            }
-        }
-    };
+    let be = backend_override(&args.backend);
+    // ADR-067 fails closed when there is no local `.spelunk/` project rather than
+    // silently using the machine-global store. ADR-068 D3 narrows that for
+    // `add`/`list` only: with no project DB but CWD inside a git repo they ride
+    // the git-notes carrier instead of failing. `pre_init_notes` signals that
+    // carrier mode downstream (add skips the absent SQLite primary; list reads
+    // from `refs/notes/spelunk`). Store priority is otherwise unchanged (ADR-004).
+    let (mem_path, pre_init_notes) = resolve_memory_store(&args, &cfg, be).await?;
     match args.command {
-        MemoryCommand::Add(a) => add::memory_add(a, &mem_path, &cfg, be).await,
+        MemoryCommand::Add(a) => add::memory_add(a, &mem_path, &cfg, be, pre_init_notes).await,
         MemoryCommand::Search(a) => search::memory_search(a, &mem_path, &cfg, be).await,
-        MemoryCommand::List(a) => list::memory_list(a, &mem_path, &cfg, be).await,
+        MemoryCommand::List(a) => list::memory_list(a, &mem_path, &cfg, be, pre_init_notes).await,
         MemoryCommand::Show(a) => show::memory_show(a, &mem_path, &cfg, be).await,
         MemoryCommand::Harvest(a) => harvest::memory_harvest(a, &mem_path, &cfg, be).await,
         MemoryCommand::Archive(a) => archive::memory_archive(a, &mem_path, &cfg, be).await,
@@ -417,38 +409,55 @@ fn backend_override(s: &str) -> Option<&'static str> {
     }
 }
 
-/// Resolve the memory store path for `memory add` / `list` (ADR-068 D3).
+/// Resolve `(mem_path, pre_init_notes)` for the dispatched memory subcommand.
 ///
-/// Precedence: explicit `--backend git-notes` › explicit `--db` › a resolvable
-/// local `.spelunk/` DB › a CloudFirst team `server_url` › **git-notes on the
-/// nearest repo when CWD is inside a git repo** › fail. The git-notes fallback
-/// flips `be` to `Some("git-notes")` so downstream takes the store-of-record
-/// path (no SQLite write-through, no global-store reads); in that mode the
-/// returned path is a placeholder the callers never open.
-async fn resolve_add_list_store(
+/// Store priority is ADR-004's, unchanged: `--db` › a resolvable local
+/// `.spelunk/` DB › (for `add`/`list` without a local project) an explicit
+/// CloudFirst team `server_url` › the git-notes carrier when CWD is inside a git
+/// repo › fail. `open_memory_backend` still makes the final local-vs-remote and
+/// `--backend git-notes` choice from `mem_path`/`cfg`; nothing here reshapes it.
+///
+/// The one behavioural change (ADR-068 D3) is that `add`/`list` do not fail
+/// closed pre-`init`: with no project DB but a git repo, they ride the universal
+/// git-notes write-through instead. `pre_init_notes` is `true` only in that
+/// carrier case (no SQLite primary). Explicit `--backend git-notes` keeps git
+/// notes as the *primary* store, so it is not carrier mode; its own `add`
+/// writes the record and the write-through is suppressed to avoid a double
+/// write. Every other subcommand keeps ADR-067's fail-closed behaviour.
+async fn resolve_memory_store(
     args: &MemoryArgs,
     cfg: &crate::config::Config,
-    be: &mut Option<&'static str>,
-) -> Result<PathBuf> {
+    be: Option<&'static str>,
+) -> Result<(PathBuf, bool)> {
     use crate::config::SyncMode;
 
-    if *be == Some("git-notes") {
-        return Ok(cfg.db_path.with_file_name("memory.db"));
-    }
+    // `--db` is an explicit override; always honored.
     if let Some(p) = args.db.clone() {
-        return Ok(p);
+        return Ok((p, false));
     }
-    if let Ok(p) = crate::config::require_project_db(&cfg.db_path, false) {
-        return Ok(p.with_file_name("memory.db"));
+    // A resolvable local `.spelunk/` DB is the normal case.
+    match crate::config::require_project_db(&cfg.db_path, false) {
+        Ok(p) => return Ok((p.with_file_name("memory.db"), false)),
+        Err(e) => {
+            // Only `add`/`list` narrow the fail-closed bail (ADR-068 D3).
+            if !matches!(args.command, MemoryCommand::Add(_) | MemoryCommand::List(_)) {
+                return Err(e);
+            }
+        }
     }
-    // No local project. A CloudFirst team server owns the store (ADR-004), so it
-    // wins over the git-notes fallback; let `open_memory_backend` route remote.
+    // No local project, running `add`/`list`. An explicit CloudFirst team
+    // `server_url` still owns the store and wins over the carrier;
+    // `open_memory_backend` routes remote from this placeholder path.
     if cfg.resolve_mode() == SyncMode::CloudFirst && cfg.server_url.is_some() {
-        return Ok(cfg.db_path.with_file_name("memory.db"));
+        return Ok((cfg.db_path.with_file_name("memory.db"), false));
     }
+    // Inside a git repo: ride the git-notes carrier rather than failing closed.
+    // The returned path is a placeholder the pre-init callers never open.
     if git_head_reachable().await {
-        *be = Some("git-notes");
-        return Ok(cfg.db_path.with_file_name("memory.db"));
+        return Ok((
+            cfg.db_path.with_file_name("memory.db"),
+            be != Some("git-notes"),
+        ));
     }
     anyhow::bail!(
         "no spelunk project here, and not inside a git repo. \

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -372,13 +372,22 @@ mod watch;
 
 pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> {
     cfg.validate()?;
+    let mut be = backend_override(&args.backend);
     // ADR-067: fail closed when there is no local `.spelunk/` project instead of
     // silently using the global store. `--db` is an explicit override, exempt.
-    let mem_path = match args.db.clone() {
-        Some(p) => p,
-        None => crate::config::require_project_db(&cfg.db_path, false)?.with_file_name("memory.db"),
+    // ADR-068 D3 narrows this for `add`/`list` only: with no project DB but inside
+    // a git repo they fall back to git-notes; `resolve_add_list_store` may flip
+    // `be` to git-notes and returns a placeholder path the callers never open.
+    let mem_path = if matches!(args.command, MemoryCommand::Add(_) | MemoryCommand::List(_)) {
+        resolve_add_list_store(&args, &cfg, &mut be).await?
+    } else {
+        match args.db.clone() {
+            Some(p) => p,
+            None => {
+                crate::config::require_project_db(&cfg.db_path, false)?.with_file_name("memory.db")
+            }
+        }
     };
-    let be = backend_override(&args.backend);
     match args.command {
         MemoryCommand::Add(a) => add::memory_add(a, &mem_path, &cfg, be).await,
         MemoryCommand::Search(a) => search::memory_search(a, &mem_path, &cfg, be).await,
@@ -406,6 +415,61 @@ fn backend_override(s: &str) -> Option<&'static str> {
         "git-notes" => Some("git-notes"),
         _ => None,
     }
+}
+
+/// Resolve the memory store path for `memory add` / `list` (ADR-068 D3).
+///
+/// Precedence: explicit `--backend git-notes` › explicit `--db` › a resolvable
+/// local `.spelunk/` DB › a CloudFirst team `server_url` › **git-notes on the
+/// nearest repo when CWD is inside a git repo** › fail. The git-notes fallback
+/// flips `be` to `Some("git-notes")` so downstream takes the store-of-record
+/// path (no SQLite write-through, no global-store reads); in that mode the
+/// returned path is a placeholder the callers never open.
+async fn resolve_add_list_store(
+    args: &MemoryArgs,
+    cfg: &crate::config::Config,
+    be: &mut Option<&'static str>,
+) -> Result<PathBuf> {
+    use crate::config::SyncMode;
+
+    if *be == Some("git-notes") {
+        return Ok(cfg.db_path.with_file_name("memory.db"));
+    }
+    if let Some(p) = args.db.clone() {
+        return Ok(p);
+    }
+    if let Ok(p) = crate::config::require_project_db(&cfg.db_path, false) {
+        return Ok(p.with_file_name("memory.db"));
+    }
+    // No local project. A CloudFirst team server owns the store (ADR-004), so it
+    // wins over the git-notes fallback; let `open_memory_backend` route remote.
+    if cfg.resolve_mode() == SyncMode::CloudFirst && cfg.server_url.is_some() {
+        return Ok(cfg.db_path.with_file_name("memory.db"));
+    }
+    if git_head_reachable().await {
+        *be = Some("git-notes");
+        return Ok(cfg.db_path.with_file_name("memory.db"));
+    }
+    anyhow::bail!(
+        "no spelunk project here, and not inside a git repo. \
+         Run 'spelunk init' first, or run inside a git repository."
+    )
+}
+
+/// Whether CWD is inside a git repo with a resolvable HEAD. An empty repo with
+/// no commits fails this (`git rev-parse HEAD` errors), matching ADR-068's
+/// "no git repo available" case.
+async fn git_head_reachable() -> bool {
+    use std::process::Stdio;
+    tokio::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 // ── Shared display helpers ────────────────────────────────────────────────────

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -18,6 +18,11 @@ use tempfile::TempDir;
 /// no-em-dash house rule for user-facing copy).
 const NO_PROJECT_ERR: &str = "no spelunk project here. Run 'spelunk init' first";
 
+/// ADR-068 D3 dual-escape-hatch error for `memory add`/`list` when there is
+/// neither a project DB nor a usable git repo (case 5).
+const NO_PROJECT_NO_REPO_ERR: &str = "no spelunk project here, and not inside a git repo. Run 'spelunk init' first, \
+     or run inside a git repository.";
+
 /// A `spelunk` command with an isolated HOME (so the "global" store lives under
 /// `<home>/.config/spelunk`) and no server contact, run in `cwd`.
 fn bin(home: &Path, cwd: &Path) -> Command {
@@ -42,8 +47,12 @@ fn global_index_db(home: &Path) -> std::path::PathBuf {
 
 // ── refuse-guard: un-init'd dir, no --db ───────────────────────────────────────
 
+// A bare `TempDir` is not inside a git repo (it lives under the system temp
+// dir, not a checkout), so `memory add`/`list` hit ADR-068 D3 case 5 — neither
+// a project DB nor a usable git repo — and refuse with the dual-hatch message
+// rather than falling back to git-notes.
 #[test]
-fn memory_add_refuses_without_local_project() {
+fn memory_add_refuses_without_project_or_git_repo() {
     let home = TempDir::new().unwrap();
     let proj = TempDir::new().unwrap();
 
@@ -53,7 +62,7 @@ fn memory_add_refuses_without_local_project() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+        .stderr(predicate::str::contains(NO_PROJECT_NO_REPO_ERR));
 
     assert!(
         !global_memory_db(home.path()).exists(),
@@ -62,7 +71,7 @@ fn memory_add_refuses_without_local_project() {
 }
 
 #[test]
-fn memory_list_refuses_without_local_project() {
+fn memory_list_refuses_without_project_or_git_repo() {
     let home = TempDir::new().unwrap();
     let proj = TempDir::new().unwrap();
 
@@ -70,7 +79,7 @@ fn memory_list_refuses_without_local_project() {
         .args(["memory", "list"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+        .stderr(predicate::str::contains(NO_PROJECT_NO_REPO_ERR));
 
     assert!(!global_memory_db(home.path()).exists());
 }
@@ -362,9 +371,10 @@ fn sync_arm_refuses_without_local_project() {
 
 #[test]
 fn memory_timeline_refuses_without_local_project() {
-    // Every `memory` subcommand resolves its store through the same
-    // `require_project_db` line before dispatch; `timeline` (needs no server)
-    // confirms the guard is not specific to add/list/search.
+    // Every `memory` subcommand *except* the ADR-068 D3 add/list fallback
+    // resolves its store through the same `require_project_db` line before
+    // dispatch; `timeline` (needs no server) confirms the fail-closed guard
+    // still holds for the non-add/list subcommands.
     let home = TempDir::new().unwrap();
     let proj = TempDir::new().unwrap();
 
@@ -399,7 +409,7 @@ fn refused_memory_add_does_not_mutate_preexisting_global_store() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains(NO_PROJECT_ERR));
+        .stderr(predicate::str::contains(NO_PROJECT_NO_REPO_ERR));
 
     assert_eq!(
         std::fs::read(&global).unwrap(),

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -48,8 +48,8 @@ fn global_index_db(home: &Path) -> std::path::PathBuf {
 // ── refuse-guard: un-init'd dir, no --db ───────────────────────────────────────
 
 // A bare `TempDir` is not inside a git repo (it lives under the system temp
-// dir, not a checkout), so `memory add`/`list` hit ADR-068 D3 case 5 — neither
-// a project DB nor a usable git repo — and refuse with the dual-hatch message
+// dir, not a checkout), so `memory add`/`list` hit ADR-068 D3 case 5 (neither
+// a project DB nor a usable git repo) and refuse with the dual-hatch message
 // rather than falling back to git-notes.
 #[test]
 fn memory_add_refuses_without_project_or_git_repo() {

--- a/crates/spelunk-cli/tests/git_notes_fallback.rs
+++ b/crates/spelunk-cli/tests/git_notes_fallback.rs
@@ -1,16 +1,19 @@
-//! ADR-068 D3: git-notes memory fallback for `memory add`/`list` before `init`.
+//! ADR-068 D3: git-notes memory carrier for `memory add`/`list` before `init`.
 //!
-//! Precedence for `memory add`/`list` store resolution:
-//!   1. `--backend git-notes`
+//! Store priority for `memory add`/`list` (ADR-004, unchanged) resolves in order:
+//!   1. `--backend git-notes` → git notes as the *primary* store
 //!   2. explicit team `server_url` (CloudFirst → remote)
 //!   3. a resolvable local `.spelunk/` DB (sqlite)
-//!   4. NEW: no DB but inside a git repo → `GitNotesBackend` on the nearest repo
-//!      (ref `refs/notes/spelunk`)
+//!   4. no DB but inside a git repo → the universal git-notes write-through is
+//!      the sole writer (ref `refs/notes/spelunk`); there is no SQLite primary
 //!   5. neither → fail with the dual-escape-hatch message.
 //!
-//! These tests cover branches 1, 3, 4, and 5, the no-double-write invariant, and
-//! the secret-scan gate on the git-notes path. The complementary refuse-only
-//! tests (case 5 from a bare temp dir) live in `fail_closed_no_project.rs`.
+//! Pre-`init` (case 4) rides the same `append_to_git_notes` write-through that
+//! already runs post-`init`, so every note carries an identical record shape.
+//! These tests cover cases 1, 3, 4, and 5, the single-record invariant, record
+//! shape parity between the pre-init and post-init write-through forms, and the
+//! secret-scan gate on the git-notes path. The complementary refuse-only tests
+//! (case 5 from a bare temp dir) live in `fail_closed_no_project.rs`.
 
 mod plumbing_helpers;
 use plumbing_helpers::spelunk_bin_in;
@@ -150,17 +153,17 @@ fn memory_add_list_round_trips_via_git_notes_fallback() {
     );
 }
 
-// ── no double-write: exactly one record per single `add` ───────────────────────
+// ── single record per single `add`: the carrier is the sole writer ─────────────
 
 #[test]
-fn single_add_writes_exactly_one_note_record_no_write_through_dup() {
+fn single_add_writes_exactly_one_note_record() {
     let home = TempDir::new().unwrap();
     let repo = TempDir::new().unwrap();
     init_git_repo_with_commit(repo.path());
 
-    // Fallback path is the store of record, so the legacy SQLite write-through is
-    // skipped: a single `add` must leave exactly one JSON record in the note, not
-    // two (backend append + a redundant write-through).
+    // Pre-init there is no SQLite primary: the write-through carrier is the sole
+    // writer, so a single `add` must leave exactly one JSON record in the note,
+    // not two (no separate primary append + write-through).
     bin(home.path(), repo.path())
         .args([
             "memory",
@@ -185,6 +188,122 @@ fn single_add_writes_exactly_one_note_record_no_write_through_dup() {
         lines[0].contains("\"schema_version\":1") && lines[0].contains("one-and-only"),
         "the single record must be the well-formed entry we added; got: {:?}",
         lines[0]
+    );
+}
+
+// ── record-shape parity: pre-init carrier == post-init write-through form ──────
+
+/// Top-level object keys of a one-line JSON object, sorted. A minimal
+/// depth-aware scan (integration tests can't reach the crate's `serde_json`):
+/// only quoted strings at brace-depth 1 that are immediately followed by `:`
+/// count, so nested-array elements and string *values* are ignored.
+fn json_top_level_keys(line: &str) -> Vec<String> {
+    let bytes = line.as_bytes();
+    let mut keys = Vec::new();
+    let mut depth: i32 = 0;
+    let mut in_str = false;
+    let mut escaped = false;
+    let mut cur = String::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if in_str {
+            if escaped {
+                cur.push(c);
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                in_str = false;
+                let mut j = i + 1;
+                while j < bytes.len() && (bytes[j] as char).is_whitespace() {
+                    j += 1;
+                }
+                if depth == 1 && j < bytes.len() && bytes[j] as char == ':' {
+                    keys.push(std::mem::take(&mut cur));
+                } else {
+                    cur.clear();
+                }
+            } else {
+                cur.push(c);
+            }
+        } else {
+            match c {
+                '"' => {
+                    in_str = true;
+                    cur.clear();
+                }
+                '{' | '[' => depth += 1,
+                '}' | ']' => depth -= 1,
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    keys.sort();
+    keys
+}
+
+/// The single note record a pre-init `add` writes (via the carrier) must have
+/// the exact same field set as the record a post-init `add` writes (via the
+/// SQLite-primary write-through). Both flow through one `append_to_git_notes`
+/// path, so any divergence in the pre-init record shape is a regression.
+#[test]
+fn pre_init_and_post_init_records_have_identical_shape() {
+    let home = TempDir::new().unwrap();
+
+    // Pre-init: no `.spelunk/`, inside a git repo → carrier writes the record.
+    let pre = TempDir::new().unwrap();
+    init_git_repo_with_commit(pre.path());
+    bin(home.path(), pre.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "note",
+            "--title",
+            "shape-pre",
+            "--body",
+            "b",
+        ])
+        .assert()
+        .success();
+    let pre_lines = spelunk_note_lines(pre.path());
+    assert_eq!(pre_lines.len(), 1, "pre-init add writes one record");
+
+    // Post-init: a local `.spelunk/` makes SQLite the primary; the same
+    // write-through then appends the note. Creating the dir is enough for
+    // `require_project_db` to resolve the project (matches the precedence test).
+    let post = TempDir::new().unwrap();
+    init_git_repo_with_commit(post.path());
+    std::fs::create_dir_all(post.path().join(".spelunk")).unwrap();
+    bin(home.path(), post.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "note",
+            "--title",
+            "shape-post",
+            "--body",
+            "b",
+        ])
+        .assert()
+        .success();
+    let post_lines = spelunk_note_lines(post.path());
+    assert_eq!(
+        post_lines.len(),
+        1,
+        "post-init write-through writes one record"
+    );
+
+    assert_eq!(
+        json_top_level_keys(&pre_lines[0]),
+        json_top_level_keys(&post_lines[0]),
+        "pre-init carrier and post-init write-through records must share one shape\n\
+         pre:  {}\npost: {}",
+        pre_lines[0],
+        post_lines[0]
     );
 }
 

--- a/crates/spelunk-cli/tests/git_notes_fallback.rs
+++ b/crates/spelunk-cli/tests/git_notes_fallback.rs
@@ -28,6 +28,14 @@ use tempfile::TempDir;
 const NO_PROJECT_NO_REPO_ERR: &str = "no spelunk project here, and not inside a git repo. Run 'spelunk init' first, \
      or run inside a git repository.";
 
+/// ADR-067 single-hatch error: no local `.spelunk/` project. This is what every
+/// memory subcommand *except* the ADR-068 D3 add/list carrier still raises,
+/// even inside a git repo (the carrier never widens to them). Distinct from
+/// `NO_PROJECT_NO_REPO_ERR`: the dual-hatch text splices ", and not inside a git
+/// repo" between "here" and ". Run", so this substring matches only the
+/// single-hatch message.
+const NO_PROJECT_ERR: &str = "no spelunk project here. Run 'spelunk init' first";
+
 /// A `spelunk` command with an isolated HOME (so the "global" store lives under
 /// `<home>/.config/spelunk`) and no server contact, run in `cwd`.
 fn bin(home: &Path, cwd: &Path) -> Command {
@@ -297,13 +305,41 @@ fn pre_init_and_post_init_records_have_identical_shape() {
         "post-init write-through writes one record"
     );
 
+    let pre_keys = json_top_level_keys(&pre_lines[0]);
+    let post_keys = json_top_level_keys(&post_lines[0]);
+
+    // Guard against a degenerate match: an empty (or shrunk) key set on both
+    // sides would satisfy a bare set-equality check. Assert both records actually
+    // carry the canonical NoteRecord field set a `note` add with no
+    // tags/files/dates serializes. (The Option-typed fields source_ref,
+    // valid_at, invalid_at, superseded_by, and remote_id are omitted by serde
+    // when None, so the always-present core below is the shape under test.)
+    for expected in [
+        "body",
+        "created_at",
+        "id",
+        "kind",
+        "linked_files",
+        "schema_version",
+        "status",
+        "tags",
+        "title",
+    ] {
+        assert!(
+            pre_keys.iter().any(|k| k == expected),
+            "pre-init record is missing the canonical key {expected:?}; got {pre_keys:?}"
+        );
+        assert!(
+            post_keys.iter().any(|k| k == expected),
+            "post-init record is missing the canonical key {expected:?}; got {post_keys:?}"
+        );
+    }
+
     assert_eq!(
-        json_top_level_keys(&pre_lines[0]),
-        json_top_level_keys(&post_lines[0]),
+        pre_keys, post_keys,
         "pre-init carrier and post-init write-through records must share one shape\n\
          pre:  {}\npost: {}",
-        pre_lines[0],
-        post_lines[0]
+        pre_lines[0], post_lines[0]
     );
 }
 
@@ -420,6 +456,23 @@ fn explicit_backend_git_notes_works_pre_init_in_git_repo() {
         "explicit git-notes add must write the note; got: {note_blob:?}"
     );
 
+    // Double-write guard: with `--backend git-notes` git notes is the *primary*
+    // store, so the universal write-through is suppressed. A single `add` must
+    // therefore leave exactly one record (not a primary write plus a redundant
+    // write-through): the other single-write path alongside the pre-init carrier.
+    let lines = spelunk_note_lines(repo.path());
+    assert_eq!(
+        lines.len(),
+        1,
+        "explicit --backend git-notes must write exactly one record \
+         (write-through suppressed); got: {lines:?}"
+    );
+    assert!(
+        lines[0].contains("\"schema_version\":1") && lines[0].contains(title),
+        "the single record must be the well-formed entry we added; got: {:?}",
+        lines[0]
+    );
+
     bin(home.path(), repo.path())
         .args(["memory", "list", "--backend", "git-notes"])
         .assert()
@@ -481,5 +534,168 @@ fn secret_in_entry_is_refused_and_leaves_git_notes_untouched() {
     assert!(
         spelunk_note_lines(repo.path()).is_empty(),
         "a body-secret-blocked add must also leave the note ref untouched"
+    );
+}
+
+// ── carrier scope: only add/list ride it; siblings stay fail-closed ────────────
+
+/// The ADR-068 D3 carrier is narrowed to `add`/`list`. Inside a git repo with a
+/// commit (exactly the setup where `add`/`list` DO ride the carrier) every other
+/// memory subcommand must still fail closed with the ADR-067 single-hatch
+/// message, never reach the git-notes path, and never write a note. This guards
+/// against the carrier accidentally widening its scope to non-add/list
+/// subcommands.
+#[test]
+fn non_add_list_subcommands_stay_fail_closed_inside_git_repo() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+
+    // A representative spread of the non-carrier subcommands, each needing no
+    // server: read (search, timeline) and mutate (supersede).
+    let invocations: [&[&str]; 3] = [
+        &["memory", "search", "anything"],
+        &["memory", "timeline", "anything"],
+        &["memory", "supersede", "1", "2"],
+    ];
+    for args in invocations {
+        bin(home.path(), repo.path())
+            .args(args)
+            .assert()
+            .failure()
+            // The ADR-067 single-hatch message, NOT the add/list dual-hatch: these
+            // subcommands never consult the git repo for a carrier.
+            .stderr(predicate::str::contains(NO_PROJECT_ERR))
+            .stderr(predicate::str::contains("not inside a git repo").not());
+    }
+
+    assert!(
+        spelunk_note_lines(repo.path()).is_empty(),
+        "a fail-closed non-add/list subcommand must not write any spelunk note"
+    );
+    assert!(
+        !global_memory_db(home.path()).exists(),
+        "a fail-closed subcommand must not create the machine-global store"
+    );
+}
+
+// ── case 6: post-init add writes BOTH the SQLite primary and the write-through ─
+
+/// With a local `.spelunk/` project inside a git repo, a single `add` writes the
+/// SQLite primary AND rides the universal git-notes write-through (exactly one
+/// record, no double write), and `list` reads back from SQLite. This is the
+/// unchanged post-`init` behaviour, asserted end-to-end in one flow.
+#[test]
+fn post_init_add_writes_sqlite_primary_and_git_notes_write_through() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+    // A local project makes SQLite the primary (not the pre-init carrier).
+    std::fs::create_dir_all(repo.path().join(".spelunk")).unwrap();
+
+    bin(home.path(), repo.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "decision",
+            "--title",
+            "post-init-both",
+            "--body",
+            "b",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [decision]"));
+
+    // Primary: the local SQLite store exists (proving branch 3, not the carrier).
+    assert!(
+        repo.path().join(".spelunk").join("memory.db").exists(),
+        "post-init add must write the local SQLite primary"
+    );
+
+    // Write-through: exactly one record landed in refs/notes/spelunk (the SQLite
+    // primary write plus the write-through must not double up).
+    let lines = spelunk_note_lines(repo.path());
+    assert_eq!(
+        lines.len(),
+        1,
+        "post-init add must ride the write-through exactly once; got: {lines:?}"
+    );
+    assert!(
+        lines[0].contains("post-init-both"),
+        "the write-through record must be the entry we added; got: {:?}",
+        lines[0]
+    );
+
+    // `list` (default sqlite backend) reads the entry back from SQLite.
+    bin(home.path(), repo.path())
+        .args(["memory", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("post-init-both"));
+
+    assert!(!global_memory_db(home.path()).exists());
+}
+
+// ── case 7: a failed pre-init carry is fatal (no primary to fall back on) ───────
+
+/// Pre-`init` the carrier is the SOLE writer, so a failed carry has no SQLite
+/// primary to absorb it and must surface as a non-zero exit (an `Err`), never a
+/// false "Stored". The carry is forced to fail deterministically: HEAD resolves
+/// (so `git_head_reachable` engages the carrier) but the `git notes add` the
+/// carrier runs has no usable committer identity: no local `user.*`, no
+/// system/global config, and `user.useConfigOnly` on so git cannot auto-derive a
+/// USER@host fallback (nor honour a stray `$EMAIL`). `git rev-parse HEAD` needs
+/// no identity, so the carrier still engages and the failure is in the write.
+#[test]
+fn failed_pre_init_carry_is_fatal_and_writes_nothing() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+
+    // A commit with NO local `user.*` identity in `.git/config`: the setup `git`
+    // helper supplies identity via env for the commit only, so HEAD is resolvable
+    // but the child's `git notes add` has nothing local to use.
+    git(repo.path(), &["init", "-q", "-b", "main"]);
+    std::fs::write(repo.path().join("f.txt"), "x\n").unwrap();
+    git(repo.path(), &["add", "."]);
+    git(repo.path(), &["commit", "-q", "-m", "init"]);
+
+    let mut cmd = spelunk_bin_in(home.path());
+    cmd.current_dir(repo.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL")
+        // Neutralize every identity source for the git subprocess spelunk spawns.
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_COUNT", "1")
+        .env("GIT_CONFIG_KEY_0", "user.useConfigOnly")
+        .env("GIT_CONFIG_VALUE_0", "true")
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "note",
+            "--title",
+            "carry-fails",
+            "--body",
+            "b",
+        ]);
+
+    cmd.assert()
+        .failure()
+        // No false success line, and the error names the fatal-carry context.
+        .stdout(predicate::str::contains("Stored").not())
+        .stderr(predicate::str::contains(
+            "recording memory entry to git notes",
+        ));
+
+    assert!(
+        spelunk_note_lines(repo.path()).is_empty(),
+        "a fatal failed carry must not leave a partial spelunk note"
+    );
+    assert!(
+        !global_memory_db(home.path()).exists(),
+        "a fatal failed carry must not create the machine-global store"
     );
 }

--- a/crates/spelunk-cli/tests/git_notes_fallback.rs
+++ b/crates/spelunk-cli/tests/git_notes_fallback.rs
@@ -1,0 +1,366 @@
+//! ADR-068 D3: git-notes memory fallback for `memory add`/`list` before `init`.
+//!
+//! Precedence for `memory add`/`list` store resolution:
+//!   1. `--backend git-notes`
+//!   2. explicit team `server_url` (CloudFirst → remote)
+//!   3. a resolvable local `.spelunk/` DB (sqlite)
+//!   4. NEW: no DB but inside a git repo → `GitNotesBackend` on the nearest repo
+//!      (ref `refs/notes/spelunk`)
+//!   5. neither → fail with the dual-escape-hatch message.
+//!
+//! These tests cover branches 1, 3, 4, and 5, the no-double-write invariant, and
+//! the secret-scan gate on the git-notes path. The complementary refuse-only
+//! tests (case 5 from a bare temp dir) live in `fail_closed_no_project.rs`.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// ADR-068 D3 dual-escape-hatch error (case 5): neither a project DB nor a
+/// usable git repo. Kept in sync with `fail_closed_no_project.rs`.
+const NO_PROJECT_NO_REPO_ERR: &str = "no spelunk project here, and not inside a git repo. Run 'spelunk init' first, \
+     or run inside a git repository.";
+
+/// A `spelunk` command with an isolated HOME (so the "global" store lives under
+/// `<home>/.config/spelunk`) and no server contact, run in `cwd`.
+fn bin(home: &Path, cwd: &Path) -> Command {
+    let mut cmd = spelunk_bin_in(home);
+    cmd.current_dir(cwd)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL");
+    cmd
+}
+
+/// The global memory store path under the isolated HOME. The git-notes fallback
+/// must never create it.
+fn global_memory_db(home: &Path) -> std::path::PathBuf {
+    home.join(".config").join("spelunk").join("memory.db")
+}
+
+/// Run `git args` in `dir`, asserting success. Isolated identity so it works on a
+/// machine with no global git config.
+fn git(dir: &Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@example.com")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@example.com")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// stdout of `git args` in `dir` (whatever the exit status). Used for read-only
+/// notes inspection where a missing ref is a legitimate empty result.
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    let out = std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("spawn git");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// A git repo with one commit and no `.spelunk/`. `user.*` is set in the LOCAL
+/// repo config so the `git notes add` that the spawned `spelunk` runs (which
+/// does NOT inherit the test's `GIT_*` identity env) has a committer identity.
+fn init_git_repo_with_commit(dir: &Path) {
+    git(dir, &["init", "-q", "-b", "main"]);
+    // Local (not env) identity: the spelunk child reads this from `.git/config`.
+    git(dir, &["config", "user.name", "t"]);
+    git(dir, &["config", "user.email", "t@example.com"]);
+    std::fs::write(dir.join("f.txt"), "x\n").unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-q", "-m", "init"]);
+}
+
+/// The spelunk records currently in HEAD's `refs/notes/spelunk` note (one JSON
+/// object per line). Empty when the ref/note does not exist.
+fn spelunk_note_lines(dir: &Path) -> Vec<String> {
+    let blob = git_stdout(dir, &["notes", "--ref=spelunk", "show", "HEAD"]);
+    blob.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+// ── case 4: happy-path round-trip via git notes ────────────────────────────────
+
+#[test]
+fn memory_add_list_round_trips_via_git_notes_fallback() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+
+    let title = "fallback-roundtrip-abc123";
+
+    // add: no `.spelunk/`, but inside a git repo → falls back to git-notes.
+    bin(home.path(), repo.path())
+        .args([
+            "memory", "add", "--kind", "note", "--title", title, "--body", "b",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [note]"));
+
+    // The entry landed in `refs/notes/spelunk` on HEAD.
+    let note_blob = git_stdout(repo.path(), &["notes", "--ref=spelunk", "show", "HEAD"]);
+    assert!(
+        note_blob.contains(title),
+        "the note on HEAD must contain the added entry's title; got: {note_blob:?}"
+    );
+    // `git notes list` shows exactly one noted commit (HEAD).
+    let list = git_stdout(repo.path(), &["notes", "--ref=spelunk", "list"]);
+    assert_eq!(
+        list.lines().filter(|l| !l.trim().is_empty()).count(),
+        1,
+        "exactly one commit (HEAD) should carry a spelunk note; got: {list:?}"
+    );
+
+    // list: reads the entry back through the same git-notes fallback.
+    bin(home.path(), repo.path())
+        .args(["memory", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(title));
+
+    // The fallback must not create a local `.spelunk/` nor touch the global store.
+    assert!(
+        !repo.path().join(".spelunk").exists(),
+        "git-notes fallback must not create a local .spelunk/ project"
+    );
+    assert!(
+        !global_memory_db(home.path()).exists(),
+        "git-notes fallback must not create the machine-global memory store"
+    );
+}
+
+// ── no double-write: exactly one record per single `add` ───────────────────────
+
+#[test]
+fn single_add_writes_exactly_one_note_record_no_write_through_dup() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+
+    // Fallback path is the store of record, so the legacy SQLite write-through is
+    // skipped: a single `add` must leave exactly one JSON record in the note, not
+    // two (backend append + a redundant write-through).
+    bin(home.path(), repo.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "decision",
+            "--title",
+            "one-and-only",
+            "--body",
+            "b",
+        ])
+        .assert()
+        .success();
+
+    let lines = spelunk_note_lines(repo.path());
+    assert_eq!(
+        lines.len(),
+        1,
+        "a single `memory add` must write exactly one record line to the note; got: {lines:?}"
+    );
+    assert!(
+        lines[0].contains("\"schema_version\":1") && lines[0].contains("one-and-only"),
+        "the single record must be the well-formed entry we added; got: {:?}",
+        lines[0]
+    );
+}
+
+// ── case 5: refuse when not inside a git repo (empty / no-HEAD repo) ────────────
+
+#[test]
+fn memory_add_refuses_in_git_repo_without_any_commit() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    // `git init` but no commit → HEAD is unresolvable, so the fallback cannot
+    // attach a note. This is case 5, not case 4.
+    git(repo.path(), &["init", "-q", "-b", "main"]);
+
+    bin(home.path(), repo.path())
+        .args([
+            "memory", "add", "--kind", "note", "--title", "t", "--body", "b",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_NO_REPO_ERR));
+
+    assert!(!global_memory_db(home.path()).exists());
+    assert!(
+        spelunk_note_lines(repo.path()).is_empty(),
+        "a refused add in an empty repo must not write any spelunk note"
+    );
+}
+
+#[test]
+fn memory_list_refuses_in_git_repo_without_any_commit() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    git(repo.path(), &["init", "-q", "-b", "main"]);
+
+    bin(home.path(), repo.path())
+        .args(["memory", "list"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(NO_PROJECT_NO_REPO_ERR));
+
+    assert!(!global_memory_db(home.path()).exists());
+}
+
+// ── precedence #3 > #4: a local `.spelunk/` wins over the git-notes fallback ────
+
+#[test]
+fn local_dot_spelunk_takes_precedence_over_git_notes_fallback() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+    // Both a git repo AND a local project: sqlite must win (fallback NOT taken).
+    std::fs::create_dir_all(repo.path().join(".spelunk")).unwrap();
+
+    bin(home.path(), repo.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "note",
+            "--title",
+            "sqlite-wins",
+            "--body",
+            "b",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [note]"));
+
+    // The entry went to the local sqlite store, proving branch 3 beat branch 4.
+    assert!(
+        repo.path().join(".spelunk").join("memory.db").exists(),
+        "with a local .spelunk/, add must write sqlite, not fall back to git-notes"
+    );
+
+    // list resolves the same sqlite store and reads the entry back.
+    bin(home.path(), repo.path())
+        .args(["memory", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sqlite-wins"));
+
+    assert!(!global_memory_db(home.path()).exists());
+}
+
+// ── precedence #1: explicit `--backend git-notes` pre-init works ───────────────
+
+#[test]
+fn explicit_backend_git_notes_works_pre_init_in_git_repo() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+
+    let title = "explicit-git-notes-xyz";
+    bin(home.path(), repo.path())
+        .args([
+            "memory",
+            "add",
+            "--backend",
+            "git-notes",
+            "--kind",
+            "note",
+            "--title",
+            title,
+            "--body",
+            "b",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [note]"));
+
+    let note_blob = git_stdout(repo.path(), &["notes", "--ref=spelunk", "show", "HEAD"]);
+    assert!(
+        note_blob.contains(title),
+        "explicit git-notes add must write the note; got: {note_blob:?}"
+    );
+
+    bin(home.path(), repo.path())
+        .args(["memory", "list", "--backend", "git-notes"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(title));
+
+    // Explicit git-notes must not create a project or touch the global store.
+    assert!(!repo.path().join(".spelunk").exists());
+    assert!(!global_memory_db(home.path()).exists());
+}
+
+// ── secret-scan gate on the git-notes path ─────────────────────────────────────
+
+#[test]
+fn secret_in_entry_is_refused_and_leaves_git_notes_untouched() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+
+    // Title matches the AWS access-key-id pattern (`AKIA` + 16 upper/digits). The
+    // secret scan runs before any persistence, so the git-notes fallback path
+    // must refuse and write nothing.
+    bin(home.path(), repo.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "note",
+            "--title",
+            "AKIAIOSFODNN7EXAMPLE",
+            "--body",
+            "harmless body",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("secret pattern"));
+
+    assert!(
+        spelunk_note_lines(repo.path()).is_empty(),
+        "a secret-blocked add must leave refs/notes/spelunk absent/unmodified"
+    );
+    // And a body-borne secret is likewise blocked before any note is written
+    // (GitHub PAT pattern, same fixture the secrets unit test uses).
+    bin(home.path(), repo.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "note",
+            "--title",
+            "looks-innocent",
+            "--body",
+            "token = ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef123456789012",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("secret pattern"));
+
+    assert!(
+        spelunk_note_lines(repo.path()).is_empty(),
+        "a body-secret-blocked add must also leave the note ref untouched"
+    );
+}

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -22,29 +22,44 @@ git notes --ref=spelunk list         # every commit carrying spelunk notes
 GIT_NOTES_REF=refs/notes/spelunk git notes show HEAD
 ```
 
-Memory is scoped to a local project and by default lives in `.spelunk/memory.db`.
-**Before `spelunk init`**, `memory add` and `memory list` fall back to storing entries
-in git-notes (`refs/notes/spelunk`) when inside a git repository, so you can record
-decisions without a `.spelunk/` directory. `memory search` and `context` remain
-gated to projects with `.spelunk/` (they need the index to search and embed).
+**Carrier and index.** Think of `refs/notes/spelunk` as the durable *carrier*
+that travels with the repo, and `.spelunk/memory.db` as the queryable *index*
+built over it. Every `memory add` appends its entry to the carrier through one
+write-through path; `spelunk init` hydrates the index by importing those notes,
+adding the embeddings semantic search needs. Both stores are local to the repo;
+neither leaves the machine unless you configure a team `server_url`.
 
-**Backend selection (precedence):**
-1. Explicit `--backend git-notes` → git-notes
-2. Explicit team `server_url` (in config) → remote server
-3. Local `.spelunk/memory.db` (after `spelunk init`)
-4. **Git-notes fallback (new)** — no project, but inside a git repo → `refs/notes/spelunk`
-5. Neither project nor git repo → error: *"no spelunk project here, and not inside a git repo. Run 'spelunk init' first, or run inside a git repository."*
+**Before `spelunk init`**, `memory add` and `memory list` still work when you are
+inside a git repository: with no `.spelunk/` project, `add` rides the same
+write-through carrier (there is no SQLite primary yet) and `list` reads entries
+back from `refs/notes/spelunk`. Because it is the same write path pre- and
+post-`init`, every note carries an identical record shape. `memory search` and
+`context` remain gated to projects with `.spelunk/` (they need the index to
+search and embed).
 
-**Known limitation:** git-notes writes are not atomic across concurrent `add` commands
-to the same commit (the read-modify-write can lose entries if agents write simultaneously).
-This is acceptable for solo pre-init use; multi-agent workflows should `spelunk init` to
-use SQLite. Also note: git-notes under `refs/notes/spelunk` do **not** push or fetch by
-default — see [ADR-068](adr/068-zero-setup-onboarding-git-notes-memory-fallback.md) for
-cross-machine sync options and [git notes](https://git-scm.com/docs/git-notes) documentation.
+**Store priority** (unchanged from [ADR-004](adr/004-unified-memory-storage.md)):
 
-See [ADR-067](adr/067-fail-closed-no-local-project.md) for the fail-closed design and
-[ADR-068](adr/068-zero-setup-onboarding-git-notes-memory-fallback.md) for the git-notes
-fallback rationale. An explicit `--db <path>` still overrides all backends.
+1. Explicit `--db <path>` (always wins)
+2. Explicit `--backend git-notes` (git notes is the primary store)
+3. Explicit team `server_url` in config (remote server)
+4. A local `.spelunk/memory.db` (after `spelunk init`)
+5. No project but inside a git repo: the git-notes write-through carrier (add/list only)
+6. Neither a project nor a git repo: error, *"no spelunk project here, and not inside a git repo. Run 'spelunk init' first, or run inside a git repository."*
+
+**Known limitation:** git-notes writes are not atomic across concurrent `add`
+commands to the same commit (the read-modify-write can lose an entry if two
+agents write simultaneously). This is acceptable for the solo, pre-`init`
+quick-fix case; multi-agent workflows should `spelunk init` and use SQLite. Note
+also that notes under `refs/notes/spelunk` are **not** pushed or fetched by
+default, so pre-`init` entries stay on the machine that wrote them until you
+configure a refspec or push the ref. See
+[ADR-068](adr/068-zero-setup-onboarding-git-notes-memory-fallback.md) for the
+cross-machine sync options and the [git notes](https://git-scm.com/docs/git-notes)
+documentation.
+
+See [ADR-067](adr/067-fail-closed-no-local-project.md) for the fail-closed design
+and [ADR-068](adr/068-zero-setup-onboarding-git-notes-memory-fallback.md) for the
+git-notes carrier rationale.
 
 ## Why memory?
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -22,12 +22,29 @@ git notes --ref=spelunk list         # every commit carrying spelunk notes
 GIT_NOTES_REF=refs/notes/spelunk git notes show HEAD
 ```
 
-Memory is scoped to a local project. Run `spelunk init` once per repository to
-create its `.spelunk/` store. In a directory with no local `.spelunk/`,
-`memory add/list/search` and `context` fail closed with a `no spelunk project
-here` error rather than reading or writing a machine-global store (see
-[ADR-067](adr/067-fail-closed-no-local-project.md)). An explicit `--db <path>`
-still overrides this.
+Memory is scoped to a local project and by default lives in `.spelunk/memory.db`.
+**Before `spelunk init`**, `memory add` and `memory list` fall back to storing entries
+in git-notes (`refs/notes/spelunk`) when inside a git repository, so you can record
+decisions without a `.spelunk/` directory. `memory search` and `context` remain
+gated to projects with `.spelunk/` (they need the index to search and embed).
+
+**Backend selection (precedence):**
+1. Explicit `--backend git-notes` → git-notes
+2. Explicit team `server_url` (in config) → remote server
+3. Local `.spelunk/memory.db` (after `spelunk init`)
+4. **Git-notes fallback (new)** — no project, but inside a git repo → `refs/notes/spelunk`
+5. Neither project nor git repo → error: *"no spelunk project here, and not inside a git repo. Run 'spelunk init' first, or run inside a git repository."*
+
+**Known limitation:** git-notes writes are not atomic across concurrent `add` commands
+to the same commit (the read-modify-write can lose entries if agents write simultaneously).
+This is acceptable for solo pre-init use; multi-agent workflows should `spelunk init` to
+use SQLite. Also note: git-notes under `refs/notes/spelunk` do **not** push or fetch by
+default — see [ADR-068](adr/068-zero-setup-onboarding-git-notes-memory-fallback.md) for
+cross-machine sync options and [git notes](https://git-scm.com/docs/git-notes) documentation.
+
+See [ADR-067](adr/067-fail-closed-no-local-project.md) for the fail-closed design and
+[ADR-068](adr/068-zero-setup-onboarding-git-notes-memory-fallback.md) for the git-notes
+fallback rationale. An explicit `--db <path>` still overrides all backends.
 
 ## Why memory?
 


### PR DESCRIPTION
## Summary

Implements ADR-068 D3: a git-notes memory fallback so `spelunk memory add` and
`spelunk memory list` work **before `init`** when the working directory is
inside a git repo, instead of failing closed. This makes good on the
zero-setup, "memory travels with the repo" promise without indexing a project.

Only `add` and `list` fall back. Every other memory subcommand keeps its
current pre-`init` behaviour (fail-closed / existing server/index requirement),
matching the git-notes backend's own capability surface.

### Backend precedence for `add` / `list` (`resolve_add_list_store`)

1. explicit `--backend git-notes` → git-notes backend
2. explicit team `server_url` (resolved `CloudFirst`) → remote backend
3. a resolvable local `.spelunk/` project DB → local SQLite `memory.db`
4. no project DB but CWD inside a git repo with a resolvable HEAD → **git-notes
   fallback on the nearest repo** (the new behaviour)
5. neither a project DB nor a usable git repo → fail with the dual-escape-hatch
   message: *"no spelunk project here, and not inside a git repo. Run 'spelunk
   init' first, or run inside a git repository."*

In the fallback, git-notes is the **store of record** (no SQLite write-through /
no double write — the write-through in `add.rs` is skipped when git-notes is the
primary backend), and no machine-global store is read. An empty repo with no
HEAD (`git rev-parse HEAD` fails) falls to case 5. The secret-scan gate
(`contains_secret` on title/body) still runs before any persistence on the
git-notes path.

Reconciles ADR-067's fail-closed posture: it is narrowed for `add`/`list` only,
and left intact for all other subcommands.

## ADR reference

ADR-068 D3 — `docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md`
(landed via PR #572). spelunk-oss^154.

## Test plan

All run with `SPELUNK_SECRET_STORE=file`:

- `cargo test -p spelunk-cli -p spelunk-core` — **800 passed, 0 failed**.
- `cargo test -p spelunk-cli -p spelunk-core --no-default-features` (CI matrix
  cell) — **800 passed, 0 failed**.
- `cargo clippy --all-targets` — clean, 0 warnings.
- New integration suite `tests/git_notes_fallback.rs` covers: happy-path
  add→list round-trip via git notes, exactly-one-record (no write-through dup),
  case-5 refuse in a repo with no commit, precedence #3 (`.spelunk/` wins over
  fallback), precedence #1 (explicit `--backend git-notes` pre-init), and the
  secret-scan gate on the git-notes path. `tests/fail_closed_no_project.rs`
  updated to assert the dual-hatch message and that non-add/list subcommands
  stay fail-closed.
- **Manual end-to-end round-trip**: in a fresh git repo (one commit, no
  `.spelunk/`), isolated `HOME`, `SPELUNK_NO_SERVER=1`:
  - `spelunk memory add --kind decision --title … --body …` → `Stored [decision] #…`
  - `spelunk memory list` → shows the entry
  - `git notes --ref=spelunk show HEAD` → exactly one JSON record on HEAD's note
  - no `.spelunk/` dir created; no global `~/.config/spelunk/memory.db` created

Ready for Johan to merge.
