### PR TITLE
docs(adr): ADR-069 D8: a notes writer that cannot take the lock fails, never proceeds unlocked

### DIFF
--- a/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
+++ b/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
@@ -345,6 +345,14 @@ lock is not optional.
 
 ### D6 – serialize note writes with a spelunk-owned lock
 
+> **The bounded-degradation clause below is superseded by D8.** Its closing
+> paragraph reads the budget's expiry as "skip the merge and read anyway," which
+> is right for the read-path merge it was written about and wrong for a writer:
+> a writer that proceeds past the budget performs the very read-modify-write
+> this section exists to prevent. D8 replaces that policy and states it per
+> caller. The rest of D6, including the decision to take a spelunk-owned lock
+> around the whole read-modify-write, stands and was not reconsidered.
+
 `append_to_git_notes` (`crates/spelunk-core/src/storage/git_notes/mod.rs:38-73`)
 is a **lock-free read-modify-write**: step 2 reads the note body
 (`notes show`), step 4 writes the whole body back (`notes add -f -F -`), and
@@ -427,6 +435,107 @@ anything that assumed so needs to stop.
 hidden, and not shouted about. `spelunk hooks install --pre-push` stays the
 porcelain a user is pointed at (D3), and the `init` announcement names that
 command, not this one.
+
+### D8 – a writer that cannot take the notes lock fails; it never proceeds unlocked
+
+Added on review of a `windows-latest` CI failure in D6's own regression guard.
+
+**The rule D6 left implicit, stated:** the contention policy is set by *what is
+lost when the lock is missing*, not by whether the caller is nominally a read or
+a write. Three cases, three answers:
+
+- **Proceeding unlocked can destroy a record.** `append_to_git_notes`,
+  `append_record` and `archive_record` are the exact read-modify-write #185
+  describes. They must hold the lock or **fail**. They never proceed unlocked.
+- **The work is idempotent and retried on the next invocation.** D5's read-path
+  merge and D7's publish lose nothing permanent by not running now. They
+  **skip**, report the skip, and never fail the caller.
+- **The lock cannot be established at all on this filesystem.** Serialization is
+  impossible there, so failing every write would make spelunk unusable on that
+  filesystem in order to prevent a race that needs a second concurrent writer to
+  matter. These **proceed unlocked, loudly**. This is the one degradation kept,
+  and it is kept narrow.
+
+**Why "never fail the caller" was the wrong reading for a writer.** D6 bounded
+the lock: "if it is contended or the wait exceeds a small budget, skip the merge
+and read anyway... A read must never fail because it could not take the lock."
+That clause is about **the merge on a read path**, where skipping costs
+freshness and nothing else. The implementation generalized it to writers.
+`lock_notes` returns `None` on a contended timeout and all three writer call
+sites discard it (`let _lock = lock_notes(...)`), so a writer that times out
+performs the unserialized read-modify-write D6 exists to prevent, and exits 0.
+"A command must never fail because of lock contention" is being bought with "a
+command sometimes silently loses the user's decision." For a tool whose promise
+is that it remembers why, that is the worse half of the trade. An error the user
+can see and retry costs them a command. A silent clobber costs them the record.
+
+**The wait budget is a watchdog, not a contention threshold.** `lock.rs`
+justifies its 5s budget by the holder cost ("~30ms"), which frames it as a
+number tuned against expected contention. That framing is wrong twice over.
+First, an OS advisory lock (`flock`, `LockFileEx`) is released by the kernel
+when the holding process dies, so a **stale lock cannot happen** and there is no
+crashed-holder case to time out for. The only thing a budget protects against is
+a live holder that never releases, which is a bug, or a deadlock. Second, a
+threshold tuned on one platform's timings becomes a correctness knob the moment
+its expiry silently changes behaviour.
+
+So the budget stays a **single constant**. It is *not* scaled per platform and
+*not* derived from observed holder cost: both add tuning to a number that should
+never be reached. It is set generously enough that reaching it means a bug
+rather than a busy repo, and its expiry is an **error**, never a downgrade.
+Making expiry loud is what makes a generous budget safe, and making the budget
+generous is what keeps the loud expiry rare enough that "a writer can fail" is
+not a practical regression.
+
+**`Option` is the wrong shape and is replaced.** `None` today means three
+different things: someone else holds the lock, the lock file cannot be opened,
+and the lock path could not be resolved. D8 gives those three different answers,
+so they cannot share one return value. `lock_notes` returns a three-way outcome
+(acquired, contended, unavailable-with-reason). The guard is `#[must_use]` so a
+caller cannot collapse the distinction back down with `let _`.
+
+**D7's publish path under contention: skip, report, do not fail the push.**
+Publishing is a fetch, a merge and a write-back, so by mechanism it is a writer.
+But its work is idempotent (D2), and records it did not publish stay in the
+local ref and publish on the next push, so a skipped publish loses nothing
+permanent. It therefore takes the second branch, not the first. This keeps D3's
+best-effort stance intact (spelunk does not block a push) without reintroducing
+the unlocked write-back that D7 moved publish into Rust to close. The skip is
+reported on the push output rather than swallowed: a user whose memory did not
+publish needs to know that it did not.
+
+**The degraded path must be observable, because its silence is why this needed a
+CI failure to surface.** Every branch above reports through `tracing::warn!`
+today. The integration tests install no subscriber, so those events go nowhere,
+and a test run cannot distinguish "the lock was held" from "the lock was skipped
+and the write raced." The outcome above is a returned value precisely so that
+callers and tests can assert on it directly rather than inferring it from
+damage.
+
+**What D8 does not do: it does not by itself fix the `windows-latest` failure
+that prompted it.** The evidence rules the timeout path out as that mechanism.
+In one run the cross-worktree guard
+(`append_to_git_notes_concurrent_worktrees_all_survive`) failed in **2.569s**,
+having lost 1 of 8 entries. In the same run, on the same runner,
+`append_to_git_notes_proceeds_when_lock_budget_is_exhausted` passed in
+**6.189s**. That test forces a real budget exhaustion, so it calibrates the cost
+of one: over 5s. A 2.569s failure cannot contain a 5s wait. In the same run the
+single-repo guard (`append_to_git_notes_concurrent_writers_all_survive`, eight
+concurrent writers in one process) **passed** in 2.460s, and the lock's own
+contract tests passed, which together show the primitive excludes and times out
+correctly on Windows.
+
+What is left is that two contenders do not converge on one lock file when they
+sit in **different worktrees** on Windows. `notes_lock_path` reaches that path by
+two different branches: a main worktree gets a relative answer from
+`git rev-parse --git-common-dir` (`.git`) and joins it against the repo root,
+while a linked worktree gets an absolute answer and uses it as-is. On unix both
+branches land on the same file, which is why only the Windows cell fails.
+Deciding which of those two strings is wrong on Windows needs a Windows host,
+and the warning that would say so is discarded, per the observability point
+above. That is a defect in lock **identity** and is fixed separately. D8 governs
+what a writer does once it knows it does not hold the lock, which is a question
+the identity fix does not answer and which the current code answers wrongly.
 
 ## Non-goals
 


### PR DESCRIPTION
## What

Amends ADR-069 rather than opening a new ADR: D6 is still the section a reader
looks in for "what happens when a notes writer cannot take the lock." Adds **D8**
and marks D6's bounded-degradation clause superseded with a blockquote, following
the pattern D1/D5/D7 already establish in that file. D6's core decision (take a
spelunk-owned lock around the whole read-modify-write) stands and was not
reconsidered.

Docs-only. No ADR number consumed.

## The decision

The contention policy is set by **what is lost when the lock is missing**, not by
whether the caller is a read or a write:

| Caller | Lock unavailable |
|---|---|
| `append_to_git_notes`, `append_record`, `archive_record` | **Fail.** Never proceed unlocked. |
| D5 read-path merge, **D7 publish** | **Skip**, report, never fail the caller. |
| Filesystem where locking is impossible | Proceed unlocked, loudly. The one degradation kept. |

Supporting changes: the budget becomes a **watchdog** whose expiry is an error
(an OS advisory lock is released by the kernel on process death, so a stale lock
cannot happen, so there is nothing to time out *for*); it is **not** scaled per
platform; and `Option` splits into a three-way outcome because `None` currently
means three things that want three different answers.

**D7's publish path under contention: skip, report, do not fail the push.**
Publish is a writer by mechanism, but its work is idempotent (D2) and unpublished
records publish on the next push, so skipping loses nothing permanent. That keeps
D3's best-effort stance without reintroducing the unlocked write-back D7 moved
publish into Rust to close.

## What I verified, and how

The brief hypothesized that the 5s budget is exhausted on Windows, so losers
"proceed unlocked" and clobber. **Refuted, with a same-run calibration point:**

- The failing test is `append_to_git_notes_concurrent_worktrees_all_survive`
  (**cross-worktree**), not the single-repo guard. Run 29409485808: FAIL in
  **2.569s**, lost id [4]. Run 29408116263: FAIL in **2.306s**, lost id [6].
- In the *same run, same runner*, `append_to_git_notes_proceeds_when_lock_budget_is_exhausted`
  **passed in 6.189s**. That test forces a real budget exhaustion, so it
  calibrates the cost of one: over 5s. A 2.569s failure cannot contain a 5s wait.
- Also in that run, the single-repo guard
  `append_to_git_notes_concurrent_writers_all_survive` (eight writers, one
  process) **passed** in 2.460s, and the lock's contract tests passed. The
  primitive excludes and times out correctly on Windows.

So writers are **not** hitting the timeout path. They believe they hold the lock.
The residual defect is lock **identity**: two worktrees do not converge on one
lock file on Windows. `notes_lock_path` reaches the path by two branches (main
worktree gets relative `.git` and joins it; linked worktree gets an absolute path
and uses it as-is). I confirmed that asymmetry locally: `git rev-parse
--git-common-dir` answers `.git` from a main worktree and an absolute path from a
linked one. On unix both land on the same file, which is why only Windows fails.

I could **not** determine which string is wrong on Windows: it needs a Windows
host, and the warning that would say so is discarded (see below). The ADR records
that boundary rather than inventing a mechanism, and scopes D8 to the policy
question the evidence does settle.

**Therefore D8 does not by itself fix the Windows failure**, and the ADR says so
explicitly. Lock identity is a separate defect needing a separate fix.

## Test plan

Docs-only, so the verification is the reasoning and the evidence:

1. Pulled both failing Windows runs and extracted per-test durations:
   `gh run view 29409485808 --log-failed` and `gh run view 29408116263 --log-failed`.
   Confirmed the failing test name, the durations above, and that the single-repo
   guard passed alongside it.
2. Read `storage/git_notes/lock.rs` and confirmed the 5s budget, the `None`
   returns, and the "~30ms holder" justification quoted in D8.
3. Confirmed **three** writer call sites discard the lock
   (`git_notes/mod.rs:128`, `:534`, `:552` are all `let _lock = lock_notes(...)`),
   and that `merge_tracking_notes:204` correctly skips via `let Some(_lock) = ... else`.
   D8's per-caller table matches the real call graph.
4. Reproduced the `--git-common-dir` asymmetry locally in a scratch repo plus
   linked worktree (relative from main, absolute from linked).
5. Grepped `docs/adr/` in **both** repos: 000-069 used (026 is a gap), so 070 was
   next-free. Chose amendment, so no number is consumed and no collision is
   created.
6. Public-repo constraints on the staged diff: board refs (both classes) clean;
   em-dashes on added lines clean.

## Needs your call

D8 makes `memory add` able to **fail** under lock contention, reversing "a
caller's command must never fail because of lock contention." I argue the budget
becoming a generous watchdog makes that practically unreachable, so it is a
safety net rather than a new failure mode. But it is a real reversal of a stated
property and it is your call to accept.

It also invalidates `append_to_git_notes_proceeds_when_lock_budget_is_exhausted`,
which encodes the behaviour being reversed. That test must invert when D8 is
implemented. `append_to_git_notes_proceeds_when_lock_file_is_unusable` stays valid
(third branch, unchanged).

## Found and deliberately left

- **PR #618** ("ADR-069 amendment - the publish merge takes the D6 lock via a
  plumbing command") looks superseded by #625, which merged the same D7
  amendment from a different branch. Not mine to close.
- The lock-identity fix itself is implementation and out of scope here.
- The tests install no `tracing` subscriber, so every `tracing::warn!` in
  `lock.rs` goes nowhere in CI. This is why the degraded path is undiagnosable
  from a CI log. D8 makes the outcome a returned value so tests can assert on it;
  wiring a subscriber into the test harness is a separate improvement I did not
  file.