### PR TITLE
fix(docker): repair the self-hosted Quick-Start build + compose path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,19 +137,13 @@ jobs:
         run: docker build -t spelunk-server:ci .
 
       # Assert the image ships the REAL server, not a placeholder: a no-op
-      # binary exits 0 on every flag, so check for actual output.
+      # binary exits 0 on every flag, so check for actual OUTPUT. Running the
+      # binary also resolves every NEEDED shared lib at load, guarding the
+      # runtime stage's lib set (a `docker build` alone never runs it).
       - name: Smoke-test the image
         run: |
           test -n "$(docker run --rm spelunk-server:ci --version)"
           docker run --rm spelunk-server:ci --print-openapi | head -c1 | grep -q .
-
-      # `docker build` never runs the binary, so a runtime stage missing a
-      # dynamically-linked shared lib (e.g. libdbus-1-3) still builds green and
-      # only fails at `docker run`. `--version` exits 0 without binding a port,
-      # but the dynamic linker still resolves every NEEDED lib at load, so this
-      # guards the runtime image's shared-lib set.
-      - name: Smoke-run image
-        run: docker run --rm spelunk-server:ci --version
 
   openapi-snapshot:
     name: OpenAPI snapshot check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,14 @@ jobs:
       - name: Build image
         run: docker build -t spelunk-server:ci .
 
+      # `docker build` never runs the binary, so a runtime stage missing a
+      # dynamically-linked shared lib (e.g. libdbus-1-3) still builds green and
+      # only fails at `docker run`. `--version` exits 0 without binding a port,
+      # but the dynamic linker still resolves every NEEDED lib at load, so this
+      # guards the runtime image's shared-lib set.
+      - name: Smoke-run image
+        run: docker run --rm spelunk-server:ci --version
+
   openapi-snapshot:
     name: OpenAPI snapshot check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,13 @@ jobs:
       - name: Build image
         run: docker build -t spelunk-server:ci .
 
+      # Assert the image ships the REAL server, not a placeholder: a no-op
+      # binary exits 0 on every flag, so check for actual output.
+      - name: Smoke-test the image
+        run: |
+          test -n "$(docker run --rm spelunk-server:ci --version)"
+          docker run --rm spelunk-server:ci --print-openapi | head -c1 | grep -q .
+
       # `docker build` never runs the binary, so a runtime stage missing a
       # dynamically-linked shared lib (e.g. libdbus-1-3) still builds green and
       # only fails at `docker run`. `--version` exits 0 without binding a port,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,18 @@ jobs:
       - name: Run doctests
         run: cargo test --doc ${{ matrix.test-flags }}
 
+  docker-build:
+    name: Docker image build
+    runs-on: ubuntu-latest
+    # The image compiles the release server (candle embedder) from scratch with
+    # no cargo cache, so allow a generous ceiling.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build image
+        run: docker build -t spelunk-server:ci .
+
   openapi-snapshot:
     name: OpenAPI snapshot check
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,20 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   old config that still carries the deprecated keys continues to load, but the
   keys are now silently ignored rather than mapped.
 
+### Fixed
+
+- **The self-hosted Docker Quick-Start builds and runs again.** The `Dockerfile`
+  now builds the Cargo workspace (per-crate manifests, `crates/spelunk-server`
+  binary) instead of the old single-crate layout, and installs the C/C++
+  toolchain plus libdbus the slim base lacks so the tokenizers build script and
+  the keyring backend link. `docker-compose.yml` no longer aborts a bare `docker
+  compose up` when `SPELUNK_SERVER_KEY` is unset (the profiled team-server key is
+  no longer evaluated at parse time), so the default loopback scaffold comes up
+  with no key while the team-server profile still requires the key and TLS. Both
+  services set `pull_policy: build`, so the image is built locally with no
+  registry pull (air-gapped friendly). A CI job now builds and smoke-runs the
+  image so a broken build is caught on PRs.
+
 ## [0.9.3] — 2026-07-08
 
 ### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,25 +40,48 @@ FROM rust:1.97.0-slim AS builder
 
 WORKDIR /build
 
-# Cache dependency compilation separately from source changes.
-COPY Cargo.toml Cargo.lock ./
-COPY src/lib.rs src/lib.rs
-# Placeholder main.rs so the dependency step compiles.
-RUN mkdir -p src/bin && \
-    echo 'fn main(){}' > src/main.rs && \
-    echo 'fn main(){}' > src/bin/spelunk_server.rs && \
-    cargo build --release --bin spelunk-server 2>/dev/null || true
+# System build deps the slim image lacks: a C/C++ toolchain for tokenizers'
+# esaxx-rs build script (embed-native default), and libdbus for libdbus-sys
+# (keyring's sync-secret-service backend, linked transitively on Linux).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential pkg-config libdbus-1-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-# Now copy the real source and build properly.
+# Cache dependency compilation separately from source changes. This is a
+# virtual Cargo workspace (no root package), so prime the cache from the
+# workspace manifests plus a placeholder source per member crate; the heavy
+# third-party deps (candle, etc.) then land in a layer that only busts when a
+# Cargo.toml / Cargo.lock changes. Every member manifest must be present and
+# its declared target source must exist, or cargo refuses to load the
+# workspace — even members the server bin doesn't depend on.
+COPY Cargo.toml Cargo.lock ./
+COPY crates/spelunk-core/Cargo.toml   crates/spelunk-core/Cargo.toml
+COPY crates/spelunk-cli/Cargo.toml    crates/spelunk-cli/Cargo.toml
+COPY crates/spelunk-embed/Cargo.toml  crates/spelunk-embed/Cargo.toml
+COPY crates/spelunk-server/Cargo.toml crates/spelunk-server/Cargo.toml
+RUN mkdir -p crates/spelunk-core/src crates/spelunk-cli/src \
+             crates/spelunk-embed/src crates/spelunk-server/src && \
+    : > crates/spelunk-core/src/lib.rs && \
+    : > crates/spelunk-embed/src/lib.rs && \
+    : > crates/spelunk-server/src/lib.rs && \
+    echo 'fn main(){}' > crates/spelunk-cli/src/main.rs && \
+    echo 'fn main(){}' > crates/spelunk-server/src/main.rs && \
+    cargo build --release --bin spelunk-server && \
+    rm -rf crates/*/src
+
+# Now copy the real source and build properly. COPY refreshes mtimes so the
+# workspace crates recompile while the cached third-party deps are reused.
 COPY . .
-RUN touch src/bin/spelunk_server.rs && \
-    cargo build --release --bin spelunk-server
+RUN cargo build --release --bin spelunk-server
 
 # ── Stage 2: runtime ──────────────────────────────────────────────────────────
 FROM debian:trixie-slim
 
+# libdbus-1-3: the binary dynamically links libdbus-1 (keyring backend), so the
+# shared lib must be present at load time even though the server uses file/env
+# secret storage.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
+    ca-certificates libdbus-1-3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -r -s /bin/false spelunk

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,10 @@ FROM rust:1.97.0-slim AS builder
 WORKDIR /build
 
 # System build deps the slim image lacks: a C/C++ toolchain for tokenizers'
-# esaxx-rs build script (embed-native default), and libdbus for libdbus-sys
-# (keyring's sync-secret-service backend, linked transitively on Linux).
+# esaxx-rs build script (embed-native default), and libdbus-1-dev to satisfy
+# libdbus-sys's build script (pulled via keyring's sync-secret-service backend).
+# Build-time only — the linker strips the unused lib, so the runtime image
+# needs no dbus package.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential pkg-config libdbus-1-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -69,19 +71,19 @@ RUN mkdir -p crates/spelunk-core/src crates/spelunk-cli/src \
     cargo build --release --bin spelunk-server && \
     rm -rf crates/*/src
 
-# Now copy the real source and build properly. COPY refreshes mtimes so the
-# workspace crates recompile while the cached third-party deps are reused.
+# Now copy the real source and build properly. BuildKit normalizes COPY mtimes
+# to a constant OLDER than the cached placeholder artifacts, so cargo's
+# freshness check would reuse the placeholder binary. `touch` every crate
+# source so the real build supersedes the cache.
 COPY . .
-RUN cargo build --release --bin spelunk-server
+RUN find crates -name '*.rs' -exec touch {} + && \
+    cargo build --release --bin spelunk-server
 
 # ── Stage 2: runtime ──────────────────────────────────────────────────────────
 FROM debian:trixie-slim
 
-# libdbus-1-3: the binary dynamically links libdbus-1 (keyring backend), so the
-# shared lib must be present at load time even though the server uses file/env
-# secret storage.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libdbus-1-3 \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -r -s /bin/false spelunk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
   spelunk-server:
     build: .
     image: spelunk-server:latest
+    # Build locally; never fall back to a registry pull (the tag isn't published).
+    pull_policy: build
     restart: unless-stopped
     volumes:
       - spelunk-data:/data
@@ -45,6 +47,7 @@ services:
   team-server:
     build: .
     image: spelunk-server:latest
+    pull_policy: build
     profiles: ["team-server"]
     restart: unless-stopped
     command: ["--host", "0.0.0.0", "--port", "7777"]
@@ -58,8 +61,11 @@ services:
       - ${SPELUNK_TLS_CERT:-/etc/spelunk/tls-cert}:/tls/cert:ro
       - ${SPELUNK_TLS_KEY:-/etc/spelunk/tls-key}:/tls/key:ro
     environment:
-      # A routable bind is refused without a key; set a real one.
-      SPELUNK_SERVER_KEY: ${SPELUNK_SERVER_KEY:?set SPELUNK_SERVER_KEY for a team server}
+      # A routable bind is refused without a key; set a real one. Left unset by
+      # default (not `:?`) so a bare `docker compose up` — which parses every
+      # service before profile filtering — doesn't abort on this profiled one.
+      # The binary still refuses a non-loopback bind without a key (ADR-066).
+      SPELUNK_SERVER_KEY: ${SPELUNK_SERVER_KEY:-}
       SPELUNK_SERVER_TLS_CERT: /tls/cert
       SPELUNK_SERVER_TLS_KEY: /tls/key
     # No container healthcheck here: the binary's built-in `--health-check` probe


### PR DESCRIPTION
## What

Repairs the self-hosted Docker Quick-Start so it builds and runs end-to-end on a clean clone. The headline path was broken at every step: the `Dockerfile` still assumed the old single-crate `src/` layout, the slim base was missing the C/C++ toolchain and libdbus the build needs, a BuildKit mtime quirk let cargo reuse a placeholder binary, `docker compose up` aborted on a required env var, and the compose services could try a registry pull for an unpublished tag.

## Why

A first-time self-hoster following the Quick-Start hit a hard failure. The three UAT findings this fixes:

- **Dockerfile built the wrong workspace layout.** The repo is now a virtual Cargo workspace (`crates/spelunk-core`, `-cli`, `-embed`, `-server`); the old `COPY src/...` steps no longer matched, and the slim base lacked `build-essential` / `pkg-config` (tokenizers' esaxx-rs build script) and `libdbus-1-dev` (keyring's secret-service backend), so the build failed to compile/link. The dep-cache priming step now lays down every member manifest plus a placeholder source per crate, and the runtime image drops libdbus (build-time only; the linker strips it).
- **`docker compose up` aborted before profile filtering.** The team-server service used `${SPELUNK_SERVER_KEY:?...}`, which Compose evaluates at parse time for *every* service, so a bare `docker compose up` of the default loopback scaffold aborted even though team-server is profile-gated. Switched to `${SPELUNK_SERVER_KEY:-}`; the binary still refuses a non-loopback bind without a key at runtime (ADR-066).
- **Compose could pull instead of build.** Both services now set `pull_policy: build`, so the local image is always built and never fetched from a registry (air-gapped friendly), since the `spelunk-server:latest` tag is not published.

A BuildKit subtlety also had to be handled: `COPY` normalizes source mtimes to a constant older than the cached placeholder artifacts, so cargo's freshness check would reuse the placeholder binary. The real build now `touch`es every crate source first so it supersedes the cache.

A new `docker-build` CI job builds the image and smoke-runs it, asserting non-empty output so a placeholder binary can never pass again.

## Test plan

Built `docker build -t spelunk-server:qa .` (exit 0) and observed the real server in the image:

- **Binary size 16,480,600 bytes (~16.5MB)** — the real release server, not a ~433KB `fn main(){}` placeholder.
- `docker run --rm spelunk-server:qa --version` → `spelunk-server 0.9.3` (real, non-empty).
- `docker run --rm spelunk-server:qa --print-openapi` → real JSON (`"openapi": "3.1.0", "info": { "title": "spelunk-server", ... }`).
- `ldd` on the runtime binary resolves every shared lib (linux-vdso, libgcc_s, libm, libc, ld-linux) with no "not found" — and no dbus lib, confirming the runtime image needs no dbus package.
- `docker compose config` (no env) exits 0, renders `pull_policy: build`, key `""`.
- `docker compose --profile team-server config` (no env) exits 0, both services render `pull_policy: build`; no parse-time abort.
- CI `docker-build` job asserts `test -n "$(… --version)"` and `--print-openapi | head -c1 | grep -q .` — output-based, so a no-op binary that exits 0 on every flag cannot pass.

Note: the CHANGELOG addition may need a trivial rebase against sibling PRs touching the same section.
