### PR TITLE
feat(memory): publish git notes on push via an opt-in pre-push hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,14 +90,35 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   remains gated to initialized projects. (ADR-068)
 - **`spelunk init` now configures the `origin` fetch refspec for `refs/notes/spelunk`**,
   so project memory notes travel automatically on `git fetch`. When init detects
-  an `origin` remote, it adds `+refs/notes/spelunk:refs/notes/spelunk` to the
-  fetch config (idempotently) and prints the push command users run to publish
-  their memory to the remote (re-run after each memory change, since every
-  memory add/remove creates a new notes commit). Teammates then run `spelunk init` in their
+  an `origin` remote, it adds the refspec to the fetch config (idempotently) and
+  names the command that publishes memory back (`spelunk hooks install
+  --pre-push`, below). Teammates then run `spelunk init` in their
   clones (or manually add the same refspec) and `git fetch` to receive notes. In
   projects without an `origin`, init prints the exact git commands to run later
   when the remote is added. See [docs/memory.md](#sharing-memory-across-clones-via-git-notes).
-  (ADR-068)
+  (ADR-068; the refspec value is corrected by ADR-069, see Fixed)
+- **`spelunk hooks install --pre-push` publishes your memory on `git push`.** The
+  hook fetches the remote's `refs/notes/spelunk`, merges it into yours with
+  `cat_sort_uniq` (a union, so neither side's entries are dropped), and pushes
+  the result to the remote you are pushing to, so decisions travel with the code
+  they describe. Publishing is **opt-in**: your memory stays local until you
+  install it, and `spelunk init` now says so and names the command. Reading a
+  teammate's memory needs no opt-in and is unchanged.
+
+  Publishing is tied to `git push` because that is the only moment that reliably
+  coincides with "this code is being shared". An entry recorded against a commit
+  you have not pushed can reach the remote while the commit does not, leaving the
+  note unresolvable in a fresh clone: it is on the remote, and nobody ever sees
+  it. That is what the old per-change manual push hint produced whenever you
+  recorded a decision before pushing the commit it describes, which is the normal
+  order of work; `init` no longer advertises it. Pushing the notes ref by hand
+  still works as a no-hook fallback, after you have pushed the commits.
+
+  The hook **never blocks your push**: on failure it warns on stderr and exits 0,
+  so a failed publish cannot cost you your code push. It retries a lost race up
+  to three times and never force-pushes. Teammates without spelunk on their PATH
+  are unaffected, and it never overwrites a pre-push hook it did not write.
+  `spelunk hooks uninstall` removes it. (ADR-069 D1/D3)
 - **Native in-process HTTPS for `spelunk-server`** via `--tls-cert`/`--tls-key`
   (env `SPELUNK_SERVER_TLS_CERT`/`SPELUNK_SERVER_TLS_KEY`), both-or-neither. The
   server terminates TLS itself, so a team/remote deployment is a routable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,8 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   if the lock is busy the merge is skipped and the read proceeds anyway (the
   union is idempotent, so the next read catches up). Your `notes.mergeStrategy`
   is never written; the strategy is passed per-invocation. *Publishing* your own
-  memory remains a manual `git push origin refs/notes/spelunk`. (ADR-069)
+  memory stays opt-in: install the pre-push hook (see Added) or push
+  `refs/notes/spelunk` by hand. (ADR-069)
 - **Memory entries now read back in chronological order after a merge.** The
   union merge sorts lines lexicographically, so a note's records are no longer
   in append order once teammates' entries are folded in. Reads now sort by

--- a/crates/spelunk-cli/src/cli/cmd/hooks.rs
+++ b/crates/spelunk-cli/src/cli/cmd/hooks.rs
@@ -9,14 +9,19 @@ pub struct HooksArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum HooksCommand {
-    /// Install a post-commit hook that auto-indexes and harvests memory
+    /// Install a post-commit hook that auto-indexes and harvests memory, or a
+    /// pre-push hook that publishes memory to the remote (`--pre-push`)
     Install(HooksInstallArgs),
-    /// Remove the spelunk post-commit hook
+    /// Remove every git hook spelunk installed
     Uninstall,
 }
 
 #[derive(Args, Debug)]
 pub struct HooksInstallArgs {
+    /// Install the pre-push hook that publishes memory notes on `git push`
+    #[arg(long, conflicts_with = "ci")]
+    pub pre_push: bool,
+
     /// Print a GitHub Actions workflow step instead of writing a git hook
     #[arg(long)]
     pub ci: bool,
@@ -44,6 +49,65 @@ spelunk index "$PROJECT_ROOT" --detach
 spelunk memory harvest --git-range HEAD~1..HEAD --detach
 "#;
 
+const PRE_PUSH_HOOK: &str = r#"#!/bin/sh
+# spelunk pre-push hook — installed by `spelunk hooks install --pre-push`
+# Publishes spelunk memory (refs/notes/spelunk) to the remote you are pushing to,
+# so decisions travel with the code they describe.
+# Silently skips if `spelunk` is not in PATH, so teammates without spelunk are unaffected.
+#
+# This hook never exits non-zero: a failing pre-push hook aborts the branch push
+# outright, and sharing memory must never cost you your push.
+
+if ! command -v spelunk >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Recursion guard. Without it the notes push below re-enters this hook: a version
+# lacking one recursed until the process table was exhausted, while every outer
+# push still reported success. `--no-verify` on that push is the real guard; this
+# sentinel is belt and braces.
+if [ -n "${SPELUNK_NOTES_PUSH:-}" ]; then
+  exit 0
+fi
+
+REMOTE="${1:-origin}"
+
+# Nothing recorded locally, or nothing resolvable to publish to.
+git rev-parse --verify --quiet refs/notes/spelunk >/dev/null 2>&1 || exit 0
+git remote get-url "$REMOTE" >/dev/null 2>&1 || exit 0
+
+attempt=1
+while [ "$attempt" -le 3 ]; do
+  # Onto the tracking ref, never over refs/notes/spelunk: fetching straight onto
+  # the working ref force-updates it and drops notes you have not pushed yet.
+  git fetch --quiet "$REMOTE" "+refs/notes/spelunk:refs/notes/origin/spelunk" >/dev/null 2>&1
+
+  # `-s` is explicit: the notes.mergeStrategy default is `manual`, which exits 1
+  # and strands .git/NOTES_MERGE_WORKTREE. Your own setting is never written.
+  if git rev-parse --verify --quiet refs/notes/origin/spelunk >/dev/null 2>&1; then
+    git notes --ref=spelunk merge -s cat_sort_uniq refs/notes/origin/spelunk >/dev/null 2>&1
+  fi
+
+  # Never forced: the union above already carries both sides, so a force-push
+  # could only discard a teammate's memory.
+  err=$(SPELUNK_NOTES_PUSH=1 git push --no-verify "$REMOTE" \
+    refs/notes/spelunk:refs/notes/spelunk 2>&1) && exit 0
+
+  # Only a lost race is retried: a teammate landed notes between our fetch and
+  # our push, so re-merging theirs lets the next attempt fast-forward. Anything
+  # else (offline, rejected by the remote) would fail identically three times.
+  case "$err" in
+    *non-fast-forward* | *"fetch first"*) ;;
+    *) break ;;
+  esac
+  attempt=$((attempt + 1))
+done
+
+echo "spelunk: could not publish memory notes to '$REMOTE'. Your code push is unaffected." >&2
+echo "spelunk: retry with: git push $REMOTE refs/notes/spelunk" >&2
+exit 0
+"#;
+
 const CI_STEP: &str = r#"# Add to your .github/workflows/ file:
 - name: Update spelunk index
   run: |
@@ -53,37 +117,76 @@ const CI_STEP: &str = r#"# Add to your .github/workflows/ file:
     fi
 "#;
 
+/// An installable hook: git's filename for it, the marker line identifying a
+/// spelunk-written copy, and the script body.
+struct HookSpec {
+    name: &'static str,
+    marker: &'static str,
+    body: &'static str,
+}
+
+const POST_COMMIT: HookSpec = HookSpec {
+    name: "post-commit",
+    marker: "spelunk post-commit hook",
+    body: POST_COMMIT_HOOK,
+};
+
+const PRE_PUSH: HookSpec = HookSpec {
+    name: "pre-push",
+    marker: "spelunk pre-push hook",
+    body: PRE_PUSH_HOOK,
+};
+
+/// Every hook `uninstall` considers.
+const ALL_HOOKS: [&HookSpec; 2] = [&POST_COMMIT, &PRE_PUSH];
+
+/// The command that installs the pre-push hook. `init` names it when it tells
+/// the user their memory stays local until they opt in (ADR-069 D3).
+pub const PRE_PUSH_INSTALL_CMD: &str = "spelunk hooks install --pre-push";
+
+/// Whether spelunk's own pre-push hook is installed in the repo holding the CWD.
+/// False for a foreign pre-push hook: that one publishes nothing.
+pub fn pre_push_installed() -> bool {
+    let Ok(git_dir) = find_git_dir() else {
+        return false;
+    };
+    std::fs::read_to_string(git_dir.join("hooks").join(PRE_PUSH.name))
+        .is_ok_and(|body| body.contains(PRE_PUSH.marker))
+}
+
 fn find_git_dir() -> Result<std::path::PathBuf> {
     let cwd = std::env::current_dir().context("getting current directory")?;
     let repo = gix::discover(&cwd).context("Not inside a git repository.")?;
     Ok(repo.git_dir().to_path_buf())
 }
 
-fn hooks_install(args: HooksInstallArgs) -> Result<()> {
-    if args.ci {
-        print!("{CI_STEP}");
-        return Ok(());
-    }
+/// Whether `write_hook` wrote the hook or found its own copy already there.
+enum Installed {
+    Wrote(std::path::PathBuf),
+    AlreadyPresent(std::path::PathBuf),
+}
 
-    let git_dir = find_git_dir()?;
-    let hooks_dir = git_dir.join("hooks");
+/// Write `spec`'s body to `<git-dir>/hooks/<name>`, refusing to clobber a hook
+/// spelunk did not write.
+fn write_hook(spec: &HookSpec) -> Result<Installed> {
+    let hooks_dir = find_git_dir()?.join("hooks");
     std::fs::create_dir_all(&hooks_dir)?;
-    let hook_path = hooks_dir.join("post-commit");
+    let hook_path = hooks_dir.join(spec.name);
 
     if hook_path.exists() {
         let existing = std::fs::read_to_string(&hook_path)?;
-        if existing.contains("spelunk post-commit hook") {
-            println!("Hook already installed at {}", hook_path.display());
-            return Ok(());
+        if existing.contains(spec.marker) {
+            return Ok(Installed::AlreadyPresent(hook_path));
         }
         anyhow::bail!(
-            "A post-commit hook already exists at {}.\n\
+            "A {} hook already exists at {}.\n\
              Inspect it and merge manually, or remove it first.",
+            spec.name,
             hook_path.display()
         );
     }
 
-    std::fs::write(&hook_path, POST_COMMIT_HOOK)?;
+    std::fs::write(&hook_path, spec.body)?;
 
     #[cfg(unix)]
     {
@@ -93,7 +196,29 @@ fn hooks_install(args: HooksInstallArgs) -> Result<()> {
         std::fs::set_permissions(&hook_path, perms)?;
     }
 
-    println!("Installed post-commit hook at {}", hook_path.display());
+    Ok(Installed::Wrote(hook_path))
+}
+
+fn hooks_install(args: HooksInstallArgs) -> Result<()> {
+    if args.ci {
+        print!("{CI_STEP}");
+        return Ok(());
+    }
+
+    if args.pre_push {
+        return install_pre_push();
+    }
+    install_post_commit()
+}
+
+fn install_post_commit() -> Result<()> {
+    match write_hook(&POST_COMMIT)? {
+        Installed::AlreadyPresent(p) => {
+            println!("Hook already installed at {}", p.display());
+            return Ok(());
+        }
+        Installed::Wrote(p) => println!("Installed post-commit hook at {}", p.display()),
+    }
     println!("After each commit, spelunk will:");
     println!("  - Re-index the project");
     println!("  - Harvest memory from the new commit");
@@ -101,24 +226,59 @@ fn hooks_install(args: HooksInstallArgs) -> Result<()> {
     Ok(())
 }
 
-fn hooks_uninstall() -> Result<()> {
-    let git_dir = find_git_dir()?;
-    let hook_path = git_dir.join("hooks").join("post-commit");
+fn install_pre_push() -> Result<()> {
+    match write_hook(&PRE_PUSH)? {
+        Installed::AlreadyPresent(p) => {
+            println!("Hook already installed at {}", p.display());
+            return Ok(());
+        }
+        Installed::Wrote(p) => println!("Installed pre-push hook at {}", p.display()),
+    }
+    println!("On each `git push`, spelunk will publish your memory to that remote:");
+    println!("  - Fetch and merge teammates' memory notes (union, nothing dropped)");
+    println!("  - Push refs/notes/spelunk alongside the code you are pushing");
+    println!("Your push is never blocked: on failure the hook warns and exits 0.");
+    println!("Teammates without spelunk installed are unaffected.");
+    Ok(())
+}
 
-    if !hook_path.exists() {
-        println!("No post-commit hook found.");
+fn hooks_uninstall() -> Result<()> {
+    let hooks_dir = find_git_dir()?.join("hooks");
+    let mut removed = 0usize;
+    let mut foreign: Vec<std::path::PathBuf> = Vec::new();
+
+    for spec in ALL_HOOKS {
+        let hook_path = hooks_dir.join(spec.name);
+        if !hook_path.exists() {
+            continue;
+        }
+        if !std::fs::read_to_string(&hook_path)?.contains(spec.marker) {
+            foreign.push(hook_path);
+            continue;
+        }
+        std::fs::remove_file(&hook_path)?;
+        println!("Removed {} hook.", spec.name);
+        removed += 1;
+    }
+
+    // Only a wholly ineffective uninstall is an error: with a spelunk hook
+    // removed, leaving someone else's hook alone is the correct outcome.
+    if removed == 0 {
+        if let Some(p) = foreign.first() {
+            anyhow::bail!(
+                "The hook at {} was not installed by spelunk. Remove it manually.",
+                p.display()
+            );
+        }
+        println!("No spelunk hooks found.");
         return Ok(());
     }
 
-    let content = std::fs::read_to_string(&hook_path)?;
-    if !content.contains("spelunk post-commit hook") {
-        anyhow::bail!(
-            "The hook at {} was not installed by spelunk. Remove it manually.",
-            hook_path.display()
+    for p in &foreign {
+        println!(
+            "Left {} alone: it was not installed by spelunk.",
+            p.display()
         );
     }
-
-    std::fs::remove_file(&hook_path)?;
-    println!("Removed post-commit hook.");
     Ok(())
 }

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -275,15 +275,14 @@ fn write_spelunk_gitignore(spelunk_dir: &std::path::Path) {
 ///
 /// Push refspec is deliberately NOT set: any `remote.origin.push` value
 /// overrides git's default branch push, so a normal `git push` would stop
-/// pushing the current branch. We keep the branch-push default intact and
-/// surface the manual notes push (needed after each memory change) instead.
+/// pushing the current branch. Publishing rides the opt-in pre-push hook
+/// instead, which this announces (ADR-069 D1/D3) because opt-in only works if
+/// it is discoverable without reading the docs.
 /// Also points `notes.rewriteRef` at spelunk's ref so memory survives history
 /// rewrites. That half is independent of `origin`: rewrites are purely local,
 /// so it runs even in a remote-less repo.
 async fn configure_notes_refspec(project_root: &std::path::Path) -> Vec<String> {
     const FETCH_REFSPEC: &str = "+refs/notes/spelunk*:refs/notes/origin/spelunk*";
-    const PUSH_HINT: &str =
-        "push notes after each memory change: git push origin refs/notes/spelunk";
 
     let git = |args: &[&str]| {
         std::process::Command::new("git")
@@ -303,7 +302,6 @@ async fn configure_notes_refspec(project_root: &std::path::Path) -> Vec<String> 
                 format!(
                     "         run later: git config --add remote.origin.fetch '{FETCH_REFSPEC}'"
                 ),
-                format!("         {PUSH_HINT}"),
             ]
         } else {
             // Idempotent: only `--add` when the identical refspec is not already present.
@@ -317,16 +315,12 @@ async fn configure_notes_refspec(project_root: &std::path::Path) -> Vec<String> 
                 })
                 .unwrap_or(false);
             if already {
-                vec![
-                    "Memory:  notes fetch refspec already configured on 'origin'".to_string(),
-                    format!("         {PUSH_HINT}"),
-                ]
+                vec!["Memory:  notes fetch refspec already configured on 'origin'".to_string()]
             } else {
                 match git(&["config", "--add", "remote.origin.fetch", FETCH_REFSPEC]) {
                     Ok(o) if o.status.success() => vec![
                         "Memory:  configured notes fetch refspec on 'origin' (teammates' memory arrives on fetch)"
                             .to_string(),
-                        format!("         {PUSH_HINT}"),
                     ],
                     Ok(o) => vec![format!(
                         "Memory:  could not configure notes refspec: {}",
@@ -339,6 +333,20 @@ async fn configure_notes_refspec(project_root: &std::path::Path) -> Vec<String> 
     };
 
     // Continuation lines: every branch above already opened a `Memory:` block.
+
+    // Reading a teammate's memory is automatic (the refspec above plus the
+    // read-path merge); publishing yours is opt-in, so say so unprompted.
+    if super::hooks::pre_push_installed() {
+        lines.push(
+            "         pre-push hook installed: your memory publishes on `git push`".to_string(),
+        );
+    } else {
+        lines.push(format!(
+            "         your memory stays local until you install the pre-push hook: {}",
+            super::hooks::PRE_PUSH_INSTALL_CMD
+        ));
+    }
+
     match ensure_notes_rewrite_ref(Some(project_root)).await {
         RewriteRefStatus::Configured => lines.push(
             "         configured notes.rewriteRef (memory survives `git commit --amend` and `git rebase`)"

--- a/crates/spelunk-cli/tests/init_notes_refspec.rs
+++ b/crates/spelunk-cli/tests/init_notes_refspec.rs
@@ -166,11 +166,15 @@ fn init_no_origin_prints_hint_and_succeeds() {
         )),
         "no-origin init should print the exact refspec hint, got:\n{stdout}"
     );
-    // The push hint frames the notes push as per-change, not one-time: each
-    // memory add/remove makes a new notes commit that must be pushed to travel.
+    // Publishing is opt-in, so init must name the hook that does it rather than
+    // the old manual push, which orphaned notes on unpushed commits (D1/D3).
     assert!(
-        stdout.contains("push notes after each memory change: git push origin refs/notes/spelunk"),
-        "no-origin init should print the per-change notes push hint, got:\n{stdout}"
+        stdout.contains("spelunk hooks install --pre-push"),
+        "no-origin init should name the pre-push hook install command, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("push notes after each memory change"),
+        "the retired per-change manual push hint must not reappear, got:\n{stdout}"
     );
     // And it must not have invented an `origin` remote.
     assert!(

--- a/crates/spelunk-cli/tests/init_notes_refspec.rs
+++ b/crates/spelunk-cli/tests/init_notes_refspec.rs
@@ -185,6 +185,37 @@ fn init_no_origin_prints_hint_and_succeeds() {
     );
 }
 
+/// (2a) With the pre-push hook installed, init announces that memory publishes
+/// rather than repeating that it stays local.
+///
+/// The announce is the only place a user learns whether their memory travels,
+/// so a summary that ignores the installed hook is init telling them the
+/// opposite of the truth.
+#[test]
+fn init_announces_the_pre_push_hook_once_installed() {
+    let tmp = tempdir().unwrap();
+    init_repo_with_commit(tmp.path());
+
+    spelunk_bin()
+        .current_dir(tmp.path())
+        .env("HOME", tmp.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .args(["hooks", "install", "--pre-push"])
+        .assert()
+        .success();
+
+    let stdout = run_init(tmp.path());
+
+    assert!(
+        stdout.contains("pre-push hook installed: your memory publishes on `git push`"),
+        "init must report the hook as installed, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("your memory stays local"),
+        "init must not claim memory stays local once the hook publishes it, got:\n{stdout}"
+    );
+}
+
 /// (2b) No `origin` remote: init still configures `notes.rewriteRef`, so memory
 /// survives `git commit --amend` and `git rebase`. The carry is purely local and
 /// must not be gated on having a remote: a remote-less repo is exactly where the

--- a/crates/spelunk-cli/tests/pre_push_hook.rs
+++ b/crates/spelunk-cli/tests/pre_push_hook.rs
@@ -12,8 +12,14 @@
 //! - a failing notes push never blocks the branch push: a hook exiting non-zero
 //!   aborts the push outright, so origin never receives the commit.
 //! - two developers annotating the same commit converge, losing neither entry.
+//! - a lost race (a teammate's notes land between our fetch and our push) is
+//!   retried and converges; a rejection is NOT retried.
+//! - a fetch failure never destroys the notes already on the remote.
+//! - the merge strands no `NOTES_MERGE_WORKTREE`.
 //! - repeated pushes are idempotent: no duplicates, no empty re-push.
-//! - graceful skip with no local notes ref, and when pushing by URL.
+//! - graceful skip with no local notes ref, when pushing by URL, and with no
+//!   `spelunk` on PATH.
+//! - the hook publishes to the remote being pushed to, not a hardcoded `origin`.
 //! - a non-spelunk pre-push hook is never clobbered.
 //! - uninstall removes the hook.
 //!
@@ -37,16 +43,9 @@ fn spelunk_bin_dir() -> PathBuf {
         .to_path_buf()
 }
 
-/// Run `git args` in `dir`, returning the `Output` without asserting.
-///
-/// Isolated identity/config so it is hermetic, and `spelunk` prepended to PATH
-/// so the installed hook clears its own `command -v spelunk` guard.
-fn git_out(dir: &Path, args: &[&str]) -> Output {
-    let path = format!(
-        "{}:{}",
-        spelunk_bin_dir().display(),
-        std::env::var("PATH").unwrap_or_default()
-    );
+/// Run `git args` in `dir` with an explicit `PATH`, returning the `Output`
+/// without asserting. Isolated identity/config so it is hermetic.
+fn git_out_with_path(dir: &Path, path: &str, args: &[&str]) -> Output {
     std::process::Command::new("git")
         .current_dir(dir)
         .args(args)
@@ -59,6 +58,19 @@ fn git_out(dir: &Path, args: &[&str]) -> Output {
         .env("GIT_CONFIG_SYSTEM", "/dev/null")
         .output()
         .expect("spawn git")
+}
+
+/// Run `git args` in `dir`, returning the `Output` without asserting.
+///
+/// `spelunk` is prepended to PATH so the installed hook clears its own
+/// `command -v spelunk` guard.
+fn git_out(dir: &Path, args: &[&str]) -> Output {
+    let path = format!(
+        "{}:{}",
+        spelunk_bin_dir().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    git_out_with_path(dir, &path, args)
 }
 
 /// Like [`git_out`] but asserts the command succeeded.
@@ -112,6 +124,57 @@ fn install_pre_push(home: &Path, repo: &Path) -> PathBuf {
 /// A bare repo standing in for `origin`.
 fn bare_origin(dir: &Path) {
     git(dir, &["init", "-q", "--bare", "-b", "main"]);
+}
+
+/// Write `body` to `path` and make it executable. Parent dirs are created: a
+/// bare repo has no `hooks/` until something needs one.
+fn write_executable(path: &Path, body: &str) {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut p = std::fs::metadata(path).unwrap().permissions();
+        p.set_mode(0o755);
+        std::fs::set_permissions(path, p).unwrap();
+    }
+}
+
+/// Reject every `refs/notes/*` update on `origin`, recording one line per
+/// attempt in `counter`. Per-ref, so the branch push is untouched.
+fn reject_notes_and_count(origin: &Path, counter: &Path) {
+    write_executable(
+        &origin.join("hooks").join("update"),
+        &format!(
+            "#!/bin/sh\ncase \"$1\" in refs/notes/*) echo try >> '{}' ; exit 1 ;; esac\nexit 0\n",
+            counter.display()
+        ),
+    );
+}
+
+/// Lines in `path`, or 0 when it was never written.
+fn line_count(path: &Path) -> usize {
+    std::fs::read_to_string(path)
+        .map(|s| s.lines().filter(|l| !l.trim().is_empty()).count())
+        .unwrap_or(0)
+}
+
+/// Publish `title` from a second clone straight onto `origin`'s notes ref,
+/// standing in for a teammate who shared memory first. Returns the annotated
+/// object, which is the commit both sides share.
+fn teammate_publishes(home: &Path, origin: &Path, dir: &Path, title: &str) -> String {
+    clone_dev(origin, dir);
+    memory_add(home, dir, title);
+    git(
+        dir,
+        &[
+            "push",
+            "-q",
+            "origin",
+            "refs/notes/spelunk:refs/notes/spelunk",
+        ],
+    );
+    git_stdout(dir, &["rev-parse", "HEAD"])
 }
 
 /// Commit `<name>.txt` in `dir`.
@@ -245,21 +308,8 @@ fn failed_notes_push_does_not_block_the_branch_push() {
     bare_origin(&origin);
     seed_origin(&origin, &dev);
 
-    // Reject only the notes ref, per-ref, so the branch push is untouched.
-    let update_hook = origin.join("hooks").join("update");
-    std::fs::create_dir_all(update_hook.parent().unwrap()).unwrap();
-    std::fs::write(
-        &update_hook,
-        "#!/bin/sh\ncase \"$1\" in refs/notes/*) exit 1 ;; esac\nexit 0\n",
-    )
-    .unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut p = std::fs::metadata(&update_hook).unwrap().permissions();
-        p.set_mode(0o755);
-        std::fs::set_permissions(&update_hook, p).unwrap();
-    }
+    let attempts = tmp.path().join("attempts");
+    reject_notes_and_count(&origin, &attempts);
 
     install_pre_push(home.path(), &dev);
     memory_add(home.path(), &dev, "rejected-notes-decision");
@@ -289,6 +339,249 @@ fn failed_notes_push_does_not_block_the_branch_push() {
         String::from_utf8_lossy(&out.stderr).contains("could not publish memory notes"),
         "the hook should warn on stderr, got: {}",
         String::from_utf8_lossy(&out.stderr)
+    );
+
+    // A rejection is not a lost race: it fails identically every time, so the
+    // hook must give up after one attempt. Retrying every failure would park a
+    // push behind three network timeouts when the remote is simply unreachable.
+    assert_eq!(
+        line_count(&attempts),
+        1,
+        "a rejected notes push must be attempted exactly once, never retried"
+    );
+}
+
+// ── D3: retry only a lost race ────────────────────────────────────────────────
+
+/// A teammate landing notes between our fetch and our push is retried, and the
+/// retry converges without dropping either side.
+///
+/// The race is reproduced by serving a stale view (the world before the
+/// teammate published) to the first fetch only, so the first push is genuinely
+/// non-fast-forward while the second fetch sees the teammate's notes and merges
+/// them. Deterministic: the served *view* changes, so nothing depends on when a
+/// side effect lands.
+#[cfg(unix)]
+#[test]
+fn a_lost_race_is_retried_and_converges_with_no_loss() {
+    let home = TempDir::new().unwrap();
+    let home2 = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let stale = tmp.path().join("stale.git");
+    let dev = tmp.path().join("dev");
+    let teammate = tmp.path().join("teammate");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    bare_origin(&origin);
+    seed_origin(&origin, &dev);
+
+    // Snapshot origin before any notes exist: this is the stale view.
+    git(
+        tmp.path(),
+        &[
+            "clone",
+            "-q",
+            "--bare",
+            origin.to_str().unwrap(),
+            stale.to_str().unwrap(),
+        ],
+    );
+
+    let shared = teammate_publishes(home2.path(), &origin, &teammate, "teammate-raced-decision");
+    assert_eq!(
+        shared,
+        git_stdout(&dev, &["rev-parse", "HEAD"]),
+        "setup: both sides must annotate the same commit"
+    );
+
+    install_pre_push(home.path(), &dev);
+    memory_add(home.path(), &dev, "dev-raced-decision");
+
+    let stamp = tmp.path().join("served-stale");
+    let calls = tmp.path().join("upload-pack-calls");
+    let wrapper = tmp.path().join("uploadpack.sh");
+    write_executable(
+        &wrapper,
+        &format!(
+            "#!/bin/sh\n\
+             echo call >> '{}'\n\
+             if [ -f '{}' ]; then exec git upload-pack '{}'; fi\n\
+             : > '{}'\n\
+             exec git upload-pack '{}'\n",
+            calls.display(),
+            stamp.display(),
+            origin.display(),
+            stamp.display(),
+            stale.display(),
+        ),
+    );
+    git(
+        &dev,
+        &[
+            "config",
+            "remote.origin.uploadpack",
+            wrapper.to_str().unwrap(),
+        ],
+    );
+
+    commit(&dev, "raced");
+    let out = git_out(&dev, &["push", "origin", "main"]);
+    assert!(
+        out.status.success(),
+        "the branch push must survive the race: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The retry happened: one fetch on the stale view, one on the real origin.
+    assert_eq!(
+        line_count(&calls),
+        2,
+        "the hook should fetch twice: the first push loses the race, the retry wins"
+    );
+
+    // Both entries reached origin, so the lost race cost nobody their memory.
+    let published = note_lines(&origin, &shared);
+    assert!(
+        published
+            .iter()
+            .any(|l| l.contains("teammate-raced-decision")),
+        "the teammate's entry must survive our retry: {published:?}"
+    );
+    assert!(
+        published.iter().any(|l| l.contains("dev-raced-decision")),
+        "our entry must land on the retry: {published:?}"
+    );
+}
+
+// ── D3: never destroy what is already published ───────────────────────────────
+
+/// A fetch that fails must never cost a teammate their published notes.
+///
+/// With the fetch broken there is no tracking ref, so nothing is merged and our
+/// notes ref is missing the teammate's entry. Publishing it anyway (a forced
+/// push) would replace their memory with ours; the correct outcome is a
+/// rejected notes push, an unaffected branch push, and their entry intact.
+#[cfg(unix)]
+#[test]
+fn a_fetch_failure_must_not_destroy_a_teammates_notes() {
+    let home = TempDir::new().unwrap();
+    let home2 = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let dev = tmp.path().join("dev");
+    let teammate = tmp.path().join("teammate");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    bare_origin(&origin);
+    seed_origin(&origin, &dev);
+
+    let shared = teammate_publishes(
+        home2.path(),
+        &origin,
+        &teammate,
+        "teammate-published-decision",
+    );
+
+    install_pre_push(home.path(), &dev);
+    memory_add(home.path(), &dev, "dev-unmergeable-decision");
+
+    // Break only the fetch: push rides receive-pack and is unaffected.
+    git(
+        &dev,
+        &[
+            "config",
+            "remote.origin.uploadpack",
+            "/nonexistent/upload-pack",
+        ],
+    );
+
+    commit(&dev, "payload");
+    let out = git_out(&dev, &["push", "origin", "main"]);
+    assert!(
+        out.status.success(),
+        "the branch push must survive a broken fetch: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        git_stdout(&dev, &["rev-parse", "HEAD"]),
+        git_stdout(&origin, &["rev-parse", "refs/heads/main"]),
+        "origin must have received the branch commit"
+    );
+
+    // The whole point: their memory is still there.
+    let published = note_lines(&origin, &shared);
+    assert!(
+        published
+            .iter()
+            .any(|l| l.contains("teammate-published-decision")),
+        "a fetch failure must never overwrite the teammate's published notes: {published:?}"
+    );
+}
+
+// ── D2: the merge leaves no wreckage ──────────────────────────────────────────
+
+/// The notes merge must strand no `NOTES_MERGE_WORKTREE`.
+///
+/// `notes.mergeStrategy` defaults to `manual`, which on a genuine add/add
+/// conflict exits 1 and leaves `.git/NOTES_MERGE_WORKTREE` behind for the user
+/// to resolve by hand. A push hook cannot ask for that, so the strategy is
+/// explicit: the union resolves the conflict and there is nothing to strand.
+#[test]
+fn the_notes_merge_strands_no_merge_worktree() {
+    let home = TempDir::new().unwrap();
+    let home2 = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let dev = tmp.path().join("dev");
+    let teammate = tmp.path().join("teammate");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    bare_origin(&origin);
+    seed_origin(&origin, &dev);
+
+    // Same object annotated on both sides: the add/add conflict `manual` cannot
+    // resolve.
+    let shared = teammate_publishes(
+        home2.path(),
+        &origin,
+        &teammate,
+        "teammate-conflict-decision",
+    );
+
+    install_pre_push(home.path(), &dev);
+    memory_add(home.path(), &dev, "dev-conflict-decision");
+
+    commit(&dev, "payload");
+    let out = git_out(&dev, &["push", "origin", "main"]);
+    assert!(
+        out.status.success(),
+        "push failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        !dev.join(".git").join("NOTES_MERGE_WORKTREE").exists(),
+        "the merge must not strand .git/NOTES_MERGE_WORKTREE for the user to clean up"
+    );
+    assert!(
+        !dev.join(".git").join("NOTES_MERGE_REF").exists(),
+        "the merge must not strand .git/NOTES_MERGE_REF"
+    );
+
+    // And the conflict was resolved by union rather than by dropping a side.
+    let published = note_lines(&origin, &shared);
+    assert!(
+        published
+            .iter()
+            .any(|l| l.contains("teammate-conflict-decision")),
+        "the union must keep the teammate's entry: {published:?}"
+    );
+    assert!(
+        published
+            .iter()
+            .any(|l| l.contains("dev-conflict-decision")),
+        "the union must keep our entry: {published:?}"
     );
 }
 
@@ -490,6 +783,114 @@ fn skips_gracefully_when_pushing_without_a_named_remote() {
     );
 }
 
+/// A teammate without spelunk installed is unaffected: the hook publishes
+/// nothing and says nothing.
+///
+/// The ambient PATH cannot be reused here: a machine with spelunk actually
+/// installed would clear the guard and void the test, so git is handed a PATH
+/// holding nothing but itself.
+#[cfg(unix)]
+#[test]
+fn skips_gracefully_without_spelunk_on_path() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let dev = tmp.path().join("dev");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    bare_origin(&origin);
+    seed_origin(&origin, &dev);
+
+    install_pre_push(home.path(), &dev);
+    memory_add(home.path(), &dev, "no-spelunk-decision");
+    commit(&dev, "no-spelunk");
+
+    let bin = tmp.path().join("git-only-bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let git_path = String::from_utf8(
+        std::process::Command::new("sh")
+            .args(["-c", "command -v git"])
+            .output()
+            .expect("locate git")
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string();
+    std::os::unix::fs::symlink(&git_path, bin.join("git")).unwrap();
+
+    let out = git_out_with_path(
+        &dev,
+        &bin.display().to_string(),
+        &["push", "origin", "main"],
+    );
+    assert!(
+        out.status.success(),
+        "the push must succeed without spelunk installed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !git_out(&origin, &["rev-parse", "refs/notes/spelunk"])
+            .status
+            .success(),
+        "the hook must publish nothing when spelunk is not installed"
+    );
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains("spelunk:"),
+        "the skip must be silent, got: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ── D1: publish to the remote actually being pushed to ────────────────────────
+
+/// Memory follows the push: a repo whose only remote is `upstream` publishes
+/// there. The remote is whatever git handed the hook, never a hardcoded name.
+#[test]
+fn publishes_to_the_remote_being_pushed_to() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let upstream = tmp.path().join("upstream.git");
+    let dev = tmp.path().join("dev");
+    std::fs::create_dir_all(&upstream).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    bare_origin(&upstream);
+
+    git(&dev, &["init", "-q", "-b", "main"]);
+    git(&dev, &["config", "user.email", "t@example.com"]);
+    git(&dev, &["config", "user.name", "Test"]);
+    git(
+        &dev,
+        &["remote", "add", "upstream", upstream.to_str().unwrap()],
+    );
+    commit(&dev, "seed");
+    git(&dev, &["push", "-q", "-u", "upstream", "main"]);
+    assert!(
+        !git_out(&dev, &["remote", "get-url", "origin"])
+            .status
+            .success(),
+        "setup: this repo must have no origin remote"
+    );
+
+    install_pre_push(home.path(), &dev);
+    memory_add(home.path(), &dev, "upstream-decision");
+    let annotated = git_stdout(&dev, &["rev-parse", "HEAD"]);
+    commit(&dev, "payload");
+    let out = git_out(&dev, &["push", "upstream", "main"]);
+    assert!(
+        out.status.success(),
+        "push failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        note_lines(&upstream, &annotated)
+            .iter()
+            .any(|l| l.contains("upstream-decision")),
+        "the notes must reach the remote being pushed to, not a hardcoded 'origin'"
+    );
+}
+
 // ── D3: never clobber someone else's hook ─────────────────────────────────────
 
 /// A pre-push hook spelunk did not write is left exactly as it was.
@@ -514,6 +915,27 @@ fn install_bails_on_a_foreign_pre_push_hook() {
         std::fs::read_to_string(&hook).unwrap(),
         foreign,
         "a foreign pre-push hook must survive byte-for-byte"
+    );
+}
+
+/// The installed hook is executable: git silently ignores a hook it cannot
+/// run, which would make every publish above a no-op rather than an error.
+#[cfg(unix)]
+#[test]
+fn installed_hook_is_executable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let home = TempDir::new().unwrap();
+    let dev = TempDir::new().unwrap();
+    git(dev.path(), &["init", "-q", "-b", "main"]);
+
+    let hook = install_pre_push(home.path(), dev.path());
+    let mode = std::fs::metadata(&hook).unwrap().permissions().mode();
+    assert_eq!(
+        mode & 0o777,
+        0o755,
+        "the installed hook must be 0755, got {:o}",
+        mode & 0o777
     );
 }
 

--- a/crates/spelunk-cli/tests/pre_push_hook.rs
+++ b/crates/spelunk-cli/tests/pre_push_hook.rs
@@ -45,7 +45,7 @@ fn spelunk_bin_dir() -> PathBuf {
 
 /// Run `git args` in `dir` with an explicit `PATH`, returning the `Output`
 /// without asserting. Isolated identity/config so it is hermetic.
-fn git_out_with_path(dir: &Path, path: &str, args: &[&str]) -> Output {
+fn git_out_with_path(dir: &Path, path: impl AsRef<std::ffi::OsStr>, args: &[&str]) -> Output {
     std::process::Command::new("git")
         .current_dir(dir)
         .args(args)
@@ -65,11 +65,14 @@ fn git_out_with_path(dir: &Path, path: &str, args: &[&str]) -> Output {
 /// `spelunk` is prepended to PATH so the installed hook clears its own
 /// `command -v spelunk` guard.
 fn git_out(dir: &Path, args: &[&str]) -> Output {
-    let path = format!(
-        "{}:{}",
-        spelunk_bin_dir().display(),
-        std::env::var("PATH").unwrap_or_default()
-    );
+    // split/join rather than a literal separator: it is `;` on Windows, and a
+    // `:` there both fails to prepend the binary and corrupts the first real
+    // entry, leaving the hook's `command -v spelunk` guard to skip everything.
+    let mut dirs = vec![spelunk_bin_dir()];
+    dirs.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let path = std::env::join_paths(dirs).expect("join PATH");
     git_out_with_path(dir, &path, args)
 }
 
@@ -126,6 +129,12 @@ fn bare_origin(dir: &Path) {
     git(dir, &["init", "-q", "--bare", "-b", "main"]);
 }
 
+/// `path` for embedding in a shell script. Single quotes reach Git Bash with
+/// backslashes intact, so a Windows path must arrive forward-slashed.
+fn sh_path(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}
+
 /// Write `body` to `path` and make it executable. Parent dirs are created: a
 /// bare repo has no `hooks/` until something needs one.
 fn write_executable(path: &Path, body: &str) {
@@ -147,7 +156,7 @@ fn reject_notes_and_count(origin: &Path, counter: &Path) {
         &origin.join("hooks").join("update"),
         &format!(
             "#!/bin/sh\ncase \"$1\" in refs/notes/*) echo try >> '{}' ; exit 1 ;; esac\nexit 0\n",
-            counter.display()
+            sh_path(counter)
         ),
     );
 }
@@ -230,7 +239,7 @@ fn instrument_hook(hook_path: &Path, counter: &Path) {
     let (shebang, rest) = body.split_once('\n').expect("hook starts with a shebang");
     std::fs::write(
         hook_path,
-        format!("{shebang}\necho fired >> '{}'\n{rest}", counter.display()),
+        format!("{shebang}\necho fired >> '{}'\n{rest}", sh_path(counter)),
     )
     .unwrap();
 }
@@ -819,11 +828,7 @@ fn skips_gracefully_without_spelunk_on_path() {
     .to_string();
     std::os::unix::fs::symlink(&git_path, bin.join("git")).unwrap();
 
-    let out = git_out_with_path(
-        &dev,
-        &bin.display().to_string(),
-        &["push", "origin", "main"],
-    );
+    let out = git_out_with_path(&dev, bin.display().to_string(), &["push", "origin", "main"]);
     assert!(
         out.status.success(),
         "the push must succeed without spelunk installed: {}",

--- a/crates/spelunk-cli/tests/pre_push_hook.rs
+++ b/crates/spelunk-cli/tests/pre_push_hook.rs
@@ -1,0 +1,557 @@
+//! ADR-069 D1/D3: the opt-in pre-push hook that publishes `refs/notes/spelunk`.
+//!
+//! Publishing is coupled to `git push` because that is the only moment that
+//! reliably coincides with "this code is being shared". A note on a locally
+//! unpushed commit reaches origin while its target object does not, and a fresh
+//! clone then cannot resolve it, so the memory is orphaned.
+//!
+//! Covered:
+//! - the hook runs exactly once per push: the nested notes push must not
+//!   re-enter it (a version without `--no-verify` recursed until the process
+//!   table was exhausted, while every outer push still reported success).
+//! - a failing notes push never blocks the branch push: a hook exiting non-zero
+//!   aborts the push outright, so origin never receives the commit.
+//! - two developers annotating the same commit converge, losing neither entry.
+//! - repeated pushes are idempotent: no duplicates, no empty re-push.
+//! - graceful skip with no local notes ref, and when pushing by URL.
+//! - a non-spelunk pre-push hook is never clobbered.
+//! - uninstall removes the hook.
+//!
+//! Every spawned `git` gets the built `spelunk` on PATH: the hook opens with a
+//! `command -v spelunk` guard, so without it every test would pass vacuously.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use assert_cmd::Command;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+use tempfile::TempDir;
+
+/// Directory holding the `spelunk` binary under test, for the hook's
+/// `command -v spelunk` guard.
+fn spelunk_bin_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_spelunk"))
+        .parent()
+        .expect("binary has a parent dir")
+        .to_path_buf()
+}
+
+/// Run `git args` in `dir`, returning the `Output` without asserting.
+///
+/// Isolated identity/config so it is hermetic, and `spelunk` prepended to PATH
+/// so the installed hook clears its own `command -v spelunk` guard.
+fn git_out(dir: &Path, args: &[&str]) -> Output {
+    let path = format!(
+        "{}:{}",
+        spelunk_bin_dir().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .env("PATH", path)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@example.com")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@example.com")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("spawn git")
+}
+
+/// Like [`git_out`] but asserts the command succeeded.
+fn git(dir: &Path, args: &[&str]) -> Output {
+    let out = git_out(dir, args);
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+/// `stdout` of `git args`, trimmed, whatever the exit status. Used for
+/// notes inspection where a missing ref is a legitimate empty result.
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    String::from_utf8_lossy(&git_out(dir, args).stdout)
+        .trim()
+        .to_string()
+}
+
+/// A `spelunk` command with an isolated HOME and no server contact.
+fn bin(home: &Path, cwd: &Path) -> Command {
+    let mut cmd = spelunk_bin_in(home);
+    cmd.current_dir(cwd)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL");
+    cmd
+}
+
+/// Record one entry through the real `memory add`, so the notes carry the real
+/// record shape rather than a hand-rolled blob.
+fn memory_add(home: &Path, repo: &Path, title: &str) {
+    bin(home, repo)
+        .args([
+            "memory", "add", "--kind", "decision", "--title", title, "--body", "why",
+        ])
+        .assert()
+        .success();
+}
+
+/// `spelunk hooks install --pre-push` in `repo`; returns the hook path.
+fn install_pre_push(home: &Path, repo: &Path) -> PathBuf {
+    bin(home, repo)
+        .args(["hooks", "install", "--pre-push"])
+        .assert()
+        .success();
+    repo.join(".git").join("hooks").join("pre-push")
+}
+
+/// A bare repo standing in for `origin`.
+fn bare_origin(dir: &Path) {
+    git(dir, &["init", "-q", "--bare", "-b", "main"]);
+}
+
+/// Commit `<name>.txt` in `dir`.
+fn commit(dir: &Path, name: &str) {
+    std::fs::write(dir.join(format!("{name}.txt")), name).unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-q", "-m", name]);
+}
+
+/// A dev clone of `origin` with an identity and one commit pushed to `main`.
+fn seed_origin(origin: &Path, dir: &Path) {
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "t@example.com"]);
+    git(dir, &["config", "user.name", "Test"]);
+    git(dir, &["remote", "add", "origin", origin.to_str().unwrap()]);
+    commit(dir, "seed");
+    git(dir, &["push", "-q", "-u", "origin", "main"]);
+}
+
+/// Clone `origin` into `dir` with an identity, as a second developer.
+fn clone_dev(origin: &Path, dir: &Path) {
+    git(
+        dir.parent().unwrap(),
+        &[
+            "clone",
+            "-q",
+            origin.to_str().unwrap(),
+            dir.to_str().unwrap(),
+        ],
+    );
+    git(dir, &["config", "user.email", "t2@example.com"]);
+    git(dir, &["config", "user.name", "Test2"]);
+}
+
+/// The note blob on `object`'s `refs/notes/spelunk`, or empty when absent.
+fn note_lines(dir: &Path, object: &str) -> Vec<String> {
+    git_stdout(dir, &["notes", "--ref=spelunk", "show", object])
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Instrument the installed hook to append one line to `counter` per run.
+///
+/// Inserted straight after the shebang, ahead of every guard, so a re-entry is
+/// counted even though a guard would exit it early. The count therefore measures
+/// git actually invoking the hook, which is exactly what `--no-verify` must
+/// prevent; a sentinel-only guard would still show 2 here.
+fn instrument_hook(hook_path: &Path, counter: &Path) {
+    let body = std::fs::read_to_string(hook_path).unwrap();
+    let (shebang, rest) = body.split_once('\n').expect("hook starts with a shebang");
+    std::fs::write(
+        hook_path,
+        format!("{shebang}\necho fired >> '{}'\n{rest}", counter.display()),
+    )
+    .unwrap();
+}
+
+/// How many times the instrumented hook ran.
+fn fire_count(counter: &Path) -> usize {
+    std::fs::read_to_string(counter)
+        .map(|s| s.lines().filter(|l| !l.trim().is_empty()).count())
+        .unwrap_or(0)
+}
+
+// ── D3: the recursion guard ───────────────────────────────────────────────────
+
+/// The hook publishes notes, and runs exactly once doing it.
+///
+/// Without `--no-verify` the nested notes push re-enters this same hook, which
+/// pushes again, which re-enters again: the observed failure recursed 740 levels
+/// and stopped only by exhausting the process table, with every outer push
+/// failing while the branch push still reported success. One fire is the proof.
+#[test]
+fn hook_publishes_notes_and_fires_exactly_once() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let dev = tmp.path().join("dev");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    bare_origin(&origin);
+    seed_origin(&origin, &dev);
+
+    let hook = install_pre_push(home.path(), &dev);
+    let counter = tmp.path().join("fires");
+    instrument_hook(&hook, &counter);
+
+    memory_add(home.path(), &dev, "recursion-guard-decision");
+    let annotated = git_stdout(&dev, &["rev-parse", "HEAD"]);
+    commit(&dev, "second");
+    git(&dev, &["push", "-q", "origin", "main"]);
+
+    assert_eq!(
+        fire_count(&counter),
+        1,
+        "the hook must run exactly once per push; more means the notes push \
+         re-entered it (the recursion the `--no-verify` guard prevents)"
+    );
+
+    // And it actually published: a guard that works by doing nothing is no good.
+    let on_origin = git_stdout(&origin, &["rev-parse", "refs/notes/spelunk"]);
+    assert!(
+        !on_origin.is_empty(),
+        "origin should carry refs/notes/spelunk after the push"
+    );
+    assert!(
+        note_lines(&origin, &annotated)
+            .iter()
+            .any(|l| l.contains("recursion-guard-decision")),
+        "the pushed note should carry the recorded decision"
+    );
+}
+
+// ── D3: never block the user's push ───────────────────────────────────────────
+
+/// A notes push the remote rejects must not cost the user their branch push.
+///
+/// A hook exiting 1 aborts the push outright and origin never receives the
+/// commit, so every failure path in the hook has to fall through to `exit 0`.
+#[test]
+fn failed_notes_push_does_not_block_the_branch_push() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let dev = tmp.path().join("dev");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    bare_origin(&origin);
+    seed_origin(&origin, &dev);
+
+    // Reject only the notes ref, per-ref, so the branch push is untouched.
+    let update_hook = origin.join("hooks").join("update");
+    std::fs::create_dir_all(update_hook.parent().unwrap()).unwrap();
+    std::fs::write(
+        &update_hook,
+        "#!/bin/sh\ncase \"$1\" in refs/notes/*) exit 1 ;; esac\nexit 0\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut p = std::fs::metadata(&update_hook).unwrap().permissions();
+        p.set_mode(0o755);
+        std::fs::set_permissions(&update_hook, p).unwrap();
+    }
+
+    install_pre_push(home.path(), &dev);
+    memory_add(home.path(), &dev, "rejected-notes-decision");
+    commit(&dev, "payload");
+
+    let out = git_out(&dev, &["push", "origin", "main"]);
+    assert!(
+        out.status.success(),
+        "the branch push must survive a rejected notes push, got: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The commit really landed, rather than the push merely reporting success.
+    let local = git_stdout(&dev, &["rev-parse", "HEAD"]);
+    let remote = git_stdout(&origin, &["rev-parse", "refs/heads/main"]);
+    assert_eq!(local, remote, "origin must have received the branch commit");
+
+    // The notes push failed, and the user was told rather than left guessing.
+    assert!(
+        git_out(&origin, &["rev-parse", "refs/notes/spelunk"])
+            .status
+            .success()
+            .eq(&false),
+        "the rejected notes ref must not exist on origin"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("could not publish memory notes"),
+        "the hook should warn on stderr, got: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ── D2/D3: two developers converge ────────────────────────────────────────────
+
+/// Two developers annotating the same commit both survive: the hook fetches and
+/// unions with `cat_sort_uniq` before pushing, so the second to push adds to the
+/// first's entry rather than replacing it. Never force-push: that would drop it.
+#[test]
+fn two_dev_divergence_converges_with_no_loss() {
+    let home1 = TempDir::new().unwrap();
+    let home2 = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let dev1 = tmp.path().join("dev1");
+    let dev2 = tmp.path().join("dev2");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev1).unwrap();
+    bare_origin(&origin);
+    seed_origin(&origin, &dev1);
+    clone_dev(&origin, &dev2);
+
+    // Both annotate the shared seed commit: the divergence is one object with
+    // two different note blobs, which is the case `cat_sort_uniq` exists for.
+    let shared = git_stdout(&dev1, &["rev-parse", "HEAD"]);
+    assert_eq!(shared, git_stdout(&dev2, &["rev-parse", "HEAD"]));
+
+    install_pre_push(home1.path(), &dev1);
+    install_pre_push(home2.path(), &dev2);
+    memory_add(home1.path(), &dev1, "dev1-only-decision");
+    memory_add(home2.path(), &dev2, "dev2-only-decision");
+
+    // Separate branches, so the branch pushes never conflict and the test is
+    // about the notes ref alone.
+    git(&dev1, &["checkout", "-q", "-b", "feature-1"]);
+    commit(&dev1, "one");
+    git(&dev1, &["push", "-q", "origin", "feature-1"]);
+
+    git(&dev2, &["checkout", "-q", "-b", "feature-2"]);
+    commit(&dev2, "two");
+    git(&dev2, &["push", "-q", "origin", "feature-2"]);
+
+    // dev2 pushed second, so its hook had to merge dev1's entry in first.
+    let merged = note_lines(&dev2, &shared);
+    assert!(
+        merged.iter().any(|l| l.contains("dev1-only-decision")),
+        "dev2 must have merged dev1's entry rather than replacing it: {merged:?}"
+    );
+    assert!(
+        merged.iter().any(|l| l.contains("dev2-only-decision")),
+        "dev2 must still have its own entry: {merged:?}"
+    );
+
+    // And the union reached origin, so dev1 gets it back on fetch + merge.
+    git(
+        &dev1,
+        &[
+            "fetch",
+            "-q",
+            "origin",
+            "+refs/notes/spelunk:refs/notes/origin/spelunk",
+        ],
+    );
+    git(
+        &dev1,
+        &[
+            "notes",
+            "--ref=spelunk",
+            "merge",
+            "-s",
+            "cat_sort_uniq",
+            "refs/notes/origin/spelunk",
+        ],
+    );
+    let round_tripped = note_lines(&dev1, &shared);
+    assert!(
+        round_tripped
+            .iter()
+            .any(|l| l.contains("dev2-only-decision")),
+        "dev1 must receive dev2's entry: {round_tripped:?}"
+    );
+    assert!(
+        round_tripped
+            .iter()
+            .any(|l| l.contains("dev1-only-decision")),
+        "dev1 must keep its own entry: {round_tripped:?}"
+    );
+}
+
+/// Repeated pushes converge: the union is idempotent, so a second sync neither
+/// duplicates entries nor fails.
+#[test]
+fn repeated_syncs_are_idempotent() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let dev = tmp.path().join("dev");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    bare_origin(&origin);
+    seed_origin(&origin, &dev);
+
+    install_pre_push(home.path(), &dev);
+    memory_add(home.path(), &dev, "idempotent-decision");
+    let annotated = git_stdout(&dev, &["rev-parse", "HEAD"]);
+
+    for i in 0..3 {
+        commit(&dev, &format!("push-{i}"));
+        let out = git_out(&dev, &["push", "origin", "main"]);
+        assert!(
+            out.status.success(),
+            "push {i} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let lines = note_lines(&dev, &annotated);
+    let hits = lines
+        .iter()
+        .filter(|l| l.contains("idempotent-decision"))
+        .count();
+    assert_eq!(
+        hits, 1,
+        "repeated syncs must not duplicate an entry: {lines:?}"
+    );
+    assert_eq!(
+        lines,
+        note_lines(&origin, &annotated),
+        "local and origin notes must have converged"
+    );
+}
+
+// ── D3: graceful skips ────────────────────────────────────────────────────────
+
+/// Nothing recorded yet: the hook has nothing to publish and must stay out of
+/// the way. This is every user who installed the hook before their first
+/// `memory add`.
+#[test]
+fn skips_gracefully_with_no_local_notes_ref() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let dev = tmp.path().join("dev");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    bare_origin(&origin);
+    seed_origin(&origin, &dev);
+
+    install_pre_push(home.path(), &dev);
+    assert!(
+        !git_out(&dev, &["rev-parse", "--verify", "refs/notes/spelunk"])
+            .status
+            .success(),
+        "setup: no notes recorded yet"
+    );
+
+    commit(&dev, "no-notes");
+    let out = git_out(&dev, &["push", "origin", "main"]);
+    assert!(
+        out.status.success(),
+        "push must succeed with no notes to publish: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !git_out(&origin, &["rev-parse", "refs/notes/spelunk"])
+            .status
+            .success(),
+        "an empty notes ref must not be invented on origin"
+    );
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains("spelunk:"),
+        "a no-op must be silent, got: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Pushing by URL rather than by remote name: there is no named remote to
+/// resolve, so the hook skips instead of guessing, and the push is unaffected.
+#[test]
+fn skips_gracefully_when_pushing_without_a_named_remote() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let dev = tmp.path().join("dev");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    bare_origin(&origin);
+    seed_origin(&origin, &dev);
+
+    install_pre_push(home.path(), &dev);
+    memory_add(home.path(), &dev, "by-url-decision");
+    commit(&dev, "by-url");
+
+    let out = git_out(&dev, &["push", origin.to_str().unwrap(), "main"]);
+    assert!(
+        out.status.success(),
+        "a push by URL must still succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ── D3: never clobber someone else's hook ─────────────────────────────────────
+
+/// A pre-push hook spelunk did not write is left exactly as it was.
+#[test]
+fn install_bails_on_a_foreign_pre_push_hook() {
+    let home = TempDir::new().unwrap();
+    let dev = TempDir::new().unwrap();
+    git(dev.path(), &["init", "-q", "-b", "main"]);
+
+    let hooks_dir = dev.path().join(".git").join("hooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    let hook = hooks_dir.join("pre-push");
+    let foreign = "#!/bin/sh\n# someone else's hook\nexit 0\n";
+    std::fs::write(&hook, foreign).unwrap();
+
+    bin(home.path(), dev.path())
+        .args(["hooks", "install", "--pre-push"])
+        .assert()
+        .failure();
+
+    assert_eq!(
+        std::fs::read_to_string(&hook).unwrap(),
+        foreign,
+        "a foreign pre-push hook must survive byte-for-byte"
+    );
+}
+
+/// Re-installing over spelunk's own hook is a no-op, not a failure.
+#[test]
+fn install_is_idempotent() {
+    let home = TempDir::new().unwrap();
+    let dev = TempDir::new().unwrap();
+    git(dev.path(), &["init", "-q", "-b", "main"]);
+
+    let hook = install_pre_push(home.path(), dev.path());
+    let first = std::fs::read_to_string(&hook).unwrap();
+    bin(home.path(), dev.path())
+        .args(["hooks", "install", "--pre-push"])
+        .assert()
+        .success();
+    assert_eq!(std::fs::read_to_string(&hook).unwrap(), first);
+}
+
+/// Uninstall removes spelunk's pre-push hook and leaves a foreign post-commit
+/// hook alone.
+#[test]
+fn uninstall_removes_the_pre_push_hook() {
+    let home = TempDir::new().unwrap();
+    let dev = TempDir::new().unwrap();
+    git(dev.path(), &["init", "-q", "-b", "main"]);
+
+    let hook = install_pre_push(home.path(), dev.path());
+    assert!(hook.exists());
+
+    let foreign = dev.path().join(".git").join("hooks").join("post-commit");
+    std::fs::write(&foreign, "#!/bin/sh\n# not ours\n").unwrap();
+
+    bin(home.path(), dev.path())
+        .args(["hooks", "uninstall"])
+        .assert()
+        .success();
+
+    assert!(!hook.exists(), "the spelunk pre-push hook must be removed");
+    assert!(foreign.exists(), "a foreign hook must be left alone");
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -402,10 +402,11 @@ spelunk autoclean
 
 ## spelunk hooks
 
-Manage git post-commit hooks.
+Manage spelunk's git hooks.
 
 ```
 spelunk hooks install [--ci]
+spelunk hooks install --pre-push
 spelunk hooks uninstall
 ```
 
@@ -413,6 +414,19 @@ spelunk hooks uninstall
 `spelunk memory harvest` after each commit (both `--detach` so git is not
 blocked). Developers without `spelunk` installed are unaffected. `--ci` prints a
 GitHub Actions workflow step instead of writing a hook.
+
+`install --pre-push` writes a pre-push hook that publishes your memory
+(`refs/notes/spelunk`) to the remote you are pushing to, so decisions travel with
+the code they describe. It merges the remote's notes into yours before pushing (a
+union, so neither side is dropped) and retries a lost race up to three times. It
+never blocks your push: on failure it warns on stderr and exits 0, and it never
+force-pushes. Publishing is opt-in, so your memory stays local until you install
+it. See [memory.md](memory.md#sharing-memory-across-clones-via-git-notes).
+
+Neither hook overwrites one it did not write: if a hook of that name already
+exists, `install` reports it and leaves the file alone.
+
+`uninstall` removes every hook spelunk installed, leaving any other hooks alone.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,8 +43,8 @@ slug.
 `refs/notes/spelunk` arrives on `git fetch`, landing on the tracking ref
 `refs/notes/origin/spelunk`. `memory list`, `context`, and `init` merge that
 tracking ref into your own notes, so *reading* teammates' memory needs no extra
-step. *Publishing* yours is still manual: the init output includes the push
-command; re-run it after each memory change so new notes commits travel. See
+step. *Publishing* yours is opt-in: your memory stays local until you install the
+pre-push hook, and the init output names the command that does it. See
 [Sharing memory across clones via git-notes](memory.md#sharing-memory-across-clones-via-git-notes).
 
 **Memory survives history rewrites:** `init` also points `notes.rewriteRef` at

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -80,7 +80,8 @@ which is automatic:
 - **Reading teammates' memory is automatic.** `spelunk init` configures the
   `origin` fetch refspec, so their notes arrive on your next `git fetch`, and
   spelunk merges them on its own read paths.
-- **Publishing your own memory is manual.** You push the notes ref yourself.
+- **Publishing your own memory is opt-in.** Your memory stays local until you
+  install the pre-push hook (or push the notes ref by hand).
 
 When you run `spelunk init` inside a git repository with an `origin` remote,
 spelunk automatically configures the fetch refspec for `origin` so that
@@ -89,7 +90,7 @@ the status:
 
 ```
 Memory:  configured notes fetch refspec on 'origin' (teammates' memory arrives on fetch)
-         push notes after each memory change: git push origin refs/notes/spelunk
+         your memory stays local until you install the pre-push hook: spelunk hooks install --pre-push
          configured notes.rewriteRef (memory survives `git commit --amend` and `git rebase`)
 ```
 
@@ -97,15 +98,49 @@ The last line is a separate setting, covered in [Surviving history
 rewrites](#surviving-history-rewrites) below. It is printed only by the run that
 sets it, so a re-run of `init` omits it.
 
-To publish your memory notes to the remote, push the notes ref:
+#### Publishing with the pre-push hook
+
+Install the hook once per clone:
+
+```bash
+spelunk hooks install --pre-push
+```
+
+From then on, every `git push` publishes your memory to the remote you are
+pushing to: the hook fetches the remote's notes, merges them into yours (a
+union, so nothing is dropped), and pushes `refs/notes/spelunk`. Once it is
+installed, the second line of `init`'s summary changes to confirm it.
+
+**Publishing is tied to `git push` on purpose.** A note attached to a commit you
+have not pushed can reach the remote while the commit itself does not, and a
+teammate's clone then cannot resolve what the note is attached to, so the entry
+is orphaned: it is on the remote, and nobody ever sees it. Pushing is the moment
+that reliably coincides with "this code is being shared", which is why the hook
+runs there rather than on each `memory add` or on a timer.
+
+**The hook never blocks your push.** If publishing fails (offline, or the remote
+rejects the notes ref) it warns on stderr and exits 0, so your code push lands
+regardless. It retries a lost race up to three times, and never force-pushes: the
+union already carries both sides, so forcing could only discard a teammate's
+memory.
+
+Teammates without spelunk installed are unaffected: the hook skips itself when
+`spelunk` is not on their PATH. Remove it with `spelunk hooks uninstall`.
+
+#### Publishing without the hook
+
+If you would rather not install a hook, push the notes ref yourself:
 
 ```bash
 git push origin refs/notes/spelunk
 ```
 
-Re-run this push whenever you record memory: each `spelunk memory add` (or
-remove) creates a new notes commit that travels only once it is pushed. The
-fetch refspec, by contrast, is configured once, so teammates' (and later
+Re-run this whenever you record memory: each `spelunk memory add` (or remove)
+creates a new notes commit that travels only once it is pushed. Push it **after**
+you have pushed the commits your entries are attached to, or those entries arrive
+orphaned (see above). The hook exists to get that ordering right for you.
+
+The fetch refspec, by contrast, is configured once, so teammates' (and later
 clones') `git fetch` then pulls whatever notes you have already pushed.
 
 **How fetched notes become visible.** The refspec fetches into a *tracking* ref,
@@ -141,11 +176,11 @@ repository), `spelunk init` prints the commands to run later:
 ```
 Memory:  no 'origin' remote, so the notes refspec is not configured
          run later: git config --add remote.origin.fetch '+refs/notes/spelunk*:refs/notes/origin/spelunk*'
-         push notes after each memory change: git push origin refs/notes/spelunk
+         your memory stays local until you install the pre-push hook: spelunk hooks install --pre-push
          configured notes.rewriteRef (memory survives `git commit --amend` and `git rebase`)
 ```
 
-Add the refspec when an `origin` is created, then push the notes as above. The
+Add the refspec when an `origin` is created, then publish as above. The
 `notes.rewriteRef` line appears here too: rewrites are purely local, so that
 setting is configured even in a repository with no remote.
 
@@ -478,6 +513,14 @@ Install the git hook and harvesting happens on every commit:
 
 ```bash
 spelunk hooks install
+```
+
+To also publish memory to your remote on every `git push`, install the pre-push
+hook (see [Sharing memory across
+clones](#sharing-memory-across-clones-via-git-notes)):
+
+```bash
+spelunk hooks install --pre-push
 ```
 
 ## Importing from a local server

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -106,10 +106,15 @@ Install the hook once per clone:
 spelunk hooks install --pre-push
 ```
 
-From then on, every `git push` publishes your memory to the remote you are
-pushing to: the hook fetches the remote's notes, merges them into yours (a
-union, so nothing is dropped), and pushes `refs/notes/spelunk`. Once it is
-installed, the second line of `init`'s summary changes to confirm it.
+From then on, every `git push` to a named remote publishes your memory there:
+the hook fetches the remote's notes, merges them into yours (a union, so nothing
+is dropped), and pushes `refs/notes/spelunk`. Once it is installed, `init`
+reports that in place of the opt-in line:
+
+```
+Memory:  notes fetch refspec already configured on 'origin'
+         pre-push hook installed: your memory publishes on `git push`
+```
 
 **Publishing is tied to `git push` on purpose.** A note attached to a commit you
 have not pushed can reach the remote while the commit itself does not, and a
@@ -120,9 +125,12 @@ runs there rather than on each `memory add` or on a timer.
 
 **The hook never blocks your push.** If publishing fails (offline, or the remote
 rejects the notes ref) it warns on stderr and exits 0, so your code push lands
-regardless. It retries a lost race up to three times, and never force-pushes: the
-union already carries both sides, so forcing could only discard a teammate's
-memory.
+regardless. Only a lost race is retried, up to three times: that is a teammate
+publishing in the window between the hook's fetch and its push, so re-merging
+theirs lets the next attempt through. Every other failure is attempted once, so
+an unreachable remote costs you one timeout rather than three. It never
+force-pushes: the union already carries both sides, so forcing could only discard
+a teammate's memory.
 
 Teammates without spelunk installed are unaffected: the hook skips itself when
 `spelunk` is not on their PATH. Remove it with `spelunk hooks uninstall`.


### PR DESCRIPTION
Implements ADR-069 **D1 + D3** — the publishing half of git-notes memory sharing. #616 landed reading (the fetch refspec, the read-path merge, the sort); this makes your own memory travel. Opt-in: nothing publishes until you install the hook.

```bash
spelunk hooks install --pre-push
```

From then on every `git push` to a named remote publishes `refs/notes/spelunk` there: fetch the remote's notes onto the tracking ref, merge with `cat_sort_uniq`, push. `hooks uninstall` removes it.

## Why the trigger is `git push`

A note attached to an unpushed commit can reach the remote while the commit does not: origin returns `fatal: could not get object info`, and a fresh clone cannot resolve what the note is attached to. The entry is on the remote and nobody ever sees it.

That makes `git push` the only honest trigger, and it retires `init`'s `PUSH_HINT`, which told users to push notes *after each memory change* and so taught exactly that failure. ADR-069 D4 records it as replaced by the hook, not kept as a fallback. `init`'s summary now announces publishing is opt-in and names the command, so the opt-in is discoverable from the tool's own output rather than only the docs (a D3 requirement on the implementation).

## Four properties are load-bearing, and each is pinned by a test

- **The nested push uses `--no-verify`.** Without it git re-enters this same hook: the observed failure **recursed 740 levels** and stopped only by exhausting the process table (`cannot fork() … Resource temporarily unavailable`), while every outer push still reported **success**. It fails invisibly while pinning the machine. An env sentinel (`SPELUNK_NOTES_PUSH`) is belt and braces on top.
- **The hook never exits non-zero.** A pre-push hook exiting 1 aborts the branch push outright, so a failed publish would cost the user their code push. All six exit paths are `exit 0`, there is no `set -e`, and failures warn on stderr.
- **It never force-pushes.** The push refspec carries no leading `+`. The union already merges both sides, so forcing could only discard a teammate's memory.
- **Only a lost race retries** (bounded at 3): a teammate publishing between our fetch and our push, where re-merging lets the next attempt through. The predicate matches `non-fast-forward` / `fetch first` and nothing else, so an unreachable remote costs one timeout rather than three.

`-s cat_sort_uniq` is passed per invocation, never read from or written to the user's `notes.mergeStrategy` (the default is `manual`, which exits 1 and strands `NOTES_MERGE_WORKTREE`). `remote.origin.push` is never set: any value overrides git's default branch push, the constraint #582 recorded.

Teammates without spelunk are unaffected: the hook skips itself when `spelunk` is not on PATH.

## Test plan

Gates run with the **actual CI commands** (CI uses nextest, not `cargo test`, and lints with `--features rich-formats`), real exit statuses, no pipes:

| Gate | RC |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --all-targets --features rich-formats -- -D warnings` | 0 |
| `cargo nextest run` | 0 (1085 passed, 0 leaky) |
| `cargo test --doc` | 0 |
| `cargo nextest run -p spelunk-core --no-default-features` | 0 |
| `cargo test --doc -p spelunk-core --no-default-features` | 0 |

16 tests. Every property was mutation-tested: each was broken deliberately, and the mutation was also run against the *pre-hardening* suite to measure what it would have caught. **Six mutations killed nothing before hardening** — the recursion guard was the only property genuinely under test:

| Mutation | Before | After |
|---|---|---|
| Remove `--no-verify` (sentinel kept) | killed | killed |
| Hook `exit 1` on failed notes push | killed | killed |
| Drop `-s cat_sort_uniq` | killed incidentally | killed directly |
| **Force-push** | **survived** | killed |
| **Retry predicate → match everything** | **survived** | killed |
| **Retry predicate → match nothing** | **survived** | killed |
| Remove foreign-hook bail | killed | killed |
| **Break init install-state detection** | **survived** | killed |
| **Remove `command -v spelunk` bail** | **survived** | killed |
| **Hardcode remote to `origin`** | **survived** | killed |

Two are worth explaining:

**Force-push was unguarded, and the divergence test could not have caught it.** The union merge runs first, so a force-push still carries both sides. The loss only appears when the *fetch* fails and no merge happens. The test breaks only the fetch (`remote.origin.uploadpack`; push rides receive-pack and is unaffected) so the local ref diverges: a normal push is rejected and the teammate's entry survives, `--force` succeeds and destroys it.

**The race test is deterministic, not timed.** A wrapper serves a stale bare clone to the first `upload-pack` and the real origin to the second, gated on a stamp file, so the served *view* changes and nothing depends on timing. Attempt 1 is a genuine `fetch first` rejection; attempt 2 merges and fast-forwards. Widening the predicate is caught by asserting a permanently-rejecting remote is attempted **exactly once**, counted server-side by an `update` hook.

Removing `--no-verify` for the recursion mutation keeps the sentinel, so the nested push re-enters once and stops there: the counter reads 2 instead of 1, enough to kill the test without re-triggering the fork bomb.

## Windows

This is the first test in the repo to execute a git hook, so the `windows-latest` cell has no precedent to lean on. Two Unix-only assumptions were found and fixed by review: the test PATH prepend used a literal `:` (Windows uses `;`, and `:` is also the drive separator, so the binary was never prepended *and* the first real entry was corrupted, silently defeating `command -v spelunk`), and paths embedded in generated shell hooks are now forward-slashed for Git Bash. The hook body itself is POSIX-only and the install writes LF endings.

Verified by reading rather than running, so **watch that cell**: if the fire-count assertion passes but a publish assertion fails, the hook ran and the PATH guard skipped it; if the fire count is 0, git is not invoking the hook at all.

## Known gap, tracked separately

The hook is a shell script and cannot take the in-process notes lock, so its merge runs unlocked and a `spelunk memory add` concurrent with a push can still lose a record. Every in-process caller does take the lock, so the hook is the only unlocked path. Deliberately out of scope here and tracked as a follow-up; the docs carry no caveat for it, since the window is narrow and a warning would outlive the bug.

Refs: ADR-069 (D1, D3, D4).
