### PR TITLE
Run index LLM summaries to completion instead of detaching a thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,21 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   different port (which left two servers on one `server.db`), and fails loudly
   if an unrelated process holds the port. A single-instance guard prevents two
   servers running against the same `server.db`.
+- **`spelunk index` no longer silently drops LLM summaries.** The summary pass
+  ran detached from the rest of the run, so an index whose other phases finished
+  first could exit with summaries still in flight: they were never generated,
+  and nothing reported it. Because a summary is secret-scanned only as it is
+  stored, a dropped summary also skipped that redaction pass. `index` now
+  finishes summaries before it returns. Generation stays best-effort (a failure
+  warns and never fails the run, so git hooks still exit 0), and `--detach` /
+  `--detach-embed` still background the whole run.
+- **`spelunk index` no longer reports success for summaries the LLM never
+  produced.** Against an unreachable or failing LLM the run printed `Summarised
+  1 batch(es).` and exited 0 while storing empty summaries. Failed batches are
+  now excluded from that count (`Summarised 0 batch(es).`) and a warning reports
+  how many produced nothing; `RUST_LOG=warn` shows the cause. Retrying needs
+  `spelunk index --force`, since a chunk whose summary failed is recorded as
+  attempted and a plain re-run skips it.
 
 ## [0.9.3] — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,11 +125,10 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 - **`spelunk index` no longer silently drops LLM summaries.** The summary pass
   ran detached from the rest of the run, so an index whose other phases finished
   first could exit with summaries still in flight: they were never generated,
-  and nothing reported it. Because a summary is secret-scanned only as it is
-  stored, a dropped summary also skipped that redaction pass. `index` now
-  finishes summaries before it returns. Generation stays best-effort (a failure
-  warns and never fails the run, so git hooks still exit 0), and `--detach` /
-  `--detach-embed` still background the whole run.
+  and nothing reported it. `index` now finishes summaries before it returns.
+  Generation stays best-effort (a failure warns and never fails the run, so git
+  hooks still exit 0), and `--detach` / `--detach-embed` still background the
+  whole run.
 - **`spelunk index` no longer reports success for summaries the LLM never
   produced.** Against an unreachable or failing LLM the run printed `Summarised
   1 batch(es).` and exited 0 while storing empty summaries. Failed batches are

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -385,39 +385,14 @@ async fn run_phases_3_to_5(
         }
     }
 
-    // Phase 4: LLM summaries — spawn a background thread so the caller
-    // returns immediately. The thread opens its own DB connection because
-    // `Database` (rusqlite::Connection) is not Send.
-    let no_summaries = args.no_summaries;
-    let summary_batch_size = args.summary_batch_size;
-    let summary_cfg = cfg.clone();
-    let summary_db_path = db_path.to_path_buf();
-    eprintln!("Generating summaries in background\u{2026}");
-    std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build();
-        match rt {
-            Ok(rt) => rt.block_on(async move {
-                match crate::storage::Database::open(&summary_db_path) {
-                    Ok(bg_db) => {
-                        if let Err(e) = summaries::generate_summaries(
-                            no_summaries,
-                            summary_batch_size,
-                            &summary_cfg,
-                            &bg_db,
-                        )
-                        .await
-                        {
-                            eprintln!("summary error: {e}");
-                        }
-                    }
-                    Err(e) => eprintln!("summary error: {e}"),
-                }
-            }),
-            Err(e) => eprintln!("summary error: could not build runtime: {e}"),
-        }
-    });
+    // Phase 4: LLM summaries. Must finish before the process exits: a summary is
+    // secret-scanned only as it is stored. Backgrounding here is process-level
+    // (--detach, --detach-embed, the phases-3-5 spawn), never a thread.
+    if let Err(e) =
+        summaries::generate_summaries(args.no_summaries, args.summary_batch_size, cfg, db).await
+    {
+        eprintln!("Warning: summary generation failed: {e:#}");
+    }
 
     // Phase 5: convention extraction (heuristic, no LLM).
     eprintln!("Extracting conventions\u{2026}");

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -385,8 +385,8 @@ async fn run_phases_3_to_5(
         }
     }
 
-    // Phase 4: LLM summaries. Must finish before the process exits: a summary is
-    // secret-scanned only as it is stored. Backgrounding here is process-level
+    // Phase 4: LLM summaries. Must finish before the process exits: an in-flight
+    // summary is silently lost. Backgrounding here is process-level
     // (--detach, --detach-embed, the phases-3-5 spawn), never a thread.
     if let Err(e) =
         summaries::generate_summaries(args.no_summaries, args.summary_batch_size, cfg, db).await

--- a/crates/spelunk-cli/src/cli/cmd/index/summaries.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/summaries.rs
@@ -48,6 +48,7 @@ pub(super) async fn generate_summaries(
     eprintln!("Generating summaries ({total_chunks} chunks, batch size {batch_size})\u{2026}");
 
     let mut batch_num = 0usize;
+    let mut failed_batches = 0usize;
     loop {
         let batch = db.chunks_without_summaries(batch_size)?;
         if batch.is_empty() {
@@ -58,6 +59,10 @@ pub(super) async fn generate_summaries(
 
         match crate::indexer::summariser::summarise_batch(&llm, &batch).await {
             Ok(summaries) => {
+                // summarise_batch reports LLM/transport failure as an empty result.
+                if summaries.is_empty() {
+                    failed_batches += 1;
+                }
                 let mut summarised_ids = std::collections::HashSet::new();
                 for (chunk_id, summary) in summaries {
                     // A secret can appear in an LLM-generated summary even when the
@@ -88,6 +93,7 @@ pub(super) async fn generate_summaries(
                 }
             }
             Err(e) => {
+                failed_batches += 1;
                 tracing::warn!("summarise_batch failed: {e}");
                 // Mark the batch as attempted so we don't loop forever.
                 for (id, _, _, _) in &batch {
@@ -97,6 +103,16 @@ pub(super) async fn generate_summaries(
         }
     }
 
-    eprintln!("  Summarised {batch_num} batch(es).");
+    let ok_batches = batch_num - failed_batches;
+    eprintln!("  Summarised {ok_batches} batch(es).");
+    if failed_batches > 0 {
+        // Failed chunks are stored as "" (not NULL), so a plain re-run skips
+        // them; --force reparses and clears the summary back to NULL.
+        eprintln!(
+            "Warning: {failed_batches} of {batch_num} summary batch(es) produced no summary; \
+             those chunks are indexed without one. Re-run with `spelunk index --force` to retry \
+             (`RUST_LOG=warn` shows the cause)."
+        );
+    }
     Ok(())
 }

--- a/crates/spelunk-cli/tests/index_summary_completion.rs
+++ b/crates/spelunk-cli/tests/index_summary_completion.rs
@@ -1,0 +1,326 @@
+//! `spelunk index` must run its LLM summary pass to completion before it returns.
+//! A summary is secret-scanned only as it is stored, so one still in flight at
+//! process exit silently skips that scan.
+//!
+//! Nothing here is timing-based: the mock `/llm/complete` cannot answer until the
+//! test releases it, so "summaries finished before phase 5" holds by program order
+//! on an awaited pass and cannot hold on a detached one.
+
+mod plumbing_helpers;
+
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::Mutex;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer};
+
+/// Failsafe only: hit solely when the child never reaches the summary pass.
+const ARRIVAL_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// A single-chunk project, so exactly one batch and one summary are expected.
+fn write_fixture(dir: &Path, name: &str) {
+    let src = dir.join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("lib.rs"),
+        "pub fn clean_fn(x: i32) -> i32 {\n    x + 1\n}\n",
+    )
+    .expect("write lib.rs");
+    std::fs::write(
+        dir.join("Cargo.toml"),
+        format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n"),
+    )
+    .expect("write Cargo.toml");
+}
+
+/// `spelunk index` as a raw `std::process::Command` so the test can hold a live
+/// `Child` across the gate; `assert_cmd`'s runner blocks until exit.
+/// Mirrors `plumbing_helpers::spelunk_bin_in`'s keychain/home pinning.
+fn index_command(home: &Path, config: &Path, db: &Path, project: &Path) -> Command {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin("spelunk"));
+    cmd.env("SPELUNK_SECRET_STORE", "file")
+        .env("HOME", home)
+        .env_remove("XDG_CONFIG_HOME")
+        .arg("--config")
+        .arg(config)
+        .arg("index")
+        .arg("--db")
+        .arg(db)
+        .arg(project);
+    cmd
+}
+
+/// `/llm/complete` responder that reports arrival, then blocks until released.
+///
+/// Parking a worker here is why the runtime below is built with several.
+struct GatedLlmResponder {
+    arrived: Mutex<Sender<()>>,
+    release: Mutex<Receiver<()>>,
+    body: String,
+}
+
+impl wiremock::Respond for GatedLlmResponder {
+    fn respond(&self, _req: &wiremock::Request) -> wiremock::ResponseTemplate {
+        let _ = self.arrived.lock().unwrap().send(());
+        let _ = self.release.lock().unwrap().recv();
+        wiremock::ResponseTemplate::new(200)
+            .insert_header("content-type", "text/event-stream")
+            .set_body_string(plumbing_helpers::sse_token_response(&self.body))
+    }
+}
+
+/// Drain stderr on its own thread: the child stays gated mid-run, and a full
+/// pipe would block it before it could answer.
+fn drain(pipe: Option<std::process::ChildStderr>) -> std::thread::JoinHandle<String> {
+    let mut pipe = pipe.expect("stderr piped");
+    std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = pipe.read_to_string(&mut s);
+        s
+    })
+}
+
+fn assert_summary_precedes_conventions(stderr: &str) {
+    let summarised = stderr
+        .find("Summarised 1 batch(es).")
+        .unwrap_or_else(|| panic!("expected a completed summary batch in stderr:\n{stderr}"));
+    let conventions = stderr
+        .find("Extracting conventions")
+        .unwrap_or_else(|| panic!("expected phase 5 to run in stderr:\n{stderr}"));
+    assert!(
+        summarised < conventions,
+        "the summary pass must complete before phase 5 begins; a detached pass lets \
+         `index` reach phase 5 (and exit) with summaries unscanned.\n--- stderr ---\n{stderr}"
+    );
+}
+
+/// The core guard: `index` cannot return until the summary pass has finished.
+#[test]
+fn summary_pass_completes_before_index_returns() {
+    let project = TempDir::new().expect("temp project dir");
+    write_fixture(project.path(), "summary-order-fixture");
+    let db_tmp = TempDir::new().expect("temp db dir");
+    let db_path = db_tmp.path().join("spelunk.db");
+
+    let (arrived_tx, arrived_rx) = mpsc::channel::<()>();
+    let (release_tx, release_rx) = mpsc::channel::<()>();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("build test runtime");
+
+    let mock_server = rt.block_on(async {
+        let server = MockServer::start().await;
+        plumbing_helpers::mount_health(&server).await;
+        plumbing_helpers::mount_index_embed(&server).await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/llm/complete$"))
+            .respond_with(GatedLlmResponder {
+                arrived: Mutex::new(arrived_tx),
+                release: Mutex::new(release_rx),
+                body: serde_json::json!([{"id": 1, "summary": "Adds one to x."}]).to_string(),
+            })
+            .mount(&server)
+            .await;
+        server
+    });
+
+    let mock_url = mock_server.uri();
+    let config_path =
+        plumbing_helpers::write_config_with_server(project.path(), &db_path, &mock_url, &mock_url);
+
+    let mut child = index_command(project.path(), &config_path, &db_path, project.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn spelunk index");
+    let stderr_reader = drain(child.stderr.take());
+
+    // Wait for the summary request to reach the mock. Exiting first is itself
+    // the bug: `index` returned without the summary pass having run.
+    let deadline = Instant::now() + ARRIVAL_TIMEOUT;
+    loop {
+        match arrived_rx.recv_timeout(Duration::from_millis(50)) {
+            Ok(()) => break,
+            Err(RecvTimeoutError::Timeout) => {
+                if let Some(status) = child.try_wait().expect("poll child") {
+                    let _ = release_tx.send(());
+                    let stderr = stderr_reader.join().expect("join stderr reader");
+                    panic!(
+                        "`index` exited ({status}) before the summary request reached the \
+                         server: the summary pass is not awaited.\n--- stderr ---\n{stderr}"
+                    );
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "timed out waiting for the summary request to reach the mock server"
+                );
+            }
+            Err(RecvTimeoutError::Disconnected) => panic!("mock dropped the arrival channel"),
+        }
+    }
+
+    // The response is still withheld, so an awaited pass is necessarily blocked here.
+    assert!(
+        child.try_wait().expect("poll child").is_none(),
+        "`index` returned while the summary request was still unanswered"
+    );
+
+    release_tx
+        .send(())
+        .expect("release the gated summary response");
+    let status = child.wait().expect("wait for index");
+    let stderr = stderr_reader.join().expect("join stderr reader");
+
+    assert!(status.success(), "index failed ({status}):\n{stderr}");
+    assert_summary_precedes_conventions(&stderr);
+
+    // Post-condition: the summary is durable by the time `index` returns.
+    let conn = rusqlite::Connection::open(&db_path).expect("open db");
+    let unsummarised: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM chunks WHERE summary IS NULL",
+            [],
+            |r| r.get(0),
+        )
+        .expect("count unsummarised chunks");
+    assert_eq!(
+        unsummarised, 0,
+        "every chunk must have been summarised before `index` returned"
+    );
+    let stored: String = conn
+        .query_row("SELECT summary FROM chunks WHERE id = 1", [], |r| r.get(0))
+        .expect("read stored summary");
+    assert_eq!(
+        stored, "Adds one to x.",
+        "the awaited summary must be the one the server returned"
+    );
+}
+
+/// A failing LLM must be visible and must not fail the index (git-hook use).
+#[test]
+fn summary_failure_is_reported_but_index_still_succeeds() {
+    let project = TempDir::new().expect("temp project dir");
+    write_fixture(project.path(), "summary-failure-fixture");
+    let db_tmp = TempDir::new().expect("temp db dir");
+    let db_path = db_tmp.path().join("spelunk.db");
+
+    let rt = tokio::runtime::Runtime::new().expect("build test runtime");
+    let mock_server = rt.block_on(async {
+        let server = MockServer::start().await;
+        plumbing_helpers::mount_health(&server).await;
+        plumbing_helpers::mount_index_embed(&server).await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/llm/complete$"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        server
+    });
+
+    let mock_url = mock_server.uri();
+    let config_path =
+        plumbing_helpers::write_config_with_server(project.path(), &db_path, &mock_url, &mock_url);
+
+    let output = index_command(project.path(), &config_path, &db_path, project.path())
+        .output()
+        .expect("run spelunk index");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert!(
+        output.status.success(),
+        "summaries are best-effort: a dead LLM must not fail the index ({}):\n{stderr}",
+        output.status
+    );
+    assert!(
+        stderr.contains("Summarised 0 batch(es)."),
+        "a failed batch must not be counted as summarised:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("1 of 1 summary batch(es) produced no summary"),
+        "the failure must be reported on stderr, not only under RUST_LOG:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--force"),
+        "the warning must name the remedy that actually retries:\n{stderr}"
+    );
+
+    // Why the remedy is `--force`: failed chunks are stored as "" rather than
+    // left NULL, and `chunks_without_summaries` only matches NULL.
+    let conn = rusqlite::Connection::open(&db_path).expect("open db");
+    let empty: i64 = conn
+        .query_row("SELECT COUNT(*) FROM chunks WHERE summary = ''", [], |r| {
+            r.get(0)
+        })
+        .expect("count empty summaries");
+    assert_eq!(
+        empty, 1,
+        "a failed chunk must be marked attempted, not left NULL"
+    );
+}
+
+/// Phases 3-5 also run in the spawned background-phases process.
+#[test]
+fn background_phases_mode_completes_summaries() {
+    let project = TempDir::new().expect("temp project dir");
+    write_fixture(project.path(), "summary-bgphases-fixture");
+    let db_tmp = TempDir::new().expect("temp db dir");
+    let db_path = db_tmp.path().join("spelunk.db");
+
+    let rt = tokio::runtime::Runtime::new().expect("build test runtime");
+    let mock_server = rt.block_on(async {
+        let server = MockServer::start().await;
+        plumbing_helpers::mount_health(&server).await;
+        plumbing_helpers::mount_index_embed(&server).await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/llm/complete$"))
+            .respond_with(move |_: &wiremock::Request| {
+                let body = serde_json::json!([{"id": 1, "summary": "Adds one to x."}]).to_string();
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(plumbing_helpers::sse_token_response(&body))
+            })
+            .mount(&server)
+            .await;
+        server
+    });
+
+    let mock_url = mock_server.uri();
+    let config_path =
+        plumbing_helpers::write_config_with_server(project.path(), &db_path, &mock_url, &mock_url);
+
+    // Populate chunks first: background-phases mode skips parse/embed.
+    let seed = index_command(project.path(), &config_path, &db_path, project.path())
+        .arg("--no-summaries")
+        .output()
+        .expect("run seeding index");
+    assert!(seed.status.success(), "seeding index failed");
+
+    let output = index_command(project.path(), &config_path, &db_path, project.path())
+        .arg("--_background-phases")
+        .output()
+        .expect("run background-phases index");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert!(
+        output.status.success(),
+        "background-phases index failed ({}):\n{stderr}",
+        output.status
+    );
+    assert_summary_precedes_conventions(&stderr);
+
+    let conn = rusqlite::Connection::open(&db_path).expect("open db");
+    let stored: String = conn
+        .query_row("SELECT summary FROM chunks WHERE id = 1", [], |r| r.get(0))
+        .expect("read stored summary");
+    assert_eq!(
+        stored, "Adds one to x.",
+        "background-phases mode must run the summary pass to completion too"
+    );
+}

--- a/crates/spelunk-cli/tests/index_summary_completion.rs
+++ b/crates/spelunk-cli/tests/index_summary_completion.rs
@@ -1,6 +1,5 @@
 //! `spelunk index` must run its LLM summary pass to completion before it returns.
-//! A summary is secret-scanned only as it is stored, so one still in flight at
-//! process exit silently skips that scan.
+//! A summary still in flight at process exit is silently lost; the run exits 0.
 //!
 //! Nothing here is timing-based: the mock `/llm/complete` cannot answer until the
 //! test releases it, so "summaries finished before phase 5" holds by program order
@@ -94,7 +93,7 @@ fn assert_summary_precedes_conventions(stderr: &str) {
     assert!(
         summarised < conventions,
         "the summary pass must complete before phase 5 begins; a detached pass lets \
-         `index` reach phase 5 (and exit) with summaries unscanned.\n--- stderr ---\n{stderr}"
+         `index` exit with summaries still in flight, losing them.\n--- stderr ---\n{stderr}"
     );
 }
 

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -149,6 +149,44 @@ impl wiremock::Respond for IndexEmbedResponder {
     }
 }
 
+/// Build the SSE body `ServerInferenceClient::llm_complete` expects: one
+/// `token` event carrying the whole payload, then a `done` terminator.
+/// Event boundary is `\n\n`, with a `data: ` prefix per line.
+pub fn sse_token_response(content: &str) -> String {
+    format!(
+        "data: {}\n\ndata: {}\n\n",
+        serde_json::json!({"kind": "token", "content": content}),
+        serde_json::json!({"kind": "done"}),
+    )
+}
+
+/// Mount `GET /v1/health` advertising the full Tier 1 capability set.
+pub async fn mount_health(server: &wiremock::MockServer) {
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/v1/health"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "ok",
+                "version": "test",
+                "capabilities": ["memory", "index.embed", "search.semantic", "explore", "plan"],
+            })),
+        )
+        .mount(server)
+        .await;
+}
+
+/// Mount `POST /v1/projects/{id}/index/embed` with [`IndexEmbedResponder`], so
+/// parsing/embedding succeeds and the summary pass is reached.
+pub async fn mount_index_embed(server: &wiremock::MockServer) {
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path_regex(
+            r"^/v1/projects/.+/index/embed$",
+        ))
+        .respond_with(IndexEmbedResponder)
+        .mount(server)
+        .await;
+}
+
 /// Run `spelunk index <fixture_dir>` backed by a mock spelunk-server.
 ///
 /// The mock server handles:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -86,6 +86,10 @@ yet – for example if a previous run parsed the tree before the embedder had
 finished loading. Unchanged, already-embedded files are skipped, so you no
 longer need `--force` just to fill in missing embeddings.
 
+Summaries are the exception: a chunk whose summary failed (say the LLM was
+unreachable) is recorded as attempted rather than missing, so a plain re-run
+skips it. Use `--force` to retry those.
+
 The embed phase calibrates its own batch size instead of guessing: it times a
 1-chunk request, then a 4-chunk request, and sizes subsequent requests (and
 their timeouts) from the observed per-chunk rate — smaller batches on slow


### PR DESCRIPTION
## Why this matters: `spelunk index` silently drops summaries and reports success

`spelunk index` ran its LLM summary pass in a detached, unjoined thread. If the rest of the run
finished first, the process exited with summaries still in flight: they were never generated, and
nothing reported it. The command exited 0 either way.

That is the bug: **silent data loss on a command that claims success.** `index` now awaits the
summary pass inline, so it cannot return with summaries outstanding.

It is also **breaking CI on unrelated PRs today.** `Test (macos-latest, --no-default-features)` is
intermittently red on `main` itself ([run 29327654901](https://github.com/spelunk-cloud/spelunk/actions/runs/29327654901),
the #601 merge). The failing assertion is `empty_summary_count == 1` in
`summary_secret_is_not_persisted`: no summary was produced at all. A slow runner loses the race a
fast one wins, which is why it is intermittent rather than always red. Expect that cell to keep
landing red on other people's PRs until this ships.

It additionally unblocks re-adding `rustls-tls-native-roots`, which #601 had to drop to merge.

> ### Correction: this is not a security issue, and an earlier version of this body claimed it was
>
> This description previously led with "a dropped summary silently skipped secret redaction" and
> framed that as the reason for prioritisation. **That was wrong.** The code is unambiguous:
> `summaries.rs:68-76` has the scan *gate* the store, one expression apart.
>
> ```rust
> let summary_to_store = if crate::indexer::secrets::contains_secret(&summary) { … };
> if let Err(e) = db.update_chunk_summary(chunk_id, summary_to_store) { … }
> ```
>
> No path stores a summary without scanning it. A summary that was never generated is never stored,
> so there is nothing to leak and nothing to redact. The scan "not running" is a no-op, not a bypass.
> The secret scanner is not implicated in this bug at all.
>
> The claim originated in the task's own filing and propagated unchallenged through four pipeline
> stages into this body. It sounded plausible and nobody asked the deciding question: *what actually
> gets stored?* Recording the correction here rather than quietly editing it away.

## The pre-existing test's coverage is timing-dependent (the test itself is fine)

`summary_secret_is_not_persisted` **passes against the broken code, 10/10** under normal local
timing: its mock answers faster than the process exit path, so the detached thread wins the race and
the summary gets stored and scanned.

That does **not** make it a bad test. It asserts that no secret is persisted, and that is true both
before and after this fix, so it verifies exactly what it set out to verify. Its
`empty_summary_count == 1` assertion is genuinely sensitive to this bug, and is what fires on the
slow macOS runner. The gap is **coverage**, not correctness: detection depends on losing a race, so
it is reliable nowhere and flaky on CI.

The three new tests in `crates/spelunk-cli/tests/index_summary_completion.rs` are the actual guard.
They are causal, not timing-based: the mock `/llm/complete` reports arrival and then **withholds the
response until the test releases it**, so "summaries finished before phase 5" holds by program order
on an awaited pass and cannot hold on a detached one. There is no `sleep` and no timing dependency;
the only `Duration` in the file is a 90s failsafe that fires solely if the child never reaches the
summary pass.

## Also fixed: success reported for summaries the LLM never produced

`summarise_batch` reports transport/LLM failure as `Ok(vec![])`. The caller treated that as success:
against an unreachable LLM the run printed `Summarised 1 batch(es).` and exited 0 while storing `''`.
Failed batches are now counted and excluded (`Summarised 0 batch(es).`), with a warning naming how
many produced nothing and pointing at `RUST_LOG=warn` for the cause.

## Latency: assessed, and the trade is narrow

`index` now waits for the LLM round-trip, so this deserved an explicit ruling rather than being
discovered later. Verified firsthand against the code:

- **No explicit `server_url` (the default UX): zero change.** `generate_summaries` returns early with
  `Skipping summaries (no server_url configured)`. Measured: 0.12s wall-clock. Summaries only ever
  run when a team `server_url` is explicitly configured.
- **Large index (>100 new files): zero change.** Phases 3-5 already detach into a separate *process*
  and the user regains the prompt immediately. That detached process now actually completes its
  summaries, which is what `background_phases_mode_completes_summaries` covers.
- **Git hooks: unchanged.** `--detach` re-execs and returns immediately; summary failure still warns
  and never fails the run (exit 0).
- **Remaining case:** explicit `server_url` plus a small incremental re-index waits for a few LLM
  batches (default batch size 10).

The thread never delivered non-blocking behaviour in the first place: only phase 5 (a local
heuristic AST pass, no LLM) and a SQLite registry write sat between the spawn and process exit, so a
real LLM round-trip lost essentially always. The pre-fix speed was the speed of doing nothing. Real
backgrounding is process-level and survives parent exit, as a thread cannot. Ruling: awaiting inline
is correct, and this is not a meaningful UX regression.

## Unblocks `rustls-tls-native-roots`

PR #601 had to drop `rustls-tls-native-roots` to merge, because the detached summary thread made
that path flaky. With the pass awaited, re-adding it was confirmed green 5/5. That experiment was
reverted out of this branch, which carries no `rustls` change, so re-adding it is a clean follow-up.

## Base

`main` advanced to `b614004b7` mid-review (PR #598, ADR-068 amendment). Merged in; the merge was
clean with no CHANGELOG conflict. Checked semantically rather than by filename: #598 changed exactly
one file, a design doc (`docs/adr/068-*.md`, +427 lines, zero code). Its only `spelunk-cli`
references are under `cli/cmd/memory/*`, disjoint from this branch's `cli/cmd/index/*`.

## Test plan

Run in this worktree with `SPELUNK_SECRET_STORE=file` and a shared `CARGO_TARGET_DIR`. Because
sibling worktrees uplift to the same `target/debug/spelunk`, every binary-level result below was
validated by `strings`-checking the uplifted binary for a marker only one side of the fix contains,
before the result was trusted.

**Pre-fix revert proof (the point of the exercise).** Reverted `index/mod.rs` alone to `main`
(restoring the detached thread), rebuilt, and confirmed via `strings` that the uplifted binary was
genuinely the pre-fix build (`Generating summaries in background` present, `Warning: summary
generation failed` absent). Result:

```
test summary_pass_completes_before_index_returns ... FAILED
test background_phases_mode_completes_summaries ... FAILED
panicked at index_summary_completion.rs:94:5:
the summary pass must complete before phase 5 begins; a detached pass lets
`index` reach phase 5 (and exit) with summaries unscanned.
```

Deterministic, not flaky: **5 consecutive pre-fix runs, 2 failed every time.**

**Both fixes independently guarded.** Restored `mod.rs`, reverted `summaries.rs` alone (binary
re-verified by marker): `summary_failure_is_reported_but_index_still_succeeds` FAILED on
`Summarised 1 batch(es).` while the two ordering tests passed. Each test fails only when its own fix
is reverted.

**Post-fix, tree restored:** `index_summary_completion` 3 passed. Full suite
`cargo test -p spelunk-cli` **498 passed, 0 failed**.

**Gates:** `cargo clippy -p spelunk-cli --all-targets -- -D warnings` exit 0; `cargo fmt --check`
exit 0; `cargo check -p spelunk-cli --no-default-features` exit 0 (CI has a no-default-features
cell).

**`--force` claim verified end-to-end**, since a warning that lies would be the same class of bug
this PR fixes. Confirmed `chunks_without_summaries` is `WHERE summary IS NULL` and both failure
paths write `""`, then proved the behaviour against a real DB: after a simulated failed batch
(`summary=''`), a plain re-run left it `''` (correctly not retried), and `--force` reparsed and
reset it to `NULL` (retryable). The documented retry path works as written.

