### PR TITLE
docs(capability-tiers): replace refused http:// examples with verified output

### DIFF
--- a/crates/spelunk-core/src/config.rs
+++ b/crates/spelunk-core/src/config.rs
@@ -297,7 +297,8 @@ pub struct Config {
     pub llm_model: Option<String>,
 
     // ── spelunk-server (optional) ─────────────────────────────────────────────
-    /// URL of the spelunk-server instance, e.g. `http://spelunk.internal:7777`.
+    /// URL of the spelunk-server instance, e.g. `https://spelunk.internal.example.com`
+    /// (or `http://127.0.0.1:7777` for loopback; non-loopback `http://` is rejected).
     /// When set, the CLI operates in Tier 1 (server-connected) mode, enabling
     /// semantic search, embedding, and explore.
     /// Set in `.spelunk/config.toml` (project-level) or via `SPELUNK_SERVER_URL`.

--- a/docs/architecture/capability-tiers.md
+++ b/docs/architecture/capability-tiers.md
@@ -170,10 +170,9 @@ and [server.md → Local server](../server.md#local-server-automatic--no-setup).
 
 ```
 Capability tier:  Offline
-  search          ast-grep + text
+  search          ast-grep + text  [set server_url to enable semantic search]
   memory          sqlite (local)
   explore         unavailable  [set server_url to enable]
-  plan            unavailable  [set server_url to enable]
 ```
 
 The `memory` line reflects the resolved backend (`sqlite` / `git-notes` /
@@ -184,28 +183,31 @@ project, `spelunk status` reports `No spelunk project here` instead (see
 **Text output (Tier 1 — server connected):**
 
 ```
-Capability tier:  Server  (http://spelunk.internal:7777)
+Capability tier:  Server  (https://spelunk.internal.example.com)
   search          ast-grep + text + semantic
+  embedder        ready
   memory          sqlite (local)
   explore         available
-  plan            available
 ```
 
-**JSON output** (`spelunk status --format json`) adds a `capabilities` object:
+The `embedder` line reports the server's `embedder.state` from `/v1/health`; it
+is omitted when the server does not report that field.
+
+**JSON output** (`spelunk status --format json`) adds a `capabilities` object
+(other fields omitted):
 
 ```json
 {
   "tier": "server",
-  "server_url": "http://spelunk.internal:7777",
+  "server_url": "https://spelunk.internal.example.com",
   "capabilities": {
-    "search_semantic": true,
-    "index_embed": true,
-    "memory_push": true,
-    "memory_pull": true,
-    "memory_search": true,
-    "memory_harvest": true,
     "explore": true,
-    "plan": true
+    "index_embed": true,
+    "memory_harvest": true,
+    "memory_pull": true,
+    "memory_push": true,
+    "memory_search": true,
+    "search_semantic": true
   }
 }
 ```
@@ -219,14 +221,14 @@ Capability tier:  Server  (http://spelunk.internal:7777)
 
 ```
 Index is up to date. (412 files indexed)
-Server:  http://spelunk.internal:7777  ✓  (semantic search, explore, plan available)
+Server:  https://spelunk.internal.example.com  ✓  (semantic search, explore available)
 ```
 
 Or on failure:
 
 ```
 Index is up to date. (412 files indexed)
-Server:  http://spelunk.internal:7777  ✗  unreachable — offline mode
+Server:  https://spelunk.internal.example.com  ✗  unreachable — offline mode
 ```
 
 ---
@@ -237,16 +239,16 @@ When a Tier 1 feature is invoked but no server is reachable, exit 2 with a
 consistent message format:
 
 ```
-error: 'spelunk explore' requires spelunk-server.
-       Set server_url in ~/.config/spelunk/config.toml to enable this feature.
-       (Tried: http://spelunk.internal:7777 — connection refused)
+Error: 'spelunk explore' requires spelunk-server.
+Set server_url in ~/.config/spelunk/config.toml to enable this feature.
+       (Tried: https://spelunk.internal.example.com — connection refused)
 ```
 
 If `server_url` is not set at all:
 
 ```
-error: 'spelunk explore' requires spelunk-server.
-       Set server_url in ~/.config/spelunk/config.toml to enable this feature.
+Error: 'spelunk explore' requires spelunk-server.
+Set server_url in ~/.config/spelunk/config.toml to enable this feature.
 ```
 
 Use `eprintln!` to stderr. Do not panic.


### PR DESCRIPTION
`docs/architecture/capability-tiers.md` stated that `server_url` must be `https://` unless it resolves to loopback, then showed example output using `http://spelunk.internal:7777`. That URL is a non-loopback plaintext address, which `validate_transport_url` hard-refuses. The config blocks earlier in the same file already used `https://`, so the file contradicted itself.

The contradiction dates to the commit that introduced the rule (`713304272`): it updated the config blocks and added the callout, but left the example output alone.

## Why this is more than a URL swap

Fixing only the URL would have left blocks that no run can produce. The transcripts were never captured from a real run: they printed a `plan` line, but `Capabilities::plan` is `#[serde(skip_serializing)]` and documented as hidden from every user-facing surface until a `spelunk plan` command ships. No such subcommand exists, and the renderer emits no `plan` line in either tier.

So every block was re-captured from the installed binary rather than hand-edited:

- URLs now use `https://spelunk.internal.example.com`, matching the config blocks.
- The `plan` lines are gone.
- The Tier 0 search hint and the Tier 1 `embedder` line are added, both of which the renderer emits.
- The JSON `capabilities` object now matches the real one: seven keys, sorted, no `plan`.
- Error blocks use the real `Error:` prefix and the real (ragged) indentation.

The `server_url` rustdoc example in `crates/spelunk-core/src/config.rs` carried the same refused URL and is corrected in the same pass. That change is comment-only, with no logic change. The test fixtures that depend on that URL staying non-loopback are untouched.

## One hand-substitution, stated rather than hidden

The hostname `https://spelunk.internal.example.com` is a placeholder, reused from `713304272` rather than invented. No real run can produce output for a fictional host, so the URL substring in three blocks was substituted after capture. This is legitimate because the URL is a pure echo of config (`status.rs:374`, `check.rs:154/157`); every other byte in those blocks is captured output. A reachable host of that name cannot exist here without editing `/etc/hosts` and minting a CA.

`(412 files indexed)` is a data-dependent illustrative count, as is `explore: true` in the JSON, which reflects a server that offers explore.

## Test plan

Verified against the installed `spelunk-cli 0.9.4-local` in an `init`-ed scratch project, never the repo, with the server probe live. `SPELUNK_NO_SERVER=1` was deliberately not set, since it short-circuits every probe and yields a false pass.

- Replayed the Tier 1 text block against a live loopback server. Output matches: `search` / `embedder ready` / `memory` / `explore`, with no `plan` line.
- Replayed `spelunk status --format json`. The real `capabilities` object is exactly the seven sorted keys now in the doc, and omits `plan` entirely, confirming the previous block could not have been captured.
- Replayed the locked-feature error block via `require_tier1` by pointing `server_url` at a dead loopback port. It reproduces byte for byte apart from the URL, including the `Error:` prefix and the ragged indent. Checked with `od -c`: the newline is followed directly by `Set`, and `(Tried:` carries seven leading spaces, both of which the `\n\` continuation in `capability.rs:657-660` produces.
- URL controls against the binary: `https://spelunk.internal.example.com` accepted, `http://127.0.0.1:7777` accepted, and the removed `http://spelunk.internal:7777` refused with the exact message quoted above.
- Confirmed `crates/spelunk-core/src/config.rs` is comment-only: filtering the diff for non-`///` changed lines returns nothing. All six fixtures using the non-loopback URL are intact, including `assert!(!is_loopback_url("http://spelunk.internal:7777"))`, which depends on that value staying non-loopback.

### Gates

- Ran: `cargo fmt --all -- --check`, exit 0, captured with no pipe.
- Skipped: `cargo nextest` and full clippy. This diff is markdown plus a rustdoc comment, so it cannot move either result, and the build host is at 96% disk with concurrent builders. The repo's pre-commit hook already ran `cargo clippy --all-targets` at commit time. Stating this plainly rather than implying gates ran that did not.

### On the two em-dashes

Both are on added lines inside code fences, and both are verbatim binary output (`check.rs:158` and `capability.rs:657` contain the literal character). They replay byte-identically. Changing them would fabricate output, so they stay.

## Known and deliberately not fixed here

Two issues in this file need a design decision about whether the doc or the binary is wrong, so they are tracked separately rather than guessed at:

1. The file claims exit 2 for a locked feature in two places. `require_tier1` uses `anyhow::bail!`, so the binary exits 1. Exit 2 is real but attached to different behaviour: an invalid non-loopback URL exits 2, as does a plumbing failure.
2. The tier table lists `Plan` as a Tier 1 capability, while the field is hidden from every user-facing surface and no `spelunk plan` command exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
