### PR TITLE
docs(adr): ADR-069 share spelunk memory on git push via an opt-in hook + tracking refspec

### DIFF
--- a/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
+++ b/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
@@ -37,8 +37,9 @@ observed behaviour, not projections.
 
 **Publish notes on `git push` through an opt-in, non-blocking pre-push hook;
 merge with `cat_sort_uniq`; fetch into a tracking ref rather than over the live
-one; and have spelunk itself merge that tracking ref on its read paths, so
-reading a teammate's memory needs no opt-in.**
+one; have spelunk itself merge that tracking ref on its read paths, so reading a
+teammate's memory needs no opt-in; and put a lock around the note
+read-modify-write, without which the merge silently eats entries.**
 
 ### D1 – notes sharing is coupled to `git push`, via an opt-in pre-push hook
 
@@ -83,11 +84,22 @@ Two consequences are accepted deliberately:
 
 - **Concurrent edits union rather than conflict.** There is no user
   interaction to resolve, and force-push never enters the picture.
-- **Read order is no longer chronological.** `cat_sort_uniq` sorts lines
+- **Read order is no longer chronological.** Confirmed on merged output, which
+  interleaves lines by `id` rather than by time. `cat_sort_uniq` sorts
   lexicographically, so `read_records`
   (`crates/spelunk-core/src/storage/git_notes/mod.rs`) must sort by `created_at`
   on read. It currently returns records in blob line order, which is
   chronological only because appends happen to land in order today.
+
+**D2's safety rests on git's newline normalization, not on spelunk's code.**
+`append_to_git_notes` builds the body as `format!("{}\n{}", …)`
+(`git_notes/mod.rs:45-49`) with **no trailing newline**. git adds it when
+storing via `notes add -F`. That is the only reason `cat_sort_uniq` does not
+weld the last line of one side onto the first line of the other and corrupt both
+records (verified: every line survives the union parseable). This is load-bearing
+behaviour owned by an external tool, so the implementation must carry a
+**regression test** that would fail if that normalization ever changed. It must
+not be left as an implicit assumption.
 
 ### D3 – opt-in, non-blocking, best-effort
 
@@ -140,23 +152,69 @@ findings force this, all on git 2.55.0:
 - **A glob alone is not enough.** `…spelunk*:…spelunk*` fixes the fetch break
   but still clobbers the local ref. Only the **tracking** destination is safe.
 
+**The tracking ref was then attacked directly, and held.** The concern worth
+testing was that the `+` still force-updates *something*, so drift or an
+unlucky interleaving might destroy user-authored notes anyway. It does not
+reproduce. Tested: a local and remote note merging; drift (fetch R1, teammate
+pushes R2, then the hook runs); a teammate pushing in the window between the
+hook's fetch and its push (non-fast-forward, and the retry converged); and a
+**remote rewind**, where the tracking ref was force-updated backwards and the
+working ref still **retained** the dropped entries. The `+` on the *tracking*
+ref destroys nothing the user authored, which is the whole point of moving the
+destination off the working ref.
+
 **Consequence, recorded plainly:** fetched notes land in
 `refs/notes/origin/spelunk` and are **not** directly visible to
 `git notes --ref=spelunk` or `spelunk memory list` until merged. "Travels
 automatically on `git fetch`" therefore becomes **fetch + merge**. D5 decides
 who performs that merge.
 
-**No migration.** #582 merged but no release was cut from it, so in practice
-nobody carries the broken refspec on disk. Anyone who built that revision and
-ran `init` is following the tree closely enough to read a CHANGELOG note and fix
-their own config. A CHANGELOG entry covers this; the implementation should not
-carry migration code for a population that almost certainly does not exist.
+**No migration.** #582's refspec landed on 2026-07-12 and the most recent tag,
+v0.9.3, predates it (2026-07-08), so no release contains the broken value and in
+practice nobody carries it on disk. Anyone who built that revision and ran
+`init` is following the tree closely enough to read a CHANGELOG note and fix
+their own config. The implementation should not carry migration code for a
+population that almost certainly does not exist.
+
+**Because migration is dropped, the CHANGELOG note is the only remedy, so the
+command it carries must actually work.** The obvious form is broken:
+
+```
+git config --unset remote.origin.fetch '+refs/notes/spelunk:refs/notes/spelunk'
+error: invalid pattern: +refs/notes/spelunk:refs/notes/spelunk
+```
+
+The value argument is a **regex**, and a leading `+` is not a valid one. The
+CHANGELOG must carry a verified form instead, either
+
+```
+git config --unset --fixed-value remote.origin.fetch '+refs/notes/spelunk:refs/notes/spelunk'
+```
+
+(git >= 2.30), or the escaped regex `'\+refs/notes/spelunk:refs/notes/spelunk'`.
+
+**Re-running `init` is the natural fix and it does not work.**
+`configure_notes_refspec` (`init.rs:263`) adds the refspec with `git config
+--add`, guarded by an idempotence check that matches only the **identical**
+string. An affected user re-running `init` therefore keeps the old clobbering
+refspec, gains the new one alongside it, stays clobbered, and is told
+`configured notes fetch refspec on 'origin'`. That trap is exactly why the
+CHANGELOG note has to name the explicit `--unset` command rather than say "run
+`init` again."
 
 The `init` push hint (`PUSH_HINT`, `init.rs:265`) tells users to push notes
 after each memory change, which is exactly the orphaning failure in D1. It is
 replaced by the hook install hint (D3), not kept as a fallback.
 
 ### D5 – spelunk performs the notes merge on its own read paths
+
+> **Provenance, recorded rather than smoothed over.** D5 was added to this ADR
+> on a review suggestion and written in untested, unlike D1 through D4, which
+> came out of the original spike. A later spike then refuted it as drafted: the
+> read-path merge silently lost entries to a lock-free write (D6), and the cheap
+> short-circuit this section originally claimed does not exist. The decision
+> survived; several of its stated properties did not. Everything below is the
+> spiked version.
 
 D4 leaves fetched notes in `refs/notes/origin/spelunk`, and D1's hook merges
 them only for people who **push**. That is not everyone. A teammate who only
@@ -183,6 +241,8 @@ hydrates the index.
 Why this rather than a hook or a git config setting:
 
 - **It covers the fetch-only consumer**, the exact population D1 cannot reach.
+  Their first merge is a fast-forward and costs almost nothing: 9.3ms at 1000
+  notes, 10.6ms at 20000.
 - **Nothing to install and no git config surgery.** It works for a teammate who
   never runs `spelunk hooks install`.
 - **The strategy stays per-invocation.** spelunk passes `-s cat_sort_uniq` on
@@ -191,20 +251,79 @@ Why this rather than a hook or a git config setting:
   configured it.
 - **Repeated reads converge.** The union merge is idempotent (D2), so a read
   path can run it every time without drift.
+- **A missing tracking ref is a silent no-op that exits 0.** Verified both for
+  users with no remote at all and after a `fetch --prune` deletes the ref. This
+  is what makes the read-path merge safe to run unconditionally: the solo user
+  never sees it, and it needs no "do I have a remote?" special case.
+
+**The merge is synchronous, not backgrounded.** The founder's constraint is that
+it must not block the user's command and must work with the network down or
+flaky. Both hold: the merge does no network (see Security implications) and the
+measured cost is inline-acceptable (see the divergent-object numbers under
+Consequences). Async fails on both counts. It defeats "reading is automatic,"
+because notes would land one invocation late, and it makes the D6 race strictly
+more likely, since a background merge is concurrent with foreground commands by
+construction.
 
 **The cost, recorded honestly:** a read command mutates a local ref, which is
-normally a thing to avoid. It is acceptable here because the mutation is
-local-only and touches no network, and because it is precisely the carrier to
-index hydration that ADR-068's model already implies (git notes are the carrier;
-the local store is the queryable index over it). The merge can short-circuit
-when the tracking ref has not moved since the last read, so the common case
-costs a ref comparison and nothing more.
+normally a thing to avoid. It is acceptable because the mutation is local-only
+and touches no network, and because it is precisely the carrier to index
+hydration that ADR-068's model already implies (git notes are the carrier; the
+local store is the queryable index over it).
+
+**There is no cheap short-circuit, and none is needed.** An earlier draft of
+this ADR claimed the merge could skip work by comparing refs, "costing a ref
+comparison and nothing more." That is false. A no-op merge is **9.2ms flat at
+every scale**, because git already short-circuits internally, and a `git
+rev-parse` subprocess guard costs **8.0ms** to save about 1ms. Only an
+in-process read of the ref file (17µs) is worth having, and it is an
+optimisation, not a correctness requirement.
+
+**D5 is safe only with D6.** As written above it silently loses entries; the
+lock is not optional.
+
+### D6 – serialize note writes with a spelunk-owned lock
+
+`append_to_git_notes` (`crates/spelunk-core/src/storage/git_notes/mod.rs:38-73`)
+is a **lock-free read-modify-write**: step 2 reads the note body
+(`notes show`), step 4 writes the whole body back (`notes add -f -F -`), and
+nothing guards the gap between them. A merge that lands in that gap is silently
+overwritten by the write-back. Measured: **40 of 40 trials lost the merged
+entry, every one exiting 0.**
+
+The loss is **sticky**, not a transient miss. The merge commit is in the working
+ref's history afterwards, so the tracking ref is an ancestor and every later
+merge correctly reports "Already up to date." The entry still exists in the
+tracking ref, but `memory list` never shows it again. Git's own ref locking
+cannot help here: the loss happens at the **content** layer, not the ref layer,
+and both writers hold the ref lock legitimately in turn.
+
+**This is live today, without D5.** Git worktrees **share one notes ref**: a
+worktree's `refs/notes/spelunk` resolves through `--git-common-dir` to the main
+repository's copy. Parallel agents working in separate worktrees are therefore
+all writing the same ref, and this project's own `CLAUDE.md` instructs every
+agent to run `spelunk memory add`. So two concurrent `memory add`s already drop
+one entry silently. D5 does not create this bug; it widens it from "two writers
+race" to "a read command silently eats a teammate's decision."
+
+**The decision:** a spelunk-owned lock (`flock` or equivalent) around the
+**whole** read-modify-write in `append_to_git_notes`, and around the D5
+read-path merge. The lock is **bounded**: if it is contended or the wait exceeds
+a small budget, **skip the merge and read anyway**. That is safe because the
+merge is idempotent (D2), so the next read catches up. A read must **never**
+fail because it could not take the lock.
 
 ## Non-goals
 
-- **Not** fixing #185, the read-modify-write race *within* a single repo. That
-  is orthogonal and still open. `cat_sort_uniq` resolves the *inter-repo* race
-  only.
+- ~~**Not** fixing #185, the read-modify-write race within a single repo.~~
+  **Withdrawn. #185 is in scope, via D6.** The first draft of this ADR deferred
+  it as an orthogonal local race. The spike showed that is not tenable: the same
+  lock-free read-modify-write that #185 describes silently swallows D5's merge in
+  40 of 40 trials, and it is **already losing entries today** for concurrent
+  agents in shared worktrees, with no D5 involved. Deferring it would ship a read
+  command that eats a teammate's decision. `cat_sort_uniq` resolves the
+  inter-repo race; only D6's lock resolves the intra-repo one, and this ADR now
+  requires both.
 - **Not** reconciling `NoteRecord.id` collisions. `id` is a local SQLite rowid
   and `remote_id` is only set on server sync, so on the local-first path two
   developers both produce `id:1` for different entries. `cat_sort_uniq` dedupes
@@ -239,15 +358,27 @@ costs a ref comparison and nothing more.
 - **Read commands acquire a local write.** `memory list` and `context` now
   merge a ref (D5). No network, no remote effect, but anything assuming these
   commands are pure reads of local state needs to account for it.
+- **#185 moves from deferred to required, and a concurrency bug gets fixed on
+  the way.** D6's lock is a precondition of D5, and it also closes a live
+  entry-losing race that predates this ADR for parallel agents in worktrees.
+- **Note size is not the cost axis; divergence is.** Growing a note is nearly
+  free (10 to 1000 entries moves the merge from 11.9ms to 14.9ms). The cost
+  scales with **divergent annotated objects**, at roughly 0.6ms each: 5000
+  annotated with 100 divergent is 94.6ms, 5000 with 5000 divergent is 2.14s, and
+  20000 with 20000 divergent is 12.7s. Realistic steady state, where a fetch
+  brings 1 to 100 changed notes, is **12 to 95ms**, which is fine inline.
 - **No migration, one CHANGELOG line.** #582 shipped in no release, so the
   broken refspec has no real population. The change note tells the handful of
-  people tracking `main` to fix their config by hand.
+  people tracking `main` to fix their config by hand, with the `--fixed-value`
+  command from D4, since re-running `init` will not fix them.
 - **`init`'s refspec test changes.** `crates/spelunk-cli/tests/init_notes_refspec.rs`
   pins the old value and its round-trip expectations; both move to the tracking
   ref.
-- **Revisit if:** the union-by-default model produces notes large or noisy
-  enough that lexicographic union becomes a readability problem, or if the D5
-  read-path merge shows up as latency on large notes.
+- **Revisit if:** the number of **divergent annotated objects** in a normal
+  fetch climbs toward the thousands, which is the axis that actually degrades
+  (seconds, not milliseconds), or if the union model produces notes noisy enough
+  that lexicographic union becomes a readability problem. Note size alone is not
+  a trigger.
 
 ## Security implications
 
@@ -258,10 +389,15 @@ costs a ref comparison and nothing more.
   both send data at moments the user did not initiate. The hook adds no egress
   the user was not already performing, and to no host other than the remote they
   chose.
-- **D5's read-path merge does not fetch.** It merges the tracking ref the user's
-  own `git fetch` already populated, so a read command reaches no network. This
-  is deliberate: making reads fetch would put egress back on a code path the
-  user did not point at a remote.
+- **D5's read-path merge does not fetch, and this was verified rather than
+  assumed.** With the remote made unreachable the merge still succeeds (~12ms).
+  `GIT_TRACE` and `GIT_TRACE_PACKET` show no transport. And the positive proof:
+  an entry pushed to the real origin *after* the tracking fetch was **absent**
+  from the merge result, so the merge demonstrably does not reach out and pick
+  up new remote state. It merges only the tracking ref the user's own `git
+  fetch` already populated. This is deliberate: making reads fetch would put
+  egress on a code path the user never pointed at a remote, and it is what lets
+  D5 work with the network down.
 - The `memory add` secret scan (`contains_secret`, run before any persistence)
   is unchanged and still runs before anything reaches a note, so the hook can
   only ever push already-scanned content.

--- a/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
+++ b/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
@@ -1,0 +1,198 @@
+# ADR-069: Share spelunk memory on `git push`, via an opt-in hook and a tracking-ref fetch refspec
+
+**Date:** 2026-07-14
+**Deciders:** founder (Johan); architect
+**Relationship to prior ADRs:** resolves the Open question
+[ADR-068](068-zero-setup-onboarding-git-notes-memory-fallback.md) deferred to
+^126 ("Does 'travels with the repo' require configuring the notes refspec?").
+ADR-068 made `refs/notes/spelunk` the durable carrier for pre-`init` memory,
+which put the whole "travels with the repo" promise on that ref being visible
+across clones. The answer is yes, and the mechanism currently on `main` (#582)
+is wrong in a way that loses notes and breaks plain `git fetch`, so this ADR
+also **corrects** it. Leaves [ADR-067](067-fail-closed-no-local-project.md)'s
+isolation floor and ADR-004's inference-vs-storage split untouched: everything
+here is repo-scoped git plumbing, with no new store of record.
+
+## Context
+
+`git notes` under `refs/notes/spelunk` are not pushed, fetched, or cloned by
+default. #582 addressed the fetch half by having `spelunk init` configure an
+`origin` fetch refspec (`configure_notes_refspec`,
+`crates/spelunk-cli/src/cli/cmd/init.rs:263`), and deliberately left the push
+half manual. Its own doc comment states the reason, and it is a real constraint
+worth keeping:
+
+> Push refspec is deliberately NOT set: any `remote.origin.push` value
+> overrides git's default branch push, so a normal `git push` would stop
+> pushing the current branch.
+
+So `init` instead prints a hint to run
+`git push origin refs/notes/spelunk` after each memory change. A spike against
+git 2.55.0 established that both halves of that design are broken: the manual
+push hint produces unreachable notes, and the configured fetch refspec both
+breaks `git fetch` and silently destroys local notes. The findings below are
+observed behaviour, not projections.
+
+## Decision
+
+**Couple notes sharing to `git push` through an opt-in, non-blocking pre-push
+hook; merge with `cat_sort_uniq`; fetch into a tracking ref rather than over the
+live one.**
+
+### D1 – notes sharing is coupled to `git push`, via an opt-in pre-push hook
+
+Not to `memory add`, and not to a timer.
+
+A note attached to a **locally unpushed commit** can reach origin while its
+target object does not. Origin then answers `fatal: could not get object info`,
+and a fresh clone fetches the notes ref but cannot resolve its target. The
+memory is **orphaned**: teammates read notes on *their* HEAD and never see it.
+This is not a corner case. It is what the current post-`memory add` push hint
+produces whenever a developer records a decision before pushing the commit it
+describes, which is the normal order of work.
+
+Push-on-`memory add` and a background timer both fail the same way, because both
+fire independently of whether the commits are pushed, and both force network
+egress outside any user-initiated sharing action. `git push` is the only moment
+that reliably coincides with "this code is being shared," so it is the only
+correct trigger. A pre-push hook also sidesteps the `remote.origin.push`
+constraint above: the hook pushes the notes ref as a separate invocation and
+never touches the branch-push default.
+
+### D2 – `cat_sort_uniq` is the canonical merge strategy for `refs/notes/spelunk`
+
+spelunk appends each entry as a JSON line to HEAD's note (`append_record`,
+`crates/spelunk-core/src/storage/git_notes/mod.rs`), which makes a note a
+**union set** of records, not a document with an authored shape. The merge
+strategy has to match that. Measured on divergent notes:
+
+| Strategy | Result |
+|---|---|
+| `cat_sort_uniq` | exit 0, clean union, both entries, no duplicates, no conflict markers |
+| `union` | keeps both, injects a blank-line artifact |
+| `ours` / `theirs` | exit 0, and **silently destroys one side's memory** |
+| default (`manual`) | **exit 1**, CONFLICT, leaves `.git/NOTES_MERGE_WORKTREE` and a stuck partial merge |
+
+Only `cat_sort_uniq` matches the union-set semantics, and it is never the
+default, so it must be passed **explicitly** on every merge. A 3-developer
+round-trip converged to identical notes with zero loss, and stayed converged
+across repeated syncs (idempotent).
+
+Two consequences are accepted deliberately:
+
+- **Concurrent edits union rather than conflict.** There is no user
+  interaction to resolve, and force-push never enters the picture.
+- **Read order is no longer chronological.** `cat_sort_uniq` sorts lines
+  lexicographically, so `read_records`
+  (`crates/spelunk-core/src/storage/git_notes/mod.rs`) must sort by `created_at`
+  on read. It currently returns records in blob line order, which is
+  chronological only because appends happen to land in order today.
+
+### D3 – opt-in, non-blocking, best-effort
+
+- **Installed explicitly** (`spelunk hooks install --pre-push`), never silently.
+  It reuses the guard pattern already established by the post-commit hook
+  (`crates/spelunk-cli/src/cli/cmd/hooks.rs`,
+  `crates/spelunk-cli/src/cli/cmd/init.rs`): bail if a non-spelunk pre-push hook
+  is present, keep an idempotent marker, and `command -v spelunk` skip so
+  teammates without spelunk are unaffected.
+- **Never blocks the user's `git push`.** A hook exiting `1` aborts the branch
+  push outright, and in the spike origin never received the commit. Memory
+  sharing must not be able to cost someone their push. The hook exits `0`
+  unconditionally and warns on stderr.
+- **A recursion guard is mandatory.** A naive pre-push hook that pushes the
+  notes ref recursed **740 levels deep** and stopped only by exhausting the
+  process table (`cannot fork() ... Resource temporarily unavailable`). All
+  outer pushes failed invisibly while the branch push still reported success.
+  The nested push MUST use `--no-verify`, which makes git skip pre-push
+  entirely; an env sentinel is belt-and-braces on top.
+- **Retry at most 3 times** on non-fast-forward. This is not a guess: under a
+  concurrent 3-way race the third developer only succeeded on attempt 3. Never
+  force-push.
+- **Hook flow:** `fetch`, then `git notes merge -s cat_sort_uniq` from the
+  tracking ref, then `push --no-verify`.
+
+### D4 – correct the fetch refspec to a tracking ref
+
+Replace #582's `+refs/notes/spelunk:refs/notes/spelunk` with
+**`+refs/notes/spelunk*:refs/notes/origin/spelunk*`**
+(`FETCH_REFSPEC`, `crates/spelunk-cli/src/cli/cmd/init.rs:264`). Three separate
+findings force this, all on git 2.55.0:
+
+- **The non-glob form breaks plain git.** It requires the remote ref to exist.
+  With no notes on the remote, which is every repo until someone pushes,
+  `git fetch origin` exits **128** and `git pull` exits **1**, both with
+  `fatal: couldn't find remote ref refs/notes/spelunk`. `spelunk init` therefore
+  breaks the user's normal git workflow. A glob tolerates the missing remote ref
+  and fetch exits 0.
+- **The leading `+` on a working ref destroys local notes.** It force-updates
+  the destination: a local unpushed note was silently replaced by the remote's
+  on a plain `git fetch`, reported only as `(forced update)`, and recoverable
+  only via reflog. That is data loss of the product's core asset.
+- **A glob alone is not enough.** `…spelunk*:…spelunk*` fixes the fetch break
+  but still clobbers the local ref. Only the **tracking** destination is safe.
+
+**Consequence, recorded plainly:** fetched notes land in
+`refs/notes/origin/spelunk` and are **not** directly visible to
+`git notes --ref=spelunk` or `spelunk memory list` until merged. "Travels
+automatically on `git fetch`" therefore becomes **fetch + merge**, where the
+merge is D1's hook. Users who already ran `init` under #582 carry the broken
+value on disk, so the implementation must **migrate** that refspec, not merely
+add the correct one alongside it. The `init` push hint (`PUSH_HINT`,
+`init.rs:265`) tells users to push notes after each memory change, which is
+exactly the orphaning failure in D1; it is replaced by the hook, not kept as a
+fallback.
+
+## Non-goals
+
+- **Not** fixing #185, the read-modify-write race *within* a single repo. That
+  is orthogonal and still open. `cat_sort_uniq` resolves the *inter-repo* race
+  only.
+- **Not** reconciling `NoteRecord.id` collisions. `id` is a local SQLite rowid
+  and `remote_id` is only set on server sync, so on the local-first path two
+  developers both produce `id:1` for different entries. `cat_sort_uniq` dedupes
+  whole lines, so nothing is lost, but the carrier can legitimately hold
+  colliding ids, and the `init`-time git-notes import must reconcile them.
+- **Not** reusing the name `spelunk memory push`. That already means "push local
+  memory to the team server," and overloading it onto the notes path would
+  conflate two different destinations.
+- **Not** setting `remote.origin.push`, for the reason #582 recorded and this
+  ADR keeps: it would override git's default branch push.
+- **Not** making notes sharing on by default. D3 is opt-in.
+
+## Consequences
+
+- **The "travels with the repo" promise becomes true, for users who opt in.**
+  ADR-068's carrier now reaches teammates on the one action that already means
+  sharing. Users who do not install the hook keep working notes locally, and the
+  docs must not claim more than that.
+- **`spelunk init` stops breaking `git fetch` / `git pull`.** This is a bug fix
+  to shipped behaviour, not only a new feature, and it is the part that should
+  land first.
+- **Notes read order must be sorted on read.** D2's lexicographic union is a
+  behaviour change that `read_records` has to absorb (sort by `created_at`).
+  Anything that assumed blob order is chronological needs to stop.
+- **A migration exists.** Repos initialised under #582 hold the clobbering
+  refspec and must be corrected in place.
+- **`init`'s refspec test changes.** `crates/spelunk-cli/tests/init_notes_refspec.rs`
+  pins the old value and its round-trip expectations; both move to the tracking
+  ref.
+- **Revisit if:** the union-by-default model produces notes large or noisy
+  enough that lexicographic union becomes a readability problem, or if per-entry
+  id collisions turn out to matter beyond the import step.
+
+## Security implications
+
+- No new trust boundary and no new store of record. Everything here is
+  repo-scoped git plumbing over a ref the user's own repo already holds.
+- **Network egress is bounded to the user's own `git push`.** This is stronger
+  than the alternatives rejected in D1: push-on-`memory add` and a timer would
+  both send data at moments the user did not initiate. The hook adds no egress
+  the user was not already performing, and to no host other than the remote they
+  chose.
+- The `memory add` secret scan (`contains_secret`, run before any persistence)
+  is unchanged and still runs before anything reaches a note, so the hook can
+  only ever push already-scanned content.
+- The hook never force-pushes (D3), so it cannot destroy remote history. The
+  destructive behaviour identified here is #582's `+` on a working ref (D4),
+  which this ADR removes.

--- a/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
+++ b/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
@@ -35,9 +35,10 @@ observed behaviour, not projections.
 
 ## Decision
 
-**Couple notes sharing to `git push` through an opt-in, non-blocking pre-push
-hook; merge with `cat_sort_uniq`; fetch into a tracking ref rather than over the
-live one.**
+**Publish notes on `git push` through an opt-in, non-blocking pre-push hook;
+merge with `cat_sort_uniq`; fetch into a tracking ref rather than over the live
+one; and have spelunk itself merge that tracking ref on its read paths, so
+reading a teammate's memory needs no opt-in.**
 
 ### D1 – notes sharing is coupled to `git push`, via an opt-in pre-push hook
 
@@ -111,6 +112,13 @@ Two consequences are accepted deliberately:
   force-push.
 - **Hook flow:** `fetch`, then `git notes merge -s cat_sort_uniq` from the
   tracking ref, then `push --no-verify`.
+- **`spelunk init` must announce the step.** Opt-in only works if it is
+  discoverable, so `init`'s summary output must state that sharing memory with
+  teammates requires installing the pre-push hook, and name the command. This is
+  a requirement on the implementation, not a docs-only note: a user who never
+  reads `docs/` must still learn that their memory stays local until they take
+  one more step. It replaces the `PUSH_HINT` line (D4), so `init` stops
+  advertising the orphan-prone manual push and points at the hook instead.
 
 ### D4 – correct the fetch refspec to a tracking ref
 
@@ -135,13 +143,62 @@ findings force this, all on git 2.55.0:
 **Consequence, recorded plainly:** fetched notes land in
 `refs/notes/origin/spelunk` and are **not** directly visible to
 `git notes --ref=spelunk` or `spelunk memory list` until merged. "Travels
-automatically on `git fetch`" therefore becomes **fetch + merge**, where the
-merge is D1's hook. Users who already ran `init` under #582 carry the broken
-value on disk, so the implementation must **migrate** that refspec, not merely
-add the correct one alongside it. The `init` push hint (`PUSH_HINT`,
-`init.rs:265`) tells users to push notes after each memory change, which is
-exactly the orphaning failure in D1; it is replaced by the hook, not kept as a
-fallback.
+automatically on `git fetch`" therefore becomes **fetch + merge**. D5 decides
+who performs that merge.
+
+**No migration.** #582 merged but no release was cut from it, so in practice
+nobody carries the broken refspec on disk. Anyone who built that revision and
+ran `init` is following the tree closely enough to read a CHANGELOG note and fix
+their own config. A CHANGELOG entry covers this; the implementation should not
+carry migration code for a population that almost certainly does not exist.
+
+The `init` push hint (`PUSH_HINT`, `init.rs:265`) tells users to push notes
+after each memory change, which is exactly the orphaning failure in D1. It is
+replaced by the hook install hint (D3), not kept as a fallback.
+
+### D5 – spelunk performs the notes merge on its own read paths
+
+D4 leaves fetched notes in `refs/notes/origin/spelunk`, and D1's hook merges
+them only for people who **push**. That is not everyone. A teammate who only
+fetches or pulls, the common case for reviewing and reading, would never trigger
+a merge and would therefore never see anyone else's memory. Closing that gap
+with a complementary fetch hook is not possible: **git has no post-fetch hook.**
+The documented hook set on git 2.55.0 is applypatch-msg, commit-msg,
+fsmonitor-watchman, the p4-* family, post-applypatch, post-checkout,
+post-commit, post-index-change, post-merge, post-receive, post-rewrite,
+post-update, pre-applypatch, pre-auto-gc, pre-commit, pre-merge-commit,
+pre-push, pre-rebase, pre-receive, prepare-commit-msg, proc-receive,
+push-to-checkout, reference-transaction, sendemail-validate, and update. Nothing
+in it fires after a bare `git fetch`. The two near misses do not work:
+`post-merge` fires on `git pull`'s merge but not on `fetch`, and
+`reference-transaction` fires on **every** ref transaction, including the notes
+merge's own ref writes (a recursion hazard), at the wrong altitude entirely.
+
+**So spelunk does the merge itself, rather than delegating it to git.** On its
+own read paths, spelunk merges `refs/notes/origin/spelunk` into
+`refs/notes/spelunk` with `-s cat_sort_uniq`: in `spelunk memory list` and
+`spelunk context`, and at `spelunk init`, where the git-notes import already
+hydrates the index.
+
+Why this rather than a hook or a git config setting:
+
+- **It covers the fetch-only consumer**, the exact population D1 cannot reach.
+- **Nothing to install and no git config surgery.** It works for a teammate who
+  never runs `spelunk hooks install`.
+- **The strategy stays per-invocation.** spelunk passes `-s cat_sort_uniq` on
+  the call and never writes the user's `notes.mergeStrategy`, whose default is
+  `manual`. Their own `git notes merge` keeps behaving exactly as they
+  configured it.
+- **Repeated reads converge.** The union merge is idempotent (D2), so a read
+  path can run it every time without drift.
+
+**The cost, recorded honestly:** a read command mutates a local ref, which is
+normally a thing to avoid. It is acceptable here because the mutation is
+local-only and touches no network, and because it is precisely the carrier to
+index hydration that ADR-068's model already implies (git notes are the carrier;
+the local store is the queryable index over it). The merge can short-circuit
+when the tracking ref has not moved since the last read, so the common case
+costs a ref comparison and nothing more.
 
 ## Non-goals
 
@@ -152,7 +209,12 @@ fallback.
   and `remote_id` is only set on server sync, so on the local-first path two
   developers both produce `id:1` for different entries. `cat_sort_uniq` dedupes
   whole lines, so nothing is lost, but the carrier can legitimately hold
-  colliding ids, and the `init`-time git-notes import must reconcile them.
+  colliding ids. **#598 resolves this**, not this ADR: it amends ADR-068 with a
+  canonical content-addressed identity (`content_id`, a `sha256` over the
+  entry's canonical JSON semantic core, plus a stable `entity_id` across edits
+  and supersede), which removes the rowid collision at its source. This ADR
+  depends on nothing more than line-level dedupe, so the two land
+  independently.
 - **Not** reusing the name `spelunk memory push`. That already means "push local
   memory to the team server," and overloading it onto the notes path would
   conflate two different destinations.
@@ -162,24 +224,30 @@ fallback.
 
 ## Consequences
 
-- **The "travels with the repo" promise becomes true, for users who opt in.**
-  ADR-068's carrier now reaches teammates on the one action that already means
-  sharing. Users who do not install the hook keep working notes locally, and the
-  docs must not claim more than that.
+- **The promise splits cleanly into reading and publishing.** *Reading*
+  teammates' memory is automatic for anyone who fetches, because spelunk merges
+  the tracking ref on its own read paths (D5). *Publishing* your own memory is
+  opt-in and needs the hook (D1, D3). So "travels with the repo" holds
+  unconditionally in the direction users notice first, and the docs should
+  describe the asymmetry rather than flatten it.
 - **`spelunk init` stops breaking `git fetch` / `git pull`.** This is a bug fix
   to shipped behaviour, not only a new feature, and it is the part that should
   land first.
 - **Notes read order must be sorted on read.** D2's lexicographic union is a
   behaviour change that `read_records` has to absorb (sort by `created_at`).
   Anything that assumed blob order is chronological needs to stop.
-- **A migration exists.** Repos initialised under #582 hold the clobbering
-  refspec and must be corrected in place.
+- **Read commands acquire a local write.** `memory list` and `context` now
+  merge a ref (D5). No network, no remote effect, but anything assuming these
+  commands are pure reads of local state needs to account for it.
+- **No migration, one CHANGELOG line.** #582 shipped in no release, so the
+  broken refspec has no real population. The change note tells the handful of
+  people tracking `main` to fix their config by hand.
 - **`init`'s refspec test changes.** `crates/spelunk-cli/tests/init_notes_refspec.rs`
   pins the old value and its round-trip expectations; both move to the tracking
   ref.
 - **Revisit if:** the union-by-default model produces notes large or noisy
-  enough that lexicographic union becomes a readability problem, or if per-entry
-  id collisions turn out to matter beyond the import step.
+  enough that lexicographic union becomes a readability problem, or if the D5
+  read-path merge shows up as latency on large notes.
 
 ## Security implications
 
@@ -190,6 +258,10 @@ fallback.
   both send data at moments the user did not initiate. The hook adds no egress
   the user was not already performing, and to no host other than the remote they
   chose.
+- **D5's read-path merge does not fetch.** It merges the tracking ref the user's
+  own `git fetch` already populated, so a read command reaches no network. This
+  is deliberate: making reads fetch would put egress back on a code path the
+  user did not point at a remote.
 - The `memory add` secret scan (`contains_secret`, run before any persistence)
   is unchanged and still runs before anything reaches a note, so the hook can
   only ever push already-scanned content.


### PR DESCRIPTION
Records the decision from the git-notes sharing spike. Resolves the open question [ADR-068](https://github.com/spelunk-cloud/spelunk/blob/main/docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md) deferred to ^126: *"Does 'travels with the repo' require configuring the notes refspec?"*

The answer is yes, and the mechanism currently on `main` (#582) is wrong in two ways that this ADR corrects.

## What it decides

- **D1 – sharing is coupled to `git push`,** via an opt-in pre-push hook. Not to `memory add`, not to a timer. A note on an unpushed commit reaches origin while its target object does not, so the memory is orphaned and teammates never see it. `git push` is the only moment that coincides with "this code is being shared." It also sidesteps the `remote.origin.push` constraint #582 correctly identified: a hook pushes the notes ref separately and leaves the branch-push default intact.
- **D2 – `cat_sort_uniq` is the canonical merge strategy.** spelunk appends each entry as a JSON line, so a note is a union set. `ours`/`theirs` exit 0 while silently destroying one side's memory; the default (`manual`) exits 1 and leaves a stuck partial merge. Only `cat_sort_uniq` unions cleanly, and it is never the default, so it must be passed explicitly.
- **D3 – opt-in, non-blocking, best-effort.** The hook must never block the user's push (a hook exiting 1 aborts the branch push). The recursion guard is mandatory: a naive version recursed 740 levels and stopped only by exhausting the process table, with outer pushes failing invisibly.
- **D4 – correct the fetch refspec to a tracking ref.** `+refs/notes/spelunk*:refs/notes/origin/spelunk*`.

## Why D4 matters most

#582's `+refs/notes/spelunk:refs/notes/spelunk` has two independent defects on git 2.55.0:

1. The non-glob form requires the remote ref to exist, so with no notes on the remote (every repo until someone pushes) `git fetch origin` exits 128 and `git pull` exits 1. **`spelunk init` breaks the user's normal git workflow today.**
2. The leading `+` on a working ref force-updates it: a local unpushed note was silently replaced by the remote's on a plain `git fetch`, recoverable only via reflog. That is data loss of the product's core asset.

A glob alone fixes (1) but not (2); only the tracking destination is safe.

## Notes for review

- Two consequences are accepted deliberately and recorded as such: concurrent edits union rather than conflict, and `cat_sort_uniq` sorts lexicographically, so `read_records` must sort by `created_at` on read.
- Repos already `init`'d under #582 hold the broken refspec on disk and must be **migrated**, not merely added-alongside.
- Explicit non-goals: this does not fix #185 (the read-modify-write race within one repo), does not reconcile `NoteRecord.id` collisions, and does not reuse the name `spelunk memory push` (already means "push to the team server").

The implementation (refspec correction + pre-push hook, plus the `init_notes_refspec.rs` test update) lands as one follow-on change once this merges.

## Test plan

Docs-only change; no runtime surface. Verified:
- `docs/adr/069-*.md` is the next free number in the global sequence (checked `docs/adr/` in both spelunk-oss and cloud-api; oss was at 068, cloud-api at 065).
- Every code reference cited in the ADR was confirmed against the tree at this SHA: `configure_notes_refspec` / `FETCH_REFSPEC` (`init.rs:263-264`), `PUSH_HINT` (`init.rs:265`), `read_records` (`git_notes/mod.rs:308`), `hooks.rs` post-commit guard pattern, `tests/init_notes_refspec.rs:27`.
- Repo pre-commit hook ran `cargo fmt --check` + `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)