### PR TITLE
Fold duplicate memory entries by identity on the git-notes read path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,23 +123,22 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- **Duplicate memory entries no longer appear when machines record the same decision
-  independently.** When two machines independently record the same decision
-  (identical `kind`, `title`, and `body`), they compute the same `entity_id` from
-  their content hash. Previously, both records would appear in `memory list`,
-  `memory context`, and `memory search` output, giving a false impression of
-  disagreement or uncertainty. The read path now folds such duplicates into one
-  entry, merging `tags` and `linked_files` across copies (values added, never
-  removed) and keeping the earliest creation time. This brings the read-time
-  behaviour into line with the import-time deduplication already performed by
-  `memory reconcile` and `spelunk init`.
+- **A decision recorded independently on two machines now lists once, not twice.**
+  Two machines that record the same decision (identical `kind`, `title`, and
+  `body`) derive the same identity from that content, but `spelunk memory list`
+  and `spelunk context` read every copy back and showed each one, so a decision
+  both teammates had recorded looked like two competing entries. Those reads now
+  fold copies by identity: one entry, `tags` and `linked_files` unioned across
+  the copies (added, never removed), and the earliest recording time kept. An
+  entry archived on any machine reads as archived everywhere. This matches the
+  identity-keyed dedup `memory reconcile` and `spelunk init` already do on
+  import.
 
-  As a side effect of this change, `memory list` and `context` are now
-  substantially faster on note-heavy repositories. The list operation previously
-  made N separate `git notes show` subprocess calls (one per commit); it now
-  makes a single `git cat-file --batch` request to fetch all note blobs at once.
-  On a 500-note repository, this reduces the time from ~7.3 seconds to ~38
-  milliseconds (~190x faster).
+  Reads that walk every note are also substantially faster. The fold has to see
+  every copy of an entry before it can emit one, so a read can no longer stop as
+  soon as it has enough entries the way it did before; note blobs are therefore
+  read with a single `git cat-file --batch` rather than one `git notes show`
+  subprocess per note.
 
 - **`spelunk init` no longer breaks plain `git fetch` / `git pull`, and no
   longer lets a fetch destroy your unpushed memory.** The fetch refspec `init`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,24 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Duplicate memory entries no longer appear when machines record the same decision
+  independently.** When two machines independently record the same decision
+  (identical `kind`, `title`, and `body`), they compute the same `entity_id` from
+  their content hash. Previously, both records would appear in `memory list`,
+  `memory context`, and `memory search` output, giving a false impression of
+  disagreement or uncertainty. The read path now folds such duplicates into one
+  entry, merging `tags` and `linked_files` across copies (values added, never
+  removed) and keeping the earliest creation time. This brings the read-time
+  behaviour into line with the import-time deduplication already performed by
+  `memory reconcile` and `spelunk init`.
+
+  As a side effect of this change, `memory list` and `context` are now
+  substantially faster on note-heavy repositories. The list operation previously
+  made N separate `git notes show` subprocess calls (one per commit); it now
+  makes a single `git cat-file --batch` request to fetch all note blobs at once.
+  On a 500-note repository, this reduces the time from ~7.3 seconds to ~38
+  milliseconds (~190x faster).
+
 - **`spelunk init` no longer breaks plain `git fetch` / `git pull`, and no
   longer lets a fetch destroy your unpushed memory.** The fetch refspec `init`
   configured, `+refs/notes/spelunk:refs/notes/spelunk`, had two failures. It is

--- a/crates/spelunk-core/src/storage/git_notes/backend_impl.rs
+++ b/crates/spelunk-core/src/storage/git_notes/backend_impl.rs
@@ -48,8 +48,8 @@ impl MemoryBackend for GitNotesBackend {
         let effective_limit = limit.min(super::GIT_NOTES_MAX_LIST);
         if limit > super::GIT_NOTES_MAX_LIST {
             tracing::warn!(
-                "GitNotesBackend::list: caller requested {} entries; capped at {} to prevent \
-                 O(n) subprocess hang. Use --backend sqlite for unbounded listing.",
+                "GitNotesBackend::list: caller requested {} entries; capped at {}. \
+                 Use --backend sqlite for unbounded listing.",
                 limit,
                 super::GIT_NOTES_MAX_LIST
             );
@@ -69,8 +69,8 @@ impl MemoryBackend for GitNotesBackend {
     }
 
     async fn get(&self, id: i64) -> Result<Option<Note>> {
-        for (sha, _) in self.noted_commits().await? {
-            for record in self.read_records(&sha).await? {
+        for noted in self.noted_commits().await? {
+            for record in self.read_records(&noted.commit).await? {
                 if record.id == id {
                     return Ok(Some(record_to_note(record)));
                 }
@@ -84,8 +84,8 @@ impl MemoryBackend for GitNotesBackend {
     }
 
     async fn archive(&self, id: i64) -> Result<bool> {
-        for (sha, _) in self.noted_commits().await? {
-            if self.archive_record(&sha, id).await? {
+        for noted in self.noted_commits().await? {
+            if self.archive_record(&noted.commit, id).await? {
                 return Ok(true);
             }
         }

--- a/crates/spelunk-core/src/storage/git_notes/fold.rs
+++ b/crates/spelunk-core/src/storage/git_notes/fold.rs
@@ -1,0 +1,211 @@
+//! Collapse the copies of one entity that `refs/notes/spelunk` accumulates.
+//!
+//! The ref is an append-only, entity-keyed event log: two machines recording
+//! the same decision write lines with the same `entity_id` but their own `id`
+//! and `created_at`, and `cat_sort_uniq` keeps both. Readers fold those copies
+//! into one entry; writers never mutate in place.
+//!
+//! Every rule here is commutative, associative and idempotent, so any merge
+//! order across any number of machines converges (ADR-068 A6).
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+
+use super::super::note_record::NoteRecord;
+
+/// Collapse each `entity_id` group in `records` into exactly one record.
+///
+/// Groups are keyed on `resolve_entity_id()`, never the raw field: a legacy
+/// line predating `entity_id` recomputes it from `{kind, title, body}` and so
+/// folds together with a fresh line for the same entry.
+///
+/// Returns one record per entity in first-encounter order, which a later stable
+/// sort turns into "`created_at` ties keep blob order" (ADR-069 D2).
+pub(super) fn fold_records(records: Vec<NoteRecord>) -> Vec<NoteRecord> {
+    let mut order: Vec<String> = Vec::new();
+    let mut groups: HashMap<String, Vec<NoteRecord>> = HashMap::new();
+
+    for record in records {
+        let key = record.resolve_entity_id();
+        match groups.entry(key) {
+            Entry::Vacant(slot) => {
+                order.push(slot.key().clone());
+                slot.insert(vec![record]);
+            }
+            Entry::Occupied(mut slot) => slot.get_mut().push(record),
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|key| groups.remove(&key).map(fold_group))
+        .collect()
+}
+
+/// Fold one entity's copies onto its base copy.
+fn fold_group(mut group: Vec<NoteRecord>) -> NoteRecord {
+    let base_idx = base_index(&group);
+    let mut base = group.swap_remove(base_idx);
+    for other in group {
+        merge_into(&mut base, other);
+    }
+    base
+}
+
+/// Index of the copy every base-sourced field is taken from.
+///
+/// Total by construction: two copies this cannot separate agree on every field
+/// it sources, so which one wins cannot change the fold's output.
+fn base_index(group: &[NoteRecord]) -> usize {
+    group
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| base_key(a).cmp(&base_key(b)))
+        .map(|(i, _)| i)
+        .expect("a group always holds the record that created it")
+}
+
+/// Earliest recording wins; the trailing fields only break a tie.
+fn base_key(r: &NoteRecord) -> (i64, i64, Option<&String>, Option<&String>, Option<i64>) {
+    (
+        r.created_at,
+        r.id,
+        r.source_ref.as_ref(),
+        r.remote_id.as_ref(),
+        r.superseded_by,
+    )
+}
+
+/// `kind`/`title`/`body` are equal by construction (they are the identity) and
+/// `created_at` is already the minimum, since `base_key` orders on it first.
+fn merge_into(base: &mut NoteRecord, other: NoteRecord) {
+    // Archival is monotonic: never un-archive (`apply_remote_note`).
+    if other.status == "archived" {
+        base.status = "archived".to_string();
+    }
+    base.schema_version = base.schema_version.max(other.schema_version);
+    base.valid_at = min_some(base.valid_at, other.valid_at);
+    base.invalid_at = min_some(base.invalid_at, other.invalid_at);
+    base.superseded_by_entity_id = min_some(
+        base.superseded_by_entity_id.take(),
+        other.superseded_by_entity_id,
+    );
+    union_into(&mut base.tags, other.tags);
+    union_into(&mut base.linked_files, other.linked_files);
+}
+
+/// Keep the smallest present value. `None` is the identity.
+fn min_some<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (a, b) => a.or(b),
+    }
+}
+
+/// Add-wins OR-Set union: an incoming member is added, none is ever dropped.
+fn union_into(base: &mut Vec<String>, other: Vec<String>) {
+    base.extend(other);
+    base.sort();
+    base.dedup();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::entity_id::entity_id;
+
+    /// Two copies of one decision, as two machines would write them.
+    fn copy(id: i64, created_at: i64, tags: &[&str]) -> NoteRecord {
+        NoteRecord {
+            schema_version: 1,
+            id,
+            kind: "decision".to_string(),
+            title: "HTTP layer".to_string(),
+            body: "use axum".to_string(),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            linked_files: vec![],
+            created_at,
+            status: "active".to_string(),
+            source_ref: None,
+            valid_at: None,
+            invalid_at: None,
+            superseded_by: None,
+            remote_id: None,
+            entity_id: Some(entity_id("decision", "HTTP layer", "use axum")),
+            superseded_by_entity_id: None,
+        }
+    }
+
+    /// One copy per machine, each differing in every foldable field.
+    fn copies() -> Vec<NoteRecord> {
+        let mut archived = copy(3, 300, &["c"]);
+        archived.status = "archived".to_string();
+        archived.superseded_by_entity_id = Some("ffff".to_string());
+
+        let mut middle = copy(2, 200, &["b"]);
+        middle.valid_at = Some(50);
+        middle.superseded_by_entity_id = Some("aaaa".to_string());
+
+        let mut earliest = copy(1, 100, &["a"]);
+        earliest.invalid_at = Some(900);
+
+        vec![earliest, middle, archived]
+    }
+
+    /// A4/A6's stated standard: every rule is order-insensitive, so any merge
+    /// order across any number of machines reaches the same entry.
+    #[test]
+    fn folding_converges_regardless_of_order() {
+        let fingerprint = |group: Vec<NoteRecord>| {
+            let folded = fold_records(group);
+            assert_eq!(folded.len(), 1, "one entity, one entry");
+            serde_json::to_string(&folded[0]).expect("serialize")
+        };
+
+        // Every permutation of three copies, plus a duplicated input to pin
+        // idempotence (folding a copy twice changes nothing).
+        let expected = fingerprint(copies());
+        for (i, j, k) in [
+            (0, 1, 2),
+            (0, 2, 1),
+            (1, 0, 2),
+            (1, 2, 0),
+            (2, 0, 1),
+            (2, 1, 0),
+        ] {
+            let c = copies();
+            let permuted = vec![copies_at(&c, i), copies_at(&c, j), copies_at(&c, k)];
+            assert_eq!(
+                fingerprint(permuted),
+                expected,
+                "permutation ({i},{j},{k}) must converge"
+            );
+        }
+
+        let mut twice = copies();
+        twice.extend(copies());
+        assert_eq!(fingerprint(twice), expected, "folding is idempotent");
+    }
+
+    /// `NoteRecord` is not `Clone`; rebuild the i-th copy instead.
+    fn copies_at(src: &[NoteRecord], i: usize) -> NoteRecord {
+        let want = &src[i];
+        let mut r = copy(want.id, want.created_at, &[]);
+        r.tags = want.tags.clone();
+        r.status = want.status.clone();
+        r.valid_at = want.valid_at;
+        r.invalid_at = want.invalid_at;
+        r.superseded_by_entity_id = want.superseded_by_entity_id.clone();
+        r
+    }
+
+    /// The fold collapses copies, never distinct entries.
+    #[test]
+    fn distinct_entities_are_not_collapsed() {
+        let mut other = copy(1, 100, &[]);
+        other.title = "storage layer".to_string();
+        other.entity_id = Some(entity_id("decision", "storage layer", "use axum"));
+
+        assert_eq!(fold_records(vec![copy(1, 100, &[]), other]).len(), 2);
+    }
+}

--- a/crates/spelunk-core/src/storage/git_notes/fold.rs
+++ b/crates/spelunk-core/src/storage/git_notes/fold.rs
@@ -115,7 +115,7 @@ mod tests {
     use crate::storage::entity_id::entity_id;
 
     /// Two copies of one decision, as two machines would write them.
-    fn copy(id: i64, created_at: i64, tags: &[&str]) -> NoteRecord {
+    pub(super) fn copy(id: i64, created_at: i64, tags: &[&str]) -> NoteRecord {
         NoteRecord {
             schema_version: 1,
             id,
@@ -207,5 +207,212 @@ mod tests {
         other.entity_id = Some(entity_id("decision", "storage layer", "use axum"));
 
         assert_eq!(fold_records(vec![copy(1, 100, &[]), other]).len(), 2);
+    }
+
+    /// The one entry a group of copies folds to, serialized for comparison.
+    fn fingerprint(records: Vec<NoteRecord>) -> String {
+        let folded = fold_records(records);
+        assert_eq!(folded.len(), 1, "the fixture must be one entity's copies");
+        serde_json::to_string(&folded[0]).expect("serialize")
+    }
+
+    /// Three copies tying on `(created_at, id)` and differing only in the
+    /// remaining fields `base` supplies.
+    fn tied_variants() -> Vec<NoteRecord> {
+        let mut high = copy(1, 100, &[]);
+        high.source_ref = Some("bbb".to_string());
+        high.remote_id = Some("zzz".to_string());
+        high.superseded_by = Some(9);
+
+        let mut low = copy(1, 100, &[]);
+        low.source_ref = Some("aaa".to_string());
+        low.remote_id = Some("yyy".to_string());
+        low.superseded_by = Some(2);
+
+        // Separated from `low` only by the last component of the key.
+        let mut mid = copy(1, 100, &[]);
+        mid.source_ref = Some("aaa".to_string());
+        mid.remote_id = Some("yyy".to_string());
+        mid.superseded_by = Some(7);
+
+        vec![high, low, mid]
+    }
+
+    /// `NoteRecord` is not `Clone`; rebuild the group in the given order.
+    fn tied_in_order(idx: [usize; 3]) -> Vec<NoteRecord> {
+        let mut src: Vec<Option<NoteRecord>> = tied_variants().into_iter().map(Some).collect();
+        idx.iter()
+            .map(|&i| src[i].take().expect("each index taken once"))
+            .collect()
+    }
+
+    /// `(created_at, id)` alone is not total: two copies can tie there and still
+    /// differ in the other fields `base` supplies, which would leave the fold
+    /// order-dependent. Ordering those too is what keeps it convergent.
+    #[test]
+    fn base_is_deterministic_when_created_at_and_id_tie() {
+        let expected = fingerprint(tied_in_order([0, 1, 2]));
+
+        for idx in [[0, 2, 1], [1, 0, 2], [1, 2, 0], [2, 0, 1], [2, 1, 0]] {
+            assert_eq!(
+                fingerprint(tied_in_order(idx)),
+                expected,
+                "copies tying on (created_at, id) must still fold identically in order {idx:?}"
+            );
+        }
+
+        let folded = fold_records(tied_in_order([2, 0, 1]));
+        assert_eq!(
+            (
+                folded[0].source_ref.as_deref(),
+                folded[0].remote_id.as_deref(),
+                folded[0].superseded_by
+            ),
+            (Some("aaa"), Some("yyy"), Some(2)),
+            "the smallest copy on the full key supplies every base field"
+        );
+    }
+}
+
+/// Convergence, over generated copies rather than a fixed fixture.
+///
+/// A6's standard is that every rule is commutative, associative and idempotent.
+/// The fixed-permutation test above pins one worked example; these pin the
+/// property itself.
+#[cfg(test)]
+mod convergence {
+    use super::tests::copy;
+    use super::*;
+    use proptest::prelude::*;
+
+    /// The fields two machines' copies of one entity may legitimately differ in.
+    #[derive(Debug, Clone)]
+    struct Spec {
+        id: i64,
+        created_at: i64,
+        archived: bool,
+        tags: Vec<String>,
+        linked_files: Vec<String>,
+        valid_at: Option<i64>,
+        invalid_at: Option<i64>,
+        superseded_by_entity_id: Option<String>,
+        source_ref: Option<String>,
+        remote_id: Option<String>,
+        superseded_by: Option<i64>,
+    }
+
+    fn build(s: &Spec) -> NoteRecord {
+        let mut r = copy(s.id, s.created_at, &[]);
+        r.tags = s.tags.clone();
+        r.linked_files = s.linked_files.clone();
+        r.status = if s.archived { "archived" } else { "active" }.to_string();
+        r.valid_at = s.valid_at;
+        r.invalid_at = s.invalid_at;
+        r.superseded_by_entity_id = s.superseded_by_entity_id.clone();
+        r.source_ref = s.source_ref.clone();
+        r.remote_id = s.remote_id.clone();
+        r.superseded_by = s.superseded_by;
+        r
+    }
+
+    /// Ranges are tiny on purpose: ties are where an incomplete order would
+    /// leak through, so the generator has to produce them often.
+    fn arb_spec() -> impl Strategy<Value = Spec> {
+        (
+            (0i64..3, 0i64..3, any::<bool>()),
+            (
+                prop::collection::vec("[a-c]", 0..3),
+                prop::collection::vec("[x-z]", 0..3),
+            ),
+            (prop::option::of(0i64..3), prop::option::of(0i64..3)),
+            (
+                prop::option::of("[a-c]"),
+                prop::option::of("[a-c]"),
+                prop::option::of("[a-c]"),
+                prop::option::of(0i64..3),
+            ),
+        )
+            .prop_map(
+                |(
+                    (id, created_at, archived),
+                    (tags, linked_files),
+                    (valid_at, invalid_at),
+                    (superseded_by_entity_id, source_ref, remote_id, superseded_by),
+                )| Spec {
+                    id,
+                    created_at,
+                    archived,
+                    tags,
+                    linked_files,
+                    valid_at,
+                    invalid_at,
+                    superseded_by_entity_id,
+                    source_ref,
+                    remote_id,
+                    superseded_by,
+                },
+            )
+    }
+
+    fn every_order(specs: &[Spec]) -> Vec<Vec<Spec>> {
+        if specs.len() <= 1 {
+            return vec![specs.to_vec()];
+        }
+        let mut out = Vec::new();
+        for i in 0..specs.len() {
+            let mut rest = specs.to_vec();
+            let head = rest.remove(i);
+            for mut order in every_order(&rest) {
+                order.insert(0, head.clone());
+                out.push(order);
+            }
+        }
+        out
+    }
+
+    fn fold_of(specs: &[Spec]) -> String {
+        entry(fold_records(specs.iter().map(build).collect()))
+    }
+
+    fn entry(folded: Vec<NoteRecord>) -> String {
+        assert_eq!(folded.len(), 1, "every spec is a copy of one entity");
+        serde_json::to_string(&folded[0]).expect("serialize")
+    }
+
+    proptest! {
+        /// Commutative: two machines holding the same copies in any order reach
+        /// the same entry.
+        #[test]
+        fn folding_converges_over_every_order(specs in prop::collection::vec(arb_spec(), 1..6)) {
+            let expected = fold_of(&specs);
+            for order in every_order(&specs) {
+                prop_assert_eq!(fold_of(&order), expected.clone(), "order {:?} diverged", order);
+            }
+        }
+
+        /// Idempotent: re-reading a folded entry changes nothing. Associative:
+        /// folding one machine's copies first reaches the same entry as folding
+        /// the union in one pass.
+        #[test]
+        fn folding_is_idempotent_and_associative(
+            left in prop::collection::vec(arb_spec(), 1..4),
+            right in prop::collection::vec(arb_spec(), 1..4),
+        ) {
+            let records = |specs: &[Spec]| -> Vec<NoteRecord> { specs.iter().map(build).collect() };
+
+            prop_assert_eq!(
+                entry(fold_records(fold_records(records(&left)))),
+                fold_of(&left),
+                "fold(fold(x)) must equal fold(x)"
+            );
+
+            let mut union = records(&left);
+            union.extend(records(&right));
+            let whole = entry(fold_records(union));
+
+            let mut partial = fold_records(records(&left));
+            partial.extend(records(&right));
+            prop_assert_eq!(entry(fold_records(partial)), whole, "partial fold diverged");
+        }
     }
 }

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -1,13 +1,15 @@
 use anyhow::{Result, anyhow};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
 use super::memory::Note;
 use super::note_record::{NoteRecord, record_to_note};
+use fold::fold_records;
 
 mod backend_impl;
+mod fold;
 mod lock;
 
 pub use lock::{NotesLock, lock_notes};
@@ -286,8 +288,8 @@ async fn run_git_with_stdin(
 
 /// Hard cap on entries returned by `list()`.
 ///
-/// Each entry requires one `git notes show` subprocess call (~13 ms).
-/// Without a guard, `list(5000)` would take ~65 seconds.
+/// Bounds output only, not work: the entity fold has to read every reachable
+/// note blob whatever the limit.
 /// Callers needing unbounded listing should use `--backend sqlite`.
 const GIT_NOTES_MAX_LIST: usize = 500;
 
@@ -395,9 +397,13 @@ impl GitNotesBackend {
         Ok(self.run(&["rev-parse", "HEAD"]).await?.trim().to_string())
     }
 
-    /// Return (commit-sha, commit-timestamp) pairs for commits that have a
-    /// spelunk note, in reverse-chronological (newest first) order.
-    async fn noted_commits(&self) -> Result<Vec<(String, i64)>> {
+    /// Commits carrying a spelunk note, in reverse-chronological (newest first)
+    /// order.
+    ///
+    /// Only commits reachable from HEAD are listed: memory travels with the
+    /// code that carries it, so a teammate's note on a fetched-but-unmerged
+    /// commit stays invisible until that commit is merged.
+    async fn noted_commits(&self) -> Result<Vec<NotedCommit>> {
         // `git notes --ref=spelunk list` → "<note-blob-sha> <commit-sha>"
         let list_out = self
             .git()
@@ -409,33 +415,85 @@ impl GitNotesBackend {
             return Ok(vec![]);
         }
 
-        let noted: HashSet<String> = String::from_utf8_lossy(&list_out.stdout)
+        let listing = String::from_utf8_lossy(&list_out.stdout);
+        let noted: HashMap<&str, &str> = listing
             .lines()
-            .filter_map(|l| l.split_whitespace().nth(1).map(str::to_owned))
+            .filter_map(|l| {
+                let mut parts = l.split_whitespace();
+                let blob = parts.next()?;
+                let commit = parts.next()?;
+                Some((commit, blob))
+            })
             .collect();
 
         if noted.is_empty() {
             return Ok(vec![]);
         }
 
-        // Walk git log in reverse-chronological order to get commit timestamps.
-        let log_out = self.git().args(["log", "--format=%H %at"]).output().await?;
+        let log_out = self.git().args(["log", "--format=%H"]).output().await?;
 
         if !log_out.status.success() {
             return Ok(vec![]);
         }
 
-        let pairs = String::from_utf8_lossy(&log_out.stdout)
+        let commits = String::from_utf8_lossy(&log_out.stdout)
             .lines()
             .filter_map(|line| {
-                let mut parts = line.split_whitespace();
-                let sha = parts.next()?.to_owned();
-                let ts: i64 = parts.next()?.parse().ok()?;
-                noted.contains(&sha).then_some((sha, ts))
+                let commit = line.trim();
+                noted.get(commit).map(|blob| NotedCommit {
+                    commit: commit.to_owned(),
+                    note_blob: (*blob).to_owned(),
+                })
             })
             .collect();
 
-        Ok(pairs)
+        Ok(commits)
+    }
+
+    /// Read every listed note blob in one `git cat-file --batch`, in the order
+    /// given.
+    ///
+    /// The fold needs every reachable blob, so a per-commit `git notes show`
+    /// would cost one subprocess each (~13 ms). Write paths keep `show`: they
+    /// read exactly one note.
+    async fn read_note_blobs(&self, blob_shas: &[String]) -> Result<Vec<String>> {
+        if blob_shas.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let mut cmd = self.git();
+        cmd.args(["cat-file", "--batch"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn()?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("failed to open stdin for git cat-file --batch"))?;
+
+        let mut request = blob_shas.join("\n");
+        request.push('\n');
+
+        // Write and drain concurrently: git blocks once the stdout pipe fills,
+        // so writing the whole request first would deadlock on a big enough repo.
+        let writer = async move {
+            stdin.write_all(request.as_bytes()).await?;
+            stdin.shutdown().await
+        };
+        let (write_res, out) = tokio::join!(writer, child.wait_with_output());
+
+        let out = out?;
+        if !out.status.success() {
+            return Err(anyhow!(
+                "git cat-file --batch: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ));
+        }
+        write_res?;
+
+        parse_cat_file_batch(&out.stdout)
     }
 
     /// Read the raw note blob for `commit_sha` (empty string if no note).
@@ -453,28 +511,12 @@ impl GitNotesBackend {
 
     /// Permissively parse the spelunk records from a commit's note blob.
     ///
-    /// The blob is JSON Lines interleaved with foreign content (prose, other
-    /// tools' lines). Foreign lines are skipped without error; only a record
-    /// from a newer, incompatible `schema_version` returns an error.
+    /// Sees one commit's blob, so it cannot see a second machine's copy of an
+    /// entity: at differing HEADs the copies land on different commits' notes.
+    /// The entity fold therefore lives in [`Self::collect`], not here.
     async fn read_records(&self, commit_sha: &str) -> Result<Vec<NoteRecord>> {
         let blob = self.read_note_blob(commit_sha).await?;
-        let mut records = Vec::new();
-        for line in blob.lines() {
-            match parse_spelunk_line(line) {
-                Some(record) => {
-                    if record.schema_version > 1 {
-                        return Err(anyhow::Error::new(
-                            crate::error::SpelunkError::SchemaMismatch {
-                                found: record.schema_version,
-                                max_known: 1,
-                            },
-                        ));
-                    }
-                    records.push(record);
-                }
-                None => continue, // foreign line: skip, never error
-            }
-        }
+        let mut records = parse_records(&blob)?;
         // `cat_sort_uniq` unions lines lexicographically, so after a merge blob
         // order is not chronological (ADR-069 D2). Stable: ties keep blob order.
         records.sort_by_key(|r| r.created_at);
@@ -529,6 +571,10 @@ impl GitNotesBackend {
         Ok(changed)
     }
 
+    /// Every entry on the ref, folded to one record per entity, then filtered.
+    ///
+    /// The only site that sees every commit's records, so the only site that
+    /// can fold an entity's copies together.
     async fn collect(
         &self,
         kind_filter: Option<&str>,
@@ -536,35 +582,125 @@ impl GitNotesBackend {
         as_of: Option<i64>,
         limit: usize,
     ) -> Result<Vec<Note>> {
-        let commits = self.noted_commits().await?;
-        let mut notes = Vec::new();
+        let blob_shas: Vec<String> = self
+            .noted_commits()
+            .await?
+            .into_iter()
+            .map(|c| c.note_blob)
+            .collect();
 
-        'outer: for (sha, _) in commits {
-            for record in self.read_records(&sha).await? {
-                if notes.len() >= limit {
-                    break 'outer;
-                }
-                if kind_filter.is_some_and(|k| record.kind != k) {
-                    continue;
-                }
-                if !include_archived && record.status == "archived" {
-                    continue;
-                }
-                if let Some(ts) = as_of {
-                    let effective = record.valid_at.unwrap_or(record.created_at);
-                    if effective > ts {
-                        continue;
-                    }
-                    if record.invalid_at.is_some_and(|ia| ia <= ts) {
-                        continue;
-                    }
-                }
-                notes.push(record_to_note(record));
-            }
+        let mut records = Vec::new();
+        for blob in self.read_note_blobs(&blob_shas).await? {
+            records.extend(parse_records(&blob)?);
         }
 
-        Ok(notes)
+        // Fold before every filter below. Dropping an archived copy first would
+        // leave a surviving active copy to resurrect the entity.
+        let mut folded = fold_records(records);
+
+        folded.retain(|record| {
+            if kind_filter.is_some_and(|k| record.kind != k) {
+                return false;
+            }
+            if !include_archived && record.status == "archived" {
+                return false;
+            }
+            if let Some(ts) = as_of {
+                let effective = record.valid_at.unwrap_or(record.created_at);
+                if effective > ts {
+                    return false;
+                }
+                if record.invalid_at.is_some_and(|ia| ia <= ts) {
+                    return false;
+                }
+            }
+            true
+        });
+
+        // Stable over first-encounter order, so ties keep blob order (D2).
+        folded.sort_by_key(|r| r.created_at);
+        if folded.len() > limit {
+            // Keep the newest, as the sqlite backend's `ORDER BY created_at
+            // DESC LIMIT` does. Folding first is what makes this exact.
+            folded.drain(..folded.len() - limit);
+        }
+
+        Ok(folded.into_iter().map(record_to_note).collect())
     }
+}
+
+/// A commit carrying a spelunk note, and the note's blob sha.
+struct NotedCommit {
+    commit: String,
+    note_blob: String,
+}
+
+/// Permissively parse the spelunk records from one note blob.
+///
+/// The blob is JSON Lines interleaved with foreign content (prose, other
+/// tools' lines). Foreign lines are skipped without error; only a record from
+/// a newer, incompatible `schema_version` returns an error.
+fn parse_records(blob: &str) -> Result<Vec<NoteRecord>> {
+    let mut records = Vec::new();
+    for line in blob.lines() {
+        match parse_spelunk_line(line) {
+            Some(record) => {
+                if record.schema_version > 1 {
+                    return Err(anyhow::Error::new(
+                        crate::error::SpelunkError::SchemaMismatch {
+                            found: record.schema_version,
+                            max_known: 1,
+                        },
+                    ));
+                }
+                records.push(record);
+            }
+            None => continue, // foreign line: skip, never error
+        }
+    }
+    Ok(records)
+}
+
+/// Split `git cat-file --batch` output into one body per requested object.
+///
+/// Each record is `<sha> <type> <size>\n<size bytes>\n`. The size header is the
+/// only safe delimiter: a note body contains newlines of its own.
+fn parse_cat_file_batch(out: &[u8]) -> Result<Vec<String>> {
+    let mut bodies = Vec::new();
+    let mut rest = out;
+
+    while !rest.is_empty() {
+        let nl = rest
+            .iter()
+            .position(|&b| b == b'\n')
+            .ok_or_else(|| anyhow!("git cat-file --batch: header with no newline"))?;
+        let header = String::from_utf8_lossy(&rest[..nl]).into_owned();
+        rest = &rest[nl + 1..];
+
+        let fields: Vec<&str> = header.split(' ').collect();
+        match fields.as_slice() {
+            // "<sha> missing" / "<sha> ambiguous": no body follows. A read must
+            // not break on one unreadable note.
+            [_, _] => bodies.push(String::new()),
+            [_, _, size] => {
+                let size: usize = size
+                    .parse()
+                    .map_err(|_| anyhow!("git cat-file --batch: bad size in {header:?}"))?;
+                if rest.len() < size + 1 {
+                    return Err(anyhow!("git cat-file --batch: truncated body"));
+                }
+                bodies.push(String::from_utf8_lossy(&rest[..size]).into_owned());
+                rest = &rest[size + 1..];
+            }
+            _ => {
+                return Err(anyhow!(
+                    "git cat-file --batch: unexpected header {header:?}"
+                ));
+            }
+        }
+    }
+
+    Ok(bodies)
 }
 
 /// Classify one line of a note blob: `Some(record)` if it parses as a JSON

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -718,3 +718,137 @@ fn parse_spelunk_line(line: &str) -> Option<NoteRecord> {
     }
     serde_json::from_value(value).ok()
 }
+
+/// The framing `git cat-file --batch` emits, pinned against git 2.55.
+#[cfg(test)]
+mod cat_file_batch {
+    use super::*;
+
+    /// One object: `<sha> <type> <size>\n<body>\n`.
+    fn framed(sha: &str, body: &str) -> String {
+        format!("{sha} blob {}\n{body}\n", body.len())
+    }
+
+    #[test]
+    fn empty_output_yields_no_bodies() {
+        assert!(parse_cat_file_batch(b"").expect("parse").is_empty());
+    }
+
+    /// A note body holds newlines of its own, so only the size header can
+    /// delimit it: a body line that mimics a header must not split it.
+    #[test]
+    fn a_body_that_mimics_a_header_is_not_split() {
+        let body = "line one\ndeadbeef blob 99\nline three";
+
+        assert_eq!(
+            parse_cat_file_batch(framed("aaa", body).as_bytes()).expect("parse"),
+            vec![body]
+        );
+    }
+
+    /// One unreadable note must not fail the whole read: git reports
+    /// `<sha> missing` with no body and still exits 0.
+    #[test]
+    fn a_missing_object_yields_an_empty_body_and_the_batch_survives() {
+        let out = format!(
+            "{}bbb missing\n{}",
+            framed("aaa", "first"),
+            framed("ccc", "third")
+        );
+
+        assert_eq!(
+            parse_cat_file_batch(out.as_bytes()).expect("parse"),
+            vec!["first", "", "third"]
+        );
+    }
+
+    /// `git notes add --allow-empty` writes the empty blob. Git still emits the
+    /// body's trailing newline, so a zero-length body must not read as truncated.
+    #[test]
+    fn an_empty_blob_parses_as_an_empty_body() {
+        assert_eq!(
+            parse_cat_file_batch(b"aaa blob 0\n\n").expect("parse"),
+            vec![""]
+        );
+    }
+
+    #[test]
+    fn a_body_shorter_than_its_header_claims_is_an_error() {
+        assert!(parse_cat_file_batch(b"aaa blob 99\nshort\n").is_err());
+    }
+
+    /// Records are consumed in request order, so a body can never be attributed
+    /// to the wrong note.
+    #[test]
+    fn bodies_come_back_in_request_order() {
+        let out = format!("{}{}", framed("aaa", "one"), framed("bbb", "two"));
+
+        assert_eq!(
+            parse_cat_file_batch(out.as_bytes()).expect("parse"),
+            vec!["one", "two"]
+        );
+    }
+
+    /// A repo carrying one note, and that note's blob sha.
+    fn repo_with_one_note() -> (tempfile::TempDir, String) {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let run = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir.path())
+                .output()
+                .expect("git");
+            assert!(
+                out.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            out
+        };
+
+        run(&["init", "-b", "main"]);
+        run(&["config", "user.email", "t@example.com"]);
+        run(&["config", "user.name", "T"]);
+        std::fs::write(dir.path().join("README.md"), "x").expect("write");
+        run(&["add", "."]);
+        run(&["commit", "--no-gpg-sign", "-m", "first"]);
+        run(&["notes", "--ref=spelunk", "add", "-m", "one\ntwo", "HEAD"]);
+
+        let listing =
+            String::from_utf8(run(&["notes", "--ref=spelunk", "list"]).stdout).expect("utf8");
+        let blob = listing
+            .split_whitespace()
+            .next()
+            .expect("a note blob sha")
+            .to_string();
+
+        (dir, blob)
+    }
+
+    /// The batch has to drain stdout while it writes stdin. Sending the whole
+    /// request first deadlocks: git stops reading once its stdout pipe fills,
+    /// and the fold reads every reachable blob, so `GIT_NOTES_MAX_LIST` does not
+    /// bound the request size.
+    ///
+    /// 5000 shas is ~205 KiB in and ~340 KiB out, past the 64 KiB pipe buffer
+    /// both ways. A regression here hangs, so the read is bounded to fail loudly.
+    #[tokio::test]
+    async fn a_request_past_the_pipe_buffer_does_not_deadlock() {
+        let (dir, blob) = repo_with_one_note();
+        let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
+
+        let bodies = tokio::time::timeout(
+            std::time::Duration::from_secs(60),
+            backend.read_note_blobs(&vec![blob; 5000]),
+        )
+        .await
+        .expect("deadlocked: stdout must drain while stdin is written")
+        .expect("read");
+
+        assert_eq!(bodies.len(), 5000, "one body per requested sha");
+        assert!(
+            bodies.iter().all(|b| b == "one\ntwo\n"),
+            "every body must survive the batch intact"
+        );
+    }
+}

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -2483,3 +2483,187 @@ async fn read_orders_records_by_created_at_with_entity_id_present() {
         "created_at order must hold with entity_id present"
     );
 }
+
+// ── The entity fold: one decision recorded twice is one entry ────────────────
+
+/// One entity, as a second machine would have recorded it: same
+/// `{kind, title, body}` (so the same `entity_id`), its own `id`/`created_at`/
+/// tags.
+fn entity_copy(title: &str, id: i64, created_at: i64, tags: &[&str]) -> NoteRecord {
+    let mut r = make_note_record(id, title);
+    r.created_at = created_at;
+    r.tags = tags.iter().map(|t| t.to_string()).collect();
+    r
+}
+
+fn write_lines(root: &std::path::Path, records: &[&NoteRecord]) {
+    let lines: Vec<String> = records
+        .iter()
+        .map(|r| serde_json::to_string(r).expect("serialize"))
+        .collect();
+    write_raw_note(root, &lines.join("\n"));
+}
+
+/// Two machines at the same HEAD: `cat_sort_uniq` leaves both copies as two
+/// lines of one blob, and the read folds them into one entry.
+#[tokio::test]
+#[serial]
+async fn same_head_duplicate_folds_to_one_entry() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    let mine = entity_copy("shared decision", 1, 100, &["a"]);
+    let theirs = entity_copy("shared decision", 7, 300, &["b"]);
+    assert_eq!(
+        mine.resolve_entity_id(),
+        theirs.resolve_entity_id(),
+        "fixture: both copies must be one entity"
+    );
+    assert_ne!(mine.id, theirs.id, "fixture: rowids differ per machine");
+
+    write_lines(root, &[&theirs, &mine]);
+
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+    let notes = backend.list(None, 50, false, None).await.expect("list");
+
+    assert_eq!(notes.len(), 1, "one decision, one entry, got: {notes:?}");
+    assert_eq!(notes[0].created_at, 100, "earliest recording survives");
+    assert_eq!(notes[0].tags, vec!["a", "b"], "tags merge by union");
+}
+
+/// Two machines at **different** HEADs: the copies land on two separate notes,
+/// so only a fold that sees every commit can collapse them.
+///
+/// This is the test that pins the fold's placement: it fails if the fold moves
+/// into `read_records`, which sees one commit's blob at a time.
+#[tokio::test]
+#[serial]
+async fn different_head_duplicate_folds_to_one_entry() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    // Their copy, recorded at their HEAD, arriving via `git fetch`.
+    append_to_git_notes(Some(root), &entity_copy("shared decision", 7, 300, &["b"]))
+        .await
+        .expect("seed theirs");
+    park_working_ref_as_tracking(root);
+
+    // We commit before recording, so our copy attaches to a different commit.
+    commit_file(root, "work.txt", "our work");
+    append_to_git_notes(Some(root), &entity_copy("shared decision", 1, 100, &["a"]))
+        .await
+        .expect("seed mine");
+
+    assert_eq!(
+        merge_tracking_notes(Some(root)).await,
+        NotesMergeOutcome::Merged
+    );
+
+    let listing = git_stdout_at(root, &["notes", "--ref=spelunk", "list"]);
+    assert_eq!(
+        listing.lines().count(),
+        2,
+        "fixture: the copies must sit on two separate notes, got: {listing}"
+    );
+
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+    let notes = backend.list(None, 50, false, None).await.expect("list");
+
+    assert_eq!(
+        notes.len(),
+        1,
+        "one decision recorded on two machines is one entry, got: {notes:?}"
+    );
+    assert_eq!(notes[0].created_at, 100, "earliest recording survives");
+    assert_eq!(
+        notes[0].tags,
+        vec!["a", "b"],
+        "tags union across two commits' notes"
+    );
+}
+
+/// Archival is monotonic, and the fold runs before the status filter: filtering
+/// first would drop the archived copy and let the active one resurrect the
+/// entity as live.
+#[tokio::test]
+#[serial]
+async fn an_archived_copy_wins_and_the_entity_stays_hidden() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    let active = entity_copy("shared decision", 1, 100, &[]);
+    let mut archived = entity_copy("shared decision", 7, 300, &[]);
+    archived.status = "archived".to_string();
+
+    write_lines(root, &[&active, &archived]);
+
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+
+    let visible = backend.list(None, 50, false, None).await.expect("list");
+    assert!(
+        visible.is_empty(),
+        "an archived entity must not come back as active, got: {visible:?}"
+    );
+
+    let all = backend.list(None, 50, true, None).await.expect("list all");
+    assert_eq!(all.len(), 1, "still one entity, got: {all:?}");
+    assert_eq!(all[0].status, "archived");
+}
+
+/// A line written before `entity_id` existed folds with a fresh copy of the
+/// same entry: `resolve_entity_id()` recomputes the key it never stored.
+#[tokio::test]
+#[serial]
+async fn a_legacy_line_folds_with_a_fresh_copy_of_the_same_entry() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    let fresh = entity_copy("shared decision", 2, 300, &["new"]);
+    let legacy = format!(
+        r#"{{"schema_version":1,"id":1,"kind":"decision","title":"shared decision","body":"{}","tags":["old"],"linked_files":[],"created_at":100,"status":"active"}}"#,
+        fresh.body
+    );
+    assert!(
+        !legacy.contains("entity_id"),
+        "fixture: the legacy line must not carry the key"
+    );
+
+    write_raw_note(
+        root,
+        &[legacy, serde_json::to_string(&fresh).expect("serialize")].join("\n"),
+    );
+
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+    let notes = backend.list(None, 50, false, None).await.expect("list");
+
+    assert_eq!(
+        notes.len(),
+        1,
+        "a recomputed entity_id must fold with a stored one, got: {notes:?}"
+    );
+    assert_eq!(notes[0].created_at, 100, "the legacy copy is the earliest");
+    assert_eq!(notes[0].tags, vec!["new", "old"], "tags merge by union");
+}
+
+/// The fold collapses copies, never distinct entries.
+#[tokio::test]
+#[serial]
+async fn three_distinct_entities_stay_three_entries() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    let first = entity_copy("first", 1, 100, &[]);
+    let second = entity_copy("second", 2, 200, &[]);
+    let third = entity_copy("third", 3, 300, &[]);
+    write_lines(root, &[&first, &second, &third]);
+
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+    let notes = backend.list(None, 50, false, None).await.expect("list");
+    let titles: Vec<&str> = notes.iter().map(|n| n.title.as_str()).collect();
+
+    assert_eq!(
+        titles,
+        vec!["first", "second", "third"],
+        "distinct entities must not collapse"
+    );
+}

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -2645,6 +2645,61 @@ async fn a_legacy_line_folds_with_a_fresh_copy_of_the_same_entry() {
     assert_eq!(notes[0].tags, vec!["new", "old"], "tags merge by union");
 }
 
+/// `limit` keeps the **newest** entries, as the sqlite backend's
+/// `ORDER BY created_at DESC LIMIT` does, and still emits them ascending.
+///
+/// The failure this pins: a repo past the cap returning its oldest entries and
+/// hiding every recent decision.
+#[tokio::test]
+#[serial]
+async fn limit_keeps_the_newest_entries_and_emits_them_ascending() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    let records: Vec<NoteRecord> = (1..=5)
+        .map(|i| entity_copy(&format!("decision {i}"), i, i * 100, &[]))
+        .collect();
+    write_lines(root, &records.iter().collect::<Vec<_>>());
+
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+    let notes = backend.list(None, 2, false, None).await.expect("list");
+    let titles: Vec<&str> = notes.iter().map(|n| n.title.as_str()).collect();
+
+    assert_eq!(
+        titles,
+        vec!["decision 4", "decision 5"],
+        "the newest N, oldest-first"
+    );
+}
+
+/// Folding before `limit` is what makes the count exact: were `limit` applied
+/// to raw records, an entity's copies would each spend a slot and the read
+/// would return fewer entries than asked for.
+#[tokio::test]
+#[serial]
+async fn duplicate_copies_do_not_spend_the_limit_budget() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    // One decision recorded on three machines, plus two others.
+    let a1 = entity_copy("recorded thrice", 1, 100, &[]);
+    let a2 = entity_copy("recorded thrice", 2, 110, &[]);
+    let a3 = entity_copy("recorded thrice", 3, 120, &[]);
+    let b = entity_copy("second", 4, 200, &[]);
+    let c = entity_copy("third", 5, 300, &[]);
+    write_lines(root, &[&a1, &a2, &a3, &b, &c]);
+
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+    let notes = backend.list(None, 3, false, None).await.expect("list");
+    let titles: Vec<&str> = notes.iter().map(|n| n.title.as_str()).collect();
+
+    assert_eq!(
+        titles,
+        vec!["recorded thrice", "second", "third"],
+        "three entities must fill a limit of three, got: {titles:?}"
+    );
+}
+
 /// The fold collapses copies, never distinct entries.
 #[tokio::test]
 #[serial]

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -41,6 +41,12 @@ changes its identity. (The numeric `id` in `memory list` output is a local row
 number rather than an identity: `spelunk init` renumbers it, and each machine
 assigns it independently.)
 
+When duplicate records of the same decision appear (for example, both machines
+pushing their notes to a shared repository), `memory list`, `memory context`,
+and `memory search` automatically fold them into one entry by identity, so you
+see each decision exactly once. Tags and linked_files are merged across copies
+(values are added, never removed), and the earliest creation time is preserved.
+
 **Before `spelunk init`**, `memory add` and `memory list` still work when you are
 inside a git repository: with no `.spelunk/` project, `add` rides the same
 write-through carrier (there is no SQLite primary yet) and `list` reads entries

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -41,11 +41,14 @@ changes its identity. (The numeric `id` in `memory list` output is a local row
 number rather than an identity: `spelunk init` renumbers it, and each machine
 assigns it independently.)
 
-When duplicate records of the same decision appear (for example, both machines
-pushing their notes to a shared repository), `memory list`, `memory context`,
-and `memory search` automatically fold them into one entry by identity, so you
-see each decision exactly once. Tags and linked_files are merged across copies
-(values are added, never removed), and the earliest creation time is preserved.
+Because identity is content-derived, two clones can carry their own copy of the
+same entry, and once the notes refs meet, both copies are there. `spelunk memory
+list` and `spelunk context` therefore fold copies by identity as they read, so a
+decision two people recorded independently appears once rather than twice. The
+surviving entry carries the earliest recording time, and the union of the copies'
+`tags` and `linked_files` (values are added, never removed). An entry archived in
+any copy reads as archived everywhere, so archiving it on one machine does not
+un-archive when a still-active copy arrives from another.
 
 **Before `spelunk init`**, `memory add` and `memory list` still work when you are
 inside a git repository: with no `.spelunk/` project, `add` rides the same


### PR DESCRIPTION
Two machines that independently record the same decision derive the same content identity for it, but the git-notes read path never used that identity. `cat_sort_uniq` kept both copies, so `spelunk memory list` and `spelunk context` showed the decision twice, with the proof they were the same entry sitting unread in both lines.

## What changed

**The fold** (`git_notes/fold.rs`, new). Records are grouped by `resolve_entity_id()` and folded to one entry per entity: `tags`/`linked_files` unioned (add-wins, never removed), earliest `created_at` kept, archived-on-any-copy wins, smallest `Some` for supersede links. Every rule is commutative, associative and idempotent, so any merge order across any number of machines converges.

**Placement is load-bearing.** The fold lives in `collect`, not `read_records`. `read_records` sees one commit's blob; once anyone has committed, two machines' copies of a decision live on *different* commits' notes, so a fold there provably cannot see them. `collect` is the only site that sees every commit.

**Order is load-bearing.** The fold runs before the kind/status/`as_of` filters and before `limit`. Filtering an archived copy out first would leave a surviving active copy to resurrect the entity: a correctness bug, not a cosmetic one. Folding before `limit` also stops duplicate copies spending the limit budget.

**Batched blob reads.** The fold has to see every copy before it can emit one, so a read can no longer stop as soon as it has enough entries. Note blobs are therefore read with a single `git cat-file --batch` rather than one `git notes show` subprocess per note. The batch writes stdin and drains stdout concurrently, because writing the whole request first deadlocks once the stdout pipe fills. Write paths keep `git notes show`, which reads a single note.

Reachability semantics are unchanged: only notes on commits reachable from HEAD are read.

## Test plan

Every step below was run against this branch. The workspace shares a `CARGO_TARGET_DIR` with other checkouts of the same package, which can silently serve another checkout's artifact as a green run, so sources were `touch`ed and each test binary was confirmed to print `Compiling spelunk-core v0.9.3` naming *this* working tree before its result was accepted.

Gates, each run without a pipe so the real exit status is observed:

- `cargo fmt --all -- --check` → 0
- `cargo clippy --all-targets --features rich-formats -- -D warnings` → 0
- `cargo nextest run` → 0, **1088 passed**
- `cargo test --doc` → 0
- `cargo nextest run -p spelunk-core --no-default-features` → 0, **439 passed**
- `cargo test --doc -p spelunk-core --no-default-features` → 0

Behaviour verified directly:

- Ran the six specified cases and confirmed each passes: same-HEAD duplicate folds to one entry (earliest `created_at`, tags unioned); different-HEAD duplicate folds to one entry; an archived copy wins and the entity stays hidden from a default `list`; a legacy line with no identity field folds with a fresh copy of the same entry; folding converges over every permutation and is idempotent; three distinct entities stay three entries.
- **Proved the placement discriminates rather than trusting it.** Temporarily moved the fold per-blob (what a fold in `read_records` can see) and re-ran: `same_head_duplicate_folds_to_one_entry` still **passed** (so it is not a placement test), while `different_head_duplicate_folds_to_one_entry` **failed `left: 2, right: 1`**, returning the decision twice with tags `["a"]` and `["b"]`: the exact user-visible bug. Reverted; tree clean, no probe left behind.
- Confirmed the `--limit` direction keeps the **newest** entries and emits them ascending, matching the sqlite backend's `ORDER BY created_at DESC LIMIT`. Read the old `collect` on `main` to confirm it early-broke at `limit` before the filters, so the batching claim in the changelog is scoped to reads that walk every note rather than stated as a universal win.
- `git cat-file --batch` edges pinned against real git: missing/garbage/ambiguous objects exit 0 and are handled as an empty body; an empty note's `size + 1` framing is exact; the concurrent-drain deadlock guard is exercised past the pipe buffer in both directions.

Documentation accuracy checked against the code rather than against the prose:

- `collect` has exactly one caller (`list`), and `GitNotesBackend`'s search methods all return `BackendUnsupported` with no fallback, so the fold is unreachable from `memory search`. An earlier draft claimed this fix changed `memory search` output; corrected.
- `context` is a top-level command (`spelunk context`), not a `memory` subcommand. An earlier draft wrote `memory context`; corrected.
- The changelog's performance note carries the mechanism and the causal story (the fold cannot stop early, therefore blobs are batched) and cites no figure, because the only measurements came from a synthetic harness that no longer exists and so cannot be reproduced by a reader.
- Re-read the whole `[Unreleased]` block: the import-time dedup entries (`memory reconcile`, `spelunk init`) are write-time and remain true, and read-time folding complements them. Nothing already in the block is falsified by this change.

Branch is even with `main` at its fork point: no commits landed on `main` since, so nothing to rebase over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
