### PR TITLE
test: isolate ambient global git config in the temp-repo harnesses

### DIFF
--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -55,7 +55,12 @@ pub fn spelunk_bin_in(home: &Path) -> Command {
         // `spelunk_config_dir()` uses `dirs::home_dir()` (HOME on Unix); unset
         // XDG_CONFIG_HOME so the file store lands under `<home>/.config/spelunk`
         // and never the developer's real config dir.
-        .env_remove("XDG_CONFIG_HOME");
+        .env_remove("XDG_CONFIG_HOME")
+        // The HOME redirect above hides `~/.gitconfig` from the git this child
+        // spawns, but an exported GIT_CONFIG_GLOBAL outranks HOME and would
+        // still reach it.
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null");
     cmd
 }
 

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -58,7 +58,8 @@ pub fn spelunk_bin_in(home: &Path) -> Command {
         .env_remove("XDG_CONFIG_HOME")
         // The HOME redirect above hides `~/.gitconfig` from the git this child
         // spawns, but an exported GIT_CONFIG_GLOBAL outranks HOME and would
-        // still reach it.
+        // still reach it. Not a Windows path, but git skips a scope whenever
+        // its var is set, whatever the path resolves to.
         .env("GIT_CONFIG_GLOBAL", "/dev/null")
         .env("GIT_CONFIG_SYSTEM", "/dev/null");
     cmd

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -21,9 +21,29 @@ use spelunk_core::storage::NoteInput;
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
+/// Drop the machine's global/system git config for every git this process
+/// spawns, including the ones the code under test spawns itself (`run_git`
+/// inherits our env, so a per-`Command` `.env()` would not reach them).
+/// An ambient value layers under the temp repo's local config and changes what
+/// the code under test reads: a global `notes.rewriteRef` reads back as
+/// already-covered and the repo never looks unconfigured.
+fn isolate_git_config() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: every git-touching helper here calls this first and `Once`
+        // blocks the rest until it returns, so no thread can be spawning git
+        // (reading environ) while these run.
+        unsafe {
+            std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
+            std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
+        }
+    });
+}
+
 /// Create a temporary git repo with one initial commit.
 /// Returns the path; the repo is cleaned up when the returned `TempDir` drops.
 fn make_temp_git_repo() -> tempfile::TempDir {
+    isolate_git_config();
     let dir = tempfile::TempDir::new().expect("tempdir");
     let p = dir.path();
 
@@ -1460,6 +1480,38 @@ async fn ensure_notes_rewrite_ref_composes_with_a_users_existing_value() {
     assert!(
         note_on_head(root).is_some_and(|b| b.contains(PRECIOUS)),
         "our note must carry too"
+    );
+}
+
+/// The read is deliberately unscoped: a value the user set in *global* scope is
+/// theirs and must be honoured, so we add nothing on top of it. Pins the intent
+/// that `isolate_git_config` would otherwise hide from every test here.
+#[tokio::test]
+#[serial]
+async fn ensure_notes_rewrite_ref_honours_a_users_global_value() {
+    let dir = rewrite_test_repo();
+    let root = dir.path();
+
+    let home = tempfile::TempDir::new().expect("tempdir");
+    let global = home.path().join("gitconfig");
+    std::fs::write(&global, "[notes]\n\trewriteRef = refs/notes/spelunk\n").expect("write");
+
+    // SAFETY: `#[serial]` keeps this the only running test under `cargo test`,
+    // and nextest gives each test its own process.
+    unsafe { std::env::set_var("GIT_CONFIG_GLOBAL", &global) };
+    let status = ensure_notes_rewrite_ref(Some(root)).await;
+    // Restore before asserting: a panic below would otherwise leak the global
+    // value into every later test in this process.
+    unsafe { std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null") };
+
+    assert_eq!(
+        status,
+        RewriteRefStatus::AlreadyCovered,
+        "a global value is the user's own and must be read"
+    );
+    assert!(
+        rewrite_ref_values(root).is_empty(),
+        "honouring the global value means writing no local one"
     );
 }
 

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -27,6 +27,9 @@ use spelunk_core::storage::NoteInput;
 /// An ambient value layers under the temp repo's local config and changes what
 /// the code under test reads: a global `notes.rewriteRef` reads back as
 /// already-covered and the repo never looks unconfigured.
+///
+/// `/dev/null` is not a Windows path, but git skips a scope whenever its var is
+/// set, whatever the path resolves to, so this isolates on Windows regardless.
 fn isolate_git_config() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {


### PR DESCRIPTION
## Why

The `notes.rewriteRef` tests read git config unscoped, but the temp-repo harnesses left the **global** scope live. A contributor whose machine sets `notes.rewriteRef` globally gets red tests on a clean checkout with nothing wrong on their side. Git's own documentation suggests `refs/notes/commits` for exactly this setting, so it is a plausible thing for a git-literate contributor to have configured.

CI can never catch this: the runners carry no ambient global config, so the gap is invisible there and only bites humans.

**The exposure is 8 tests, not the 4 originally reported.** Sizing it required `--no-fail-fast`; fail-fast truncated the first sweep at 163/1069 and surfaced only one of them.

## What changed

Tests only. Two files, no production code.

- `make_temp_git_repo` now points `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at `/dev/null` process-wide, behind a `Once`. It has to be process-wide rather than per-`Command`: the code under test spawns its own git, which inherits the process environment, so a per-`Command` `.env()` would not reach it.
- `spelunk_bin_in` does the same for the child it spawns. Its existing HOME redirect hid `~/.gitconfig`, but an exported `GIT_CONFIG_GLOBAL` outranks HOME and would still reach through.
- Adds `ensure_notes_rewrite_ref_honours_a_users_global_value`, pinning the all-scopes read.

**`ensure_notes_rewrite_ref` is deliberately unchanged and is byte-identical to `main`.** Reading all config scopes is correct: a user who set the value anywhere must be left alone. The fix belongs in the harness, not the helper.

### On `/dev/null` and Windows

`/dev/null` is a Unix path and these tests are not `cfg(unix)`-gated, so the obvious worry is that it silently fails to isolate on `windows-latest`. It does not, and the reason does not depend on the path resolving: git skips a config scope whenever its variable is *set*, before any file access. Verified against git 2.55.0, with a positive control confirming the poison was live:

| `GIT_CONFIG_GLOBAL` | ambient `~/.gitconfig` |
| --- | --- |
| pointed at the poison file | read (control: poison is live) |
| `/dev/null` | suppressed |
| `/nonexistent/nope/xyz` | suppressed, no error |
| `C:\dev\null` (simulates non-translation) | suppressed |
| `nul` | suppressed |
| a directory | suppressed |

Every resolution outcome fails safe (skip, therefore isolated), never silently-open. A garbage value still beats a real poisoned `~/.gitconfig`. The one theoretical break needs a genuine readable config file at whatever Windows resolves the path to, and garbage there would fail loudly. A comment pins this invariant at both sites, because `context.rs` already warns that `/dev/null` is Unix-only, which makes these sites look like a bug and invites a wrong "fix".

## Test plan

All commands run with `SPELUNK_SECRET_STORE=file`, bare, checking real exit status (no pipes).

**Red-before / green-after, the contrast that proves it.** With a global config containing `notes.rewriteRef = refs/notes/*`, after confirming with a positive control that the poison was actually live:

- Reverting both test files to `main` and re-running the full suite with `--no-fail-fast`: **8 failed** (5 in `integration_git_notes`, 2 more in the same file beyond the reported set, 1 in `init_notes_refspec` in a different crate).
- On this branch, same poison, full suite: **1070/1070 passed, 0 failed.**

**Both exposure routes, not just the repro mechanism.** A real contributor has a `~/.gitconfig`, not an exported variable. Re-ran the full suite with the poison delivered through a real `~/.gitconfig` in a fake HOME: **1070/1070 passed**.

**Coverage beyond the filed key.** Ran the full suite against a broad, realistic contributor config (`notes.rewriteRef`, `notes.displayRef`, `init.defaultBranch = trunk`, `core.autocrlf`, `diff.noprefix`, `pull.rebase`, `fetch.prune`, `merge.ff`, `log.date`, `status.short`): **1070/1070 passed**. Not a vacuous result, since the same delivery mechanism demonstrably reached test processes on `main`.

**Gates**, all exit 0:

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --all-targets --features rich-formats -- -D warnings` | 0 |
| `cargo nextest run` | 0 (1070 passed, 9 skipped) |
| `cargo test --doc` | 0 |
| `cargo nextest run -p spelunk-core --no-default-features` | 0 (421 passed) |
| `cargo test --doc -p spelunk-core --no-default-features` | 0 |

Confirmed `git diff main..HEAD -- crates/spelunk-core/src/storage/git_notes/mod.rs` is empty, so the all-scopes read is untouched. Also confirmed the new pin test is the sole guard of that intent: with the helper mutated to read `--local` only, it is the only test in the file that fails.

## Known gap, pre-existing and not addressed here

A contributor with `commit.gpgsign = true` set globally gets 6 red tests (`harvest_ref_injection`, `memory_add_secret_gate`), because those files run their setup git commands directly and inherit ambient config. Verified this reproduces **identically on `main`** (6 failed, same tests), so it is not a regression from this change and is a separate defect with a different root cause. Worth noting it is realistic: the tests fabricate a user identity, so even a contributor with a valid signing key fails, since the key cannot sign for the fabricated identity. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
