### PR TITLE
fix(bench): portable timeout detection in setup_repos.sh (spelunk-oss^153)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -40,6 +40,8 @@ bash bench/setup_repos.sh
 
 This fetches task metadata from HuggingFace (`princeton-nlp/SWE-bench_Verified`) and clones each repo at the correct base commit. Re-running is idempotent; already-correct checkouts are skipped. Requires internet access and `uv`.
 
+`--git-timeout` is enforced via a `timeout`/`gtimeout` binary. macOS ships neither; install GNU coreutils (`brew install coreutils`) for `gtimeout` to enforce it, otherwise the script runs git ops without a per-command timeout.
+
 Options: `--tasks N` (first N only) · `--repos-dir DIR` · `--dataset SLUG`
 
 **For Claude benchmarks (secondary):**

--- a/bench/setup_repos.sh
+++ b/bench/setup_repos.sh
@@ -57,6 +57,31 @@ done
 mkdir -p "$REPOS_DIR"
 
 # ---------------------------------------------------------------------------
+# Timeout wrapper — macOS ships no `timeout`; prefer it, else `gtimeout` (GNU
+# coreutils). If neither exists, run git ops without a limit rather than failing
+# with exit 127 (which would masquerade as a clone failure).
+# ---------------------------------------------------------------------------
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    TIMEOUT_BIN=""
+    echo "WARNING: no 'timeout' binary found — --git-timeout (${GIT_TIMEOUT}s) will NOT be enforced." >&2
+    echo "         Install GNU coreutils for 'gtimeout' (macOS: brew install coreutils)." >&2
+fi
+
+# Run a command under the timeout limit when a timeout binary exists; otherwise
+# run it directly (portable no-op passthrough).
+git_timeout() {
+    if [[ -n "$TIMEOUT_BIN" ]]; then
+        "$TIMEOUT_BIN" "$GIT_TIMEOUT" "$@"
+    else
+        "$@"
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # Retry helper — retries a command with exponential backoff.
 # Usage: retry <attempts> <description> <command...>
 # ---------------------------------------------------------------------------
@@ -68,8 +93,9 @@ retry() {
     local attempt=1
     local delay=5
     local rc=0
+    local errfile="/tmp/spelunk-setup-git-stderr.$$"
     while [[ $attempt -le $attempts ]]; do
-        "$@" 2>/tmp/spelunk-setup-git-stderr.$$ && return 0
+        "$@" 2>"$errfile" && return 0
         rc=$?
         if [[ $attempt -lt $attempts ]]; then
             echo "    Retry ${attempt}/${attempts}: ${desc} failed (exit ${rc}), retrying in ${delay}s..." >&2
@@ -80,6 +106,9 @@ retry() {
         fi
         attempt=$((attempt + 1))
     done
+    # Surface the real cause instead of a bare exit code (e.g. 127 = missing
+    # binary vs a genuine clone/network error).
+    echo "    ${desc} failed (exit ${rc}): $(tail -3 "$errfile" 2>/dev/null | tr '\n' ' ')" >&2
     return $rc
 }
 
@@ -196,7 +225,7 @@ while IFS= read -r line; do
         # Existing repo: fetch with timeout and retry
         echo "  Fetching origin..."
         if ! retry "$MAX_RETRIES" "git fetch" \
-            timeout "$GIT_TIMEOUT" git -C "$DEST" fetch --quiet origin; then
+            git_timeout git -C "$DEST" fetch --quiet origin; then
             echo "  ERROR: git fetch failed after ${MAX_RETRIES} retries."
             FAILED_TASKS+=("${INSTANCE_ID}: git fetch failed")
             continue
@@ -205,10 +234,10 @@ while IFS= read -r line; do
         # New clone — try partial (blobless) clone first, fall back to full clone
         echo "  Cloning ${CLONE_URL}..."
         if retry "$MAX_RETRIES" "git clone (blobless)" \
-            timeout "$GIT_TIMEOUT" git clone --filter=blob:none --no-checkout --quiet "$CLONE_URL" "$DEST" 2>/dev/null; then
+            git_timeout git clone --filter=blob:none --no-checkout --quiet "$CLONE_URL" "$DEST"; then
             echo "    (partial clone OK)"
         elif retry "$MAX_RETRIES" "git clone (full)" \
-            timeout "$GIT_TIMEOUT" git clone --no-checkout --quiet "$CLONE_URL" "$DEST" 2>/dev/null; then
+            git_timeout git clone --no-checkout --quiet "$CLONE_URL" "$DEST"; then
             echo "    (full clone OK — partial clone not supported by server)"
         else
             echo "  ERROR: git clone failed after retries."


### PR DESCRIPTION
## What

`bench/setup_repos.sh` wrapped every git clone/fetch in `timeout "$GIT_TIMEOUT" …`. macOS ships no `timeout` binary, so on a dev Mac the wrapper failed with exit 127. The blobless/full clone calls also had `2>/dev/null`, so the missing-binary failure was swallowed and surfaced only as a generic "git clone failed after retries" — misdiagnosing a missing coreutils install as a network/clone problem.

## Fix

- Detect a timeout binary once at startup: prefer `timeout`, then `gtimeout` (GNU coreutils). If neither exists, emit a single clear stderr warning that `--git-timeout` is unenforced plus a `brew install coreutils` hint, and set an empty sentinel.
- New `git_timeout()` wrapper routes all git ops: runs under `$TIMEOUT_BIN $GIT_TIMEOUT …` when a binary exists, otherwise a no-op passthrough that runs the command directly (preserving its real exit code) instead of exit-127 failing.
- All previously `timeout`-wrapped git calls (existing-repo fetch, blobless clone, full clone) now route through `git_timeout`; no bare `timeout` invocations remain.
- Removed the `2>/dev/null` masking on the clone calls; the `retry` helper now tails captured stderr into its failure message so the real cause (missing binary vs genuine clone/network error) is surfaced.
- `bench/README.md` documents the optional GNU coreutils dependency for `--git-timeout` enforcement.

Change is confined to `bench/` (script + README); no Rust/`crates/` touched. Style matches the existing bash script (`[[ … ]]`, same shebang).

## Test plan

Verified on a macOS box where neither `timeout` nor `gtimeout` exists:

- `bash -n bench/setup_repos.sh` — syntax OK.
- Extracted the detection block + `git_timeout()` verbatim into a harness and exercised the neither-present fallback: emits exactly one warning (+ coreutils hint) to stderr; `git_timeout git --version` runs via no-op passthrough and returns exit 0; a genuine git failure (`git <bad-subcommand>`) preserves exit 1 rather than being masked as 127.
- Simulated the other two branches with fake `timeout`/`gtimeout` binaries on PATH: with both present the wrapper selects `timeout` and invokes it as `timeout 120 git …`; with only `gtimeout` present it selects and invokes `gtimeout`.
- `shellcheck` is not installed on this box, so it was not run (noted).
- No Rust changed, so cargo suites are out of scope for this bench-script fix.