### PR TITLE
test: isolate spelunk-cli git tests from ambient global git config

### DIFF
--- a/crates/spelunk-cli/tests/harvest_ref_injection.rs
+++ b/crates/spelunk-cli/tests/harvest_ref_injection.rs
@@ -8,11 +8,10 @@
 //! overwrite the target file.
 
 mod plumbing_helpers;
-use plumbing_helpers::spelunk_bin;
+use plumbing_helpers::{init_git_repo, spelunk_bin};
 
 use predicates::prelude::*;
 use std::fs;
-use std::process::Command as StdCommand;
 use tempfile::tempdir;
 
 fn write_harvest_config(dir: &std::path::Path, extra: &str) -> std::path::PathBuf {
@@ -28,20 +27,7 @@ fn write_harvest_config(dir: &std::path::Path, extra: &str) -> std::path::PathBu
 
 /// Initialize a throwaway git repo with a single commit so a real HEAD exists.
 fn init_repo(dir: &std::path::Path) {
-    let run = |args: &[&str]| {
-        let status = StdCommand::new("git")
-            .args(args)
-            .current_dir(dir)
-            .status()
-            .expect("run git");
-        assert!(status.success(), "git {args:?} failed");
-    };
-    run(&["init", "-q"]);
-    run(&["config", "user.email", "test@example.com"]);
-    run(&["config", "user.name", "Test"]);
-    fs::write(dir.join("README.md"), "hello\n").unwrap();
-    run(&["add", "."]);
-    run(&["commit", "-q", "-m", "initial commit"]);
+    init_git_repo(dir);
     // ADR-067: `memory harvest` fails closed without a local `.spelunk/` project,
     // so make this repo a real project — otherwise the guard fires before the
     // ref-injection check under test is reached.

--- a/crates/spelunk-cli/tests/memory_add_secret_gate.rs
+++ b/crates/spelunk-cli/tests/memory_add_secret_gate.rs
@@ -13,7 +13,7 @@
 //! check the error/SQLite side can use a plain temp dir.
 
 mod plumbing_helpers;
-use plumbing_helpers::spelunk_bin;
+use plumbing_helpers::{init_git_repo, spelunk_bin};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -133,34 +133,8 @@ fn clean_input_writes_sqlite_row_and_git_note() {
     let tmp = TempDir::new().unwrap();
 
     // Initialise a real git repo so `append_to_git_notes` has somewhere to write.
-    std::process::Command::new("git")
-        .arg("init")
-        .current_dir(tmp.path())
-        .output()
-        .expect("git init");
-    std::process::Command::new("git")
-        .args(["config", "user.email", "test@example.com"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("git config email");
-    std::process::Command::new("git")
-        .args(["config", "user.name", "Test"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("git config name");
-    // Create an initial commit so HEAD exists (required for git notes).
-    let readme = tmp.path().join("README.md");
-    std::fs::write(&readme, "# test").unwrap();
-    std::process::Command::new("git")
-        .args(["add", "README.md"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("git add");
-    std::process::Command::new("git")
-        .args(["commit", "-m", "init"])
-        .current_dir(tmp.path())
-        .output()
-        .expect("git commit");
+    // Creates the initial commit HEAD that git notes require.
+    init_git_repo(tmp.path());
 
     let mem_db = tmp.path().join("memory.db");
     // store_in_git_notes = true (default)

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -9,6 +9,54 @@ use assert_cmd::Command;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
+/// Drop the machine's global/system git config for every git this process
+/// spawns, including a setup git a test runs directly. Must be process-wide,
+/// not per-`Command`: a helper only controls the git it spawns itself, never
+/// one the code under test spawns for itself.
+///
+/// A temp repo's local config does not shadow an ambient value the repo never
+/// sets. A global `commit.gpgsign = true` makes setup commits sign as the
+/// fabricated test identity below, which no contributor holds a key for, so
+/// the commit exits non-zero.
+///
+/// `/dev/null` is not a Windows path, but git skips a scope whenever its var
+/// is set, whatever the path resolves to, so this isolates on Windows too.
+pub fn isolate_git_config() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: every git-touching helper here calls this first and `Once`
+        // blocks the rest until it returns, so no thread can be spawning git
+        // (reading environ) while these run.
+        unsafe {
+            std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
+            std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
+        }
+    });
+}
+
+/// Create a git repo in `dir` with a fabricated identity and one initial
+/// commit, isolated from the developer's ambient git config.
+///
+/// Every setup git step is asserted: a silent setup failure surfaces later as
+/// an unrelated assertion on the command under test.
+pub fn init_git_repo(dir: &Path) {
+    isolate_git_config();
+    let run = |args: &[&str]| {
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    run(&["init", "-q"]);
+    run(&["config", "user.email", "test@example.com"]);
+    run(&["config", "user.name", "Test"]);
+    std::fs::write(dir.join("README.md"), "hello\n").expect("write README.md");
+    run(&["add", "."]);
+    run(&["commit", "-q", "-m", "initial commit"]);
+}
+
 /// Build a `spelunk` test command that never touches the OS keychain and never
 /// reads or writes the developer's real `~/.config/spelunk`.
 ///


### PR DESCRIPTION
## What

Six `spelunk-cli` tests go red on a clean checkout for a contributor whose global git config sets `commit.gpgsign = true`, when using git's default (gpg) signing format.

The tests fabricate an identity in a throwaway repo (`user.email = test@example.com`). A temp repo's local config does not shadow an ambient value the repo never sets, so `commit.gpgsign` survives into the setup commit. Gpg-format signing resolves a key *by committer identity*, so git tries to sign as that fabricated identity, which no contributor holds a key for:

```
error: gpg failed to sign the data:
gpg: skipped "Test <test@example.com>": No secret key
```

### Scope: this is not every signing contributor

The blast radius is the **default gpg format only**. Contributors on `gpg.format = ssh` are unaffected: ssh signing uses the configured key file and never looks a key up by identity, so the setup commit succeeds and all tests pass. Verified both branches explicitly (see the test plan). So this hits the default-format majority, not everyone who signs.

## Why it surfaced so badly

`memory_add_secret_gate.rs` ran its setup git via `.output()`, which swallows a non-zero exit. The failing signed commit was silent, and the test then failed much later with the unrelated-looking:

```
expected at least one spelunk git note after clean memory add
```

Setup git steps now assert, so a setup failure reports itself as a setup failure.

## What changed

`isolate_git_config()` + `init_git_repo()` added to `crates/spelunk-cli/tests/plumbing_helpers.rs`, with `harvest_ref_injection.rs` and `memory_add_secret_gate.rs` routed through them. This mirrors the process-wide pattern already established in `spelunk-core/tests/integration_git_notes.rs`.

Isolation is process-wide (`GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM`) rather than per-`Command`, so it also reaches a git that the code under test spawns for itself, and it immunises against the whole ambient-config class rather than this one key.

**Tests only. No production code changed.**

## Test plan

Ambient config was injected only via `GIT_CONFIG_GLOBAL` pointed at a scratch file. No global git config was modified.

**Before/after repro** (scratch config: `[commit] gpgsign = true`, default gpg format):

| Run | Result |
| --- | --- |
| `origin/main` @ `241efbd3e`, gpg format injected | `9 tests run: 3 passed, 6 failed` |
| this branch, same injection | `9 tests run: 9 passed` |
| `origin/main`, **ssh** format + `gpgsign = true` | `9 tests run: 9 passed` (exempt) |

The 6 that fail on `main` are exactly:

- `harvest_ref_injection::harvest_rejects_bare_double_dash_branch`
- `harvest_ref_injection::harvest_rejects_option_like_branch_and_does_not_touch_victim_file`
- `harvest_ref_injection::harvest_rejects_option_like_branch_with_shell_metacharacters`
- `harvest_ref_injection::harvest_rejects_option_like_git_range`
- `harvest_ref_injection::harvest_rejects_short_option_like_branch`
- `memory_add_secret_gate::clean_input_writes_sqlite_row_and_git_note`

Sized with `--no-fail-fast` so the failure set is not truncated.

Raw git mechanism probe, confirming the identity-lookup story:

```
gpg format  -> git commit rc=128  (gpg: skipped "Test <test@example.com>": No secret key)
ssh format  -> git commit rc=0
/dev/null   -> git commit rc=0
```

**Full gates**, clean env (no injected config), `SPELUNK_SECRET_STORE=file`:

| Gate | Exit |
| --- | --- |
| `cargo fmt --check` | 0 |
| `cargo clippy --all-targets --features rich-formats -- -D warnings` | 0 |
| `cargo nextest run` | 0 (1089 passed, 9 skipped) |
| `cargo test --doc` | 0 |
| `cargo nextest run -p spelunk-core --no-default-features` | 0 (440 passed, 1 skipped) |
| `cargo test --doc -p spelunk-core --no-default-features` | 0 |

Also ran the two touched test binaries under the threaded runner (`cargo test`, 3 repeats, injected config): 9 passed each time, no flake.

## Reviewer note

The `isolate_git_config()` SAFETY comment states that every git-touching helper calls it first, so nothing can be spawning while `set_var` runs. In this file `spelunk_bin()` does not call it, yet does spawn. Under `cargo nextest` (what CI runs) every test is its own process, so this is unreachable; under threaded `cargo test` it is a theoretical race that did not reproduce in 3 repeats. No isolation gap results either way, because `spelunk_bin_in` already pins both vars per-`Command` on the child. Flagging only because the comment's reasoning is load-bearing for a future reader. The wording is inherited verbatim from the existing `spelunk-core` copy, so tightening it is arguably a separate, both-copies change.
