### PR TITLE
feat(init): configure origin notes refspec so memory travels (spelunk-oss^126, ADR-068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,9 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 - **`spelunk init` now configures the `origin` fetch refspec for `refs/notes/spelunk`**,
   so project memory notes travel automatically on `git fetch`. When init detects
   an `origin` remote, it adds `+refs/notes/spelunk:refs/notes/spelunk` to the
-  fetch config (idempotently) and prints a one-time push command so users can
-  publish their memory to the remote. Teammates then run `spelunk init` in their
+  fetch config (idempotently) and prints the push command users run to publish
+  their memory to the remote (re-run after each memory change, since every
+  memory add/remove creates a new notes commit). Teammates then run `spelunk init` in their
   clones (or manually add the same refspec) and `git fetch` to receive notes. In
   projects without an `origin`, init prints the exact git commands to run later
   when the remote is added. See [docs/memory.md](#sharing-memory-across-clones-via-git-notes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   (spelunk-oss^147)
 ### Added
 
+- **`spelunk init` now configures the `origin` fetch refspec for `refs/notes/spelunk`**,
+  so project memory notes travel automatically on `git fetch`. When init detects
+  an `origin` remote, it adds `+refs/notes/spelunk:refs/notes/spelunk` to the
+  fetch config (idempotently) and prints a one-time push command so users can
+  publish their memory to the remote. Teammates then run `spelunk init` in their
+  clones (or manually add the same refspec) and `git fetch` to receive notes. In
+  projects without an `origin`, init prints the exact git commands to run later
+  when the remote is added. See [docs/memory.md](#sharing-memory-across-clones-via-git-notes).
+  (ADR-068, spelunk-oss^126)
 - **Native in-process HTTPS for `spelunk-server`** via `--tls-cert`/`--tls-key`
   (env `SPELUNK_SERVER_TLS_CERT`/`SPELUNK_SERVER_TLS_KEY`), both-or-neither. The
   server terminates TLS itself, so a team/remote deployment is a routable

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -221,6 +221,13 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
         }
     };
 
+    // ── 7b. Configure git-notes refspec on `origin` (only inside a git repo) ──
+    let notes_lines = if git_root.is_some() {
+        configure_notes_refspec(&project_root)
+    } else {
+        Vec::new()
+    };
+
     // ── 8. Print success summary ──────────────────────────────────────────────
     println!();
     println!("spelunk initialised for {}", project_slug);
@@ -243,6 +250,9 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
     println!("  Hook:    {}", hook_status);
     if let Some(line) = server_line {
         println!("  Server:  {line}");
+    }
+    for line in &notes_lines {
+        println!("  {line}");
     }
     println!();
     println!("Next steps:");
@@ -271,6 +281,67 @@ fn write_spelunk_gitignore(spelunk_dir: &std::path::Path) {
     }
     if let Err(e) = std::fs::write(&gitignore_path, GITIGNORE) {
         eprintln!("Warning: could not write {}: {e}", gitignore_path.display());
+    }
+}
+
+/// Configure the `origin` fetch refspec so `refs/notes/spelunk` (spelunk's
+/// memory) travels on clone/fetch. Returns announce lines for the init summary.
+///
+/// Push refspec is deliberately NOT set: any `remote.origin.push` value
+/// overrides git's default branch push, so a normal `git push` would stop
+/// pushing the current branch. We keep the branch-push default intact and
+/// surface the one-time manual notes push instead.
+fn configure_notes_refspec(project_root: &std::path::Path) -> Vec<String> {
+    const FETCH_REFSPEC: &str = "+refs/notes/spelunk:refs/notes/spelunk";
+    const PUSH_HINT: &str = "notes push (one-time): git push origin refs/notes/spelunk";
+
+    let git = |args: &[&str]| {
+        std::process::Command::new("git")
+            .current_dir(project_root)
+            .args(args)
+            .output()
+    };
+
+    // No `origin` remote → skip gracefully with the exact manual commands.
+    let has_origin = git(&["remote", "get-url", "origin"])
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !has_origin {
+        return vec![
+            "Memory:  no 'origin' remote — notes refspec not configured".to_string(),
+            format!("         run later: git config --add remote.origin.fetch '{FETCH_REFSPEC}'"),
+            format!("         {PUSH_HINT}"),
+        ];
+    }
+
+    // Idempotent: only `--add` when the identical refspec is not already present.
+    let already = git(&["config", "--get-all", "remote.origin.fetch"])
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .any(|l| l.trim() == FETCH_REFSPEC)
+        })
+        .unwrap_or(false);
+    if already {
+        return vec![
+            "Memory:  notes fetch refspec already configured on 'origin'".to_string(),
+            format!("         {PUSH_HINT}"),
+        ];
+    }
+
+    match git(&["config", "--add", "remote.origin.fetch", FETCH_REFSPEC]) {
+        Ok(o) if o.status.success() => vec![
+            "Memory:  configured notes fetch refspec on 'origin' (refs/notes/spelunk travels on fetch)"
+                .to_string(),
+            format!("         {PUSH_HINT}"),
+        ],
+        Ok(o) => vec![format!(
+            "Memory:  could not configure notes refspec: {}",
+            String::from_utf8_lossy(&o.stderr).trim()
+        )],
+        Err(e) => vec![format!("Memory:  could not configure notes refspec: {e}")],
     }
 }
 

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -237,10 +237,11 @@ fn write_spelunk_gitignore(spelunk_dir: &std::path::Path) {
 /// Push refspec is deliberately NOT set: any `remote.origin.push` value
 /// overrides git's default branch push, so a normal `git push` would stop
 /// pushing the current branch. We keep the branch-push default intact and
-/// surface the one-time manual notes push instead.
+/// surface the manual notes push (needed after each memory change) instead.
 fn configure_notes_refspec(project_root: &std::path::Path) -> Vec<String> {
     const FETCH_REFSPEC: &str = "+refs/notes/spelunk:refs/notes/spelunk";
-    const PUSH_HINT: &str = "notes push (one-time): git push origin refs/notes/spelunk";
+    const PUSH_HINT: &str =
+        "push notes after each memory change: git push origin refs/notes/spelunk";
 
     let git = |args: &[&str]| {
         std::process::Command::new("git")

--- a/crates/spelunk-cli/tests/init_notes_refspec.rs
+++ b/crates/spelunk-cli/tests/init_notes_refspec.rs
@@ -1,0 +1,353 @@
+//! Integration tests for `spelunk init` configuring the `origin` git-notes
+//! fetch refspec so `refs/notes/spelunk` (spelunk's memory) travels on
+//! clone/fetch (spelunk-oss^126, ADR-068).
+//!
+//! Covered:
+//! - origin present: `remote.origin.fetch` gains `+refs/notes/spelunk:…` and
+//!   init announces the configured line.
+//! - origin absent: init still exits 0 and prints the exact manual hint.
+//! - idempotent: two inits leave exactly ONE notes refspec + "already
+//!   configured" announce on the second run.
+//! - push preserved: `remote.origin.push` stays unset (branch-push default).
+//! - round-trip: notes pushed to a bare origin are fetchable back via the
+//!   configured refspec into a fresh clone.
+//! - non-TTY: piped-stdin init completes without prompting/hanging.
+//!
+//! Every spawned `spelunk` uses `spelunk_bin` (pins `SPELUNK_SECRET_STORE=file`),
+//! `SPELUNK_NO_SERVER=1`, and `init --no-index` for an offline, fast run.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
+use predicates::prelude::*;
+use std::path::Path;
+use std::process::Output;
+use tempfile::tempdir;
+
+const NOTES_REFSPEC: &str = "+refs/notes/spelunk:refs/notes/spelunk";
+
+/// Run `git args` in `dir`, asserting success. Isolated identity + config so it
+/// works hermetically on a machine with (or without) a global git config.
+fn git(dir: &Path, args: &[&str]) {
+    let out = git_out(dir, args);
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Like [`git`] but returns the captured `Output` without asserting success.
+fn git_out(dir: &Path, args: &[&str]) -> Output {
+    std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@example.com")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@example.com")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("spawn git")
+}
+
+/// `stdout` of `git args` as a trimmed `String`.
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    String::from_utf8_lossy(&git_out(dir, args).stdout)
+        .trim()
+        .to_string()
+}
+
+/// A git repo with a real identity + one commit. Returns nothing; caller owns
+/// the dir. Local identity is set so spawned `git` (and spelunk's inner git)
+/// can commit without inheriting the test-runner's global config.
+fn init_repo_with_commit(dir: &Path) {
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@example.com"]);
+    git(dir, &["config", "user.name", "Test"]);
+    std::fs::write(dir.join("README.md"), "# test\n").unwrap();
+    git(dir, &["add", "README.md"]);
+    git(dir, &["commit", "-q", "-m", "init"]);
+}
+
+/// Write an empty spelunk config (init needs `--config` but no values here).
+fn empty_config(dir: &Path) -> std::path::PathBuf {
+    let cfg = dir.join("config.toml");
+    std::fs::write(&cfg, "").unwrap();
+    cfg
+}
+
+/// Run `spelunk init --no-index` in `dir` (offline, non-TTY) and return stdout.
+fn run_init(dir: &Path) -> String {
+    let cfg = empty_config(dir);
+    let out = spelunk_bin()
+        .current_dir(dir)
+        .env("HOME", dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&cfg)
+        .args(["init", "--no-index"])
+        .output()
+        .expect("spawn spelunk init");
+    assert!(
+        out.status.success(),
+        "spelunk init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// (1) With an `origin` remote: init adds the notes fetch refspec and announces it.
+#[test]
+fn init_configures_notes_refspec_when_origin_present() {
+    let tmp = tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    let origin = tmp.path().join("origin.git");
+    std::fs::create_dir_all(&repo).unwrap();
+
+    git(
+        tmp.path(),
+        &["init", "--bare", "-q", origin.to_str().unwrap()],
+    );
+    init_repo_with_commit(&repo);
+    git(
+        &repo,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+
+    let stdout = run_init(&repo);
+
+    let fetch = git_stdout(&repo, &["config", "--get-all", "remote.origin.fetch"]);
+    assert!(
+        fetch.lines().any(|l| l.trim() == NOTES_REFSPEC),
+        "remote.origin.fetch should contain the notes refspec, got:\n{fetch}"
+    );
+    assert!(
+        stdout.contains("Memory:") && stdout.contains("configured notes fetch refspec on 'origin'"),
+        "init stdout should announce the configured refspec, got:\n{stdout}"
+    );
+}
+
+/// (2) No `origin` remote: init still succeeds and prints the exact manual hint.
+#[test]
+fn init_no_origin_prints_hint_and_succeeds() {
+    let tmp = tempdir().unwrap();
+    init_repo_with_commit(tmp.path());
+
+    let stdout = run_init(tmp.path()); // asserts exit 0 internally
+
+    assert!(
+        stdout.contains(&format!(
+            "git config --add remote.origin.fetch '{NOTES_REFSPEC}'"
+        )),
+        "no-origin init should print the exact refspec hint, got:\n{stdout}"
+    );
+    // And it must not have invented an `origin` remote.
+    assert!(
+        !git_out(tmp.path(), &["remote", "get-url", "origin"])
+            .status
+            .success(),
+        "init must not create an origin remote when none exists"
+    );
+}
+
+/// (3) Idempotent: two inits leave exactly one notes refspec + "already
+/// configured" announce on the second run.
+#[test]
+fn init_notes_refspec_is_idempotent() {
+    let tmp = tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    let origin = tmp.path().join("origin.git");
+    std::fs::create_dir_all(&repo).unwrap();
+
+    git(
+        tmp.path(),
+        &["init", "--bare", "-q", origin.to_str().unwrap()],
+    );
+    init_repo_with_commit(&repo);
+    git(
+        &repo,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+
+    run_init(&repo);
+    let second = run_init(&repo);
+
+    let count = git_stdout(&repo, &["config", "--get-all", "remote.origin.fetch"])
+        .lines()
+        .filter(|l| l.trim() == NOTES_REFSPEC)
+        .count();
+    assert_eq!(
+        count, 1,
+        "notes refspec must appear exactly once after two inits"
+    );
+    assert!(
+        second.contains("already configured"),
+        "second init should report the refspec is already configured, got:\n{second}"
+    );
+}
+
+/// (4) Push default preserved: `remote.origin.push` stays unset so a normal
+/// `git push` keeps pushing the current branch (the engineer set no push refspec).
+#[test]
+fn init_does_not_set_origin_push_refspec() {
+    let tmp = tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    let origin = tmp.path().join("origin.git");
+    std::fs::create_dir_all(&repo).unwrap();
+
+    git(
+        tmp.path(),
+        &["init", "--bare", "-q", origin.to_str().unwrap()],
+    );
+    init_repo_with_commit(&repo);
+    git(
+        &repo,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+
+    run_init(&repo);
+
+    let push = git_out(&repo, &["config", "--get", "remote.origin.push"]);
+    assert!(
+        !push.status.success() && String::from_utf8_lossy(&push.stdout).trim().is_empty(),
+        "remote.origin.push must remain unset, got: {:?}",
+        String::from_utf8_lossy(&push.stdout)
+    );
+}
+
+/// (5) Round-trip (the promise): a note pushed to the bare origin is fetchable
+/// back into a fresh clone via the configured notes refspec.
+///
+/// A. init in repo (configures the refspec) → add a decision (git note on
+///    refs/notes/spelunk) → push the branch + notes ref to the bare origin.
+/// B. clone origin → run init in the clone (adds the same fetch refspec) →
+///    plain `git fetch origin` pulls the notes → `git notes --ref=spelunk`
+///    surfaces the decision. This proves the ref is publishable AND that the
+///    init-configured refspec is what fetches it.
+#[test]
+fn notes_round_trip_through_bare_origin() {
+    let tmp = tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    let origin = tmp.path().join("origin.git");
+    let clone = tmp.path().join("clone");
+    std::fs::create_dir_all(&repo).unwrap();
+
+    git(
+        tmp.path(),
+        &["init", "--bare", "-q", origin.to_str().unwrap()],
+    );
+    init_repo_with_commit(&repo);
+    git(
+        &repo,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+
+    // A. Configure the refspec, then add a decision via `spelunk memory add`
+    //    (store_in_git_notes = true → writes refs/notes/spelunk).
+    run_init(&repo);
+
+    let mem_db = repo.join(".spelunk").join("memory.db");
+    let cfg = repo.join("mem-config.toml");
+    std::fs::write(
+        &cfg,
+        format!(
+            "db_path = {:?}\nllm_model = \"x\"\nstore_in_git_notes = true\n",
+            mem_db
+        ),
+    )
+    .unwrap();
+
+    let unique = "notes travel via the origin refspec";
+    spelunk_bin()
+        .current_dir(&repo)
+        .env("HOME", &repo)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&cfg)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_db)
+        .arg("add")
+        .arg("--kind")
+        .arg("decision")
+        .arg("--title")
+        .arg(unique)
+        .arg("--body")
+        .arg("Chosen so refs/notes/spelunk clone/fetch behaviour is observable.")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [decision]"));
+
+    // Sanity: the note exists locally on refs/notes/spelunk.
+    assert!(
+        !git_stdout(&repo, &["notes", "--ref=spelunk", "list"]).is_empty(),
+        "expected a local spelunk note after memory add"
+    );
+
+    // Publish branch + notes to the bare origin.
+    git(&repo, &["push", "-q", "origin", "main"]);
+    git(&repo, &["push", "-q", "origin", "refs/notes/spelunk"]);
+
+    // B. Fresh clone gets the branch but NOT notes by default…
+    git(
+        tmp.path(),
+        &[
+            "clone",
+            "-q",
+            origin.to_str().unwrap(),
+            clone.to_str().unwrap(),
+        ],
+    );
+    // clone identity for its own inner git (init announces, no commit needed).
+    git(&clone, &["config", "user.email", "clone@example.com"]);
+    git(&clone, &["config", "user.name", "Clone"]);
+    assert!(
+        git_stdout(&clone, &["notes", "--ref=spelunk", "list"]).is_empty(),
+        "a fresh clone should not have spelunk notes before fetch"
+    );
+
+    // …init in the clone configures the notes fetch refspec, and a plain fetch
+    // then pulls the notes ref — the end-to-end promise.
+    run_init(&clone);
+    git(&clone, &["fetch", "-q", "origin"]);
+
+    let notes = git_stdout(&clone, &["notes", "--ref=spelunk", "list"]);
+    assert!(
+        !notes.is_empty(),
+        "clone should have the spelunk note after init-configured fetch"
+    );
+
+    // The decision content travelled, not just an empty ref. `list` lines are
+    // `<note-obj> <annotated-obj>`; show the annotated object explicitly rather
+    // than relying on the clone's HEAD matching it.
+    let annotated = notes
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .expect("note list line has an annotated object")
+        .to_string();
+    let shown = git_stdout(&clone, &["notes", "--ref=spelunk", "show", &annotated]);
+    assert!(
+        shown.contains(unique),
+        "fetched note should contain the decision title, got:\n{shown}"
+    );
+}
+
+/// (6) Non-TTY: init run with piped stdin (as assert_cmd/Output does) must not
+/// prompt or hang — it returns and exits 0. Explicit guard for the hook/CI path.
+#[test]
+fn init_non_tty_does_not_prompt_or_hang() {
+    let tmp = tempdir().unwrap();
+    init_repo_with_commit(tmp.path());
+
+    // run_init spawns with piped (non-TTY) stdin and asserts exit 0; reaching
+    // this line at all means init completed without blocking on input.
+    let stdout = run_init(tmp.path());
+    assert!(
+        stdout.contains("spelunk initialised for"),
+        "init should print its success summary in non-TTY mode, got:\n{stdout}"
+    );
+}

--- a/crates/spelunk-cli/tests/init_notes_refspec.rs
+++ b/crates/spelunk-cli/tests/init_notes_refspec.rs
@@ -143,6 +143,12 @@ fn init_no_origin_prints_hint_and_succeeds() {
         )),
         "no-origin init should print the exact refspec hint, got:\n{stdout}"
     );
+    // The push hint frames the notes push as per-change, not one-time: each
+    // memory add/remove makes a new notes commit that must be pushed to travel.
+    assert!(
+        stdout.contains("push notes after each memory change: git push origin refs/notes/spelunk"),
+        "no-origin init should print the per-change notes push hint, got:\n{stdout}"
+    );
     // And it must not have invented an `origin` remote.
     assert!(
         !git_out(tmp.path(), &["remote", "get-url", "origin"])

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -41,7 +41,8 @@ slug.
 **Memory notes travel with the repository:** When run inside a git repo with an
 `origin` remote, `init` configures `remote.origin.fetch` to include
 `refs/notes/spelunk`, so project memory automatically travels on `git fetch`.
-The init output includes a one-time push command to publish your notes. See
+The init output includes the push command to publish your notes; re-run it
+after each memory change so new notes commits travel. See
 [Sharing memory across clones via git-notes](memory.md#sharing-memory-across-clones-via-git-notes).
 
 **Example:**

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,7 +16,9 @@ always-available commands (`graph`, text/ast-grep `search`, `memory add/list`,
 ## spelunk init
 
 Initialise spelunk for the current project: register it, parse and chunk the
-source tree, start the local server if needed, and embed the code.
+source tree, start the local server if needed, embed the code, and (when inside
+a git repo with an `origin` remote) configure the fetch refspec so project
+memory notes travel automatically on `git fetch`.
 
 ```
 spelunk init [options]
@@ -35,6 +37,12 @@ canonical path. Pass `--name` to set an explicit slug for a repo without a remot
 or to choose your own. An existing `project_id` in config is never rewritten, so
 re-running `init` (or running it after a rename) does not change an established
 slug.
+
+**Memory notes travel with the repository:** When run inside a git repo with an
+`origin` remote, `init` configures `remote.origin.fetch` to include
+`refs/notes/spelunk`, so project memory automatically travels on `git fetch`.
+The init output includes a one-time push command to publish your notes. See
+[Sharing memory across clones via git-notes](memory.md#sharing-memory-across-clones-via-git-notes).
 
 **Example:**
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -22,6 +22,47 @@ git notes --ref=spelunk list         # every commit carrying spelunk notes
 GIT_NOTES_REF=refs/notes/spelunk git notes show HEAD
 ```
 
+### Sharing memory across clones via git-notes
+
+When you run `spelunk init` inside a git repository with an `origin` remote,
+spelunk automatically configures the fetch refspec for `origin` so that
+`refs/notes/spelunk` travels on `git fetch`. The init command prints the status:
+
+```
+Memory:  configured notes fetch refspec on 'origin' (refs/notes/spelunk travels on fetch)
+         notes push (one-time): git push origin refs/notes/spelunk
+```
+
+To publish your memory notes to the remote, run the one-time push command:
+
+```bash
+git push origin refs/notes/spelunk
+```
+
+Push only once; subsequent `git fetch` commands from teammates (or later clones)
+will automatically pull the notes because the refspec is configured.
+
+**For teammates to receive the notes:**
+
+1. Clone the repository normally: `git clone <repo>`
+2. Run `spelunk init` in the clone (or manually add the refspec with `git config --add remote.origin.fetch '+refs/notes/spelunk:refs/notes/spelunk'`)
+3. Fetch: `git fetch`
+
+A fresh clone does **not** inherit the source's local git config, so `git fetch`
+alone won't pull the notes. The teammate must either run `spelunk init` (which
+configures the refspec automatically) or add it manually, then fetch.
+
+**If there is no `origin` remote** (for example, in a local-only or detached
+repository), `spelunk init` prints the commands to run later:
+
+```
+Memory:  no 'origin' remote — notes refspec not configured
+         run later: git config --add remote.origin.fetch '+refs/notes/spelunk:refs/notes/spelunk'
+         notes push (one-time): git push origin refs/notes/spelunk
+```
+
+Add the refspec when an `origin` is created, then push the notes as above.
+
 Memory is scoped to a local project. Run `spelunk init` once per repository to
 create its `.spelunk/` store. In a directory with no local `.spelunk/`,
 `memory add/list/search` and `context` fail closed with a `no spelunk project

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -30,17 +30,19 @@ spelunk automatically configures the fetch refspec for `origin` so that
 
 ```
 Memory:  configured notes fetch refspec on 'origin' (refs/notes/spelunk travels on fetch)
-         notes push (one-time): git push origin refs/notes/spelunk
+         push notes after each memory change: git push origin refs/notes/spelunk
 ```
 
-To publish your memory notes to the remote, run the one-time push command:
+To publish your memory notes to the remote, push the notes ref:
 
 ```bash
 git push origin refs/notes/spelunk
 ```
 
-Push only once; subsequent `git fetch` commands from teammates (or later clones)
-will automatically pull the notes because the refspec is configured.
+Re-run this push whenever you record memory: each `spelunk memory add` (or
+remove) creates a new notes commit that travels only once it is pushed. The
+fetch refspec, by contrast, is configured once, so teammates' (and later
+clones') `git fetch` then pulls whatever notes you have already pushed.
 
 **For teammates to receive the notes:**
 
@@ -58,7 +60,7 @@ repository), `spelunk init` prints the commands to run later:
 ```
 Memory:  no 'origin' remote — notes refspec not configured
          run later: git config --add remote.origin.fetch '+refs/notes/spelunk:refs/notes/spelunk'
-         notes push (one-time): git push origin refs/notes/spelunk
+         push notes after each memory change: git push origin refs/notes/spelunk
 ```
 
 Add the refspec when an `origin` is created, then push the notes as above.


### PR DESCRIPTION
## What

`spelunk init` now configures the `origin` **fetch** refspec so project memory
(`refs/notes/spelunk`) travels on `git fetch`. When init runs inside a git repo
with an `origin` remote, it idempotently adds
`+refs/notes/spelunk:refs/notes/spelunk` to `remote.origin.fetch` (checks
`--get-all` first, no duplicate on re-run) and announces the change in the init
summary. It never writes git config silently. (spelunk-oss^126, ADR-068)

## Fetch-only refspec, no push refspec — and why

The change deliberately does **not** set `remote.origin.push`. Any
`remote.origin.push` value overrides git's default branch push, so a normal
`git push` would stop pushing the current branch. To keep the branch-push
default intact, init instead surfaces the one-time manual publish command:

```
git push origin refs/notes/spelunk
```

- No `origin` remote or non-TTY: graceful skip, exit 0, no prompt/hang. In the
  no-origin case init prints the exact `git config --add …` + push commands to
  run later.
- Uses `refs/notes/spelunk` (spelunk's ref), not `refs/notes/commits`.

## Docs

`docs/memory.md`, `docs/commands.md`, and `CHANGELOG.md` document the flow and are
careful **not** to overstate: notes do not travel automatically on `git clone`
(a fresh clone does not inherit the source's local git config). Teammates must
run `spelunk init` in their clone (or add the refspec manually) and then
`git fetch`; the publisher pushes once. The marketing-site getting-started
wording is a separate follow-up, not in this PR.

## Test plan (actual steps run in this review)

- `cargo test -p spelunk-cli` → all green, including the 6 new tests in
  `tests/init_notes_refspec.rs` (origin-present config, no-origin hint,
  idempotency, `remote.origin.push` stays unset, non-TTY no-hang, and a
  bare-origin round-trip).
- `cargo test -p spelunk-cli --no-default-features` → all green (new tests pass).
- `cargo clippy --all-targets` → clean, no warnings.
- Round-trip test (`notes_round_trip_through_bare_origin`) verified to be a real
  assertion, not a no-op: it pushes a `memory add` decision note to a bare
  origin, clones fresh, asserts the clone has **no** spelunk notes pre-fetch,
  runs init + `git fetch` in the clone, then `git notes --ref=spelunk show`s the
  annotated object and asserts the decision **title/content** arrived.

Sibling: overlaps init.rs with #579 (^141); expect a trivial merge-order
conflict, resolvable by keeping both changes.
