### PR TITLE
fix(memory): set notes.rewriteRef so memory survives git commit --amend and git rebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,23 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Memory attached to a commit now survives `git commit --amend` and `git
+  rebase`.** git carries a note onto a rewritten commit only when
+  `notes.rewriteRef` names the ref, and it has no built-in default, so an
+  unconfigured repository silently orphaned every entry the rewrite touched: the
+  note stayed bound to the dead sha, and `memory list` never surfaced it again.
+  Pre-`init`, git notes is the sole store, so that was total loss of the only
+  copy. spelunk now points `notes.rewriteRef` at `refs/notes/spelunk` in the
+  repository's own config (never global) at `spelunk init`, at the first
+  pre-`init` note write, and on the `--backend git-notes` write path. It composes
+  with any value you set yourself rather than replacing it, honours an existing
+  value that already covers the ref, announces itself on the run that sets it,
+  and warns without failing when it cannot be written. `notes.rewriteMode` is
+  deliberately left at its `concatenate` default, which keeps both entries when
+  two noted commits are squashed together. Known gap: git honours the setting for
+  `amend` and `rebase` only, so `git merge --squash` and cherry-picking onto a
+  divergent base still do not carry notes. See
+  [docs/memory.md](#surviving-history-rewrites). (ADR-068)
 - **The self-hosted Docker Quick-Start builds and runs again.** The `Dockerfile`
   now builds the Cargo workspace (per-crate manifests, `crates/spelunk-server`
   binary) instead of the old single-crate layout, and installs the C/C++

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -18,7 +18,12 @@ pub struct InitArgs {
     pub name: Option<String>,
 }
 
-use crate::{capability, config::Config, registry::Registry, storage::Database};
+use crate::{
+    capability,
+    config::Config,
+    registry::Registry,
+    storage::{Database, RewriteRefStatus, ensure_notes_rewrite_ref},
+};
 
 pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
     // ── 1. Detect project root ────────────────────────────────────────────────
@@ -189,7 +194,7 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
 
     // ── 7. Configure git-notes refspec on `origin` (only inside a git repo) ───
     let notes_lines = if git_root.is_some() {
-        configure_notes_refspec(&project_root)
+        configure_notes_refspec(&project_root).await
     } else {
         Vec::new()
     };
@@ -260,7 +265,10 @@ fn write_spelunk_gitignore(spelunk_dir: &std::path::Path) {
 /// overrides git's default branch push, so a normal `git push` would stop
 /// pushing the current branch. We keep the branch-push default intact and
 /// surface the manual notes push (needed after each memory change) instead.
-fn configure_notes_refspec(project_root: &std::path::Path) -> Vec<String> {
+/// Also points `notes.rewriteRef` at spelunk's ref so memory survives history
+/// rewrites. That half is independent of `origin`: rewrites are purely local,
+/// so it runs even in a remote-less repo.
+async fn configure_notes_refspec(project_root: &std::path::Path) -> Vec<String> {
     const FETCH_REFSPEC: &str = "+refs/notes/spelunk:refs/notes/spelunk";
     const PUSH_HINT: &str =
         "push notes after each memory change: git push origin refs/notes/spelunk";
@@ -272,47 +280,71 @@ fn configure_notes_refspec(project_root: &std::path::Path) -> Vec<String> {
             .output()
     };
 
-    // No `origin` remote → skip gracefully with the exact manual commands.
-    let has_origin = git(&["remote", "get-url", "origin"])
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    if !has_origin {
-        return vec![
-            "Memory:  no 'origin' remote — notes refspec not configured".to_string(),
-            format!("         run later: git config --add remote.origin.fetch '{FETCH_REFSPEC}'"),
-            format!("         {PUSH_HINT}"),
-        ];
-    }
+    let mut lines = {
+        // No `origin` remote → skip gracefully with the exact manual commands.
+        let has_origin = git(&["remote", "get-url", "origin"])
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !has_origin {
+            vec![
+                "Memory:  no 'origin' remote — notes refspec not configured".to_string(),
+                format!(
+                    "         run later: git config --add remote.origin.fetch '{FETCH_REFSPEC}'"
+                ),
+                format!("         {PUSH_HINT}"),
+            ]
+        } else {
+            // Idempotent: only `--add` when the identical refspec is not already present.
+            let already = git(&["config", "--get-all", "remote.origin.fetch"])
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| {
+                    String::from_utf8_lossy(&o.stdout)
+                        .lines()
+                        .any(|l| l.trim() == FETCH_REFSPEC)
+                })
+                .unwrap_or(false);
+            if already {
+                vec![
+                    "Memory:  notes fetch refspec already configured on 'origin'".to_string(),
+                    format!("         {PUSH_HINT}"),
+                ]
+            } else {
+                match git(&["config", "--add", "remote.origin.fetch", FETCH_REFSPEC]) {
+                    Ok(o) if o.status.success() => vec![
+                        "Memory:  configured notes fetch refspec on 'origin' (refs/notes/spelunk travels on fetch)"
+                            .to_string(),
+                        format!("         {PUSH_HINT}"),
+                    ],
+                    Ok(o) => vec![format!(
+                        "Memory:  could not configure notes refspec: {}",
+                        String::from_utf8_lossy(&o.stderr).trim()
+                    )],
+                    Err(e) => vec![format!("Memory:  could not configure notes refspec: {e}")],
+                }
+            }
+        }
+    };
 
-    // Idempotent: only `--add` when the identical refspec is not already present.
-    let already = git(&["config", "--get-all", "remote.origin.fetch"])
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| {
-            String::from_utf8_lossy(&o.stdout)
-                .lines()
-                .any(|l| l.trim() == FETCH_REFSPEC)
-        })
-        .unwrap_or(false);
-    if already {
-        return vec![
-            "Memory:  notes fetch refspec already configured on 'origin'".to_string(),
-            format!("         {PUSH_HINT}"),
-        ];
-    }
-
-    match git(&["config", "--add", "remote.origin.fetch", FETCH_REFSPEC]) {
-        Ok(o) if o.status.success() => vec![
-            "Memory:  configured notes fetch refspec on 'origin' (refs/notes/spelunk travels on fetch)"
+    // Continuation lines: every branch above already opened a `Memory:` block.
+    match ensure_notes_rewrite_ref(Some(project_root)).await {
+        RewriteRefStatus::Configured => lines.push(
+            "         configured notes.rewriteRef (memory survives `git commit --amend` and `git rebase`)"
                 .to_string(),
-            format!("         {PUSH_HINT}"),
-        ],
-        Ok(o) => vec![format!(
-            "Memory:  could not configure notes refspec: {}",
-            String::from_utf8_lossy(&o.stderr).trim()
-        )],
-        Err(e) => vec![format!("Memory:  could not configure notes refspec: {e}")],
+        ),
+        RewriteRefStatus::AlreadyCovered => {}
+        RewriteRefStatus::Failed => {
+            lines.push(
+                "         could not set notes.rewriteRef; memory will not survive `git commit --amend` or `git rebase`"
+                    .to_string(),
+            );
+            lines.push(
+                "         run later: git config --add notes.rewriteRef refs/notes/spelunk"
+                    .to_string(),
+            );
+        }
     }
+    lines
 }
 
 /// Walk up from `start` to find the nearest `.git` directory.

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -7,7 +7,8 @@ use crate::{
     indexer::secrets::contains_secret,
     server_client::ServerInferenceClient,
     storage::{
-        NoteInput, NoteRecord, append_to_git_notes, now_millis, now_secs, open_memory_backend,
+        NoteInput, NoteRecord, RewriteRefStatus, append_to_git_notes, now_millis, now_secs,
+        open_memory_backend,
     },
 };
 
@@ -132,6 +133,7 @@ pub(super) async fn memory_add(
     // the entry); pre-`init` it is the sole store, so a failed carry is fatal.
     let write_through =
         pre_init_notes || (cfg.store_in_git_notes && backend_override != Some("git-notes"));
+    let mut notes_rewrite_note: Option<&str> = None;
     if write_through {
         let record = NoteRecord {
             schema_version: 1,
@@ -153,7 +155,21 @@ pub(super) async fn memory_add(
         // Use process CWD (None) — the CLI is always run from the project root.
         // Secret scan already ran above; no second check needed here.
         match append_to_git_notes(None, &record).await {
-            Ok(()) => {}
+            // Announce only the call that set it, so a repo says this once.
+            Ok(RewriteRefStatus::Configured) => {
+                notes_rewrite_note = Some(
+                    "Configured git notes.rewriteRef in this repo, so memory now survives \
+                     `git commit --amend` and `git rebase`.",
+                );
+            }
+            Ok(RewriteRefStatus::Failed) => {
+                notes_rewrite_note = Some(
+                    "Warning: could not set git notes.rewriteRef, so memory may not survive \
+                     `git commit --amend` or `git rebase`. Set it with: \
+                     git config --add notes.rewriteRef refs/notes/spelunk",
+                );
+            }
+            Ok(RewriteRefStatus::AlreadyCovered) => {}
             Err(e) if pre_init_notes => {
                 return Err(e.context(
                     "recording memory entry to git notes (no local project store to fall back on)",
@@ -164,6 +180,9 @@ pub(super) async fn memory_add(
     }
 
     println!("Stored [{kind}] #{id}: {title}", kind = args.kind);
+    if let Some(line) = notes_rewrite_note {
+        println!("{line}");
+    }
     Ok(())
 }
 

--- a/crates/spelunk-cli/tests/init_notes_refspec.rs
+++ b/crates/spelunk-cli/tests/init_notes_refspec.rs
@@ -158,6 +158,41 @@ fn init_no_origin_prints_hint_and_succeeds() {
     );
 }
 
+/// (2b) No `origin` remote: init still configures `notes.rewriteRef`, so memory
+/// survives `git commit --amend` and `git rebase`. The carry is purely local and
+/// must not be gated on having a remote: a remote-less repo is exactly where the
+/// note is the only copy of an entry.
+///
+/// Read `--local` so the assertion is about what init wrote to this repo, not
+/// about an ambient global value on the machine running the test.
+#[test]
+fn init_configures_notes_rewrite_ref_without_an_origin_remote() {
+    let tmp = tempdir().unwrap();
+    init_repo_with_commit(tmp.path());
+    assert!(
+        !git_out(tmp.path(), &["remote", "get-url", "origin"])
+            .status
+            .success(),
+        "setup: this repo must have no origin remote"
+    );
+
+    let stdout = run_init(tmp.path());
+
+    assert_eq!(
+        git_stdout(
+            tmp.path(),
+            &["config", "--local", "--get-all", "notes.rewriteRef"]
+        )
+        .trim(),
+        "refs/notes/spelunk",
+        "init must configure the notes carry ref even with no origin, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("configured notes.rewriteRef"),
+        "init should announce the carry config, got:\n{stdout}"
+    );
+}
+
 /// (3) Idempotent: two inits leave exactly one notes refspec + "already
 /// configured" announce on the second run.
 #[test]

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -12,6 +12,83 @@ mod lock;
 
 pub use lock::{NotesLock, lock_notes};
 
+// ── Carry config: surviving history rewrites ─────────────────────────────────
+
+/// The ref spelunk stores memory notes on.
+const SPELUNK_NOTES_REF: &str = "refs/notes/spelunk";
+
+/// The namespace git is willing to rewrite notes in.
+const NOTES_NAMESPACE: &str = "refs/notes/";
+
+/// What [`ensure_notes_rewrite_ref`] found or did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RewriteRefStatus {
+    /// This call added the setting; announce it once.
+    Configured,
+    /// Already named by an existing value (exactly, or via a glob).
+    AlreadyCovered,
+    /// Could not be set; the reason is logged. Entries stay at risk.
+    Failed,
+}
+
+/// Point `notes.rewriteRef` at spelunk's notes ref in this repo.
+///
+/// Gotcha: git carries a note onto a rewritten commit (`commit --amend`,
+/// `rebase`) only if `notes.rewriteRef` names the ref, and it has **no**
+/// built-in default, so an unconfigured repo silently orphans every entry.
+/// Pre-`init` git notes is the sole store, making that total loss.
+///
+/// `notes.rewriteMode` is deliberately left alone: its `concatenate` default
+/// keeps every JSON line, whereas `overwrite` and `ignore` each drop one side
+/// of a squashed pair, causing the loss this is meant to prevent.
+///
+/// Never returns an error: the write it guards may be an entry's only copy, so
+/// a config failure must not sink it.
+pub async fn ensure_notes_rewrite_ref(git_root: Option<&std::path::Path>) -> RewriteRefStatus {
+    // Reads local, global and system scopes, so a user who set this themselves
+    // anywhere is left alone. Absent (exit 1) means unset, not an error.
+    let existing = run_git(git_root, &["config", "--get-all", "notes.rewriteRef"])
+        .await
+        .unwrap_or_default();
+    if existing.lines().any(rewrite_ref_covers_spelunk) {
+        return RewriteRefStatus::AlreadyCovered;
+    }
+
+    // Multi-valued: `--add` composes with any value the user already has, and
+    // writes to the repo-local config (never global).
+    match run_git(
+        git_root,
+        &["config", "--add", "notes.rewriteRef", SPELUNK_NOTES_REF],
+    )
+    .await
+    {
+        Ok(_) => RewriteRefStatus::Configured,
+        Err(e) => {
+            tracing::warn!(
+                "could not set notes.rewriteRef ({e}); memory will not survive \
+                 `git commit --amend` or `git rebase`"
+            );
+            RewriteRefStatus::Failed
+        }
+    }
+}
+
+/// Whether an existing `notes.rewriteRef` value already names spelunk's ref.
+///
+/// Values may be globs. git refuses to rewrite notes outside `refs/notes/`, so
+/// a glob only counts while it stays inside that namespace: `refs/notes/*`
+/// covers us, `refs/*` does not. A false negative only re-adds the exact ref,
+/// which stays correct, so matching a trailing `*` is enough.
+fn rewrite_ref_covers_spelunk(value: &str) -> bool {
+    let value = value.trim();
+    if value == SPELUNK_NOTES_REF {
+        return true;
+    }
+    value.strip_suffix('*').is_some_and(|prefix| {
+        prefix.starts_with(NOTES_NAMESPACE) && SPELUNK_NOTES_REF.starts_with(prefix)
+    })
+}
+
 // ── Write-through helper (free function) ─────────────────────────────────────
 
 /// Append a `NoteRecord` as a JSON line to `refs/notes/spelunk` on HEAD.
@@ -25,8 +102,8 @@ pub use lock::{NotesLock, lock_notes};
 /// reads the same body and silently drops this entry on write-back (#185).
 ///
 /// Errors are intentionally non-fatal: the caller should log `tracing::warn!`
-/// and continue.  This function returns `Ok(())` on success or propagates
-/// an error for the caller to handle gracefully.
+/// and continue.  On success it returns the [`RewriteRefStatus`] of the carry
+/// config ensured along the way, so a CLI caller can announce it once.
 ///
 /// # Arguments
 /// * `git_root` — directory passed to `git -C`; `None` uses the process CWD.
@@ -34,7 +111,11 @@ pub use lock::{NotesLock, lock_notes};
 pub async fn append_to_git_notes(
     git_root: Option<&std::path::Path>,
     record: &NoteRecord,
-) -> Result<()> {
+) -> Result<RewriteRefStatus> {
+    // Touches `git config` only, never the notes ref, so it stays outside the
+    // lock: serializing it would widen the guarded section for nothing.
+    let rewrite_ref = ensure_notes_rewrite_ref(git_root).await;
+
     // Guard all four steps. Contention must never fail the caller's write, so
     // an unavailable lock degrades to the pre-#185 unserialized behaviour.
     let _lock = lock_notes(git_root).await;
@@ -82,7 +163,7 @@ pub async fn append_to_git_notes(
     )
     .await?;
 
-    Ok(())
+    Ok(rewrite_ref)
 }
 
 /// Run a git subprocess, optionally in `dir`, and return stdout as a `String`.
@@ -339,6 +420,11 @@ impl GitNotesBackend {
     /// Append `record` as a new JSON line to `object`'s note, preserving every
     /// existing line (spelunk records and foreign content) byte-for-byte.
     async fn append_record(&self, object: &str, record: &NoteRecord) -> Result<()> {
+        // git notes is the primary store on this path (`--backend git-notes`),
+        // so an unconfigured carry ref orphans the only copy. Status is dropped:
+        // this path has no command output to announce on.
+        ensure_notes_rewrite_ref(self.git_root.as_deref()).await;
+
         let _lock = lock_notes(self.git_root.as_deref()).await;
 
         let existing = self.read_note_blob(object).await?;

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -19,7 +19,10 @@ pub use backend::{LocalMemoryBackend, MemoryBackend, NoteInput};
 pub use conventions::{ConventionRow, RawChunkRow, has_doc_prefix};
 pub use db::Database;
 pub use files::FileRecord;
-pub use git_notes::{GitNotesBackend, NotesLock, append_to_git_notes, lock_notes};
+pub use git_notes::{
+    GitNotesBackend, NotesLock, RewriteRefStatus, append_to_git_notes, ensure_notes_rewrite_ref,
+    lock_notes,
+};
 pub use graph::GraphEdge;
 pub use memory::{MemoryEdge, MemoryStore, SyncRow};
 pub use note_record::{NoteRecord, now_millis, now_secs};

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -1460,6 +1460,11 @@ async fn ensure_notes_rewrite_ref_composes_with_a_users_existing_value() {
 }
 
 /// A user glob that already covers our ref is left alone.
+///
+/// Deferring is only safe if the glob genuinely carries, so this asserts git's
+/// behaviour end to end rather than trusting our reading of it: silently
+/// skipping the fix against a glob that did not really cover us would orphan
+/// the entry, which is the whole bug.
 #[tokio::test]
 #[serial]
 async fn ensure_notes_rewrite_ref_defers_to_a_covering_glob() {
@@ -1478,6 +1483,18 @@ async fn ensure_notes_rewrite_ref_defers_to_a_covering_glob() {
         rewrite_ref_values(root),
         vec!["refs/notes/*"],
         "a covering glob needs no addition"
+    );
+
+    append_to_git_notes(Some(root), &make_note_record(1, PRECIOUS))
+        .await
+        .expect("append should succeed");
+    git_ok(
+        root,
+        &["commit", "--amend", "--no-gpg-sign", "-m", "amended"],
+    );
+    assert!(
+        note_on_head(root).is_some_and(|b| b.contains(PRECIOUS)),
+        "the glob we deferred to must actually carry the entry"
     );
 }
 
@@ -1507,5 +1524,149 @@ async fn ensure_notes_rewrite_ref_ignores_a_glob_outside_the_notes_namespace() {
     assert!(
         note_on_head(root).is_some_and(|b| b.contains(PRECIOUS)),
         "entry must survive despite the user's out-of-namespace glob"
+    );
+}
+
+/// `--backend git-notes` makes notes the primary store, so an unconfigured carry
+/// ref there orphans the only copy. Asserted through `list`, not just the raw
+/// note: `list` intersects against `git log`, which is what actually made the
+/// orphaned entry unreachable.
+#[tokio::test]
+#[serial]
+async fn git_notes_backend_add_configures_carry_and_entry_survives_amend() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+
+    backend
+        .add(note_input("decision", PRECIOUS))
+        .await
+        .expect("add");
+
+    assert_eq!(
+        rewrite_ref_values(root),
+        vec!["refs/notes/spelunk"],
+        "the backend write path must configure the carry ref too"
+    );
+
+    let before = git_stdout_ok(root, &["rev-parse", "HEAD"]);
+    git_ok(
+        root,
+        &[
+            "commit",
+            "--amend",
+            "--no-gpg-sign",
+            "-m",
+            "amended subject",
+        ],
+    );
+    assert_ne!(
+        before,
+        git_stdout_ok(root, &["rev-parse", "HEAD"]),
+        "the amend must actually have rewritten the commit"
+    );
+
+    let entries = backend
+        .list(Some("decision"), 100, false, None)
+        .await
+        .expect("list");
+    assert_eq!(
+        entries.iter().filter(|n| n.title == PRECIOUS).count(),
+        1,
+        "the entry must still be reachable after an amend; got: {:?}",
+        entries.iter().map(|n| &n.title).collect::<Vec<_>>()
+    );
+}
+
+/// The carry config is ensured even when the notes lock is unavailable. It runs
+/// before `lock_notes` and guards a write that proceeds either way, so moving it
+/// inside the lock-acquired branch would silently stop configuring it under
+/// contention, which is exactly when an entry is most at risk.
+#[tokio::test]
+#[serial]
+async fn append_to_git_notes_ensures_carry_config_even_when_the_lock_is_unusable() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+
+    std::fs::create_dir_all(notes_lock_path(root)).expect("place a directory at the lock path");
+    assert!(
+        lock_notes(Some(root)).await.is_none(),
+        "setup: an unopenable lock path must yield None"
+    );
+
+    append_to_git_notes(Some(root), &make_note_record(1, PRECIOUS))
+        .await
+        .expect("append should succeed");
+
+    assert_eq!(
+        rewrite_ref_values(root),
+        vec!["refs/notes/spelunk"],
+        "the carry config must be set even when the lock degrades to unlocked"
+    );
+}
+
+/// A carry config that cannot be written reports `Failed` and the write still
+/// proceeds: pre-`init` the entry has no other copy, so a config failure must
+/// never sink it.
+///
+/// A read-only `.git` blocks the config lock file while leaving object and ref
+/// writes working (they land in subdirectories), isolating a config failure from
+/// the note write. Unix-only: it turns on the directory mode.
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn append_to_git_notes_proceeds_when_the_carry_config_cannot_be_written() {
+    use std::os::unix::fs::PermissionsExt;
+
+    const ONLY_COPY: &str = "a config failure must not sink the entry";
+
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+    let git_dir = root.join(".git");
+    let original = std::fs::metadata(&git_dir)
+        .expect("stat .git")
+        .permissions();
+
+    let mut read_only = original.clone();
+    read_only.set_mode(0o555);
+    std::fs::set_permissions(&git_dir, read_only).expect("make .git read-only");
+
+    // Probe with raw git, never with the code under test: root (or a mount that
+    // ignores the mode) can still write the config, and there is no failure to
+    // assert against then. Deciding that from the status would let a mutation
+    // that misreports failure as success route itself into the skip and pass.
+    let enforced = !std::process::Command::new("git")
+        .current_dir(root)
+        .args(["config", "--add", "notes.rewriteRefProbe", "x"])
+        .output()
+        .expect("git config probe")
+        .status
+        .success();
+    if !enforced {
+        std::fs::set_permissions(&git_dir, original).expect("restore .git permissions");
+        return;
+    }
+
+    let status = ensure_notes_rewrite_ref(Some(root)).await;
+    let write = append_to_git_notes(Some(root), &make_note_record(1, ONLY_COPY)).await;
+    let note = note_on_head(root);
+
+    // Restore before asserting: a panic below would otherwise leave a read-only
+    // directory behind that `TempDir` cannot clean up.
+    std::fs::set_permissions(&git_dir, original).expect("restore .git permissions");
+
+    assert_eq!(
+        status,
+        RewriteRefStatus::Failed,
+        "an unwritable config must report Failed"
+    );
+    assert_eq!(
+        write.expect("a config failure must never fail the write"),
+        RewriteRefStatus::Failed,
+        "the write must report the carry it could not make"
+    );
+    assert!(
+        note.is_some_and(|b| b.contains(ONLY_COPY)),
+        "the entry must still be written when the carry config fails"
     );
 }

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -1155,3 +1155,357 @@ async fn git_notes_backend_uncontended_add_and_archive_never_reach_the_wait_budg
         );
     }
 }
+
+// ── survival across git history rewrites ─────────────────────────────────────
+//
+// git copies a note onto a rewritten commit only when `notes.rewriteRef` names
+// the ref, and it has no built-in default. Pre-`init` git notes is the sole
+// store, so an unconfigured repo lost the only copy on every amend/rebase.
+//
+// Known gap: `merge --squash` and cherry-pick onto a divergent base do not
+// carry notes even with `notes.rewriteRef` set. git honours it for `amend` and
+// `rebase` only.
+
+/// Run `git args` in `root`, asserting success.
+fn git_ok(root: &std::path::Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .output()
+        .expect("git command");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Trimmed stdout of `git args` in `root`, asserting success.
+fn git_stdout_ok(root: &std::path::Path, args: &[&str]) -> String {
+    let out = std::process::Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .output()
+        .expect("git command");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Run a rebase with scripted editors. git runs an editor through a shell when
+/// the command holds shell metacharacters, so a value ending in `>` redirects
+/// into the file git appends as the trailing argument. Portable across the CI
+/// matrix, unlike `sed -i` (BSD and GNU disagree on its argument).
+fn git_rebase_scripted(root: &std::path::Path, args: &[&str], seq_editor: &str, editor: &str) {
+    let out = std::process::Command::new("git")
+        .current_dir(root)
+        .args(args)
+        .env("GIT_SEQUENCE_EDITOR", seq_editor)
+        .env("GIT_EDITOR", editor)
+        .output()
+        .expect("git rebase");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The spelunk note body on HEAD, or `None` when HEAD carries no note.
+fn note_on_head(root: &std::path::Path) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .current_dir(root)
+        .args(["notes", "--ref=spelunk", "show", "HEAD"])
+        .output()
+        .expect("git notes show");
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Commit a new `file` in `root` with subject `msg`.
+fn commit_file(root: &std::path::Path, file: &str, msg: &str) {
+    std::fs::write(root.join(file), "x").expect("write");
+    git_ok(root, &["add", "."]);
+    git_ok(root, &["commit", "--no-gpg-sign", "-m", msg]);
+}
+
+/// A repo whose rewrites are deterministic regardless of ambient git config.
+fn rewrite_test_repo() -> tempfile::TempDir {
+    let dir = make_temp_git_repo();
+    git_ok(dir.path(), &["config", "commit.gpgsign", "false"]);
+    dir
+}
+
+const PRECIOUS: &str = "precious decision";
+
+/// `git commit --amend` must carry the entry onto the rewritten commit.
+#[tokio::test]
+#[serial]
+async fn note_survives_git_commit_amend() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+
+    append_to_git_notes(Some(root), &make_note_record(1, PRECIOUS))
+        .await
+        .expect("append should succeed");
+
+    let before = git_stdout_ok(root, &["rev-parse", "HEAD"]);
+    // Amend the subject, not just `--no-edit`: an amend that changes nothing
+    // re-creates a byte-identical commit object within the same second, so the
+    // sha is unchanged and the note is never actually asked to move.
+    git_ok(
+        root,
+        &[
+            "commit",
+            "--amend",
+            "--no-gpg-sign",
+            "-m",
+            "amended subject",
+        ],
+    );
+    assert_ne!(
+        before,
+        git_stdout_ok(root, &["rev-parse", "HEAD"]),
+        "the amend must actually have rewritten the commit"
+    );
+
+    let body = note_on_head(root).expect("entry must survive `git commit --amend`");
+    assert!(
+        body.contains(PRECIOUS),
+        "amended HEAD must carry the entry; got: {body:?}"
+    );
+}
+
+/// A plain `git rebase` must carry the entry onto the replayed commit.
+#[tokio::test]
+#[serial]
+async fn note_survives_git_rebase() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+
+    git_ok(root, &["checkout", "-q", "-b", "feat"]);
+    commit_file(root, "feat.txt", "feat work");
+    append_to_git_notes(Some(root), &make_note_record(1, PRECIOUS))
+        .await
+        .expect("append should succeed");
+
+    // Move main ahead so the rebase really replays onto new shas.
+    git_ok(root, &["checkout", "-q", "main"]);
+    commit_file(root, "main.txt", "main moves");
+    git_ok(root, &["checkout", "-q", "feat"]);
+    git_ok(root, &["rebase", "main"]);
+
+    let body = note_on_head(root).expect("entry must survive `git rebase`");
+    assert!(
+        body.contains(PRECIOUS),
+        "rebased HEAD must carry the entry; got: {body:?}"
+    );
+}
+
+/// `git rebase -i` reword must carry the entry.
+#[tokio::test]
+#[serial]
+async fn note_survives_rebase_interactive_reword() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+
+    commit_file(root, "work.txt", "target commit");
+    append_to_git_notes(Some(root), &make_note_record(1, PRECIOUS))
+        .await
+        .expect("append should succeed");
+
+    let sha = git_stdout_ok(root, &["rev-parse", "--short", "HEAD"]);
+    git_rebase_scripted(
+        root,
+        &["rebase", "-i", "HEAD~1"],
+        &format!("printf 'reword {sha}\\n' >"),
+        "printf 'reworded subject\\n' >",
+    );
+
+    assert_eq!(
+        git_stdout_ok(root, &["log", "-1", "--format=%s"]),
+        "reworded subject",
+        "the reword must actually have rewritten the commit"
+    );
+    let body = note_on_head(root).expect("entry must survive a `rebase -i` reword");
+    assert!(
+        body.contains(PRECIOUS),
+        "reworded HEAD must carry the entry; got: {body:?}"
+    );
+}
+
+/// `git rebase --autosquash` (fixup) must carry the entry onto the squashed commit.
+#[tokio::test]
+#[serial]
+async fn note_survives_rebase_autosquash_fixup() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+
+    commit_file(root, "work.txt", "target commit");
+    append_to_git_notes(Some(root), &make_note_record(1, PRECIOUS))
+        .await
+        .expect("append should succeed");
+
+    let noted = git_stdout_ok(root, &["rev-parse", "HEAD"]);
+    std::fs::write(root.join("more.txt"), "x").expect("write");
+    git_ok(root, &["add", "."]);
+    git_ok(root, &["commit", "--no-gpg-sign", "--fixup", &noted]);
+
+    // `-i` plus a no-op sequence editor accepts the autosquash-arranged todo.
+    // A non-interactive `--autosquash` would need git >= 2.38.
+    git_rebase_scripted(
+        root,
+        &["rebase", "-i", "--autosquash", "HEAD~2"],
+        "exit 0 #",
+        "exit 0 #",
+    );
+
+    assert_eq!(
+        git_stdout_ok(root, &["log", "--oneline"]).lines().count(),
+        2,
+        "the fixup must actually have been squashed away"
+    );
+    let body = note_on_head(root).expect("entry must survive an autosquash fixup");
+    assert!(
+        body.contains(PRECIOUS),
+        "squashed HEAD must carry the entry; got: {body:?}"
+    );
+}
+
+// ── notes.rewriteRef carry config ────────────────────────────────────────────
+
+use spelunk_core::storage::{RewriteRefStatus, ensure_notes_rewrite_ref};
+
+/// Every configured `notes.rewriteRef` value, in config order.
+fn rewrite_ref_values(root: &std::path::Path) -> Vec<String> {
+    let out = std::process::Command::new("git")
+        .current_dir(root)
+        .args(["config", "--get-all", "notes.rewriteRef"])
+        .output()
+        .expect("git config");
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(|l| l.trim().to_string())
+        .collect()
+}
+
+/// Re-running must not stack duplicate config lines.
+#[tokio::test]
+#[serial]
+async fn ensure_notes_rewrite_ref_is_idempotent() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+
+    assert_eq!(
+        ensure_notes_rewrite_ref(Some(root)).await,
+        RewriteRefStatus::Configured,
+        "first call must set it"
+    );
+    assert_eq!(
+        ensure_notes_rewrite_ref(Some(root)).await,
+        RewriteRefStatus::AlreadyCovered,
+        "second call must detect its own value and stay quiet"
+    );
+    assert_eq!(
+        rewrite_ref_values(root),
+        vec!["refs/notes/spelunk"],
+        "re-running must not duplicate the config line"
+    );
+}
+
+/// A user's own rewriteRef must survive: the value is multi-valued, so `--add`
+/// composes instead of clobbering, and both refs keep carrying.
+#[tokio::test]
+#[serial]
+async fn ensure_notes_rewrite_ref_composes_with_a_users_existing_value() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+    git_ok(
+        root,
+        &["config", "--add", "notes.rewriteRef", "refs/notes/commits"],
+    );
+    git_ok(
+        root,
+        &["notes", "--ref=commits", "add", "-m", "user note", "HEAD"],
+    );
+
+    assert_eq!(
+        ensure_notes_rewrite_ref(Some(root)).await,
+        RewriteRefStatus::Configured
+    );
+    assert_eq!(
+        rewrite_ref_values(root),
+        vec!["refs/notes/commits", "refs/notes/spelunk"],
+        "the user's value must be kept alongside ours"
+    );
+
+    append_to_git_notes(Some(root), &make_note_record(1, PRECIOUS))
+        .await
+        .expect("append should succeed");
+    git_ok(
+        root,
+        &["commit", "--amend", "--no-gpg-sign", "-m", "amended"],
+    );
+
+    let user_note = git_stdout_ok(root, &["notes", "--ref=commits", "show", "HEAD"]);
+    assert_eq!(user_note, "user note", "the user's note must still carry");
+    assert!(
+        note_on_head(root).is_some_and(|b| b.contains(PRECIOUS)),
+        "our note must carry too"
+    );
+}
+
+/// A user glob that already covers our ref is left alone.
+#[tokio::test]
+#[serial]
+async fn ensure_notes_rewrite_ref_defers_to_a_covering_glob() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+    git_ok(
+        root,
+        &["config", "--add", "notes.rewriteRef", "refs/notes/*"],
+    );
+
+    assert_eq!(
+        ensure_notes_rewrite_ref(Some(root)).await,
+        RewriteRefStatus::AlreadyCovered
+    );
+    assert_eq!(
+        rewrite_ref_values(root),
+        vec!["refs/notes/*"],
+        "a covering glob needs no addition"
+    );
+}
+
+/// A glob reaching outside `refs/notes/` does NOT cover us: git refuses to
+/// rewrite notes there ("Refusing to rewrite notes in refs/*"), so treating it
+/// as coverage would silently skip the fix and lose the entry.
+#[tokio::test]
+#[serial]
+async fn ensure_notes_rewrite_ref_ignores_a_glob_outside_the_notes_namespace() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+    git_ok(root, &["config", "--add", "notes.rewriteRef", "refs/*"]);
+
+    assert_eq!(
+        ensure_notes_rewrite_ref(Some(root)).await,
+        RewriteRefStatus::Configured,
+        "refs/* is not coverage; our exact ref must still be added"
+    );
+
+    append_to_git_notes(Some(root), &make_note_record(1, PRECIOUS))
+        .await
+        .expect("append should succeed");
+    git_ok(
+        root,
+        &["commit", "--amend", "--no-gpg-sign", "-m", "amended"],
+    );
+    assert!(
+        note_on_head(root).is_some_and(|b| b.contains(PRECIOUS)),
+        "entry must survive despite the user's out-of-namespace glob"
+    );
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -45,6 +45,14 @@ The init output includes the push command to publish your notes; re-run it
 after each memory change so new notes commits travel. See
 [Sharing memory across clones via git-notes](memory.md#sharing-memory-across-clones-via-git-notes).
 
+**Memory survives history rewrites:** `init` also points `notes.rewriteRef` at
+`refs/notes/spelunk` in the repository's own config, so memory attached to a
+commit is carried onto its replacement by `git commit --amend` and `git rebase`
+rather than orphaned on the old sha. This runs even without an `origin`, since
+rewrites are local. Note that `git merge --squash` and cherry-picking onto a
+divergent base still do not carry notes. See [Surviving history
+rewrites](memory.md#surviving-history-rewrites).
+
 If the repo already carries memory on `refs/notes/spelunk`, `init` also hydrates
 the new `memory.db` from those notes: every entry not already present is imported
 (idempotent, no embeddings), and it prints `Memory:  imported N entries from git

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -71,7 +71,12 @@ spelunk automatically configures the fetch refspec for `origin` so that
 ```
 Memory:  configured notes fetch refspec on 'origin' (refs/notes/spelunk travels on fetch)
          push notes after each memory change: git push origin refs/notes/spelunk
+         configured notes.rewriteRef (memory survives `git commit --amend` and `git rebase`)
 ```
+
+The last line is a separate setting, covered in [Surviving history
+rewrites](#surviving-history-rewrites) below. It is printed only by the run that
+sets it, so a re-run of `init` omits it.
 
 To publish your memory notes to the remote, push the notes ref:
 
@@ -101,9 +106,12 @@ repository), `spelunk init` prints the commands to run later:
 Memory:  no 'origin' remote — notes refspec not configured
          run later: git config --add remote.origin.fetch '+refs/notes/spelunk:refs/notes/spelunk'
          push notes after each memory change: git push origin refs/notes/spelunk
+         configured notes.rewriteRef (memory survives `git commit --amend` and `git rebase`)
 ```
 
-Add the refspec when an `origin` is created, then push the notes as above.
+Add the refspec when an `origin` is created, then push the notes as above. The
+`notes.rewriteRef` line appears here too: rewrites are purely local, so that
+setting is configured even in a repository with no remote.
 
 If the repository already carries memory on `refs/notes/spelunk` (for example a
 fresh clone of a project whose team records memory through git notes), `spelunk
@@ -117,6 +125,57 @@ notes refspec, since git does not fetch `refs/notes/*` by default (see above).
 git-notes is the durable carrier here and `memory.db` is a local index rebuilt
 from it; see
 [ADR-068](adr/068-zero-setup-onboarding-git-notes-memory-fallback.md).
+
+### Surviving history rewrites
+
+`git commit --amend` and `git rebase` replace a commit with a new sha. A note is
+bound to the sha it was written on, and git carries it onto the replacement only
+when `notes.rewriteRef` names the ref the note lives on. That setting has **no
+built-in default**: in an unconfigured repository, amending or rebasing a commit
+that carries memory orphans every entry on the dead sha. `memory list` never
+shows those entries again, because it lists notes that are reachable from `git
+log`, and the dead sha no longer is.
+
+spelunk therefore points `notes.rewriteRef` at `refs/notes/spelunk` for you. It
+is written to the repository's own config, never your global config, at whichever
+of these comes first:
+
+- `spelunk init`, alongside the fetch refspec. Independent of `origin`, since
+  rewrites are purely local, so a repository with no remote is covered too.
+- The first `memory add` write-through, which reaches repositories where you
+  never run `init`.
+- The `--backend git-notes` write path, where notes are the primary store.
+
+Setting it is announced, never silent. The run that sets it prints:
+
+```
+Configured git notes.rewriteRef in this repo, so memory now survives `git commit --amend` and `git rebase`.
+```
+
+Later runs stay quiet, since the setting is already in place. `--add` composes
+with any value you set yourself rather than replacing it, and an existing value
+that already covers the ref (exactly, or via a glob that stays inside
+`refs/notes/`) is left alone. If the setting cannot be written, spelunk warns and
+continues rather than failing the write, and names the command to run:
+
+```
+Warning: could not set git notes.rewriteRef, so memory may not survive `git commit --amend` or `git rebase`. Set it with: git config --add notes.rewriteRef refs/notes/spelunk
+```
+
+`notes.rewriteMode` is deliberately left at its `concatenate` default, which
+keeps both sides when two noted commits are squashed into one. `overwrite` and
+`ignore` each drop one of them, causing the loss this is meant to prevent.
+
+**Known limitation:** git honours `notes.rewriteRef` for `commit --amend` and
+`rebase` only. `git merge --squash`, and cherry-picking onto a divergent base, do
+**not** carry notes, even with the setting configured. Memory attached to a
+commit that reaches your branch by either of those routes is still orphaned on
+the original sha. If those entries matter, re-record them on the new commit
+before the original is discarded.
+
+This is about surviving a rewrite of your own local history. It is a separate
+concern from whether notes reach a teammate, which still depends on the notes ref
+being pushed and fetched (see above).
 
 ## Why memory?
 


### PR DESCRIPTION
## What

Memory attached to a commit was **silently orphaned** by `git commit --amend` and
`git rebase`. Git carries a note onto a rewritten commit only when
`notes.rewriteRef` names the ref, and it has **no built-in default** — so the note
stayed bound to the dead sha and `memory list` never surfaced it again (it
intersects `notes list` against `git log`, and a dead sha never appears there).

**Pre-`init`, git notes is the sole store, so this was total loss of the only copy**
on the zero-setup flow. Post-`init` the entry survived in `memory.db`, but the
carrier silently stopped reaching teammates.

Reproduced on git 2.55.0: a plain `git rebase` orphans every note on the rebased
commits — the rebase-onto-main that precedes most PRs.

## The fix

New `ensure_notes_rewrite_ref() -> RewriteRefStatus { Configured, AlreadyCovered, Failed }`
points `notes.rewriteRef` at `refs/notes/spelunk` in the repository's own config
(never global), at three write points:

- `spelunk init` (folded into the existing refspec configuration, which already
  writes git config and announces it). Deliberately **independent of `origin`** —
  rewrites are local, so a remote-less repo is covered too.
- the first pre-`init` note write (those users never run `init`, and that tier is
  where notes are the only copy).
- the `--backend git-notes` write path, where notes are likewise the primary store.

It composes with a value you set yourself (`--add`, multi-valued) rather than
replacing it, honours an existing value that already covers the ref, announces
itself only on the run that sets it, and **warns without failing** when it cannot
be written — a config failure must never sink the entry it guards.

`notes.rewriteMode` is deliberately left at its `concatenate` default: that keeps
both entries when two noted commits are squashed, whereas `overwrite` and `ignore`
each drop one, causing the loss this prevents.

### The namespace check is load-bearing

Git refuses to rewrite notes outside `refs/notes/` (`warning: Refusing to rewrite
notes in refs/* (outside of refs/notes/)`) and drops the note. So treating an
out-of-namespace value like `refs/*` as "already covered" would silently skip the
fix and cause the exact data loss. Coverage is only honoured for globs inside
`refs/notes/`; a regression here is pinned by a dedicated test.

## Known limitation (documented)

Git honours `notes.rewriteRef` for `commit --amend` and `rebase` only.
`git merge --squash`, and cherry-picking onto a divergent base, do **not** carry
notes even with the setting configured. Documented in `docs/memory.md`,
`docs/commands.md` and the changelog rather than left as a code comment.

## Test plan

All gates captured with real exit statuses (no pipe):
`cargo fmt --check` 0 · `cargo test -p spelunk-cli -p spelunk-core` 0 ·
`cargo test -p spelunk-core --no-default-features` 0 ·
`cargo clippy --all-targets -- -D warnings` 0.

- **Before:** 4 repro tests fail (amend / rebase / `rebase -i` reword /
  `rebase --autosquash` fixup), each at the note-missing assertion, with a setup
  guard first asserting the rewrite genuinely happened.
- **After:** 12 pass — the 4 repro plus idempotency, composition with a user's
  existing value, covering glob, out-of-namespace glob, the `--backend git-notes`
  path, `init` without an `origin` remote, the `Failed` warn-and-continue path,
  and an ordering guard (the config call must stay outside the notes lock, or it
  silently stops configuring under contention).
- **Mutation-tested**, not merely passing: a no-op helper kills all 4 repro tests
  at the right assertion; treating `refs/*` as covering kills only the
  out-of-namespace test; `--add`→`--replace-all` kills the composition test;
  dropping glob support kills the covering-glob test; re-gating `init` on `origin`
  kills the no-origin test.
- **Verified against the real CLI**, not only tests: pre-`init` `memory add` →
  `git commit --amend` → `memory list` returns 2 (previously 0, permanently).
- Repo-local scoping verified empirically: an isolated `GIT_CONFIG_GLOBAL` is left
  byte-empty.

Refs: ADR-068 (git notes as the memory carrier).
