### PR TITLE
docs(adr): clarify ADR-059 D1 git-notes collision surface for the custom refs/notes/spelunk ref

### DIFF
--- a/docs/adr/059-git-notes-v1-format-freeze.md
+++ b/docs/adr/059-git-notes-v1-format-freeze.md
@@ -131,6 +131,17 @@ read. Serialization of *our* records uses the canonical `serde_json::to_string`
 one-line form; a record we did not touch is re-emitted from its original source
 text, not re-serialized (so we never reformat another writer's spacing).
 
+> **Clarification (2026-07-12, collision surface is narrower than the opening
+> sentence implies):** The "we do not own the store; other tools and humans may
+> write into the same note" framing above overstates the collision risk.
+> `refs/notes/spelunk` is a spelunk-specific notes ref, not git's default
+> `refs/notes/commits`, so no default git tooling writes to it. The realistic
+> foreign-content surface is limited to another tool deliberately targeting this
+> custom ref, or a human editing it by hand. The permissive-read,
+> non-clobbering-write design still stands regardless: it is sound defensive
+> engineering independent of how narrow that surface is, and it is what lets the
+> interleaved-prose conformance fixture below round-trip.
+
 ### D2 – optional additive `remote_id` (uuid)
 
 Add an **optional, additive** `remote_id` to the three distributed surfaces. It


### PR DESCRIPTION
## Summary

Appends a dated forward-note to ADR-059 decision **D1** correcting an overstated sentence about the git-notes collision surface. The opening framing ("we do not own the store; other tools and humans may write into the same note") implied a broad collision risk. In fact spelunk writes to `refs/notes/spelunk`, a spelunk-specific notes ref, not git's default `refs/notes/commits` — so no default git tooling writes to it. The realistic foreign-content surface is limited to a tool deliberately targeting the custom ref, or a human editing it by hand.

The permissive-read, non-clobbering-write design is left standing unchanged: it remains sound defensive engineering regardless of how narrow that surface is, and it is what lets the interleaved-prose conformance fixture round-trip.

The frozen D1 decision body is untouched; this is a pure additive clarification, consistent with the existing forward-note style in ADR-056.

## Test plan

- `git diff` confirms a single-file, addition-only change (11 insertions, 0 deletions) to `docs/adr/059-git-notes-v1-format-freeze.md`.
- The immutable D1 decision text is unchanged; the note is inserted inside D1, ahead of the D2 heading.
- Format matches the existing `> **Clarification (YYYY-MM-DD, …):**` forward-note style in ADR-056.
- No em-dash characters; markdown blockquote is well-formed and renders correctly.