### PR TITLE
docs(adr): mark ADR-002's lm_studio_url migration block superseded

### DIFF
--- a/docs/adr/002-server-ai-endpoints.md
+++ b/docs/adr/002-server-ai-endpoints.md
@@ -35,6 +35,14 @@ emits an actionable error (`harvest_requires_server`).
 
 ## Migration — `lm_studio_url` users
 
+> **Superseded. Kept as the v0.8 record.** Both halves below have since been
+> overtaken: the shipped binary refuses a non-loopback plaintext `http://`
+> `server_url` (use `https://`, or a loopback host), and `api_base_url` /
+> `lm_studio_url` are now parsed but ignored rather than still serving
+> `explore` and `index --summarize`. All inference routes through
+> `spelunk-server`. For current `server_url` configuration see
+> [Team setup](../getting-started.md#team-setup-shared-memory-with-spelunk-server).
+
 If you previously used `lm_studio_url` (or `api_base_url`) in your config for
 `spelunk memory harvest`, update `~/.config/spelunk/config.toml`:
 


### PR DESCRIPTION
ADR-002's "Migration — `lm_studio_url` users" block hands the reader a config the shipped binary hard-refuses. This marks the block superseded rather than rewriting it.

## The defect

Line 46 instructs:

```toml
server_url = "http://your-spelunk-server:7777"
```

Pasted verbatim into a project config against `spelunk-cli 0.9.4-local`, that gives **exit 2** on `memory add`, `search` and `check`:

```
error: invalid server URL "http://your-spelunk-server:7777": plaintext http:// is only allowed to a
loopback address (127.0.0.1/::1/localhost); use https:// for any other host
```

Enforced by `validate_transport_url` (`config.rs:924`) via `storage/mod.rs:114`, `capability.rs:443`, `server_client.rs:155`. The `https://` variant clears it (exit 0). A reader following the migration lands on a hard refusal with no working value anywhere in the block.

## Why superseded rather than corrected

The obvious fix is `http://` → `https://`. That would be wrong, and this is the reasoning worth your eye.

**The block has a second, independent defect** that the original report missed: lines 59-61 claim `api_base_url` / `lm_studio_url` "continue to work for `spelunk explore` and `spelunk index --summarize`". That is false today. There are zero production references; `config.rs:1181-1206` locks them as pruned-dead keys that parse but are ignored (a forward-compat guard for pre-0.9 configs); and the 0.9.3 CHANGELOG records "Retired the `api_base_url` client egress path". All inference now routes through `spelunk-server`.

Once **both** halves are stale, the block is no longer live guidance - it is history. Correcting the scheme in place would have made an obsolete v0.8 path look current and maintained, which is a worse failure than the one being fixed: it would convert a visibly-broken recipe into an invisibly-broken one.

So the block is marked and its contents left untouched. The v0.8 record survives intact. The concrete fix (`use https://, or a loopback host`) sits **inside** the marker, so a skimming reader still gets a working value without the block pretending to be live, and a pointer goes to `docs/getting-started.md` Team setup - the live maintained surface, which already states the loopback/https rule with a correct example.

## The policy this establishes

Recorded in the architect persona instructions rather than a freestanding doc. The test:

- **Is this still the path we want a reader on?** If no: blockquote it; the contents become provenance.
- **If yes: is the defect in the decision, or the illustration?** Illustrations (placeholder hosts, schemes, formatting) are fixable in place. Decisions and their consequences get marked, never rewritten.

"It was true when written" does not settle it - everything in an ADR was. This will recur every time a rule invalidates an older ADR's example, so the policy is the durable artifact here; this file is just the first application.

## Verification

Docs-only; no code changes, so no test suite applies. What was actually done rather than asserted:

- Reproduced the refusal in an `init`-ed scratch project against the installed binary, on three commands, and confirmed the `https://` variant clears.
- Traced enforcement to `validate_transport_url` and its three call sites.
- **Two hypotheses were formed and killed by checking.** First: that `server_url` relocates the memory store - it does not; only `CloudFirst` mode routes remote (`storage/mod.rs:102`). Second: that the migration was superseded "by v0.9" - wrong; routing changed at **0.8.0**, ADR-002's own era. That second check caught a bad pointer in the first draft, which cited a CHANGELOG section that turned out to sit under 0.8.0.

No Status field touched; the decision text and security notes are untouched.

## Also found, filed separately

**ADR-002's number is used twice**: `002-server-ai-endpoint-contract.md` (the decision doc) and `002-server-ai-endpoints.md` (added later with the implementation; the only one carrying the migration block). ADR numbering is a single global sequence, so this wants cleanup - out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)