### PR TITLE
docs(skill): correct worktree index auto-resolution guidance + regression tests

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -207,16 +207,23 @@ spelunk unlink <path>
 
 ## Git worktrees
 
-Worktrees automatically share the main worktree's index. Just run
-`spelunk index .` from inside the worktree — spelunk creates the link for you:
+Read/query commands (`context`, `check`, `search`, `memory`, `graph`, `status`)
+run from a linked worktree resolve to the main worktree's index automatically,
+with no setup step. Nothing is written into the worktree:
 
 ```bash
 git worktree add ../my-feature my-feature-branch
 cd ../my-feature
-spelunk index .    # links to main worktree's index; all commands work immediately
+spelunk context    # resolves to the main worktree's index; no init needed
 ```
 
-Run `spelunk autoclean` after removing a worktree to tidy up the registry.
+`spelunk index .` from a worktree is optional. Run it only to refresh the
+shared index with files you changed in that worktree; it re-indexes into the
+shared `<main-worktree>/.spelunk/index.db`.
+
+`spelunk autoclean` prunes stale registry entries (e.g. after a worktree or
+project directory is removed). It does not write to or clean anything inside
+the worktree.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -207,15 +207,23 @@ spelunk unlink <path>
 
 ## Git worktrees
 
-Read/query commands (`context`, `check`, `search`, `memory`, `graph`, `status`)
-run from a linked worktree resolve to the main worktree's index automatically,
-with no setup step. Nothing is written into the worktree:
+Read/query commands (`context`, `check`, `search`, `memory list`,
+`memory search`, `graph`, `status`) run from a linked worktree resolve to the
+main worktree's shared index automatically, with no setup step. Nothing is
+written into the worktree:
 
 ```bash
 git worktree add ../my-feature my-feature-branch
 cd ../my-feature
 spelunk context    # resolves to the main worktree's index; no init needed
 ```
+
+`memory add` is a write, not a read/query command, but it resolves the same
+way: an entry recorded from a linked worktree lands in the main worktree's
+shared `<main-worktree>/.spelunk/memory.db`, and its git-notes write-through
+appends to the repo's shared `refs/notes/spelunk`. There is no separate
+per-worktree memory store, so recording memory from a worktree needs no setup
+and stays in one place.
 
 `spelunk index .` from a worktree is optional. Run it only to refresh the
 shared index with files you changed in that worktree; it re-indexes into the

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -2295,7 +2295,7 @@ project_id = "team/new"
     #[test]
     fn find_project_db_resolves_worktree_to_main_index() {
         // A linked worktree with no local `.spelunk/` resolves reads to the
-        // main worktree's shared index, with no setup step (spelunk-oss^138).
+        // main worktree's shared index, with no setup step.
         let tmp = TempDir::new().unwrap();
         let (_main_root, wt_root, index_db) = linked_worktree_fixture(&tmp);
         assert!(

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -2265,4 +2265,52 @@ project_id = "team/new"
         let got = require_project_db_at(tmp.path(), &global, true).unwrap();
         assert_eq!(got, global);
     }
+
+    /// Build a linked-worktree fixture: `<main>/.spelunk/index.db` exists and
+    /// `<wt>` is a linked worktree with NO local `.spelunk/`. Returns
+    /// `(main_root, wt_root, index_db)`. Mirrors the fixture in `utils::tests`.
+    fn linked_worktree_fixture(tmp: &TempDir) -> (PathBuf, PathBuf, PathBuf) {
+        let main_root = tmp.path().join("main");
+        let wt_root = tmp.path().join("feat-branch");
+        std::fs::create_dir_all(&main_root).unwrap();
+        std::fs::create_dir_all(&wt_root).unwrap();
+
+        // Main worktree owns the shared index.
+        std::fs::create_dir_all(main_root.join(".spelunk")).unwrap();
+        let index_db = main_root.join(".spelunk").join("index.db");
+        std::fs::write(&index_db, b"").unwrap();
+
+        // wt_root/.git is a file pointing at <main>/.git/worktrees/<name>.
+        let gitdir_entry = main_root.join(".git").join("worktrees").join("feat-branch");
+        std::fs::create_dir_all(&gitdir_entry).unwrap();
+        std::fs::write(
+            wt_root.join(".git"),
+            format!("gitdir: {}\n", gitdir_entry.display()),
+        )
+        .unwrap();
+
+        (main_root, wt_root, index_db)
+    }
+
+    #[test]
+    fn find_project_db_resolves_worktree_to_main_index() {
+        // A linked worktree with no local `.spelunk/` resolves reads to the
+        // main worktree's shared index, with no setup step (spelunk-oss^138).
+        let tmp = TempDir::new().unwrap();
+        let (_main_root, wt_root, index_db) = linked_worktree_fixture(&tmp);
+        assert!(
+            !wt_root.join(".spelunk").exists(),
+            "worktree must have no local .spelunk/"
+        );
+        assert_eq!(find_project_db(&wt_root), Some(index_db));
+    }
+
+    #[test]
+    fn require_project_db_at_resolves_worktree_to_main_index() {
+        let tmp = TempDir::new().unwrap();
+        let (main_root, wt_root, _index_db) = linked_worktree_fixture(&tmp);
+        let global = PathBuf::from("/nonexistent/global/index.db");
+        let got = require_project_db_at(&wt_root, &global, false).unwrap();
+        assert_eq!(got, main_root.join(".spelunk").join("index.db"));
+    }
 }

--- a/crates/spelunk-core/tests/worktree_index_resolution.rs
+++ b/crates/spelunk-core/tests/worktree_index_resolution.rs
@@ -1,0 +1,94 @@
+//! Integration test for worktree → main-index resolution over a REAL
+//! `git worktree` (spelunk-oss^138).
+//!
+//! The `config.rs` unit fixtures build a `.git`-*file* by hand, on which
+//! `gix::discover` fails — so they exercise only the manual fallback branch of
+//! `resolve_main_worktree_root`. This test creates a genuine linked worktree via
+//! `git worktree add`, so `gix::discover` succeeds and the primary gix branch is
+//! covered end to end. It also guards the real-path shape gix returns (e.g. the
+//! macOS `/var` → `/private/var` symlink), which string-only fixtures cannot.
+//!
+//! Requires `git` on PATH; fully hermetic (everything lives under a TempDir that
+//! is removed on drop, taking the linked worktree with it — no orphans).
+
+use spelunk_core::config::find_project_db;
+use spelunk_core::utils::resolve_main_worktree_root;
+
+fn git(cwd: &std::path::Path, args: &[&str]) -> std::process::Output {
+    std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("git command")
+}
+
+/// Compare two paths after canonicalising both, so a symlinked temp prefix
+/// (macOS `/var` vs `/private/var`) does not spuriously fail the assertion.
+fn same_path(a: &std::path::Path, b: &std::path::Path) {
+    let ca = std::fs::canonicalize(a).unwrap();
+    let cb = std::fs::canonicalize(b).unwrap();
+    assert_eq!(ca, cb, "{} != {}", a.display(), b.display());
+}
+
+#[test]
+fn real_git_worktree_resolves_to_main_index() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let main_root = tmp.path().join("main");
+    let wt_root = tmp.path().join("feat-branch");
+    std::fs::create_dir_all(&main_root).unwrap();
+
+    // Real main repo with one commit so a worktree can be added.
+    git(&main_root, &["init", "-b", "main"]);
+    git(&main_root, &["config", "user.email", "test@example.com"]);
+    git(&main_root, &["config", "user.name", "Test"]);
+    std::fs::write(main_root.join("README.md"), "test").unwrap();
+    git(&main_root, &["add", "."]);
+    git(
+        &main_root,
+        &[
+            "commit",
+            "--no-gpg-sign",
+            "-m",
+            "init",
+            "--allow-empty-message",
+        ],
+    );
+
+    // Add a REAL linked worktree; wt_root/.git becomes a gitdir file pointing at
+    // <main>/.git/worktrees/feat-branch — the layout gix::discover resolves.
+    let out = git(
+        &main_root,
+        &["worktree", "add", wt_root.to_str().unwrap(), "-b", "feat"],
+    );
+    assert!(
+        out.status.success(),
+        "git worktree add failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        wt_root.join(".git").is_file(),
+        "worktree .git must be a file"
+    );
+    assert!(
+        !wt_root.join(".spelunk").exists(),
+        "worktree must have no local .spelunk/"
+    );
+
+    // The shared index lives only in the main worktree.
+    std::fs::create_dir_all(main_root.join(".spelunk")).unwrap();
+    let index_db = main_root.join(".spelunk").join("index.db");
+    std::fs::write(&index_db, b"").unwrap();
+
+    // Primary gix branch: discovery from inside the linked worktree resolves to
+    // the main worktree root, and a read from the worktree finds the main index.
+    same_path(&resolve_main_worktree_root(&wt_root), &main_root);
+    same_path(
+        &find_project_db(&wt_root).expect("worktree resolves to main index"),
+        &index_db,
+    );
+
+    // A subdirectory inside the worktree resolves the same way (gix walks up).
+    let sub = wt_root.join("nested").join("dir");
+    std::fs::create_dir_all(&sub).unwrap();
+    same_path(&resolve_main_worktree_root(&sub), &main_root);
+}

--- a/crates/spelunk-core/tests/worktree_index_resolution.rs
+++ b/crates/spelunk-core/tests/worktree_index_resolution.rs
@@ -1,5 +1,5 @@
 //! Integration test for worktree → main-index resolution over a REAL
-//! `git worktree` (spelunk-oss^138).
+//! `git worktree`.
 //!
 //! The `config.rs` unit fixtures build a `.git`-*file* by hand, on which
 //! `gix::discover` fails — so they exercise only the manual fallback branch of


### PR DESCRIPTION
## What

Corrects the SKILL.md "Git worktrees" section, which previously told users to run
`spelunk index .` inside a linked worktree to "link" the index. That step is not
required: read/query commands (`context`, `check`, `search`, `memory`, `graph`,
`status`) run from a linked worktree already resolve to the main worktree's shared
`.spelunk/index.db` automatically, writing nothing into the worktree.

The rewrite now states:
- Read/query commands auto-resolve to the main index, no setup step.
- `spelunk index .` from a worktree is optional, only to refresh the shared index
  with files changed in that worktree.
- `spelunk autoclean` prunes stale registry entries and does not touch the worktree.

## Changes

- `SKILL.md` — rewrite the Git worktrees section to match actual resolution behavior.
- `crates/spelunk-core/src/config.rs` — 2 unit regression tests covering
  worktree -> main-index resolution via `find_project_db` and `require_project_db_at`.
- `crates/spelunk-core/tests/worktree_index_resolution.rs` — hermetic integration
  test over a REAL `git worktree add`, exercising the primary `gix::discover` branch
  that the hand-built `.git`-file unit fixtures cannot reach. Fully self-contained
  under a TempDir (removed on drop, no orphaned worktrees).

No production logic change; documentation + tests only.

## Test plan

- `cargo test -p spelunk-core -p spelunk-cli` green on **default** features:
  2 new unit tests + 1 new integration test pass, no failures.
- `cargo test -p spelunk-core -p spelunk-cli --no-default-features` green:
  new tests pass, no failures.
- `cargo clippy ... --all-targets -- -D warnings` clean on both feature configs.
- SKILL.md guidance verified against the resolution code exercised by the tests.
