### PR TITLE
docs(adr): ADR-069 D9 - the notes lock's scope on the publish path

### DIFF
--- a/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
+++ b/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
@@ -537,6 +537,62 @@ above. That is a defect in lock **identity** and is fixed separately. D8 governs
 what a writer does once it knows it does not hold the lock, which is a question
 the identity fix does not answer and which the current code answers wrongly.
 
+### D9 – the notes lock covers the merge only, never the fetch or the push
+
+Added on review of D7's implementation (#630), which has this right and records
+nothing about why.
+
+D7 puts a fetch, a merge and a push behind one command, and D8 makes a writer
+that cannot take the lock fail. Together they make the lock's **scope** inside
+`publish-notes` load-bearing in a way neither section states. Taking the lock
+once around the whole operation is the tidier-looking code and is the bug.
+
+**The budget is bounded; network I/O is not.** D8 sets the wait budget as a
+watchdog, "generously enough that reaching it means a bug rather than a busy
+repo", and rests its case that "a writer can fail" is not a practical regression
+on exactly that rarity. A `fetch` or a `push` against a slow or unreachable
+remote outlasts any budget chosen on that reasoning. A lock spanning either does
+not merely stretch D8's premise, it **falsifies** it: budget expiry stops meaning
+a bug and starts meaning a slow network, and a `memory add` that happens to
+coincide with such a push fails for a reason that is not a bug. D8's error is
+correct because it is rare. D9 is what keeps it rare.
+
+`lock.rs` shows how directly this is load-bearing. It justifies its budget by the
+holder cost, "a few git subprocesses, ~30ms", and concludes that the budget is
+"orders of magnitude above realistic contention". That holds only while a holder
+does local git work and nothing else. Scope the lock over a fetch or a push and
+the holder cost stops being a spelunk constant and becomes the remote's latency.
+
+The constraint outlives the policy it was first drafted against. Under D6's
+withdrawn proceed-unlocked clause a network-spanning lock converted a rare race
+into a reliable one; under D8 it converts a rare failure into a reliable one. It
+is the same defect either way, which is why the scope rule is stated separately
+from the contention policy: the lock's hold time stops being a property of
+spelunk's own work and becomes a property of the network.
+
+**Neither network step needs the lock.** `fetch` writes only the tracking ref
+(D4), so it never contends for the working ref's content. `push` only reads the
+working ref, and git's ref locking already makes that read atomic; the worst case
+is that it publishes a state one entry stale, which the next push carries.
+Staleness is not loss.
+
+**Per attempt, not around the retry loop.** D3 retries a lost race up to 3 times,
+and each attempt is a fetch, a merge and a push. The lock is taken and released
+inside each attempt's merge. A guard hoisted out of the loop would hold it across
+up to three network round trips, which is the same defect three times over.
+
+**#630 satisfies this by reuse rather than by intent, which is the reason to
+record it.** `publish_notes` runs `fetch` and `push` itself and delegates the
+merge to `merge_tracking_notes`, which takes `lock_notes` in its own body and
+drops the guard on return, so no lock is held across either network call. Nothing
+at that call site says the arrangement is load-bearing. The obvious tidy-up,
+hoisting the lock to the top of `publish_notes` so that the whole flow is
+"properly" serialized, removes it silently and reads as an improvement.
+
+D8 governs what publish does when it **cannot** take the lock: skip, report, do
+not fail the push. D9 governs how much of publish the lock covers when it
+**can**.
+
 ## Non-goals
 
 - ~~**Not** fixing #185, the read-modify-write race within a single repo.~~


### PR DESCRIPTION
Adds **D9** to ADR-069: the notes lock covers the merge only, never the fetch or the push.

This PR has been **reduced to a single decision section** (56 lines, from 183). It was opened before #625 (D7) and #626 (D8) merged, and those two took most of its ground. What is left is the one constraint neither of them states.

## Why this is worth a section rather than a code comment

D7 moved publish into `spelunk plumbing publish-notes`, so one Rust command now performs fetch, merge and push. D8 made a writer that cannot take the notes lock **fail** rather than proceed unlocked.

Neither says how much of publish the lock may cover. Taking it once around the whole operation looks more correct while being the bug, and it is now a non-obvious *internal* constraint rather than a structural one:

- Under a `merge-notes` command (this PR's original proposal) the constraint was nearly automatic, because the command *was* only the merge.
- Under D7's `publish-notes` a single `let _lock = ...` at the top of the function spans two network round trips and reads as a tidy-up.

The interlock with D8 is what makes this load-bearing now. D8 justifies "a writer can fail" on the wait budget being reached only by a bug, never by a busy repo. A lock spanning network I/O falsifies that premise: against a slow or unreachable remote the hold time outlasts any budget picked on that reasoning, so budget expiry starts meaning *a slow network*, and a `memory add` that coincides with such a push fails for a reason that is not a bug. D9 is what keeps D8's error rare, and rarity is D8's whole argument.

`lock.rs` shows how direct this is: it justifies its 5s budget by the holder cost, "a few git subprocesses, ~30ms", which holds only while a holder does local git work and nothing else.

## This records shipped behaviour, verified

#630's `crates/spelunk-core/src/storage/git_notes/publish.rs` already satisfies D9. Checked, not assumed:

- `publish_notes` runs `git fetch` and `git push --no-verify` directly, unlocked.
- It delegates the merge to `merge_tracking_notes`, which binds `let Some(_lock) = lock_notes(...)` **in its own body**, so the guard drops on return, before the push.
- The lock is taken per retry attempt, never hoisted around the 3-attempt loop.

It satisfies D9 by *reuse* rather than by intent, which is precisely the reason to record it: nothing at the call site says the arrangement is load-bearing.

## What was dropped, and why

| Dropped | Superseded by |
|---|---|
| A0, A1 (`plumbing merge-notes`) | **D7**, which moves the whole flow, not just the merge |
| A3 + the replayability discriminator | **D8**, which generalises it better (policy set by what is lost, not by read-vs-write) |
| A4 (Interface) | specified `merge-notes`, which does not exist. The index-gate constraint it raised is implemented in #630 and carries its own in-code comment citing ADR-068 |
| A5, A6 | already rejected/stated by D7 and D8 |
| Pointers into D3 and D6 | both now belong to D7/D8 |

Because every pointer into shipped decisions was dropped, this is a **pure addition**. No shipped decision text is touched, so no provenance blockquote is needed.

## Test plan

Docs only, one file, no `.rs` touched.

1. `git log --oneline origin/main..HEAD` shows one commit; `git diff --stat origin/main` shows one `.md` file, 56 insertions, 0 deletions.
2. Board-id leak gate (both classes, prefixed and bare) returns clean:
   `grep -nE '(spelunk-oss|cloud-api|web-app|marketing-site)?\^[0-9]+|task_[0-9a-f]{6,}|agentic-os\.|/t/[a-z-]+/[0-9]+' docs/adr/069-*.md`
3. Em-dash gate returns clean: `grep -n '—' docs/adr/069-*.md`
4. No Status field, no TBD, no pending-review markers: `grep -nEi 'TBD|pending review|^Status:' docs/adr/069-*.md`
5. Pre-commit hook ran `cargo fmt --check` and `cargo clippy` green.

## CI: `Test (windows-latest)` is red, inherited not caused

This PR is docs-only (one `.md`, **zero `.rs`**), so it cannot affect any Rust test. The `windows-latest` cell is flaky across the whole concurrent-git-notes family and alternates on main independently of content: #626 fail, #628 pass, #629 pass, #623 fail, #625 pass, #622 fail. **main's tip `57cbb54d1`, this PR's base, is itself red.**

Three runs, three different members of the same family:

| Run | Failing test | Detail |
|---|---|---|
| main tip `57cbb54d1` | `append_to_git_notes_concurrent_worktrees_all_survive` (15.384s) + `append_to_git_notes_concurrent_writers_all_survive` (13.714s) | `lost 6 of 8 concurrent entries` |
| this PR | `git_notes_backend_concurrent_adds_all_survive` (**2.308s**) | `lost 1 of 8 concurrent backend adds` |
| the run D8 cites | worktrees guard only | writers guard passed at 2.460s |

Every one of these guards comes from `134daa95c5`, the D6 lock implementation. Both runs stopped early behind nextest fail-fast (234 and 209 tests not run), so each failure set is a floor, not a total.

**This does not change D9**, which constrains lock *scope* and is orthogonal to whether the primitive excludes. But it is worth flagging for whoever picks up the Windows fix, because the evidence D8 narrows on does not hold:

- D8 infers from the single-repo guard passing that "the primitive excludes and times out correctly on Windows", and concludes "what is left is that two contenders do not converge on one lock file when they sit in **different worktrees**". This PR's failure is `git_notes_backend_concurrent_adds_all_survive`: **one repo, one process, no worktree identity involved**. Worktree lock-path identity cannot explain it.
- D8 rules out budget exhaustion because "a 2.569s failure cannot contain a 5s wait". That reasoning holds here and points the same way: this failure took **2.308s**, so it is not a timeout either. An entry was lost while a writer believed it held the lock.

Read together, the defect looks like the primitive failing to exclude on Windows generally, not only across worktrees. That is a bigger fix than the identity repair D8 anticipates.

## Note for the reviewer, not a blocker

D9 describes behaviour #630 already has, so the two are consistent and can land in either order. One observation on #630 that belongs to that PR rather than this one: `publish_notes` calls `merge_tracking_notes(git_root).await;` and **discards** the outcome, so a `LockUnavailable` is swallowed and the push proceeds. D8 requires that skip to be *reported* ("a user whose memory did not publish needs to know that it did not"). That is a D8 compliance gap in #630, not a D9 one.
