### PR TITLE
docs: drop dangling THREAT-MODEL req #9 citations from the auto-spawn path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -795,7 +795,6 @@ to re-embed. (#439, #441)
 - **Auto-spawned `spelunk-server` now binds to `127.0.0.1` only.** Previously
   the server started by `spelunk init` / `ensure_server_running` defaulted to
   `0.0.0.0`, making the unauthenticated local server LAN-reachable.
-  (THREAT-MODEL req #9, decision #88)
 
 ### Added
 

--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -745,7 +745,7 @@ fn find_available_port(start: u16, range: u16) -> Result<u16> {
 /// Build the argument list passed to `spelunk-server` when auto-spawning the daemon.
 ///
 /// Extracted from the spawn helpers so that unit tests can verify the args
-/// without actually launching a process (THREAT-MODEL req #9 / decision #88).
+/// without actually launching a process.
 ///
 /// The returned `Vec` contains every argument **after** the binary path, in
 /// order, as it would be appended to `std::process::Command`.
@@ -767,10 +767,9 @@ pub(super) fn build_daemon_args(db: &Path, port: u16) -> Vec<std::ffi::OsString>
 /// CLI process exits after writing the PID/port state files, at which point
 /// the child is reparented to init/launchd and becomes fully detached.
 ///
-/// `--host 127.0.0.1` is always passed so the auto-spawned daemon only binds
-/// the loopback interface (THREAT-MODEL req #9 / decision #88).  Without this
-/// flag spelunk-server defaults to 0.0.0.0 and would be LAN-reachable while
-/// unauthenticated.
+/// `--host 127.0.0.1` is always passed explicitly. The auto-spawned daemon is
+/// unauthenticated, so it must only ever bind loopback; passing the flag keeps
+/// that true regardless of spelunk-server's own default.
 #[cfg(unix)]
 fn spawn_daemon_unix(
     bin: &Path,
@@ -796,10 +795,9 @@ fn spawn_daemon_unix(
 
 /// Spawn the server on Windows with `CREATE_NEW_PROCESS_GROUP`.
 ///
-/// `--host 127.0.0.1` is always passed so the auto-spawned daemon only binds
-/// the loopback interface (THREAT-MODEL req #9 / decision #88).  Without this
-/// flag spelunk-server defaults to 0.0.0.0 and would be LAN-reachable while
-/// unauthenticated.
+/// `--host 127.0.0.1` is always passed explicitly. The auto-spawned daemon is
+/// unauthenticated, so it must only ever bind loopback; passing the flag keeps
+/// that true regardless of spelunk-server's own default.
 #[cfg(windows)]
 fn spawn_daemon_windows(
     bin: &Path,
@@ -1184,19 +1182,16 @@ mod tests {
         assert!(result.is_err(), "should fail when binary is not on PATH");
     }
 
-    // ── spawn_daemon arg list (THREAT-MODEL req #9) ──────────────────────────
+    // ── spawn_daemon arg list: loopback-only bind ────────────────────────────
     //
-    // Security invariant: the auto-spawned spelunk-server daemon MUST bind
-    // only the loopback interface.  Without `--host 127.0.0.1` the server
-    // defaults to 0.0.0.0 and becomes LAN-reachable while unauthenticated.
+    // Security invariant: the auto-spawned spelunk-server daemon is
+    // unauthenticated, so it MUST only ever bind the loopback interface.
     //
-    // These tests verify the arg list produced by `build_daemon_args` — the
+    // These tests pin the arg list produced by `build_daemon_args` — the
     // single source of truth for both the Unix and Windows spawn helpers —
     // so that a future refactor cannot silently drop the flag.
-    //
-    // refs: https://github.com/spelunk-cloud/spelunk/pull/365
 
-    /// `--host 127.0.0.1` must appear in the daemon arg list (THREAT-MODEL req #9).
+    /// `--host 127.0.0.1` must appear in the daemon arg list.
     #[test]
     fn spawn_daemon_args_bind_loopback() {
         let tmp = TempDir::new().unwrap();
@@ -1212,7 +1207,7 @@ mod tests {
         // `--host` flag must be present.
         assert!(
             args_str.contains(&"--host".to_string()),
-            "THREAT-MODEL req #9: --host flag missing from daemon args: {args_str:?}"
+            "daemon must bind loopback: --host flag missing from daemon args: {args_str:?}"
         );
 
         // The value immediately following `--host` must be `127.0.0.1`.
@@ -1225,11 +1220,11 @@ mod tests {
             .expect("--host must be followed by a value");
         assert_eq!(
             host_value, "127.0.0.1",
-            "THREAT-MODEL req #9: daemon must bind 127.0.0.1 only, got {host_value:?}"
+            "daemon must bind 127.0.0.1 only, got {host_value:?}"
         );
     }
 
-    /// `0.0.0.0` must NOT appear in the daemon arg list (THREAT-MODEL req #9).
+    /// `0.0.0.0` must NOT appear in the daemon arg list.
     #[test]
     fn spawn_daemon_args_do_not_bind_wildcard() {
         let tmp = TempDir::new().unwrap();
@@ -1243,7 +1238,7 @@ mod tests {
 
         assert!(
             !args_str.contains(&"0.0.0.0".to_string()),
-            "THREAT-MODEL req #9: daemon args must not contain 0.0.0.0 (wildcard bind): {args_str:?}"
+            "daemon args must not contain 0.0.0.0 (wildcard bind): {args_str:?}"
         );
     }
 


### PR DESCRIPTION
Nine comments in `crates/spelunk-cli/src/cli/cmd/server.rs`, plus one CHANGELOG entry, cited **"THREAT-MODEL req #9 / decision #88"**. Neither referent exists:

- The binding-requirements list in `docs/security/THREAT-MODEL.md` ends at **#8**. The two commits that introduced the citations (`464a84f4`, `dea84b8a`) never touched that doc, so #9 was cited but never written.
- `decision #88` is an internal decision id with no public referent. It does not belong in a public repo.

Every one of these pointed a public reader at a requirement that is not in the repo.

## The rationale had also gone stale

The comments claimed that without `--host 127.0.0.1`, spelunk-server *"defaults to 0.0.0.0 and would be LAN-reachable while unauthenticated."* That was true when written (2026-06-09). It is not true now:

- The server's default host is `127.0.0.1` (`spelunk-server/src/main.rs`), flipped on 2026-07-01.
- `check_bind_safety()` refuses a non-loopback plaintext bind unconditionally, and runs before the bind. The auto-spawned daemon passes no TLS cert or key, so if the flag were dropped *and* the default flipped back, the daemon would **refuse to start** rather than silently expose a LAN port. It fails closed.

So the comments were wrong twice over: a dangling citation and a stale threat description.

## What this PR does

Keeps the invariant, drops the citation, corrects the rationale. The invariant is still worth pinning: `spawn_daemon` must pass `--host 127.0.0.1` and must never pass `0.0.0.0`, so the CLI does not depend on the server's default staying loopback. The comments now state that directly, matching the house rule that a comment states the constraint rather than the ticket.

The two tests are unchanged in behavior; only the `THREAT-MODEL req #9:` prefix is removed from their assert messages (it would otherwise print a bogus reference on failure).

**No THREAT-MODEL change.** The threat is already covered by the matrix row *"Server bound to 0.0.0.0 exposes data on LAN/internet"*, marked **Enforced** via ADR-066 §4. Adding a binding requirement #9 would have restated an already-enforced row.

**CHANGELOG:** the entry sits under released `[0.8.1]` and its prose is an accurate record of that release, so only the dangling citation parenthetical is removed. The history is not rewritten.

## Test plan

- `cargo test -p spelunk-cli spawn_daemon_args` — 4 passed (`..._bind_loopback`, `..._do_not_bind_wildcard`, `..._include_db_path`, `..._include_port`).
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p spelunk-cli --all-targets --no-default-features` — exit 0 (the CI matrix cell with `embed-native` off).
- `grep -rn "THREAT-MODEL req #9\|decision #88"` over `*.rs`/`*.md` — no matches remain.

Found during the board-id scrub, which correctly left it alone: this is doc-drift, not a board-id leak, and fixing it meant deciding what the requirement said. Johan made that call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
