### PR TITLE
chore(cli): drop pre-1.0 older-build/upgrade advice from embed messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 - **`spelunk init` no longer writes a `CLAUDE.md` into the target repository.**
   Users who want an agent guide should manually copy `docs/examples/AGENT.md`
   and rename it to `CLAUDE.md` or `AGENT.md` as needed.
+- **`spelunk index` embed-phase messages drop the pre-1.0 "older build /
+  upgrade the server" advice.** The three user-facing embed messages keep their
+  actionable guidance (the request-budget hint and the conservative-budget
+  fallback) but no longer suggest the server may be a legacy build or tell users
+  to upgrade or restart it. The request-budget fallback behaviour is unchanged.
 
 ### Added
 

--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -253,8 +253,8 @@ struct ReqChunk {
 }
 
 /// Report an unrecoverable embed-phase failure: abandon the progress bar and
-/// print an actionable message to stderr (naming the server request budget and a
-/// possible server-version mismatch). Does NOT return `Err` — callers report the
+/// print an actionable message to stderr (naming the server request budget).
+/// Does NOT return `Err` — callers report the
 /// count embedded so far via `Ok(embedded)`.
 fn report_embed_failure(
     bar: &ProgressBar,
@@ -274,9 +274,7 @@ fn report_embed_failure(
     );
     eprintln!(
         "If this keeps happening: the spelunk-server at {server_url} may be enforcing a \
-         smaller request budget than this batch needs, or may be running an older build \
-         that predates the long-running-embed fix (upgrading the server, or running \
-         `spelunk server stop && spelunk server start` to pick up a newer build, may help)."
+         smaller request budget than this batch needs."
     );
 }
 
@@ -318,9 +316,8 @@ pub(super) async fn run_embed_phase(
         // 30s budget. Target smaller batches to keep the run working.
         eprintln!(
             "Note: spelunk-server at {server_url} did not report its /index/embed request \
-             budget (older server build) — assuming a conservative {LEGACY_SERVER_REQUEST_BUDGET_SECS}s \
-             legacy budget and targeting smaller batches accordingly. If this looks slower than \
-             expected, consider upgrading the server."
+             budget; assuming a conservative {LEGACY_SERVER_REQUEST_BUDGET_SECS}s budget and \
+             targeting smaller batches accordingly."
         );
     }
 
@@ -448,8 +445,7 @@ pub(super) async fn run_embed_phase(
                         escalated_calibration_once = true;
                         eprintln!(
                             "First embed request timed out (server request budget \
-                             may be smaller than expected, or this server predates \
-                             the long-running-embed fix) — retrying with more patience\u{2026}"
+                             may be smaller than expected); retrying with more patience\u{2026}"
                         );
                         continue 'retry;
                     }


### PR DESCRIPTION
## What

Rewords the three user-facing `spelunk index` embed-phase `eprintln!` messages in `crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs` to drop the "older build / predates the fix / upgrade or restart the server" framing, while keeping the actionable request-budget hint. Adds a `### Changed` CHANGELOG entry.

## Why

Pre-1.0 has no legacy install base, so advising users their server "may be running an older build" or to "upgrade the server" / `spelunk server stop && start` is confusing noise. The messages now state the actionable part (the server may be enforcing a smaller request budget than the batch needs, or a conservative budget is being assumed) and stop there.

Behaviour is unchanged: the `LEGACY_SERVER_REQUEST_BUDGET_SECS` constant, `resolve_target_batch_seconds`, and the `limits`-absent fallback path are untouched. This is a wording-only change. Internal doc-comments and code comments that describe the compat layer were intentionally left alone.

## Test plan

Run in the task worktree:

- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli` — green (all tests pass, incl. the two known pre-existing flakes `init_import_skips_entries_already_in_memory_db` and `test_index_prints_note_when_no_server_configured`, which passed here).
- `cargo build --no-default-features` — green (embed-native off).
- `cargo clippy --all-targets` — clean, no warnings.
- `cargo fmt --check` — clean.

Note: CHANGELOG may need a trivial rebase against sibling PRs touching the same `### Changed` block.