### PR TITLE
fix(graph): reword live-scan empty message and point at the full index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **`spelunk graph <symbol>` no longer implies a heavily-referenced symbol is
+  unused.** The live structural scan matches only bare call syntax
+  (`symbol(...)`), so class, constant, association, and receiver-method
+  references never appear in it. When the scan finds no call sites but the
+  directory has scannable source, the message now reads "No call-site
+  invocations of '<symbol>' found (live structural scan matches '<symbol>(...)'
+  calls only)." and points at `spelunk init`, whose index carries the
+  imports/extends/implements edges the call-scan cannot see. The empty/umbrella
+  directory message is unchanged and still never suggests `init`.
 - **`graph`, `chunks`, `explore`, and `check` no longer read the machine-global
   index (`~/.config/spelunk/index.db`) from an un-`init`'d directory**, extending
   the ADR-067 fail-closed posture to these read-only display commands (previously
@@ -25,9 +34,9 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   <symbol> --live` for a structural scan; when the index holds no graph data at
   all, it auto-falls-back to that live scan (matching the no-project behaviour).
   The live scan distinguishes an empty or umbrella directory ("No scannable
-  source files under this directory") from a genuine no-match ("No callers found
-  for '<symbol>' (live scan)"), and never suggests `spelunk init` for an
-  already-initialized project.
+  source files under this directory") from a genuine no-call result (see the
+  reworded call-site message above), and never suggests `spelunk init` for an
+  empty/umbrella tree.
 - **`spelunk init` no longer writes a `CLAUDE.md` into the target repository.**
   Users who want an agent guide should manually copy `docs/examples/AGENT.md`
   and rename it to `CLAUDE.md` or `AGENT.md` as needed. (spelunk-oss^141)

--- a/crates/spelunk-cli/src/cli/cmd/graph.rs
+++ b/crates/spelunk-cli/src/cli/cmd/graph.rs
@@ -144,11 +144,18 @@ fn graph_live(symbol: &str, format: &str, kind_filter: &Option<String>, root: &P
     }
 
     if edges.is_empty() {
-        // Disambiguate a true leaf/typo (source present) from an empty tree
-        // (e.g. an umbrella repo with uninitialized submodules). The live scan
-        // never suggests `init`.
+        // Disambiguate a leaf/no-call symbol (source present) from an empty tree
+        // (e.g. an umbrella repo with uninitialized submodules). The empty-tree
+        // branch never suggests `init`; only the source-present branch does, since
+        // the live scan is structurally call-syntax-only and an empty result there
+        // means "no bare calls", not "unused".
         if crate::search::live::has_scannable_source(root) {
-            println!("No callers found for '{symbol}' (live scan).");
+            println!(
+                "No call-site invocations of '{symbol}' found (live structural scan matches '{symbol}(...)' calls only)."
+            );
+            println!(
+                "Class, constant, association, and receiver-method references never take that form. Run 'spelunk init' to build an index with imports/extends/implements plus call edges that surface them."
+            );
         } else {
             println!(
                 "No scannable source files under this directory (live scan). Check you're in a populated subdirectory, or that git submodules are initialized."

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -774,6 +774,47 @@ fn graph_populated_dir_no_match_reports_live_scan() {
     );
 }
 
+/// Deferral anchor: the live scan matches only bare `symbol($$$)` call syntax, so
+/// a symbol reached solely through a receiver (`X.new(...)`, `obj.method(...)`)
+/// currently falls into the same "no call-site invocations" branch as a class or
+/// constant reference. Broadening the matcher to receiver-method
+/// `$_.<symbol>($$$)` calls was intentionally left out of this change; this test
+/// pins the present behaviour so that future broadening has a failing anchor to
+/// flip rather than silently changing an untested path.
+#[test]
+fn graph_receiver_method_only_symbol_reports_no_call_site_match() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    // `Widget` appears only as the receiver of `Widget.new(1)` and never as a bare
+    // `Widget(...)` call. The receiver-method form is not yet scanned, so the live
+    // result is empty and takes the source-present no-match branch.
+    std::fs::write(
+        proj.path().join("factory.rb"),
+        "def make\n  Widget.new(1)\nend\n",
+    )
+    .unwrap();
+
+    let assert = bin(home.path(), proj.path())
+        .args(["graph", "Widget"])
+        .assert()
+        .success()
+        // Receiver-method usage is not matched, so it reads as the call-site
+        // no-match line (source is present), not as an edge and not as empty-tree.
+        .stdout(predicate::str::contains(
+            "No call-site invocations of 'Widget' found",
+        ))
+        .stdout(predicate::str::contains("receiver-method references"))
+        .stdout(predicate::str::contains("Incoming to 'Widget'").not())
+        .stdout(predicate::str::contains("No scannable source files").not());
+
+    // Same no-em-dash guard as the sibling no-match test.
+    let out = assert.get_output();
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains('\u{2014}'),
+        "graph live empty message must not contain an em-dash"
+    );
+}
+
 #[test]
 fn graph_populated_dir_with_call_site_still_prints_edges() {
     // Regression guard: the zero-result branching must not swallow a real hit.

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -731,25 +731,47 @@ fn graph_empty_dir_reports_no_scannable_source_hint() {
         .success()
         .stdout(predicate::str::contains("No scannable source files"))
         .stdout(predicate::str::contains("submodules are initialized"))
-        .stdout(predicate::str::contains("spelunk init").not());
+        .stdout(predicate::str::contains("spelunk init").not())
+        // The source-present call-scan wording must not leak into the empty-tree branch.
+        .stdout(predicate::str::contains("No call-site invocations").not());
 }
 
 #[test]
 fn graph_populated_dir_no_match_reports_live_scan() {
     let home = TempDir::new().unwrap();
     let proj = TempDir::new().unwrap();
-    // Scannable source exists, but nothing calls `helper` — a true leaf/typo.
-    std::fs::write(proj.path().join("lib.rs"), "fn helper() {}\n").unwrap();
+    // Scannable source exists, but `BillingEntity` is only referenced as a class,
+    // never invoked as a bare `BillingEntity(...)` call. The live structural scan
+    // is call-syntax-only, so it finds nothing even though the symbol is heavily
+    // used, not unused. The message must say so and point at the full index.
+    std::fs::write(
+        proj.path().join("model.rb"),
+        "class BillingEntity\nend\nclass Invoice < BillingEntity\nend\n",
+    )
+    .unwrap();
 
-    bin(home.path(), proj.path())
-        .args(["graph", "helper"])
+    let assert = bin(home.path(), proj.path())
+        .args(["graph", "BillingEntity"])
         .assert()
         .success()
+        // New wording: scope the empty result to call-site syntax, not "unused".
         .stdout(predicate::str::contains(
-            "No callers found for 'helper' (live scan).",
+            "No call-site invocations of 'BillingEntity' found",
         ))
-        .stdout(predicate::str::contains("spelunk init").not())
+        .stdout(predicate::str::contains("calls only"))
+        // Source is present, so the full-index hint is appended.
+        .stdout(predicate::str::contains("spelunk init"))
+        .stdout(predicate::str::contains("imports/extends/implements"))
+        // The old misleading "No callers found ... (live scan)" wording is gone.
+        .stdout(predicate::str::contains("No callers found").not())
         .stdout(predicate::str::contains("No scannable source files").not());
+
+    // No em-dash in any user-facing line (reads as an AI-tell in public copy).
+    let out = assert.get_output();
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains('\u{2014}'),
+        "graph live empty message must not contain an em-dash"
+    );
 }
 
 #[test]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -303,6 +303,12 @@ spelunk graph <symbol> [options]
 | `--no-stale-check` | false | Suppress the stale-index warning |
 | `--live` | false | Skip the index and scan live files directly |
 
+The live scan is structural and matches only call-site `symbol(...)`
+invocations, so a zero result means "no bare calls", not "unused". Class,
+constant, association, and receiver-method references never take that form. Run
+`spelunk init` to build the full graph, which adds imports/extends/implements
+edges alongside call edges.
+
 **Example:**
 
 ```bash


### PR DESCRIPTION
## The bug

`spelunk graph <symbol>` live structural scan matches only bare call syntax (`symbol(...)`). For a heavily-referenced class, constant, association, or receiver-method symbol, that scan finds zero call sites and previously printed "No callers found for '<symbol>' (live scan)." That reads as "unused" for a symbol that is in fact widely used, the exact opposite of the truth.

## The fix

`graph_live`'s source-present empty branch now prints an accurate message that scopes the zero result to call-site syntax and points at the full index:

> No call-site invocations of '<symbol>' found (live structural scan matches '<symbol>(...)' calls only).
> Class, constant, association, and receiver-method references never take that form. Run 'spelunk init' to build an index with imports/extends/implements plus call edges that surface them.

The empty/umbrella-tree branch (no scannable source) is unchanged and still never suggests `init`. The `mode`/positive-edge output paths are untouched.

## Deferral

Broadening the matcher to receiver-method calls (`$_.<symbol>($$$)`, e.g. `Widget.new(1)`) is intentionally out of scope. A characterization test pins the current behaviour (receiver-only symbols fall into the same call-site no-match branch) so a future broadening has a failing anchor to flip rather than silently changing an untested path.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli -p spelunk-core` (default): 820 passed, 0 failed
- Same on `--no-default-features`: 820 passed, 0 failed
- Graph tests exercised: `graph_empty_dir_reports_no_scannable_source_hint` (no leak of new wording into empty-tree branch), `graph_populated_dir_no_match_reports_live_scan` (new wording + init hint, old string gone, no em-dash), `graph_populated_dir_with_call_site_still_prints_edges` (positive control: paren-invoked symbol returns an edge), `graph_receiver_method_only_symbol_reports_no_call_site_match` (deferral anchor) — all pass
- `cargo clippy --all-targets` clean; `cargo fmt --check` clean

Docs (`docs/commands.md`) and CHANGELOG updated to match the runtime message.