### PR TITLE
feat(search): point --mode text empty-index error at zero-setup search modes

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -105,6 +105,15 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
             .and_then(|db| db.stats())
             .is_ok_and(|s| s.chunk_count == 0)
     {
+        // Text mode has no index yet: point at the zero-setup modes that need
+        // none (auto default, ast-grep) rather than only demanding an index.
+        if mode == "text" {
+            return Err(anyhow::anyhow!(
+                "no FTS index yet for --mode text. Run `spelunk index <path>` first,\n\
+                 or try `spelunk search \"...\" --mode ast-grep` (or omit --mode) for a\n\
+                 zero-setup search."
+            ));
+        }
         return Err(crate::error::SearchError::EmptyIndex.into());
     }
 

--- a/crates/spelunk-cli/tests/search_empty_index_mode.rs
+++ b/crates/spelunk-cli/tests/search_empty_index_mode.rs
@@ -1,5 +1,4 @@
-//! End-to-end coverage for the `search --mode text` empty-index guidance
-//! (spelunk-oss^129).
+//! End-to-end coverage for the `search --mode text` empty-index guidance.
 //!
 //! On an initialized-but-empty project (`.spelunk/index.db` exists but holds
 //! zero chunks), an explicit `--mode text` search previously emitted only the

--- a/crates/spelunk-cli/tests/search_empty_index_mode.rs
+++ b/crates/spelunk-cli/tests/search_empty_index_mode.rs
@@ -1,0 +1,139 @@
+//! End-to-end coverage for the `search --mode text` empty-index guidance
+//! (spelunk-oss^129).
+//!
+//! On an initialized-but-empty project (`.spelunk/index.db` exists but holds
+//! zero chunks), an explicit `--mode text` search previously emitted only the
+//! shared `EmptyIndex` message ("index is empty — run `spelunk index` first"),
+//! which demands an index the user may not want. The fix points `--mode text`
+//! at the zero-setup modes that need no index (ast-grep, or omitting `--mode`).
+//!
+//! `--mode semantic`/`--mode hybrid` are deliberately left on the original
+//! shared message: those modes genuinely need an index (plus an embedder), so
+//! redirecting them to ast-grep would be misleading. These tests pin both the
+//! new text-mode copy AND that the change is scoped to text mode.
+//!
+//! Driven through the real CLI (not the pure message selector) so a wiring
+//! regression — e.g. the text branch being reordered after the shared return,
+//! or the `mode == "text"` guard drifting — is caught end to end.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use std::path::Path;
+use tempfile::TempDir;
+
+/// The em-dash that must never appear in the new `--mode text` copy: user-facing
+/// spelunk output follows the no-em-dash house rule. Its absence is a guard on
+/// the copy itself, independent of the wording assertions below.
+const EM_DASH: &str = "—";
+
+/// Build an initialized-but-empty project: `<proj>/.spelunk/index.db` exists but
+/// contains zero chunks (`chunk_count == 0`).
+///
+/// Indexing a directory with no indexable source files still runs migrations and
+/// writes the project DB, so the DB exists (the resolver's existence check
+/// passes) while the stats report zero chunks — exactly the state the empty-index
+/// branch keys off. Offline (`SPELUNK_NO_SERVER=1`): with no chunks there is
+/// nothing to embed, so no server is needed.
+fn init_empty_project(home: &Path, proj: &Path) {
+    spelunk_bin_in(home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(proj)
+        .args(["index", "."])
+        .assert()
+        .success();
+
+    assert!(
+        proj.join(".spelunk").join("index.db").exists(),
+        "indexing an empty dir must still create the project index.db"
+    );
+}
+
+/// (a) `--mode text` on an empty index fails and redirects to the zero-setup
+/// modes, with no em-dash in the copy.
+#[test]
+fn search_mode_text_empty_index_points_at_zero_setup_modes() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_empty_project(home.path(), proj.path());
+
+    let assert = spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(proj.path())
+        .args(["search", "anything", "--mode", "text"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+
+    assert!(
+        stderr.contains("no FTS index"),
+        "text-mode empty-index error must name the missing FTS index; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("ast-grep"),
+        "must offer the zero-setup ast-grep mode; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("omit --mode"),
+        "must offer omitting --mode (auto) as a zero-setup path; got: {stderr}"
+    );
+    assert!(
+        !stderr.contains(EM_DASH),
+        "user-facing copy must not contain an em-dash; got: {stderr}"
+    );
+}
+
+/// (b) Regression guard: `--mode semantic` on the SAME empty index still emits
+/// the original shared `index is empty` message — the fix is scoped to text mode.
+#[test]
+fn search_mode_semantic_empty_index_keeps_shared_message() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_empty_project(home.path(), proj.path());
+
+    let assert = spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(proj.path())
+        .args(["search", "anything", "--mode", "semantic"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+    assert!(
+        stderr.contains("index is empty"),
+        "semantic mode must keep the original EmptyIndex message; got: {stderr}"
+    );
+    // The text-mode redirect copy must NOT leak into the semantic path.
+    assert!(
+        !stderr.contains("no FTS index"),
+        "semantic mode must not use the text-mode redirect copy; got: {stderr}"
+    );
+}
+
+/// (b, cont.) `--mode hybrid` shares the semantic path's index requirement, so it
+/// too keeps the shared message. Covered independently since it is a distinct
+/// mode string reaching the same branch.
+#[test]
+fn search_mode_hybrid_empty_index_keeps_shared_message() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_empty_project(home.path(), proj.path());
+
+    let assert = spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(proj.path())
+        .args(["search", "anything", "--mode", "hybrid"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+    assert!(
+        stderr.contains("index is empty"),
+        "hybrid mode must keep the original EmptyIndex message; got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("no FTS index"),
+        "hybrid mode must not use the text-mode redirect copy; got: {stderr}"
+    );
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -126,7 +126,9 @@ spelunk search <query> [options]
 
 `semantic`/`hybrid` uses LinearRAG: a two-stage entity-activation + personalised
 PageRank pipeline that improves multi-hop recall over raw KNN. `text` and
-`ast-grep` need no embedding model or server.
+`ast-grep` need no embedding model or server. `text` does run over the FTS
+index, so it needs `spelunk index` first; `ast-grep` and the `auto` default
+work with no index at all.
 
 In `ast-grep` mode (and the `auto` fallback used when there is no index or
 server), a plain-string query matches case-insensitively as a substring of


### PR DESCRIPTION
## What

On an initialized-but-empty index (`.spelunk/index.db` exists but holds zero chunks), an explicit `spelunk search ... --mode text` previously emitted only the shared `EmptyIndex` message, which demands an index the user may not want. `--mode text` now returns a dedicated error that points at the zero-setup modes needing no index (`--mode ast-grep`, or omitting `--mode` for the `auto` default), while still noting `spelunk index` for those who do want FTS.

`--mode semantic` and `--mode hybrid` deliberately keep the original shared `EmptyIndex` message: those modes genuinely require an index (and an embedder), so redirecting them to ast-grep would be misleading.

Docs updated: one line in `docs/commands.md` clarifying that `text` runs over the FTS index (so it needs `spelunk index` first) while `ast-grep` and the `auto` default work with no index at all.

## Test plan

- `crates/spelunk-cli/tests/search_empty_index_mode.rs` adds 3 e2e tests driven through the real CLI:
  - `--mode text` on an empty index fails, names the missing FTS index, offers `ast-grep` and "omit --mode", and contains no em-dash (house-rule guard on the copy).
  - `--mode semantic` on the same empty index still emits the original `index is empty` message and does not leak the text-mode copy.
  - `--mode hybrid` likewise keeps the shared message (distinct mode string reaching the same branch).
- `cargo test -p spelunk-cli -p spelunk-core` green on default features and again with `--no-default-features`; all 3 new tests pass in both configs.
- `cargo clippy -p spelunk-cli -p spelunk-core --all-targets` clean.
- Verified the `docs/commands.md` claim matches the code behavior.