### PR TITLE
docs: remove dangling internal tracker refs from public docs

### DIFF
--- a/bench/agents/aggregate_telemetry.py
+++ b/bench/agents/aggregate_telemetry.py
@@ -9,7 +9,7 @@ output tokens, turns, and wall seconds. Given a committed price config, we also
 extrapolate cost per cell and project cost for prospective (not-yet-run) cells.
 
 Provenance contract: rows follow bench/agents/README.md "Reproducibility /
-provenance contract" (harness-matrix fields land via the oss^84 harness
+provenance contract" (harness-matrix fields land via the harness
 adapters). Legacy rows with no `harness` field are treated as harness "none".
 
 Reported as tokens-to-outcome, never a headline "tokens saved" (binding P8).

--- a/docs/adr/050-cli-auto-update-check.md
+++ b/docs/adr/050-cli-auto-update-check.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-28  
 **Deciders:** Architect  
-**Trigger:** spelunk-oss^27 — users on the curl/PowerShell installer have no way to
+**Trigger:** Users on the curl/PowerShell installer have no way to
 learn that a newer release exists; they keep running an old `spelunk` until they
 happen to re-run the install one-liner. We want a lightweight, opt-out update
 *notification* that respects package-manager- and MDM-managed installs.
@@ -17,12 +17,12 @@ The CLI is distributed through several channels:
   `spelunk` + `spelunk-server` into `/usr/local/bin` or `~/.local/bin` and
   downloads `spelunk-${VERSION}-${TARGET}.tar.gz` from
   `https://github.com/spelunk-cloud/spelunk/releases`.
-- Package managers (Homebrew is live; winget is planned in spelunk-oss^31). These
+- Package managers (Homebrew is live; winget is planned). These
   own the binary, place it under a manager-controlled prefix (Homebrew Cellar,
   `/opt/homebrew`, `/usr/local/Cellar`, …), and expect the user to upgrade
   *through the manager* (`brew upgrade`). The binary is often on a read-only or
   manager-owned path.
-- IT/MDM provisioning (spelunk-oss^28 will ship an MDM example), where the
+- IT/MDM provisioning (an MDM example is planned), where the
   endpoint is centrally managed and the user must not self-mutate it.
 
 Current facts the design builds on:
@@ -47,7 +47,7 @@ Current facts the design builds on:
   parse error must never delay or fail `spelunk search`, `spelunk index`, etc.
 - **Cheap to maintain.** The founder's intent is explicitly "doesn't have to be
   advanced." We want the smallest thing that is useful and safe.
-- **Forward-compatible disable surface.** spelunk-oss^28 (MDM) and ^31 (winget)
+- **Forward-compatible disable surface.** The planned MDM and winget paths
   both need a single, well-known way to turn this off. That mechanism is the
   load-bearing part of this ADR.
 
@@ -188,7 +188,7 @@ Concrete names to implement:
   tokens; written with `0600` for tidiness.
 - **MDM/managed honour.** Auto-detection (D2.3) plus the env/config disables
   ensure a centrally managed endpoint is never told to self-upgrade. This is the
-  acceptance-critical security property for spelunk-oss^28.
+  acceptance-critical security property for the MDM path.
 - This ADR introduces a new outbound network call (CLI → api.github.com) and a
   new state file; update `docs/security/THREAT-MODEL.md` accordingly during
   implementation.
@@ -197,10 +197,10 @@ Concrete names to implement:
 
 ## Consequences
 
-- spelunk-oss^28 (MDM example) documents `SPELUNK_NO_UPDATE_CHECK=1` (and/or
+- The MDM example documents `SPELUNK_NO_UPDATE_CHECK=1` (and/or
   `[update] check = false`) as the managed-install opt-out; auto-detection is a
   belt-and-braces backstop.
-- spelunk-oss^31 (winget) relies on the same disable surface + the winget path
+- The winget path relies on the same disable surface + the winget path
   heuristic in D2.3 so winget-managed installs don't self-nag.
 - A future `spelunk self-update` subcommand can reuse D4's release lookup and the
   asset `digest` (`sha256:<hex>`) for verified, explicit, opt-in upgrades — but

--- a/docs/adr/052-f2llm-cpu-batch-throughput.md
+++ b/docs/adr/052-f2llm-cpu-batch-throughput.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-30  
 **Deciders:** Architect  
-**Trigger:** spelunk-oss^16 — on GPU-less machines (Linux CI runners, low-cost
+**Trigger:** On GPU-less machines (Linux CI runners, low-cost
 cloud VMs, developer laptops with no Apple Silicon Metal) the native
 F2LLM-v2-330M embedder drives 100% of one CPU core and produces roughly
 ~400 ms per chunk at the current `EMBED_BATCH_SIZE = 8`. Indexing a large

--- a/docs/adr/058-team-server-bare-metal-deployment.md
+++ b/docs/adr/058-team-server-bare-metal-deployment.md
@@ -9,7 +9,7 @@
 
 **Date:** 2026-07-05
 **Deciders:** founder (Johan), architect
-**Trigger:** founder review on PR #516 (spelunk-oss^79). The pre-v1.0 server
+**Trigger:** founder review on PR #516. The pre-v1.0 server
 hardening made `spelunk-server` refuse a non-loopback plaintext bind
 *unconditionally*, and the founder review of that PR removed the bundled
 reverse-proxy/TLS-sidecar packaging entirely (Caddyfile and
@@ -75,8 +75,8 @@ Only a **same-host bare-metal** process can bind the host's real loopback and be
 reached there by a same-host TLS terminator. This is the mechanical reason
 bare-metal — not Docker — is the deployment vehicle for a networked team server.
 
-This also resolves the [spelunk-oss^70](../remote-agents.md) friction (Docker
-remote-agent loopback): the fix is to containerize the **agent**, not the
+This also resolves the [Docker remote-agent loopback](../remote-agents.md)
+friction: the fix is to containerize the **agent**, not the
 **server**. With the server on bare-metal loopback behind the operator's TLS
 terminator, a containerized agent connects to the operator's `https://`
 endpoint the same way any other client does — the terminator forwards to
@@ -250,8 +250,8 @@ in the implementation PR, not in this ADR's PR:
   containerized agent's `server_url` points at the operator's `https://`
   terminator (the same one clients use), not the Docker bridge gateway or
   `host.docker.internal`, which does not reach a host-loopback-bound server on
-  native Linux. This is the concrete [spelunk-oss^70](../remote-agents.md) fix;
-  add a one-line cross-reference that the server-side of a team deployment is
+  native Linux. This is the concrete [remote-agent loopback](../remote-agents.md)
+  fix; add a one-line cross-reference that the server-side of a team deployment is
   the bare-metal path in `self-hosting.md`.
 
 ### 5. Interaction with the health/limits surface
@@ -265,7 +265,7 @@ health body reflects the unit's `User=spelunk`, which is the identity the CLI's
 loopback auto-discovery guards against reusing — a deployed team server on a
 shared host is a distinct identity from a developer's auto-started loopback
 server, and that is correct. The `/index/embed` route is already exempt from the
-30 s request timeout (spelunk-oss^71/^73/^74), so large embed batches over the
+30 s request timeout, so large embed batches over the
 proxy are not cut off by the router timeout; the operator's proxy
 `proxy_read_timeout`/equivalent must be set generously to match (the
 `self-hosting.md` nginx example already does this for the SSE stream). If a
@@ -332,7 +332,7 @@ ADR does not depend on that field existing.
     `MemoryDenyWriteExecute`).
   - Execute the §4 docs restructure across `server.md`, `self-hosting.md`,
     `docker-compose.yml`, and `remote-agents.md` (including the R1
-    TLS-endpoint rework, the concrete spelunk-oss^70 fix), superseding the
+    TLS-endpoint rework, the concrete remote-agent loopback fix), superseding the
     PR #516 interim pointer.
   - Reconcile `self-hosting.md`'s existing systemd block (currently
     `Environment=`-based, `User=spelunk`) with the credential-based §2 unit.

--- a/docs/adr/062-temporal-as-of-semantic-search.md
+++ b/docs/adr/062-temporal-as-of-semantic-search.md
@@ -13,14 +13,14 @@
 `spelunk search --as-of <sha>` shipped a storage layer for "semantically search
 the codebase as it was at commit N" but was never wired to indexing. Nothing
 ever called `create_snapshot` / `insert_snapshot_*`, so `list_snapshots()` was
-always empty and every `--as-of` invocation errored. spelunk-oss^67 removed the
+always empty and every `--as-of` invocation errored. A later change removed the
 surface outright (commit `633276682`): it deleted `storage/snapshots.rs`, dropped
 the `--as-of` flag, and added migration `021_drop_snapshots.sql` to remove the
 dead `snapshots` / `snapshot_files` / `snapshot_chunks` / `snapshot_embeddings`
 tables. The original implementation (`69f070fc8`, migrations 016/017) is retained
 in git history.
 
-The task that spawned this ADR (spelunk-oss^69) asks us to confirm the feature is
+The task that spawned this ADR asks us to confirm the feature is
 worth its cost **before** rebuilding it. This is that confirmation. Four
 questions decide it: what triggers a snapshot, how snapshots are reclaimed, what
 net-new value they add over `git show`, and whether the whole thing fits the
@@ -129,7 +129,7 @@ trade against every one of those.
 ## Non-goals
 
 - **No implementation.** No code is written by this ADR. The removal in
-  spelunk-oss^67 stands; migration `021_drop_snapshots.sql` is not reverted.
+  commit `633276682` stands; migration `021_drop_snapshots.sql` is not reverted.
 - **No change to memory temporal features.** `memory --as-of <date>`,
   `timeline`, and `supersede` are unaffected. They are the endorsed temporal
   surface and remain the place the "history" need is served.
@@ -140,8 +140,8 @@ trade against every one of those.
 
 ## Consequences
 
-- The `--as-of` surface stays removed. spelunk-oss^69 closes as `wont_do` once
-  this ADR clears review; no scoped implementation task follows.
+- The `--as-of` surface stays removed. The task that spawned this ADR closes as
+  `wont_do` once this ADR clears review; no scoped implementation task follows.
 - The temporal story for spelunk is memory-layer only: decisions and their
   supersession over time, not code-state over time.
 - **Revisit if:** concrete, repeated user demand appears for semantic search over

--- a/docs/adr/066-native-tls-in-spelunk-server.md
+++ b/docs/adr/066-native-tls-in-spelunk-server.md
@@ -14,7 +14,7 @@ in-process TLS, which this ADR removes).
 `check_bind_safety` (`crates/spelunk-server/src/main.rs`), refuses **every**
 non-loopback bind, whether keyless (an open server) or keyed (the bearer key
 would cross the wire in cleartext). That refusal is unconditional and has no
-opt-out (hardened in spelunk-oss^122). Loopback binds are always allowed.
+opt-out (hardened pre-v1.0). Loopback binds are always allowed.
 
 The consequence: the only code-supported way to reach the server from another
 machine is to bind loopback and put an operator-owned TLS reverse proxy in front
@@ -120,7 +120,7 @@ a direct encoding of "local = HTTP no key, remote = HTTPS + key":
 
 Nothing currently permitted is removed: the keyed-non-loopback-plaintext bind
 that ADR-058 described as "permitted by the binary" was **already refused** by
-the time of this ADR (spelunk-oss^122 removed it). The only change is additive –
+the time of this ADR (the pre-v1.0 hardening removed it). The only change is additive –
 a non-loopback bind becomes allowed when, and only when, TLS **and** a key are
 both configured. Plaintext off-host stays refused with no opt-out.
 
@@ -185,7 +185,7 @@ bearer key in ADR-058:
 - **`examples/mdm/`** (macOS `.mobileconfig`, Windows service installer, README)
   – switch the daemon arguments from `--host 127.0.0.1` + a proxy note back to a
   routable bind with `--tls-cert`/`--tls-key`, undoing the interim
-  proxy-pointer that spelunk-oss^120 (PR #559) added as a stopgap under the
+  proxy-pointer that PR #559 added as a stopgap under the
   no-native-TLS constraint.
 - **`docs/remote-agents.md`** and **`packaging/*.service`** – point at the
   server's own `https://` endpoint; reconcile the shipped units with §6.

--- a/docs/adr/067-fail-closed-no-local-project.md
+++ b/docs/adr/067-fail-closed-no-local-project.md
@@ -106,8 +106,8 @@ describing the global store as if it were the current project's.
 ## Scope and non-goals
 
 - **Broader UX direction is out of scope.** Whether spelunk should engineer true
-  zero-setup usage or lead with `init` is a separate product decision
-  (spelunk-oss^134). D1/D2/D3 are the minimal fail-closed correctness fix and
+  zero-setup usage or lead with `init` is a separate product decision.
+  D1/D2/D3 are the minimal fail-closed correctness fix and
   foreclose neither direction: a future zero-setup design can define its own
   scoped store, and a lead-with-init design already matches this behaviour.
 - **The global store is not deleted or migrated.** Existing data under
@@ -142,4 +142,4 @@ describing the global store as if it were the current project's.
 ## Status
 
 P0 data-isolation fix. Implementation is gated on founder approval of this ADR
-and tracked on spelunk-oss^131.
+and tracked separately.

--- a/docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md
+++ b/docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md
@@ -3,8 +3,8 @@
 **Date:** 2026-07-11
 **Deciders:** founder (Johan); architect
 **Relationship to prior ADRs:** completes the product-direction decision that
-[ADR-067](067-fail-closed-no-local-project.md) explicitly deferred to
-spelunk-oss^134 ("Broader UX direction is out of scope … a separate product
+[ADR-067](067-fail-closed-no-local-project.md) explicitly deferred
+("Broader UX direction is out of scope … a separate product
 decision"). Builds on ADR-067's isolation floor but **narrows** its
 "fail-closed for memory" posture: where ADR-067 refused all memory operations
 without a local `.spelunk/` project, this ADR routes `memory add` / `memory
@@ -32,9 +32,9 @@ docs at the commands that genuinely work with no `init`, and to make `memory
 add` / `memory list` honour the "stored in git notes — travels with the repo"
 claim before `init` as well.
 
-### What actually runs before `init` (on `main`, after oss^147)
+### What actually runs before `init` (on `main`, after the global-store fix)
 
-`oss^147` (merged) closed the ADR-067 global-store residual: `graph`, `chunks`,
+A merged fix closed the ADR-067 global-store residual: `graph`, `chunks`,
 `check`, and `explore` now route through `require_project_db` and no longer fall
 back to the machine-global `~/.config/spelunk/index.db`. Nothing reads that
 global store implicitly any more. Current behaviour in an un-`init`'d, populated
@@ -44,8 +44,8 @@ repo:
 |---|---|
 | `spelunk search "…"` (**auto**, no `--mode`) | Degrades to `search_live` (ast-grep structural scan) when no index is present. This is the genuine zero-setup search surface; the doc never showed it. |
 | `spelunk search "…" --mode text` | Explicit FTS-over-index mode. Fails closed via `require_project_db` with *"no spelunk project here. Run 'spelunk init' first"*. Correct for an index-only mode — the doc simply led with the wrong invocation. |
-| `spelunk graph <symbol>` | Falls to the ast-grep `symbol($$$)` live call-site scan (exact, unranked) when no index opens; no longer reads any global store (oss^147). Zero results print `No scannable source files under this directory` (empty/umbrella dir) or `No callers found for '<symbol>' (live scan)` (source present, no match); the live scan never suggests `init` (oss^127). |
-| `spelunk graph <file-path>` / `chunks` / `check` / `explore` | Index-backed. Refuse with *"no spelunk project here. Run 'spelunk init' first"* (post-^147). |
+| `spelunk graph <symbol>` | Falls to the ast-grep `symbol($$$)` live call-site scan (exact, unranked) when no index opens; no longer reads any global store (the global-store fix). Zero results print `No scannable source files under this directory` (empty/umbrella dir) or `No callers found for '<symbol>' (live scan)` (source present, no match); the live scan never suggests `init`. |
+| `spelunk graph <file-path>` / `chunks` / `check` / `explore` | Index-backed. Refuse with *"no spelunk project here. Run 'spelunk init' first"* (after the global-store fix). |
 | `spelunk memory add` / `list` / `search` | **Currently** all fail closed pre-`init`: `memory/mod.rs:377–380` calls `require_project_db(&cfg.db_path, false)` and bails without a `.spelunk/` dir. This ADR changes `add` / `list` (see D3). |
 
 ### The architectural fault line
@@ -55,7 +55,7 @@ The code already draws the line the product decision needs:
 - **Working-tree-only, index-free, global-store-free** commands: `search "…"`
   (auto→ast-grep), `search --mode ast-grep`, `graph --live` / `graph <symbol>`'s
   ast-grep fallback. ADR-067 D1 exempts ast-grep because it "touches no index and
-  no global store," and oss^147 removed the residual global read. These are the
+  no global store," and the global-store fix removed the residual global read. These are the
   real zero-setup surface and are safe to run anywhere.
 - **Index-backed** commands: `search --mode text` (FTS), `graph <file>`,
   `chunks`, `check`, `explore`. These need `spelunk index` and correctly refuse
@@ -111,7 +111,7 @@ The docs must showcase the invocations that work as written — bare `search "�
 not `--mode text`; `graph <symbol>` / `--live`, not `graph <file>` — and frame
 the code-search/graph pieces as a *live structural scan*, not the full indexed
 graph/search. Working-tree-only is a hard constraint: none of these may read a
-machine-global store (oss^147 already guarantees this for `graph`).
+machine-global store (the global-store fix already guarantees this for `graph`).
 
 ### D3 — git-notes memory fallback for `add` / `list` before `init` (new feature)
 
@@ -128,7 +128,7 @@ and via `list` visibility into what is stored, without indexing the project.
 > priority for no reason. The corrected model below does not touch store
 > priority: it leans on the universal `store_in_git_notes` write-through that
 > already runs on every `memory add`, and only stops `add` / `list` from failing
-> closed before `init`. #580 (^154) implemented the superseded framing and is
+> closed before `init`. #580 implemented the superseded framing and is
 > re-scoped to this model.
 
 **The carrier already exists.** `memory add` already appends every new entry as
@@ -145,7 +145,7 @@ before `add` ever runs.
 notes (`refs/notes/spelunk`) are the durable carrier that travels with the repo;
 the local SQLite `memory.db` is the queryable index over that carrier. It holds
 the embeddings semantic `memory search` needs and is hydrated from the notes
-(the `init`-time git-notes import, ^155, is exactly that hydration step). This
+(the `init`-time git-notes import is exactly that hydration step). This
 does **not** contradict ADR-004. ADR-004 resolved a *local-vs-server*
 split-brain: it makes `memory.db` canonical *relative to a shared team server*
 and holds that memory stays local unless an explicit team `server_url` relocates
@@ -168,7 +168,7 @@ single change is at the pre-dispatch `require_project_db` bail:
   **one write path** pre- and post-`init`, so every note in `refs/notes/spelunk`
   carries an identical record shape (`schema_version`, timestamps, `remote_id`).
   That uniformity is the robustness win over a separate `GitNotesBackend.add`
-  path: it keeps the `init`-time import (^155) and plain
+  path: it keeps the `init`-time import and plain
   `git notes --ref=spelunk …` inspection consistent.
 - **`memory list`:** with no `memory.db`, read the entries back from
   `refs/notes/spelunk`.
@@ -214,18 +214,18 @@ returns a clear message pointing at the right next step — `spelunk init`,
 `spelunk server start`, or `--mode text` — rather than implying a **team**
 `server_url` is required (the current message misleads a solo user).
 
-## Per-ticket disposition
+## Per-item disposition
 
-| Ticket | Disposition under keep-zero-setup + git-notes fallback |
+| Item | Disposition under keep-zero-setup + git-notes fallback |
 |---|---|
-| **^127 / ^128** — `graph` exact-match only, no signal on zero results | **Survives, rescoped to a zero-result affordance.** When `graph <symbol>` finds nothing, guide the user to `spelunk graph --live` (structural scan) or `spelunk init` (full graph), optionally a did-you-mean. No global-store risk remains (oss^147 merged). Drop any "fuzzy graph before init" goal. |
-| **^129** — `search --mode text` hard-errors, demands `index` | **Mooted as a code bug; becomes a doc fix (marketing-site^33).** The hard error is correct for an explicit index-only mode. The zero-setup example must use bare `search "…"` (auto→ast-grep); `--mode text` is shown as a post-`init` example. No spelunk-oss change. |
-| **^130** — ast-grep fallback has no substring/fuzzy | **Optional enhancement, not a blocker.** Ship a clear "no matches (live structural scan) — run `spelunk init` for full search" hint now; treat fuzzy/substring as a later nice-to-have. |
-| **^131 / ^132** — memory scoping (silent global DB; git-notes not the default backend / no sync consumer) | **Direction changes from fail-closed-refuse to git-notes fallback (D3).** ADR-067 already closed the silent-global-DB leak. This ADR now makes git-notes the **pre-`init` memory path** for `add` / `list` — which reverses ^132's "git-notes is not the default backend" premise for the pre-`init` case. Follow-up: ^132's "no sync consumer" and ^126's "notes don't travel via push/fetch/clone by default" become **material** to the "travels with the repo" promise — see Open questions. |
-| **^133** — `memory search` misleadingly suggests team `server_url` | **Messaging fix (D4).** Point at `spelunk init` / `spelunk server start` / `--mode text`, not a team server. Consider defaulting to `--mode text` when no embedder is available. |
-| **^126** — git notes don't travel via push/fetch/clone by default | **Elevated by this decision.** Once git-notes is the pre-`init` "memory that travels with the repo," the promise only fully holds if `refs/notes/spelunk` is push/fetch-visible. Decide whether the fallback (or `init`, or a documented one-time git config) should configure the notes refspec — see Open questions. |
-| **^140** — manual git-notes inspection docs | **Elevated.** More users will now have notes written via the fallback; the inspection docs (`git notes --ref=spelunk …`, and `spelunk memory list`) are the transparency surface. Keep them current. |
-| **marketing-site ^32 / ^33** — getting-started rewrite | **Primary doc deliverable.** Keep the zero-setup framing (D1). Fix the broken examples to use commands that actually work with no `init` (D2): bare `search "…"`, `graph <symbol>` / `--live`, and `memory add` / `list` via the git-notes fallback (D3). Move `--mode text`, indexed graph, and semantic examples into a clearly-marked "after `spelunk init`" section without displacing the zero-setup headline. |
+| **`graph` exact-match only, no signal on zero results** | **Survives, rescoped to a zero-result affordance.** When `graph <symbol>` finds nothing, guide the user to `spelunk graph --live` (structural scan) or `spelunk init` (full graph), optionally a did-you-mean. No global-store risk remains (the global-store fix is merged). Drop any "fuzzy graph before init" goal. |
+| **`search --mode text` hard-errors, demands `index`** | **Mooted as a code bug; becomes a getting-started doc fix.** The hard error is correct for an explicit index-only mode. The zero-setup example must use bare `search "…"` (auto→ast-grep); `--mode text` is shown as a post-`init` example. No spelunk-oss change. |
+| **ast-grep fallback has no substring/fuzzy** | **Optional enhancement, not a blocker.** Ship a clear "no matches (live structural scan); run `spelunk init` for full search" hint now; treat fuzzy/substring as a later nice-to-have. |
+| **Memory scoping** (silent global DB; git-notes not the default backend / no sync consumer) | **Direction changes from fail-closed-refuse to git-notes fallback (D3).** ADR-067 already closed the silent-global-DB leak. This ADR now makes git-notes the **pre-`init` memory path** for `add` / `list`, which reverses the "git-notes is not the default backend" premise for the pre-`init` case. Follow-up: the absent sync consumer and the fact that notes don't travel via push/fetch/clone by default become **material** to the "travels with the repo" promise; see Open questions. |
+| **`memory search` misleadingly suggests team `server_url`** | **Messaging fix (D4).** Point at `spelunk init` / `spelunk server start` / `--mode text`, not a team server. Consider defaulting to `--mode text` when no embedder is available. |
+| **Git notes don't travel via push/fetch/clone by default** | **Elevated by this decision.** Once git-notes is the pre-`init` "memory that travels with the repo," the promise only fully holds if `refs/notes/spelunk` is push/fetch-visible. Decide whether the fallback (or `init`, or a documented one-time git config) should configure the notes refspec (see Open questions). |
+| **Manual git-notes inspection docs** | **Elevated.** More users will now have notes written via the fallback; the inspection docs (`git notes --ref=spelunk …`, and `spelunk memory list`) are the transparency surface. Keep them current. |
+| **getting-started rewrite** (marketing site) | **Primary doc deliverable.** Keep the zero-setup framing (D1). Fix the broken examples to use commands that actually work with no `init` (D2): bare `search "…"`, `graph <symbol>` / `--live`, and `memory add` / `list` via the git-notes fallback (D3). Move `--mode text`, indexed graph, and semantic examples into a clearly-marked "after `spelunk init`" section without displacing the zero-setup headline. |
 | **New work item — git-notes memory fallback** | **Implement D3** in spelunk-cli: before `init` (no `.spelunk/` project) but inside a git repo, stop `memory add` / `list` failing at the `require_project_db` bail. `add` skips the absent SQLite primary and lets the existing `store_in_git_notes` write-through carry the entry to `refs/notes/spelunk`; `list` reads it back from the notes; explicit `--backend git-notes` suppresses the write-through so an entry is not written twice. Fail only when there is neither a DB nor a git repo. File under spelunk-oss. |
 
 ## Non-goals
@@ -256,13 +256,15 @@ returns a clear message pointing at the right next step — `spelunk init`,
   behaviour and a partial reversal of ADR-067's
   fail-closed-for-memory posture: fail-closed now means "fall back to git notes
   if a repo exists, else refuse," not "always refuse without `.spelunk/`."
-- **git-notes visibility becomes a promise-load-bearing concern.** ^126 (notes
-  don't push/fetch/clone by default) and ^132 (no sync consumer) move from
-  cleanup to "does the 'travels with the repo' claim actually hold?" — resolved
-  in Open questions / follow-up, not silently assumed.
-- **The ticket set shrinks to messaging + docs + one new feature.** ^129 is a doc
-  fix; ^131/^132 reframe to the git-notes fallback; ^127/^128/^133 are small
-  affordance/messaging fixes; ^130 is optional; ^126/^140 are elevated; plus the
+- **git-notes visibility becomes a promise-load-bearing concern.** Notes not
+  pushing/fetching/cloning by default, and the absence of a sync consumer, move
+  from cleanup to "does the 'travels with the repo' claim actually hold?", a
+  question resolved in Open questions / follow-up rather than silently assumed.
+- **The work shrinks to messaging + docs + one new feature.** The `--mode text`
+  hard error is a doc fix; memory scoping reframes to the git-notes fallback; the
+  `graph` zero-result affordance and the `memory search` message are small
+  affordance/messaging fixes; ast-grep fuzzy matching is optional; notes
+  visibility and the git-notes inspection docs are elevated; plus the
   one new implementation item (D3).
 - **Revisit if:** the "travels with the repo" promise cannot be honoured without
   surprising git config changes (see Open questions), in which case the doc claim
@@ -279,13 +281,13 @@ returns a clear message pointing at the right next step — `spelunk init`,
   body, run **before** any persistence) applies unchanged on the git-notes path,
   so no credential reaches the note.
 - D2's working-tree-only constraint on the index-free surface is preserved by
-  oss^147 (no machine-global read from `graph`).
+  the global-store fix (no machine-global read from `graph`).
 
 ## Open questions
 
 - **Does "travels with the repo" require configuring the notes refspec?**
   `git notes` under `refs/notes/spelunk` are **not** pushed, fetched, or cloned
-  by default (^126). Because D3 makes those notes the durable carrier for
+  by default. Because D3 makes those notes the durable carrier for
   pre-`init` memory (not a second copy of a SQLite store of record), the
   "travels with the repo" claim now rests entirely on that ref being visible
   across clones. For the promise to hold across machines / teammates, either
@@ -295,7 +297,8 @@ returns a clear message pointing at the right next step — `spelunk init`,
   direction: have `init` offer to configure the refspec, and until then keep the
   doc claim accurate ("stored in git notes; run
   `spelunk memory list` to inspect") rather than over-promising cross-machine
-  sync. Track under ^126; do not block D3's local `add` / `list` on it.
+  sync. Track the notes-refspec question separately; do not block D3's local
+  `add` / `list` on it.
 
 ## Amendment (2026-07-13): canonical content-addressed identity for memory entries
 

--- a/docs/security/V1-SERVER-AUDIT.md
+++ b/docs/security/V1-SERVER-AUDIT.md
@@ -44,8 +44,8 @@ keys-table / scoped-key model are relabelled accordingly.
 
 | Check | Status |
 |---|---|
-| Configured key never held or compared as plaintext | ☑ `auth.rs::ApiKeyAuth::new` hashes the key with BLAKE3 into a 32-byte digest at construction; the plaintext is not retained (oss^58) |
-| Key comparison uses constant-time equality (not `==` on strings) | ☑ `auth.rs` hashes the provided token and compares digests with `constant_time_eq::constant_time_eq_32` (oss^58) |
+| Configured key never held or compared as plaintext | ☑ `auth.rs::ApiKeyAuth::new` hashes the key with BLAKE3 into a 32-byte digest at construction; the plaintext is not retained |
+| Key comparison uses constant-time equality (not `==` on strings) | ☑ `auth.rs` hashes the provided token and compares digests with `constant_time_eq::constant_time_eq_32` |
 | `sk-sp-` prefix format validated before any DB lookup | N/A (cloud-only). The OSS server has no `sk-sp-` prefix and no per-key DB lookup; the key is opaque and matched by digest. |
 | Revoked/deleted keys rejected immediately (no cache window) | N/A (cloud-only). There is no key store to revoke from; a single shared key is rotated by restarting the server with a new value (ADR-056). |
 | Key scope enforced: project-scoped key cannot write to other projects | N/A by design (ADR-056). The shared key grants full access to every project on the instance; isolation is by running separate instances. |
@@ -80,7 +80,7 @@ case (the bearer key would cross the network in the clear). The refusal names th
 interface/port. There is no
 override; the only supported posture for a shared server is to bind loopback.
 Covered by unit test
-`non_loopback_with_key_plaintext_is_refused_unconditionally` (oss^79).
+`non_loopback_with_key_plaintext_is_refused_unconditionally`.
 
 ## 4. Input validation
 
@@ -89,18 +89,18 @@ UUIDs, so the "malformed UUID" row is reframed as a slug length/sanity cap.
 
 | Check | Status |
 |---|---|
-| Title field: max 500 characters enforced at route handler | ☑ `handlers.rs` `MAX_TITLE_LEN = 500`, returns 400 on violation (oss^60) |
-| Body field: max 50 000 characters enforced at route handler | ☑ `handlers.rs` `MAX_BODY_LEN = 50_000`, returns 400 on violation (oss^60) |
-| Path param (project slug) validated; an over-long slug returns 400, not 500 | ☑ `handlers.rs` `MAX_SLUG_LEN = 200`, enforced in `require_project` and the handlers that bypass it (add_note / index_embed / project_search / explore / llm_complete) (oss^60) |
-| All SQL uses parameterised queries, no string concatenation | ☑ verified: `db.rs` uses `params!` throughout (no `format!`/concatenation into SQL across `crates/spelunk-server/src/`); FTS5 terms are quoted as literals via `fts5_quote_literal` (oss^65) |
+| Title field: max 500 characters enforced at route handler | ☑ `handlers.rs` `MAX_TITLE_LEN = 500`, returns 400 on violation |
+| Body field: max 50 000 characters enforced at route handler | ☑ `handlers.rs` `MAX_BODY_LEN = 50_000`, returns 400 on violation |
+| Path param (project slug) validated; an over-long slug returns 400, not 500 | ☑ `handlers.rs` `MAX_SLUG_LEN = 200`, enforced in `require_project` and the handlers that bypass it (add_note / index_embed / project_search / explore / llm_complete) |
+| All SQL uses parameterised queries, no string concatenation | ☑ verified: `db.rs` uses `params!` throughout (no `format!`/concatenation into SQL across `crates/spelunk-server/src/`); FTS5 terms are quoted as literals via `fts5_quote_literal` |
 
-Beyond this table, oss^60 also added a `tower_http` middleware stack (see §DoS in
+Beyond this table, the input-validation hardening also added a `tower_http` middleware stack (see §DoS in
 [`THREAT-MODEL.md`](THREAT-MODEL.md#d--denial-of-service)): `RequestBodyLimitLayer`
 (2 MiB), `TimeoutLayer` (30s, exempting `/memory/stream`), `ConcurrencyLimitLayer`
 (256), plus IP-keyed rate limiting on `/explore` and `/llm/complete`, and an
 embedding-vector-length check against the configured dim.
 
-**`/index/embed` timeout carve-out (spelunk-oss^71/^73/^74, PR #513 field-failure
+**`/index/embed` timeout carve-out (PR #513 field-failure
 follow-up):** the blanket 30s `TimeoutLayer` above made `/index/embed` unusable — a
 legitimate calibrated batch (or even a single oversized chunk on slow/CPU-only
 hardware) genuinely needs minutes, and was being killed at 30s regardless of what
@@ -147,7 +147,7 @@ service authenticated by one bearer key. The JWT/database rows are relabelled.
 
 | Check | Status |
 |---|---|
-| Server refuses to start if `JWT_SECRET` is absent or < 32 bytes | N/A (cloud-only). The OSS server has no JWT; auth is the shared `SPELUNK_SERVER_KEY`. The applicable startup guard is `main.rs::check_bind_safety`, ☑ implemented: it refuses a non-loopback plaintext bind **unconditionally** in both the keyless case (open server) and the keyed case (bearer key in cleartext), naming the interface. Neither refusal has an opt-out (oss^79). |
+| Server refuses to start if `JWT_SECRET` is absent or < 32 bytes | N/A (cloud-only). The OSS server has no JWT; auth is the shared `SPELUNK_SERVER_KEY`. The applicable startup guard is `main.rs::check_bind_safety`, ☑ implemented: it refuses a non-loopback plaintext bind **unconditionally** in both the keyless case (open server) and the keyed case (bearer key in cleartext), naming the interface. Neither refusal has an opt-out. |
 | `DATABASE_URL` never logged | N/A (cloud-only). No `DATABASE_URL`; the DB is a local SQLite file path. The applicable rule, that the bearer key is never logged, holds: ☑ `auth.rs` never logs the key or its hash. |
 | No secrets in default config files or committed `.env` files | ☑ verified: no committed `.env` and no secrets in the server's default config; `SPELUNK_SERVER_KEY` is supplied by the operator at runtime |
 | `.env*` excluded from any server-side file operations | N/A. The server does not walk the filesystem or index files; only the CLI indexer reads project trees (where `.env*` exclusion applies, and is documented in the CLI program). |
@@ -156,19 +156,19 @@ service authenticated by one bearer key. The JWT/database rows are relabelled.
 
 | Check | Status |
 |---|---|
-| 5xx responses do not leak stack traces or internal paths | ☑ `AppError::Internal` returns a fixed generic "Internal server error" 500 regardless of the underlying error text; the one safe case (embedding dim mismatch) is a typed 400 with a fixed message (`lib.rs`, `db.rs`) (oss^65, PR #509) |
+| 5xx responses do not leak stack traces or internal paths | ☑ `AppError::Internal` returns a fixed generic "Internal server error" 500 regardless of the underlying error text; the one safe case (embedding dim mismatch) is a typed 400 with a fixed message (`lib.rs`, `db.rs`) (PR #509) |
 | 422 injection responses reveal category, not pattern | ☑ `handlers.rs` returns `{field, category, message}`; the raw regex is never exposed (see §1) |
 | 401 responses consistent (cannot distinguish a missing key from a wrong key) | ☑ `auth.rs` returns the same `AuthError("Unauthorized")` mapped to 401 for both a missing `Authorization` header and a wrong bearer token; there is no 403 path (single shared key), so the missing-vs-wrong distinction does not leak |
 
-<!-- Evidence note (oss^65, PR #509, merged): AppError::Internal no longer sniffs the error
+<!-- Evidence note (PR #509, merged): AppError::Internal no longer sniffs the error
      Display text for substrings like "mismatch"/"required"; that was the leak. The one
      legitimately safe case (per-project embedding dimension mismatch) is now a typed
      DimensionMismatch error mapped to a 400 with a fixed safe message
      (crates/spelunk-server/src/db.rs, lib.rs); every other Internal error returns a fixed generic
      "Internal server error" 500. The same PR also quoted FTS5 MATCH terms as literals
      (crates/spelunk-core/src/utils/mod.rs fts5_quote_literal, applied in storage/search.rs +
-     storage/memory/search.rs), with an embedded-NUL-byte edge case tracked as a follow-up in
-     spelunk-oss^75, and added a uniform MAX_FILE_BYTES gate in
+     storage/memory/search.rs), with an embedded-NUL-byte edge case tracked as a separate
+     follow-up, and added a uniform MAX_FILE_BYTES gate in
      crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs. -->
 
 ---


### PR DESCRIPTION
## What

Removes internal tracker references (62 occurrences across 9 files) from the public repo's docs. These read as **dangling references to any outside reader**: nobody outside the project can resolve them, so they were noise in otherwise self-contained decision records.

This is hygiene, not an incident. No credentials, no strategy, no infrastructure detail was exposed. Docs-only: no `.rs` touched, no behaviour change.

## Approach

Two rules drove every edit:

1. **Remove a *reference*, never an *assertion*.** ADRs are decision records; de-referencing must not weaken what they decide. Where a sentence would have lost meaning, the subject was named instead of the claim being dropped.
2. **Keep anchors that actually resolve for an outside reader.** PR numbers (#509, #513, #516, #559, #580), the commit sha `633276682`, and bare project names ("File under spelunk-oss") are kept. A project name is not a tracker id.

Where a name was needed, it was taken from the document's own vocabulary rather than invented: e.g. ADR-058's existing phrase "the pre-v1.0 server hardening", and its own parenthetical "Docker remote-agent loopback".

One improvement fell out: ADR-062's non-goals previously anchored on a tracker ref; it now anchors on commit `633276682`, which the ADR's own Context already cited. An unresolvable ref became a resolvable one.

The largest change is ADR-068's disposition table, which was *keyed* on refs. Every row already stated its subject immediately after the ref, so the subject was promoted to the key and the column renamed `Ticket` to `Item`. No subject was invented.

## Test plan

- **Acceptance grep, before:** on the base commit, 62 ref occurrences across the 9 files (7 in ADR-050, 26 in ADR-068, 13 in the server audit, remainder spread across ADR-052/058/062/066/067 and the bench script).
- **Acceptance grep, after:**
  ```
  rg -nP '\b(spelunk-oss|oss|marketing-site|cloud-api|web-app)\^[0-9]+|(?<![A-Za-z0-9^])\^[0-9]+|task_[0-9a-f]{20}' --glob '!target/**' --glob '!.git/**'
  ```
  Returns **only** the two `deny.toml` hits below. `deny.toml` is not in this diff.
- **Assertion preservation:** read the full diff against the base. Verified each of the three sentences where de-referencing would have changed a claim still asserts what it did (ADR-062 Consequences, ADR-067 Status, ADR-068 Open questions). Verified the ADR-068 Consequences bullet that consisted of *nothing but* refs preserves all eight referents in its rewrite, cross-checking each against its disposition-table row.
- **Table integrity:** all 9 ADR-068 table rows parse as well-formed 2-column rows.
- **Python:** `python3 -m py_compile bench/agents/aggregate_telemetry.py` → rc=0. The edit is inside the module docstring (confirmed via `ast.get_docstring`), so it is non-functional.
- **House style:** zero em-dashes on added lines; the three that landed on rewritten table rows were restructured (punctuation only).
- **Gates:** `git diff --name-only` against the base shows 0 `.rs` files, so the Rust gates are not implicated.

## Known false positive: please do not "fix" this

The acceptance pattern permanently matches two lines in `deny.toml`:

```
deny.toml:83:  … calamine 0.35.0 (^0.39, XLSX/ODS) and
deny.toml:84:  docx-rs 0.4.20 (^0.36, DOCX) — both latest …
```

These are **legitimate Cargo caret-semver constraints**, not tracker refs. The `^` in `^0.39` is semver syntax. They are a documented, permanent false positive of this pattern and must be left alone. Anyone re-running this check should expect exactly these two hits and no others.
