### PR TITLE
chore: remove internal tracker ids from source comments

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -65,10 +65,10 @@ fn read_server_port_file() -> Option<u16> {
 static TIER: OnceCell<Tier> = OnceCell::const_new();
 
 /// Server-side embedder readiness, mirrored from the `/v1/health` `embedder.state`
-/// field (spelunk-oss^50 PR A). The CLI uses this to distinguish, when semantic
-/// search is unavailable, between "no server reachable", "server up but the model
-/// is still warming up", and "the model failed to load" — so it can print an
-/// actionable one-line notice rather than silently degrading (task item #5).
+/// field. The CLI uses this to distinguish, when semantic search is unavailable,
+/// between "no server reachable", "server up but the model is still warming up",
+/// and "the model failed to load" — so it can print an actionable one-line notice
+/// rather than silently degrading.
 ///
 /// Serialized lowercase to match the server's health body and to feed
 /// `spelunk status --format json`.
@@ -84,7 +84,7 @@ pub enum EmbedderState {
     /// Server started with no in-process model to load (external embedding URL,
     /// or no embedder feature). Treated as ready.
     Disabled,
-    /// Field absent from the health body (server pre-dates PR A). Unknown state.
+    /// Field absent from the health body (server pre-dates it). Unknown state.
     #[default]
     Unknown,
 }
@@ -104,9 +104,8 @@ impl EmbedderState {
 }
 
 /// Server-enforced operative limits relevant to sizing an `/index/embed`
-/// request, mirrored from `/v1/health`'s `limits` object (spelunk-oss^71/^73/
-/// ^74, PR #513 field-failure follow-up: `crates/spelunk-server/src/handlers.rs`
-/// `ServerLimits`).
+/// request, mirrored from `/v1/health`'s `limits` object (see
+/// `crates/spelunk-server/src/handlers.rs` `ServerLimits`).
 ///
 /// `None` on a `Tier::Server` (rather than this struct being absent) means the
 /// server pre-dates this field — the embed phase treats that as "assume the
@@ -203,17 +202,17 @@ pub enum Tier {
         /// Consumed by `is_auto_discovered()` and sub-issue #324 UX wiring.
         auto_discovered: bool,
         /// Server-side embedder readiness, mirrored from the `/v1/health`
-        /// `embedder.state` field (spelunk-oss^50). `Unknown` when the field is
-        /// absent (server pre-dates PR A). Lets the CLI distinguish "server up
-        /// but model still warming up / failed to load" from a ready server when
-        /// semantic search is unavailable (task item #5; rendered by `status`).
+        /// `embedder.state` field. `Unknown` when the field is absent (server
+        /// pre-dates it). Lets the CLI distinguish "server up but model still
+        /// warming up / failed to load" from a ready server when semantic
+        /// search is unavailable (rendered by `status`).
         embedder_state: EmbedderState,
         /// Server-enforced `/index/embed` limits, mirrored from `/v1/health`'s
-        /// `limits` object (spelunk-oss^71/^73/^74). `None` when the field is
-        /// absent — a server that pre-dates this fix and still enforces the
-        /// old blanket 30s budget with no `/index/embed` exemption. The embed
-        /// phase (`embed_phase.rs`) reads this to clamp its own calibration to
-        /// what this particular server actually supports instead of assuming.
+        /// `limits` object. `None` when the field is absent — a server that
+        /// pre-dates this fix and still enforces the old blanket 30s budget
+        /// with no `/index/embed` exemption. The embed phase
+        /// (`embed_phase.rs`) reads this to clamp its own calibration to what
+        /// this particular server actually supports instead of assuming.
         server_limits: Option<ServerLimits>,
     },
 }
@@ -244,7 +243,7 @@ impl Tier {
     /// offline. `EmbedderState::Unknown` is returned for a reachable server that
     /// pre-dates the `embedder.state` health field. Used by the offline notice
     /// (`search`/`index`) and by `spelunk status` to explain why semantic search
-    /// is unavailable (spelunk-oss^50).
+    /// is unavailable.
     pub fn embedder_state(&self) -> Option<EmbedderState> {
         match self {
             Tier::Server { embedder_state, .. } => Some(*embedder_state),
@@ -255,8 +254,7 @@ impl Tier {
     /// Server-enforced `/index/embed` limits for a `Server` tier, or `None`
     /// when offline *or* when the server pre-dates the `/v1/health` `limits`
     /// field. Used by the embed phase (`embed_phase.rs`) to clamp its own
-    /// calibration to what this particular server actually supports —
-    /// see spelunk-oss^71/^73/^74 (PR #513 field-failure follow-up).
+    /// calibration to what this particular server actually supports.
     pub fn server_limits(&self) -> Option<ServerLimits> {
         match self {
             Tier::Server { server_limits, .. } => *server_limits,
@@ -441,8 +439,7 @@ async fn probe_url(
     server_ca: Option<&std::path::Path>,
 ) -> Result<Tier, String> {
     // Non-loopback plaintext http:// is invalid config — reject before sending
-    // anything. No opt-out (Johan, 2026-07-02 — see spelunk-oss^63): the fix is
-    // always "use https, or loopback".
+    // anything. No opt-out: the fix is always "use https, or loopback".
     spelunk_core::config::validate_transport_url(url)?;
 
     let builder = match spelunk_core::config::apply_server_ca(reqwest::Client::builder(), server_ca)
@@ -461,8 +458,7 @@ async fn probe_url(
         }
     };
 
-    // `/v1/health` is an unauthenticated endpoint (spelunk-oss^56) — do not send
-    // a bearer to it (spelunk-oss^63).
+    // `/v1/health` is an unauthenticated endpoint — do not send a bearer to it.
     let req = client.get(format!("{}/v1/health", url.trim_end_matches('/')));
 
     match req.send().await {
@@ -531,15 +527,15 @@ async fn probe_url(
 /// or when no embedder is loaded. A `0` dim skips the dimension check in `probe_url`
 /// for backward compatibility.
 ///
-/// `embedder_state` mirrors the `/v1/health` `embedder.state` field shipped in
-/// spelunk-oss^50 PR A (`embedder: { state, detail }`). It is `Unknown` when the
-/// sub-object is absent (older server) or the body is legacy plain-text.
+/// `embedder_state` mirrors the `/v1/health` `embedder.state` field
+/// (`embedder: { state, detail }`). It is `Unknown` when the sub-object is
+/// absent (older server) or the body is legacy plain-text.
 ///
-/// `server_limits` mirrors `/v1/health`'s `limits` object (spelunk-oss^71/^73/
-/// ^74). `None` when absent — a server that pre-dates the field, which is
-/// exactly the version-skew case: it still enforces the old blanket 30s
-/// `/index/embed` budget with no exemption, regardless of what the CLI's own
-/// calibration would otherwise target.
+/// `server_limits` mirrors `/v1/health`'s `limits` object. `None` when absent —
+/// a server that pre-dates the field, which is exactly the version-skew case:
+/// it still enforces the old blanket 30s `/index/embed` budget with no
+/// exemption, regardless of what the CLI's own calibration would otherwise
+/// target.
 async fn parse_health(
     url: &str,
     resp: reqwest::Response,
@@ -560,11 +556,11 @@ async fn parse_health(
         /// Absent on old servers that pre-date this field; defaults to 0 (skip check).
         #[serde(default)]
         embedding_dim: usize,
-        /// Embedder readiness sub-object (spelunk-oss^50). Absent on older servers
+        /// Embedder readiness sub-object. Absent on older servers
         /// → `embedder_state` stays `Unknown`.
         #[serde(default)]
         embedder: Option<EmbedderBody>,
-        /// Server-enforced `/index/embed` limits (spelunk-oss^71/^73/^74).
+        /// Server-enforced `/index/embed` limits.
         /// Absent on older servers → `server_limits` stays `None`.
         #[serde(default)]
         limits: Option<ServerLimits>,
@@ -918,7 +914,7 @@ mod tests {
         assert_eq!(eff.inference_url, None);
     }
 
-    // ── inference_server_required_message (oss^133) ──────────────────────────
+    // ── inference_server_required_message ────────────────────────────────────
 
     /// No server reachable AND no `server_url` configured (solo user, no local
     /// server running): the message must point at the zero-setup local server
@@ -1108,8 +1104,7 @@ mod tests {
         );
     }
 
-    // ── ServerLimits parsing (spelunk-oss^71/^73/^74, PR #513 field-failure
-    //    fix: /v1/health `limits` object) ────────────────────────────────────
+    // ── ServerLimits parsing (/v1/health `limits` object) ──────────────────────
 
     /// A server that DOES advertise `limits` must have it parsed into
     /// `Tier::Server.server_limits`. This is the non-version-skew case: a
@@ -1267,7 +1262,7 @@ mod tests {
         );
     }
 
-    // ── transport-scheme validation (spelunk-oss^63) ─────────────────────────
+    // ── transport-scheme validation ──────────────────────────────────────────
 
     /// A non-loopback `http://` URL must be rejected before any request is
     /// sent — no mock is mounted, so a request would fail with "connection
@@ -1321,7 +1316,7 @@ mod tests {
     }
 
     /// `/v1/health` must never carry an `Authorization` header — it is an
-    /// unauthenticated endpoint (spelunk-oss^56 server-side companion).
+    /// unauthenticated endpoint.
     #[tokio::test]
     async fn probe_url_health_request_carries_no_bearer_header() {
         use wiremock::matchers::{method, path};
@@ -1347,7 +1342,7 @@ mod tests {
         );
     }
 
-    // ── EmbedderState (spelunk-oss^50) ───────────────────────────────────────
+    // ── EmbedderState ────────────────────────────────────────────────────────
 
     #[test]
     fn embedder_state_default_is_unknown() {

--- a/crates/spelunk-cli/src/cli/cmd/auth_api.rs
+++ b/crates/spelunk-cli/src/cli/cmd/auth_api.rs
@@ -656,7 +656,7 @@ mod tests {
         assert!(!is_prod_cloud_url("http://127.0.0.1:8080"));
     }
 
-    // ── ensure_fresh_token (expiry guard, spelunk-oss^40) ────────────────────────
+    // ── ensure_fresh_token (expiry guard) ────────────────────────────────────────
 
     /// A still-valid access token is returned unchanged with NO network call and
     /// NO persist call (the persist closure would panic if invoked).

--- a/crates/spelunk-cli/src/cli/cmd/context.rs
+++ b/crates/spelunk-cli/src/cli/cmd/context.rs
@@ -391,7 +391,7 @@ mod tests {
 
     #[test]
     fn default_limits_are_small_for_every_section() {
-        // Regression for spelunk-oss^143: question/requirement were 500.
+        // Regression: question/requirement defaults were once 500.
         assert_eq!(section_limit("handoff", None), 3);
         assert_eq!(section_limit("question", None), 10);
         assert_eq!(section_limit("decision", None), 10);
@@ -464,7 +464,7 @@ mod tests {
         assert!(conv.len() < 5);
     }
 
-    // ── Coverage pass (spelunk-oss^143 Test Engineer) ────────────────────────
+    // ── Coverage pass ────────────────────────────────────────────────────────
 
     /// Minimal parser so we can exercise `ContextArgs` clap parsing (incl. the
     /// declared `conflicts_with`) without pulling in the whole top-level `Cli`.
@@ -599,9 +599,9 @@ mod tests {
 
     #[test]
     fn budget_prioritizes_durable_over_questions() {
-        // Ticket ^149: under a tight budget, durable decision/requirement notes
-        // must survive while ephemeral questions drop first, regardless of the
-        // fact that `question` is displayed before decision/requirement.
+        // Under a tight budget, durable decision/requirement notes must survive
+        // while ephemeral questions drop first, regardless of the fact that
+        // `question` is displayed before decision/requirement.
         let body = "x".repeat(400); // title(1)+body(100) = 101 tokens each
         let mut sections = vec![
             ("handoff".to_string(), vec![note(0, "handoff", "ti", &body)]),

--- a/crates/spelunk-cli/src/cli/cmd/helpers.rs
+++ b/crates/spelunk-cli/src/cli/cmd/helpers.rs
@@ -34,9 +34,9 @@ pub(crate) fn open_project_db(
 /// `server_url` is not configured.
 pub(crate) fn require_server_client(cfg: &Config, feature: &str) -> Result<ServerInferenceClient> {
     // Inference-only feature: a local `spelunk server start` is enough, so the
-    // guidance must not tell a solo user to configure a team `server_url`
-    // (oss^133). `cfg.server_url` here is the effective config, so it is `None`
-    // for an auto-discovered loopback and `Some` only for an explicit team URL.
+    // guidance must not tell a solo user to configure a team `server_url`.
+    // `cfg.server_url` here is the effective config, so it is `None` for an
+    // auto-discovered loopback and `Some` only for an explicit team URL.
     ServerInferenceClient::from_config(cfg).ok_or_else(|| {
         anyhow::anyhow!(crate::capability::inference_server_required_message(
             feature

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -172,10 +172,10 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     // server is reachable but the model is still `loading` or has failed
     // (`unavailable`), skip embedding and print a visible, differentiated
     // notice rather than letting the embed request 503 out mid-index or
-    // silently producing an unembedded index (spelunk-oss^50 #5).
+    // silently producing an unembedded index.
     let embed_ready = matches!(tier.caps(), Some(c) if c.index_embed);
     if tier.is_server() && embed_ready {
-        // ── Detached embed (spelunk-oss^74) ──────────────────────────────────
+        // ── Detached embed ───────────────────────────────────────────────────
         // Parsing is done and the chunks are persisted; hand the (usually long)
         // embedding phase to a background process so the user regains the
         // prompt now. The subprocess (`--_embed-phases`) rebuilds the embed
@@ -239,7 +239,7 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
 
 /// Spawn a detached background process to run the embed phase (plus phases 3–5)
 /// against the chunks the foreground run just parsed, reusing the internal
-/// `--_embed-phases` mode (spelunk-oss^74). Mirrors the phases-3–5 background
+/// `--_embed-phases` mode. Mirrors the phases-3–5 background
 /// spawn: stdio is closed so the parent regains its prompt immediately.
 ///
 /// Returns `Ok(true)` when the subprocess was launched (caller should return),
@@ -271,7 +271,7 @@ fn spawn_embed_subprocess(args: &IndexArgs) -> Result<bool> {
 
 /// Embed-only entry point for the detached `--_embed-phases` subprocess: rebuild
 /// the embed queue from the chunks already in the DB (no re-parse), run the
-/// embed phase, then phases 3–5 (spelunk-oss^74).
+/// embed phase, then phases 3–5.
 async fn run_embed_phases(
     args: &IndexArgs,
     cfg: &Config,
@@ -305,9 +305,9 @@ async fn run_embed_phases(
 }
 
 /// Build the differentiated notice lines shown when the embedding phase is
-/// skipped, so an unembedded index is never a silent surprise (spelunk-oss^50
-/// #5). Pure so it can be unit-tested; the four cases mirror PR A's readiness
-/// contract. `server_url` is `cfg.server_url` (used only for the offline case).
+/// skipped, so an unembedded index is never a silent surprise. Pure so it can
+/// be unit-tested; the four cases mirror the server's readiness contract.
+/// `server_url` is `cfg.server_url` (used only for the offline case).
 fn embed_skipped_lines(
     embedder_state: Option<capability::EmbedderState>,
     server_url: Option<&str>,

--- a/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
@@ -145,7 +145,7 @@ pub(super) fn run_parse_phase(
     // the embedder was still loading, so the embed phase was skipped). These
     // belong to unchanged files that the hash-based skip above never re-emits,
     // so without this union a plain `spelunk index` would report "nothing to
-    // do" and leave them permanently unembedded (spelunk-oss^72).
+    // do" and leave them permanently unembedded.
     //
     // Freshly-parsed chunks from this run also lack an embedding row, so they
     // appear here too; dedupe against the ids we already queued to avoid
@@ -171,9 +171,9 @@ pub(super) fn run_parse_phase(
 /// Build the `(chunk_id, embedding_text)` list for every chunk in the index
 /// that has no embedding row yet, reconstructing each chunk's document text
 /// from its stored columns. This is the same union `run_parse_phase` applies as
-/// a backfill (spelunk-oss^72); exposed separately so a detached embed-only
+/// a backfill; exposed separately so a detached embed-only
 /// subprocess can rebuild the embed queue straight from the DB without
-/// re-parsing (spelunk-oss^74).
+/// re-parsing.
 pub(super) fn missing_embedding_texts(db: &Database) -> Result<Vec<(i64, String)>> {
     let mut out = Vec::new();
     for (chunk_id, name, metadata, summary, content) in db.chunks_missing_embeddings()? {
@@ -567,7 +567,7 @@ mod tests {
     /// The DB-side reconstruction used to backfill unembedded chunks must
     /// produce byte-for-byte the same document text as `Chunk::embedding_text()`
     /// did at store time, so a backfilled embedding is identical to one written
-    /// during a normal parse (spelunk-oss^72). Covers: name present/absent and
+    /// during a normal parse. Covers: name present/absent and
     /// docstring present/absent (summary is always None at store time).
     #[test]
     fn reconstruct_embedding_text_matches_chunk_embedding_text() {
@@ -614,7 +614,7 @@ mod tests {
     /// chunk (`chunks.summary`) before a later re-index backfills its embedding,
     /// so the backfill path reconstructs with a non-null `summary` and must
     /// produce the exact `title: {name} | summary: {summary} | text: {body}`
-    /// document (spelunk-oss^72). Covers summary × docstring present/absent.
+    /// document. Covers summary × docstring present/absent.
     #[test]
     fn reconstruct_embedding_text_matches_chunk_embedding_text_with_summary() {
         use crate::indexer::{Chunk, ChunkKind};
@@ -665,7 +665,7 @@ mod tests {
     }
 
     // ── End-to-end backfill: parse-only run leaves chunks unembedded, a
-    //    second parse run backfills them without reparsing (spelunk-oss^72) ────
+    //    second parse run backfills them without reparsing ────
 
     /// `run_parse_phase` stores chunks but never writes embeddings — that is the
     /// embed phase's job. So a single parse run models the real bug: an
@@ -769,7 +769,6 @@ mod tests {
     }
 
     // ── missing_embedding_texts: detached embed-only queue reconstruction ──────
-    // (spelunk-oss^74)
 
     /// The detached `--_embed-phases` subprocess rebuilds its embed queue purely
     /// from the DB via `missing_embedding_texts()` — it never re-parses. This test

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -366,7 +366,7 @@ mod tests {
         });
     }
 
-    /// Regression guard for the opt-in fix (spelunk-oss^64 #5): a script left
+    /// Regression guard for the opt-in fix: a script left
     /// at the *old*, unguarded location (`~/scripts/web-to-md.ts`) must NOT be
     /// picked up any more — only the fixed `~/.config/spelunk/scripts/` path
     /// counts. Prior to the fix, any attacker-writable home-dir script at the

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -59,7 +59,7 @@ pub(super) async fn memory_harvest(
     let cfg = &eff_cfg;
 
     // Tier-0: harvest requires server inference (#259 locked-feature error).
-    // Guidance points at the local auto-server, never team `server_url` setup (oss^133).
+    // Guidance points at the local auto-server, never team `server_url` setup.
     if cfg.resolve_inference_url().is_none() {
         return Err(harvest_requires_server());
     }

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -49,7 +49,7 @@ pub async fn memory_push(
     let src_path = args.source.as_deref().unwrap_or(mem_path);
     let local = MemoryStore::open(src_path)
         .with_context(|| format!("opening local memory at {}", src_path.display()))?;
-    // Refresh a stale WorkOS access token before the cloud-api call (oss^40).
+    // Refresh a stale WorkOS access token before the cloud-api call.
     let key = auth_api::ensure_fresh_server_key(cfg).await?;
     let client = CloudSyncClient::new(
         &base_url,

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -307,7 +307,7 @@ mod tests {
         assert!(parse_iso_to_secs("not-a-timestamp") > 0);
     }
 
-    // ── resolve_sync_project (spelunk-oss^47) ──────────────────────────────
+    // ── resolve_sync_project ───────────────────────────────────────────────
     // Sync must never invent a project name. With neither `--project` nor a
     // configured `project_id`, the call halts with a message pointing the user
     // at `--project <slug>`; with an explicit slug (or configured id), that slug
@@ -361,7 +361,7 @@ mod tests {
         assert!(resolve_sync_project(Some("   "), &cfg).is_err());
     }
 
-    // ── end-to-end first-run path (spelunk-oss^47 QA handback) ─────────────
+    // ── end-to-end first-run path ──────────────────────────────────────────
     // The story's target path: a first-run user has a non-loopback team
     // `server_url`, NO configured `project_id`, and passes `--project <slug>`.
     // Before the fix this was rejected at dispatch by `cfg.validate()` before
@@ -421,7 +421,7 @@ mod tests {
     }
 
     // ── push_local end-to-end: remote_id stamping + idempotent re-sync ─────
-    // spelunk-oss^112: the local-first push path is where the server-minted
+    // The local-first push path is where the server-minted
     // cross-machine id is PERSISTED — stamped onto `notes.remote_id` from the
     // 207 batch result — not the `RemoteMemoryBackend::add` debug-log path
     // (which is the cloud-first, remote-is-store-of-record case with no local

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -213,7 +213,7 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
         // In auto mode, if the embedding call fails (e.g. embedder unreachable or
         // still warming up), fall back to ast-grep. Print a visible, one-line
         // notice first so the degradation isn't silent and a downstream
-        // "ast-grep not found" error isn't misattributed (spelunk-oss^50 #5).
+        // "ast-grep not found" error isn't misattributed.
         if auto_mode && query_vec_result.is_err() {
             sp.finish_and_clear();
             eprint_semantic_unavailable_notice(tier, &cfg);
@@ -509,7 +509,7 @@ pub(crate) fn search_all_dbs_linearrag(
 /// external `ast-grep` binary — matching runs in-process via `ast-grep-core`
 /// (see `spelunk_core::search::live`). A structural pattern (with metavariables)
 /// matches structurally; a plain string matches case-insensitively by substring
-/// on identifier/text nodes, with a literal line scan beneath (spelunk-oss^130).
+/// on identifier/text nodes, with a literal line scan beneath.
 /// It mirrors the `graph_live` pattern in `graph.rs`, but maps matches into
 /// `SearchResult` structs so the output shape is **identical** to the
 /// regular/semantic search paths.
@@ -575,7 +575,7 @@ pub(crate) fn search_live(
 
 /// Build the one-line notice explaining why `auto`-mode search is falling back
 /// from semantic to ast-grep, differentiating the cases the readiness contract
-/// exposes (spelunk-oss^50 #5).
+/// exposes.
 ///
 /// Pure so it can be unit-tested without capturing stderr; `has_server_url` is
 /// `cfg.server_url.is_some()`.

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -116,7 +116,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
             ),
         };
 
-        // Server-side embedder readiness (spelunk-oss^50). `null` when offline
+        // Server-side embedder readiness. `null` when offline
         // or when talking to a server that pre-dates the readiness field.
         let embedder_state_json: serde_json::Value = match tier.embedder_state() {
             Some(capability::EmbedderState::Unknown) | None => serde_json::Value::Null,
@@ -284,7 +284,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
     // Surface an in-progress (or interrupted) embed pass: when chunks outnumber
     // embeddings there is embedding work left, e.g. a detached `--detach-embed`
     // run still working through batches, or an interrupted run to resume. This
-    // is the completion check for a backgrounded embed (spelunk-oss^74).
+    // is the completion check for a backgrounded embed.
     if let Some(line) = embedding_progress_line(s.chunk_count, s.embedding_count) {
         println!("{line}");
     }
@@ -409,7 +409,7 @@ fn memory_backend_label(kind: &str) -> &str {
 /// Render the `embedder` line for `spelunk status` (text mode) from the
 /// server-side readiness state, or `None` when there is nothing useful to show
 /// (an older server that never reported readiness). Pure so it can be unit
-/// tested without capturing stdout (spelunk-oss^50).
+/// tested without capturing stdout.
 fn embedder_status_line(state: &capability::EmbedderState) -> Option<String> {
     use capability::EmbedderState;
     let line = match state {
@@ -436,8 +436,7 @@ fn embedder_status_line(state: &capability::EmbedderState) -> Option<String> {
 /// has more chunks than embeddings, i.e. an embed pass is still running (e.g. a
 /// detached `--detach-embed` subprocess) or was interrupted and can be resumed.
 /// Returns `None` when every chunk is embedded (or the index is empty), so a
-/// fully-embedded index prints nothing extra. Pure so it can be unit tested
-/// (spelunk-oss^74).
+/// fully-embedded index prints nothing extra. Pure so it can be unit tested.
 fn embedding_progress_line(chunk_count: i64, embedding_count: i64) -> Option<String> {
     if chunk_count <= 0 || embedding_count >= chunk_count {
         return None;
@@ -511,7 +510,6 @@ mod tests {
     }
 
     // ── embedding_progress_line: detached / interrupted embed signal ────────────
-    // (spelunk-oss^74)
 
     #[test]
     fn embedding_progress_shown_when_chunks_outnumber_embeddings() {

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -154,8 +154,8 @@ impl ServerInferenceClient {
             .to_string();
         if let Err(msg) = spelunk_core::config::validate_transport_url(&base_url) {
             // Fail loudly and immediately: the alternative is silently sending a
-            // bearer token in the clear. No opt-out (Johan, 2026-07-02 — see
-            // spelunk-oss^63): the fix is always "use https, or loopback".
+            // bearer token in the clear. No opt-out: the fix is always "use
+            // https, or loopback".
             eprintln!("error: {msg}");
             std::process::exit(2);
         }
@@ -454,7 +454,7 @@ impl ServerInferenceClient {
             .context("POST /index/embed (query vector)")?;
         // Surface the server's structured reason (e.g. embedder still loading /
         // failed to load) instead of a bare "HTTP status 503" so a memory search
-        // against a warming-up local server gets actionable guidance (oss^133).
+        // against a warming-up local server gets actionable guidance.
         let status = resp.status();
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
@@ -578,7 +578,7 @@ impl spelunk_core::llm::LlmBackend for ServerLlmAdapter {
 /// The server returns a `{ error, state, detail }` JSON body for an unready
 /// embedder (state `loading`/`unavailable`). `reqwest::error_for_status` throws
 /// that body away and yields a bare "HTTP status 503", so we parse it here and
-/// append a next-step hint (oss^133).
+/// append a next-step hint.
 fn server_inference_error(endpoint: &str, status: reqwest::StatusCode, body: &str) -> String {
     let parsed: Option<serde_json::Value> = serde_json::from_str(body).ok();
     let field = |k: &str| {
@@ -975,7 +975,7 @@ mod tests {
         assert!(chunk_id.starts_with("query:"));
     }
 
-    // ── transport-scheme validation (spelunk-oss^63) ─────────────────────────
+    // ── transport-scheme validation ──────────────────────────────────────────
     //
     // `from_config` hard-exits the process on an invalid (non-loopback http://)
     // inference URL, so the exit path itself isn't exercised in-process here
@@ -1032,7 +1032,7 @@ mod tests {
         );
     }
 
-    // ── server_inference_error (oss^133 bare-503 surfacing) ──────────────────
+    // ── server_inference_error ───────────────────────────────────────────────
 
     #[test]
     fn inference_error_surfaces_loading_detail_and_retry_hint() {

--- a/crates/spelunk-cli/tests/context.rs
+++ b/crates/spelunk-cli/tests/context.rs
@@ -196,7 +196,7 @@ fn setup_budget_project() -> (TempDir, PathBuf) {
     (tmp, config_path)
 }
 
-// ── budget: durable priority end-to-end (spelunk-oss^149) ─────────────────────
+// ── budget: durable priority end-to-end ───────────────────────────────────────
 
 #[test]
 fn context_budget_keeps_durable_drops_questions_e2e() {

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -60,14 +60,15 @@ fn test_help_text_accuracy_guards() {
         .stdout(predicate::str::contains("alias").not());
 }
 
-/// spelunk-oss^67 regression: `spelunk search --as-of <sha>` (snapshot
-/// search) was removed outright — the flag no longer exists on the top-level
-/// `search` command. `spelunk search --help` must not mention `--as-of`.
+/// regression: `spelunk search --as-of <sha>` (snapshot search) was removed
+/// outright — the flag no longer exists on the top-level `search` command.
+/// `spelunk search --help` must not mention `--as-of`.
 ///
 /// This is deliberately scoped to top-level `search --help` only. It must NOT
 /// be confused with the unrelated, still-live `--as-of <date>` flag on
 /// `memory list` / `memory search` / `memory failures` (point-in-time memory
-/// queries, untouched by ^67) — asserting its absence there would be wrong.
+/// queries, untouched by the snapshot removal) — asserting its absence there
+/// would be wrong.
 #[test]
 fn test_search_help_does_not_list_as_of() {
     spelunk_bin()
@@ -1154,8 +1155,8 @@ fn git_init_repo(dir: &std::path::Path) {
     }
 }
 
-/// spelunk-oss^141: `spelunk init` must NOT create an uninvited `CLAUDE.md` in
-/// the user's repo, and must not claim to have written one.
+/// `spelunk init` must NOT create an uninvited `CLAUDE.md` in the user's repo,
+/// and must not claim to have written one.
 #[test]
 fn test_init_does_not_write_claude_md() {
     let tmp = tempdir().unwrap();
@@ -1182,8 +1183,8 @@ fn test_init_does_not_write_claude_md() {
     );
 }
 
-/// spelunk-oss^141: a pre-existing `CLAUDE.md` must be left byte-for-byte
-/// untouched — init must never overwrite a user's own file.
+/// A pre-existing `CLAUDE.md` must be left byte-for-byte untouched — init must
+/// never overwrite a user's own file.
 #[test]
 fn test_init_leaves_existing_claude_md_untouched() {
     let tmp = tempdir().unwrap();

--- a/crates/spelunk-cli/tests/fail_closed_no_project.rs
+++ b/crates/spelunk-cli/tests/fail_closed_no_project.rs
@@ -1,5 +1,4 @@
-//! Fail-closed behaviour when there is no local `.spelunk/` project (ADR-067,
-//! spelunk-oss^131).
+//! Fail-closed behaviour when there is no local `.spelunk/` project (ADR-067).
 //!
 //! In a directory that was never `spelunk init`'d, memory/context/index-backed
 //! search must refuse rather than silently read or write the machine-global
@@ -40,7 +39,7 @@ fn global_memory_db(home: &Path) -> std::path::PathBuf {
 }
 
 /// The global index store path under the isolated HOME. Display commands must
-/// never read or create it from an un-init'd dir (ADR-067, spelunk-oss^147).
+/// never read or create it from an un-init'd dir (ADR-067).
 fn global_index_db(home: &Path) -> std::path::PathBuf {
     home.join(".config").join("spelunk").join("index.db")
 }
@@ -168,7 +167,7 @@ fn ast_grep_search_works_without_local_project() {
     assert!(!global_memory_db(home.path()).exists());
 }
 
-// ── zero-setup plain-string substring search (spelunk-oss^130) ─────────────────
+// ── zero-setup plain-string substring search ───────────────────────────────────
 
 /// The reported bug: an exact identifier matched but a *substring* of it (and
 /// case variants) returned "No results found." in the index-free path, both in
@@ -443,7 +442,7 @@ fn refused_index_search_does_not_touch_preexisting_global_index() {
     );
 }
 
-// ── display commands: graph / chunks / explore / check (spelunk-oss^147) ───────
+// ── display commands: graph / chunks / explore / check ─────────────────────────
 //
 // These read-only commands previously resolved their DB via the legacy
 // `open_project_db`/`resolve_db` path, which fell back to the machine-global

--- a/crates/spelunk-cli/tests/harvest_upfront_check.rs
+++ b/crates/spelunk-cli/tests/harvest_upfront_check.rs
@@ -63,8 +63,8 @@ fn harvest_fails_with_actionable_error_when_no_server_and_no_model() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(SERVER_REQUIRED))
-        // oss^133: with no `server_url` the guidance must point at the local
-        // server and must NOT tell a solo user to configure a team `server_url`.
+        // With no `server_url` the guidance must point at the local server and
+        // must NOT tell a solo user to configure a team `server_url`.
         .stderr(predicate::str::contains("spelunk server start"))
         .stderr(predicate::str::contains("server_url").not());
 }

--- a/crates/spelunk-cli/tests/inference_server_message.rs
+++ b/crates/spelunk-cli/tests/inference_server_message.rs
@@ -1,4 +1,4 @@
-//! End-to-end coverage for the inference-server-required guidance (oss^133).
+//! End-to-end coverage for the inference-server-required guidance.
 //!
 //! The bug: inference-only commands (`memory search --mode semantic|hybrid`,
 //! `memory timeline`, `plumbing embed`) told a solo user with no server to set a
@@ -59,7 +59,7 @@ fn assert_local_start_no_server_url(stderr: &str) {
     );
     assert!(
         !stderr.contains(REGRESSION_SUBSTR),
-        "no-server message must NOT mention `server_url` (oss^133 regression); got: {stderr}"
+        "no-server message must NOT mention `server_url`; got: {stderr}"
     );
 }
 

--- a/crates/spelunk-cli/tests/init_notes_refspec.rs
+++ b/crates/spelunk-cli/tests/init_notes_refspec.rs
@@ -1,6 +1,6 @@
 //! Integration tests for `spelunk init` configuring the `origin` git-notes
 //! fetch refspec so `refs/notes/spelunk` (spelunk's memory) travels on
-//! clone/fetch (spelunk-oss^126, ADR-068).
+//! clone/fetch (ADR-068).
 //!
 //! Covered:
 //! - origin present: `remote.origin.fetch` gains `+refs/notes/spelunk:…` and

--- a/crates/spelunk-core/migrations/021_drop_snapshots.sql
+++ b/crates/spelunk-core/migrations/021_drop_snapshots.sql
@@ -1,4 +1,4 @@
--- spelunk-oss^67: remove the snapshot storage layer.
+-- Remove the snapshot storage layer.
 --
 -- `spelunk search --as-of <sha>` was never wired to indexing: nothing ever
 -- called create_snapshot/insert_snapshot_*/update_snapshot_stats, so

--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -482,7 +482,7 @@ impl Config {
         };
 
         // A bare `server_key` in the *personal* global config is the legacy
-        // plaintext credential we migrate into the secret store (spelunk-oss^23).
+        // plaintext credential we migrate into the secret store.
         // Captured before the project-level merge so we never migrate a shared
         // team key from a checked-in `.spelunk/config.toml`.
         let global_bare_server_key = cfg.server_key.clone();
@@ -681,10 +681,10 @@ impl Config {
 /// (macOS Keychain / Linux Secret Service / Windows Credential Manager) by
 /// default, falling back to an owner-only file when no keychain backend is
 /// available (CI / headless). The credential is **never** written to
-/// `config.toml` (spelunk-oss^23).
+/// `config.toml`.
 ///
 /// The store is credential-format-agnostic, so the same call path serves a
-/// future WorkOS-token migration (spelunk-oss^22).
+/// future WorkOS-token migration.
 pub fn save_server_key(key: &str) -> Result<()> {
     let store = secret_store::default_store(&spelunk_config_dir())?;
     save_server_key_with(key, store.as_ref())
@@ -910,8 +910,8 @@ pub fn is_loopback_url(url: &str) -> bool {
 ///
 /// A non-loopback `http://` URL is invalid config — plaintext HTTP outside the
 /// loopback interface would send the bearer token (and query content) in the
-/// clear. There is no opt-out env var (Johan, 2026-07-02 — see spelunk-oss^63):
-/// the fix is always "use https, or loopback".
+/// clear. There is no opt-out env var: the fix is always "use https, or
+/// loopback".
 ///
 /// Like [`is_loopback_url`], this is a lightweight string check on the literal
 /// host — there is no DNS resolution. A `/etc/hosts` alias or other custom DNS
@@ -1343,7 +1343,7 @@ memory_server_key = "old-token"
         assert!(cfg.validate().is_err());
     }
 
-    // ── validate_with_project() — --project satisfies the requirement (oss^47) ─
+    // ── validate_with_project() — --project satisfies the requirement ──────────
 
     #[test]
     fn validate_with_project_true_passes_non_loopback_without_project_id() {
@@ -1426,7 +1426,7 @@ memory_server_key = "old-token"
         assert!(!is_loopback_url("http://example.com/proxy/127.0.0.1"));
     }
 
-    // ── validate_transport_url (spelunk-oss^63: loopback-only plaintext http) ──
+    // ── validate_transport_url (loopback-only plaintext http) ──────────────────
 
     #[test]
     fn validate_transport_url_rejects_non_loopback_http() {
@@ -1970,7 +1970,7 @@ project_id = "team/new"
         }
     }
 
-    // ── spelunk-oss^23: keychain secret store migration / precedence ─────────
+    // ── keychain secret store migration / precedence ─────────────────────────
     //
     // These exercise the credential paths through an injected `MemoryStore`, so
     // no real keychain or Secret Service daemon is required (CI-safe).

--- a/crates/spelunk-core/src/config/secret_store.rs
+++ b/crates/spelunk-core/src/config/secret_store.rs
@@ -16,7 +16,7 @@
 //!
 //! The store holds **opaque string secrets keyed by name** — it does not know
 //! or care whether a value is today's `sk-sp-…` bearer key or a future WorkOS
-//! access/refresh token (spelunk-oss^22). Callers pick the key name; this module
+//! access/refresh token. Callers pick the key name; this module
 //! just persists and retrieves the bytes. That keeps the storage layer reusable
 //! when the credential format changes.
 //!
@@ -360,8 +360,8 @@ mod tests {
 
     #[test]
     fn file_store_is_format_agnostic_multiple_keys() {
-        // The store holds opaque values under arbitrary names — proving ^22 can
-        // reuse it for access/refresh tokens without code changes here.
+        // The store holds opaque values under arbitrary names, so a future
+        // access/refresh-token migration can reuse it with no changes here.
         let tmp = TempDir::new().unwrap();
         let store = FileStore::new(tmp.path().join("secrets.toml"));
         store.set("access_token", "at-123").unwrap();

--- a/crates/spelunk-core/src/search/live.rs
+++ b/crates/spelunk-core/src/search/live.rs
@@ -61,7 +61,7 @@ fn detect_support_lang(path: &Path) -> Option<SupportLang> {
 
 /// A query is a structural ast-grep pattern when it contains a metavariable
 /// (`$X`, `$$FOO`, `$$$ARGS`). Plain strings have none and are matched by
-/// substring rather than node-text equality (spelunk-oss^130).
+/// substring rather than node-text equality.
 fn is_structural_pattern(query: &str) -> bool {
     query.contains('$')
 }
@@ -72,7 +72,7 @@ fn is_structural_pattern(query: &str) -> bool {
 /// unchanged. A plain string is matched **case-insensitively**: first as a
 /// substring of identifier/text (named-leaf) nodes, then — for any file the
 /// node pass leaves uncovered — as a literal line scan, so a substring that
-/// demonstrably exists in a file never returns empty (spelunk-oss^130).
+/// demonstrably exists in a file never returns empty.
 pub fn search_live_query(query: &str, root: &Path, limit: usize) -> Vec<LiveMatch> {
     if query.is_empty() || limit == 0 {
         return Vec::new();
@@ -288,7 +288,7 @@ mod tests {
         assert_eq!(matches[0].language, "python");
     }
 
-    // ── plain-string substring search (spelunk-oss^130) ─────────────────────────
+    // ── plain-string substring search ───────────────────────────────────────────
 
     #[test]
     fn plain_substring_matches_identifier() {
@@ -373,7 +373,7 @@ mod tests {
         assert!(matches[0].text.contains("a.foo()"));
     }
 
-    // ── independent coverage pass (spelunk-oss^130, Test Engineer) ──────────────
+    // ── independent coverage pass ───────────────────────────────────────────────
 
     #[test]
     fn plain_substring_uppercase_query_lowercase_identifier() {

--- a/crates/spelunk-core/src/storage/chunks.rs
+++ b/crates/spelunk-core/src/storage/chunks.rs
@@ -294,7 +294,7 @@ mod tests {
     /// A chunk with no matching `embeddings` row must surface via
     /// `chunks_missing_embeddings` (the parse phase unions these into the embed
     /// batch so a parse-only index doesn't leave chunks permanently
-    /// unembedded — spelunk-oss^72). Once an embedding is inserted, the chunk
+    /// unembedded). Once an embedding is inserted, the chunk
     /// drops out of the result.
     #[test]
     fn chunks_missing_embeddings_finds_unembedded_then_clears() {

--- a/crates/spelunk-core/src/storage/db.rs
+++ b/crates/spelunk-core/src/storage/db.rs
@@ -344,7 +344,7 @@ impl Database {
         Ok(())
     }
 
-    /// Drop the snapshot storage tables (spelunk-oss^67).
+    /// Drop the snapshot storage tables.
     ///
     /// `snapshots`/`snapshot_files`/`snapshot_chunks` were created by
     /// `016_snapshots.sql` and `snapshot_embeddings` by

--- a/crates/spelunk-core/src/storage/memory/search.rs
+++ b/crates/spelunk-core/src/storage/memory/search.rs
@@ -240,7 +240,6 @@ mod tests {
     /// A query term containing an embedded NUL byte must not surface a raw
     /// FTS5 "unterminated string" parse error via this memory-search path
     /// too (same fix as the code-search path in `storage::search::tests`).
-    /// See spelunk-oss^65 follow-up.
     #[test]
     fn search_text_embedded_nul_byte_still_leaks_raw_parse_error() {
         let store = open_store();

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -96,7 +96,7 @@ pub async fn open_memory_backend(
     // cloud; `offline` and `local_first` resolve to the local store.
     let route_remote = cfg.resolve_mode() == SyncMode::CloudFirst;
     if let Some(url) = cfg.server_url.as_ref().filter(|_| route_remote) {
-        // spelunk-oss^63 follow-up (^77): the cloud-routing path attaches
+        // The cloud-routing path attaches
         // `Authorization: Bearer {server_key}` to every memory request
         // (`RemoteMemoryBackend::authed`) and to the slug→UUID `GET
         // /v1/projects` lookup. A non-loopback plaintext `http://` `server_url`
@@ -288,9 +288,9 @@ mod backend_selection_tests {
         // ADR-005 D5: a `project_id` that is already a UUID is used directly,
         // so the remote backend is constructed without any slug→UUID lookup
         // (no network call against the unreachable team.example.com host).
-        // A non-loopback host must be `https://` to clear the transport guard
-        // (spelunk-oss^63/^77); the scheme is irrelevant to the raw-UUID path
-        // otherwise, since nothing is sent here.
+        // A non-loopback host must be `https://` to clear the transport guard;
+        // the scheme is irrelevant to the raw-UUID path otherwise, since
+        // nothing is sent here.
         let cfg = Config {
             server_url: Some("https://team.example.com:7777".to_string()),
             project_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
@@ -327,7 +327,7 @@ mod backend_selection_tests {
     /// network or DNS.
     ///
     /// That same non-loopback plaintext `http://` url is now rejected by
-    /// `open_memory_backend`'s transport guard (spelunk-oss^63/^77), so this
+    /// `open_memory_backend`'s transport guard, so this
     /// test enters at the `open_remote_memory_backend` seam directly.
     /// Production reaches that seam only *after* the guard has passed; the guard
     /// itself is covered by `cloud_first_rejects_non_loopback_http` below.
@@ -417,7 +417,7 @@ mod backend_selection_tests {
         );
     }
 
-    /// spelunk-oss^63 follow-up (^77): a `cloud_first` config with a non-loopback
+    /// A `cloud_first` config with a non-loopback
     /// plaintext `http://` `server_url` must be rejected by `open_memory_backend`
     /// before any bearer token is sent — over the memory REST calls
     /// (`RemoteMemoryBackend::authed`) or the slug→UUID `GET /v1/projects`

--- a/crates/spelunk-core/src/storage/remote/sync.rs
+++ b/crates/spelunk-core/src/storage/remote/sync.rs
@@ -119,7 +119,7 @@ impl CloudSyncClient {
         server_ca: Option<&std::path::Path>,
     ) -> Result<Self> {
         // Fail closed before building the client: a bearer must never travel over
-        // plaintext http to a non-loopback host (spelunk-oss^63). Keyless
+        // plaintext http to a non-loopback host. Keyless
         // loopback-dev construction is unaffected — nothing to leak.
         if api_key.is_some() {
             crate::config::validate_transport_url(base_url).map_err(anyhow::Error::msg)?;
@@ -373,7 +373,7 @@ mod tests {
 
     #[tokio::test]
     async fn push_batch_threads_explicit_slug_into_request_path() {
-        // spelunk-oss^47: an explicit project slug (e.g. from `spelunk sync
+        // An explicit project slug (e.g. from `spelunk sync
         // --project acme/new-app`) must reach the server verbatim in the request
         // path, so the server can lazily create/reuse that project on first sync.
         // The mock only matches the slug-scoped path, so a match proves it.
@@ -392,7 +392,7 @@ mod tests {
         assert_eq!(res.created, 1);
     }
 
-    // ── transport-scheme guard at construction (spelunk-oss^78) ──────────────
+    // ── transport-scheme guard at construction ───────────────────────────────
     // A bearer must never travel over plaintext http to a non-loopback host;
     // keyless construction is unaffected. Mirrors config::validate_transport_url_*.
 

--- a/crates/spelunk-core/src/storage/search.rs
+++ b/crates/spelunk-core/src/storage/search.rs
@@ -241,7 +241,7 @@ mod tests {
     /// embedded `\0` before quoting, since FTS5's own query-string parser
     /// treats `\0` as an early string terminator (distinct from SQLite's
     /// NUL-safe text binding), which would otherwise hide the closing `"` we
-    /// append. See spelunk-oss^65 follow-up.
+    /// append.
     #[test]
     fn search_text_embedded_nul_byte_still_leaks_raw_parse_error() {
         let db = open_db();

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -408,7 +408,7 @@ async fn append_to_git_notes_returns_err_outside_git_repo() {
 
 // ── security regression: note bodies must go via stdin, never argv ──────────
 //
-// oss^61: `git notes add` used to receive the note body as a `-m <arg>` argv
+// `git notes add` used to receive the note body as a `-m <arg>` argv
 // value. A body that itself looked like a git option (e.g. starting with `-`)
 // could previously be misparsed as an option to `git notes add` rather than
 // literal note content. These tests prove (a) option-like / metacharacter-

--- a/crates/spelunk-core/tests/lang_csharp_kotlin_swift.rs
+++ b/crates/spelunk-core/tests/lang_csharp_kotlin_swift.rs
@@ -1,4 +1,4 @@
-//! Indexer coverage for C#, Kotlin, and Swift (spelunk-oss^49, batch 2).
+//! Indexer coverage for C#, Kotlin, and Swift.
 //!
 //! Asserts that `SourceParser::parse` produces the expected semantic chunks and
 //! that `EdgeExtractor::extract` produces the expected import/call/inheritance

--- a/crates/spelunk-core/tests/lang_php_ruby.rs
+++ b/crates/spelunk-core/tests/lang_php_ruby.rs
@@ -1,4 +1,4 @@
-//! Indexer coverage for PHP and Ruby (spelunk-oss^49, batch 1).
+//! Indexer coverage for PHP and Ruby.
 //!
 //! Asserts that `SourceParser::parse` produces the expected semantic chunks and
 //! that `EdgeExtractor::extract` produces the expected import/call/inheritance

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -85,7 +85,7 @@ fn embedding_text_prepends_docstring() {
     );
 }
 
-// ── MAX_CHUNK_TOKENS ceiling (oss^114) ───────────────────────────────────────
+// ── MAX_CHUNK_TOKENS ceiling ─────────────────────────────────────────────────
 
 /// A Rust function with `body_lines` short statements, guaranteed short enough
 /// per line that any 120-line window stays under the cap.

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -2702,9 +2702,9 @@ mod tests {
             Err(_elapsed) => panic!(
                 "the SSE connection was still open {overall_deadline:?} after a HangingLlm \
                  backend started generating — llm_generate_with_timeout did not cut it off \
-                 within its {generation_budget:?} budget. This is exactly the bug QA flagged \
-                 (spelunk-oss^60): /explore's TimeoutLayer can't see spawned generation work, \
-                 so a hung backend would otherwise hold the connection open indefinitely."
+                 within its {generation_budget:?} budget. /explore's TimeoutLayer can't see \
+                 spawned generation work, so a hung backend would otherwise hold the \
+                 connection open indefinitely."
             ),
         }
     }

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -885,8 +885,8 @@ mod arg_tests {
     use clap::Parser;
 
     /// The server binary default host must be loopback (127.0.0.1), not the
-    /// wildcard (0.0.0.0). The wildcard bind is now an explicit `--host 0.0.0.0`
-    /// opt-in (loopback is firewall-exempt and the safer default). oss^50 / req #6.
+    /// wildcard (0.0.0.0). The wildcard bind is an explicit `--host 0.0.0.0`
+    /// opt-in (loopback is firewall-exempt and the safer default).
     #[test]
     fn default_host_is_loopback() {
         let args = Args::parse_from(["spelunk-server"]);


### PR DESCRIPTION
Internal task-tracker ids had leaked into tracked source comments across the
workspace (~95 occurrences in 35 files). This strips them. Public code should
not carry pointers into a private board: they are unresolvable for anyone
reading this repo, and they expose internal process detail.

## Approach

Comments were reworded, not deleted. Where the only content was the id, the
comment now states the invariant it was pinning:

```diff
-/// <tracker-id> regression: `spelunk search --as-of <sha>` (snapshot
+/// regression: `spelunk search --as-of <sha>` (snapshot search) was removed
 /// search) was removed outright ...
```

Comments were also tightened to state the constraint rather than the history,
per the house style: attribution ("decided by X on DATE"), sub-item numbers,
and internal role names carried no information for a reader of this repo and
went with the ids.

Three classes of reference removed:

1. The ids themselves, in every form present.
2. Neighbouring internal labels left dangling once an id went: internal
   workstream names, sub-item numbers, and internal role names.
3. Prefix-less continuation ids. Some comments carried a lead id plus bare
   follow-on refs, and some referred to a tracker item with no prefix at all.
   These do not match a search for the main id form, so they would have
   survived an obvious sweep. Five such refs were found and removed.

## Scope

- `docs/adr/` is untouched, deliberately: a separate call.
- `ADR-NNN` cross-references are preserved (202 remain in `crates/`). Those
  resolve inside this repo and are legitimate.
- Diff is comment-only, with two exceptions: test assertion *messages* in
  `handlers.rs` and `inference_server_message.rs` quoted an id in their text.
  Behaviour is unchanged.

## Left alone, needs a separate decision

`crates/spelunk-cli/src/cli/cmd/server.rs` cites "THREAT-MODEL req #9" in nine
places, but the binding-requirements list in `docs/security/THREAT-MODEL.md`
ends at #8, so the reference resolves to nothing. That is doc drift rather than
an id leak, and fixing it means deciding what the requirement should say, so it
is not in this PR.

## Test plan

Run from the workspace root with `SPELUNK_SECRET_STORE=file` exported:

- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`: clean
- `cargo test --workspace`: green
- `cargo test --workspace --no-default-features`: green

To confirm the sweep is complete, search `crates/` for the tracker-id forms and
for bare `^<digits>` refs. Both return nothing (the only `^` hit is an `O(n^2)`
in a comment).
