### PR TITLE
Bench: reach the spelunk condition from opencode and claude-code over a local MCP server

### DIFF
--- a/bench/agents/README.md
+++ b/bench/agents/README.md
@@ -49,16 +49,39 @@ runs; it is kept only so old invocations in scrollback don't 404.
 | `spelunk_full` | baseline + `spelunk_search` + `spelunk_graph` + `spelunk_memory_search` |
 
 `condition` and `harness` are independent dimensions — vary exactly one
-at a time between comparisons (bench/AGENTS.md principle #1). `spelunk_search`
-/ `spelunk_full` are meaningful only for `--harness none` (see "Harnesses"
-below); opencode and claude-code are generic coding agents, not
-spelunk-instrumented, so they only ever run as `baseline` —
-`swebench_run.sh` errors if `--condition` isn't `baseline` for those two
-harnesses, and each harness's own result JSON records `condition` from
-`--condition` (default `baseline`) rather than a hardcoded per-harness
-string, so the value in the JSON always matches what was requested. (The
+at a time between comparisons (bench/AGENTS.md principle #1). All three
+conditions run under all three harnesses. `--harness none` (`agent.py`) calls
+the spelunk tools in-process; opencode and claude-code reach the same tools
+over `spelunk_mcp_server.py`, a bench-local stdio MCP server that *imports*
+`agent.py`'s tool functions and schemas rather than reimplementing them, so
+the capability behind a `spelunk` condition cannot drift between harnesses.
+Each harness's result JSON records `condition` from `--condition`, so the
+value in the JSON always matches what was requested. (The
 DeepSeek-vs-native-Claude distinction for the claude-code harness lives in
 `endpoint_kind`, not `condition` — see the provenance table below.)
+
+**Tool names differ by harness; capability does not.** Under `--harness none`
+the model sees `spelunk_search`; under the MCP harnesses it sees
+`mcp__spelunk__spelunk_search`. Names, descriptions, and schemas are
+otherwise identical because they are the same objects. Transport differs,
+capability does not — the one accepted, documented asymmetry.
+
+**MCP hygiene (`--strict-mcp-config`).** The claude-code adapter passes
+`--strict-mcp-config` in *both* arms, so only the bench's own `--mcp-config`
+is loaded. A dev host with its own MCP servers configured would otherwise
+leak them into baseline *and* spelunk, contaminating both. opencode has no
+equivalent flag; its generated `opencode.json` is repo-scoped, and on
+v1.17.20 `mcp` servers declared in a global `~/.config/opencode/` config were
+observed not to spawn for a repo-scoped run. That is an observed behaviour,
+not a documented guarantee — unlike `--strict-mcp-config`, nothing enforces
+it, so re-check it when bumping opencode.
+
+**Tool-invocation telemetry.** Runs on a spelunk condition report
+`spelunk_mcp_server_spawned` plus `spelunk_tool_calls` /
+`spelunk_tool_calls_by_tool`. These separate three outcomes that otherwise
+look alike: the server never spawned (broken wiring — a baseline run with
+extra latency, not a spelunk cell), it spawned but the model never reached
+for a tool (a real result), or it was used.
 
 ## Harnesses
 
@@ -241,13 +264,12 @@ Reads `bench/agents/tasks_50.json`, expects repos checked out at
 where repos live without needing `--repos-dir` on every invocation).
 Override either with `--repos-dir`.
 
-For `--harness none` with `spelunk_search`/`spelunk_full` conditions, runs
-`spelunk index` (and, for `spelunk_full`, `spelunk memory harvest`) on each
-repo before the agent, unless `--skip-index` is set. The `opencode` and
-`claude-code` harnesses never invoke spelunk — they are generic coding
-agents being measured on their own, not spelunk-instrumented (see
-"Harnesses" above) — so this step is skipped entirely for them regardless of
-`--skip-index`.
+For `spelunk_search`/`spelunk_full` conditions, runs `spelunk index` (and,
+for `spelunk_full`, `spelunk memory harvest`) on each repo before the agent,
+unless `--skip-index` is set. This is gated on the condition, not the
+harness: every harness reaches the same tools on a spelunk condition, and
+without the index the spelunk arm is a silent no-op that scores like
+baseline.
 
 Each task's patch is saved to
 `bench/patches/<condition>-<timestamp>/<task_id>.patch` for `--harness none`,

--- a/bench/agents/README.md
+++ b/bench/agents/README.md
@@ -64,7 +64,19 @@ DeepSeek-vs-native-Claude distinction for the claude-code harness lives in
 the model sees `spelunk_search`; under the MCP harnesses it sees
 `mcp__spelunk__spelunk_search`. Names, descriptions, and schemas are
 otherwise identical because they are the same objects. Transport differs,
-capability does not — the one accepted, documented asymmetry.
+capability does not.
+
+**The system prompt is not identical across harnesses.** Each harness keeps
+its own base prompt; on a spelunk condition it appends a guidance sentence
+naming that harness's tool names rather than reusing `agent.py`'s whole
+`SYSTEM_PROMPT_SPELUNK`. That sentence is held as an exact substring of
+`SYSTEM_PROMPT_SPELUNK` and asserted by the offline suite, so an upstream
+reword fails loudly, but a spelunk arm's full prompt is *not* byte-identical
+to `agent.py`'s. Unlike the tool schemas, this is not equivalence by
+construction: it is the second accepted asymmetry alongside tool namespacing.
+Within a harness the baseline/spelunk contrast is unaffected (same base
+prompt on both sides); weigh it when comparing spelunk uplift *across*
+harnesses.
 
 **MCP hygiene (`--strict-mcp-config`).** The claude-code adapter passes
 `--strict-mcp-config` in *both* arms, so only the bench's own `--mcp-config`

--- a/bench/agents/README.md
+++ b/bench/agents/README.md
@@ -66,17 +66,32 @@ the model sees `spelunk_search`; under the MCP harnesses it sees
 otherwise identical because they are the same objects. Transport differs,
 capability does not.
 
-**The system prompt is not identical across harnesses.** Each harness keeps
-its own base prompt; on a spelunk condition it appends a guidance sentence
-naming that harness's tool names rather than reusing `agent.py`'s whole
-`SYSTEM_PROMPT_SPELUNK`. That sentence is held as an exact substring of
-`SYSTEM_PROMPT_SPELUNK` and asserted by the offline suite, so an upstream
-reword fails loudly, but a spelunk arm's full prompt is *not* byte-identical
-to `agent.py`'s. Unlike the tool schemas, this is not equivalence by
-construction: it is the second accepted asymmetry alongside tool namespacing.
-Within a harness the baseline/spelunk contrast is unaffected (same base
-prompt on both sides); weigh it when comparing spelunk uplift *across*
-harnesses.
+**The system prompt is not byte-identical across all three harnesses.**
+There are two distinct base prompts, not three: `opencode` and `claude-code`
+share a byte-identical base, and `agent.py` (`--harness none`) differs from
+them by one clause describing how that harness applies edits. `agent.py` edits
+only through its own tool dispatch ("use the available tools ... and apply the
+fix"); the MCP harnesses edit with their native editing loop ("apply the fix
+directly by editing files in the repository"). That clause is load-bearing, so
+the prompts are deliberately *not* unified: giving either harness the other's
+sentence would describe an edit mechanism it does not have.
+
+On a spelunk condition each harness appends a guidance sentence naming its own
+tool names rather than reusing `agent.py`'s whole `SYSTEM_PROMPT_SPELUNK`. The
+sentence is held as an exact substring of `SYSTEM_PROMPT_SPELUNK` and asserted
+by the offline suite, so an upstream reword fails loudly.
+
+What that means when reading a result:
+
+- *Within* a harness the baseline/spelunk contrast is clean. The baseline arm
+  gets that harness's base prompt verbatim, the spelunk arm gets the same base
+  plus the guidance sentence, so the base cancels out of the uplift.
+- `opencode` vs `claude-code` spelunk uplift is also prompt-clean: identical
+  base, identical guidance core, differing only in tool names, which MCP
+  namespacing forces.
+- Only comparisons *against* `--harness none` carry the one-clause difference,
+  and there it is one of several irreducible differences between an in-process
+  agent and a subprocess one. Weigh it there, not across the MCP harnesses.
 
 **MCP hygiene (`--strict-mcp-config`).** The claude-code adapter passes
 `--strict-mcp-config` in *both* arms, so only the bench's own `--mcp-config`
@@ -85,13 +100,13 @@ leak them into baseline *and* spelunk, contaminating both. opencode has no
 equivalent flag; its generated `opencode.json` is repo-scoped, and on
 v1.17.20 `mcp` servers declared in a global `~/.config/opencode/` config were
 observed not to spawn for a repo-scoped run. That is an observed behaviour,
-not a documented guarantee — unlike `--strict-mcp-config`, nothing enforces
-it, so re-check it when bumping opencode.
+not a documented guarantee. Unlike `--strict-mcp-config`, nothing enforces it,
+so re-check it when bumping opencode.
 
 **Tool-invocation telemetry.** Runs on a spelunk condition report
 `spelunk_mcp_server_spawned` plus `spelunk_tool_calls` /
 `spelunk_tool_calls_by_tool`. These separate three outcomes that otherwise
-look alike: the server never spawned (broken wiring — a baseline run with
+look alike: the server never spawned (broken wiring, i.e. a baseline run with
 extra latency, not a spelunk cell), it spawned but the model never reached
 for a tool (a real result), or it was used.
 

--- a/bench/agents/agent.py
+++ b/bench/agents/agent.py
@@ -24,6 +24,8 @@ Usage:
 Output: single JSON object on stdout (reproducibility contract fields).
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os
@@ -31,15 +33,10 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from dotenv import load_dotenv
-from openai import OpenAI
-
-# Auto-load .env.local from project root if present
-_load_root = Path(__file__).resolve().parents[2]
-_dotenv_path = _load_root / ".env.local"
-if _dotenv_path.exists():
-    load_dotenv(_dotenv_path)
+if TYPE_CHECKING:
+    from openai import OpenAI
 
 # ---------------------------------------------------------------------------
 # Tool definitions (OpenAI function-calling format)
@@ -479,6 +476,16 @@ def main() -> None:
         help="Save git diff to this file after agent finishes (for SWE-bench eval).",
     )
     args = parser.parse_args()
+
+    # Lazy on purpose: importing this module must not require the LLM stack, so
+    # the tool schemas stay reachable offline (spelunk_mcp_server.py, tests).
+    from dotenv import load_dotenv
+    from openai import OpenAI
+
+    # Auto-load .env.local from project root if present
+    dotenv_path = Path(__file__).resolve().parents[2] / ".env.local"
+    if dotenv_path.exists():
+        load_dotenv(dotenv_path)
 
     repo_path = Path(args.repo_path).resolve()
     if not repo_path.is_dir():

--- a/bench/agents/harness_claude_code.py
+++ b/bench/agents/harness_claude_code.py
@@ -54,6 +54,7 @@ agent.py, plus the harness-dimension fields — see bench/agents/README.md).
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import time
@@ -161,10 +162,10 @@ def build_claude_cmd(
     if condition in SPELUNK_CONDITIONS and mcp_config_path:
         cmd += ["--mcp-config", str(mcp_config_path)]
         # acceptEdits covers file edits, not MCP tool calls; a headless -p run
-        # that hits a permission prompt is a lost cell. The `mcp__spelunk`
-        # server-wide shorthand also works, but naming each tool keeps the
-        # allow-list itself condition-gated rather than trusting the server to
-        # advertise only what the condition warrants.
+        # that hits a permission prompt is a lost cell. Each tool is named in
+        # full: whether the `mcp__spelunk` server-wide shorthand is honoured
+        # is unverified, and naming them keeps the allow-list condition-gated
+        # independently of what the server advertises.
         cmd += ["--allowedTools", *mcp_tool_names_for_condition(condition)]
     if thinking:
         cmd += ["--append-system-prompt", "Think step by step before acting."]
@@ -360,18 +361,21 @@ def main() -> None:
         else None
     )
 
-    agent_result = run_claude_code(
-        repo_path=repo_path,
-        issue_text=issue_text,
-        model=args.model,
-        effort=args.effort,
-        thinking=args.thinking,
-        env=env,
-        condition=args.condition,
-        mcp_config_path=mcp_config_path,
-    )
-
-    telemetry = read_telemetry(telemetry_log)
+    try:
+        agent_result = run_claude_code(
+            repo_path=repo_path,
+            issue_text=issue_text,
+            model=args.model,
+            effort=args.effort,
+            thinking=args.thinking,
+            env=env,
+            condition=args.condition,
+            mcp_config_path=mcp_config_path,
+        )
+        # Read before the scratch dir goes away.
+        telemetry = read_telemetry(telemetry_log)
+    finally:
+        shutil.rmtree(scratch_dir, ignore_errors=True)
 
     patch_path = extract_patch(repo_path, args.save_patch)
 

--- a/bench/agents/harness_claude_code.py
+++ b/bench/agents/harness_claude_code.py
@@ -55,10 +55,19 @@ import argparse
 import json
 import os
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 
-from harness_common import extract_patch, read_issue_text
+from agent import get_spelunk_version
+from harness_common import CONDITIONS, build_system_prompt, extract_patch, read_issue_text
+from spelunk_mcp_server import (
+    SERVER_NAME,
+    SPELUNK_CONDITIONS,
+    mcp_server_command,
+    mcp_tool_names_for_condition,
+    read_telemetry,
+)
 
 DEEPSEEK_ANTHROPIC_BASE_URL = "https://api.deepseek.com/anthropic"
 
@@ -105,20 +114,35 @@ def _deepseek_anthropic_env(api_key: str, model: str, base_url: str) -> dict:
     return env
 
 
-def run_claude_code(
-    repo_path: Path,
-    issue_text: str,
-    model: str,
+def write_mcp_config(
+    config_dir: Path, condition: str, repo_path: Path, telemetry_log: Path | None
+) -> Path:
+    """Write a --mcp-config JSON registering the bench-local spelunk server.
+
+    Written outside repo_path so it can never land in the extracted patch.
+    """
+    argv = mcp_server_command(condition, repo_path, telemetry_log)
+    config = {
+        "mcpServers": {
+            SERVER_NAME: {
+                "command": argv[0],
+                "args": argv[1:],
+                "env": {"SPELUNK_SECRET_STORE": "file"},
+            }
+        }
+    }
+    config_path = config_dir / "mcp-config.json"
+    config_path.write_text(json.dumps(config, indent=2))
+    return config_path
+
+
+def build_claude_cmd(
+    prompt: str,
     effort: str,
     thinking: bool,
-    env: dict,
-) -> dict:
-    prompt = (
-        f"{CLAUDE_CODE_PROMPT_PREFIX}\n\n"
-        f"Repository path: {repo_path}\n\nIssue:\n{issue_text}\n\n"
-        "Please investigate the issue and apply a fix."
-    )
-
+    condition: str,
+    mcp_config_path: Path | None,
+) -> list[str]:
     cmd = [
         "claude",
         "-p",
@@ -129,9 +153,48 @@ def run_claude_code(
         "acceptEdits",  # headless: accept file edits without a TTY prompt
         "--effort",
         effort,
+        # Both arms, baseline included: the bench host has its own MCP
+        # servers configured, and without this they leak into *both* arms and
+        # the comparison is unpublishable.
+        "--strict-mcp-config",
     ]
+    if condition in SPELUNK_CONDITIONS and mcp_config_path:
+        cmd += ["--mcp-config", str(mcp_config_path)]
+        # acceptEdits covers file edits, not MCP tool calls; a headless -p run
+        # that hits a permission prompt is a lost cell. The `mcp__spelunk`
+        # server-wide shorthand also works, but naming each tool keeps the
+        # allow-list itself condition-gated rather than trusting the server to
+        # advertise only what the condition warrants.
+        cmd += ["--allowedTools", *mcp_tool_names_for_condition(condition)]
     if thinking:
         cmd += ["--append-system-prompt", "Think step by step before acting."]
+    return cmd
+
+
+def run_claude_code(
+    repo_path: Path,
+    issue_text: str,
+    model: str,
+    effort: str,
+    thinking: bool,
+    env: dict,
+    condition: str = "baseline",
+    mcp_config_path: Path | None = None,
+) -> dict:
+    system_prompt = build_system_prompt(
+        CLAUDE_CODE_PROMPT_PREFIX,
+        condition,
+        mcp_tool_names_for_condition(condition)
+        if condition in SPELUNK_CONDITIONS
+        else [],
+    )
+    prompt = (
+        f"{system_prompt}\n\n"
+        f"Repository path: {repo_path}\n\nIssue:\n{issue_text}\n\n"
+        "Please investigate the issue and apply a fix."
+    )
+
+    cmd = build_claude_cmd(prompt, effort, thinking, condition, mcp_config_path)
 
     start = time.monotonic()
     result = subprocess.run(
@@ -183,11 +246,12 @@ def main() -> None:
     parser.add_argument(
         "--condition",
         default="baseline",
+        choices=list(CONDITIONS),
         help=(
-            "Recorded verbatim in provenance as condition. claude-code is a "
-            "generic coding agent, not spelunk-instrumented, so this is "
-            "always baseline in practice — see bench/agents/README.md. The "
-            "deepseek-vs-native distinction lives in endpoint_kind, not here."
+            "Recorded verbatim in provenance as condition. On a spelunk "
+            "condition the spelunk tools are wired in over a bench-local MCP "
+            "server — see bench/agents/README.md. The deepseek-vs-native "
+            "distinction lives in endpoint_kind, not here."
         ),
     )
     parser.add_argument("--task-id", required=True)
@@ -288,6 +352,14 @@ def main() -> None:
         env = _deepseek_anthropic_env(api_key, args.model, base_url_used)
         endpoint_kind = args.endpoint_kind
 
+    scratch_dir = Path(tempfile.mkdtemp(prefix="spelunk-bench-mcp-"))
+    telemetry_log = scratch_dir / "tool_calls.jsonl"
+    mcp_config_path = (
+        write_mcp_config(scratch_dir, args.condition, repo_path, telemetry_log)
+        if args.condition in SPELUNK_CONDITIONS
+        else None
+    )
+
     agent_result = run_claude_code(
         repo_path=repo_path,
         issue_text=issue_text,
@@ -295,7 +367,11 @@ def main() -> None:
         effort=args.effort,
         thinking=args.thinking,
         env=env,
+        condition=args.condition,
+        mcp_config_path=mcp_config_path,
     )
+
+    telemetry = read_telemetry(telemetry_log)
 
     patch_path = extract_patch(repo_path, args.save_patch)
 
@@ -311,7 +387,10 @@ def main() -> None:
         "model_source": "api",
         "api_base_url": base_url_used,
         "api_key_source": api_key_source,
-        "spelunk_version": None,  # claude-code harness does not invoke spelunk tools
+        # Null only on baseline, where no spelunk tools are wired in.
+        "spelunk_version": (
+            get_spelunk_version() if args.condition in SPELUNK_CONDITIONS else None
+        ),
         "seed": args.seed,
         "run_seed": args.seed,
         "max_turns": args.max_turns,
@@ -323,6 +402,7 @@ def main() -> None:
         "judge_model": None,
         "judge_version": None,
         "judge_error_rate": None,
+        **telemetry,
         **agent_result,
     }
     print(json.dumps(output))

--- a/bench/agents/harness_common.py
+++ b/bench/agents/harness_common.py
@@ -11,6 +11,36 @@ import sys
 import time
 from pathlib import Path
 
+# Every condition agent.py accepts. The harness adapters validate against
+# this rather than a per-harness subset: all three conditions now run under
+# all three harnesses (spelunk tools reach opencode/claude-code over the
+# bench-local MCP server, see spelunk_mcp_server.py).
+CONDITIONS = ("baseline", "spelunk_search", "spelunk_full")
+
+# Mirrors the sentence agent.py's SYSTEM_PROMPT_SPELUNK adds over
+# SYSTEM_PROMPT_BASE. Not imported verbatim: agent.py's wording names bare
+# tool names, but an MCP client's model only ever sees the namespaced
+# `mcp__spelunk__*` spelling, so a verbatim copy would point the model at
+# names that don't exist in these harnesses.
+SPELUNK_PROMPT_GUIDANCE = (
+    "You have access to spelunk tools for fast semantic code search, code "
+    "graph traversal, and project memory retrieval — use them to locate "
+    "relevant code and context before diving into files. They are available "
+    "as these tools: {tools}."
+)
+
+
+def build_system_prompt(base_prompt: str, condition: str, tool_names: list[str]) -> str:
+    """Mirror agent.py's get_system_prompt() split for a harness adapter.
+
+    Without this the spelunk arm is handed tools it is never told to use —
+    handicapped against agent.py's spelunk arm rather than comparable to it.
+    base_prompt stays each harness's own so the baseline arm is untouched.
+    """
+    if condition == "baseline":
+        return base_prompt
+    return f"{base_prompt} {SPELUNK_PROMPT_GUIDANCE.format(tools=', '.join(tool_names))}"
+
 # Same allowlist as agent.py's --save-patch handling. Keeping this as a
 # single shared list (imported by every adapter) is the point: if the
 # denylist-vs-allowlist tradeoff is ever revisited, it only needs to change

--- a/bench/agents/harness_common.py
+++ b/bench/agents/harness_common.py
@@ -17,16 +17,21 @@ from pathlib import Path
 # bench-local MCP server, see spelunk_mcp_server.py).
 CONDITIONS = ("baseline", "spelunk_search", "spelunk_full")
 
-# Mirrors the sentence agent.py's SYSTEM_PROMPT_SPELUNK adds over
-# SYSTEM_PROMPT_BASE. Not imported verbatim: agent.py's wording names bare
-# tool names, but an MCP client's model only ever sees the namespaced
-# `mcp__spelunk__*` spelling, so a verbatim copy would point the model at
-# names that don't exist in these harnesses.
-SPELUNK_PROMPT_GUIDANCE = (
+# Restates the sentence agent.py's SYSTEM_PROMPT_SPELUNK adds over
+# SYSTEM_PROMPT_BASE, then names the namespaced tools this harness's model
+# actually sees. Restated rather than imported because agent.py exposes only
+# whole prompts, not that delta, and each harness keeps its own base prompt.
+# The leading sentence is kept an exact substring of SYSTEM_PROMPT_SPELUNK so
+# the offline suite can assert it and make drift fail loudly.
+# Exact substring of agent.py's SYSTEM_PROMPT_SPELUNK — assert, don't edit.
+SPELUNK_GUIDANCE_CORE = (
     "You have access to spelunk tools for fast semantic code search, code "
     "graph traversal, and project memory retrieval — use them to locate "
-    "relevant code and context before diving into files. They are available "
-    "as these tools: {tools}."
+    "relevant code and context before diving into files."
+)
+
+SPELUNK_PROMPT_GUIDANCE = (
+    SPELUNK_GUIDANCE_CORE + " They are available as these tools: {tools}."
 )
 
 

--- a/bench/agents/harness_opencode.py
+++ b/bench/agents/harness_opencode.py
@@ -269,8 +269,8 @@ def main() -> None:
     opencode_cmd = get_opencode_command()
     opencode_version = get_opencode_version(opencode_cmd)
 
-    telemetry_dir = tempfile.mkdtemp(prefix="spelunk-bench-mcp-")
-    telemetry_log = Path(telemetry_dir) / "tool_calls.jsonl"
+    scratch_dir = Path(tempfile.mkdtemp(prefix="spelunk-bench-mcp-"))
+    telemetry_log = scratch_dir / "tool_calls.jsonl"
 
     config_path = write_provider_config(
         repo_path,
@@ -291,14 +291,15 @@ def main() -> None:
             opencode_cmd=opencode_cmd,
             condition=args.condition,
         )
+        # Read before the scratch dir goes away.
+        telemetry = read_telemetry(telemetry_log)
     finally:
         # Don't leave bench-generated provider config in the task repo's
         # working tree — it would otherwise show up in the saved patch
         # despite being outside SOURCE_PATHSPECS (harmless there, but
         # cleaner to remove) and would leak the API key into repo state.
         config_path.unlink(missing_ok=True)
-
-    telemetry = read_telemetry(telemetry_log)
+        shutil.rmtree(scratch_dir, ignore_errors=True)
 
     patch_path = extract_patch(repo_path, args.save_patch)
 

--- a/bench/agents/harness_opencode.py
+++ b/bench/agents/harness_opencode.py
@@ -33,10 +33,19 @@ import json
 import os
 import shutil
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 
-from harness_common import extract_patch, read_issue_text
+from agent import get_spelunk_version
+from harness_common import CONDITIONS, build_system_prompt, extract_patch, read_issue_text
+from spelunk_mcp_server import (
+    SERVER_NAME,
+    SPELUNK_CONDITIONS,
+    mcp_server_command,
+    mcp_tool_names_for_condition,
+    read_telemetry,
+)
 
 PROVIDER_ID = "spelunk-bench-deepseek"
 
@@ -74,10 +83,18 @@ def get_opencode_version(opencode_cmd: list[str]) -> str:
     return "unknown"
 
 
-def write_provider_config(repo_path: Path, model: str, api_base_url: str, api_key: str) -> Path:
+def write_provider_config(
+    repo_path: Path,
+    model: str,
+    api_base_url: str,
+    api_key: str,
+    condition: str = "baseline",
+    telemetry_log: Path | None = None,
+) -> Path:
     """Write an opencode.json in the task repo registering DeepSeek as a
     custom OpenAI-compatible provider (native DeepSeek endpoint — not the
-    Anthropic-compat shim used by the claude-code harness).
+    Anthropic-compat shim used by the claude-code harness), plus the spelunk
+    MCP server on a spelunk condition.
 
     Scoped to the repo directory (not global ~/.config/opencode/) so
     concurrent/parallel task runs never race on a shared config file, and so
@@ -99,6 +116,15 @@ def write_provider_config(repo_path: Path, model: str, api_base_url: str, api_ke
             }
         },
     }
+    if condition in SPELUNK_CONDITIONS:
+        config["mcp"] = {
+            SERVER_NAME: {
+                "type": "local",
+                "command": mcp_server_command(condition, repo_path, telemetry_log),
+                "environment": {"SPELUNK_SECRET_STORE": "file"},
+                "enabled": True,
+            }
+        }
     config_path = repo_path / "opencode.json"
     config_path.write_text(json.dumps(config, indent=2))
     return config_path
@@ -113,9 +139,15 @@ def run_opencode(
     max_turns: int,  # accepted for CLI-contract parity; opencode has no
     # per-task turn cap of its own, see README "Adapter notes"
     opencode_cmd: list[str],
+    condition: str = "baseline",
 ) -> dict:
+    system_prompt = build_system_prompt(
+        OPENCODE_SYSTEM_PROMPT,
+        condition,
+        mcp_tool_names_for_condition(condition) if condition in SPELUNK_CONDITIONS else [],
+    )
     prompt = (
-        f"{OPENCODE_SYSTEM_PROMPT}\n\n"
+        f"{system_prompt}\n\n"
         f"Repository path: {repo_path}\n\nIssue:\n{issue_text}\n\n"
         "Please investigate the issue and apply a fix."
     )
@@ -195,10 +227,11 @@ def main() -> None:
     parser.add_argument(
         "--condition",
         default="baseline",
+        choices=list(CONDITIONS),
         help=(
-            "Recorded verbatim in provenance as condition. opencode is a "
-            "generic coding agent, not spelunk-instrumented, so this is "
-            "always baseline in practice — see bench/agents/README.md."
+            "Recorded verbatim in provenance as condition. On a spelunk "
+            "condition the spelunk tools are wired in over a bench-local MCP "
+            "server — see bench/agents/README.md."
         ),
     )
     parser.add_argument("--task-id", required=True)
@@ -236,8 +269,16 @@ def main() -> None:
     opencode_cmd = get_opencode_command()
     opencode_version = get_opencode_version(opencode_cmd)
 
+    telemetry_dir = tempfile.mkdtemp(prefix="spelunk-bench-mcp-")
+    telemetry_log = Path(telemetry_dir) / "tool_calls.jsonl"
+
     config_path = write_provider_config(
-        repo_path, args.model, args.api_base_url, api_key
+        repo_path,
+        args.model,
+        args.api_base_url,
+        api_key,
+        condition=args.condition,
+        telemetry_log=telemetry_log,
     )
     try:
         agent_result = run_opencode(
@@ -248,6 +289,7 @@ def main() -> None:
             api_key=api_key,
             max_turns=args.max_turns,
             opencode_cmd=opencode_cmd,
+            condition=args.condition,
         )
     finally:
         # Don't leave bench-generated provider config in the task repo's
@@ -255,6 +297,8 @@ def main() -> None:
         # despite being outside SOURCE_PATHSPECS (harmless there, but
         # cleaner to remove) and would leak the API key into repo state.
         config_path.unlink(missing_ok=True)
+
+    telemetry = read_telemetry(telemetry_log)
 
     patch_path = extract_patch(repo_path, args.save_patch)
 
@@ -275,7 +319,10 @@ def main() -> None:
         "model_source": "api",
         "api_base_url": args.api_base_url,
         "api_key_source": api_key_source,
-        "spelunk_version": None,  # opencode harness does not invoke spelunk tools
+        # Null only on baseline, where no spelunk tools are wired in.
+        "spelunk_version": (
+            get_spelunk_version() if args.condition in SPELUNK_CONDITIONS else None
+        ),
         "seed": args.seed,
         "run_seed": args.seed,
         "max_turns": args.max_turns,
@@ -287,6 +334,7 @@ def main() -> None:
         "judge_model": None,
         "judge_version": None,
         "judge_error_rate": None,
+        **telemetry,
         **agent_result,
     }
     print(json.dumps(output))

--- a/bench/agents/spelunk_mcp_server.py
+++ b/bench/agents/spelunk_mcp_server.py
@@ -109,35 +109,46 @@ def mcp_server_command(
 
 
 # ---------------------------------------------------------------------------
-# Tool-invocation telemetry
+# Telemetry
 #
-# Without this, "spelunk didn't help" and "spelunk was never invoked" are
-# indistinguishable in the results — and a spelunk-labelled cell where the
-# tools were never called is a baseline run with extra latency.
+# Separates three outcomes a spelunk-labelled cell can't otherwise be told
+# apart by: the server never spawned (wiring is broken, the cell is baseline
+# with extra latency), it spawned but the model never reached for a tool
+# (a real result), or it was used. Only the last two are publishable as
+# spelunk cells.
 # ---------------------------------------------------------------------------
 
 
-def log_tool_call(telemetry_log: Path | None, tool_name: str) -> None:
+def _append(telemetry_log: Path | None, record: dict) -> None:
     if not telemetry_log:
         return
     try:
         with open(telemetry_log, "a") as f:
-            f.write(json.dumps({"tool": tool_name, "ts": time.time()}) + "\n")
+            f.write(json.dumps({**record, "ts": time.time()}) + "\n")
             f.flush()
     except Exception:
         # Telemetry must never take the run down with it.
         pass
 
 
+def log_server_start(telemetry_log: Path | None, condition: str) -> None:
+    _append(telemetry_log, {"event": "server_start", "condition": condition})
+
+
+def log_tool_call(telemetry_log: Path | None, tool_name: str) -> None:
+    _append(telemetry_log, {"event": "tool_call", "tool": tool_name})
+
+
 def read_telemetry(telemetry_log: Path | None) -> dict:
     """Summarise a telemetry log for the harness's result JSON.
 
-    A missing log means zero calls, not an error: the client only spawns the
-    server lazily, so a run where the model never reached for a spelunk tool
-    legitimately leaves no file behind.
+    A missing log is a real, reportable outcome (server never spawned), not
+    an error — the client spawns the server itself, so its absence is
+    evidence about the wiring rather than a failure to read.
     """
     by_tool: dict[str, int] = {}
     total = 0
+    spawned = False
     if telemetry_log and Path(telemetry_log).exists():
         for line in Path(telemetry_log).read_text().splitlines():
             line = line.strip()
@@ -147,12 +158,14 @@ def read_telemetry(telemetry_log: Path | None) -> dict:
                 rec = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            name = rec.get("tool")
-            if not name:
-                continue
-            by_tool[name] = by_tool.get(name, 0) + 1
-            total += 1
+            event = rec.get("event")
+            if event == "server_start":
+                spawned = True
+            elif event == "tool_call" and rec.get("tool"):
+                by_tool[rec["tool"]] = by_tool.get(rec["tool"], 0) + 1
+                total += 1
     return {
+        "spelunk_mcp_server_spawned": spawned,
         "spelunk_tool_calls": total,
         "spelunk_tool_calls_by_tool": by_tool or None,
     }
@@ -172,6 +185,11 @@ async def serve(condition: str, repo_path: Path, telemetry_log: Path | None) -> 
     exposed = {t["function"]["name"] for t in tools}
     dispatch = build_dispatch_table(repo_path)
     server: Server = Server(SERVER_NAME)
+
+    # Recorded before the handshake, so it survives a client that spawns us
+    # and disconnects: the question this answers is whether the harness
+    # spawned the server at all, not whether a session completed.
+    log_server_start(telemetry_log, condition)
 
     @server.list_tools()
     async def list_tools() -> list[types.Tool]:

--- a/bench/agents/spelunk_mcp_server.py
+++ b/bench/agents/spelunk_mcp_server.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Bench-local stdio MCP server re-exposing agent.py's spelunk tools.
+
+Lets an external coding-agent harness (opencode, claude-code) run a spelunk
+condition, so `condition` and `harness` stay independent dimensions
+(bench/AGENTS.md principle #1) instead of `spelunk_*` being reachable only
+through `--harness none`.
+
+Every tool function and JSON schema here is *imported* from agent.py, never
+reimplemented: the `spelunk` condition must mean the same capability
+whichever harness carries it, and importing makes that hold by construction
+rather than by review. Do not inline a tool body or copy a schema into this
+file — a second implementation is free to drift, and drift is exactly what
+would make a cross-harness comparison dishonest.
+
+spelunk itself ships no MCP server (there is no `spelunk mcp` subcommand);
+this wrapper is bench scaffolding, not a product surface.
+
+Usage (spawned by an MCP client, not run by hand):
+    python spelunk_mcp_server.py \\
+        --repo-path /path/to/repo \\
+        --condition spelunk_search|spelunk_full \\
+        [--telemetry-log /path/to/calls.jsonl]
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# Every spelunk invocation must be keychain-free regardless of how the MCP
+# client spawned us; a macOS Keychain prompt has no TTY to answer it.
+os.environ.setdefault("SPELUNK_SECRET_STORE", "file")
+
+# bench/agents/*.py are plain scripts, not an installed package, and an MCP
+# client spawns this file by absolute path from an arbitrary cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agent import BASE_TOOLS, build_dispatch_table, build_tools  # noqa: E402
+
+SERVER_NAME = "spelunk"
+
+# Conditions that expose spelunk tools. "baseline" is deliberately absent:
+# on baseline this server must never be spawned at all.
+SPELUNK_CONDITIONS = ("spelunk_search", "spelunk_full")
+
+
+def spelunk_tools_for_condition(condition: str) -> list[dict]:
+    """The spelunk tools agent.py would expose for this condition.
+
+    Derived by subtracting agent.py's own BASE_TOOLS from build_tools() —
+    never a hand-listed set, so this cannot drift from agent.py. The base
+    read_file/run_bash/write_file tools are excluded because each harness
+    already ships its own natively; re-exposing them over MCP would hand the
+    model two of each.
+    """
+    if condition not in SPELUNK_CONDITIONS:
+        raise ValueError(
+            f"condition must be one of {list(SPELUNK_CONDITIONS)} (got: {condition})"
+        )
+    base_names = {t["function"]["name"] for t in BASE_TOOLS}
+    return [
+        t for t in build_tools(condition) if t["function"]["name"] not in base_names
+    ]
+
+
+def tool_names_for_condition(condition: str) -> list[str]:
+    """Bare tool names, as agent.py's model sees them."""
+    return [t["function"]["name"] for t in spelunk_tools_for_condition(condition)]
+
+
+def mcp_tool_names_for_condition(condition: str) -> list[str]:
+    """Namespaced names, as an MCP client's model sees them.
+
+    MCP clients namespace tools `mcp__<server>__<tool>`; the capability is
+    agent.py's, the spelling is not. This is the one accepted, documented
+    difference from harness=none (see README "Conditions").
+    """
+    return [f"mcp__{SERVER_NAME}__{n}" for n in tool_names_for_condition(condition)]
+
+
+def mcp_server_command(
+    condition: str,
+    repo_path: Path,
+    telemetry_log: Path | None = None,
+    python_executable: str | None = None,
+) -> list[str]:
+    """argv an MCP client should spawn to get this server.
+
+    Defaults to sys.executable, not a bare "python3": the harness runs under
+    `uv run --with-requirements bench/requirements.txt`, and only that
+    interpreter has the `mcp` SDK. A bare "python3" would resolve to the
+    host's system interpreter and fail to import.
+    """
+    cmd = [
+        python_executable or sys.executable,
+        str(Path(__file__).resolve()),
+        "--repo-path",
+        str(Path(repo_path).resolve()),
+        "--condition",
+        condition,
+    ]
+    if telemetry_log:
+        cmd += ["--telemetry-log", str(telemetry_log)]
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# Tool-invocation telemetry
+#
+# Without this, "spelunk didn't help" and "spelunk was never invoked" are
+# indistinguishable in the results — and a spelunk-labelled cell where the
+# tools were never called is a baseline run with extra latency.
+# ---------------------------------------------------------------------------
+
+
+def log_tool_call(telemetry_log: Path | None, tool_name: str) -> None:
+    if not telemetry_log:
+        return
+    try:
+        with open(telemetry_log, "a") as f:
+            f.write(json.dumps({"tool": tool_name, "ts": time.time()}) + "\n")
+            f.flush()
+    except Exception:
+        # Telemetry must never take the run down with it.
+        pass
+
+
+def read_telemetry(telemetry_log: Path | None) -> dict:
+    """Summarise a telemetry log for the harness's result JSON.
+
+    A missing log means zero calls, not an error: the client only spawns the
+    server lazily, so a run where the model never reached for a spelunk tool
+    legitimately leaves no file behind.
+    """
+    by_tool: dict[str, int] = {}
+    total = 0
+    if telemetry_log and Path(telemetry_log).exists():
+        for line in Path(telemetry_log).read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            name = rec.get("tool")
+            if not name:
+                continue
+            by_tool[name] = by_tool.get(name, 0) + 1
+            total += 1
+    return {
+        "spelunk_tool_calls": total,
+        "spelunk_tool_calls_by_tool": by_tool or None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+
+
+async def serve(condition: str, repo_path: Path, telemetry_log: Path | None) -> None:
+    import mcp.types as types
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+
+    tools = spelunk_tools_for_condition(condition)
+    exposed = {t["function"]["name"] for t in tools}
+    dispatch = build_dispatch_table(repo_path)
+    server: Server = Server(SERVER_NAME)
+
+    @server.list_tools()
+    async def list_tools() -> list[types.Tool]:
+        return [
+            types.Tool(
+                name=t["function"]["name"],
+                description=t["function"]["description"],
+                inputSchema=t["function"]["parameters"],
+            )
+            for t in tools
+        ]
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+        # The condition gate lives here as well as in list_tools: a client
+        # that calls a name we never advertised must not reach the tool.
+        if name not in exposed:
+            raise ValueError(f"Unknown tool for condition {condition}: {name}")
+        log_tool_call(telemetry_log, name)
+        # dispatch entries shell out to spelunk synchronously; off-thread so
+        # a slow search can't stall the stdio event loop.
+        result = await asyncio.to_thread(dispatch[name], arguments or {})
+        return [types.TextContent(type="text", text=result)]
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream, write_stream, server.create_initialization_options()
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Bench-local stdio MCP server exposing agent.py's spelunk tools."
+    )
+    parser.add_argument(
+        "--repo-path",
+        required=True,
+        help="Repo to run spelunk in. Explicit rather than inherited cwd — an "
+        "MCP client's spawn cwd is not guaranteed.",
+    )
+    parser.add_argument("--condition", required=True, choices=list(SPELUNK_CONDITIONS))
+    parser.add_argument(
+        "--telemetry-log",
+        default=None,
+        help="Append one JSON line per tools/call here.",
+    )
+    args = parser.parse_args()
+
+    repo_path = Path(args.repo_path).resolve()
+    if not repo_path.is_dir():
+        parser.error(f"repo-path does not exist: {repo_path}")
+
+    telemetry_log = Path(args.telemetry_log) if args.telemetry_log else None
+    asyncio.run(serve(args.condition, repo_path, telemetry_log))
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/agents/swebench_run.sh
+++ b/bench/agents/swebench_run.sh
@@ -18,11 +18,10 @@
 #       [--tasks 50] [--max-turns 20] [--seed 42] [--eval]
 #
 # Options:
-#   --condition     baseline|spelunk_search|spelunk_full   (required; must be
-#                           "baseline" for --harness opencode|claude-code —
-#                           those harnesses are generic coding agents, not
-#                           spelunk-instrumented, so spelunk_search/spelunk_full
-#                           don't apply to them)
+#   --condition     baseline|spelunk_search|spelunk_full   (required; valid for
+#                           every harness — opencode/claude-code reach the
+#                           spelunk tools over the bench-local MCP server, see
+#                           bench/agents/spelunk_mcp_server.py)
 #   --harness       none|opencode|claude-code               (default: none)
 #                   none:        agent.py's own tool-calling loop (component-clean cell)
 #                   opencode:    headless `opencode run`, DeepSeek via a generated
@@ -39,8 +38,7 @@
 #   --max-turns     N       max agent turns per task (default: 20)
 #   --seed          N       random seed (default: 42)
 #   --skip-index            skip spelunk index (if repos are pre-indexed;
-#                           --harness none only — opencode/claude-code cells
-#                           never invoke spelunk, see README "Adapter notes")
+#                           applies to any harness on a spelunk condition)
 #   --repos-dir     DIR     checkout root (default: bench/repos)
 #   --patches-dir   DIR     where per-task .patch files are saved
 #                           (default: bench/patches/<condition>-<timestamp>)
@@ -142,17 +140,15 @@ case "$HARNESS" in
     *) echo "Error: --harness must be one of none|opencode|claude-code (got: ${HARNESS})" >&2; exit 1 ;;
 esac
 
-# opencode/claude-code are generic coding agents, not spelunk-instrumented —
-# spelunk_search/spelunk_full only mean something for --harness none (they
-# vary spelunk tool access, which these two harnesses never have). Enforcing
-# this here (rather than just documenting it) keeps the per-task result
-# JSON's own "condition" field — which each harness script now sets from
-# --condition, see harness_opencode.py/harness_claude_code.py — from ever
-# disagreeing with what --condition claimed to request.
-if [[ "$HARNESS" != "none" && "$CONDITION" != "baseline" ]]; then
-    echo "Error: --condition must be baseline for --harness ${HARNESS} (got: ${CONDITION})." >&2
-    exit 1
-fi
+# All three conditions are valid for all three harnesses: opencode and
+# claude-code reach the spelunk tools over the bench-local MCP server (see
+# bench/agents/spelunk_mcp_server.py). Validating the value here keeps the
+# per-task result JSON's own "condition" field — which each harness script
+# sets from --condition — from ever recording a typo as a real cell.
+case "$CONDITION" in
+    baseline|spelunk_search|spelunk_full) ;;
+    *) echo "Error: --condition must be one of baseline|spelunk_search|spelunk_full (got: ${CONDITION})" >&2; exit 1 ;;
+esac
 
 if [[ "$HARNESS" == "claude-code" && "$ENDPOINT_KIND" == "shim" && -z "$SHIM_BASE_URL" ]]; then
     echo "Error: --shim-base-url is required with --harness claude-code --endpoint-kind shim." >&2
@@ -251,24 +247,19 @@ for TASK_ID in $ALL_TASK_IDS; do
         continue
     fi
 
-    # spelunk indexing / memory harvest only apply to the harness=none cell —
-    # opencode and claude-code are generic coding-agent harnesses, not
-    # spelunk-instrumented (see README "Adapter notes"). Gating on $HARNESS
-    # keeps this the single place that decides whether spelunk touches the
-    # repo, rather than duplicating the condition check per-harness.
-    if [[ "$HARNESS" == "none" ]]; then
-        # Index the repo for spelunk conditions (unless --skip-index)
-        if [[ "$CONDITION" != "baseline" && "$SKIP_INDEX" != "true" ]]; then
-            echo "  Indexing repo..."
-            spelunk index "$TASK_REPO" 2>&1 | tail -1 || true
-        fi
+    # Condition, not harness, decides whether spelunk touches the repo: every
+    # harness reaches the same tools on a spelunk condition. Without the
+    # index the spelunk arm is a silent no-op that scores like baseline.
+    if [[ "$CONDITION" != "baseline" && "$SKIP_INDEX" != "true" ]]; then
+        echo "  Indexing repo..."
+        spelunk index "$TASK_REPO" 2>&1 | tail -1 || true
+    fi
 
-        # For spelunk_full: attempt memory harvest from git history.
-        # Best-effort — single-commit SWE-bench repos have no harvestable history.
-        if [[ "$CONDITION" == "spelunk_full" ]]; then
-            echo "  Harvesting memory (best-effort)..."
-            spelunk memory harvest --git-range HEAD~50..HEAD "$TASK_REPO" 2>&1 | tail -1 || true
-        fi
+    # For spelunk_full: attempt memory harvest from git history.
+    # Best-effort — single-commit SWE-bench repos have no harvestable history.
+    if [[ "$CONDITION" == "spelunk_full" ]]; then
+        echo "  Harvesting memory (best-effort)..."
+        spelunk memory harvest --git-range HEAD~50..HEAD "$TASK_REPO" 2>&1 | tail -1 || true
     fi
 
     # Build the per-harness command. Each harness script takes the same

--- a/bench/agents/tests/test_harness_claude_code.py
+++ b/bench/agents/tests/test_harness_claude_code.py
@@ -6,9 +6,20 @@ Run:
 Network-free, no DEEPSEEK_API_KEY, no claude binary required.
 """
 
+import json
 import os
 
-from harness_claude_code import _deepseek_anthropic_env
+import pytest
+from harness_claude_code import (
+    SERVER_NAME,
+    _deepseek_anthropic_env,
+    build_claude_cmd,
+    write_mcp_config,
+)
+from spelunk_mcp_server import mcp_tool_names_for_condition
+
+CONDITIONS = ["baseline", "spelunk_search", "spelunk_full"]
+SPELUNK_CONDITIONS = ["spelunk_search", "spelunk_full"]
 
 
 class TestDeepseekAnthropicEnv:
@@ -65,3 +76,99 @@ class TestDeepseekAnthropicEnv:
             base_url="https://api.deepseek.com/anthropic",
         )
         assert env["SOME_UNRELATED_VAR"] == "keep-me"
+
+
+def _cmd(condition, mcp_config_path=None):
+    return build_claude_cmd(
+        prompt="fix it",
+        effort="high",
+        thinking=False,
+        condition=condition,
+        mcp_config_path=mcp_config_path,
+    )
+
+
+class TestStrictMcpConfig:
+    """The bench host has its own MCP servers configured. Without
+    --strict-mcp-config they load into *both* arms, so baseline and spelunk
+    are contaminated alike and the numbers are unpublishable. Verified on
+    this host during adapter work: a host server appeared in the run's
+    mcp_servers without the flag, and mcp_servers was empty with it.
+    """
+
+    @pytest.mark.parametrize("condition", CONDITIONS)
+    def test_passed_in_every_arm_including_baseline(self, condition, tmp_path):
+        assert "--strict-mcp-config" in _cmd(condition, tmp_path / "mcp.json")
+
+    def test_passed_on_baseline_even_with_no_mcp_config(self):
+        # How main() actually calls it on baseline: flag still required.
+        assert "--strict-mcp-config" in _cmd("baseline")
+
+
+class TestMcpConfigIsConditionGated:
+    def test_only_spelunk_arms_load_the_bench_server(self, tmp_path):
+        # One predicate, both directions: the absence assertion below is only
+        # evidence because the same check finds the flag when it is present.
+        cfg = tmp_path / "mcp.json"
+        assert "--mcp-config" in _cmd("spelunk_search", cfg)
+        assert "--mcp-config" not in _cmd("baseline", cfg)
+
+    def test_baseline_ignores_a_config_path_it_was_handed(self, tmp_path):
+        # Gating is on the condition, not on the caller remembering to pass
+        # None: a baseline arm that quietly gained spelunk tools would
+        # invalidate results in the opposite direction.
+        cfg = tmp_path / "mcp.json"
+        assert str(cfg) not in _cmd("baseline", cfg)
+
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_spelunk_arms_point_at_the_written_config(self, condition, tmp_path):
+        cfg = tmp_path / "mcp.json"
+        cmd = _cmd(condition, cfg)
+        assert cmd[cmd.index("--mcp-config") + 1] == str(cfg)
+
+
+class TestAllowedTools:
+    """--permission-mode acceptEdits covers file edits, not MCP tool calls. A
+    headless -p run that hits a permission prompt is a lost cell."""
+
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_names_every_exposed_tool_in_full(self, condition, tmp_path):
+        cmd = _cmd(condition, tmp_path / "mcp.json")
+        expected = mcp_tool_names_for_condition(condition)
+        assert set(expected) <= set(cmd)
+        # Named individually rather than relying on the `mcp__spelunk`
+        # server-wide shorthand, which is unverified.
+        assert f"mcp__{SERVER_NAME}" not in cmd
+
+    def test_allow_list_is_condition_gated(self, tmp_path):
+        cfg = tmp_path / "mcp.json"
+        search = _cmd("spelunk_search", cfg)
+        full = _cmd("spelunk_full", cfg)
+        assert f"mcp__{SERVER_NAME}__spelunk_graph" not in search
+        assert f"mcp__{SERVER_NAME}__spelunk_graph" in full
+
+    def test_absent_on_baseline(self, tmp_path):
+        cfg = tmp_path / "mcp.json"
+        assert "--allowedTools" in _cmd("spelunk_search", cfg)
+        assert "--allowedTools" not in _cmd("baseline", cfg)
+
+
+class TestWriteMcpConfig:
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_registers_the_bench_server_under_mcp_servers(self, condition, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        path = write_mcp_config(tmp_path, condition, repo, None)
+        server = json.loads(path.read_text())["mcpServers"][SERVER_NAME]
+        assert server["args"][0].endswith("spelunk_mcp_server.py")
+        assert server["args"][server["args"].index("--condition") + 1] == condition
+        assert server["env"]["SPELUNK_SECRET_STORE"] == "file"
+
+    def test_written_outside_the_task_repo(self, tmp_path):
+        # Anything written inside repo_path can land in the extracted patch.
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        path = write_mcp_config(scratch, "spelunk_search", repo, None)
+        assert repo not in path.parents

--- a/bench/agents/tests/test_harness_common.py
+++ b/bench/agents/tests/test_harness_common.py
@@ -13,7 +13,13 @@ from pathlib import Path
 
 import pytest
 
-from harness_common import extract_patch
+import agent
+from harness_claude_code import CLAUDE_CODE_PROMPT_PREFIX
+from harness_common import SPELUNK_GUIDANCE_CORE, build_system_prompt, extract_patch
+from harness_opencode import OPENCODE_SYSTEM_PROMPT
+from spelunk_mcp_server import SPELUNK_CONDITIONS, mcp_tool_names_for_condition
+
+BASE_PROMPTS = [OPENCODE_SYSTEM_PROMPT, CLAUDE_CODE_PROMPT_PREFIX]
 
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
@@ -31,6 +37,46 @@ def _init_repo(repo: Path) -> None:
     _git(repo, "init", "-q")
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "config", "user.name", "Test")
+
+
+class TestBuildSystemPrompt:
+    """Tools the model is never told about are a handicap, not a condition:
+    agent.py's spelunk arm swaps its whole prompt, so an adapter that kept a
+    baseline-flavoured prompt would hand the spelunk arm tools it never uses.
+
+    An adapter can only restate that delta (agent.py exposes whole prompts,
+    not the difference), so the restatement is pinned to agent.py's own text
+    and drift fails here rather than silently skewing a cell.
+    """
+
+    def test_guidance_core_is_still_an_exact_substring_of_agent_pys_prompt(self):
+        assert SPELUNK_GUIDANCE_CORE in agent.SYSTEM_PROMPT_SPELUNK
+
+    @pytest.mark.parametrize("base", BASE_PROMPTS)
+    def test_baseline_prompt_is_left_untouched(self, base):
+        assert build_system_prompt(base, "baseline", []) == base
+
+    @pytest.mark.parametrize("base", BASE_PROMPTS)
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_spelunk_prompt_names_every_tool_the_model_can_see(self, base, condition):
+        names = mcp_tool_names_for_condition(condition)
+        prompt = build_system_prompt(base, condition, names)
+        assert base in prompt
+        assert SPELUNK_GUIDANCE_CORE in prompt
+        for name in names:
+            assert name in prompt
+
+    @pytest.mark.parametrize("base", BASE_PROMPTS)
+    def test_prompt_never_advertises_a_tool_the_condition_withholds(self, base):
+        # Positive control below: the same name is present for spelunk_full.
+        search = build_system_prompt(
+            base, "spelunk_search", mcp_tool_names_for_condition("spelunk_search")
+        )
+        full = build_system_prompt(
+            base, "spelunk_full", mcp_tool_names_for_condition("spelunk_full")
+        )
+        assert "spelunk_graph" not in search
+        assert "spelunk_graph" in full
 
 
 class TestExtractPatchNormalCase:

--- a/bench/agents/tests/test_harness_common.py
+++ b/bench/agents/tests/test_harness_common.py
@@ -52,6 +52,12 @@ class TestBuildSystemPrompt:
     def test_guidance_core_is_still_an_exact_substring_of_agent_pys_prompt(self):
         assert SPELUNK_GUIDANCE_CORE in agent.SYSTEM_PROMPT_SPELUNK
 
+    def test_the_two_mcp_harnesses_share_one_base_prompt(self):
+        # What makes opencode-vs-claude-code spelunk uplift prompt-clean, and
+        # what the README states. Diverge these and that comparison silently
+        # gains a confound: the base no longer cancels across harnesses.
+        assert OPENCODE_SYSTEM_PROMPT == CLAUDE_CODE_PROMPT_PREFIX
+
     @pytest.mark.parametrize("base", BASE_PROMPTS)
     def test_baseline_prompt_is_left_untouched(self, base):
         assert build_system_prompt(base, "baseline", []) == base

--- a/bench/agents/tests/test_harness_opencode.py
+++ b/bench/agents/tests/test_harness_opencode.py
@@ -136,43 +136,6 @@ class TestMcpBlockIsConditionGated:
         assert config["$schema"] == "https://opencode.ai/config.json"
 
 
-class TestSystemPromptNamesTheToolsOnSpelunkConditions:
-    """Tools the model is never told about are a handicap, not a condition.
-    agent.py swaps its whole prompt; a harness adapter can only restate the
-    delta, so the restatement is pinned to agent.py's own text.
-    """
-
-    def test_guidance_core_is_an_exact_substring_of_agent_prompt(self):
-        import agent
-        from harness_common import SPELUNK_GUIDANCE_CORE
-
-        assert SPELUNK_GUIDANCE_CORE in agent.SYSTEM_PROMPT_SPELUNK
-
-    def test_baseline_prompt_is_untouched(self):
-        from harness_common import build_system_prompt
-        from harness_opencode import OPENCODE_SYSTEM_PROMPT
-
-        assert (
-            build_system_prompt(OPENCODE_SYSTEM_PROMPT, "baseline", [])
-            == OPENCODE_SYSTEM_PROMPT
-        )
-
-    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
-    def test_spelunk_prompt_names_every_tool_the_model_can_see(self, condition):
-        from harness_common import build_system_prompt
-        from harness_opencode import OPENCODE_SYSTEM_PROMPT
-        from spelunk_mcp_server import mcp_tool_names_for_condition
-
-        names = mcp_tool_names_for_condition(condition)
-        prompt = build_system_prompt(OPENCODE_SYSTEM_PROMPT, condition, names)
-        for name in names:
-            assert name in prompt
-        # Gating again: the prompt must not advertise a tool the condition
-        # does not expose.
-        if condition == "spelunk_search":
-            assert "spelunk_graph" not in prompt
-
-
 class TestGetOpencodeCommand:
     def test_prefers_installed_binary_when_on_path(self, monkeypatch):
         monkeypatch.setattr(

--- a/bench/agents/tests/test_harness_opencode.py
+++ b/bench/agents/tests/test_harness_opencode.py
@@ -9,7 +9,27 @@ and npx fallback are exercised via monkeypatched shutil.which).
 
 import json
 
-from harness_opencode import PROVIDER_ID, get_opencode_command, write_provider_config
+import pytest
+from harness_opencode import (
+    PROVIDER_ID,
+    SERVER_NAME,
+    get_opencode_command,
+    write_provider_config,
+)
+
+SPELUNK_CONDITIONS = ["spelunk_search", "spelunk_full"]
+
+
+def _config(repo_path, condition="baseline", telemetry_log=None):
+    path = write_provider_config(
+        repo_path,
+        "deepseek-v4-flash",
+        "https://api.deepseek.com/v1",
+        "sk-test-123",
+        condition=condition,
+        telemetry_log=telemetry_log,
+    )
+    return json.loads(path.read_text())
 
 
 class TestWriteProviderConfig:
@@ -66,6 +86,91 @@ class TestWriteProviderConfig:
         # Written with indent=2 -- sanity check it isn't a single unindented line.
         assert "\n" in text
         json.loads(text)  # must parse cleanly
+
+
+class TestMcpBlockIsConditionGated:
+    """The spelunk tools reach opencode through an `mcp` block in the same
+    generated, repo-scoped config. Gating is on the condition: a baseline arm
+    that silently gained spelunk tools would invalidate results just as badly
+    as a spelunk arm that never got them.
+    """
+
+    def test_only_spelunk_conditions_declare_an_mcp_block(self, tmp_path):
+        # One predicate, both directions: the absence below is only evidence
+        # because the same check finds the block when it is present.
+        assert "mcp" in _config(tmp_path, condition="spelunk_search")
+        assert "mcp" not in _config(tmp_path, condition="baseline")
+
+    def test_default_condition_declares_no_mcp_block(self, tmp_path):
+        assert "mcp" not in _config(tmp_path)
+
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_block_matches_the_documented_local_server_schema(self, condition, tmp_path):
+        # Shape per opencode.ai/config.json: local entries require type +
+        # command; environment/enabled are optional.
+        block = _config(tmp_path, condition=condition)["mcp"][SERVER_NAME]
+        assert block["type"] == "local"
+        assert isinstance(block["command"], list)
+        assert all(isinstance(part, str) for part in block["command"])
+        assert block["environment"] == {"SPELUNK_SECRET_STORE": "file"}
+        assert block["enabled"] is True
+
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_command_spawns_the_bench_server_for_this_condition(self, condition, tmp_path):
+        command = _config(tmp_path, condition=condition)["mcp"][SERVER_NAME]["command"]
+        assert command[1].endswith("spelunk_mcp_server.py")
+        assert command[command.index("--condition") + 1] == condition
+        assert command[command.index("--repo-path") + 1] == str(tmp_path.resolve())
+
+    def test_telemetry_log_wired_through_when_requested(self, tmp_path):
+        log = tmp_path / "calls.jsonl"
+        command = _config(tmp_path, condition="spelunk_full", telemetry_log=log)["mcp"][
+            SERVER_NAME
+        ]["command"]
+        assert command[command.index("--telemetry-log") + 1] == str(log)
+
+    def test_provider_block_survives_on_a_spelunk_condition(self, tmp_path):
+        # The mcp block is a sibling of provider, not a replacement.
+        config = _config(tmp_path, condition="spelunk_full")
+        assert config["provider"][PROVIDER_ID]["options"]["apiKey"] == "sk-test-123"
+        assert config["$schema"] == "https://opencode.ai/config.json"
+
+
+class TestSystemPromptNamesTheToolsOnSpelunkConditions:
+    """Tools the model is never told about are a handicap, not a condition.
+    agent.py swaps its whole prompt; a harness adapter can only restate the
+    delta, so the restatement is pinned to agent.py's own text.
+    """
+
+    def test_guidance_core_is_an_exact_substring_of_agent_prompt(self):
+        import agent
+        from harness_common import SPELUNK_GUIDANCE_CORE
+
+        assert SPELUNK_GUIDANCE_CORE in agent.SYSTEM_PROMPT_SPELUNK
+
+    def test_baseline_prompt_is_untouched(self):
+        from harness_common import build_system_prompt
+        from harness_opencode import OPENCODE_SYSTEM_PROMPT
+
+        assert (
+            build_system_prompt(OPENCODE_SYSTEM_PROMPT, "baseline", [])
+            == OPENCODE_SYSTEM_PROMPT
+        )
+
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_spelunk_prompt_names_every_tool_the_model_can_see(self, condition):
+        from harness_common import build_system_prompt
+        from harness_opencode import OPENCODE_SYSTEM_PROMPT
+        from spelunk_mcp_server import mcp_tool_names_for_condition
+
+        names = mcp_tool_names_for_condition(condition)
+        prompt = build_system_prompt(OPENCODE_SYSTEM_PROMPT, condition, names)
+        for name in names:
+            assert name in prompt
+        # Gating again: the prompt must not advertise a tool the condition
+        # does not expose.
+        if condition == "spelunk_search":
+            assert "spelunk_graph" not in prompt
 
 
 class TestGetOpencodeCommand:

--- a/bench/agents/tests/test_provenance_contract.py
+++ b/bench/agents/tests/test_provenance_contract.py
@@ -210,10 +210,11 @@ class TestProvenanceAdditiveContract:
     def test_condition_flows_from_flag_not_hardcoded(
         self, fake_claude_on_path, throwaway_repo, tmp_path
     ):
-        # Pass a value that's neither the old hardcoded strings
-        # ("claude_code_deepseek"/"claude_code_native") nor the new default
-        # ("baseline"), to prove the output really tracks --condition rather
-        # than a fixed per-harness string.
+        # Neither the old hardcoded strings
+        # ("claude_code_deepseek"/"claude_code_native") nor the default
+        # ("baseline"), to prove the output tracks --condition rather than a
+        # fixed per-harness string. A real condition rather than a sentinel:
+        # --condition is validated against the condition set.
         issue_file = tmp_path / "ISSUE.txt"
         issue_file.write_text("Fix the bug.")
 
@@ -229,7 +230,7 @@ class TestProvenanceAdditiveContract:
                 str(issue_file),
                 "--no-deepseek",
                 "--condition",
-                "condition_passthrough_probe",
+                "spelunk_search",
             ],
             capture_output=True,
             text=True,
@@ -240,7 +241,7 @@ class TestProvenanceAdditiveContract:
         assert result.returncode == 0, result.stderr
         line = [l for l in result.stdout.splitlines() if l.startswith("{")][-1]
         payload = json.loads(line)
-        assert payload["condition"] == "condition_passthrough_probe"
+        assert payload["condition"] == "spelunk_search"
 
 
 class TestOpencodeProvenanceAdditiveContract:

--- a/bench/agents/tests/test_provenance_contract.py
+++ b/bench/agents/tests/test_provenance_contract.py
@@ -202,10 +202,12 @@ class TestProvenanceAdditiveContract:
         # --no-deepseek path: no live DeepSeek key/base-url involved.
         assert payload["endpoint_kind"] == "native"
         # condition defaults to "baseline" (not a harness-specific hardcoded
-        # string like the old "claude_code_native"/"claude_code_deepseek") --
-        # see README "Conditions": claude-code is generic, not
-        # spelunk-instrumented, so condition is always baseline in practice.
+        # string like the old "claude_code_native"/"claude_code_deepseek").
         assert payload["condition"] == "baseline"
+        # No spelunk tools wired in on baseline, so provenance must not claim
+        # a version. Positive control:
+        # TestSpelunkProvenance.test_version_recorded_on_spelunk_condition.
+        assert payload["spelunk_version"] is None
 
     def test_condition_flows_from_flag_not_hardcoded(
         self, fake_claude_on_path, throwaway_repo, tmp_path
@@ -242,6 +244,84 @@ class TestProvenanceAdditiveContract:
         line = [l for l in result.stdout.splitlines() if l.startswith("{")][-1]
         payload = json.loads(line)
         assert payload["condition"] == "spelunk_search"
+
+
+class TestSpelunkProvenance:
+    """A spelunk cell whose provenance lies about what was wired in is worse
+    than no cell. Driven through the fake `claude` shim, which never spawns
+    the MCP server, so the telemetry here is the never-spawned case."""
+
+    def test_version_recorded_on_spelunk_condition(
+        self, fake_claude_on_path, throwaway_repo, tmp_path
+    ):
+        issue_file = tmp_path / "ISSUE.txt"
+        issue_file.write_text("Fix the bug.")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(HARNESS_CLAUDE_CODE),
+                "--task-id",
+                "fake__task-1c",
+                "--repo-path",
+                str(throwaway_repo),
+                "--issue",
+                str(issue_file),
+                "--no-deepseek",
+                "--condition",
+                "spelunk_full",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=fake_claude_on_path,
+        )
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(
+            [l for l in result.stdout.splitlines() if l.startswith("{")][-1]
+        )
+        # Real version string if spelunk is installed, "unknown" if not.
+        # Never None on a spelunk condition, which is the old bug: both
+        # harnesses hardcoded None and the record disagreed with the wiring.
+        assert payload["spelunk_version"] is not None
+        assert payload["condition"] == "spelunk_full"
+
+    def test_telemetry_reports_a_server_that_never_spawned(
+        self, fake_claude_on_path, throwaway_repo, tmp_path
+    ):
+        # The fake shim ignores --mcp-config entirely, so this is exactly the
+        # "spelunk-labelled cell that is really baseline with extra latency"
+        # case the telemetry exists to expose.
+        issue_file = tmp_path / "ISSUE.txt"
+        issue_file.write_text("Fix the bug.")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(HARNESS_CLAUDE_CODE),
+                "--task-id",
+                "fake__task-1d",
+                "--repo-path",
+                str(throwaway_repo),
+                "--issue",
+                str(issue_file),
+                "--no-deepseek",
+                "--condition",
+                "spelunk_search",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=fake_claude_on_path,
+        )
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(
+            [l for l in result.stdout.splitlines() if l.startswith("{")][-1]
+        )
+        assert payload["spelunk_mcp_server_spawned"] is False
+        assert payload["spelunk_tool_calls"] == 0
 
 
 class TestOpencodeProvenanceAdditiveContract:

--- a/bench/agents/tests/test_spelunk_mcp_server.py
+++ b/bench/agents/tests/test_spelunk_mcp_server.py
@@ -1,8 +1,7 @@
 """Tests for bench/agents/spelunk_mcp_server.py.
 
 Run:
-    uv run --with pytest --with-requirements bench/requirements.txt \
-        pytest bench/agents/tests/ -v
+    uv run --with pytest pytest bench/agents/tests/ -v
 
 Network-free, no spelunk binary, no MCP handshake: these target the tool
 layer the server builds before any client connects (schemas, condition

--- a/bench/agents/tests/test_spelunk_mcp_server.py
+++ b/bench/agents/tests/test_spelunk_mcp_server.py
@@ -1,0 +1,174 @@
+"""Tests for bench/agents/spelunk_mcp_server.py.
+
+Run:
+    uv run --with pytest --with-requirements bench/requirements.txt \
+        pytest bench/agents/tests/ -v
+
+Network-free, no spelunk binary, no MCP handshake: these target the tool
+layer the server builds before any client connects (schemas, condition
+gating, spawn argv, telemetry).
+"""
+
+import json
+import sys
+
+import agent
+import pytest
+from spelunk_mcp_server import (
+    SERVER_NAME,
+    SPELUNK_CONDITIONS,
+    mcp_server_command,
+    mcp_tool_names_for_condition,
+    read_telemetry,
+    spelunk_tools_for_condition,
+    tool_names_for_condition,
+)
+
+AGENT_BASE_TOOL_NAMES = {t["function"]["name"] for t in agent.BASE_TOOLS}
+
+
+class TestEquivalenceWithAgentPy:
+    """The property the whole harness matrix rests on: a `spelunk` condition
+    must mean the same capability whichever harness carries it.
+
+    Importing agent.py's objects makes that hold by construction, so these
+    assert *identity*, not equality. An inlined copy of a schema passes `==`
+    while being free to drift; only `is` catches it. Anchored on
+    agent.build_tools(), never a list restated here.
+    """
+
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_exposed_tools_are_agent_py_objects_not_copies(self, condition):
+        agent_tools = agent.build_tools(condition)
+        exposed = spelunk_tools_for_condition(condition)
+        assert exposed, "a spelunk condition must expose at least one tool"
+        for tool in exposed:
+            assert any(tool is t for t in agent_tools), (
+                f"{tool['function']['name']} is not agent.py's own object. "
+                "A copied schema drifts silently and makes the cross-harness "
+                "comparison dishonest."
+            )
+
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_exposes_exactly_the_spelunk_tools_agent_py_would(self, condition):
+        expected = {
+            t["function"]["name"] for t in agent.build_tools(condition)
+        } - AGENT_BASE_TOOL_NAMES
+        assert set(tool_names_for_condition(condition)) == expected
+
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_never_re_exposes_tools_the_harness_ships_natively(self, condition):
+        # Each harness has its own read_file/run_bash/write_file. Re-exposing
+        # them over MCP would hand the model two of each.
+        assert not AGENT_BASE_TOOL_NAMES & set(tool_names_for_condition(condition))
+
+    def test_spelunk_full_is_a_strict_superset_of_spelunk_search(self):
+        assert set(tool_names_for_condition("spelunk_search")) < set(
+            tool_names_for_condition("spelunk_full")
+        )
+
+
+class TestConditionGate:
+    def test_baseline_is_refused(self):
+        # On baseline this server must never be spawned at all; if it is,
+        # refusing beats silently exposing an empty toolset that reads as a
+        # real spelunk cell.
+        with pytest.raises(ValueError, match="condition must be one of"):
+            spelunk_tools_for_condition("baseline")
+
+    def test_unknown_condition_is_refused(self):
+        with pytest.raises(ValueError, match="condition must be one of"):
+            spelunk_tools_for_condition("spelunk_xxx")
+
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_positive_control_spelunk_conditions_are_accepted(self, condition):
+        # Proves the two raises above are the gate firing, not the call
+        # raising for every input.
+        assert spelunk_tools_for_condition(condition)
+
+
+class TestMcpToolNames:
+    @pytest.mark.parametrize("condition", SPELUNK_CONDITIONS)
+    def test_names_are_namespaced_but_track_agent_pys_bare_names(self, condition):
+        # The one accepted difference from harness=none: transport renames,
+        # capability does not.
+        assert mcp_tool_names_for_condition(condition) == [
+            f"mcp__{SERVER_NAME}__{n}" for n in tool_names_for_condition(condition)
+        ]
+
+
+class TestMcpServerCommand:
+    def test_spawns_this_interpreter_not_a_bare_python3(self, tmp_path):
+        # The harness runs under `uv run --with-requirements`; only that
+        # interpreter has the mcp SDK. A bare "python3" resolves to the
+        # host's system interpreter and fails to import.
+        cmd = mcp_server_command("spelunk_search", tmp_path)
+        assert cmd[0] == sys.executable
+
+    def test_carries_repo_path_and_condition(self, tmp_path):
+        cmd = mcp_server_command("spelunk_full", tmp_path)
+        assert cmd[cmd.index("--repo-path") + 1] == str(tmp_path.resolve())
+        assert cmd[cmd.index("--condition") + 1] == "spelunk_full"
+
+    def test_telemetry_log_is_opt_in(self, tmp_path):
+        log = tmp_path / "calls.jsonl"
+        without = mcp_server_command("spelunk_search", tmp_path)
+        with_log = mcp_server_command("spelunk_search", tmp_path, telemetry_log=log)
+        assert "--telemetry-log" not in without
+        assert with_log[with_log.index("--telemetry-log") + 1] == str(log)
+
+
+class TestReadTelemetry:
+    """Separates the three outcomes a spelunk-labelled cell otherwise can't
+    be told apart by: never spawned, spawned but unused, used."""
+
+    def test_missing_log_reports_never_spawned(self, tmp_path):
+        summary = read_telemetry(tmp_path / "absent.jsonl")
+        assert summary["spelunk_mcp_server_spawned"] is False
+        assert summary["spelunk_tool_calls"] == 0
+        assert summary["spelunk_tool_calls_by_tool"] is None
+
+    def test_no_log_requested_reports_never_spawned(self):
+        assert read_telemetry(None)["spelunk_mcp_server_spawned"] is False
+
+    def test_spawned_but_unused_is_distinct_from_never_spawned(self, tmp_path):
+        log = tmp_path / "calls.jsonl"
+        log.write_text(json.dumps({"event": "server_start", "condition": "spelunk_search"}) + "\n")
+        summary = read_telemetry(log)
+        assert summary["spelunk_mcp_server_spawned"] is True
+        assert summary["spelunk_tool_calls"] == 0
+
+    def test_counts_calls_per_tool(self, tmp_path):
+        log = tmp_path / "calls.jsonl"
+        log.write_text(
+            "\n".join(
+                json.dumps(r)
+                for r in (
+                    {"event": "server_start", "condition": "spelunk_full"},
+                    {"event": "tool_call", "tool": "spelunk_search"},
+                    {"event": "tool_call", "tool": "spelunk_search"},
+                    {"event": "tool_call", "tool": "spelunk_graph"},
+                )
+            )
+            + "\n"
+        )
+        summary = read_telemetry(log)
+        assert summary["spelunk_mcp_server_spawned"] is True
+        assert summary["spelunk_tool_calls"] == 3
+        assert summary["spelunk_tool_calls_by_tool"] == {
+            "spelunk_search": 2,
+            "spelunk_graph": 1,
+        }
+
+    def test_survives_a_truncated_trailing_line(self, tmp_path):
+        # The server appends and flushes per call; a killed run can leave a
+        # half-written line. Losing it must not lose the whole record.
+        log = tmp_path / "calls.jsonl"
+        log.write_text(
+            json.dumps({"event": "server_start", "condition": "spelunk_search"}) + "\n"
+            + json.dumps({"event": "tool_call", "tool": "spelunk_search"}) + "\n"
+            + '{"event": "tool_ca'
+        )
+        summary = read_telemetry(log)
+        assert summary["spelunk_mcp_server_spawned"] is True
+        assert summary["spelunk_tool_calls"] == 1

--- a/bench/agents/tests/test_swebench_run_args.py
+++ b/bench/agents/tests/test_swebench_run_args.py
@@ -76,38 +76,30 @@ class TestHarnessEnumValidation:
             assert "--harness must be one of" not in result.stderr
 
 
-class TestConditionMustBeBaselineForNonNoneHarness:
-    """opencode/claude-code are generic coding agents, not
-    spelunk-instrumented, so spelunk_search/spelunk_full don't apply to them
-    (README "Conditions"). Enforced here rather than just documented, so a
-    mismatched --condition can't silently produce a result JSON whose
-    condition field disagrees with what --condition claimed to request."""
+class TestConditionValidatedAgainstConditionSet:
+    """Every condition is valid for every harness: opencode/claude-code reach
+    the spelunk tools over the bench-local MCP server. --condition is
+    validated against the condition set alone, so a typo can't be recorded as
+    a real cell, but a spelunk condition is never rejected by harness.
 
-    def test_rejects_non_baseline_condition_for_opencode(self):
+    Replaces an earlier rule that forced --condition=baseline for these two
+    harnesses, which made the spelunk arm unreachable for them."""
+
+    @pytest.mark.parametrize("harness", ["none", "opencode", "claude-code"])
+    def test_rejects_unknown_condition(self, harness):
         result = run_script(
-            ["--condition", "spelunk_full", "--harness", "opencode", "--api-key", "fake-key"]
+            ["--condition", "spelunk_xxx", "--harness", harness, "--api-key", "fake-key"]
         )
         assert result.returncode != 0
-        assert "--condition must be baseline for --harness opencode" in result.stderr
+        assert "--condition must be one of baseline|spelunk_search|spelunk_full" in result.stderr
 
-    def test_rejects_non_baseline_condition_for_claude_code(self):
+    @pytest.mark.parametrize("harness", ["none", "opencode", "claude-code"])
+    @pytest.mark.parametrize("condition", ["baseline", "spelunk_search", "spelunk_full"])
+    def test_accepts_every_condition_for_every_harness(self, harness, condition):
         result = run_script(
-            ["--condition", "spelunk_search", "--harness", "claude-code", "--api-key", "fake-key"]
+            ["--condition", condition, "--harness", harness, "--api-key", "fake-key", "--tasks", "0"]
         )
-        assert result.returncode != 0
-        assert "--condition must be baseline for --harness claude-code" in result.stderr
-
-    def test_baseline_condition_passes_for_opencode(self):
-        result = run_script(
-            ["--condition", "baseline", "--harness", "opencode", "--api-key", "fake-key", "--tasks", "0"]
-        )
-        assert "--condition must be baseline" not in result.stderr
-
-    def test_non_baseline_condition_still_allowed_for_harness_none(self):
-        result = run_script(
-            ["--condition", "spelunk_full", "--harness", "none", "--api-key", "fake-key", "--tasks", "0"]
-        )
-        assert "--condition must be baseline" not in result.stderr
+        assert "--condition must be" not in result.stderr
 
 
 class TestConditionRequired:

--- a/bench/requirements.txt
+++ b/bench/requirements.txt
@@ -1,5 +1,6 @@
 openai>=1.0.0
 python-dotenv>=1.0.0
+mcp>=1.0.0
 datasets>=2.0.0
 numpy>=1.24.0
 scikit-learn>=1.0.0


### PR DESCRIPTION
## What this unblocks

The `spelunk` condition is now reachable through the `opencode` and `claude-code` harnesses, not just `--harness none`. **Priority 2 of the bench matrix becomes runnable.**

`bench/agents/spelunk_mcp_server.py` is a bench-local stdio MCP server that *imports* `agent.py`'s tool functions and JSON schemas and re-exposes them over MCP. It never reimplements them. The harness adapters register it when `--condition` is `spelunk_search` or `spelunk_full`.

## Ruling: is the system prompt asymmetry acceptable for published numbers?

**Yes, and it is narrower than it was described.** This is the judgement the story turns on, so it is stated here rather than buried.

The concern going in was that each harness keeps its own base prompt, so a spelunk arm's full prompt is not byte-identical to `agent.py`'s, and cross-harness uplift comparisons would be confounded. Measured, the picture is better:

```
opencode base == claude-code base : True     <- byte-identical
opencode base == agent.py base    : False    <- differs by ONE clause
```

There are **two** distinct base prompts across three harnesses, not three. Consequences:

1. **Within a harness, the contrast is clean.** Verified directly: the baseline arm receives that harness's base prompt verbatim, and the spelunk arm receives the same base plus the guidance sentence. The base cancels out of the uplift. The primary "does spelunk help?" result is unaffected.
2. **opencode vs claude-code uplift is prompt-clean.** Identical base, identical guidance core, differing only in tool names, which MCP namespacing forces and which are named to the model. This is the comparison Priority 2 actually needs, and it is sound.
3. **Only comparisons against `--harness none` carry the one-clause difference**, and that clause is load-bearing:
   - `agent.py`: "Use the available tools to explore the codebase ... and apply the fix."
   - MCP harnesses: "Explore the codebase ... and apply the fix directly by editing files in the repository."

   `agent.py`'s model can only edit through `agent.py`'s own tool dispatch. The MCP harnesses edit with their native editing loop. Each prompt describes the mechanism that harness actually has.

**So prompt unification is the wrong fix.** Making the strings byte-identical would hand one harness a sentence describing an edit mechanism it does not have, trading a documented and semantically necessary difference for a prompt that is wrong. Against `--harness none` this clause is one of several irreducible differences between an in-process agent and a subprocess one; the transport, the tool-calling loop and the scaffold all differ too. The prompt is not the binding constraint there.

I took option three from the brief, **narrow what the benchmark claims**, and made the narrow claim true and enforced rather than accepting a broad claim that is subtly false. This did not need a founder call: the facts were determinable by measurement, and the answer came out narrower and stronger than the framing assumed.

**Reviewer changes made under this ruling:** the README described three per-harness base prompts, which understated the guarantee and would lead a reader to distrust a comparison that is in fact clean. It now states the two-prompt reality and why the clause stays. Nothing enforced the shared base, so a reword of either harness prompt could silently reintroduce the confound the README calls absent. `test_the_two_mcp_harnesses_share_one_base_prompt` now pins it.

## Equivalence, and how it is enforced

The tools are equivalent by construction: the MCP server exposes `agent.py`'s own objects, derived by subtracting `BASE_TOOLS` from `build_tools()`, never a hand-listed set. Identity assertions (`is`, not `==`) catch a copied schema that equality would wave through.

## Known limits, stated plainly

- **The claude-code arm is not runnable**, blocked on a separate issue: it authenticates before initialising MCP servers, so a DeepSeek 401 kills the run at ~1.3s with the server never spawned. Acceptance is split deliberately: opencode is validated by live e2e (`astropy__astropy-12907`, `spelunk_full`, real DeepSeek, `spelunk_mcp_server_spawned: true`), claude-code by wiring plus offline tests only. A 401 there is not a regression in this PR.
- **opencode global-config non-merge** is documented as observed on one version (v1.17.20) on one host, with no enforcing flag. It is deliberately not pinned as a contract. Re-check when bumping opencode.
- **`serve()`'s MCP handshake is untested**; it needs a live client and the SDK owns it. The tool layer beneath it is covered.
- The `mcp__spelunk` server-wide shorthand is unverified and not relied on; tools are allow-listed by full name.

## Test plan

Run from the worktree root with `SPELUNK_SECRET_STORE=file`.

**Suite, documented command (no `--with-requirements`):**
```
$ uv run --with pytest pytest bench/agents/tests/ -q
119 passed in 2.88s
```

**Suite, with requirements:**
```
$ uv run --with pytest --with-requirements bench/requirements.txt pytest bench/agents/tests/ -q
119 passed in 2.36s
```

**Offline by construction, not by stub:**
```
$ uv run python -c "import agent, sys; print('openai' in sys.modules, 'dotenv' in sys.modules)"
False False
```
Agreed with the engineer's call to reject a suite-wide `sys.modules` stub. A stub would make the suite blind to a real `openai` dependency appearing, which is the failure it is meant to detect.

**Containment argument, verified rather than accepted:**
```
opencode    : baseline arm == its own base, untouched : True
opencode    : spelunk arm starts with the SAME base   : True
claude_code : baseline arm == its own base, untouched : True
claude_code : spelunk arm starts with the SAME base   : True
```

**Mutation: does the equivalence guard bite?** Wrapped `spelunk_tools_for_condition`'s return in `copy.deepcopy`:
```
FAILED test_exposed_tools_are_agent_py_objects_not_copies[spelunk_search]
FAILED test_exposed_tools_are_agent_py_objects_not_copies[spelunk_full]
2 failed, 116 passed
```
Exactly the two identity assertions fail; the equality tests all pass, confirming they are blind to a deep copy. Reverted, tree clean.

**Mutation: is `--strict-mcp-config` really in both arms?** Moved it to the spelunk arm only:
```
FAILED TestStrictMcpConfig::test_passed_in_every_arm_including_baseline[baseline]
FAILED TestStrictMcpConfig::test_passed_on_baseline_even_with_no_mcp_config
2 failed, 116 passed
```
The two baseline-specific assertions fail while the spelunk arm still carries the flag, which is what a naive "flag present" test would miss. Contamination is real on this host. Reverted, tree clean.

**Mutation: does the new base-prompt guard bite?** Reworded opencode's base prompt by one sentence:
```
FAILED TestBuildSystemPrompt::test_the_two_mcp_harnesses_share_one_base_prompt
1 failed, 20 passed
```
Reverted, tree clean.

## Branch staleness

Branch was cut at `b614004b7`; `main` has since gained #605, #607, #608, #609, #610, #611 and #612. Checked with three-dot diff and merge-base.

- **Textual:** the file sets are disjoint. Nothing on main touches `bench/`.
- **Semantic, which a disjoint file set does not cover:** main changed `cli/cmd/search.rs` and `storage/memory/search.rs`, which are exactly the surfaces `agent.py` shells out to and parses as `--format json`. Inspected both diffs: they are comment-only, from #611 scrubbing tracker ids. No JSON contract change. Main also changed `index/summaries.rs` to run LLM summaries to completion rather than detaching; `swebench_run.sh` calls `spelunk index` unwrapped and with `|| true`, so that change makes the step slower and more complete, never failing.

Not rebased: no conflict and no contract drift.

## Public repo gates

- Tracker ids in diff: none.
- Competitor names or strategy internals under `bench/`: none.
- **Em-dashes:** fixed the 2 in `README.md`, which is public prose. Left the 13 in code and shell comments, and that is a deliberate call worth flagging. One of them sits inside `SPELUNK_GUIDANCE_CORE` and is copied verbatim from `agent.py`'s `SYSTEM_PROMPT_SPELUNK`, which already carries it on `main`. Removing it would break the exact-substring pin that makes upstream drift fail loudly, and fixing it at the source would mean editing the measured prompt and invalidating comparability with prior runs. The rest are maintainer comments explaining invariants, and main's own code comments use em-dashes throughout (14 in `cli/cmd/search.rs` alone), so enforcing the rule there would make this diff inconsistent with every file around it. The rule's rationale is public-facing prose, which is where I applied it.
