### PR TITLE
Pool convention confidence across .ts/.tsx instead of taking the max of splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,19 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   before storage, so overlapping generic and language-specific rules (for
   example `naming.functions` and `docs`) each surface once instead of two or
   three times.
+- **`spelunk context` no longer lists `.tsx` conventions twice, and no longer
+  overstates their confidence.** Conventions from `.tsx` files surfaced under
+  both a `typescript` and a `tsx` label, because the TypeScript rule set labelled
+  every record `typescript` while the generic rules labelled by the chunk's own
+  language. `.tsx` now folds onto the `typescript` label it already shares
+  heuristics with, so each convention appears once. The two labels had also held
+  separate partial views of a single language, and merging them kept the *higher*
+  of the two confidences: a project with 9 async functions out of 16 reported
+  `async` at 100% instead of 56%. Confidence is now pooled across all of a
+  language's chunks, so mixed `.ts`/`.tsx` projects may see reported confidence
+  drop. The lower figure is the accurate one, and no conventions are lost.
+  `spelunk plumbing read-conventions --lang tsx` now matches no rows (exit 1);
+  use `--lang typescript`.
 - **`spelunk server stop` reliably terminates a wedged local server.** A daemon
   whose `/v1/health` had stopped responding could not be stopped and was
   silently orphaned across a `stop && start`. `stop` now recognises a hung

--- a/crates/spelunk-core/src/conventions/extractor.rs
+++ b/crates/spelunk-core/src/conventions/extractor.rs
@@ -32,26 +32,27 @@ impl ConventionExtractor {
             .map(|d| d.as_secs() as i64)
             .unwrap_or(0);
 
-        // Group chunks by language.
+        // Group by canonical language, so every rule set sees one group per label.
         let mut by_lang: std::collections::HashMap<&str, Vec<&ChunkSummary>> =
             std::collections::HashMap::new();
         for c in chunks {
-            by_lang.entry(c.language.as_str()).or_default().push(c);
+            by_lang
+                .entry(canonical_language(&c.language))
+                .or_default()
+                .push(c);
         }
 
-        // Both the language-specific set and the always-run generic set emit
-        // overlapping categories (naming.functions, docs); tsx chunks also route
-        // through the typescript set, which self-labels every record "typescript",
-        // colliding with the typescript group. Tag each record with its source so
-        // the merge below can prefer language-specific over generic.
+        // The language-specific set and the always-run generic set emit
+        // overlapping categories (naming.functions, docs). Tag each record with
+        // its source so the merge below can prefer language-specific over generic.
         let mut tagged: Vec<(Source, ConventionRecord)> = Vec::new();
         for (lang, lang_chunks) in &by_lang {
-            let is_specific = matches!(*lang, "rust" | "typescript" | "tsx");
             let specific = match *lang {
-                "rust" => Some(rules::rust::extract(lang_chunks, now)),
-                "typescript" | "tsx" => Some(rules::typescript::extract(lang_chunks, now)),
+                "rust" => Some(rules::rust::extract(lang_chunks, lang, now)),
+                "typescript" => Some(rules::typescript::extract(lang_chunks, lang, now)),
                 _ => None,
             };
+            let is_specific = specific.is_some();
             if let Some(recs) = specific {
                 tagged.extend(recs.into_iter().map(|r| (Source::LanguageSpecific, r)));
             }
@@ -63,13 +64,23 @@ impl ConventionExtractor {
                 Source::LanguageSpecific
             };
             tagged.extend(
-                rules::generic::extract(lang_chunks, now)
+                rules::generic::extract(lang_chunks, lang, now)
                     .into_iter()
                     .map(|r| (source, r)),
             );
         }
 
         dedup_by_language_category(tagged)
+    }
+}
+
+/// Fold dialects onto the language they share conventions with.
+/// tsx is typescript plus JSX: naming, async, testing and docs are identical,
+/// so both surface under one label instead of duplicating every record.
+fn canonical_language(lang: &str) -> &str {
+    match lang {
+        "tsx" => "typescript",
+        other => other,
     }
 }
 
@@ -86,8 +97,7 @@ enum Source {
 ///
 /// Language-specific records win over generic ones. Between two records of the
 /// same source, the higher-confidence description is kept and evidence counts
-/// are summed (e.g. tsx chunks routed through the typescript set). Output is
-/// ordered by `(language, category)` for determinism.
+/// are summed. Output is ordered by `(language, category)` for determinism.
 fn dedup_by_language_category(tagged: Vec<(Source, ConventionRecord)>) -> Vec<ConventionRecord> {
     use std::collections::BTreeMap;
 

--- a/crates/spelunk-core/src/conventions/extractor.rs
+++ b/crates/spelunk-core/src/conventions/extractor.rs
@@ -95,9 +95,10 @@ enum Source {
 
 /// Collapse records to one per `(language, category)`.
 ///
-/// Language-specific records win over generic ones. Between two records of the
-/// same source, the higher-confidence description is kept and evidence counts
-/// are summed. Output is ordered by `(language, category)` for determinism.
+/// Language-specific records win over generic ones. Two records of the same
+/// source cannot collide: there is one group per canonical language, each rule
+/// set labels with that group's language and emits each category at most once.
+/// Output is ordered by `(language, category)` for determinism.
 fn dedup_by_language_category(tagged: Vec<(Source, ConventionRecord)>) -> Vec<ConventionRecord> {
     use std::collections::BTreeMap;
 
@@ -109,19 +110,14 @@ fn dedup_by_language_category(tagged: Vec<(Source, ConventionRecord)>) -> Vec<Co
                 merged.insert(key, (source, rec));
             }
             Some((kept_source, kept)) => {
+                // Language-specific replaces generic outright; the reverse is
+                // discarded. Never merge two partial views: confidence is a rate
+                // over a group's chunks, so it is only correct when pooled by the
+                // rule set itself, not recombined here.
                 if source == Source::LanguageSpecific && *kept_source == Source::Generic {
-                    // Language-specific replaces generic outright.
                     *kept_source = source;
                     *kept = rec;
-                } else if source == *kept_source {
-                    // Same source: aggregate evidence, keep higher-confidence fields.
-                    kept.evidence_count = kept.evidence_count.saturating_add(rec.evidence_count);
-                    if rec.confidence > kept.confidence {
-                        kept.description = rec.description;
-                        kept.confidence = rec.confidence;
-                    }
                 }
-                // else: incoming is Generic, kept is LanguageSpecific — discard.
             }
         }
     }

--- a/crates/spelunk-core/src/conventions/rules/generic.rs
+++ b/crates/spelunk-core/src/conventions/rules/generic.rs
@@ -7,13 +7,7 @@ use super::{
     naming_record,
 };
 
-pub fn extract(chunks: &[&ChunkSummary], now: i64) -> Vec<ConventionRecord> {
-    // Use the first chunk's language as the label (all chunks here share it).
-    let lang = chunks
-        .first()
-        .map(|c| c.language.as_str())
-        .unwrap_or("unknown");
-
+pub fn extract(chunks: &[&ChunkSummary], lang: &str, now: i64) -> Vec<ConventionRecord> {
     let mut records = Vec::new();
 
     // ── naming.functions ─────────────────────────────────────────────────────

--- a/crates/spelunk-core/src/conventions/rules/rust.rs
+++ b/crates/spelunk-core/src/conventions/rules/rust.rs
@@ -39,8 +39,7 @@ impl RustPatterns {
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
-pub fn extract(chunks: &[&ChunkSummary], now: i64) -> Vec<ConventionRecord> {
-    let lang = "rust";
+pub fn extract(chunks: &[&ChunkSummary], lang: &str, now: i64) -> Vec<ConventionRecord> {
     let mut records = Vec::new();
 
     // ── naming.functions ─────────────────────────────────────────────────────

--- a/crates/spelunk-core/src/conventions/rules/rust.rs
+++ b/crates/spelunk-core/src/conventions/rules/rust.rs
@@ -66,17 +66,17 @@ pub fn extract(chunks: &[&ChunkSummary], lang: &str, now: i64) -> Vec<Convention
     }
 
     // ── error_handling ────────────────────────────────────────────────────────
-    if let Some(r) = error_handling_record(chunks, now) {
+    if let Some(r) = error_handling_record(chunks, lang, now) {
         records.push(r);
     }
 
     // ── async ─────────────────────────────────────────────────────────────────
-    if let Some(r) = async_record(chunks, now) {
+    if let Some(r) = async_record(chunks, lang, now) {
         records.push(r);
     }
 
     // ── testing ───────────────────────────────────────────────────────────────
-    if let Some(r) = testing_record(chunks, now) {
+    if let Some(r) = testing_record(chunks, lang, now) {
         records.push(r);
     }
 
@@ -99,7 +99,11 @@ pub fn extract(chunks: &[&ChunkSummary], lang: &str, now: i64) -> Vec<Convention
 
 // ── Private helpers ───────────────────────────────────────────────────────────
 
-fn error_handling_record(chunks: &[&ChunkSummary], now: i64) -> Option<ConventionRecord> {
+fn error_handling_record(
+    chunks: &[&ChunkSummary],
+    lang: &str,
+    now: i64,
+) -> Option<ConventionRecord> {
     let p = patterns();
     let mut anyhow_count = 0u32;
     let mut thiserror_count = 0u32;
@@ -142,7 +146,7 @@ fn error_handling_record(chunks: &[&ChunkSummary], now: i64) -> Option<Conventio
 
     let confidence = dominant_count as f32 / total as f32;
     Some(ConventionRecord {
-        language: "rust".to_string(),
+        language: lang.to_string(),
         category: "error_handling".to_string(),
         description,
         confidence,
@@ -151,7 +155,7 @@ fn error_handling_record(chunks: &[&ChunkSummary], now: i64) -> Option<Conventio
     })
 }
 
-fn async_record(chunks: &[&ChunkSummary], now: i64) -> Option<ConventionRecord> {
+fn async_record(chunks: &[&ChunkSummary], lang: &str, now: i64) -> Option<ConventionRecord> {
     let p = patterns();
     let function_chunks: Vec<_> = chunks
         .iter()
@@ -183,7 +187,7 @@ fn async_record(chunks: &[&ChunkSummary], now: i64) -> Option<ConventionRecord> 
     let confidence = ratio;
 
     Some(ConventionRecord {
-        language: "rust".to_string(),
+        language: lang.to_string(),
         category: "async".to_string(),
         description: format!("Async runtime: {runtime}"),
         confidence,
@@ -192,7 +196,7 @@ fn async_record(chunks: &[&ChunkSummary], now: i64) -> Option<ConventionRecord> 
     })
 }
 
-fn testing_record(chunks: &[&ChunkSummary], now: i64) -> Option<ConventionRecord> {
+fn testing_record(chunks: &[&ChunkSummary], lang: &str, now: i64) -> Option<ConventionRecord> {
     let p = patterns();
     // Detect files in test locations.
     let test_files_count = chunks
@@ -228,7 +232,7 @@ fn testing_record(chunks: &[&ChunkSummary], now: i64) -> Option<ConventionRecord
 
     let confidence = dominant_count as f32 / total as f32;
     Some(ConventionRecord {
-        language: "rust".to_string(),
+        language: lang.to_string(),
         category: "testing".to_string(),
         description,
         confidence,

--- a/crates/spelunk-core/src/conventions/rules/typescript.rs
+++ b/crates/spelunk-core/src/conventions/rules/typescript.rs
@@ -27,8 +27,7 @@ impl TsPatterns {
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
-pub fn extract(chunks: &[&ChunkSummary], now: i64) -> Vec<ConventionRecord> {
-    let lang = "typescript";
+pub fn extract(chunks: &[&ChunkSummary], lang: &str, now: i64) -> Vec<ConventionRecord> {
     let mut records = Vec::new();
 
     // ── naming.functions ─────────────────────────────────────────────────────

--- a/crates/spelunk-core/tests/conventions.rs
+++ b/crates/spelunk-core/tests/conventions.rs
@@ -60,6 +60,17 @@ fn ts_class(name: &str) -> ChunkSummary {
     }
 }
 
+fn tsx_fn(name: &str, content: &str) -> ChunkSummary {
+    ChunkSummary {
+        language: "tsx".into(),
+        node_type: "function".into(),
+        name: Some(name.into()),
+        content: content.into(),
+        file_path: "src/App.tsx".into(),
+        has_docstring: content.trim_start().starts_with("/**"),
+    }
+}
+
 fn find_record<'a>(
     records: &'a [ConventionRecord],
     category: &str,
@@ -278,16 +289,14 @@ fn extractor_dedups_language_category() {
             )
         })
         .collect();
-    // tsx chunks: the typescript rule set self-labels these "typescript", so
-    // without dedup they collide with the ts group's records.
+    // tsx chunks canonicalize onto the typescript label, so without dedup they
+    // collide with the ts group's records.
     let tsx_chunks: Vec<ChunkSummary> = (0..10)
-        .map(|i| ChunkSummary {
-            language: "tsx".into(),
-            node_type: "function".into(),
-            name: Some(format!("renderThing{i}")),
-            content: "/** doc */\nfunction renderThing() {}".into(),
-            file_path: "src/App.tsx".into(),
-            has_docstring: true,
+        .map(|i| {
+            tsx_fn(
+                &format!("renderThing{i}"),
+                "/** doc */\nfunction renderThing() {}",
+            )
         })
         .collect();
 
@@ -384,23 +393,15 @@ fn extractor_language_specific_wins_over_generic() {
     );
 }
 
-/// Same-source duplicates aggregate evidence. tsx chunks route through the
-/// typescript set (self-labelled "typescript") — both are LanguageSpecific — so
-/// their `naming.functions` evidence is summed into one record (5 ts + 5 tsx).
+/// .ts and .tsx chunks land in one canonical group, so a single
+/// `naming.functions` record counts all of them (5 ts + 5 tsx).
 #[test]
-fn extractor_sums_evidence_across_ts_and_tsx() {
+fn extractor_pools_evidence_across_ts_and_tsx() {
     let ts_chunks: Vec<ChunkSummary> = (0..5)
         .map(|i| ts_fn(&format!("getThing{i}"), "function getThing() {}"))
         .collect();
     let tsx_chunks: Vec<ChunkSummary> = (0..5)
-        .map(|i| ChunkSummary {
-            language: "tsx".into(),
-            node_type: "function".into(),
-            name: Some(format!("renderThing{i}")),
-            content: "function renderThing() {}".into(),
-            file_path: "src/App.tsx".into(),
-            has_docstring: false,
-        })
+        .map(|i| tsx_fn(&format!("renderThing{i}"), "function renderThing() {}"))
         .collect();
     let all: Vec<ChunkSummary> = ts_chunks.into_iter().chain(tsx_chunks).collect();
 
@@ -414,7 +415,7 @@ fn extractor_sums_evidence_across_ts_and_tsx() {
     );
     assert_eq!(
         naming[0].evidence_count, 10,
-        "ts (5) + tsx (5) same-source evidence must sum to 10"
+        "ts (5) + tsx (5) evidence must pool to 10"
     );
     assert!(
         !records.iter().any(|r| r.language == "tsx"),
@@ -439,14 +440,7 @@ fn extractor_extract_is_deterministic() {
         })
         .collect();
     let tsx_chunks: Vec<ChunkSummary> = (0..8)
-        .map(|i| ChunkSummary {
-            language: "tsx".into(),
-            node_type: "function".into(),
-            name: Some(format!("renderThing{i}")),
-            content: "function renderThing() {}".into(),
-            file_path: "src/App.tsx".into(),
-            has_docstring: false,
-        })
+        .map(|i| tsx_fn(&format!("renderThing{i}"), "function renderThing() {}"))
         .collect();
     let all: Vec<ChunkSummary> = rust_chunks
         .into_iter()
@@ -472,9 +466,13 @@ fn extractor_extract_is_deterministic() {
     );
 }
 
-/// No regression for generic-only languages: go/js/ruby have no dedicated rule
-/// set, so they flow through the generic set alone. Dedup must not drop their
-/// legitimate distinct records.
+/// No regression for generic-only languages: go/js/jsx/ruby have no dedicated
+/// rule set, so they flow through the generic set alone. Dedup must not drop
+/// their legitimate distinct records.
+///
+/// jsx keeps its own label: only tsx is canonicalized, because only tsx routes
+/// through a language-specific set and so could surface under two labels.
+/// Folding jsx into javascript would pool their evidence here instead.
 #[test]
 fn extractor_preserves_generic_only_languages() {
     fn fn_chunk(lang: &str, name: &str) -> ChunkSummary {
@@ -492,12 +490,13 @@ fn extractor_preserves_generic_only_languages() {
     for i in 0..6 {
         all.push(fn_chunk("go", &format!("HandleRequest{i}"))); // PascalCase
         all.push(fn_chunk("javascript", &format!("handleClick{i}"))); // camelCase
+        all.push(fn_chunk("jsx", &format!("renderRow{i}"))); // camelCase
         all.push(fn_chunk("ruby", &format!("handle_request_{i}"))); // snake_case
     }
 
     let records = ConventionExtractor::new().extract(&all);
 
-    for lang in ["go", "javascript", "ruby"] {
+    for lang in ["go", "javascript", "jsx", "ruby"] {
         let naming = find_lang_cat(&records, lang, "naming.functions");
         assert_eq!(
             naming.len(),
@@ -513,14 +512,7 @@ fn extractor_preserves_generic_only_languages() {
 #[test]
 fn extractor_tsx_conventions_canonicalize_onto_typescript_label_only() {
     let tsx_chunks: Vec<ChunkSummary> = (0..8)
-        .map(|i| ChunkSummary {
-            language: "tsx".into(),
-            node_type: "function".into(),
-            name: Some(format!("renderThing{i}")),
-            content: "function renderThing() {}".into(),
-            file_path: "src/App.tsx".into(),
-            has_docstring: false,
-        })
+        .map(|i| tsx_fn(&format!("renderThing{i}"), "function renderThing() {}"))
         .collect();
 
     let records = ConventionExtractor::new().extract(&tsx_chunks);
@@ -543,6 +535,68 @@ fn extractor_tsx_conventions_canonicalize_onto_typescript_label_only() {
     assert!(
         !records.iter().any(|r| r.language == "tsx"),
         "no category may carry the tsx label"
+    );
+}
+
+/// Confidence must describe the whole corpus, not the most extreme dialect.
+///
+/// Splitting .ts from .tsx produced two partial `async` views that the merge
+/// collapsed by keeping the *higher* confidence, so a small all-async .tsx group
+/// made "async/await is widely used" read 100% when only 9 of 16 functions were
+/// async. Pooling the evidence before the rate is computed is what keeps the
+/// number honest, and it is what `spelunk context` reports to an agent.
+#[test]
+fn extractor_async_confidence_pools_evidence_rather_than_taking_max_of_splits() {
+    // 10 .ts functions, 3 async.
+    let ts_chunks: Vec<ChunkSummary> = (0..10)
+        .map(|i| {
+            let content = if i < 3 {
+                format!("async function loadThing{i}() {{ await fetch('/api'); }}")
+            } else {
+                format!("function getThing{i}() {{ return 1; }}")
+            };
+            ts_fn(&format!("thing{i}"), &content)
+        })
+        .collect();
+    // 6 .tsx functions, all async: the lopsided split that used to win outright.
+    let tsx_chunks: Vec<ChunkSummary> = (0..6)
+        .map(|i| {
+            tsx_fn(
+                &format!("renderThing{i}"),
+                &format!("async function renderThing{i}() {{ await load(); }}"),
+            )
+        })
+        .collect();
+
+    let all: Vec<ChunkSummary> = ts_chunks
+        .iter()
+        .cloned()
+        .chain(tsx_chunks.iter().cloned())
+        .collect();
+    let records = ConventionExtractor::new().extract(&all);
+
+    let async_recs = find_lang_cat(&records, "typescript", "async");
+    assert_eq!(async_recs.len(), 1, "typescript async must be unique");
+    let pooled = async_recs[0];
+
+    assert_eq!(pooled.evidence_count, 9, "3 ts + 6 tsx async functions");
+    assert!(
+        (pooled.confidence - 9.0 / 16.0).abs() < 1e-6,
+        "confidence must be the pooled 9/16 rate, got {}",
+        pooled.confidence
+    );
+
+    // Extracting the .tsx chunks alone reproduces the split whose 100% used to
+    // be adopted wholesale.
+    let tsx_refs: Vec<&ChunkSummary> = tsx_chunks.iter().collect();
+    let split = spelunk_core::conventions::rules::typescript::extract(&tsx_refs, "typescript", 0);
+    let split_async = find_record(&split, "async").expect("tsx-only async record");
+    assert_eq!(split_async.confidence, 1.0, "tsx-only split is 100% async");
+    assert!(
+        pooled.confidence < split_async.confidence,
+        "pooled confidence ({}) must not inherit the max-of-splits value ({})",
+        pooled.confidence,
+        split_async.confidence
     );
 }
 

--- a/crates/spelunk-core/tests/conventions.rs
+++ b/crates/spelunk-core/tests/conventions.rs
@@ -75,7 +75,7 @@ fn rust_functions_snake_case() {
         .map(|i| rust_fn(&format!("do_thing_{i}"), "fn do_thing() {}"))
         .collect();
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, "rust", 0);
     let r = find_record(&records, "naming.functions").expect("naming.functions record");
     assert!(r.confidence >= 0.9, "confidence={}", r.confidence);
     assert!(
@@ -92,7 +92,7 @@ fn rust_types_pascal_case() {
         .map(|n| rust_struct(n))
         .collect();
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, "rust", 0);
     let r = find_record(&records, "naming.types").expect("naming.types record");
     assert!(
         r.description.contains("PascalCase"),
@@ -106,7 +106,7 @@ fn rust_error_handling_anyhow() {
     let content = "use anyhow::Result; fn foo() -> Result<()> { Ok(()) }";
     let chunks: Vec<ChunkSummary> = (0..8).map(|_| rust_fn("foo", content)).collect();
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, "rust", 0);
     let r = find_record(&records, "error_handling").expect("error_handling record");
     assert!(r.description.contains("anyhow"), "desc={}", r.description);
 }
@@ -116,7 +116,7 @@ fn rust_async_runtime_detected() {
     let content = "use tokio::time; async fn handler() { tokio::spawn(async {}); }";
     let chunks: Vec<ChunkSummary> = (0..6).map(|_| rust_fn("handler", content)).collect();
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, "rust", 0);
     let r = find_record(&records, "async").expect("async record");
     assert!(r.description.contains("tokio"), "desc={}", r.description);
 }
@@ -132,7 +132,7 @@ fn rust_testing_cfg_test() {
         })
         .collect();
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, "rust", 0);
     let r = find_record(&records, "testing").expect("testing record");
     assert!(
         r.description.contains("cfg(test)"),
@@ -148,7 +148,7 @@ fn rust_doc_coverage_high() {
         .chain((0..2).map(|i| rust_fn(&format!("undoc_{i}"), "fn undoc() {}")))
         .collect();
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let records = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let records = spelunk_core::conventions::rules::rust::extract(&refs, "rust", 0);
     let r = find_record(&records, "docs").expect("docs record");
     assert!(r.description.contains("high"), "desc={}", r.description);
 }
@@ -170,7 +170,7 @@ fn ts_functions_camel_case() {
     .map(|n| ts_fn(n, &format!("function {n}() {{}}")))
     .collect();
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let records = spelunk_core::conventions::rules::typescript::extract(&refs, 0);
+    let records = spelunk_core::conventions::rules::typescript::extract(&refs, "typescript", 0);
     let r = find_record(&records, "naming.functions").expect("naming.functions record");
     assert!(
         r.description.contains("camelCase"),
@@ -192,7 +192,7 @@ fn ts_types_pascal_case() {
     .map(|n| ts_class(n))
     .collect();
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let records = spelunk_core::conventions::rules::typescript::extract(&refs, 0);
+    let records = spelunk_core::conventions::rules::typescript::extract(&refs, "typescript", 0);
     let r = find_record(&records, "naming.types").expect("naming.types record");
     assert!(
         r.description.contains("PascalCase"),
@@ -208,7 +208,7 @@ fn ts_async_usage_detected() {
         .map(|i| ts_fn(&format!("fetchUser{i}"), content))
         .collect();
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let records = spelunk_core::conventions::rules::typescript::extract(&refs, 0);
+    let records = spelunk_core::conventions::rules::typescript::extract(&refs, "typescript", 0);
     let r = find_record(&records, "async").expect("async record");
     assert!(r.description.contains("async"), "desc={}", r.description);
     assert!(r.confidence > 0.2, "confidence={}", r.confidence);
@@ -227,7 +227,7 @@ fn ts_testing_spec_files() {
         })
         .collect();
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let records = spelunk_core::conventions::rules::typescript::extract(&refs, 0);
+    let records = spelunk_core::conventions::rules::typescript::extract(&refs, "typescript", 0);
     let r = find_record(&records, "testing").expect("testing record");
     assert!(r.description.contains("spec.ts"), "desc={}", r.description);
 }
@@ -416,6 +416,10 @@ fn extractor_sums_evidence_across_ts_and_tsx() {
         naming[0].evidence_count, 10,
         "ts (5) + tsx (5) same-source evidence must sum to 10"
     );
+    assert!(
+        !records.iter().any(|r| r.language == "tsx"),
+        "tsx must not survive as its own language group"
+    );
 }
 
 /// Determinism: `extract` is backed by a BTreeMap keyed on (language, category),
@@ -504,16 +508,10 @@ fn extractor_preserves_generic_only_languages() {
     }
 }
 
-/// Documents current (quirky) behavior of tsx routing. OUT OF SCOPE to fix here.
-///
-/// tsx chunks feed two rule sets with conflicting language labels: the
-/// typescript set self-labels its records "typescript", while the generic set
-/// (layered on top) uses the chunk's own language, "tsx". Those land under
-/// different (language, category) keys, so dedup does NOT collapse them — a
-/// single tsx convention surfaces under BOTH "typescript" and "tsx". This test
-/// pins that down so a future relabel is a conscious change, not a silent one.
+/// tsx is typescript plus JSX, so its conventions canonicalize onto the
+/// "typescript" label: never emitted under "tsx", and never twice.
 #[test]
-fn extractor_tsx_records_surface_under_typescript() {
+fn extractor_tsx_conventions_canonicalize_onto_typescript_label_only() {
     let tsx_chunks: Vec<ChunkSummary> = (0..8)
         .map(|i| ChunkSummary {
             language: "tsx".into(),
@@ -527,18 +525,24 @@ fn extractor_tsx_records_surface_under_typescript() {
 
     let records = ConventionExtractor::new().extract(&tsx_chunks);
 
-    // The language-specific set relabels tsx conventions as "typescript".
+    let ts = find_lang_cat(&records, "typescript", "naming.functions");
     assert_eq!(
-        find_lang_cat(&records, "typescript", "naming.functions").len(),
+        ts.len(),
         1,
-        "tsx naming.functions currently self-labels as typescript"
+        "tsx naming.functions surfaces once, as typescript"
     );
-    // The generic set keeps the original "tsx" label, so the same convention
-    // is currently duplicated across two language labels (a future-fix target).
     assert_eq!(
-        find_lang_cat(&records, "tsx", "naming.functions").len(),
-        1,
-        "generic set currently also emits a tsx-labelled record"
+        ts[0].evidence_count, 8,
+        "all tsx evidence lands on that record"
+    );
+
+    assert!(
+        find_lang_cat(&records, "tsx", "naming.functions").is_empty(),
+        "no record may carry the tsx label"
+    );
+    assert!(
+        !records.iter().any(|r| r.language == "tsx"),
+        "no category may carry the tsx label"
     );
 }
 
@@ -697,7 +701,7 @@ fn extractor_emits_low_evidence_raw_records() {
         rust_fn("small_set_b", "fn small_set_b() {}"),
     ];
     let refs: Vec<&ChunkSummary> = chunks.iter().collect();
-    let raw = spelunk_core::conventions::rules::rust::extract(&refs, 0);
+    let raw = spelunk_core::conventions::rules::rust::extract(&refs, "rust", 0);
     if let Some(r) = raw.iter().find(|r| r.category == "naming.functions") {
         assert!(
             r.evidence_count < 5,


### PR DESCRIPTION
## `spelunk context` reported `async` at 100% when the real rate was 56%

The headline is a correctness fix, not a cosmetic one.

Conventions from `.ts` and `.tsx` files were extracted as two separate groups, each producing its own partial view of what is one language. When dedup merged them it kept the **higher** of the two confidences. A project with 9 async functions out of 16 was told `async/await is widely used` at **100%** confidence, when the honest pooled figure is **56%**.

That is the worst shape a bug can take for this product: agents read `spelunk context` to learn a codebase's conventions, and we were handing them a confidently wrong number. Confidence is a rate over a group's chunks, so it is only meaningful pooled across all of a language's evidence.

The label cleanup is the mechanism, and secondary: `.tsx` chunks routed through the TypeScript rule set, which self-labelled every record `typescript`, while the generic rules layered on top labelled by the chunk's own language (`tsx`). Those are distinct `(language, category)` keys, so dedup never collapsed them and every `.tsx` convention surfaced twice in `spelunk context`.

## What changed

- Group chunks by a **canonical language** (`tsx` -> `typescript`), so each rule set sees one group per label and evidence is pooled before any confidence is computed.
- Pass the label **from the grouping into every rule set**, so a rule set cannot self-label a group it does not match. This is now true for the rust set too, which still built three of its records with a hardcoded `"rust"`.
- **Remove the max-of-splits merge** from `dedup_by_language_category`. Canonical grouping made that branch unreachable, and it was the exact logic that produced the 100% figure. Leaving wrong-but-plausible merge code in a dead branch invites a future refactor to route duplicates back into it.

A mixed `.ts`/`.tsx` fixture goes from 6 convention records to 4, with no conventions lost.

## Behaviour change worth your attention

`spelunk plumbing read-conventions --lang tsx` now matches no rows and exits 1; `--lang typescript` is the replacement. It is in the CHANGELOG.

I ruled that documenting this is sufficient rather than aliasing `tsx` -> `typescript` in the `--lang` filter, and want to flag the call explicitly since `plumbing/` is the scriptable surface:

- Pre-v1.0 with no install base, which is exactly when the model should be made coherent.
- An alias would return rows whose `language` field reads `typescript` in response to a `--lang tsx` query. For a machine-facing surface that is incoherent: a script that filters by `tsx` then groups by `.language` gets back `typescript`.
- It would put canonicalization in a second layer, free to drift from the extractor's map.
- `tsx` genuinely is not a convention label in this model any more. Matching nothing is the accurate signal, not a regression to paper over.

Say the word if you would rather have the alias and I will add it.

## Test plan

Run in the task worktree, `SPELUNK_SECRET_STORE=file`, after merging `origin/main` (see below).

**The guard actually fails on the pre-fix code.** I reproduced the old grouping (raw language keys, `tsx` routed to the typescript set with a self-label) and ran the new pinning test against it:

```
test extractor_async_confidence_pools_evidence_rather_than_taking_max_of_splits ... FAILED
panicked at crates/spelunk-core/tests/conventions.rs:583:5:
confidence must be the pooled 9/16 rate, got 1
```

`got 1` is the 100% max-of-splits bug reproduced. The source was then restored and the tree confirmed clean.

**The removed merge branch is genuinely unreachable.** I replaced its body with a `panic!` and ran the full `spelunk-core` suite: 375 pass, the probe never fires. Static argument agrees: one group per canonical language, every rule set labels with its group's language, each set emits a category at most once, so two same-source records cannot share a `(language, category)` key.

**Arithmetic**, checked independently of the test: `.ts` split 3/10 = 0.30, `.tsx` split 6/6 = 1.00, old max-of-splits = 1.00, pooled = 9/16 = 0.5625 = 56%.

**Gates**, all on the post-merge tree:

| Check | Result |
| --- | --- |
| `cargo test -p spelunk-core` | 375 passed, 0 failed |
| `cargo clippy -p spelunk-core --all-targets` | clean |
| `cargo fmt --check` | clean |
| `cargo check -p spelunk-core --no-default-features` | clean |
| `cargo check -p spelunk-cli -p spelunk-server` | clean (builds against the changed signatures) |

## Base

`main` moved from `0aca43363` to `b614004b7` mid-sweep (#598, the ADR-068 amendment, merged 13:19:55Z). I merged `origin/main` into this branch and re-ran the full gate set above on the merged result. The staleness is textual only and semantically inert here: #598 added a single ADR markdown file and touched no Rust or Cargo, so no contract this change depends on moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
