### PR TITLE
Derive the .deb Depends from the binaries so the installed spelunk actually starts

### DIFF
--- a/.github/scripts/write-deb-control.js
+++ b/.github/scripts/write-deb-control.js
@@ -9,9 +9,13 @@
 // Usage:
 //   node write-deb-control.js \
 //     --deb-version 0.8.1 \
+//     --depends 'libc6 (>= 2.39), libdbus-1-3 (>= 1.9.14)' \
 //     [--out BUILD/DEBIAN/control]
 //
-// DEB_VERSION may also come from the DEB_VERSION env var (flag wins).
+// DEB_VERSION / DEB_DEPENDS may also come from the environment (flag wins).
+//
+// --depends is required and deliberately has no default: it must be derived
+// from the shipped binaries with dpkg-shlibdeps, never hardcoded here.
 //
 // Only Node.js builtins are used (fs, path) — no extra npm dependencies.
 
@@ -47,7 +51,21 @@ function requireValue(name, ...sources) {
   );
 }
 
-function buildControl(debVersion) {
+// Accepts raw `dpkg-shlibdeps -O` output ("shlibs:Depends=…") or a bare list.
+// Must fold to one line: a newline would truncate the field and silently drop
+// the remaining dependencies.
+function normaliseDepends(raw) {
+  const depends = raw
+    .replace(/^shlibs:Depends=/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (depends === "") {
+    throw new Error("--depends resolved to an empty dependency list");
+  }
+  return depends;
+}
+
+function buildControl(debVersion, depends) {
   // Leading whitespace matters for dpkg: field names must start at column 0.
   // The long-description line must be preceded by a single space and exactly
   // one blank line after the short description.
@@ -55,7 +73,7 @@ function buildControl(debVersion) {
 Version: ${debVersion}
 Architecture: amd64
 Maintainer: spelunk-cloud <hello@spelunk.cloud>
-Depends: libc6 (>= 2.17)
+Depends: ${depends}
 Description: Code intelligence for AI agents
  spelunk provides persistent memory, a code graph, and semantic search
  for AI coding agents. Includes the spelunk CLI and spelunk-server.
@@ -73,6 +91,10 @@ function main() {
     env.DEB_VERSION
   );
 
+  const depends = normaliseDepends(
+    requireValue("--depends", args.depends, env.DEB_DEPENDS)
+  );
+
   const outPath = path.resolve(
     requireValue("--out", args.out, "BUILD/DEBIAN/control")
   );
@@ -80,7 +102,7 @@ function main() {
   // Ensure parent directory exists
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
 
-  const control = buildControl(debVersion);
+  const control = buildControl(debVersion, depends);
 
   fs.writeFileSync(outPath, control, "utf8");
   process.stdout.write(`Wrote ${outPath}\n`);

--- a/.github/scripts/write-deb-control.test.js
+++ b/.github/scripts/write-deb-control.test.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+//
+// Guard rails for write-deb-control.js.
+// Run: node --test .github/scripts/write-deb-control.test.js
+// (--test won't discover inside a dot-directory, so name the file.)
+//
+// node:test is a Node builtin, so this needs no package.json and no install.
+// Black-box over the subprocess because that is the contract release.yml uses.
+//
+// Every case here is one way `Depends:` could go stale, blank, or truncated —
+// the failure mode that shipped a .deb missing libdbus-1-3.
+
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const SCRIPT = path.join(__dirname, "write-deb-control.js");
+
+function run({ args = [], env = {} } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "deb-control-"));
+  const out = path.join(dir, "control");
+  const res = spawnSync(process.execPath, [SCRIPT, ...args, "--out", out], {
+    encoding: "utf8",
+    // Blank the inherited DEB_* so an ambient value can't mask a missing input.
+    env: { ...process.env, DEB_VERSION: "", DEB_DEPENDS: "", ...env },
+  });
+  const control = fs.existsSync(out) ? fs.readFileSync(out, "utf8") : null;
+  fs.rmSync(dir, { recursive: true, force: true });
+  return { status: res.status, stderr: res.stderr, control };
+}
+
+const dependsLine = (control) =>
+  control.split("\n").find((l) => l.startsWith("Depends:"));
+
+test("--depends has no default: refuses rather than emitting a stale list", () => {
+  const r = run({ args: ["--deb-version", "0.9.3"] });
+  assert.equal(r.status, 1);
+  assert.equal(r.control, null, "must not write a control file");
+  assert.match(r.stderr, /--depends/);
+});
+
+test("an empty derived list fails instead of writing a blank Depends", () => {
+  for (const depends of ["   ", "\n", "shlibs:Depends="]) {
+    const r = run({ args: ["--deb-version", "0.9.3", "--depends", depends] });
+    assert.equal(r.status, 1, `expected failure for ${JSON.stringify(depends)}`);
+    assert.equal(r.control, null);
+  }
+});
+
+test("folds dpkg-shlibdeps -O output onto one line, prefix stripped", () => {
+  // A newline would end the field and silently drop the rest of the deps.
+  const r = run({
+    env: {
+      DEB_VERSION: "0.9.3",
+      DEB_DEPENDS:
+        "shlibs:Depends=libc6 (>= 2.39),\nlibdbus-1-3 (>= 1.9.14),\nlibgcc-s1 (>= 4.2)",
+    },
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(
+    dependsLine(r.control),
+    "Depends: libc6 (>= 2.39), libdbus-1-3 (>= 1.9.14), libgcc-s1 (>= 4.2)"
+  );
+});

--- a/.github/scripts/write-deb-control.test.js
+++ b/.github/scripts/write-deb-control.test.js
@@ -7,7 +7,7 @@
 // node:test is a Node builtin, so this needs no package.json and no install.
 // Black-box over the subprocess because that is the contract release.yml uses.
 //
-// Every case here is one way `Depends:` could go stale, blank, or truncated —
+// Every case here is one way `Depends:` could go stale, blank, or truncated –
 // the failure mode that shipped a .deb missing libdbus-1-3.
 
 "use strict";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,18 @@ jobs:
       - name: Run doctests
         run: cargo test --doc ${{ matrix.test-flags }}
 
+  release-scripts:
+    name: Release script tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      # The packaging scripts only otherwise run at release-tag time, where a
+      # break is expensive. node:test is a builtin: nothing to install.
+      - name: Test packaging scripts
+        run: node --test .github/scripts/write-deb-control.test.js
+
   docker-build:
     name: Docker image build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,19 @@ jobs:
         run: |
           dpkg-deb --build BUILD "spelunk_${{ env.DEB_VERSION }}_amd64.deb"
 
+      # apt-get install SUCCEEDS on a .deb whose Depends omits a linked library;
+      # only executing the binary resolves its NEEDED libs and surfaces the gap.
+      # Pinned to 24.04: it supplies the GLIBC_2.39 the derived libc6 floor
+      # targets, so a failure here means the .deb no longer installs on it.
+      - name: Smoke-test the .deb in a clean container
+        run: |
+          docker run --rm -v "$PWD:/w" -w /w ubuntu:24.04 bash -euc '
+            apt-get update -qq
+            apt-get install -y -qq ./spelunk_${{ env.DEB_VERSION }}_amd64.deb
+            test -n "$(spelunk --version)"
+            test -n "$(spelunk-server --version)"
+          '
+
       - name: Upload deb artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,16 @@ jobs:
           tar -xzf linux-amd64/spelunk-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz \
             -C linux-amd64
 
+      # dpkg-shlibdeps can only map a linked library to its owning package if
+      # that package is installed here, so the binaries' runtime libs must be
+      # present on this runner even though nothing is compiled in this job.
+      - name: Install packaging tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            dpkg-dev \
+            libdbus-1-3
+
       - name: Assemble deb layout
         run: |
           VERSION="${{ github.ref_name }}"
@@ -188,7 +198,20 @@ jobs:
           install -m 644 packaging/spelunk-server.service \
             BUILD/usr/lib/systemd/user/spelunk-server.service
 
+          # Depends is derived from the packaged binaries, never hardcoded.
+          # dpkg-shlibdeps needs a debian/control in its working dir, and errors
+          # out if a linked library maps to no installed package.
+          mkdir -p shlibdeps/debian
+          printf 'Source: spelunk\nMaintainer: spelunk-cloud <hello@spelunk.cloud>\n\nPackage: spelunk\nArchitecture: amd64\nDescription: placeholder\n placeholder\n' \
+            > shlibdeps/debian/control
+          DEB_DEPENDS="$(cd shlibdeps && dpkg-shlibdeps -O \
+            ../BUILD/usr/bin/spelunk \
+            ../BUILD/usr/bin/spelunk-server)"
+          rm -rf shlibdeps
+          echo "Derived ${DEB_DEPENDS}"
+
           # DEBIAN/control — written via JS to avoid YAML heredoc issues
+          DEB_DEPENDS="${DEB_DEPENDS}" \
           node .github/scripts/write-deb-control.js \
             --deb-version "${DEB_VERSION}" \
             --out BUILD/DEBIAN/control

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,20 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The Debian package no longer installs a `spelunk` that cannot start.** The
+  `.deb` declared `libc6` as its only dependency, omitting `libdbus-1-3`, which
+  the `spelunk` binary dynamically links via the keyring's secret-service
+  backend. On a machine without libdbus already present the install *reported
+  success* and the binary then failed to load with `libdbus-1.so.3: cannot open
+  shared object file` (exit 127). `Depends:` is now derived from the packaged
+  binaries at release time with `dpkg-shlibdeps` instead of being hand-written,
+  so it lists every shared library they actually link (`libc6`, `libdbus-1-3`,
+  and `libgcc-s1`) and the package manager pulls them in. The declared `libc6`
+  floor now also reflects the glibc the release binaries are built against
+  (2.39), so a system with an older glibc gets an accurate refusal at install
+  time rather than a package that installs and then crashes. A release-pipeline
+  check now installs the `.deb` in a clean container and runs both binaries, so
+  a missing dependency fails the build instead of shipping.
 - **The self-hosted Docker Quick-Start builds and runs again.** The `Dockerfile`
   now builds the Cargo workspace (per-crate manifests, `crates/spelunk-server`
   binary) instead of the old single-crate layout, and installs the C/C++

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -102,9 +102,15 @@ for `<version>` (e.g. `0.8.0`). The download path is pinned to the release tag
 
 ```bash
 curl -fsSLO https://github.com/spelunk-cloud/spelunk/releases/download/v<version>/spelunk_<version>_amd64.deb
-sudo dpkg -i spelunk_<version>_amd64.deb
+sudo apt install ./spelunk_<version>_amd64.deb
 spelunk --version
 ```
+
+> Install with `apt`, not `dpkg -i`. The package declares the shared libraries
+> the binaries link against (including `libdbus-1-3`); `apt` pulls those in,
+> whereas `dpkg -i` does not resolve dependencies and leaves the package
+> unconfigured on a machine that lacks them. The leading `./` is required, or
+> `apt` treats the argument as a package name instead of a file.
 
 ### Manual tarball / zip (any platform)
 


### PR DESCRIPTION
## Why

The release `.deb` declared `Depends: libc6 (>= 2.17)` and nothing else. That was wrong twice: it omitted `libdbus-1-3` (the `spelunk` CLI links libdbus via the keyring's secret-service backend), and it understated the glibc floor (release binaries are built on `ubuntu-latest`, so they need GLIBC_2.39).

The failure mode is nasty: **`apt` reports success and the binary then fails to load.** Nothing in the pipeline installed the artifact, so this shipped.

`Depends:` is now derived from the packaged binaries with `dpkg-shlibdeps` at release time instead of being hand-written, and a clean-container smoke test now *executes* both binaries before the artifact is uploaded.

## The bug, reproduced against the shipped v0.9.3 artifact

Not a hypothetical. Downloading the `.deb` this pipeline actually published and installing it on a clean `ubuntu:24.04`:

```
$ dpkg-deb -I spelunk_0.9.3_amd64.deb | grep Depends
 Depends: libc6 (>= 2.17)

$ apt-get install -y ./spelunk_0.9.3_amd64.deb
apt exit code: 0                       <-- reports success

$ spelunk --version
spelunk: error while loading shared libraries: libdbus-1.so.3:
  cannot open shared object file: No such file or directory
exit: 127
```

The understated glibc floor is the same story on `ubuntu:22.04` (glibc 2.35), where `>= 2.17` is satisfied so apt installs happily:

```
$ apt-get install -y ./spelunk_0.9.3_amd64.deb   # exit 0
$ spelunk-server --version
spelunk-server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
exit: 1
```

## What changed

- **`write-deb-control.js`** takes `--depends`, required, with no default: it exits 1 rather than emitting a stale hardcoded list. Folds `dpkg-shlibdeps -O` output to one line (a newline would truncate the field and silently drop the rest).
- **`release.yml`** derives `Depends:` via `dpkg-shlibdeps` in the `deb` job, installs the binaries' runtime libs on the runner so shlibdeps can map them to packages, and smoke-tests the `.deb` in a clean `ubuntu:24.04` container before `Upload deb artifact`.
- **`ci.yml`** runs the packaging script tests on every push, since these scripts otherwise only execute at release-tag time where a break is expensive.
- **`docs/getting-started.md`** switches the documented install from `dpkg -i` to `apt install ./…` (see below).
- **CHANGELOG** entry under `### Fixed`.

## Test plan

Verification was done independently against real pipeline-built binaries (the v0.9.3 `x86_64-unknown-linux-gnu` release tarball), not a local build, replaying the exact `release.yml` steps in `ubuntu:24.04`. Binaries confirmed real by size and output (63MB / 14MB, `spelunk --help` renders the real CLI) rather than by exit code alone.

**1. The derived `Depends:` is what we claim.** Real `dpkg-shlibdeps -O` output against the shipped binaries:

```
shlibs:Depends=libc6 (>= 2.39), libdbus-1-3 (>= 1.9.14), libgcc-s1 (>= 4.2)
```

producing:

```
Package: spelunk
Version: 0.9.3
Architecture: amd64
Maintainer: spelunk-cloud <hello@spelunk.cloud>
Depends: libc6 (>= 2.39), libdbus-1-3 (>= 1.9.14), libgcc-s1 (>= 4.2)
```

**2. The fixed `.deb` installs and runs on a clean `ubuntu:24.04`** with no libdbus present beforehand:

```
libdbus present before install? NO
apt exit code: 0
libdbus pulled in?  install ok installed

$ spelunk --version
spelunk-cli 0.9.3
exit: 0
$ spelunk-server --version
spelunk-server 0.9.3
exit: 0
```

**3. Older distros now refuse cleanly instead of installing and crashing.** Fixed `.deb` on `ubuntu:22.04` (glibc 2.35) and `debian:bookworm` (glibc 2.36):

```
E: Unable to correct problems, you have held broken packages.
apt exit: 100
installed? [NOT-INSTALLED]
```

**4. `node --test .github/scripts/write-deb-control.test.js`**: 3 tests, 3 pass, 0 fail. Omitting `--depends` exits 1 and writes no control file; an empty or `shlibs:Depends=`-only value exits 1; multi-line shlibdeps output folds to a single field.

**5. Workflow structure.** Both `release.yml` and `ci.yml` parse. The `deb` job step order puts `Smoke-test the .deb in a clean container` (step 6) before `Upload deb artifact` (step 7), so a missing dependency fails the build instead of shipping.

## The doc change is load-bearing, not cosmetic

`docs/getting-started.md` documented `sudo dpkg -i`, which does **not** resolve dependencies. An honestly-declared `libdbus-1-3` therefore breaks the previously documented command. Verified on the fixed `.deb`:

```
$ dpkg -i ./spelunk_0.9.3_amd64.deb
dpkg: dependency problems prevent configuration of spelunk:
 spelunk depends on libdbus-1-3 (>= 1.9.14); however:
  Package libdbus-1-3 is not installed.
dpkg: error processing package spelunk (--install):
 dependency problems - leaving unconfigured
exit: 1

package status: install ok unpacked   (iU)
$ spelunk --version    # still broken
exit: 127
```

So the dependency fix shipped alone would have traded one broken install path for another. The doc now points at `apt install ./…`, which is the same path CI smoke-tests.

## Open product question, not blocking this PR

The `.deb` now correctly refuses to install on Debian bookworm (glibc 2.36) and Ubuntu 22.04 (glibc 2.35). `README.md`, `docs/getting-started.md`, `docs/README.md` and `examples/mdm/README.md` all promise Debian/Ubuntu support with no glibc floor stated, so that promise is now overpromised.

This PR deliberately does not resolve it. "Which distros do we support" is a product call, not something to invent in a packaging fix, and the new behaviour is strictly better than the status quo either way: an accurate refusal at install time beats a package that installs and then crashes. Tracked separately as `^184` for a decision on the support floor, which may mean building on an older runner image, documenting the floor, or dropping the claim. Worth your call there.

Two smaller judgement calls, both settled in review:

- **The `ubuntu:24.04` pin in the smoke test is deliberate** and encodes the support floor. If `ubuntu-latest` moves to a newer image, the derived `libc6` floor rises and this step fails. That failure is correct and informative: it means the `.deb` silently stopped installing on 24.04, and it forces a deliberate decision at release time rather than a silent drop discovered by users. Same question as `^184`.
- **`normaliseDepends` strips only a leading `shlibs:Depends=`.** A hypothetical second substvar line would splice into the field. Confirmed theoretical: `dpkg-shlibdeps -O` with our invocation emits a single substvar, and if it ever did splice it fails loudly rather than shipping quietly, since `dpkg-deb --build` rejects the malformed field (`syntax error after reference to package 'libc6'`, exit 2). No guard added.

## Note on the base

`main` advanced to `b614004b7` (PR #598, ADR-068 amendment) while this branch was in flight. Merged in; the merge was clean and touched only a new ADR doc with no overlap with the six files here. Checked semantically as well as textually: #598 is memory identity, unrelated to packaging contracts. All verification above was re-run after the merge.
