### PR TITLE
docs(adr): ADR-070: init embed lifecycle and the search warmup contract

### DIFF
--- a/docs/adr/070-init-embed-lifecycle-and-search-warmup-contract.md
+++ b/docs/adr/070-init-embed-lifecycle-and-search-warmup-contract.md
@@ -364,25 +364,53 @@ whose unit does not match the cost it is predicting.
 
 The second face is measured. On a 581-chunk index the CLI sent **837 chunks
 across 7 requests**; `837 − 581 = 256`, exactly one batch computed by the server
-and then discarded:
+and then discarded. `RateEstimate` is an EMA, so the state that set batch 5's
+deadline is the blend of every sample before it, not the latest sample.
+Reconstructed from the request arrival times (the audit log fires on handler
+entry, and the global concurrency cap of 256 means the retry never queued, so
+each timestamp is a send time):
 
-1. Batch 4 was 256 tiny chunks (192 chars each) and ran in 7s, so `per_entry`
-   calibrated to **27ms**.
-2. `next_batch_size` divided the 240s target by 27ms, asked for far more than the
-   `MAX_BATCH = 256` ceiling, and got 256.
-3. `batch_timeout` = `TIMEOUT_SAFETY_FACTOR (4) × 0.027 × 256` = **28s**, floored
-   up to `MIN_REQUEST_TIMEOUT` = **60s**.
-4. Batch 5 was 256 chunks at **7.4x the size** and needed **73s**. At 73s > 60s
-   the client abandoned it, halved to 128 and retried. The server never learns a
-   client gave up: it finished all 73s of GPU work and threw the result away.
+| batch | chunks | took | sample | `per_entry` (EMA) | `batch_timeout` |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 1 | 0.054s | 54.0ms | 54.0ms | 60.0s (floored) |
+| 2 | 4 | 0.219s | 54.8ms | 54.7ms | 60.0s (floored) |
+| 3 | 32 | 5.717s | 178.7ms | 116.7ms | 119.5s |
+| 4 | 256 | 6.795s | 26.5ms | **71.6ms** | **73.3s** |
+| 5 | 256 | **≥73.076s** | **≥285.5ms** | - | - |
+
+1. After four batches the EMA sits at `per_entry` = **71.6ms**. Batch 4's raw
+   sample was 26.5ms, but the blend is dominated by batch 3's slow 178.7ms
+   sample.
+2. `next_batch_size` divided the 240s target by 71.6ms, asked for 3,352 chunks,
+   far more than the `MAX_BATCH = 256` ceiling, and got 256.
+3. `batch_timeout` = `TIMEOUT_SAFETY_FACTOR (4) × 0.0716 × 256` = **73.3s**,
+   comfortably inside the `[60s, 1800s]` clamp range: **no clamping occurred,
+   and the `MIN_REQUEST_TIMEOUT` floor never engaged.**
+4. Batch 5 was 256 chunks at **7.4x the size** (192 to 1,415 chars/chunk, as
+   the queue crosses from tiny chunks into 120-line windowed ones), and its
+   real cost was **≥285.5ms/chunk**. At 73.3s the client abandoned it, halved
+   to 128 and retried. The server never learns a client gave up: it finished
+   all ~73s of GPU work and threw the result away.
+
+The predicted 73.3s deadline matches the observed 73.076s gap between the
+abandoning request and its retry to **0.3%**, which is strong evidence this
+reconstruction is the actual mechanism and not a story fitted after the fact.
 
 **~73s of a 198.2s run is wasted GPU: 37%.** Reproduced on an idle box, so it is
-not contention. Note which guard saved it: the 4x safety factor did **not**. It
-computed 28s for a batch that needed 73s, because a 4x margin on a rate that is
-wrong by 7.4x is still wrong. Only the 60s floor, which is not derived from the
-rate at all, bounded the damage. And the sizing consumer is not an innocent
-bystander here: the same bad rate is what selected an oversized batch *and* then
-under-budgeted the time for it.
+not contention. Note which guard saved it: **none did.** The 4x safety factor
+did not, because batch 5's real cost was a **4.0x** under-estimate
+(285.5 / 71.6) against a 4x margin: the margin was consumed exactly, leaving
+zero. The floor did nothing; it was never reached. Nothing bounded the damage.
+The deadline landed essentially on the batch's own completion time, which is
+the *maximal-waste* case: the client waits the full duration and then throws
+the result away anyway. And the sizing consumer is not an innocent bystander
+here: the same rate selected an oversized batch *and* set the deadline that
+batch's own cost would consume to the wire.
+
+That the server computes an abandoned batch to completion regardless is an
+**independent fault (no request cancellation on client disconnect) with an
+independent fix**: a token-weighted rate makes spurious timeouts rarer, not
+impossible, so this is out of scope here and tracked as issue #631.
 
 So the estimator defect and the timeout defect are **one defect with two faces**,
 and a token-weighted rate addresses both. This is why the fix belongs in D6's
@@ -390,10 +418,15 @@ fold into D4 rather than in a separate throughput ticket: an engineer sent to fi
 "the ETA" would correct the user-visible number and leave a timeout running on
 the same broken input, still burning a batch of GPU per size transition. The
 estimator is not only the user's window onto a detached pass; it is also feeding
-a deadline that is wrong by more than 2x on a realistic queue. This is plausibly
-also the mechanism behind the connect-timeout reports on large repos, which are
-tracked separately; that link is offered as a lead, not as an established
-diagnosis.
+a deadline whose entire safety margin had been consumed by the rate error. The
+exposed case is scoped by the data: **abrupt per-batch cost transitions, not
+repo size.** The large repo behind this cluster ran its full 102.9-minute embed
+with zero retries, because its per-batch cost changes gradually across ~108
+batches and the EMA tracks it; the small repo above jumps 7.4x in a single
+batch. This is plausibly also the mechanism behind the connect-timeout reports
+on large repos, which are tracked separately; if so, the trigger there was a
+local transition in the queue rather than the repo's scale, which is a testable
+prediction. That link is offered as a lead, not as an established diagnosis.
 
 #### One boundary the fix must respect: ratios cancel the bias, budgets do not.
 

--- a/docs/adr/070-init-embed-lifecycle-and-search-warmup-contract.md
+++ b/docs/adr/070-init-embed-lifecycle-and-search-warmup-contract.md
@@ -1,0 +1,500 @@
+# ADR-070: `init` embed lifecycle, and the search warmup contract
+
+**Date:** 2026-07-15
+**Deciders:** founder (Johan); architect
+**Relationship to prior ADRs:** operates strictly inside ADR-010's embedding
+split (the server computes vectors, the CLI is the only persistent store for
+index data) and does not reopen it. Extends
+[ADR-068](068-zero-setup-onboarding-git-notes-memory-fallback.md)'s honesty
+posture (a surface that cannot answer says so, and says what would make it
+answer) from the pre-`init` memory surface to the post-`init` search surface.
+
+## Context
+
+A fresh `spelunk init` on a large real-world checkout, on a machine with **no**
+`spelunk-server` already running, produces an index with **zero** embeddings and
+a semantic search that answers `No results found.` for every query, forever,
+until the user happens to re-run `spelunk index` by hand. Nothing in the output
+says the index is unusable. The recorded reproduction, on a mid-size repo of
+roughly 8.2k files and 27.7k chunks:
+
+```
+Index: 8226 files, 27734 chunks, 0 embeddings
+Server: http://127.0.0.1:7777  ✓  (auto-started)
+```
+
+and then, five minutes later, a server resident at roughly 800MB doing 0% CPU
+and 0% GPU, with `spelunk status` reporting `Embeddings: 0`.
+
+This is the worst class of defect the product can have. The tool is not slow and
+it is not erroring. It is confidently reporting the absence of evidence over a
+corpus it never looked at.
+
+### The mechanism, traced in code
+
+Four independent facts compose into the failure. Each was verified against the
+tree, and two of them are not what the intake ticket recorded.
+
+1. **`init` embeds before it starts the server.** The index/embed step runs
+   first, and the server auto-start runs after it. On a fresh machine the embed
+   step therefore probes for a server that this very command is about to start.
+
+2. **A not-ready embedder is treated as terminal.** The embed step is gated on
+   `let embed_ready = matches!(tier.caps(), Some(c) if c.index_embed);` and
+   `if tier.is_server() && embed_ready`. When the probe fails, the phase is
+   skipped and a notice is printed. The chunks are already durably stored, so
+   nothing is lost, but nothing schedules the work either.
+
+3. **The server cannot rescue this, by design.** It is stateless with respect to
+   index data. `POST /v1/projects/{id}/index/embed` takes chunk texts in the
+   request body and returns vectors; the handler's own contract says the server
+   does not store them. The server has no access to the project's SQLite
+   database, no notion of which chunks lack embeddings, and no project path. A
+   server-side drain loop is not missing, it is **not expressible** without
+   inverting ADR-010. The idle server is correct behaviour, not a bug.
+
+4. **Search then declines to fall back.** In `auto` mode the fallback to
+   ast-grep on an empty result set is gated on `index_is_stale(&db_path)`, which
+   samples file hashes for drift. A just-built index is not stale, so the guard
+   is false, so no fallback fires, so `No results found.` prints.
+
+### Two corrections to the record
+
+Both of these were carried as settled premises into this decision and are wrong.
+They are recorded rather than quietly fixed, because in each case acting on the
+stated premise produces a change that ships green and fixes nothing.
+
+> **The empty-index guard is not what suppressed the fallback.** The intake
+> ticket's root cause reads "chunk_count≠0 so the empty-index fallback doesn't
+> fire". There *is* a real `chunk_count == 0` fast path in `search`, and it is
+> not the guard that failed here. The guard that should have fired and did not
+> is the staleness check on the empty-result path. An engineer sent to fix "the
+> `chunk_count` guard" edits a correct line and leaves the defect standing.
+
+> **Detaching the embed is inert on its own.** The detach proposal's headline
+> item is that `init` hardcodes `detach_embed: false` and that flipping it is
+> "nearly a one-line change". It is one line, and on the reported bug it is a
+> **no-op**. `args.detach_embed` is evaluated *inside* the
+> `if tier.is_server() && embed_ready` branch. On a fresh install that branch is
+> not taken, so the flag is never read, so the embed is skipped exactly as it is
+> today. The change demos green on any machine that already has a warm server,
+> which is every developer machine that has run the tool once. This is the
+> single highest-risk item in this cluster: a fix that passes review, passes a
+> hand-check, and does not touch the bug.
+
+## Decision
+
+### D1 – The framing is a false dichotomy. The reorder and the detach are one change.
+
+The intake ticket frames an architect call between (a) starting the server
+before the embed phase so a fresh `init` embeds inline, at the cost of restoring
+a very long foreground wait, and (b) wiring a detached background embed instead
+of silently skipping.
+
+Neither is a choice, because neither works alone:
+
+- **(a) alone** buys a correct index for the price of holding the terminal for
+  the entire embed pass. On the measured repo that is **102.9 minutes** of embed
+  inside a 104.2-minute `init`: over an hour and three quarters (see D6). That is
+  not a fix, it is a different complaint.
+- **(b) alone** is the no-op above. The detach lives behind the readiness gate
+  that the missing server fails.
+
+The decision is **both, as a single indivisible change**: start the server
+before the embed phase *and* hand the embed pass to the detached worker. The
+reorder is what makes the detach reachable; the detach is what keeps the reorder
+from becoming a foreground wall. Shipping either half alone is a regression or a
+placebo, so they do not get separate reviews.
+
+### D2 – A not-ready embedder is a transient condition to wait on, not a terminal condition to skip.
+
+The reorder alone does not fix the cold-start case, and this is the part that no
+ticket in the cluster records.
+
+`ensure_server_running` waits for **liveness**, not model readiness. Its own
+comment is explicit: health goes live at socket bind, deliberately, *before* the
+model is loaded. The model then loads on a background task and flips the
+embedder slot to `ready` some time later. So after the reorder, a genuinely
+fresh machine still arrives at the embed step with the embedder in `loading`,
+still computes `embed_ready == false`, and still skips. The reorder converts
+"no server" into "server warming" and produces the identical zero-embedding
+index.
+
+Therefore: **the embed worker owns the wait.** It polls the embedder state with
+a bounded backoff and proceeds when the state reaches `ready`. Only `unavailable`
+and `disabled` are terminal, and each already has a distinct, actionable notice
+that must be preserved. `loading` is never a reason to abandon durable queued
+work.
+
+This needs no new persistence. The enabling fact, verified: the queue is already
+durable and resumable. `chunks_missing_embeddings` reconstructs it with a
+`LEFT JOIN ... WHERE e.chunk_id IS NULL`, and the detached entry point rebuilds
+the queue from the database rather than carrying it across the process boundary.
+The recovery path has always worked. It was only ever undiscoverable.
+
+Resume granularity is **per chunk, not per batch**. `insert_embedding` issues a
+bare `INSERT OR REPLACE` on the connection, and the embed phase calls it in a
+plain `for` loop with no enclosing transaction, so every row commits in its own
+implicit transaction. This strengthens the argument rather than weakening it: a
+worker killed mid-batch keeps every chunk it had already written, and the
+`LEFT JOIN` picks up from exactly there. It is not free, at a measured ~+5.2ms
+per chunk on the profiled repo, but that cost is already being paid today and
+buying finer resumability than this ADR requires. Batching those commits is a
+throughput question, out of scope here; it is noted only so that a future change
+knows it would be trading resume granularity for speed, rather than discovering
+that trade after the fact.
+
+### D3 – Search never reports an absence it cannot substantiate.
+
+This is the invariant the cluster exists to protect, and it is stated once, in
+one place, so that no future gate can quietly fail open again:
+
+> **`No results found.` is only ever printed when the corpus that was searched
+> was complete.** Whenever coverage is partial, the output names what was
+> incomplete. Silence is not an available option.
+
+Embedding coverage becomes a first-class input to `search`, replacing the
+staleness proxy on the empty-result path. Three states, exhaustively:
+
+| Coverage | `auto` mode | Explicit `semantic` / `hybrid` |
+| --- | --- | --- |
+| `0` | Fall back to text/ast-grep, with a notice naming warmup as the reason | Actionable error naming warmup and the resume command. Never `No results found.` |
+| `0 < c < 100` | Run KNN; **always** emit a one-line warmup notice carrying the coverage percentage and its shape (below). If the result set is empty, fall back to text rather than print `No results found.` | Run KNN; emit the same warmup notice so a thin result set is never mistaken for a complete one |
+| `100` | Today's behaviour, no notice | Today's behaviour, no notice |
+
+**Coverage is measured in chunks**, and that is the right unit for it: it answers
+"what fraction of the corpus can KNN see", and a chunk that is embedded really is
+searchable. This is deliberately *not* the unit D4 uses to report progress, for
+reasons D4 and D6 develop. The two are different questions and this ADR keeps
+them apart everywhere.
+
+Partial coverage is safe to serve, and this is load-bearing rather than
+optimistic: `search_similar` is a pure KNN over whatever rows exist in the
+`embeddings` table, with no completeness gate at the storage layer, and KNN is
+order-independent. Any prefix of the queue is immediately useful. That is what
+makes progressive availability nearly free, and it is why the honest thing to do
+with a partial index is to serve it and label it, rather than withhold it.
+
+**But the prefix has a shape, and the notice must not let a reader assume the
+wrong one.** Because the queue is `ORDER BY c.id` and ids follow the indexer's
+walk, a prefix is *the first N files*, not a sample spread across the repo. At 40%
+coverage the user does not have a thinner picture of the whole codebase; they have
+a complete picture of some of it and a **systematic blind spot** over the rest.
+Those two failure modes want different reactions, and a bare percentage reads as
+the first. So the notice names the shape, not just the number: coverage is
+described as partial *and* front-loaded by indexing order, so a user who gets no
+hit for a subsystem knows that "not embedded yet" is a live explanation rather
+than a remote one. This is the D3 invariant applied to itself. An honest
+percentage attached to a misleading mental model still leaves the user reasoning
+from an absence the tool cannot substantiate.
+
+**No coverage threshold is introduced.** A threshold is a tuning knob that
+invites bikeshedding and, worse, encodes a claim ("90% is basically complete")
+that the tool cannot substantiate for any particular query. "Incomplete" is a
+fact; the percentage is reported and the user judges. Routing stays as it is,
+since hybrid already blends.
+
+All notices go to **stderr**, matching the existing skip notices, so `--format
+json` and `jsonl` output stay machine-clean.
+
+### D4 – `status` knows about its own background job. It does not guess.
+
+Today `status` prints, at `0/27734` against a demonstrably idle server:
+
+```
+Embedding in progress  0/27734 embedded (27734 pending) (a background embed may be running; re-run `spelunk index` to resume if not)
+```
+
+Both halves of that line are defects. It asserts "in progress" from a pure
+function of two integers, which cannot distinguish a running job from an
+abandoned one, and then hedges the assertion away in the same breath. A tool
+guessing about its own subprocess is worse than one that stays quiet, because
+the guess is what stops the user from investigating.
+
+The detached worker records its liveness, and `status` reads it. There is
+already a correct precedent in-tree to copy rather than reinvent: the server's
+own pid / port / db-path state files, its `pid_is_alive` check, and its
+classification of a recorded-but-unresponsive daemon into healthy, hung-ours,
+and foreign (pid reused by an unrelated process). The worker reuses that shape,
+including the foreign-pid case.
+
+This is **liveness**, which is a distinct concern from **diagnostics**. The
+detached children's stdout and stderr are separately being routed to an
+`index-background.log` beside the index, with a pointer printed after the status
+line (#624). That work stands on its own and D4 does not duplicate it: a log
+says what the worker *said*, a pid says whether it is *there*, and `status`
+needs the second to stop guessing. D4 builds on that change rather than
+re-plumbing the spawn, and the two must not land as competing edits to the same
+spawn path.
+
+`status` then reports what it knows:
+
+- worker alive → `Embedding in progress`, with the two measures below
+- no worker, pending > 0 → `Embedding incomplete`, with the same two measures,
+  plus the resume command. Not "in progress".
+- embedder `unavailable` → say so, and point at the server logs.
+
+The hedging parenthetical is deleted, not reworded.
+
+#### Coverage and progress are two measures, in two units, under two names.
+
+This is the part of D4 that is easiest to get wrong, because the wrong version is
+what the line already prints and it looks correct.
+
+`N/M (x%)` embedded-chunks-over-total-chunks is **the same numerator shape that
+produces the estimator defect in D6**, and it is wrong for the same reason. The
+queue runs in `chunks.id` order and mean chunk size grows roughly 4x through it
+(137 → 577 tokens across the id range on the profiled repo), so a chunk fraction
+early in the run is not a work fraction:
+
+| measured at | chunks done | work done |
+| --- | --- | --- |
+| sample point | 42.6% | **21.2%** |
+
+So `Embedding in progress 11813/27734 (42%)` beside an ETA is a **true statement
+about coverage and a false one about progress**. The user infers most of the wait
+is behind them when **79% of it is ahead**. That is D6's own defect re-entering
+through a different line, and fixing D6's estimator while leaving this one alone
+fixes half of it.
+
+The decision:
+
+- **Coverage stays chunk-shaped** (D3). 42% of chunks really are searchable, so
+  the number is not wrong; it is only wrong as an answer to a question nobody
+  asked it.
+- **Progress and the ETA become token-weighted**, over `chunks.token_count`,
+  which already exists (added by migration `008_token_counts.sql`, written on
+  chunk insert, with a backfill path for pre-existing indexes). Note that
+  `chunks_missing_embeddings` does not currently project that column; it will
+  need to, or the denominator needs its own aggregate.
+- **The two never share a name, and no percentage is ever printed bare.** Every
+  percentage names its denominator, so the two can be seen to be different rather
+  than looking like a disagreement:
+
+```
+Embedding in progress   searchable 11813/27734 chunks (42%)  ·  21% of work done, ~54 min left
+```
+
+`searchable` answers "what can search see"; `of work done` answers "how much of
+the wait is behind me". They are *supposed* to diverge, and on a real repo they
+diverge by 2x. Two numbers under one label reads as a bug; two numbers under two
+labels reads as the fact it is.
+
+`token_count` is good enough for this, and the honest caveats are that it stores
+`estimate_tokens(content)` (`chars/4`, not a tokenizer count) and carries roughly
+±25% per-chunk error (direct tokenization of all 27,734 chunks: 91.9% within
+±25%, p10/p50/p90 = 0.774 / 0.912 / 1.086). Neither sinks it, and the comparison
+is what matters rather than the absolute accuracy: **that error is unbiased and
+averages out over tens of thousands of chunks, whereas chunk-counting is wrong by
+a systematic 4.4x in a consistent direction across the run.** The choice is not
+between an estimate and the truth, it is between an unbiased estimate and a
+biased one.
+
+### D5 – Queue ordering lands after, and stays decoupled.
+
+Prioritising the embed queue (recency first on a cold index, graph rank first on
+a warm one, replacing today's `ORDER BY c.id`) is correct and is **not** part of
+this change. It is not required for correctness: ordering only becomes
+observable once a partial index is reachable at all, which is what D1 through D4
+deliver. It changes the same query the worker consumes, so landing it
+concurrently buys two contended edits in one file for no user-visible benefit
+during the window when the index is still unreachable.
+
+Measurement sharpens *why* it is worth doing later, and narrows what it may
+claim. **Reordering does not reduce total work, and must not be justified as if
+it did**: measured tokens/s is roughly flat across the run (1.4x variance,
+against 4.4x for chunks/s), so the queue costs what it costs regardless of the
+order it is drained in. Its entire value is **which chunks land first**: in id
+order a partial index is an arbitrary alphabetical slice, in graph-rank order it
+is the most important code first. That is a claim about the D3/D4 surface, which
+is precisely why it sequences after D1 through D4 rather than beside them: before
+those land there is no partial index for an ordering to be observable in, and
+afterwards the value is immediate and needs no throughput argument to carry it.
+
+One constraint on it, so this decision does not foreclose a live one: the
+ordering key is computed from file metadata and graph rank, both of which are
+independent of chunk boundaries. Chunk granularity is under separate active
+investigation, and an ordering keyed on anything chunk-shaped would have to be
+redone when that lands.
+
+### D6 – The measured cost, and what it means for the ETA.
+
+The figure attached to this cluster is wrong in both of the ways a number can be
+wrong, and the corrected version changes what the work is.
+
+> **The embed phase is not "~28 min".** The ETA-derived "~28 min" that titles the
+> throughput ticket was never a measurement. It is what the progress estimator
+> *predicted*, sampled early in the run. The measured wall clock for `init` on
+> the same repo (8,226 files / 27,734 chunks) is **6,250.65s = 104.2 minutes**:
+> embed **6,176.07s (98.81%)**, parse 73.31s (1.17%), graph rank and conventions
+> 1.27s (0.02%). The estimator under-reported by **3.2x**: sampled at 42.6% of
+> chunks, only 21.2% of tokens were done, giving a 16.8-minute chunk-derived ETA
+> against a 54.3-minute token-derived one. The corrected number must be used
+> everywhere; "28 minutes" should not be repeated.
+
+> **The docs framing on that ticket was already withdrawn and does not survive.**
+> Its title still reads "contradicts the five minutes doc promise". The founder
+> corrected this on the ticket itself: the getting-started doc's "first five
+> minutes" scopes to the sections *before* indexing, and introduces `init`
+> afterwards as a separate later step. The doc never claimed indexing is fast,
+> so there is no contradiction to fix. The ticket was explicitly downgraded at
+> that time. Reviving the "broken promise" framing on the strength of the larger
+> number would re-file a complaint the founder has already rejected on the
+> merits, and the larger number does not revive it, because the promise never
+> covered this step.
+
+What genuinely remains from that ticket is narrower, and it is a consequence of
+D1 rather than an independent item: **the progress estimator itself
+under-reports.** Once the embed pass is detached, `status` is the only window
+onto it, so an ETA that is wrong by 3x stops being a cosmetic annoyance and
+becomes the primary signal a user has. The estimator correction therefore folds
+into the `status` work in D4. Any prose about realistic timings belongs to the
+marketing site, not to this repo.
+
+#### The root cause has a second consequence, and it is not cosmetic.
+
+`per_entry` is a per-**chunk** rate, calibrated on early chunks and applied to a
+queue whose per-chunk cost is **not stationary**: it grows ~4x through the id
+order (D4). That single fact is not one bug in the ETA. `RateEstimate`'s own doc
+comment names its consumers: *"`next_batch_size`, `batch_timeout`, and the
+displayed ETA (`format_eta`) all read `per_entry()` from the same instance so
+they can't disagree."* The design goal is sound and achieved. They do not
+disagree. **They are consistently wrong together**, because they share one input
+whose unit does not match the cost it is predicting.
+
+The second face is measured. On a 581-chunk index the CLI sent **837 chunks
+across 7 requests**; `837 − 581 = 256`, exactly one batch computed by the server
+and then discarded:
+
+1. Batch 4 was 256 tiny chunks (192 chars each) and ran in 7s, so `per_entry`
+   calibrated to **27ms**.
+2. `next_batch_size` divided the 240s target by 27ms, asked for far more than the
+   `MAX_BATCH = 256` ceiling, and got 256.
+3. `batch_timeout` = `TIMEOUT_SAFETY_FACTOR (4) × 0.027 × 256` = **28s**, floored
+   up to `MIN_REQUEST_TIMEOUT` = **60s**.
+4. Batch 5 was 256 chunks at **7.4x the size** and needed **73s**. At 73s > 60s
+   the client abandoned it, halved to 128 and retried. The server never learns a
+   client gave up: it finished all 73s of GPU work and threw the result away.
+
+**~73s of a 198.2s run is wasted GPU: 37%.** Reproduced on an idle box, so it is
+not contention. Note which guard saved it: the 4x safety factor did **not**. It
+computed 28s for a batch that needed 73s, because a 4x margin on a rate that is
+wrong by 7.4x is still wrong. Only the 60s floor, which is not derived from the
+rate at all, bounded the damage. And the sizing consumer is not an innocent
+bystander here: the same bad rate is what selected an oversized batch *and* then
+under-budgeted the time for it.
+
+So the estimator defect and the timeout defect are **one defect with two faces**,
+and a token-weighted rate addresses both. This is why the fix belongs in D6's
+fold into D4 rather than in a separate throughput ticket: an engineer sent to fix
+"the ETA" would correct the user-visible number and leave a timeout running on
+the same broken input, still burning a batch of GPU per size transition. The
+estimator is not only the user's window onto a detached pass; it is also feeding
+a deadline that is wrong by more than 2x on a realistic queue. This is plausibly
+also the mechanism behind the connect-timeout reports on large repos, which are
+tracked separately; that link is offered as a lead, not as an established
+diagnosis.
+
+#### One boundary the fix must respect: ratios cancel the bias, budgets do not.
+
+`estimate_tokens` is `chars/4`, and its bias is **corpus-dependent, not
+constant**: aggregate `real/est` measures **0.930** on a Ruby/TS repo and
+**1.387** on an MDX/TS repo, so the same estimator over-counts one corpus by 7%
+and under-counts another by 39%. It is a **scale factor**, which is what makes it
+tractable, and it fixes what the fix is allowed to look like:
+
+- It **cancels in a ratio** (tokens done / tokens total). D4's progress
+  percentage is safe by construction.
+- It **cancels in a rate that is calibrated in the same units it predicts in**.
+  A `per_token` measured this run as `elapsed / estimated tokens in the batch`
+  absorbs the corpus's bias into the calibration constant, and `batch_timeout`
+  built from it is then predicting estimated-tokens against a rate per
+  estimated-token. The bias appears on both sides and drops out.
+- It **does not cancel where an estimated token count meets a constant expressed
+  in true tokens.** `batch_timeout` is exactly this kind of absolute-budget
+  consumer, so the constraint is: the rate stays **measured, per-run, and
+  continuously recalibrated**. A hardcoded tokens/sec throughput constant is not
+  a valid substitute, and **a rate cached across runs or reused across repos is
+  a defect**, not an optimisation to warm the ETA up faster. A 1.49x swing in
+  bias between two real corpora is a foreseeable 1.49x error in an absolute
+  deadline. Keeping the EMA also matters for the same reason within a single run,
+  since a repo whose file types are unevenly distributed through the walk has a
+  bias that drifts as the walk proceeds.
+
+The existing `RateEstimate` shape already satisfies all of this. The change is to
+its **unit**, not to its architecture: one authoritative rate, calibrated from
+observation, read by every consumer. That was the right design and it stays.
+
+## Consequences
+
+- A fresh `init` returns the prompt after parsing, with embeddings arriving in
+  the background, and every surface that can observe partial coverage says so.
+- The pathological case is inverted: the tool's least-informed moment is now its
+  most talkative, rather than its most confident.
+- `init` gains a dependency on the server having been started first. The
+  auto-start is TTY-gated, so non-interactive `init` (CI, hooks) still legitimately
+  produces an unembedded index. That path is now **required** to state it, under
+  D3, rather than being distinguishable only by reading the chunk counts.
+- Users on a warm server see a behaviour change: `init` no longer blocks through
+  the embed pass. The opt-out for scripted use is retained.
+- The notice during warmup will be seen often on large repos, for a long window.
+  This is intended. The window is real, and the alternative to mentioning it is
+  the defect this ADR exists to remove.
+- **Two percentages now exist where users saw one, and they will disagree by 2x
+  on a real repo.** That is the intended outcome, not a rough edge to sand down:
+  coverage and progress are different questions with different answers, and the
+  single number that used to serve both was the defect. The cost is that both
+  numbers must always be labelled, everywhere, including anywhere a future
+  surface reports embedding state. An unlabelled percentage is a regression to
+  the behaviour D4 removes.
+- Making the rate token-weighted changes `batch_timeout` and `next_batch_size`
+  as a side effect, because they read the same rate. This is intended and is the
+  point of D6, but it means the change touches request sizing and deadlines, not
+  only a displayed string, and should be tested as such. The expected direction
+  is fewer abandoned batches; the 37% wasted-GPU case above is the specific thing
+  that should stop reproducing.
+
+## Non-goals
+
+- **Chunk granularity.** Under separate active investigation, with an unmeasured
+  recall cost and a throughput win **still being measured**. The throughput half
+  is currently *modelled*, not measured, and the model assumed a chunker we do
+  not have: it assumed oversized chunks split into pieces at or under the token
+  cap, whereas the re-window path is **line-based** (120 lines, 15 overlap)
+  regardless of that cap, so lowering the cap constant alone would not produce
+  chunks at the cap. The number will move. This is recorded so the sentence is
+  not later quoted as settled; it changes no decision here, and D5 keeps the
+  ordering key independent of chunk boundaries either way. Not decided here.
+- **Embedder throughput, device selection, and GPU acceleration.** The embedder
+  is ~99.8% GPU-bound (measured again here: GPU utilization 96-99%, mean 98.2%,
+  during embed, against 0.06% of CLI CPU), so disaggregating it is a no-op. Not
+  decided here.
+
+  One trap worth recording, because the obvious experiment would come back green
+  and mean nothing. **On any non-CPU device the sub-batch sizing constants are
+  unreachable, not merely ineffective.** In `embed_batch` the device check
+  precedes the length check in the same short-circuiting condition
+  (`b == 1 || !matches!(self.device, Device::Cpu) || max_seq > BATCH_MAX_SEQ`),
+  so Metal takes the sequential path unconditionally and `BATCH_MAX_SEQ` is never
+  evaluated. Measured: 8 chunks in one request take 202.4ms, the same 8 as eight
+  separate requests take 208.6ms, a ratio of **1.03**. The forward pass is not
+  batched at all on that device, so the constants cannot matter, and **an A/B of
+  them on a Mac would measure a no-op and prove nothing**. This scopes rather
+  than contradicts [ADR-052](052-f2llm-cpu-batch-throughput.md), whose batching
+  work is explicitly the `Device::Cpu` path, where these constants are live.
+- **Cloud or remote embedding.** Trades a GPU-bound constraint for a metered
+  network one with no wall-clock win.
+- **Reopening ADR-010.** The server stays stateless with respect to index data.
+  Every alternative that "just has the server finish the job" is a rewrite of
+  the storage boundary, and none of them is needed: the CLI-side worker already
+  has the database, the queue, and the resume path.
+
+## Security implications
+
+None material. The change reorders existing phases, extends an existing
+subprocess spawn, and adds a pid-liveness file alongside the server's existing
+state files in the same state directory, under the same permissions. No new
+network surface, no new authentication path, and no new data leaves the machine.
+The embed endpoint remains auth-gated and batch-capped as it is today. The
+foreign-pid case in D4 is explicitly handled so a recycled pid cannot be
+misreported as a live embed worker.


### PR DESCRIPTION
## Revision 3: D6's walkthrough corrected to the EMA reconstruction

The reviewer's follow-up comment was edited in place after the revision-2 amend, and D6's
"second face" walkthrough had faithfully reproduced its pre-correction arithmetic. Fixed:
`per_entry` for batch 5 was the **71.6ms EMA** (dominated by batch 3's slow sample), not
batch 4's raw 26.5ms; `batch_timeout` was **73.3s with no clamping**, so the 60s floor never
engaged and the revision-2 claim below that only the floor bounded the damage is **retracted**;
batch 5's real cost was a **4.0x** under-estimate exactly consuming the 4x safety factor, so
nothing bounded the damage (the predicted 73.3s matches the observed 73.076s gap to 0.3%).
The exposed case is scoped to abrupt per-batch cost transitions rather than repo size, and the
independent no-cancellation-on-disconnect fault is named out of scope in D6, tracked as #631.
Everything the re-review confirmed against the measured data is untouched.

## Revision 2 — in response to the profiling review

Rebased onto current `main`. Both review comments are adopted in full. The cited
numbers were confirmed by the profiling run and are unchanged; what changed is
**D4**, and **D6** now names its second consequence.

### The substantive change: D4 separates coverage from progress

Adopted as suggested. D3's coverage **stays chunk-shaped**; D4's progress and ETA
become **token-weighted** over `chunks.token_count`. The two are now named
differently because they answer different questions, which was the crux of the
review point:

```
Embedding in progress   searchable 11813/27734 chunks (42%)  ·  21% of work done, ~54 min left
```

`searchable` answers "what can search see" (42%). `of work done` answers "how much
of the wait is behind me" (21%). D4 now states the rule that produced those names:
**the two never share a label, and no percentage is ever printed bare** — every
percentage names its denominator. Two numbers under one label reads as a bug; two
numbers under two labels reads as the fact it is. A new Consequences bullet records
that they *will* disagree by 2x on a real repo and that this is the intended
outcome, not a rough edge to sand down.

One implementation note added, found while verifying: `chunks_missing_embeddings`
does not currently project `token_count`, so it will need to (or the denominator
needs its own aggregate). `token_count` itself checks out — migration
`008_token_counts.sql`, written on insert, with a `backfill_token_counts` path for
pre-existing indexes.

### D6 now names the `batch_timeout` consequence, and the argument is sound

**I judge "one defect, two faces" correct, and the tree makes the case more
strongly than the comment does.** `RateEstimate`'s own doc comment names its
consumers: *"`next_batch_size`, `batch_timeout`, and the displayed ETA
(`format_eta`) all read `per_entry()` from the same instance so they can't
disagree."* The design goal is sound and achieved. They do not disagree — **they
are consistently wrong together**, because they share one input whose unit does
not match the cost it predicts.

Two refinements on top of the comment:

- **It is three consumers, not two.** `next_batch_size` reads the same rate, and
  in the traced failure it is not a bystander: at `per_entry` = 27ms it divided the
  240s target by 27ms, asked for far more than `MAX_BATCH = 256`, and got 256. The
  same bad rate **selected an oversized batch and then under-budgeted the time for
  it**. The third face is milder (a target, not a deadline) but it is the same
  broken input. *(Numbers corrected in revision 3: `per_entry` = 71.6ms, quotient
  3,352; the conclusion is unchanged.)*
- ~~**Which guard saved it is worth recording.** The 4x safety factor did not: a 4x
  margin on a rate wrong by 7.4x is still wrong. Only the 60s floor, which is not
  derived from the rate at all, bounded the damage.~~ **Retracted in revision 3**:
  this reproduced the pre-correction arithmetic. The floor never engaged; the 4x
  margin was exactly consumed by a 4.0x rate error and nothing bounded the damage.

The connect-timeout link is recorded as "plausibly ... offered as a lead, not as an
established diagnosis", matching how you put it. No tracker ref (public repo).

### The corpus-dependent bias boundary

Handled as a named constraint on the fix, since it decides what the fix may look
like. The bias is a scale factor, so:

- it **cancels in a ratio** (tokens done / tokens total) — D4's percentage is safe
  by construction;
- it **cancels in a rate calibrated in the same units it predicts in** — a
  `per_token` measured this run as `elapsed / estimated tokens` absorbs the corpus's
  bias into the calibration constant, and `batch_timeout` built from it has the bias
  on both sides;
- it **does not cancel where an estimated token count meets a constant expressed in
  true tokens**, and `batch_timeout` is exactly that kind of absolute-budget
  consumer.

So the recorded constraint is: the rate stays **measured, per-run, continuously
recalibrated**. A hardcoded tokens/sec constant is not a valid substitute, and **a
rate cached across runs or reused across repos is a defect, not an optimisation** —
the 0.930 vs 1.387 swing is a foreseeable 1.49x error in an absolute deadline. This
also re-justifies keeping the EMA, since a repo whose file types are unevenly
distributed through the walk has a bias that drifts within a single run. The
existing `RateEstimate` architecture already satisfies all of this: **the change is
to its unit, not its shape.**

### The four corrections

| Correction | Done |
| --- | --- |
| D2 "commit per batch" → **per chunk** | Verified in code before writing: `insert_embedding` issues a bare `INSERT OR REPLACE` on the connection; `embed_phase.rs` calls it in a plain `for` loop with no enclosing transaction (no `transaction`/`BEGIN`/savepoint anywhere in the file). Recorded as strengthening resumability, with the ~+5.2ms/chunk cost noted as already-paid and the batching trade named so a future change does not discover it by accident. |
| D1 "most of an hour and a half" | Now "**102.9 minutes** of embed inside a 104.2-minute `init`: over an hour and three quarters". |
| Inert sub-batch constants | Recorded with the receipt and the stronger reason, **as a trap**: the obvious A/B on a Mac would come back green and mean nothing. |
| Non-goal precision | Reworded to "an unmeasured recall cost and a throughput win **still being measured**", with the line-based re-window reason, explicitly so the sentence is not later quoted as settled. Decides nothing about chunk granularity. |

### One place I went further than the review

**The "inert constants" note is scoped to non-CPU devices, deliberately.** The
mechanism is a short-circuit in one condition —
`b == 1 || !matches!(self.device, Device::Cpu) || max_seq > BATCH_MAX_SEQ` — so on
Metal `BATCH_MAX_SEQ` is never *evaluated*. But that also means the constants are
live on `Device::Cpu`, which is the entire subject of ADR-052. The draft's flat
"the sub-batch sizing constants are inert" would have read as contradicting a
shipped ADR. It now says unreachable **on any non-CPU device** and cites ADR-052 as
scoped rather than contradicted.

### D3 / D5

- **D3** names the shape of partial coverage: a prefix is *the first N files*, not a
  sample spread across the repo, so at 40% the user has a **systematic blind spot**
  over the rest rather than a thinner picture of all of it. The notice names the
  shape, not just the number. Framed as the D3 invariant applied to itself: an
  honest percentage attached to a misleading mental model still leaves the user
  reasoning from an absence the tool cannot substantiate.
- **D5** now carries your stronger argument and drops the weaker one: **reordering
  does not reduce total work and must not be justified as if it did** (tokens/s flat,
  1.4x, against 4.4x for chunks/s). Its entire value is which chunks land first,
  which is the D3/D4 surface — which is precisely why it sequences after them.

No decision changed. D1 through D5 stand; D4's *unit* changed and D6 grew a second
consequence.

---

## What this decides

A fresh `spelunk init` on a machine with **no** running server ships an index with
**zero embeddings** and a semantic search that answers `No results found.` for every
query, forever, until the user re-runs `spelunk index` by hand. Nothing says the index
is unusable. This ADR decides the direction for that bug and the two implementing
tasks behind it.

The intake framed an architect call between **(a)** reorder the server start before the
embed phase, or **(b)** wire a detached background embed.

**It is a false dichotomy, and this is the main finding.** The answer is both, as one
indivisible change, plus a third piece nobody had written down.

## The three findings that drove it

**1. The detach flag is a no-op on the bug it is meant to fix.** The detach task's
headline item is that `init` hardcodes `detach_embed: false` and flipping it is "nearly
a one-line change". It is one line, and it changes nothing here: `args.detach_embed` is
evaluated *inside* the `if tier.is_server() && embed_ready` branch. On a fresh install
that branch is not taken, so the flag is never read. **It would demo green on any machine
that already has a warm server, which is every dev machine that has run the tool once,
and leave the bug fully standing.** That is the highest-risk item in this cluster.

**2. The reorder alone does not fix the cold start either.** `ensure_server_running`
waits for **liveness, not model readiness**, by design (its own comment says so: health
goes live at socket bind, before the model loads). So after the reorder a genuinely fresh
machine still reaches the embed step with the embedder `loading`, still computes
`embed_ready == false`, and still skips. The reorder converts "no server" into "server
warming" and produces the identical zero-embedding index. Root cause is therefore deeper
than step order: **a transient embedder state is being treated as terminal.**

**3. The server cannot rescue this, by design.** The intake describes a "missing drain
loop" in the server. The server is stateless w.r.t. index data (its own handler contract:
it does not store vectors, the CLI is the only persistent store). It has no access to the
project SQLite DB and no notion of which chunks lack embeddings. A server-side drain loop
is not missing, it is **not expressible** without inverting ADR-010. The idle server is
correct behaviour.

## The invariant

> `No results found.` is only ever printed when the corpus that was searched was complete.

Coverage becomes a first-class input to search, replacing the staleness proxy on the
empty-result path. Notices go to stderr so `--format json` stays clean. No coverage
threshold is introduced (a threshold encodes a claim the tool cannot substantiate;
"incomplete" is a fact, the percentage is reported).

## Two stale premises corrected, recorded not smoothed over

- **The empty-index guard is not what suppressed the fallback.** The intake root cause
  says "chunk_count≠0 so the empty-index fallback doesn't fire". There *is* a real
  `chunk_count == 0` fast path, and it is **not** the guard that failed. The guard that
  should have fired is the `index_is_stale()` check on the empty-result path: a fresh
  index is not stale, so it is false, so no fallback fires. An engineer sent to fix "the
  chunk_count guard" edits a correct line.
- **The embed phase is not "~28 min".** That number titles the throughput ticket and was
  never a measurement: it is what the progress estimator *predicted*. Measured `init` wall
  clock on the same repo is **104.2 minutes** (embed 98.81%). The estimator under-reports
  by **3.2x**, which matters *more* once detached, because `status` becomes the only
  window onto it. The estimator fix folds into the status work.

## For Johan

- **The docs-promise framing stays withdrawn.** I did **not** revive the throughput
  ticket's "contradicts the five minutes doc promise" framing, even though the real
  number makes the gap far larger. You withdrew that framing on the ticket itself on
  2026-07-10: the getting-started doc's "first five minutes" scopes to the sections
  *before* indexing, and `init` is introduced later as a separate step, so the promise
  never covered this step. A bigger number does not revive a promise that never applied.
  ADR §D6 records the reasoning. Unchanged in this revision.
- **Worth your eye:** the D4 output line above is illustrative, not a decided string.
  What D4 decides is the *rule* (two measures, two units, two names, no bare
  percentages); the exact wording is the implementer's, within that rule.
- The remaining docs work from that ticket belongs to marketing-site, not this repo.

## Scope

Decided: direction, the search warmup contract, status self-knowledge, and how the two
implementing tasks sequence. **Not decided** (deliberately, and D5 keeps the design from
foreclosing it): chunk granularity, embedder throughput / GPU accel, cloud embedding, and
anything that reopens ADR-010.

Coordination: complementary to #624 (now merged; routes detached children's stdio to a
log). That is *diagnostics*; D4 is *liveness*. A log says what the worker said, a pid says
whether it is there. D4 builds on #624 rather than re-plumbing the same spawn path, and
the ADR says so.

## Test plan

Docs-only change; no runtime surface. What was verified firsthand **for this revision**
(the original verification table stands and is not repeated):

| Claim | How verified | Result |
|---|---|---|
| Embeddings commit **per chunk**, not per batch | Read `db.rs:411` `insert_embedding` (bare `conn.execute`); read `embed_phase.rs:498-508` (plain `for` loop); grepped the whole file for `transaction`/`BEGIN`/`COMMIT`/savepoint | Confirmed — review correction is right |
| `chunks.token_count` exists and is populated | `008_token_counts.sql` adds the column; `chunks.rs:19-29` writes it on insert; `backfill_token_counts` covers old indexes | Confirmed |
| `estimate_tokens` is `chars/4` | `search/tokens.rs:2-4`: `(text.chars().count() / 4).max(1)` | Confirmed |
| `chunks_missing_embeddings` does **not** project `token_count` | Read the query: selects `c.id, c.name, c.metadata, c.summary, c.content` | Confirmed — noted in D4 as an implementation consequence |
| One rate feeds ETA + timeout + sizing | `RateEstimate` doc comment names all three; `batch_timeout` and `next_batch_size` both take `per_entry` | Confirmed — strengthens the "one defect" argument |
| `MAX_BATCH = 256` is why batch 5 was 256 | `embed_phase.rs:15`; `next_batch_size` clamps to the ceiling | Confirmed — sizing overshot and saturated |
| Device check precedes length check in `embed_batch` | `embedder_native.rs:316`: `b == 1 \|\| !matches!(self.device, Device::Cpu) \|\| max_seq > BATCH_MAX_SEQ` short-circuits | Confirmed — `BATCH_MAX_SEQ` unreachable on Metal |
| ADR-052 is the CPU path | Read ADR-052: explicitly scoped to `Device::Cpu`, cites `BATCH_MAX_SEQ` as live there | Confirmed — scoped the non-goal to non-CPU rather than contradict it |

Gates (pre-commit hook, real exit status):

| gate | result |
|---|---|
| `cargo fmt --check` | 0 |
| `cargo clippy` | 0 (all four crates checked) |

ADR numbering re-verified before committing: `070` appears in **no** other worktree, **no**
other remote branch, and is not in `origin/main`. Highest in `main` is 069 across both
`docs/adr/` trees. The only 070 anywhere is this branch. 026 remains a deliberate gap.

Public-repo checks re-run on the file: no board refs (both classes), no em-dashes on added
lines, no Status field, no pending-review markers, no link to the private repo.

