### PR TITLE
fix(server): reliable stop of wedged daemon, no port drift, single-instance guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,18 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   old config that still carries the deprecated keys continues to load, but the
   keys are now silently ignored rather than mapped.
 
+### Fixed
+
+- **`spelunk server stop` reliably terminates a wedged local server.** A daemon
+  whose `/v1/health` had stopped responding could not be stopped and was
+  silently orphaned across a `stop && start`. `stop` now recognises a hung
+  daemon as ours, sends SIGTERM, escalates to SIGKILL after a bounded wait, and
+  reports success only once the process is confirmed gone. `start` reclaims a
+  stale or hung prior daemon on the requested port instead of drifting to a
+  different port (which left two servers on one `server.db`), and fails loudly
+  if an unrelated process holds the port. A single-instance guard prevents two
+  servers running against the same `server.db`.
+
 ## [0.9.3] — 2026-07-08
 
 ### Removed

--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -3,7 +3,8 @@
 //! ## Subcommands
 //!
 //! - `spelunk server start`  — daemonise spelunk-server; write PID/port/log files.
-//! - `spelunk server stop`   — send SIGTERM to the running daemon and wait for exit.
+//! - `spelunk server stop`   — terminate the running daemon (SIGTERM, then
+//!   SIGKILL if it won't exit) and verify it is gone.
 //! - `spelunk server status` — print PID, port, instance_id, and uptime.
 //! - `spelunk server logs`   — print the last N lines from the server log.
 //!
@@ -222,6 +223,205 @@ fn pid_is_alive(pid: u32) -> bool {
     }
 }
 
+// ── Process lifecycle helpers ──────────────────────────────────────────────────
+
+/// Grace period for a `SIGTERM`ed daemon to exit before escalation.
+const GRACEFUL_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+/// Extra window for the process to disappear after `SIGKILL` (Unix).
+const FORCE_KILL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// `server.db-path` records the DB the running daemon was started against, so a
+/// second `start` can refuse to point a new server at a different DB.
+fn db_path_file(state_dir: &Path) -> PathBuf {
+    state_dir.join("server.db-path")
+}
+
+/// Read the DB path recorded for the running daemon. `None` if absent/empty.
+fn read_db_path(state_dir: &Path) -> Option<PathBuf> {
+    std::fs::read_to_string(db_path_file(state_dir))
+        .ok()
+        .map(|s| PathBuf::from(s.trim()))
+        .filter(|p| !p.as_os_str().is_empty())
+}
+
+/// Best-effort path equality that tolerates symlinks / `.` / `..` by
+/// canonicalising each side when it exists, falling back to the raw path.
+fn same_path(a: &Path, b: &Path) -> bool {
+    let ca = std::fs::canonicalize(a).unwrap_or_else(|_| a.to_path_buf());
+    let cb = std::fs::canonicalize(b).unwrap_or_else(|_| b.to_path_buf());
+    ca == cb
+}
+
+/// Return `true` when `pid`'s command line looks like a `spelunk-server`.
+///
+/// This is the identity signal used when `/v1/health` does *not* respond: a
+/// wedged/hung daemon still exists as a `spelunk-server` process, so we can
+/// safely terminate it, whereas a PID reused by an unrelated process after a
+/// crash must not be killed. Uses `ps` (Unix) / `tasklist` (Windows).
+fn process_matches_server(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        match std::process::Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "args="])
+            .output()
+        {
+            Ok(out) if out.status.success() => {
+                String::from_utf8_lossy(&out.stdout).contains("spelunk-server")
+            }
+            _ => false,
+        }
+    }
+    #[cfg(windows)]
+    {
+        match std::process::Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+            .output()
+        {
+            Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+                .to_lowercase()
+                .contains("spelunk-server"),
+            _ => false,
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+/// Classification of a live PID recorded in the state dir.
+enum RunningServer {
+    /// `/v1/health` responded on the recorded port — a healthy daemon.
+    Healthy { port: u16 },
+    /// Alive and a `spelunk-server` process, but `/v1/health` is silent — our
+    /// wedged daemon. Safe to terminate/reclaim.
+    HungOurs,
+    /// Alive but neither healthy nor a `spelunk-server` — the PID was almost
+    /// certainly reused by an unrelated process after a crash. Do not signal it.
+    Foreign,
+}
+
+/// Classify the live process `pid` recorded in `state_dir`.
+///
+/// Health probe first (definitive "ours + reachable"); on no response, fall
+/// back to a process-command identity check so a *hung* daemon is still
+/// recognised as ours and can be reclaimed — the previous health-only check
+/// refused to stop a wedged server, which is the core bug this fixes.
+async fn classify_running_server(state_dir: &Path, pid: u32) -> RunningServer {
+    if let Some(port) = read_port(state_dir)
+        && probe_health(port).await.is_some()
+    {
+        return RunningServer::Healthy { port };
+    }
+    if process_matches_server(pid) {
+        return RunningServer::HungOurs;
+    }
+    RunningServer::Foreign
+}
+
+/// `SIGKILL` on Unix. Tolerates a process that already exited (`ESRCH`).
+#[cfg(unix)]
+fn force_kill(pid: u32) -> Result<()> {
+    unsafe extern "C" {
+        fn kill(pid: i32, sig: i32) -> i32;
+    }
+    const SIGKILL: i32 = 9;
+    let rc = unsafe { kill(pid as i32, SIGKILL) };
+    if rc != 0 && pid_is_alive(pid) {
+        anyhow::bail!("kill({pid}, SIGKILL) failed");
+    }
+    Ok(())
+}
+
+/// Poll until `pid` is gone or `timeout` elapses. Returns `true` if gone.
+async fn wait_for_exit(pid: u32, timeout: Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if !pid_is_alive(pid) {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    !pid_is_alive(pid)
+}
+
+/// Terminate `pid` and confirm it is gone. Returns `Ok(true)` only when the
+/// process has actually exited.
+///
+/// Unix: `SIGTERM`, wait [`GRACEFUL_STOP_TIMEOUT`], then escalate to `SIGKILL`
+/// and wait [`FORCE_KILL_TIMEOUT`]. Windows: `taskkill /F` (already forceful),
+/// then wait. Never reports success on a still-running process.
+async fn terminate_and_wait(pid: u32) -> Result<bool> {
+    // Graceful signal. If it errored only because the process already exited
+    // (a race between classify and here), treat that as success.
+    if let Err(e) = terminate_process(pid) {
+        if !pid_is_alive(pid) {
+            return Ok(true);
+        }
+        return Err(e);
+    }
+    if wait_for_exit(pid, GRACEFUL_STOP_TIMEOUT).await {
+        return Ok(true);
+    }
+    #[cfg(unix)]
+    if pid_is_alive(pid) {
+        force_kill(pid)?;
+        if wait_for_exit(pid, FORCE_KILL_TIMEOUT).await {
+            return Ok(true);
+        }
+    }
+    Ok(!pid_is_alive(pid))
+}
+
+/// Held for the duration of a `start` sequence so two concurrent
+/// `spelunk server start` invocations can't both spawn a daemon against the
+/// same state dir / DB. The lock is advisory (`flock`, Unix) and releases when
+/// the guard drops (the CLI process exits or `start` returns).
+#[cfg(unix)]
+struct StartLock {
+    _file: std::fs::File,
+}
+
+/// Acquire the single-instance `start` lock. Fails fast if another start is in
+/// progress. No-op guard on non-Unix platforms.
+#[cfg(unix)]
+fn acquire_start_lock(state_dir: &Path) -> Result<StartLock> {
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::io::AsRawFd;
+
+    let path = state_dir.join("server.lock");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(&path)
+        .with_context(|| format!("opening {}", path.display()))?;
+
+    unsafe extern "C" {
+        fn flock(fd: i32, operation: i32) -> i32;
+    }
+    const LOCK_EX: i32 = 2;
+    const LOCK_NB: i32 = 4;
+    let rc = unsafe { flock(file.as_raw_fd(), LOCK_EX | LOCK_NB) };
+    if rc != 0 {
+        anyhow::bail!(
+            "another `spelunk server start` is already in progress for this machine. \
+             Wait for it to finish, or check `spelunk server status`."
+        );
+    }
+    Ok(StartLock { _file: file })
+}
+
+#[cfg(not(unix))]
+struct StartLock;
+
+#[cfg(not(unix))]
+fn acquire_start_lock(_state_dir: &Path) -> Result<StartLock> {
+    Ok(StartLock)
+}
+
 // ── CLI types ─────────────────────────────────────────────────────────────────
 
 #[derive(Args, Debug)]
@@ -244,7 +444,8 @@ pub enum ServerCommand {
 
 #[derive(Args, Debug)]
 pub struct ServerStartArgs {
-    /// Port to try first (then 7778–7787 on collision)
+    /// Port to bind (default 7777). Explicit `start` does not drift to another
+    /// port: if this one is held by an unrelated process, start fails loudly.
     #[arg(long, default_value = "7777")]
     pub port: u16,
 
@@ -287,13 +488,28 @@ pub async fn ensure_server_running(start_port: u16) -> Result<(u16, bool)> {
     let state_dir = spelunk_state_dir()?;
     create_state_dir(&state_dir)?;
 
-    // Already running and healthy?
+    // Serialise against a concurrent `server start` so we don't race two
+    // daemons onto the same DB.
+    let _start_lock = acquire_start_lock(&state_dir)?;
+
+    // Inspect any recorded daemon before spawning. A wedged ("hung") daemon
+    // must be reclaimed, not left running while we bind a *different* port —
+    // that leaves two servers on one DB (the leaked-process + port-drift bug).
     if let Some(pid) = read_pid(&state_dir)
         && pid_is_alive(pid)
-        && let Some(port) = read_port(&state_dir)
-        && probe_health(port).await.is_some()
     {
-        return Ok((port, false));
+        match classify_running_server(&state_dir, pid).await {
+            RunningServer::Healthy { port } => return Ok((port, false)),
+            RunningServer::HungOurs => {
+                tracing::warn!("reclaiming unresponsive spelunk-server (pid={pid}) before restart");
+                let _ = terminate_and_wait(pid).await;
+                cleanup_state_files(&state_dir);
+            }
+            RunningServer::Foreign => {
+                // PID reused by an unrelated process; recorded state is stale.
+                cleanup_state_files(&state_dir);
+            }
+        }
     }
 
     let bin = which_spelunk_server()?;
@@ -312,6 +528,8 @@ pub async fn ensure_server_running(start_port: u16) -> Result<(u16, bool)> {
     write_state_file(&pid_path(&state_dir), &format!("{pid}\n")).context("writing server.pid")?;
     write_state_file(&port_path(&state_dir), &format!("{port}\n"))
         .context("writing server.port")?;
+    write_state_file(&db_path_file(&state_dir), &format!("{}\n", db.display()))
+        .context("writing server.db-path")?;
 
     // Wait for *liveness* (the port binds, /v1/health responds) — not model
     // readiness. Health now goes live at bind, before the model download, so
@@ -340,18 +558,63 @@ async fn cmd_start(args: ServerStartArgs) -> Result<()> {
     let state_dir = spelunk_state_dir()?;
     create_state_dir(&state_dir)?;
 
-    // ── Idempotency check ────────────────────────────────────────────────────
-    if let Some(pid) = read_pid(&state_dir)
-        && pid_is_alive(pid)
-    {
-        if let Some(port) = read_port(&state_dir)
-            && probe_health(port).await.is_some()
-        {
-            println!("spelunk-server is already running (pid={pid}, port={port}).");
-            return Ok(());
+    // Single-instance guard: block a concurrent `server start` from racing us
+    // into a second daemon on the same DB.
+    let _start_lock = acquire_start_lock(&state_dir)?;
+
+    // ── Default DB path ──────────────────────────────────────────────────────
+    let db = args
+        .db
+        .clone()
+        .unwrap_or_else(|| state_dir.join("server.db"));
+
+    // ── Reclaim / idempotency ────────────────────────────────────────────────
+    // The previous code fell through to `find_available_port` whenever a
+    // recorded PID was alive-but-unhealthy, silently binding a *new* port and
+    // leaving the wedged daemon holding the old one — two servers on one DB.
+    // Instead: return early if healthy, reclaim if wedged, clear stale state.
+    if let Some(pid) = read_pid(&state_dir) {
+        if pid_is_alive(pid) {
+            match classify_running_server(&state_dir, pid).await {
+                RunningServer::Healthy { port } => {
+                    // Refuse to start a second server against a *different* DB —
+                    // the single state dir tracks one daemon; clobbering it would
+                    // orphan the running one.
+                    if let Some(running_db) = read_db_path(&state_dir)
+                        && !same_path(&running_db, &db)
+                    {
+                        anyhow::bail!(
+                            "a spelunk-server is already running (pid={pid}, port={port}) against \
+                             {}. Stop it first with `spelunk server stop` before starting one \
+                             against {}.",
+                            running_db.display(),
+                            db.display()
+                        );
+                    }
+                    println!("spelunk-server is already running (pid={pid}, port={port}).");
+                    return Ok(());
+                }
+                RunningServer::HungOurs => {
+                    println!("Reclaiming unresponsive spelunk-server (pid={pid})...");
+                    if !terminate_and_wait(pid).await? {
+                        anyhow::bail!(
+                            "could not stop the unresponsive spelunk-server (pid={pid}); it \
+                             survived SIGTERM and SIGKILL. Kill it manually and retry."
+                        );
+                    }
+                    cleanup_state_files(&state_dir);
+                }
+                RunningServer::Foreign => {
+                    tracing::warn!(
+                        "recorded pid={pid} is not a spelunk-server (PID reused); clearing stale state"
+                    );
+                    cleanup_state_files(&state_dir);
+                }
+            }
+        } else {
+            // Dead PID — clear stale state before starting fresh.
+            cleanup_state_files(&state_dir);
         }
-        // PID alive but no health response — stale state; fall through to restart.
-        tracing::warn!("pid {pid} is alive but /v1/health did not respond; restarting");
     }
 
     // ── Find the binary ──────────────────────────────────────────────────────
@@ -365,12 +628,12 @@ async fn cmd_start(args: ServerStartArgs) -> Result<()> {
         None => which_spelunk_server()?,
     };
 
-    // ── Default DB path ──────────────────────────────────────────────────────
-    let db = args.db.unwrap_or_else(|| state_dir.join("server.db"));
-
-    // ── Port selection (7777–7787) ───────────────────────────────────────────
-    const PORT_RANGE: u16 = 11; // 7777..=7787
-    let port = find_available_port(args.port, PORT_RANGE)?;
+    // ── Port (no silent drift) ───────────────────────────────────────────────
+    // Any wedged daemon of ours was reclaimed above, freeing its port. If the
+    // requested port is still occupied, it belongs to an unrelated process —
+    // fail loudly rather than binding elsewhere.
+    let port = args.port;
+    ensure_port_available_for_start(port).await?;
 
     // ── Spawn daemonised process ─────────────────────────────────────────────
     let log_file = open_log_file_for_append(&log_path(&state_dir))?;
@@ -386,6 +649,8 @@ async fn cmd_start(args: ServerStartArgs) -> Result<()> {
     write_state_file(&pid_path(&state_dir), &format!("{pid}\n")).context("writing server.pid")?;
     write_state_file(&port_path(&state_dir), &format!("{port}\n"))
         .context("writing server.port")?;
+    write_state_file(&db_path_file(&state_dir), &format!("{}\n", db.display()))
+        .context("writing server.db-path")?;
 
     // Wait up to 30 s for the server to become reachable (liveness, not model
     // readiness — /v1/health is live at bind, before any model download).
@@ -439,6 +704,27 @@ fn which_spelunk_server() -> Result<PathBuf> {
                  Install it alongside `spelunk` or pass --bin <path>."
             )
         })
+}
+
+/// Verify the requested `start` port is bindable, failing loudly if not.
+///
+/// Explicit `server start` never drifts to a different port (a silent drift is
+/// what leaves a stale daemon on the old port and a new one elsewhere). A short
+/// bounded retry absorbs the brief window after reclaiming our own daemon while
+/// the OS releases its listening socket.
+async fn ensure_port_available_for_start(port: u16) -> Result<()> {
+    for attempt in 0..10 {
+        if std::net::TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return Ok(());
+        }
+        if attempt < 9 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+    anyhow::bail!(
+        "port {port} is already in use by another process. If it is a spelunk-server not \
+         managed here, stop it; otherwise free the port or pass `--port <N>`."
+    );
 }
 
 /// Walk ports `start..start+range` to find the first unbound one.
@@ -584,73 +870,37 @@ async fn cmd_stop() -> Result<()> {
     }
 
     // ── Identity check ───────────────────────────────────────────────────────
-    // A liveness check alone (`pid_is_alive`) is not enough: PIDs are reused
-    // by the OS, so after a crash/reboot the recorded PID may now belong to
-    // an entirely unrelated process. Verify it is actually *our* server
-    // before sending a kill signal — mirroring the health-check `start`
-    // already does on its restart path (see `cmd_start`'s idempotency
-    // check above).
-    verify_server_identity(&state_dir, pid)
-        .await
-        .with_context(|| {
-            format!(
-                "refusing to stop pid={pid}: it does not look like the spelunk-server \
-             recorded in {}. If the server crashed and this PID was reused by an \
-             unrelated process, remove the stale state files manually \
-             (`server.pid`, `server.port` under {}) and retry.",
+    // A liveness check alone is not enough: PIDs are reused, so after a
+    // crash/reboot the recorded PID may belong to an unrelated process. But a
+    // *health*-only check (the previous behaviour) is too strict — it refused
+    // to stop a wedged daemon whose `/v1/health` had stopped responding, which
+    // is exactly the hang this command must handle. Classify instead: a healthy
+    // *or* a hung-but-still-`spelunk-server` process is ours to kill; only a
+    // truly foreign process is refused.
+    match classify_running_server(&state_dir, pid).await {
+        RunningServer::Healthy { .. } | RunningServer::HungOurs => {}
+        RunningServer::Foreign => {
+            anyhow::bail!(
+                "refusing to stop pid={pid}: it does not look like the spelunk-server recorded \
+                 in {}. If the server crashed and this PID was reused by an unrelated process, \
+                 remove the stale state files manually (under {}) and retry.",
                 pid_path(&state_dir).display(),
                 state_dir.display()
-            )
-        })?;
-
-    // Send SIGTERM (Unix) or TerminateProcess (Windows).
-    terminate_process(pid)?;
-
-    // Wait up to 10 s for the process to exit.
-    let deadline = std::time::Instant::now() + Duration::from_secs(10);
-    while std::time::Instant::now() < deadline {
-        if !pid_is_alive(pid) {
-            break;
+            );
         }
-        tokio::time::sleep(Duration::from_millis(200)).await;
     }
 
-    if pid_is_alive(pid) {
-        eprintln!("warning: spelunk-server (pid={pid}) did not stop within 10 s.");
-    } else {
+    // Terminate (SIGTERM → SIGKILL on Unix) and confirm the process is gone
+    // before reporting success — never claim a stop that didn't happen.
+    if terminate_and_wait(pid).await? {
         println!("spelunk-server stopped.");
         cleanup_state_files(&state_dir);
-    }
-
-    Ok(())
-}
-
-/// Verify that `pid` is actually the spelunk-server we started, not some
-/// unrelated process that happens to have reused the PID after a crash.
-///
-/// Mirrors the health-check `start` already performs on its restart path:
-/// read the recorded port, probe `/v1/health`, and require a response.
-/// A `state_dir` written by *this* CLI always has a `server.port` alongside
-/// `server.pid` (both are written together in `cmd_start` /
-/// `ensure_server_running`), so a healthy probe on that port is strong
-/// evidence the PID still names our daemon. If no port is recorded or the
-/// probe fails, we do not have enough signal to safely distinguish "our
-/// server, just briefly unhealthy" from "PID reused by something else" —
-/// refuse rather than guess.
-///
-/// We do not attempt to also match `instance_id` against a previously
-/// recorded value because none is persisted to disk today (only exposed at
-/// runtime via `/v1/health`); a live, successful health response on the
-/// port we ourselves recorded is the available identity signal.
-async fn verify_server_identity(state_dir: &Path, pid: u32) -> Result<()> {
-    let port = read_port(state_dir).ok_or_else(|| {
-        anyhow::anyhow!("no server.port recorded — cannot verify pid={pid} is spelunk-server")
-    })?;
-    match probe_health(port).await {
-        Some(_instance_id) => Ok(()),
-        None => Err(anyhow::anyhow!(
-            "pid={pid} is alive but /v1/health on port {port} did not respond"
-        )),
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "spelunk-server (pid={pid}) is still running after SIGTERM and SIGKILL. State files \
+             left in place; retry `spelunk server stop` or kill the process manually."
+        );
     }
 }
 
@@ -684,6 +934,7 @@ fn terminate_process(pid: u32) -> Result<()> {
 fn cleanup_state_files(state_dir: &Path) {
     let _ = std::fs::remove_file(pid_path(state_dir));
     let _ = std::fs::remove_file(port_path(state_dir));
+    let _ = std::fs::remove_file(db_path_file(state_dir));
 }
 
 // ── status ────────────────────────────────────────────────────────────────────
@@ -1049,46 +1300,44 @@ mod tests {
         );
     }
 
-    // ── verify_server_identity (PID-reuse hardening, spelunk-oss^64 #1) ──────
+    // ── classify_running_server (PID-reuse + hung-server handling) ───────────
 
-    /// `stop` must refuse to signal a PID whose recorded port is unreachable
-    /// (the PID may have been reused by an unrelated process after a crash).
+    /// A PID with no recorded port and no matching process command classifies
+    /// as `Foreign` — `stop` must refuse to signal it (possible PID reuse).
     #[tokio::test]
-    async fn verify_server_identity_rejects_no_port_recorded() {
+    async fn classify_foreign_when_no_port_and_no_match() {
         let tmp = TempDir::new().unwrap();
-        // No server.port written — nothing to verify against.
-        let result = verify_server_identity(tmp.path(), 999_999).await;
+        // No server.port written; PID 999_999 is not a spelunk-server process.
+        let class = classify_running_server(tmp.path(), 999_999).await;
         assert!(
-            result.is_err(),
-            "identity check must fail when no port is recorded"
+            matches!(class, RunningServer::Foreign),
+            "expected Foreign when nothing identifies the PID as our server"
         );
     }
 
-    /// `stop` must refuse to signal a PID when the recorded port's
-    /// `/v1/health` does not respond — most commonly because that PID was
-    /// reused by an unrelated process after the real server crashed.
+    /// An unreachable recorded port plus a non-matching process command is
+    /// still `Foreign` (health silent AND not a spelunk-server process).
     #[tokio::test]
-    async fn verify_server_identity_rejects_unhealthy_port() {
+    async fn classify_foreign_when_unhealthy_and_no_match() {
         let tmp = TempDir::new().unwrap();
-        // Bind (but don't serve HTTP on) an ephemeral port so it's a real,
-        // non-listening-for-HTTP port rather than a guessed free one.
+        // Bind then free an ephemeral port so it's real but not serving HTTP.
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let port = listener.local_addr().unwrap().port();
-        drop(listener); // free the port again, but /v1/health still won't respond
+        drop(listener);
 
         std::fs::write(port_path(tmp.path()), format!("{port}\n")).unwrap();
 
-        let result = verify_server_identity(tmp.path(), 999_999).await;
+        let class = classify_running_server(tmp.path(), 999_999).await;
         assert!(
-            result.is_err(),
-            "identity check must fail when /v1/health does not respond on the recorded port"
+            matches!(class, RunningServer::Foreign),
+            "expected Foreign when /v1/health is silent and the PID isn't spelunk-server"
         );
     }
 
-    /// `stop` proceeds only when the recorded port's `/v1/health` responds —
-    /// this is the positive case mirroring a genuinely-running server.
+    /// A responding `/v1/health` on the recorded port classifies as `Healthy`
+    /// regardless of the PID — the positive case mirroring a live server.
     #[tokio::test]
-    async fn verify_server_identity_accepts_healthy_port() {
+    async fn classify_healthy_when_health_responds() {
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -1106,14 +1355,64 @@ mod tests {
         let port = server.address().port();
         std::fs::write(port_path(tmp.path()), format!("{port}\n")).unwrap();
 
-        let result = verify_server_identity(tmp.path(), 999_999).await;
+        let class = classify_running_server(tmp.path(), 999_999).await;
         assert!(
-            result.is_ok(),
-            "identity check must succeed when /v1/health responds: {result:?}"
+            matches!(class, RunningServer::Healthy { .. }),
+            "expected Healthy when /v1/health responds on the recorded port"
         );
     }
 
-    // ── state file / dir permissions (unix-gated, spelunk-oss^64 #2) ─────────
+    // ── db-path state file (single-instance / different-DB guard) ────────────
+
+    #[test]
+    fn read_db_path_round_trips() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(db_path_file(tmp.path()), "/some/where/server.db\n").unwrap();
+        assert_eq!(
+            read_db_path(tmp.path()),
+            Some(PathBuf::from("/some/where/server.db"))
+        );
+    }
+
+    #[test]
+    fn read_db_path_none_when_missing_or_empty() {
+        let tmp = TempDir::new().unwrap();
+        assert!(read_db_path(tmp.path()).is_none());
+        std::fs::write(db_path_file(tmp.path()), "\n").unwrap();
+        assert!(read_db_path(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn cleanup_removes_db_path_file() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(pid_path(tmp.path()), "1\n").unwrap();
+        std::fs::write(port_path(tmp.path()), "7777\n").unwrap();
+        std::fs::write(db_path_file(tmp.path()), "/x/server.db\n").unwrap();
+        cleanup_state_files(tmp.path());
+        assert!(!db_path_file(tmp.path()).exists());
+        assert!(!pid_path(tmp.path()).exists());
+        assert!(!port_path(tmp.path()).exists());
+    }
+
+    // ── start lock (single-instance guard) ───────────────────────────────────
+
+    /// A second `acquire_start_lock` on the same state dir must fail while the
+    /// first guard is still held (serialises concurrent `server start`).
+    #[cfg(unix)]
+    #[test]
+    fn start_lock_is_exclusive_while_held() {
+        let tmp = TempDir::new().unwrap();
+        let first = acquire_start_lock(tmp.path()).expect("first lock acquires");
+        assert!(
+            acquire_start_lock(tmp.path()).is_err(),
+            "second lock must fail while the first is held"
+        );
+        drop(first);
+        // Released — a fresh acquire now succeeds.
+        assert!(acquire_start_lock(tmp.path()).is_ok(), "lock frees on drop");
+    }
+
+    // ── state file / dir permissions (unix-gated) ───────────────────────────
 
     #[cfg(unix)]
     #[test]

--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -1398,8 +1398,14 @@ mod tests {
 
     /// A second `acquire_start_lock` on the same state dir must fail while the
     /// first guard is still held (serialises concurrent `server start`).
+    ///
+    /// `#[serial(server_start_lock)]`: this test asserts on `flock` release
+    /// timing, which a concurrent `fork()+exec()` in another test can delay (a
+    /// forked child transiently inherits the lock fd until it execs). Grouped
+    /// with the process-spawning tests below so they never overlap.
     #[cfg(unix)]
     #[test]
+    #[serial(server_start_lock)]
     fn start_lock_is_exclusive_while_held() {
         let tmp = TempDir::new().unwrap();
         let first = acquire_start_lock(tmp.path()).expect("first lock acquires");
@@ -1480,6 +1486,289 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(&outside_target).unwrap(),
             "do not overwrite me"
+        );
+    }
+
+    // ── same_path (different-DB start guard predicate) ───────────────────────
+    //
+    // `cmd_start` refuses to start a second server against a *different* DB by
+    // comparing the recorded db-path against the requested one via `same_path`.
+    // The full decision runs against the real home state dir + a live daemon
+    // (an e2e-only path), so these cover the load-bearing predicate directly.
+
+    #[test]
+    fn same_path_true_for_identical() {
+        let tmp = TempDir::new().unwrap();
+        let p = tmp.path().join("server.db");
+        std::fs::write(&p, b"x").unwrap();
+        assert!(same_path(&p, &p));
+    }
+
+    #[test]
+    fn same_path_false_for_distinct() {
+        let tmp = TempDir::new().unwrap();
+        // Non-existent distinct paths fall back to raw comparison → not equal.
+        assert!(!same_path(
+            &tmp.path().join("a.db"),
+            &tmp.path().join("b.db")
+        ));
+    }
+
+    /// A symlink and its target name the same DB — the guard must treat a
+    /// `start` against either as the same server, not a different DB.
+    #[cfg(unix)]
+    #[test]
+    fn same_path_true_across_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("real.db");
+        std::fs::write(&target, b"x").unwrap();
+        let link = tmp.path().join("link.db");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(
+            same_path(&target, &link),
+            "a symlink and its target are the same DB"
+        );
+    }
+
+    // ── ensure_port_available_for_start (no silent port drift) ───────────────
+
+    /// A free port passes — `start` binds the exact requested port.
+    #[tokio::test]
+    async fn ensure_port_available_for_start_ok_when_free() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        assert!(ensure_port_available_for_start(port).await.is_ok());
+    }
+
+    /// A port held by an unrelated process makes `start` fail loudly (naming
+    /// the port) instead of drifting to a different one.
+    #[tokio::test]
+    async fn ensure_port_available_for_start_fails_when_port_held() {
+        // Hold the listener for the whole call so the bounded retry never frees.
+        let _held = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = _held.local_addr().unwrap().port();
+        let err = ensure_port_available_for_start(port)
+            .await
+            .expect_err("must fail while the port is held");
+        assert!(
+            err.to_string().contains(&format!("port {port}")),
+            "error should name the occupied port, got: {err}"
+        );
+    }
+
+    // ── Live-process helpers: identity + termination ─────────────────────────
+    //
+    // These spawn a real short-lived process to exercise the Unix signal /
+    // identity paths that only a real PID can drive. Every spawned process is
+    // reaped: a background thread `wait()`s it (so a killed process can't linger
+    // as a zombie — a zombie still answers `kill(pid, 0)` and would fool
+    // `pid_is_alive`), and `Drop` SIGKILLs any still-live helper.
+
+    #[cfg(unix)]
+    struct DummyProc {
+        pid: u32,
+        done: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        reaper: Option<std::thread::JoinHandle<()>>,
+    }
+
+    #[cfg(unix)]
+    impl DummyProc {
+        /// Spawn `cmd` detached from stdio and start reaping it immediately.
+        fn spawn(cmd: &mut std::process::Command) -> Self {
+            use std::sync::Arc;
+            use std::sync::atomic::{AtomicBool, Ordering};
+
+            let mut child = cmd
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .expect("spawn dummy process");
+            let pid = child.id();
+            let done = Arc::new(AtomicBool::new(false));
+            let done_reaper = Arc::clone(&done);
+            let reaper = std::thread::spawn(move || {
+                let _ = child.wait();
+                done_reaper.store(true, Ordering::SeqCst);
+            });
+            DummyProc {
+                pid,
+                done,
+                reaper: Some(reaper),
+            }
+        }
+
+        /// A `sleep`-style process that responds normally to SIGTERM.
+        fn graceful() -> Self {
+            DummyProc::spawn(std::process::Command::new("sleep").arg("30"))
+        }
+
+        /// A process that ignores SIGTERM from birth (only SIGKILL reaps it) —
+        /// a wedged daemon. `pre_exec` sets SIGTERM to `SIG_IGN`, which is
+        /// preserved across the `exec` into `sleep` (POSIX), so there is no
+        /// trap-install race and no shell child to orphan on SIGKILL.
+        fn ignores_sigterm() -> Self {
+            use std::os::unix::process::CommandExt;
+            let mut cmd = std::process::Command::new("sleep");
+            cmd.arg("30");
+            // SAFETY: the closure only calls `signal`, which is async-signal-safe.
+            unsafe {
+                cmd.pre_exec(|| {
+                    unsafe extern "C" {
+                        fn signal(signum: i32, handler: usize) -> usize;
+                    }
+                    const SIGTERM: i32 = 15;
+                    const SIG_IGN: usize = 1;
+                    signal(SIGTERM, SIG_IGN);
+                    Ok(())
+                });
+            }
+            DummyProc::spawn(&mut cmd)
+        }
+
+        /// A live process whose command line contains `spelunk-server`, so
+        /// `process_matches_server` recognises it as ours.
+        fn named_server() -> (Self, TempDir) {
+            use std::os::unix::fs::PermissionsExt;
+            let dir = TempDir::new().unwrap();
+            let bin = dir.path().join("spelunk-server");
+            std::fs::write(&bin, "#!/bin/sh\nsleep 30\n").unwrap();
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+            (DummyProc::spawn(&mut std::process::Command::new(&bin)), dir)
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for DummyProc {
+        fn drop(&mut self) {
+            use std::sync::atomic::Ordering;
+            // SIGKILL only if it hasn't already exited, to avoid signalling a
+            // reused PID after the reaper collected ours.
+            if !self.done.load(Ordering::SeqCst) {
+                let _ = force_kill(self.pid);
+            }
+            if let Some(h) = self.reaper.take() {
+                let _ = h.join();
+            }
+        }
+    }
+
+    // ── process_matches_server (hung-server identity signal) ─────────────────
+
+    #[cfg(unix)]
+    #[test]
+    #[serial(server_start_lock)]
+    fn process_matches_server_true_for_named_process() {
+        let (proc, _dir) = DummyProc::named_server();
+        assert!(
+            process_matches_server(proc.pid),
+            "a process whose command line contains 'spelunk-server' must match"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial(server_start_lock)]
+    fn process_matches_server_false_for_unrelated_process() {
+        let proc = DummyProc::graceful();
+        assert!(
+            !process_matches_server(proc.pid),
+            "an unrelated process must not be mistaken for a spelunk-server"
+        );
+    }
+
+    // ── classify_running_server: HungOurs (reclaimable wedged daemon) ────────
+
+    /// A live `spelunk-server` process with a silent `/v1/health` (no recorded
+    /// port) is our wedged daemon — classified `HungOurs`, not `Foreign`, so
+    /// `stop`/`start` reclaim it instead of refusing. This is the core of the
+    /// fix: the old health-only check gave up on a hung server.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial(server_start_lock)]
+    async fn classify_hung_ours_when_process_matches_but_health_silent() {
+        let (proc, _dir) = DummyProc::named_server();
+        let tmp = TempDir::new().unwrap(); // no server.port → health probe skipped
+        let class = classify_running_server(tmp.path(), proc.pid).await;
+        assert!(
+            matches!(class, RunningServer::HungOurs),
+            "expected HungOurs for a live spelunk-server process with silent health"
+        );
+    }
+
+    // ── terminate_and_wait / force_kill / wait_for_exit ──────────────────────
+
+    /// `wait_for_exit` must NOT report a still-running process as gone — the
+    /// guard that keeps `terminate_and_wait` from claiming a stop that didn't
+    /// happen.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial(server_start_lock)]
+    async fn wait_for_exit_false_for_live_process() {
+        let proc = DummyProc::graceful();
+        assert!(
+            !wait_for_exit(proc.pid, Duration::from_millis(300)).await,
+            "a live process must not be reported as exited"
+        );
+    }
+
+    /// Graceful path: a SIGTERM-responsive process is terminated and only
+    /// reported stopped once the PID is confirmed gone.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial(server_start_lock)]
+    async fn terminate_and_wait_stops_graceful_process() {
+        let proc = DummyProc::graceful();
+        assert!(pid_is_alive(proc.pid));
+        let stopped = terminate_and_wait(proc.pid).await.expect("terminate");
+        assert!(stopped, "graceful process should be reported stopped");
+        assert!(!pid_is_alive(proc.pid), "process must actually be gone");
+    }
+
+    /// Escalation seam: SIGKILL reaps a process that ignores SIGTERM, and
+    /// `wait_for_exit` confirms it is gone — the mechanism `terminate_and_wait`
+    /// falls back to for a wedged daemon.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial(server_start_lock)]
+    async fn force_kill_reaps_sigterm_ignoring_process() {
+        let proc = DummyProc::ignores_sigterm();
+        assert!(pid_is_alive(proc.pid));
+        // SIGTERM alone leaves it running (trap ignores it).
+        terminate_process(proc.pid).expect("SIGTERM");
+        assert!(
+            !wait_for_exit(proc.pid, Duration::from_millis(400)).await,
+            "SIGTERM-ignoring process should survive SIGTERM"
+        );
+        // SIGKILL cannot be trapped; it must go.
+        force_kill(proc.pid).expect("SIGKILL");
+        assert!(
+            wait_for_exit(proc.pid, FORCE_KILL_TIMEOUT).await,
+            "SIGKILL must reap the process"
+        );
+    }
+
+    /// Integrated wedged-stop: `terminate_and_wait` on a daemon that ignores
+    /// SIGTERM escalates to SIGKILL and reports success only once the PID is
+    /// gone. Slow (spans the graceful-stop timeout) but captures the exact
+    /// behaviour the fix is about — previously only exercised by hand.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial(server_start_lock)]
+    async fn terminate_and_wait_escalates_when_sigterm_ignored() {
+        let proc = DummyProc::ignores_sigterm();
+        assert!(pid_is_alive(proc.pid));
+        let stopped = terminate_and_wait(proc.pid)
+            .await
+            .expect("terminate should not error");
+        assert!(
+            stopped,
+            "a SIGTERM-ignoring daemon must still be stopped via SIGKILL"
+        );
+        assert!(
+            !pid_is_alive(proc.pid),
+            "success must mean the PID is actually gone"
         );
     }
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -416,8 +416,8 @@ spelunk server logs [-n <lines>]
 
 | Subcommand | Notes |
 |------------|-------|
-| `start` | Idempotent; tries `--port` (default 7777) then 7778–7787 on collision; auto-binds `127.0.0.1` |
-| `stop` | SIGTERM the running daemon and wait for exit |
+| `start` | Idempotent; binds `--port` exactly (default 7777) on `127.0.0.1`. Reclaims a wedged prior daemon of ours instead of drifting to a new port; fails loudly if an unrelated process holds the port. A single-instance guard refuses a second server against a different `server.db`. |
+| `stop` | Graceful SIGTERM, then SIGKILL escalation for an unresponsive daemon; reports success only once the process is confirmed gone. |
 | `status` | Print PID, port, instance id, and uptime |
 | `logs` | Print the last N lines of the server log (`-n`, default 50) |
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -35,6 +35,14 @@ spelunk server status    # show whether a local server is running and its PID
 spelunk server logs      # tail the local server's logs
 ```
 
+`stop` terminates even a wedged server whose `/v1/health` has stopped
+responding: it sends SIGTERM, escalates to SIGKILL after a bounded wait, and
+reports success only once the process is confirmed gone. `start` reclaims a
+stale or hung prior daemon on the requested port rather than drifting to a
+different one, and fails loudly if an unrelated process already holds that port.
+A single-instance guard keeps two servers from running against the same
+`server.db`.
+
 To opt out entirely and keep spelunk fully offline, set `SPELUNK_NO_SERVER=1`
 (see [Capability tiers](getting-started.md#capability-tiers-where-inference-and-memory-live)).
 With it set, spelunk never autostarts a server and inference-only features exit


### PR DESCRIPTION
## What

`spelunk server` stop/start lifecycle is now reliable against a wedged daemon.

- **`server stop` actually stops a wedged server.** Previously stop refused to
  signal a daemon whose `/v1/health` was silent, so a hung process could never
  be reaped. Stop now falls back to a process-identity check (`ps`/`tasklist`
  for a `spelunk-server` command line), escalates SIGTERM to SIGKILL on Unix
  (`taskkill /F` on Windows), and verifies the PID is actually gone before
  reporting success. It never claims a stop that did not happen, and refuses to
  signal a foreign process that reused the recorded PID after a crash.
- **`server start` no longer drifts the port silently.** Explicit `start` binds
  the exact requested port; if an unrelated process holds it, start fails loudly
  instead of quietly binding a different one. A hung "ours" daemon is reclaimed
  (terminated and cleaned up) before a fresh start rather than being left
  running on the old port.
- **Single-instance guard.** A `flock`-based start lock plus a `server.db-path`
  guard prevents two servers from coming up on the same state dir / DB. The
  guard is idempotent for a legitimately-restarting server: a healthy existing
  daemon is detected and reused, only a genuinely wedged one is reclaimed.

Scope: `crates/spelunk-cli/src/cli/cmd/server.rs` plus docs
(`server.md`, `commands.md`, `CHANGELOG.md`). All Unix-only mechanisms
(SIGKILL, `flock`, `kill`) are `#[cfg(unix)]`-guarded with Windows/`not(unix)`
counterparts; the shared path leaks no platform-specific symbols.

## Why

A wedged `spelunk-server` was previously unkillable via the CLI (stop refused
to act without a health response) and a restart could silently bind a different
port, leaving two servers racing on one DB. This fixes the leaked-process /
port-drift bug and makes stop/start deterministic.

## Test plan

Ran locally in both CI feature configurations with `SPELUNK_SECRET_STORE=file`:

- `cargo test -p spelunk-cli` (default features): green — 277 lib unit tests
  plus integration suites, 0 failed. Includes 36 server-module tests covering
  wedged-stop (`terminate_and_wait_escalates_when_sigterm_ignored`,
  `force_kill_reaps_sigterm_ignoring_process`), hung-daemon classification
  (`classify_hung_ours_when_process_matches_but_health_silent`,
  `classify_foreign_when_unhealthy_and_no_match`), exact-port binding
  (`ensure_port_available_for_start_ok_when_free` /
  `..._fails_when_port_held`), and the single-instance lock
  (`start_lock_is_exclusive_while_held`).
- Re-ran the 36 server-module tests twice for determinism (they are
  `#[serial]` and spawn real processes): 36 passed both runs, ~11.5s each. The
  ~11s runtime is the SIGKILL-escalation test legitimately walking the graceful
  timeout, not a hang.
- `cargo build --no-default-features`: green (exercises the `--no-default-features`
  CI matrix cell).
- `cargo clippy --all-targets`: clean, no warnings.
- `cargo fmt --check`: clean.

Note: the CHANGELOG Unreleased section may need a trivial rebase against a
sibling TLS-CA PR that also edits Unreleased.
