### PR TITLE
docs: remove Docker and MDM recipes the CLI refuses; add CA trust guidance

### DIFF
--- a/docs/remote-agents.md
+++ b/docs/remote-agents.md
@@ -16,7 +16,7 @@ The shapes we distinguish:
 | Shape | Where the agent runs | `SPELUNK_SERVER_URL` |
 |---|---|---|
 | Local (R0) | Your workstation | `http://127.0.0.1:7777` (auto) |
-| **Local Docker (R1)** | A container on your machine | `https://spelunk.your-domain` (portable) — or `http://host.docker.internal:7777` on Docker Desktop only |
+| **Local Docker (R1)** | A container on your machine | `https://spelunk.your-domain` (portable) |
 | Cloud-managed (R2) | A cloud workspace (e.g. Background Agents) | `https://api.spelunk.cloud` |
 | Self-hosted remote (R3) | Your own VM / pod | `https://spelunk.your-domain` — see [Self-hosting](self-hosting.md) |
 
@@ -66,6 +66,31 @@ docker run --rm -it \
   path if your agent image runs as a non-root user — match its `$HOME`.)
 - `-w /work` runs the agent in the mounted repo.
 
+If the server's certificate chains to a publicly trusted CA, that is everything
+the container needs. If it is signed by a self-signed or internal CA (the usual
+case when you stand the server up yourself), the container must also be given
+the CA bundle, or the TLS handshake fails. Mount the bundle read-only and point
+`SPELUNK_SERVER_CA` at it:
+
+```bash
+docker run --rm -it \
+  -e SPELUNK_SERVER_URL=https://spelunk.example.com \
+  -e SPELUNK_SERVER_KEY=your-shared-api-key \
+  -e SPELUNK_SERVER_CA=/etc/spelunk/internal-ca.pem \
+  -v /etc/spelunk/internal-ca.pem:/etc/spelunk/internal-ca.pem:ro \
+  -v "$PWD":/work \
+  -v "$HOME/.config/spelunk":/root/.config/spelunk \
+  -w /work \
+  your-agent-image
+```
+
+The bundle is added as a trust anchor on top of the built-in roots, and
+certificate verification stays on. It must contain the issuing **CA**
+certificate, not the server's leaf. `SPELUNK_SERVER_CA` overrides the
+`server_ca` config key; see
+[Trusting the server's certificate](self-hosting.md#trusting-the-servers-certificate-on-the-client)
+for how to generate the CA and issue the server a leaf from it.
+
 Inside the container, the CLI behaves exactly as it would on the host:
 
 ```bash
@@ -76,43 +101,43 @@ spelunk search "auth tokens"  # semantic search via the server
 The **server side** of this (the routable TLS bind and the systemd unit) is the
 bare-metal path in [Self-hosting](self-hosting.md).
 
-### Docker Desktop convenience (solo, non-portable)
+### No bridge shortcut, on any platform
 
-If you're a solo developer with only the auto-started local loopback server (no
-team server) and you're on **Docker Desktop** (macOS/Windows), Docker Desktop
-special-cases the DNS name `host.docker.internal` to reach the host's loopback,
-so you can skip the TLS endpoint and point straight at the host server:
+It is tempting to skip the TLS endpoint and point the container at the host over
+a Docker bridge address. There is no working version of that on any platform,
+including Docker Desktop. It fails on two independent counts.
 
-```bash
-docker run --rm -it \
-  -e SPELUNK_SERVER_URL=http://host.docker.internal:7777 \
-  -v "$PWD":/work \
-  -v "$HOME/.config/spelunk":/root/.config/spelunk \
-  -w /work \
-  your-agent-image
+**A bridge address does not reach a loopback-bound server.** On plain Linux
+Docker, the default bridge gateway (`172.17.0.1`) and
+`--add-host=host.docker.internal:host-gateway` both resolve to the host's
+**routable** interface, not its loopback, so a server bound to `127.0.0.1` is
+not listening where the container can reach it. On Docker Desktop,
+`host.docker.internal` resolves to the gateway of the Docker VM, so traffic
+crosses a virtual network that sibling containers share rather than staying on
+the host's loopback.
+
+**The CLI refuses plaintext to a non-loopback host anyway.** The transport check
+matches the literal host string and performs no DNS resolution: only `127.x`,
+`::1`, and `localhost` count as loopback. Docker's DNS special-casing therefore
+never enters into it, and both bridge addresses are rejected on every platform.
+Setting `SPELUNK_SERVER_URL=http://host.docker.internal:7777` (or
+`http://172.17.0.1:7777`) fails the moment the CLI needs the server:
+
+```
+error: invalid server URL "http://host.docker.internal:7777": plaintext http:// is only
+allowed to a loopback address (127.0.0.1/::1/localhost); use https:// for any other host
 ```
 
-This is a **Docker Desktop-only** convenience. It does not work on native Linux
-Docker (see below), so don't bake it into anything you also run on Linux.
+That refusal is deliberate, and it is not a false positive: those addresses
+genuinely are off-loopback, so the bearer key and your query content would cross
+a shared virtual network in cleartext. There is no opt-out. Binding the server
+to the bridge address over plaintext instead runs into the mirror-image rule on
+the server side, which refuses a non-loopback plaintext bind unconditionally; a
+routable bind is only allowed with `--tls-cert`/`--tls-key` and a key.
 
-### Native Linux: no loopback shortcut
-
-Plain Linux Docker (not Docker Desktop) has **no** way to reach a
-host-loopback-bound server from a container:
-
-- The default bridge gateway (`172.17.0.1`) and
-  `--add-host=host.docker.internal:host-gateway` both resolve to the host's
-  **routable** interface, not its loopback, so a local server bound to
-  `127.0.0.1` is not listening where the container can reach it.
-- Binding the server to the bridge address over plaintext instead is a
-  **non-loopback plaintext bind, which `spelunk-server` refuses
-  unconditionally**: there is no override. A routable bind is only allowed with
-  `--tls-cert`/`--tls-key` and a key, i.e. the HTTPS endpoint below.
-
-So on native Linux there is no bridge shortcut: use the recommended HTTPS-endpoint
-path above. The team server's own routable TLS listener (per
-[Self-hosting](self-hosting.md)) is what makes it reachable from a container, and
-it does so the same way on every platform.
+Use the recommended HTTPS-endpoint path above. The server's own routable TLS
+listener (per [Self-hosting](self-hosting.md)) is what makes it reachable from a
+container, and it does so the same way on every platform.
 
 ### Notes
 

--- a/examples/mdm/spelunk-config.toml
+++ b/examples/mdm/spelunk-config.toml
@@ -21,7 +21,11 @@
 # --- Shared team memory server -----------------------------------------------
 # When set, the CLI shares memory (decisions, requirements, context) through a
 # long-lived deployed server. Leave unset to keep every machine fully local.
-server_url = "http://spelunk.internal:7777"
+# Must be https:// for any non-loopback host: plaintext http:// is accepted only
+# to 127.0.0.1/::1/localhost, and there is no opt-out. If the server's
+# certificate is signed by an internal CA, set SPELUNK_SERVER_CA (or server_ca)
+# to the CA bundle on each machine.
+server_url = "https://spelunk.internal"
 
 # Human-readable project slug. Required when server_url points at a non-loopback
 # host. The CLI resolves the slug to the server's internal id on first use.

--- a/examples/mdm/spelunk.env.example
+++ b/examples/mdm/spelunk.env.example
@@ -13,7 +13,15 @@
 SPELUNK_SERVER_KEY=replace-with-your-shared-api-key
 
 # Point every machine at the same shared server (overrides config server_url).
-SPELUNK_SERVER_URL=http://spelunk.internal:7777
+# Must be https:// for any non-loopback host. Plaintext http:// is accepted only
+# to 127.0.0.1/::1/localhost, so the shared key above is never sent in the clear;
+# there is no opt-out.
+SPELUNK_SERVER_URL=https://spelunk.internal
+
+# If that server's certificate is signed by an internal or self-signed CA, every
+# machine also needs the CA bundle to verify it. Added as a trust anchor on top
+# of the built-in roots; verification stays on.
+# SPELUNK_SERVER_CA=/etc/spelunk/internal-ca.pem
 
 # Project slug (overrides config project_id).
 SPELUNK_PROJECT_ID=acme/my-app


### PR DESCRIPTION
## Why

`docs/remote-agents.md` shipped a "Docker Desktop convenience" block telling users to set
`SPELUNK_SERVER_URL=http://host.docker.internal:7777`. The CLI **hard-refuses that URL**. We were
documenting a command that cannot work.

The transport check (`validate_transport_url`) allows plaintext `http://` only to a loopback host,
and `is_loopback_url` is a literal string match over `localhost` / `127.0.0.1` / `::1` / `127.*`
with **no DNS resolution**. Docker Desktop's DNS special-casing of `host.docker.internal` therefore
never enters into it. The refusal is deliberate and correct rather than a false positive: on Docker
Desktop that name resolves to the Docker VM's gateway, not the host's loopback, so the bearer key
would cross a virtual network that sibling containers share, in cleartext.

ADR-066 §5 already supplies the first-party answer (the server terminates HTTPS in-process on a
routable bind), so no escape hatch is needed or wanted. This change makes the docs match the binary.

## What changed

**`docs/remote-agents.md`**
- Dropped the `host.docker.internal` clause from the R1 table row.
- Deleted the "Docker Desktop convenience (solo, non-portable)" section and its `docker run` block.
- Reframed "Native Linux: no loopback shortcut" into "No bridge shortcut, on any platform", stating
  both independent reasons: a bridge address does not reach a loopback-bound server, **and** the CLI
  refuses non-loopback plaintext regardless of platform or DNS. Quotes the real error text.
- Closed a genuine gap in the surviving HTTPS path: it had no `SPELUNK_SERVER_CA` guidance, yet a
  solo dev standing up their own server will have a self-signed cert and would fail the TLS
  handshake with nothing to point at. Adds the read-only mount plus the env var, with the caveat
  that the bundle must be the issuing CA and not the server's leaf, cross-linked to
  `self-hosting.md`.

**`examples/mdm/`** (see the scope note below)
- `spelunk.env.example` and `spelunk-config.toml` both shipped a non-loopback plaintext
  `http://spelunk.internal:7777`, directly beneath a bearer key. Both are refused by the binary.
  Changed to `https://spelunk.internal` with commented `SPELUNK_SERVER_CA` guidance.

## Scope ruling: expanded scope accepted

The refined story scoped this to `remote-agents.md` and nothing else. That boundary came from a
repo sweep that grepped only `host.docker.internal|172.17.0.1`, so it missed the same defect under a
different hostname. The two `examples/mdm/` files are in.

Accepted rather than split out, on three grounds:

1. **Same defect class, same fix shape.** A shipped, copyable config the binary hard-refuses;
   `http://` to a non-loopback host becomes `https://` plus CA guidance. Not adjacent work.
2. **Strictly higher severity than the original.** The MDM example places the refused URL directly
   under `SPELUNK_SERVER_KEY=...`, which is exactly the exposure the rule exists to prevent, and it
   is fleet-wide policy an admin copies to every machine, not a solo convenience.
3. **Review tractability is unaffected.** 16 lines across two plain config examples, no code, no
   ADR, no runtime surface, same reviewer and same risk profile as the rest of the diff.

A story premised on "we must not ship commands that cannot work" should not close while shipping two
more of them, and the excluding boundary was an oversight in a sweep rather than a deliberate
exclusion. The genuinely deliberate exclusions were respected: the ADRs are immutable and untouched,
and `docs/server.md` / `docs/self-hosting.md` / `docker-compose.yml` are already consistent.

Scope was **not** widened indiscriminately. `docs/architecture/capability-tiers.md` has the same
contradiction in illustrative transcript output, and `config.rs` has a rustdoc example of a refused
URL. Both were left alone as a different shape (stale transcripts, and source rather than docs) and
are tracked separately.

## Test plan

Verified against the installed `spelunk-cli 0.9.4-local`, in a scratch `spelunk init` project
(`check` fail-closes outside one). Every URL the docs now recommend is accepted; every URL the docs
show as refused is refused:

```
ACCEPTED  https://spelunk.example.com
ACCEPTED  https://spelunk.internal
ACCEPTED  https://spelunk.your-domain
ACCEPTED  https://api.spelunk.cloud
ACCEPTED  http://127.0.0.1:7777
REFUSED   http://host.docker.internal:7777
REFUSED   http://172.17.0.1:7777
REFUSED   http://spelunk.internal:7777
```

The error text quoted in the doc matches the binary verbatim:

```
$ SPELUNK_SERVER_URL=http://host.docker.internal:7777 spelunk check
error: invalid server URL "http://host.docker.internal:7777": plaintext http:// is only allowed to
a loopback address (127.0.0.1/::1/localhost); use https:// for any other host
```

The `SPELUNK_SERVER_CA` guidance was verified **from the code, not from the CLI**, because `spelunk
check` degrades to offline before it ever touches the CA. Confirmed directly: a deliberately bogus
`SPELUNK_SERVER_CA=/nonexistent/bogus-ca.pem` with an `https://` URL prints `unreachable, offline
mode` and exits 0, so absence of an error there proves nothing. From source instead:

- `config.rs:555-556` reads `SPELUNK_SERVER_CA` and overrides the `server_ca` config key, covered by
  the `server_ca_env_overrides_config` test.
- `apply_server_ca` calls only `add_root_certificate`, so the bundle is added as a trust anchor on
  top of the built-in roots and verification stays on. The only `danger_accept_invalid_certs` uses
  in the repo are in the server's own TLS test harness, never the client path.
- The "issuing CA, not the leaf" caveat matches the linked `self-hosting.md` section, which explains
  that rustls rejects a self-signed CA cert presented as an end-entity cert.

Other checks:

- Anchor `self-hosting.md#trusting-the-servers-certificate-on-the-client` resolves to the real
  heading `### Trusting the server's certificate on the client`.
- No dangling "see below" / "see above" left after the deletion.
- Independent repo-wide sweep on a broader pattern than the original found nothing else in this
  class. Remaining `http://` non-loopback hits are an immutable ADR, a CHANGELOG entry that quotes
  the URL as the config now refused, and an unrelated Ubuntu ports URI in CI.
- Diff is docs and examples only. No `.rs`, `.sql`, or `Cargo.toml`.
- `main` advanced to `b614004b7` during this sweep (the ADR-068 amendment). Rebased onto it, clean,
  zero conflicts. Checked semantically as well as mechanically: the only file that moved is
  `docs/adr/068-*.md`, with no hits on TLS, transport, loopback, or `server_url`, so nothing that
  merged since the fork changes the contract this documents.
