### PR TITLE
fix(memory): D8 writer lock policy + failed-note-read clobber guard (fixes the windows-latest entry loss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,33 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Concurrent memory writes can no longer silently erase each other's
+  entries.** The git-notes write path is a read-modify-write of the note on
+  `HEAD`, and nothing serialized it: two simultaneous `memory add` commands
+  could read the same note body, and the later write-back dropped the earlier
+  writer's entry, with both exiting 0. Worse, a writer treated *any* failure to
+  read the existing note as "no note yet", so one transient git failure inside
+  the write rewrote the whole note as just that writer's line, erasing every
+  prior entry (observed live on Windows CI, where it wiped 6 of 8 concurrent
+  entries). Three changes close this. Writes are now serialized end to end by a
+  cross-process lock file in the git common dir, one lock shared by all
+  worktrees because worktrees share the notes ref. A failed note read is
+  retried briefly and then fails the writer, rather than being mistaken for an
+  empty note. And a writer that cannot take the lock within its 5-second wait
+  fails with an error naming the lock file and telling you to retry; it never
+  writes unlocked. Many concurrent writers on a slow machine can exceed that
+  wait legitimately: every entry already written is intact, and retrying the
+  failed command is the remedy. What the failure looks like depends on the
+  store: after `spelunk init` the entry is already safe in `memory.db`, so
+  `memory add` exits 0 and prints `Warning: entry stored locally, but the
+  git-notes carry failed, so it will not travel with the repo: …` on stderr
+  (previously a failed carry was logged where nobody saw it); before `init`,
+  and with `--backend git-notes`, git notes is the primary store, so `memory
+  add` fails. On the rare filesystem where the lock file cannot be created at
+  all, the write-through proceeds unserialized and prints `Warning: wrote to
+  git notes without the cross-process lock …` on stderr: concurrent writes
+  there can still lose entries, and the warning says so. (#185, #632; ADR-069
+  D6/D8)
 - **A decision recorded independently on two machines now lists once, not twice.**
   Two machines that record the same decision (identical `kind`, `title`, and
   `body`) derive the same identity from that content, but `spelunk memory list`

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -179,7 +179,14 @@ pub(super) async fn memory_add(
                     "recording memory entry to git notes (no local project store to fall back on)",
                 ));
             }
-            Err(e) => tracing::warn!("git-notes write-through failed (non-fatal): {e}"),
+            // Visible without RUST_LOG: a swallowed carry failure is how an
+            // entry silently stops traveling with the repo (ADR-069 D8).
+            Err(e) => {
+                eprintln!(
+                    "Warning: entry stored locally, but the git-notes carry failed, \
+                     so it will not travel with the repo: {e:#}"
+                );
+            }
         }
     }
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -159,21 +159,31 @@ pub(super) async fn memory_add(
         // Use process CWD (None) — the CLI is always run from the project root.
         // Secret scan already ran above; no second check needed here.
         match append_to_git_notes(None, &record).await {
-            // Announce only the call that set it, so a repo says this once.
-            Ok(RewriteRefStatus::Configured) => {
-                notes_rewrite_note = Some(
-                    "Configured git notes.rewriteRef in this repo, so memory now survives \
-                     `git commit --amend` and `git rebase`.",
-                );
+            Ok(outcome) => {
+                // Visible without RUST_LOG: an unserialized write can lose a
+                // concurrent entry, and this is the only channel that reaches
+                // the user (ADR-069 D8: proceed unlocked, loudly).
+                if let Some(degradation) = outcome.lock_degradation {
+                    eprintln!("Warning: {degradation}");
+                }
+                match outcome.rewrite_ref {
+                    // Announce only the call that set it, so a repo says this once.
+                    RewriteRefStatus::Configured => {
+                        notes_rewrite_note = Some(
+                            "Configured git notes.rewriteRef in this repo, so memory now survives \
+                             `git commit --amend` and `git rebase`.",
+                        );
+                    }
+                    RewriteRefStatus::Failed => {
+                        notes_rewrite_note = Some(
+                            "Warning: could not set git notes.rewriteRef, so memory may not survive \
+                             `git commit --amend` or `git rebase`. Set it with: \
+                             git config --add notes.rewriteRef refs/notes/spelunk",
+                        );
+                    }
+                    RewriteRefStatus::AlreadyCovered => {}
+                }
             }
-            Ok(RewriteRefStatus::Failed) => {
-                notes_rewrite_note = Some(
-                    "Warning: could not set git notes.rewriteRef, so memory may not survive \
-                     `git commit --amend` or `git rebase`. Set it with: \
-                     git config --add notes.rewriteRef refs/notes/spelunk",
-                );
-            }
-            Ok(RewriteRefStatus::AlreadyCovered) => {}
             Err(e) if pre_init_notes => {
                 return Err(e.context(
                     "recording memory entry to git notes (no local project store to fall back on)",

--- a/crates/spelunk-cli/tests/git_notes_fallback.rs
+++ b/crates/spelunk-cli/tests/git_notes_fallback.rs
@@ -901,3 +901,46 @@ fn contended_notes_lock_fails_the_pre_init_carry_and_writes_nothing() {
         "a contended carry must write nothing; got: {lines:?}"
     );
 }
+
+/// D8's one kept degradation must be **visible**, not merely traced: an
+/// unusable lock file makes the write proceed unserialized, and the user must
+/// be told on stderr even with `RUST_LOG` unset, because a warning routed only
+/// through `tracing` reaches nobody in the shipped binary.
+///
+/// A directory planted at the lock path makes the open fail deterministically
+/// on every platform (EISDIR on unix, access-denied on Windows).
+#[test]
+fn unusable_notes_lock_degradation_is_visible_without_rust_log() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+
+    std::fs::create_dir_all(notes_lock_path(repo.path()))
+        .expect("plant a directory at the notes lock path");
+
+    bin(home.path(), repo.path())
+        .env_remove("RUST_LOG")
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "note",
+            "--title",
+            "unusable-lock-still-stores",
+            "--body",
+            "b",
+        ])
+        .assert()
+        // The write itself proceeds: failing every write on a lock-hostile
+        // filesystem would make spelunk unusable there (ADR-069 D8).
+        .success()
+        .stdout(predicate::str::contains("Stored [note]"))
+        // And the degradation is surfaced, not swallowed.
+        .stderr(predicate::str::contains("without the cross-process lock"));
+
+    let lines = spelunk_note_lines(repo.path());
+    assert!(
+        lines.len() == 1 && lines[0].contains("unusable-lock-still-stores"),
+        "the degraded write must still land exactly one record; got: {lines:?}"
+    );
+}

--- a/crates/spelunk-cli/tests/git_notes_fallback.rs
+++ b/crates/spelunk-cli/tests/git_notes_fallback.rs
@@ -816,14 +816,14 @@ fn failed_pre_init_carry_is_fatal_and_writes_nothing() {
     );
 }
 
-// ── the notes lock must not weaponize the fatal carry (ADR-069 D6 x D3) ────────
+// ── a contended notes lock fails the writer, loudly (ADR-069 D8) ──────────────
 
 /// The wait budget the carrier allows before giving up on a contended notes
 /// lock. Mirrors `LOCK_WAIT_BUDGET` in `storage/git_notes/lock.rs`.
 const LOCK_WAIT_BUDGET: Duration = Duration::from_secs(5);
 
 /// `<git-common-dir>/spelunk-notes.lock` — the file the carrier locks, resolved
-/// the way the production code resolves it.
+/// the way the production code resolves it, canonicalization included.
 fn notes_lock_path(repo: &Path) -> std::path::PathBuf {
     let raw = git_stdout(repo, &["rev-parse", "--git-common-dir"]);
     let raw = raw.trim();
@@ -833,26 +833,25 @@ fn notes_lock_path(repo: &Path) -> std::path::PathBuf {
     } else {
         repo.join(raw)
     };
+    let common_dir = std::fs::canonicalize(&common_dir).unwrap_or(common_dir);
     common_dir.join("spelunk-notes.lock")
 }
 
-/// A contended notes lock must never turn a working `memory add` into a failure.
+/// A pre-`init` `memory add` that cannot take a contended notes lock fails,
+/// visibly, and writes nothing (ADR-069 D8).
 ///
-/// Case 7 above makes a failed pre-`init` carry fatal: there is no SQLite
-/// primary to absorb it. The carrier's lock (ADR-069 D6) is therefore bounded
-/// and non-fatal by design — on contention it warns and writes unlocked. If it
-/// ever returned an `Err` instead, contention alone would break `memory add` on
-/// exactly the path that has nowhere to fall back to.
+/// This inverts the pre-D8 pin that stood here: contention used to warn and
+/// write unlocked, which is the unserialized read-modify-write that silently
+/// erases a concurrent writer's entry (#185). An error the user can see and
+/// retry costs a command; the silent clobber costs the record.
 ///
 /// Deterministic: this test holds the lock across the child's whole run, from a
 /// separate process, so the child is guaranteed to exhaust its budget.
 #[test]
-fn contended_notes_lock_does_not_fail_the_fatal_pre_init_carry() {
+fn contended_notes_lock_fails_the_pre_init_carry_and_writes_nothing() {
     let home = TempDir::new().unwrap();
     let repo = TempDir::new().unwrap();
     init_git_repo_with_commit(repo.path());
-
-    let title = "contended-lock-still-stored";
 
     let held = std::fs::OpenOptions::new()
         .read(true)
@@ -867,11 +866,20 @@ fn contended_notes_lock_does_not_fail_the_fatal_pre_init_carry() {
     let started = Instant::now();
     bin(home.path(), repo.path())
         .args([
-            "memory", "add", "--kind", "note", "--title", title, "--body", "b",
+            "memory",
+            "add",
+            "--kind",
+            "note",
+            "--title",
+            "contended-lock-must-not-store",
+            "--body",
+            "b",
         ])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("Stored [note]"));
+        .failure()
+        // No false success line, and the error tells the user what to do.
+        .stdout(predicate::str::contains("Stored").not())
+        .stderr(predicate::str::contains("notes lock").and(predicate::str::contains("Retry")));
     let took = started.elapsed();
 
     drop(held);
@@ -886,16 +894,10 @@ fn contended_notes_lock_does_not_fail_the_fatal_pre_init_carry() {
         notes_lock_path(repo.path()).display()
     );
 
-    // The whole point: the entry is still there, written unlocked.
+    // The whole point: nothing may be written without the lock.
     let lines = spelunk_note_lines(repo.path());
-    assert_eq!(
-        lines.len(),
-        1,
-        "a contended carry must still write exactly one record; got: {lines:?}"
-    );
     assert!(
-        lines[0].contains(title),
-        "the record must be the entry we added; got: {:?}",
-        lines[0]
+        lines.is_empty(),
+        "a contended carry must write nothing; got: {lines:?}"
     );
 }

--- a/crates/spelunk-core/src/storage/git_notes/lock.rs
+++ b/crates/spelunk-core/src/storage/git_notes/lock.rs
@@ -3,6 +3,10 @@
 //! Git's own ref locking cannot help here: the loss happens at the content
 //! layer, not the ref layer, and racing writers each hold the ref lock
 //! legitimately in turn. See issue #185 and ADR-069 (D6).
+//!
+//! Contention policy is the caller's, per ADR-069 D8: a writer that is handed
+//! [`LockAttempt::Contended`] must fail, never write unlocked; idempotent
+//! callers (the read-path merge, publish) skip and report.
 
 use anyhow::Result;
 use std::fs::{File, OpenOptions, TryLockError};
@@ -12,11 +16,13 @@ use std::time::{Duration, Instant};
 /// Lock file name, created inside the git **common** dir.
 const LOCK_FILE_NAME: &str = "spelunk-notes.lock";
 
-/// Bounded wait before giving up on a contended lock. Each holder keeps the
-/// lock for one read-modify-write (a few git subprocesses, ~30ms), so this is
-/// orders of magnitude above realistic contention; reaching it means something
-/// pathological, not a busy repo.
-const LOCK_WAIT_BUDGET: Duration = Duration::from_secs(5);
+/// Bounded wait before giving up on a contended lock.
+///
+/// A watchdog, not a contention threshold (ADR-069 D8): the OS releases an
+/// advisory lock when its holder exits, so there is no crashed-holder case to
+/// time out for. Reaching this means a live holder is stuck, which is a bug,
+/// and the expiry is reported to the caller, never silently downgraded.
+pub const LOCK_WAIT_BUDGET: Duration = Duration::from_secs(5);
 
 /// Poll interval while the lock is held by another process.
 const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -26,6 +32,34 @@ const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(10);
 pub struct NotesLock {
     // Dropping the File closes the fd, which releases the OS lock.
     _file: File,
+    path: PathBuf,
+}
+
+impl NotesLock {
+    /// The lock file this guard holds.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// One attempt to take the notes lock (ADR-069 D8).
+///
+/// The non-acquired arms are distinct because they demand different answers
+/// from a writer: `Contended` means serialization exists and someone else has
+/// it, so writing anyway is the #185 data loss; `Unusable` means serialization
+/// cannot exist here at all.
+#[must_use]
+#[derive(Debug)]
+pub enum LockAttempt {
+    /// Held until the guard drops.
+    Acquired(NotesLock),
+    /// Another holder kept it past [`LOCK_WAIT_BUDGET`]. A writer must fail;
+    /// idempotent work skips and reports.
+    Contended { path: PathBuf },
+    /// The lock file cannot be opened or locked on this filesystem, so
+    /// serialization is impossible here. Writers proceed unlocked, loudly;
+    /// this is the one degradation kept, and it is kept narrow.
+    Unusable { path: PathBuf, reason: String },
 }
 
 /// Resolve the lock path: `<git-common-dir>/spelunk-notes.lock`.
@@ -34,40 +68,64 @@ pub struct NotesLock {
 /// `refs/notes/spelunk`, so a per-worktree lock would fail to serialize the
 /// actual contenders.
 async fn notes_lock_path(git_root: Option<&Path>) -> Result<PathBuf> {
-    let raw = super::run_git(git_root, &["rev-parse", "--git-common-dir"]).await?;
-    let raw = Path::new(raw.trim());
+    // `--path-format=absolute` (git >= 2.31) answers absolute from a main and
+    // a linked worktree alike, so every contender computes one identity.
+    let flagged = super::run_git(
+        git_root,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )
+    .await;
 
-    // git may answer with a path relative to the dir it ran in.
-    let common_dir = if raw.is_absolute() {
-        raw.to_path_buf()
-    } else {
-        match git_root {
-            Some(root) => root.join(raw),
-            None => std::env::current_dir()?.join(raw),
+    let common_dir = match flagged.ok().and_then(|out| parse_absolute_dir(&out)) {
+        Some(dir) => dir,
+        // Older git. Note it does not reject the flag: rev-parse echoes
+        // unknown options back with exit 0, which is why the parse above
+        // validates the output instead of trusting the exit code.
+        None => {
+            let raw = super::run_git(git_root, &["rev-parse", "--git-common-dir"]).await?;
+            let raw = Path::new(raw.trim());
+
+            // git may answer with a path relative to the dir it ran in.
+            if raw.is_absolute() {
+                raw.to_path_buf()
+            } else {
+                match git_root {
+                    Some(root) => root.join(raw),
+                    None => std::env::current_dir()?.join(raw),
+                }
+            }
         }
     };
+
+    // One spelling for every contender: case, separators, 8.3 short names and
+    // symlinks can otherwise differ per worktree, most visibly on Windows.
+    let common_dir = std::fs::canonicalize(&common_dir).unwrap_or(common_dir);
 
     Ok(common_dir.join(LOCK_FILE_NAME))
 }
 
+/// The single absolute path in `rev-parse --path-format=absolute` output, or
+/// `None` when the output is an echoed unknown flag (git < 2.31).
+fn parse_absolute_dir(out: &str) -> Option<PathBuf> {
+    let mut lines = out.lines().filter(|l| !l.trim().is_empty());
+    let first = lines.next()?.trim();
+    if lines.next().is_some() || first.starts_with("--") {
+        return None;
+    }
+    let p = Path::new(first);
+    p.is_absolute().then(|| p.to_path_buf())
+}
+
 /// Acquire the notes lock, waiting up to [`LOCK_WAIT_BUDGET`].
 ///
-/// Returns `None` if the lock could not be taken (contended past the budget,
-/// or unusable — e.g. a read-only or lock-hostile filesystem). Callers must
-/// treat `None` as "proceed without serialization" or "skip the optional
-/// work", never as a hard error: a caller's command must never fail because of
-/// lock contention.
+/// `Err` means the lock path could not be resolved, which is git itself
+/// failing; a writer's own git calls are about to fail the same way, so this
+/// surfaces rather than degrades.
 ///
 /// Held across the whole read-modify-write, not just the write: the race is
 /// the gap between reading the note body and writing it back.
-pub async fn lock_notes(git_root: Option<&Path>) -> Option<NotesLock> {
-    let path = match notes_lock_path(git_root).await {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::warn!("could not resolve git notes lock path ({e}); proceeding unlocked");
-            return None;
-        }
-    };
+pub async fn lock_notes(git_root: Option<&Path>) -> Result<LockAttempt> {
+    let path = notes_lock_path(git_root).await?;
 
     let file = match OpenOptions::new()
         .read(true)
@@ -78,32 +136,58 @@ pub async fn lock_notes(git_root: Option<&Path>) -> Option<NotesLock> {
     {
         Ok(f) => f,
         Err(e) => {
-            tracing::warn!(
-                "could not open git notes lock {}: {e}; proceeding unlocked",
-                path.display()
-            );
-            return None;
+            return Ok(LockAttempt::Unusable {
+                path,
+                reason: format!("could not open: {e}"),
+            });
         }
     };
 
     let deadline = Instant::now() + LOCK_WAIT_BUDGET;
     loop {
         match file.try_lock() {
-            Ok(()) => return Some(NotesLock { _file: file }),
+            Ok(()) => return Ok(LockAttempt::Acquired(NotesLock { _file: file, path })),
             Err(TryLockError::WouldBlock) => {
                 if Instant::now() >= deadline {
-                    tracing::warn!(
-                        "git notes lock still held after {:?}; proceeding unlocked",
-                        LOCK_WAIT_BUDGET
-                    );
-                    return None;
+                    return Ok(LockAttempt::Contended { path });
                 }
                 tokio::time::sleep(LOCK_POLL_INTERVAL).await;
             }
             Err(TryLockError::Error(e)) => {
-                tracing::warn!("git notes lock unusable ({e}); proceeding unlocked");
-                return None;
+                return Ok(LockAttempt::Unusable {
+                    path,
+                    reason: format!("could not lock: {e}"),
+                });
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// git < 2.31 echoes the unknown flag back with exit 0, so the fallback
+    /// trigger is the output shape, not the exit code. Trusting the exit code
+    /// would aim the lock at a path spelled `--path-format=absolute`.
+    #[test]
+    fn echoed_flag_output_is_rejected() {
+        assert_eq!(parse_absolute_dir("--path-format=absolute\n.git\n"), None);
+        assert_eq!(parse_absolute_dir(".git\n"), None, "relative is rejected");
+        assert_eq!(parse_absolute_dir(""), None);
+    }
+
+    #[test]
+    fn a_single_absolute_line_is_accepted() {
+        #[cfg(unix)]
+        assert_eq!(
+            parse_absolute_dir("/repo/.git\n"),
+            Some(PathBuf::from("/repo/.git"))
+        );
+        #[cfg(windows)]
+        assert_eq!(
+            parse_absolute_dir("C:/repo/.git\n"),
+            Some(PathBuf::from("C:/repo/.git"))
+        );
     }
 }

--- a/crates/spelunk-core/src/storage/git_notes/lock.rs
+++ b/crates/spelunk-core/src/storage/git_notes/lock.rs
@@ -18,10 +18,12 @@ const LOCK_FILE_NAME: &str = "spelunk-notes.lock";
 
 /// Bounded wait before giving up on a contended lock.
 ///
-/// A watchdog, not a contention threshold (ADR-069 D8): the OS releases an
-/// advisory lock when its holder exits, so there is no crashed-holder case to
-/// time out for. Reaching this means a live holder is stuck, which is a bug,
-/// and the expiry is reported to the caller, never silently downgraded.
+/// The OS releases an advisory lock when its holder exits, so there is no
+/// crashed-holder case to time out for. Reaching this means either a stuck
+/// live holder or a queue of legitimate writers on a slow machine (observed
+/// on CI: 8 serialized appends exceed 5s when process spawns are expensive).
+/// Either way expiry is reported to the caller, never silently downgraded
+/// (ADR-069 D8); a failed writer retries, a wedged holder is a bug.
 pub const LOCK_WAIT_BUDGET: Duration = Duration::from_secs(5);
 
 /// Poll interval while the lock is held by another process.

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use std::collections::HashMap;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
@@ -13,7 +13,7 @@ mod fold;
 mod lock;
 mod publish;
 
-pub use lock::{NotesLock, lock_notes};
+pub use lock::{LOCK_WAIT_BUDGET, LockAttempt, NotesLock, lock_notes};
 pub use publish::{PublishOutcome, SkipReason, publish_notes};
 
 // ── Carry config: surviving history rewrites ─────────────────────────────────
@@ -100,6 +100,70 @@ fn rewrite_ref_covers_spelunk(value: &str) -> bool {
 
 // ── Write-through helper (free function) ─────────────────────────────────────
 
+/// Take the notes lock for a writer, per ADR-069 D8: hold it or fail, except
+/// where the lock cannot exist at all, which degrades unlocked and loudly.
+///
+/// `Ok(None)` is that one degradation. `Err` is contention (someone else holds
+/// the lock; writing anyway is the #185 loss) or a failed path resolution
+/// (git itself is failing, and the writer's own git calls are next).
+async fn writer_lock(git_root: Option<&std::path::Path>) -> Result<Option<NotesLock>> {
+    match lock_notes(git_root).await? {
+        LockAttempt::Acquired(guard) => Ok(Some(guard)),
+        LockAttempt::Contended { path } => Err(anyhow!(
+            "another process has held the git notes lock ({}) for over {:?}; \
+             not writing without it, because an unserialized write can silently \
+             erase a concurrent writer's entry. Retry the command; if this \
+             persists, a spelunk or git process is stuck holding the lock \
+             (it frees itself when that process exits)",
+            path.display(),
+            lock::LOCK_WAIT_BUDGET,
+        )),
+        LockAttempt::Unusable { path, reason } => {
+            tracing::warn!(
+                "git notes lock {} unusable ({reason}); writing without \
+                 serialization, so a concurrent memory write could be lost",
+                path.display()
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Read the spelunk note body on `object`, distinguishing "no note" (`None`)
+/// from a failed read (`Err`).
+///
+/// The distinction is load-bearing: a writer that mistakes a failed read for
+/// "no note yet" rewrites the whole note as just its own line, erasing every
+/// sibling entry. Seen live on Windows CI, where a transient git failure
+/// inside the guarded section wiped 6 of 8 concurrent entries (#185).
+///
+/// Matches on the exit code, not the message: "no note found" exits 1, while
+/// infrastructure failures die with 128, and the message text is localized.
+async fn read_note_body(
+    git_root: Option<&std::path::Path>,
+    object: &str,
+) -> Result<Option<String>> {
+    let mut cmd = Command::new("git");
+    if let Some(d) = git_root {
+        cmd.current_dir(d);
+    }
+    let out = cmd
+        .args(["notes", "--ref=spelunk", "show", "--", object])
+        .output()
+        .await?;
+
+    if out.status.success() {
+        return Ok(Some(String::from_utf8_lossy(&out.stdout).into_owned()));
+    }
+    if out.status.code() == Some(1) {
+        return Ok(None);
+    }
+    Err(anyhow!(
+        "git notes show -- {object}: {}",
+        String::from_utf8_lossy(&out.stderr).trim()
+    ))
+}
+
 /// Append a `NoteRecord` as a JSON line to `refs/notes/spelunk` on HEAD.
 ///
 /// Read-modify-write with append semantics: the existing blob is read and its
@@ -109,10 +173,11 @@ fn rewrite_ref_covers_spelunk(value: &str) -> bool {
 ///
 /// Serialized end to end by [`lock_notes`]; without it a concurrent writer
 /// reads the same body and silently drops this entry on write-back (#185).
+/// Per ADR-069 D8 a contended lock is an `Err` and nothing is written; only a
+/// lock that cannot exist on this filesystem degrades to an unlocked write.
 ///
-/// Errors are intentionally non-fatal: the caller should log `tracing::warn!`
-/// and continue.  On success it returns the [`RewriteRefStatus`] of the carry
-/// config ensured along the way, so a CLI caller can announce it once.
+/// On success it returns the [`RewriteRefStatus`] of the carry config ensured
+/// along the way, so a CLI caller can announce it once.
 ///
 /// # Arguments
 /// * `git_root` — directory passed to `git -C`; `None` uses the process CWD.
@@ -125,9 +190,8 @@ pub async fn append_to_git_notes(
     // lock: serializing it would widen the guarded section for nothing.
     let rewrite_ref = ensure_notes_rewrite_ref(git_root).await;
 
-    // Guard all four steps. Contention must never fail the caller's write, so
-    // an unavailable lock degrades to the pre-#185 unserialized behaviour.
-    let _lock = lock_notes(git_root).await;
+    // Guards all four steps (D8).
+    let _lock = writer_lock(git_root).await?;
 
     // ── 1. Get HEAD sha ───────────────────────────────────────────────────────
     let head = run_git(git_root, &["rev-parse", "HEAD"])
@@ -135,17 +199,18 @@ pub async fn append_to_git_notes(
         .map(|s| s.trim().to_string())?;
 
     // ── 2. Read existing note (may not exist) ─────────────────────────────────
-    let existing = run_git(git_root, &["notes", "--ref=spelunk", "show", "--", &head])
+    let existing = read_note_body(git_root, &head)
         .await
-        .unwrap_or_default();
+        .context("could not read the existing note, so not overwriting it")?;
 
     // ── 3. Append new entry ───────────────────────────────────────────────────
     let new_line = serde_json::to_string(record)?;
 
-    let combined = if existing.trim().is_empty() {
-        new_line
-    } else {
-        format!("{}\n{}", existing.trim_end_matches('\n'), new_line)
+    let combined = match existing {
+        Some(body) if !body.trim().is_empty() => {
+            format!("{}\n{}", body.trim_end_matches('\n'), new_line)
+        }
+        _ => new_line,
     };
 
     // ── 4. Write back ─────────────────────────────────────────────────────────
@@ -202,9 +267,18 @@ pub enum NotesMergeOutcome {
 /// the merge rather than waiting the caller out.
 pub async fn merge_tracking_notes(git_root: Option<&std::path::Path>) -> NotesMergeOutcome {
     // Without this, a concurrent `append_to_git_notes` read-modify-write
-    // silently overwrites the merged entries (#185 / ADR-069 D6).
-    let Some(_lock) = lock_notes(git_root).await else {
-        return NotesMergeOutcome::LockUnavailable;
+    // silently overwrites the merged entries (#185 / ADR-069 D6). Unlike a
+    // writer, every non-acquired outcome skips: the union is idempotent, so
+    // the next read catches up, and a read must never fail over the lock.
+    let _lock = match lock_notes(git_root).await {
+        Ok(LockAttempt::Acquired(guard)) => guard,
+        Ok(LockAttempt::Contended { .. }) | Ok(LockAttempt::Unusable { .. }) => {
+            return NotesMergeOutcome::LockUnavailable;
+        }
+        Err(e) => {
+            tracing::debug!("notes merge skipped, lock path unresolved: {e}");
+            return NotesMergeOutcome::LockUnavailable;
+        }
     };
 
     // `-s` is explicit on every call: the `notes.mergeStrategy` default is
@@ -499,16 +573,14 @@ impl GitNotesBackend {
     }
 
     /// Read the raw note blob for `commit_sha` (empty string if no note).
+    ///
+    /// A failed read is an `Err`, never an empty blob: `append_record` and
+    /// `archive_record` write back what this returns, so conflating the two
+    /// turns one transient git failure into a wiped note (#185).
     async fn read_note_blob(&self, commit_sha: &str) -> Result<String> {
-        let out = self
-            .git()
-            .args(["notes", "--ref=spelunk", "show", "--", commit_sha])
-            .output()
-            .await?;
-        if !out.status.success() {
-            return Ok(String::new());
-        }
-        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+        Ok(read_note_body(self.git_root.as_deref(), commit_sha)
+            .await?
+            .unwrap_or_default())
     }
 
     /// Permissively parse the spelunk records from a commit's note blob.
@@ -533,7 +605,7 @@ impl GitNotesBackend {
         // this path has no command output to announce on.
         ensure_notes_rewrite_ref(self.git_root.as_deref()).await;
 
-        let _lock = lock_notes(self.git_root.as_deref()).await;
+        let _lock = writer_lock(self.git_root.as_deref()).await?;
 
         let existing = self.read_note_blob(object).await?;
         let new_line = serde_json::to_string(record)?;
@@ -551,7 +623,7 @@ impl GitNotesBackend {
     /// the matched record's line is re-serialized. Returns whether a match was
     /// rewritten.
     async fn archive_record(&self, object: &str, id: i64) -> Result<bool> {
-        let _lock = lock_notes(self.git_root.as_deref()).await;
+        let _lock = writer_lock(self.git_root.as_deref()).await?;
 
         let blob = self.read_note_blob(object).await?;
         let mut out_lines: Vec<String> = Vec::new();

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -129,6 +129,44 @@ async fn writer_lock(git_root: Option<&std::path::Path>) -> Result<Option<NotesL
     }
 }
 
+/// Attempts for [`read_note_body`] before its failure is surfaced. The
+/// windows-latest losses were transient: the same read succeeded for every
+/// sibling writer moments apart, so a brief, bounded retry of a side-effect
+/// free read absorbs the flake without hiding a persistent failure.
+const NOTE_READ_ATTEMPTS: u32 = 4;
+
+/// Base backoff between read attempts; grows linearly per attempt.
+const NOTE_READ_BACKOFF: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// [`read_note_body`], retried up to [`NOTE_READ_ATTEMPTS`] times.
+///
+/// Retries only genuine failures, never "no note found": the read has no side
+/// effects, so retrying cannot double-apply anything, and a persistent failure
+/// still reaches the caller as the `Err` that keeps a writer from wiping the
+/// note. Total added wait is bounded well under the lock budget, so a holder's
+/// cost stays local work (ADR-069 D9).
+async fn read_note_body_with_retry(
+    git_root: Option<&std::path::Path>,
+    object: &str,
+) -> Result<Option<String>> {
+    let mut last_err = None;
+    for attempt in 1..=NOTE_READ_ATTEMPTS {
+        match read_note_body(git_root, object).await {
+            Ok(body) => return Ok(body),
+            Err(e) => {
+                tracing::warn!(
+                    "reading existing note failed (attempt {attempt}/{NOTE_READ_ATTEMPTS}): {e}"
+                );
+                last_err = Some(e);
+                if attempt < NOTE_READ_ATTEMPTS {
+                    tokio::time::sleep(NOTE_READ_BACKOFF * attempt).await;
+                }
+            }
+        }
+    }
+    Err(last_err.expect("at least one attempt ran"))
+}
+
 /// Read the spelunk note body on `object`, distinguishing "no note" (`None`)
 /// from a failed read (`Err`).
 ///
@@ -199,7 +237,7 @@ pub async fn append_to_git_notes(
         .map(|s| s.trim().to_string())?;
 
     // ── 2. Read existing note (may not exist) ─────────────────────────────────
-    let existing = read_note_body(git_root, &head)
+    let existing = read_note_body_with_retry(git_root, &head)
         .await
         .context("could not read the existing note, so not overwriting it")?;
 
@@ -578,9 +616,11 @@ impl GitNotesBackend {
     /// `archive_record` write back what this returns, so conflating the two
     /// turns one transient git failure into a wiped note (#185).
     async fn read_note_blob(&self, commit_sha: &str) -> Result<String> {
-        Ok(read_note_body(self.git_root.as_deref(), commit_sha)
-            .await?
-            .unwrap_or_default())
+        Ok(
+            read_note_body_with_retry(self.git_root.as_deref(), commit_sha)
+                .await?
+                .unwrap_or_default(),
+        )
     }
 
     /// Permissively parse the spelunk records from a commit's note blob.

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, anyhow};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -100,15 +101,30 @@ fn rewrite_ref_covers_spelunk(value: &str) -> bool {
 
 // ── Write-through helper (free function) ─────────────────────────────────────
 
+/// How a writer holds, or legitimately does not hold, the notes lock.
+///
+/// `Unlocked` is ADR-069 D8's one kept degradation, and it is a **returned
+/// value** so a caller can surface it: a `tracing::warn!` reaches nobody
+/// without `RUST_LOG`, and a degradation no caller can see is how silent data
+/// loss stayed invisible in the first place.
+#[must_use]
+enum WriterLock {
+    /// Held until dropped; the guard is retained only for its `Drop`.
+    Held { _guard: NotesLock },
+    /// The lock cannot exist here; the write proceeds unserialized.
+    Unlocked { path: PathBuf, reason: String },
+}
+
 /// Take the notes lock for a writer, per ADR-069 D8: hold it or fail, except
 /// where the lock cannot exist at all, which degrades unlocked and loudly.
 ///
-/// `Ok(None)` is that one degradation. `Err` is contention (someone else holds
-/// the lock; writing anyway is the #185 loss) or a failed path resolution
-/// (git itself is failing, and the writer's own git calls are next).
-async fn writer_lock(git_root: Option<&std::path::Path>) -> Result<Option<NotesLock>> {
+/// `Ok(WriterLock::Unlocked { .. })` is that one degradation. `Err` is
+/// contention (someone else holds the lock; writing anyway is the #185 loss)
+/// or a failed path resolution (git itself is failing, and the writer's own
+/// git calls are next).
+async fn writer_lock(git_root: Option<&std::path::Path>) -> Result<WriterLock> {
     match lock_notes(git_root).await? {
-        LockAttempt::Acquired(guard) => Ok(Some(guard)),
+        LockAttempt::Acquired(guard) => Ok(WriterLock::Held { _guard: guard }),
         LockAttempt::Contended { path } => Err(anyhow!(
             "the git notes lock ({}) stayed held by other writers for over {:?}; \
              not writing without it, because an unserialized write can silently \
@@ -125,7 +141,7 @@ async fn writer_lock(git_root: Option<&std::path::Path>) -> Result<Option<NotesL
                  serialization, so a concurrent memory write could be lost",
                 path.display()
             );
-            Ok(None)
+            Ok(WriterLock::Unlocked { path, reason })
         }
     }
 }
@@ -203,6 +219,19 @@ async fn read_note_body(
     ))
 }
 
+/// What [`append_to_git_notes`] did, beyond writing the entry.
+#[derive(Debug)]
+pub struct AppendOutcome {
+    /// The carry-config status ensured along the way; a CLI caller announces
+    /// it once.
+    pub rewrite_ref: RewriteRefStatus,
+    /// Set when the write proceeded **without** the notes lock (ADR-069 D8's
+    /// one kept degradation, on a filesystem where the lock cannot exist).
+    /// The caller must show it to the user: this return value is the only
+    /// channel that works without `RUST_LOG`.
+    pub lock_degradation: Option<String>,
+}
+
 /// Append a `NoteRecord` as a JSON line to `refs/notes/spelunk` on HEAD.
 ///
 /// Read-modify-write with append semantics: the existing blob is read and its
@@ -213,10 +242,8 @@ async fn read_note_body(
 /// Serialized end to end by [`lock_notes`]; without it a concurrent writer
 /// reads the same body and silently drops this entry on write-back (#185).
 /// Per ADR-069 D8 a contended lock is an `Err` and nothing is written; only a
-/// lock that cannot exist on this filesystem degrades to an unlocked write.
-///
-/// On success it returns the [`RewriteRefStatus`] of the carry config ensured
-/// along the way, so a CLI caller can announce it once.
+/// lock that cannot exist on this filesystem degrades to an unlocked write,
+/// reported in [`AppendOutcome::lock_degradation`].
 ///
 /// # Arguments
 /// * `git_root` — directory passed to `git -C`; `None` uses the process CWD.
@@ -224,13 +251,23 @@ async fn read_note_body(
 pub async fn append_to_git_notes(
     git_root: Option<&std::path::Path>,
     record: &NoteRecord,
-) -> Result<RewriteRefStatus> {
+) -> Result<AppendOutcome> {
     // Touches `git config` only, never the notes ref, so it stays outside the
     // lock: serializing it would widen the guarded section for nothing.
     let rewrite_ref = ensure_notes_rewrite_ref(git_root).await;
 
-    // Guards all four steps (D8).
-    let _lock = writer_lock(git_root).await?;
+    // Guards all four steps (D8). Bind the whole enum: `Held`'s guard must
+    // live to the end of the function.
+    let lock = writer_lock(git_root).await?;
+    let lock_degradation = match &lock {
+        WriterLock::Held { .. } => None,
+        WriterLock::Unlocked { path, reason } => Some(format!(
+            "wrote to git notes without the cross-process lock (lock file {} \
+             unusable: {reason}); concurrent memory writes in this repo can \
+             lose entries",
+            path.display()
+        )),
+    };
 
     // ── 1. Get HEAD sha ───────────────────────────────────────────────────────
     let head = run_git(git_root, &["rev-parse", "HEAD"])
@@ -276,7 +313,10 @@ pub async fn append_to_git_notes(
     )
     .await?;
 
-    Ok(rewrite_ref)
+    Ok(AppendOutcome {
+        rewrite_ref,
+        lock_degradation,
+    })
 }
 
 // ── Read-path merge: making fetched notes visible ────────────────────────────

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -110,11 +110,12 @@ async fn writer_lock(git_root: Option<&std::path::Path>) -> Result<Option<NotesL
     match lock_notes(git_root).await? {
         LockAttempt::Acquired(guard) => Ok(Some(guard)),
         LockAttempt::Contended { path } => Err(anyhow!(
-            "another process has held the git notes lock ({}) for over {:?}; \
+            "the git notes lock ({}) stayed held by other writers for over {:?}; \
              not writing without it, because an unserialized write can silently \
-             erase a concurrent writer's entry. Retry the command; if this \
-             persists, a spelunk or git process is stuck holding the lock \
-             (it frees itself when that process exits)",
+             erase a concurrent writer's entry. Retry the command (many \
+             concurrent writers can exceed the wait legitimately); if it \
+             persists with nothing else running, a spelunk or git process is \
+             stuck holding the lock (it frees itself when that process exits)",
             path.display(),
             lock::LOCK_WAIT_BUDGET,
         )),

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -22,8 +22,9 @@ pub use db::Database;
 pub use entity_id::{entity_id, note_entity_id};
 pub use files::FileRecord;
 pub use git_notes::{
-    GitNotesBackend, NotesLock, NotesMergeOutcome, PublishOutcome, RewriteRefStatus, SkipReason,
-    append_to_git_notes, ensure_notes_rewrite_ref, lock_notes, merge_tracking_notes, publish_notes,
+    GitNotesBackend, LOCK_WAIT_BUDGET, LockAttempt, NotesLock, NotesMergeOutcome, PublishOutcome,
+    RewriteRefStatus, SkipReason, append_to_git_notes, ensure_notes_rewrite_ref, lock_notes,
+    merge_tracking_notes, publish_notes,
 };
 pub use graph::GraphEdge;
 pub use memory::{MemoryEdge, MemoryStore, SyncRow};

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -22,9 +22,9 @@ pub use db::Database;
 pub use entity_id::{entity_id, note_entity_id};
 pub use files::FileRecord;
 pub use git_notes::{
-    GitNotesBackend, LOCK_WAIT_BUDGET, LockAttempt, NotesLock, NotesMergeOutcome, PublishOutcome,
-    RewriteRefStatus, SkipReason, append_to_git_notes, ensure_notes_rewrite_ref, lock_notes,
-    merge_tracking_notes, publish_notes,
+    AppendOutcome, GitNotesBackend, LOCK_WAIT_BUDGET, LockAttempt, NotesLock, NotesMergeOutcome,
+    PublishOutcome, RewriteRefStatus, SkipReason, append_to_git_notes, ensure_notes_rewrite_ref,
+    lock_notes, merge_tracking_notes, publish_notes,
 };
 pub use graph::GraphEdge;
 pub use memory::{MemoryEdge, MemoryStore, SyncRow};

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -772,18 +772,24 @@ async fn append_to_git_notes_concurrent_writers_all_survive() {
         let root = root.clone();
         tasks.push(tokio::spawn(async move {
             let record = make_note_record(id, &format!("concurrent decision {id}"));
-            append_to_git_notes(Some(&root), &record).await
+            let started = std::time::Instant::now();
+            let result = append_to_git_notes(Some(&root), &record).await;
+            (id, result, started.elapsed())
         }));
     }
 
+    // Collect every writer's outcome before asserting: when this fails on CI,
+    // the per-writer report below is the only diagnostic there is.
+    let mut failures = Vec::new();
     for task in tasks {
-        task.await
-            .expect("writer task should not panic")
-            .expect("append should succeed");
+        let (id, result, took) = task.await.expect("writer task should not panic");
+        if let Err(e) = result {
+            failures.push(format!("writer {id} failed after {took:?}: {e:#}"));
+        }
     }
 
     // Every writer's entry must be present in the final note body.
-    let blob = read_raw_note(&root);
+    let blob = note_on_head(&root).unwrap_or_default();
     let found: Vec<i64> = blob
         .lines()
         .filter_map(|l| serde_json::from_str::<serde_json::Value>(l.trim()).ok())
@@ -792,8 +798,9 @@ async fn append_to_git_notes_concurrent_writers_all_survive() {
 
     let missing: Vec<i64> = (1..=WRITERS).filter(|id| !found.contains(id)).collect();
     assert!(
-        missing.is_empty(),
-        "lost {} of {WRITERS} concurrent entries (ids {missing:?}); surviving ids {found:?}",
+        missing.is_empty() && failures.is_empty(),
+        "lost {} of {WRITERS} concurrent entries (ids {missing:?}); surviving ids {found:?}\n\
+         writer failures: {failures:#?}\nfinal note body:\n{blob}",
         missing.len(),
     );
 }
@@ -850,19 +857,25 @@ async fn append_to_git_notes_concurrent_worktrees_all_survive() {
             let id = base + n;
             tasks.push(tokio::spawn(async move {
                 let record = make_note_record(id, &format!("worktree decision {id}"));
-                append_to_git_notes(Some(&root), &record).await
+                let started = std::time::Instant::now();
+                let result = append_to_git_notes(Some(&root), &record).await;
+                (id, result, started.elapsed())
             }));
         }
     }
 
+    // Collect every writer's outcome before asserting: when this fails on CI,
+    // the per-writer report below is the only diagnostic there is.
+    let mut failures = Vec::new();
     for task in tasks {
-        task.await
-            .expect("writer task should not panic")
-            .expect("append should succeed");
+        let (id, result, took) = task.await.expect("writer task should not panic");
+        if let Err(e) = result {
+            failures.push(format!("writer {id} failed after {took:?}: {e:#}"));
+        }
     }
 
     let total = PER_TREE * 2;
-    let blob = read_raw_note(&main_root);
+    let blob = note_on_head(&main_root).unwrap_or_default();
     let found: Vec<i64> = blob
         .lines()
         .filter_map(|l| serde_json::from_str::<serde_json::Value>(l.trim()).ok())
@@ -871,23 +884,20 @@ async fn append_to_git_notes_concurrent_worktrees_all_survive() {
 
     let missing: Vec<i64> = (1..=total).filter(|id| !found.contains(id)).collect();
     assert!(
-        missing.is_empty(),
-        "lost {} of {total} cross-worktree entries (ids {missing:?}); surviving ids {found:?}",
+        missing.is_empty() && failures.is_empty(),
+        "lost {} of {total} cross-worktree entries (ids {missing:?}); surviving ids {found:?}\n\
+         writer failures: {failures:#?}\nfinal note body:\n{blob}",
         missing.len(),
     );
 }
 
 // ── the lock itself: contract and degraded paths (ADR-069 D6) ────────────────
 
-use spelunk_core::storage::lock_notes;
-
-/// The wait budget `lock_notes` allows before giving up on a contended lock.
-/// Mirrors `LOCK_WAIT_BUDGET` in `storage/git_notes/lock.rs` (not exported).
-const LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+use spelunk_core::storage::{LOCK_WAIT_BUDGET, LockAttempt, lock_notes};
 
 /// The path production locks: `<git-common-dir>/spelunk-notes.lock`. Mirrors
 /// `notes_lock_path`, including resolving git's relative answer (a plain repo
-/// answers `.git`) against the repo root.
+/// answers `.git`) against the repo root and canonicalizing the result.
 fn notes_lock_path(root: &std::path::Path) -> std::path::PathBuf {
     let out = std::process::Command::new("git")
         .args([
@@ -907,6 +917,7 @@ fn notes_lock_path(root: &std::path::Path) -> std::path::PathBuf {
     } else {
         root.join(raw)
     };
+    let common_dir = std::fs::canonicalize(&common_dir).unwrap_or(common_dir);
     common_dir.join("spelunk-notes.lock")
 }
 
@@ -924,30 +935,33 @@ fn open_lock_file(path: &std::path::Path) -> std::fs::File {
         .expect("open notes lock file")
 }
 
-/// The `lock_notes` contract D5 builds on: `Some` when free, `None` when
-/// contended past the budget, and the guard releases on drop.
+/// The `lock_notes` contract D5 and D8 build on: `Acquired` when free,
+/// `Contended` when held past the budget, and the guard releases on drop.
 ///
-/// D5 reads `None` as "skip the merge, read anyway", so `None` must be reachable
-/// (never an indefinite block) and a dropped guard must not keep the lock held.
+/// `Contended` must be reachable (never an indefinite block) and a dropped
+/// guard must not keep the lock held.
 #[tokio::test]
 #[serial]
-async fn lock_notes_grants_when_free_yields_none_when_contended_and_frees_on_drop() {
+async fn lock_notes_grants_when_free_reports_contention_and_frees_on_drop() {
     let dir = make_temp_git_repo();
     let root = dir.path();
 
-    let held = lock_notes(Some(root)).await;
-    assert!(held.is_some(), "an uncontended lock must be granted");
+    let held = lock_notes(Some(root)).await.expect("resolve lock path");
+    assert!(
+        matches!(held, LockAttempt::Acquired(_)),
+        "an uncontended lock must be granted, got {held:?}"
+    );
 
     let started = std::time::Instant::now();
-    let contended = lock_notes(Some(root)).await;
+    let contended = lock_notes(Some(root)).await.expect("resolve lock path");
     let waited = started.elapsed();
     assert!(
-        contended.is_none(),
-        "a lock held elsewhere must yield None, not block indefinitely"
+        matches!(contended, LockAttempt::Contended { .. }),
+        "a lock held elsewhere must report Contended, not block indefinitely \
+         or degrade; got {contended:?}"
     );
-    // Negative control: a `None` returned immediately would mean the lock was
-    // never taken (a bad path, an unopenable file) and the contention above was
-    // never actually exercised.
+    // Negative control: a `Contended` returned immediately would mean the lock
+    // was never taken and the contention above was never actually exercised.
     assert!(
         waited >= LOCK_WAIT_BUDGET,
         "the contended caller must wait out the {LOCK_WAIT_BUDGET:?} budget before giving up; \
@@ -957,15 +971,66 @@ async fn lock_notes_grants_when_free_yields_none_when_contended_and_frees_on_dro
     drop(held);
 
     assert!(
-        lock_notes(Some(root)).await.is_some(),
+        matches!(
+            lock_notes(Some(root)).await.expect("resolve lock path"),
+            LockAttempt::Acquired(_)
+        ),
         "the guard must release the lock on drop"
+    );
+}
+
+/// Contenders in **separate worktrees** must converge on one lock file.
+///
+/// A linked worktree's `--git-common-dir` answer and the main worktree's
+/// relative answer must resolve to the same identity; if each computed its
+/// own, the cross-worktree writers the lock exists for would exclude nothing.
+#[tokio::test]
+#[serial]
+async fn lock_notes_contends_across_worktrees() {
+    let dir = make_temp_git_repo();
+    let main_root = dir.path();
+
+    let wt_parent = tempfile::TempDir::new().expect("tempdir");
+    let wt_root = wt_parent.path().join("wt");
+    let out = std::process::Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "wt-lock",
+            wt_root.to_str().unwrap(),
+        ])
+        .current_dir(main_root)
+        .output()
+        .expect("git worktree add");
+    assert!(
+        out.status.success(),
+        "worktree add: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let held = lock_notes(Some(main_root))
+        .await
+        .expect("resolve lock path");
+    let LockAttempt::Acquired(guard) = held else {
+        panic!("main worktree must acquire the free lock, got {held:?}");
+    };
+
+    let from_worktree = lock_notes(Some(&wt_root)).await.expect("resolve lock path");
+    assert!(
+        matches!(from_worktree, LockAttempt::Contended { .. }),
+        "a lock held from the main worktree must contend from a linked \
+         worktree; anything else means the two resolved different lock files. \
+         Held: {:?}, got: {from_worktree:?}",
+        guard.path(),
     );
 }
 
 /// An unusable lock file degrades to an unlocked write, never an `Err`.
 ///
-/// `memory add` treats a failed pre-`init` carry as fatal (ADR-068 D3), so a
-/// lock that cannot even be opened must not surface as a command failure.
+/// ADR-069 D8's one kept degradation: where the lock cannot exist at all,
+/// failing every write would make spelunk unusable on that filesystem to
+/// prevent a race that needs a second concurrent writer to matter.
 ///
 /// A directory at the lock path makes the open fail deterministically on every
 /// platform (EISDIR on unix, access-denied on Windows).
@@ -981,8 +1046,11 @@ async fn append_to_git_notes_proceeds_when_lock_file_is_unusable() {
     // resolves, so the write below exercises the degraded path rather than
     // quietly locking a file this test never blocked.
     assert!(
-        lock_notes(Some(root)).await.is_none(),
-        "setup: an unopenable lock path must yield None"
+        matches!(
+            lock_notes(Some(root)).await.expect("resolve lock path"),
+            LockAttempt::Unusable { .. }
+        ),
+        "setup: an unopenable lock path must report Unusable"
     );
 
     let record = make_note_record(1, "unusable lock still writes");
@@ -996,14 +1064,15 @@ async fn append_to_git_notes_proceeds_when_lock_file_is_unusable() {
     );
 }
 
-/// Contention past the wait budget degrades to an unlocked write, never an `Err`
-/// (the other half of the ADR-068 D3 interaction above).
+/// A writer that cannot take a **contended** lock fails and writes nothing
+/// (ADR-069 D8). Proceeding unlocked here is the #185 read-modify-write this
+/// lock exists to prevent: the holder's entry would be silently erased.
 ///
 /// Deterministic: the lock is held here for the whole call, so the writer is
 /// guaranteed to exhaust its budget rather than race for it.
 #[tokio::test]
 #[serial]
-async fn append_to_git_notes_proceeds_when_lock_budget_is_exhausted() {
+async fn append_to_git_notes_fails_when_the_lock_is_contended() {
     let dir = make_temp_git_repo();
     let root = dir.path();
 
@@ -1014,24 +1083,149 @@ async fn append_to_git_notes_proceeds_when_lock_budget_is_exhausted() {
     let started = std::time::Instant::now();
     let result = append_to_git_notes(
         Some(root),
-        &make_note_record(1, "contended lock still writes"),
+        &make_note_record(1, "contended lock must not write"),
     )
     .await;
     let waited = started.elapsed();
 
     drop(held);
 
-    result.expect("lock contention must never fail the caller's write");
+    let err = result.expect_err(
+        "a writer that cannot take a contended lock must fail, never proceed unlocked (D8)",
+    );
     // Negative control: too fast means the writer took the lock uncontended, so
-    // the degraded path was never exercised.
+    // the contended path was never exercised.
     assert!(
         waited >= LOCK_WAIT_BUDGET,
         "the writer must have waited out the {LOCK_WAIT_BUDGET:?} budget; \
          returned after {waited:?}, so it never contended"
     );
+    // The error must be actionable: name the lock and tell the user what to do.
+    let msg = format!("{err:#}");
     assert!(
-        read_raw_note(root).contains("contended lock still writes"),
-        "the entry must still be written after the lock budget is exhausted"
+        msg.contains("notes lock") && msg.contains("Retry"),
+        "the error must name the lock and say to retry; got: {msg}"
+    );
+    assert!(
+        note_on_head(root).is_none(),
+        "nothing may be written when the lock is contended; the unserialized \
+         write is exactly the data loss D8 forbids"
+    );
+}
+
+// ── a failed note read must never be mistaken for "no note yet" ───────────────
+//
+// The windows-latest losses on main (#185's worst case): a writer whose
+// `git notes show` failed transiently treated the note as empty and rewrote it
+// as just its own line, erasing every sibling entry while holding the lock.
+// Survivor patterns in the CI logs (a contiguous tail of the serialization
+// order) are the fingerprint of exactly one such wipe per run.
+
+/// Delete the note's blob object so reads of it fail while writes still work:
+/// `git notes show` dies (exit 128), but `git notes add -f` never opens the
+/// old blob, so an unguarded read-modify-write would "succeed" and wipe it.
+fn corrupt_note_blob(root: &std::path::Path) {
+    let listing = git_stdout_ok(root, &["notes", "--ref=spelunk", "list"]);
+    let blob_sha = listing
+        .split_whitespace()
+        .next()
+        .expect("a note blob sha")
+        .to_string();
+    let object = root
+        .join(".git")
+        .join("objects")
+        .join(&blob_sha[..2])
+        .join(&blob_sha[2..]);
+    // Loose objects are read-only; make the unlink work on every platform.
+    let mut perms = std::fs::metadata(&object)
+        .expect("stat object")
+        .permissions();
+    #[allow(clippy::permissions_set_readonly_false)]
+    perms.set_readonly(false);
+    std::fs::set_permissions(&object, perms).expect("make object writable");
+    std::fs::remove_file(&object).expect("remove note blob object");
+
+    // Negative controls: the read must now fail, and the ref must still point
+    // at the blob, so a write-back would replace a body that still "exists".
+    let show = std::process::Command::new("git")
+        .args([
+            "-C",
+            root.to_str().unwrap(),
+            "notes",
+            "--ref=spelunk",
+            "show",
+            "HEAD",
+        ])
+        .output()
+        .expect("git notes show");
+    assert!(
+        !show.status.success() && show.status.code() != Some(1),
+        "setup: the note read must fail hard, not report a missing note"
+    );
+}
+
+/// A writer whose read of the existing note fails must fail too, leaving the
+/// note alone. Treating the failure as "no note yet" is how one transient git
+/// error erased 6 of 8 entries on Windows CI.
+#[tokio::test]
+#[serial]
+async fn append_to_git_notes_fails_when_the_existing_note_cannot_be_read() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    append_to_git_notes(
+        Some(root),
+        &make_note_record(1, "the sibling entry at stake"),
+    )
+    .await
+    .expect("seed");
+    let ref_before = git_stdout_ok(root, &["rev-parse", "refs/notes/spelunk"]);
+
+    corrupt_note_blob(root);
+
+    let err = append_to_git_notes(Some(root), &make_note_record(2, "must not land"))
+        .await
+        .expect_err("a failed read of the existing note must fail the append, not wipe the note");
+    assert!(
+        format!("{err:#}").contains("not overwriting"),
+        "the error must say the note was left alone; got: {err:#}"
+    );
+    assert_eq!(
+        git_stdout_ok(root, &["rev-parse", "refs/notes/spelunk"]),
+        ref_before,
+        "the note ref must be untouched after a failed read"
+    );
+}
+
+/// The `--backend git-notes` write paths carry the same read-modify-write and
+/// need the same guarantee, for both `add` and `archive`.
+#[tokio::test]
+#[serial]
+async fn git_notes_backend_add_and_archive_fail_when_the_note_cannot_be_read() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+
+    let id = backend
+        .add(note_input("decision", "the sibling entry at stake"))
+        .await
+        .expect("seed");
+    let ref_before = git_stdout_ok(root, &["rev-parse", "refs/notes/spelunk"]);
+
+    corrupt_note_blob(root);
+
+    backend
+        .add(note_input("decision", "must not land"))
+        .await
+        .expect_err("a failed read must fail the add, not wipe the note");
+    backend
+        .archive(id)
+        .await
+        .expect_err("a failed read must fail the archive, not report the entry missing");
+    assert_eq!(
+        git_stdout_ok(root, &["rev-parse", "refs/notes/spelunk"]),
+        ref_before,
+        "the note ref must be untouched after failed writes"
     );
 }
 
@@ -1649,8 +1843,11 @@ async fn append_to_git_notes_ensures_carry_config_even_when_the_lock_is_unusable
 
     std::fs::create_dir_all(notes_lock_path(root)).expect("place a directory at the lock path");
     assert!(
-        lock_notes(Some(root)).await.is_none(),
-        "setup: an unopenable lock path must yield None"
+        matches!(
+            lock_notes(Some(root)).await.expect("resolve lock path"),
+            LockAttempt::Unusable { .. }
+        ),
+        "setup: an unopenable lock path must report Unusable"
     );
 
     append_to_git_notes(Some(root), &make_note_record(1, PRECIOUS))
@@ -2328,9 +2525,10 @@ async fn lock_holder_child() {
     };
     let root = std::path::PathBuf::from(root);
 
-    let guard = lock_notes(Some(&root))
-        .await
-        .expect("helper must get the lock: the parent takes it only after we signal");
+    let attempt = lock_notes(Some(&root)).await.expect("resolve lock path");
+    let LockAttempt::Acquired(guard) = attempt else {
+        panic!("helper must get the lock (the parent takes it only after we signal): {attempt:?}");
+    };
     std::fs::write(held_marker(&root), "held").expect("write held marker");
 
     // Hold until released, with a ceiling so a wedged parent cannot leak this

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -9,8 +9,11 @@
 //! Writes are a read-modify-write that rewrites the HEAD note with
 //! `git notes add -f` (replace semantics). Two agents writing to the *same
 //! HEAD* concurrently would race, and the loser's entry would vanish silently
-//! with both exiting 0. ADR-069 (D6) closes that: every read-modify-write is
-//! serialized by a lock in the git common dir, so all writers survive.
+//! with both exiting 0. ADR-069 (D6) serializes every read-modify-write with a
+//! lock in the git common dir; D8 makes a writer that cannot take it fail
+//! visibly. The invariant is therefore "every entry lands or its writer fails
+//! loudly", never "all must land": heavy legitimate contention may exceed the
+//! wait budget, and that surfaces as an error, not a loss.
 
 mod common;
 
@@ -751,17 +754,26 @@ async fn git_notes_archive_does_not_clobber_siblings_or_prose() {
     assert_eq!(rec2.status, "archived", "only record 2 is archived");
 }
 
-// ── concurrent append safety (#185) ──────────────────────────────────────────
+// ── concurrent append safety (#185 / ADR-069 D8) ─────────────────────────────
 
-/// N concurrent `append_to_git_notes` calls against one HEAD must all survive.
+/// The D8 invariant for N concurrent writers: every writer's entry **lands or
+/// its writer fails visibly**, and the two sets are disjoint and complete.
 ///
-/// Regression guard for #185: the read-modify-write is only safe while every
-/// writer holds the notes lock across all four steps. Without it, two writers
-/// read the same body and the later write-back drops the earlier entry, both
-/// exiting 0.
+/// Regression guard for #185, where an unserialized read-modify-write dropped
+/// entries with every writer exiting 0. "All must land" is deliberately NOT
+/// the invariant: on a slow runner, N queued writers legitimately exceed the
+/// lock's wait budget and the back of the queue fails with the D8 error. That
+/// is the designed outcome; silence is the bug.
+///
+/// Asserts, given landed = ids read back and failed = ids whose append
+/// returned `Err`:
+/// - silent loss is zero: every id is in landed or in failed,
+/// - no false failure: no id is in both (an `Err` writer must not have written),
+/// - landed is non-empty: the first holder takes a free lock, so a wedged
+///   lock cannot vacuously pass as eight visible failures.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
-async fn append_to_git_notes_concurrent_writers_all_survive() {
+async fn append_to_git_notes_concurrent_writers_land_or_fail_visibly() {
     const WRITERS: i64 = 8;
 
     let dir = make_temp_git_repo();
@@ -778,34 +790,53 @@ async fn append_to_git_notes_concurrent_writers_all_survive() {
         }));
     }
 
-    // Collect every writer's outcome before asserting: when this fails on CI,
-    // the per-writer report below is the only diagnostic there is.
-    let mut failures = Vec::new();
+    let mut failed: Vec<i64> = Vec::new();
+    let mut failure_msgs = Vec::new();
     for task in tasks {
         let (id, result, took) = task.await.expect("writer task should not panic");
         if let Err(e) = result {
-            failures.push(format!("writer {id} failed after {took:?}: {e:#}"));
+            failed.push(id);
+            failure_msgs.push(format!("writer {id} failed after {took:?}: {e:#}"));
         }
     }
 
-    // Every writer's entry must be present in the final note body.
     let blob = note_on_head(&root).unwrap_or_default();
-    let found: Vec<i64> = blob
+    let landed: Vec<i64> = blob
         .lines()
         .filter_map(|l| serde_json::from_str::<serde_json::Value>(l.trim()).ok())
         .filter_map(|v| v["id"].as_i64())
         .collect();
 
-    let missing: Vec<i64> = (1..=WRITERS).filter(|id| !found.contains(id)).collect();
+    let silent: Vec<i64> = (1..=WRITERS)
+        .filter(|id| !landed.contains(id) && !failed.contains(id))
+        .collect();
+    let both: Vec<i64> = landed
+        .iter()
+        .copied()
+        .filter(|id| failed.contains(id))
+        .collect();
+
     assert!(
-        missing.is_empty() && failures.is_empty(),
-        "lost {} of {WRITERS} concurrent entries (ids {missing:?}); surviving ids {found:?}\n\
-         writer failures: {failures:#?}\nfinal note body:\n{blob}",
-        missing.len(),
+        silent.is_empty(),
+        "SILENT LOSS of {} of {WRITERS} entries (ids {silent:?}): neither landed \
+         {landed:?} nor failed visibly {failed:?}\n\
+         failures: {failure_msgs:#?}\nfinal note body:\n{blob}",
+        silent.len(),
+    );
+    assert!(
+        both.is_empty(),
+        "writers {both:?} reported failure but their entries landed; an `Err` \
+         append must not write\nfailures: {failure_msgs:#?}"
+    );
+    assert!(
+        !landed.is_empty(),
+        "no writer landed at all; the first holder takes a free lock, so this \
+         means the lock or the write path is wedged\nfailures: {failure_msgs:#?}"
     );
 }
 
-/// Concurrent writers in **separate worktrees** must all survive.
+/// The same D8 invariant across **separate worktrees**: land or fail visibly,
+/// disjoint and complete, at least one landing.
 ///
 /// Worktrees share one `refs/notes/spelunk` (it resolves through the git
 /// common dir to the main repo's copy), so they are real contenders on one
@@ -814,7 +845,7 @@ async fn append_to_git_notes_concurrent_writers_all_survive() {
 /// serializing nothing here.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
-async fn append_to_git_notes_concurrent_worktrees_all_survive() {
+async fn append_to_git_notes_concurrent_worktrees_land_or_fail_visibly() {
     const PER_TREE: i64 = 4;
 
     let dir = make_temp_git_repo();
@@ -864,30 +895,49 @@ async fn append_to_git_notes_concurrent_worktrees_all_survive() {
         }
     }
 
-    // Collect every writer's outcome before asserting: when this fails on CI,
-    // the per-writer report below is the only diagnostic there is.
-    let mut failures = Vec::new();
+    let mut failed: Vec<i64> = Vec::new();
+    let mut failure_msgs = Vec::new();
     for task in tasks {
         let (id, result, took) = task.await.expect("writer task should not panic");
         if let Err(e) = result {
-            failures.push(format!("writer {id} failed after {took:?}: {e:#}"));
+            failed.push(id);
+            failure_msgs.push(format!("writer {id} failed after {took:?}: {e:#}"));
         }
     }
 
     let total = PER_TREE * 2;
     let blob = note_on_head(&main_root).unwrap_or_default();
-    let found: Vec<i64> = blob
+    let landed: Vec<i64> = blob
         .lines()
         .filter_map(|l| serde_json::from_str::<serde_json::Value>(l.trim()).ok())
         .filter_map(|v| v["id"].as_i64())
         .collect();
 
-    let missing: Vec<i64> = (1..=total).filter(|id| !found.contains(id)).collect();
+    let silent: Vec<i64> = (1..=total)
+        .filter(|id| !landed.contains(id) && !failed.contains(id))
+        .collect();
+    let both: Vec<i64> = landed
+        .iter()
+        .copied()
+        .filter(|id| failed.contains(id))
+        .collect();
+
     assert!(
-        missing.is_empty() && failures.is_empty(),
-        "lost {} of {total} cross-worktree entries (ids {missing:?}); surviving ids {found:?}\n\
-         writer failures: {failures:#?}\nfinal note body:\n{blob}",
-        missing.len(),
+        silent.is_empty(),
+        "SILENT LOSS of {} of {total} cross-worktree entries (ids {silent:?}): \
+         neither landed {landed:?} nor failed visibly {failed:?}\n\
+         failures: {failure_msgs:#?}\nfinal note body:\n{blob}",
+        silent.len(),
+    );
+    assert!(
+        both.is_empty(),
+        "writers {both:?} reported failure but their entries landed; an `Err` \
+         append must not write\nfailures: {failure_msgs:#?}"
+    );
+    assert!(
+        !landed.is_empty(),
+        "no writer landed at all; the first holder takes a free lock, so this \
+         means the lock or the write path is wedged\nfailures: {failure_msgs:#?}"
     );
 }
 

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -1678,15 +1678,18 @@ async fn old_git_echoing_the_flag_still_locks_the_real_common_dir() {
 // ── the `--backend git-notes` path (append_record / archive_record) ───────────
 
 /// `GitNotesBackend::add` → `append_record` carries the same read-modify-write
-/// as the write-through helper, so it needs the same guarantee: N concurrent
-/// adds against one HEAD all survive.
+/// as the write-through helper, so it gets the same D8 invariant as the
+/// free-function guards: every add lands or fails visibly, disjoint and
+/// complete, and at least one lands. "All succeed" is deliberately not
+/// asserted: on a slow runner N queued writers legitimately exceed the lock's
+/// wait budget and the back of the queue fails with the D8 error.
 ///
 /// Asserted on titles, not ids: `add` mints its id from `now_millis()` *before*
 /// taking the lock, so adds landing in one millisecond can share an id. Entry
 /// survival is what the lock guarantees.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
-async fn git_notes_backend_concurrent_adds_all_survive() {
+async fn git_notes_backend_concurrent_adds_land_or_fail_visibly() {
     const WRITERS: usize = 8;
 
     let dir = make_temp_git_repo();
@@ -1696,15 +1699,21 @@ async fn git_notes_backend_concurrent_adds_all_survive() {
     for n in 1..=WRITERS {
         let root = root.clone();
         tasks.push(tokio::spawn(async move {
-            GitNotesBackend::with_root(root)
+            let result = GitNotesBackend::with_root(root)
                 .add(note_input("decision", &format!("backend writer {n}")))
-                .await
+                .await;
+            (n, result)
         }));
     }
+
+    let mut failed: Vec<usize> = Vec::new();
+    let mut failure_msgs = Vec::new();
     for task in tasks {
-        task.await
-            .expect("writer task should not panic")
-            .expect("backend add should succeed");
+        let (n, result) = task.await.expect("writer task should not panic");
+        if let Err(e) = result {
+            failed.push(n);
+            failure_msgs.push(format!("backend writer {n} failed: {e:#}"));
+        }
     }
 
     let notes = GitNotesBackend::with_root(root)
@@ -1712,25 +1721,46 @@ async fn git_notes_backend_concurrent_adds_all_survive() {
         .await
         .expect("list");
     let titles: std::collections::HashSet<String> = notes.into_iter().map(|n| n.title).collect();
-
-    let missing: Vec<String> = (1..=WRITERS)
-        .map(|n| format!("backend writer {n}"))
-        .filter(|t| !titles.contains(t))
+    let landed: Vec<usize> = (1..=WRITERS)
+        .filter(|n| titles.contains(&format!("backend writer {n}")))
         .collect();
+
+    let silent: Vec<usize> = (1..=WRITERS)
+        .filter(|n| !landed.contains(n) && !failed.contains(n))
+        .collect();
+    let both: Vec<usize> = landed
+        .iter()
+        .copied()
+        .filter(|n| failed.contains(n))
+        .collect();
+
     assert!(
-        missing.is_empty(),
-        "lost {} of {WRITERS} concurrent backend adds ({missing:?}); surviving {titles:?}",
-        missing.len(),
+        silent.is_empty(),
+        "SILENT LOSS of {} of {WRITERS} backend adds ({silent:?}): neither landed \
+         {landed:?} nor failed visibly {failed:?}\nfailures: {failure_msgs:#?}",
+        silent.len(),
+    );
+    assert!(
+        both.is_empty(),
+        "backend adds {both:?} reported failure but their entries landed; an \
+         `Err` add must not write\nfailures: {failure_msgs:#?}"
+    );
+    assert!(
+        !landed.is_empty(),
+        "no backend add landed at all; the first holder takes a free lock, so \
+         this means the lock or the write path is wedged\nfailures: {failure_msgs:#?}"
     );
 }
 
 /// `GitNotesBackend::archive` → `archive_record` is the same read-modify-write
-/// in reverse, and needs the same guarantee. Concurrent archives of distinct
-/// entries must each land: unserialized, each writer's write-back would revive
-/// the entries its peers had just archived.
+/// in reverse, with the same D8 invariant: each archive of a distinct seeded
+/// entry either lands (the entry ends archived) or fails visibly (the entry
+/// stays active), the two sets are exactly complementary, and at least one
+/// lands. Unserialized, each writer's write-back would revive the entries its
+/// peers had just archived, silently.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[serial]
-async fn git_notes_backend_concurrent_archives_all_land() {
+async fn git_notes_backend_concurrent_archives_land_or_fail_visibly() {
     const ENTRIES: usize = 6;
 
     let dir = make_temp_git_repo();
@@ -1756,26 +1786,31 @@ async fn git_notes_backend_concurrent_archives_all_land() {
     for id in ids {
         let root = root.clone();
         tasks.push(tokio::spawn(async move {
-            GitNotesBackend::with_root(root).archive(id).await
+            let result = GitNotesBackend::with_root(root).archive(id).await;
+            (id, result)
         }));
     }
-    for task in tasks {
-        assert!(
-            task.await
-                .expect("archive task should not panic")
-                .expect("archive should succeed"),
-            "each archive must find and rewrite its entry"
-        );
-    }
 
-    let active = backend
-        .list(Some("decision"), 100, false, None)
-        .await
-        .expect("list active");
+    let mut failed: std::collections::HashSet<i64> = std::collections::HashSet::new();
+    let mut failure_msgs = Vec::new();
+    let mut not_found: Vec<i64> = Vec::new();
+    for task in tasks {
+        let (id, result) = task.await.expect("archive task should not panic");
+        match result {
+            Ok(true) => {}
+            Ok(false) => not_found.push(id),
+            Err(e) => {
+                failed.insert(id);
+                failure_msgs.push(format!("archive of {id} failed: {e:#}"));
+            }
+        }
+    }
+    // Every id was seeded, so "entry not found" is neither a landing nor a
+    // visible failure: it is a silent anomaly.
     assert!(
-        active.is_empty(),
-        "every concurrently archived entry must stay archived; still active: {:?}",
-        active.iter().map(|n| &n.title).collect::<Vec<_>>()
+        not_found.is_empty(),
+        "archives {not_found:?} reported their entry missing; every id exists, \
+         so a miss is a silently lost archive"
     );
 
     let all = backend
@@ -1786,6 +1821,26 @@ async fn git_notes_backend_concurrent_archives_all_land() {
         all.len(),
         ENTRIES,
         "archiving must rewrite entries in place, never drop them"
+    );
+
+    // Exactly the visibly-failed archives may remain active: an active entry
+    // whose archive reported success is a silently revived/lost archive, and
+    // an archived entry whose archive reported failure wrote after erroring.
+    let active: std::collections::HashSet<i64> = backend
+        .list(Some("decision"), 100, false, None)
+        .await
+        .expect("list active")
+        .into_iter()
+        .map(|n| n.id)
+        .collect();
+    assert_eq!(
+        active, failed,
+        "the active set must be exactly the visibly-failed set\nfailures: {failure_msgs:#?}"
+    );
+    assert!(
+        failed.len() < ENTRIES,
+        "no archive landed at all; the first holder takes a free lock, so this \
+         means the lock or the write path is wedged\nfailures: {failure_msgs:#?}"
     );
 }
 
@@ -2363,7 +2418,9 @@ async fn append_to_git_notes_proceeds_when_the_carry_config_cannot_be_written() 
         "an unwritable config must report Failed"
     );
     assert_eq!(
-        write.expect("a config failure must never fail the write"),
+        write
+            .expect("a config failure must never fail the write")
+            .rewrite_ref,
         RewriteRefStatus::Failed,
         "the write must report the carry it could not make"
     );

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -1076,6 +1076,70 @@ async fn lock_notes_contends_across_worktrees() {
     );
 }
 
+/// The lock path itself is one identity: absolute, inside an existing git
+/// common dir, and byte-identical whether resolved from the main worktree or a
+/// linked one.
+///
+/// The contention test above proves the two exclude each other while both
+/// locks are live; this pins the path property directly, so a resolution
+/// change that happens to keep same-process exclusion (say, one spelling
+/// absolute and one relative to a shared cwd) still fails.
+#[tokio::test]
+#[serial]
+async fn lock_path_is_one_identity_from_main_and_linked_worktrees() {
+    let dir = make_temp_git_repo();
+    let main_root = dir.path();
+
+    let wt_parent = tempfile::TempDir::new().expect("tempdir");
+    let wt_root = wt_parent.path().join("wt");
+    let out = std::process::Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "wt-lock-path",
+            wt_root.to_str().unwrap(),
+        ])
+        .current_dir(main_root)
+        .output()
+        .expect("git worktree add");
+    assert!(
+        out.status.success(),
+        "worktree add: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let from_main = match lock_notes(Some(main_root))
+        .await
+        .expect("resolve lock path")
+    {
+        LockAttempt::Acquired(guard) => guard.path().to_path_buf(),
+        other => panic!("main worktree must acquire the free lock, got {other:?}"),
+    };
+    // Sequential acquisitions: the first guard is dropped, so this re-acquires
+    // rather than contends, and only the resolved paths are compared.
+    let from_linked = match lock_notes(Some(&wt_root)).await.expect("resolve lock path") {
+        LockAttempt::Acquired(guard) => guard.path().to_path_buf(),
+        other => panic!("linked worktree must acquire the free lock, got {other:?}"),
+    };
+
+    assert!(
+        from_main.is_absolute(),
+        "the lock path must be absolute, got {}",
+        from_main.display()
+    );
+    assert_eq!(
+        from_main, from_linked,
+        "both worktrees must resolve one lock file identity"
+    );
+    assert!(
+        from_main.parent().is_some_and(|d| d.is_dir()),
+        "the lock must live in an existing directory (the git common dir), \
+         got {}",
+        from_main.display()
+    );
+}
+
 /// An unusable lock file degrades to an unlocked write, never an `Err`.
 ///
 /// ADR-069 D8's one kept degradation: where the lock cannot exist at all,
@@ -1160,6 +1224,63 @@ async fn append_to_git_notes_fails_when_the_lock_is_contended() {
         note_on_head(root).is_none(),
         "nothing may be written when the lock is contended; the unserialized \
          write is exactly the data loss D8 forbids"
+    );
+}
+
+/// The `--backend git-notes` writers carry the same D8 contract as the
+/// write-through helper: a contended lock fails `add` and `archive`, and
+/// nothing is written. Each call site matches on the lock outcome on its own,
+/// so one swallowed arm reopens the #185 unlocked write at that site only;
+/// this pins both sites, not just the shared helper.
+#[tokio::test]
+#[serial]
+async fn git_notes_backend_add_and_archive_fail_when_the_lock_is_contended() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+
+    let id = backend
+        .add(note_input("decision", "the sibling entry at stake"))
+        .await
+        .expect("seed");
+    let ref_before = git_stdout_ok(root, &["rev-parse", "refs/notes/spelunk"]);
+
+    let held = open_lock_file(&notes_lock_path(root));
+    held.lock().expect("hold the notes lock across both writes");
+
+    let started = std::time::Instant::now();
+    let err = backend
+        .add(note_input("decision", "must not land"))
+        .await
+        .expect_err("a contended lock must fail the backend add, never write unlocked (D8)");
+    let waited = started.elapsed();
+    // Negative control: too fast means the add failed for some unrelated
+    // reason instead of waiting out a held lock.
+    assert!(
+        waited >= LOCK_WAIT_BUDGET,
+        "the add must have waited out the {LOCK_WAIT_BUDGET:?} budget; \
+         returned after {waited:?}, so it never contended"
+    );
+    assert!(
+        format!("{err:#}").contains("notes lock"),
+        "the add error must name the lock; got: {err:#}"
+    );
+
+    let err = backend
+        .archive(id)
+        .await
+        .expect_err("a contended lock must fail the backend archive, never write unlocked (D8)");
+    assert!(
+        format!("{err:#}").contains("notes lock"),
+        "the archive error must name the lock; got: {err:#}"
+    );
+
+    drop(held);
+
+    assert_eq!(
+        git_stdout_ok(root, &["rev-parse", "refs/notes/spelunk"]),
+        ref_before,
+        "the note ref must be untouched after both contended writes"
     );
 }
 
@@ -1276,6 +1397,281 @@ async fn git_notes_backend_add_and_archive_fail_when_the_note_cannot_be_read() {
         git_stdout_ok(root, &["rev-parse", "refs/notes/spelunk"]),
         ref_before,
         "the note ref must be untouched after failed writes"
+    );
+}
+
+/// The in-lock read retry paces its attempts: a persistently failing read
+/// waits out the inter-attempt backoff before surfacing, never burns its
+/// attempts in one instant.
+///
+/// Four attempts with a linearly growing 50ms base backoff sleep 300ms in
+/// total, so the 250ms floor holds deterministically on the unmutated code,
+/// while a backoff zeroed out (or a loop that no longer retries) returns in
+/// the time of a few git spawns. Pins the retry pacing that keeps the
+/// windows-latest flake absorbable; a deliberate retuning of the constants
+/// updates this floor with it.
+#[tokio::test]
+#[serial]
+async fn append_read_retry_paces_its_attempts_before_surfacing_the_failure() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    append_to_git_notes(
+        Some(root),
+        &make_note_record(1, "the sibling entry at stake"),
+    )
+    .await
+    .expect("seed");
+    corrupt_note_blob(root);
+
+    let started = std::time::Instant::now();
+    append_to_git_notes(Some(root), &make_note_record(2, "must not land"))
+        .await
+        .expect_err("a persistent read failure must still surface after the retries");
+    let took = started.elapsed();
+
+    assert!(
+        took >= std::time::Duration::from_millis(250),
+        "a persistently failing read must wait out ~300ms of backoff across \
+         its retries; returned after {took:?}, so it never retried or never \
+         slept between attempts"
+    );
+}
+
+// ── fault injection: a scripted `git` on PATH ─────────────────────────────────
+//
+// The corruption tests above can only make a read fail *persistently*; the
+// windows-latest loss was a *transient* failure, gone by the next attempt.
+// Only unix, because the shim is a shell script: the same retry code runs on
+// Windows, where the persistent-failure tests above still pin classification
+// and pacing.
+
+/// A `git` shim prepended to PATH. Pass-through except for one scripted
+/// behaviour scoped to a single repo (matched on the child's physical cwd),
+/// so concurrent git use elsewhere is untouched. Restores PATH on drop.
+#[cfg(unix)]
+mod git_shim {
+    use std::path::{Path, PathBuf};
+
+    pub struct ShimGuard {
+        original_path: std::ffi::OsString,
+        counter: PathBuf,
+        _dir: tempfile::TempDir,
+    }
+
+    impl Drop for ShimGuard {
+        fn drop(&mut self) {
+            // SAFETY: every test in this binary is #[serial] (and nextest runs
+            // one process per test), so nothing reads the environment
+            // concurrently. Same argument as `isolate_git_config` above.
+            unsafe { std::env::set_var("PATH", &self.original_path) };
+        }
+    }
+
+    impl ShimGuard {
+        /// How many spelunk note reads the shim has intercepted so far.
+        pub fn note_reads(&self) -> u32 {
+            std::fs::read_to_string(&self.counter)
+                .ok()
+                .and_then(|s| s.trim().parse().ok())
+                .unwrap_or(0)
+        }
+    }
+
+    /// The real git, resolved before the shim shadows the name.
+    fn real_git() -> String {
+        let out = std::process::Command::new("sh")
+            .args(["-c", "command -v git"])
+            .output()
+            .expect("resolve the real git");
+        assert!(out.status.success(), "git must be on PATH");
+        String::from_utf8(out.stdout)
+            .expect("utf8 git path")
+            .trim()
+            .to_string()
+    }
+
+    fn install(dir: tempfile::TempDir, script: String, counter: PathBuf) -> ShimGuard {
+        use std::os::unix::fs::PermissionsExt;
+        let shim = dir.path().join("git");
+        std::fs::write(&shim, script).expect("write shim");
+        std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod shim");
+
+        let original_path = std::env::var_os("PATH").expect("PATH is set");
+        let mut parts = vec![dir.path().to_path_buf()];
+        parts.extend(std::env::split_paths(&original_path));
+        let new_path = std::env::join_paths(parts).expect("join PATH");
+        // SAFETY: see Drop.
+        unsafe { std::env::set_var("PATH", &new_path) };
+
+        ShimGuard {
+            original_path,
+            counter,
+            _dir: dir,
+        }
+    }
+
+    /// Count every `notes --ref=spelunk show` in `repo`, failing the first
+    /// `fail_n` of them with exit 128 (the transient-infrastructure shape the
+    /// windows-latest losses had). Everything else passes through.
+    pub fn failing_note_reads(repo: &Path, fail_n: u32) -> ShimGuard {
+        let repo = std::fs::canonicalize(repo).expect("canonical repo path");
+        let real = real_git();
+        let dir = tempfile::TempDir::new().expect("shim dir");
+        let counter = dir.path().join("note-reads");
+        let script = format!(
+            "#!/bin/sh\n\
+             case \" $* \" in\n\
+               *\" notes --ref=spelunk show \"*)\n\
+                 if [ \"$(pwd -P)\" = \"{repo}\" ]; then\n\
+                   n=$(cat \"{counter}\" 2>/dev/null || echo 0)\n\
+                   n=$((n+1))\n\
+                   printf '%s\\n' \"$n\" > \"{counter}\"\n\
+                   if [ \"$n\" -le {fail_n} ]; then\n\
+                     echo 'shim: simulated transient note read failure' >&2\n\
+                     exit 128\n\
+                   fi\n\
+                 fi\n\
+                 ;;\n\
+             esac\n\
+             exec \"{real}\" \"$@\"\n",
+            repo = repo.display(),
+            counter = counter.display(),
+        );
+        install(dir, script, counter)
+    }
+
+    /// Emulate git < 2.31 for `repo`: `rev-parse --path-format=absolute
+    /// --git-common-dir` echoes the unknown flag back and exits 0, exactly the
+    /// output shape old git produces. Everything else passes through.
+    pub fn old_git_echoing_path_format(repo: &Path) -> ShimGuard {
+        let repo = std::fs::canonicalize(repo).expect("canonical repo path");
+        let real = real_git();
+        let dir = tempfile::TempDir::new().expect("shim dir");
+        let counter = dir.path().join("note-reads");
+        let script = format!(
+            "#!/bin/sh\n\
+             if [ \"$*\" = \"rev-parse --path-format=absolute --git-common-dir\" ] \
+                && [ \"$(pwd -P)\" = \"{repo}\" ]; then\n\
+               printf '%s\\n%s\\n' '--path-format=absolute' '.git'\n\
+               exit 0\n\
+             fi\n\
+             exec \"{real}\" \"$@\"\n",
+            repo = repo.display(),
+        );
+        install(dir, script, counter)
+    }
+}
+
+/// A transiently failing note read is absorbed by the in-lock retry: the
+/// append succeeds on a later attempt and every sibling entry survives. This
+/// is the windows-latest #185 shape itself: the same read succeeded for every
+/// sibling writer moments apart.
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn append_read_retry_absorbs_a_transient_note_read_failure() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    append_to_git_notes(
+        Some(root),
+        &make_note_record(1, "the sibling entry at stake"),
+    )
+    .await
+    .expect("seed");
+
+    // The first two reads fail, the third succeeds; well inside the four
+    // attempts the retry allows.
+    let shim = git_shim::failing_note_reads(root, 2);
+
+    append_to_git_notes(
+        Some(root),
+        &make_note_record(2, "lands on the third attempt"),
+    )
+    .await
+    .expect("a transient read failure must be absorbed by the in-lock retry, not surfaced");
+    let reads = shim.note_reads();
+    drop(shim);
+
+    assert!(
+        reads >= 3,
+        "the append must have read again past the two failed attempts; \
+         saw {reads} read(s)"
+    );
+    let blob = note_on_head(root).expect("note on HEAD");
+    assert!(
+        blob.contains("the sibling entry at stake") && blob.contains("lands on the third attempt"),
+        "both entries must survive the transient failure; note body:\n{blob}"
+    );
+}
+
+/// "No note yet" is a definitive answer and is not retried: the append's one
+/// read exits 1 and the write proceeds immediately. Retrying it would bill
+/// every first write on a commit the full retry backoff for nothing.
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn a_missing_note_is_answered_in_one_read_without_retrying() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    // Count only (fail_n = 0): HEAD has no note, so the read exits 1.
+    let shim = git_shim::failing_note_reads(root, 0);
+
+    append_to_git_notes(
+        Some(root),
+        &make_note_record(1, "first entry on a bare HEAD"),
+    )
+    .await
+    .expect("append");
+    let reads = shim.note_reads();
+    drop(shim);
+
+    assert_eq!(
+        reads, 1,
+        "a missing note must be read exactly once, never retried"
+    );
+    assert!(
+        note_on_head(root)
+            .expect("note on HEAD")
+            .contains("first entry on a bare HEAD"),
+        "the first entry must land"
+    );
+}
+
+/// Under git < 2.31 (the flag echoed back, exit 0) the lock still lands in
+/// the real common dir, canonicalized, and no path spelled after the echoed
+/// flag is ever used. The unit tests pin `parse_absolute_dir` itself; this
+/// pins that `notes_lock_path` actually routes through that validation and
+/// that its fallback converges on the same canonical identity.
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn old_git_echoing_the_flag_still_locks_the_real_common_dir() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    let shim = git_shim::old_git_echoing_path_format(root);
+    let attempt = lock_notes(Some(root)).await.expect("resolve lock path");
+    drop(shim);
+
+    let LockAttempt::Acquired(guard) = attempt else {
+        panic!("the fallback must still acquire a free lock under old git, got {attempt:?}");
+    };
+    let expected = std::fs::canonicalize(root.join(".git"))
+        .expect("the common dir exists")
+        .join("spelunk-notes.lock");
+    assert_eq!(
+        guard.path(),
+        expected.as_path(),
+        "old git's echoed flag must fall back to the real common dir, in the \
+         one canonical spelling every contender computes"
+    );
+    assert!(
+        !root.join("--path-format=absolute").exists(),
+        "no path spelled after the echoed flag may be created"
     );
 }
 

--- a/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
+++ b/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
@@ -466,6 +466,20 @@ Added on review of a `windows-latest` CI failure in D6's own regression guard.
 > path never excluded nothing; only paths resolving to genuinely different
 > files could, and no failing run required that. D8's contention policy is
 > unchanged by this; what it governs was never the loss mechanism observed.
+>
+> **A second premise below is also corrected by observation: budget expiry is
+> not always a bug's symptom.** This section argues the budget is "set
+> generously enough that reaching it means a bug rather than a busy repo". A
+> `windows-latest` run falsified that: eight legitimate concurrent writers
+> serialized correctly on a slow runner, and the back of the queue exceeded
+> the 5s budget with nothing pathological anywhere; every over-budget writer
+> failed visibly (~5.4s in, naming the lock) while every serialized entry
+> survived. The policy stands exactly as written, since expiry stays an error
+> and never a downgrade. What does not stand is reading that error as proof of
+> a stuck holder: heavy legitimate write concurrency can reach it, the normal
+> remedy is a retry, and the error text says so. The concurrency guards assert
+> the D8 invariant accordingly: every entry lands or its writer fails visibly,
+> never "all must land".
 
 **The rule D6 left implicit, stated:** the contention policy is set by *what is
 lost when the lock is missing*, not by whether the caller is nominally a read or

--- a/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
+++ b/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
@@ -440,6 +440,31 @@ command, not this one.
 
 Added on review of a `windows-latest` CI failure in D6's own regression guard.
 
+> **The closing diagnosis below ("What D8 does not do") is superseded by the
+> implementation's evidence.** It reasoned from a single run that lost 1 of 8
+> entries and concluded the defect was lock **identity** across worktrees.
+> Three further `windows-latest` failures refute that as the mechanism: one
+> lost **6 of 8** entries in the single-repo guard, one process, one repo, no
+> worktrees, where no identity split is possible. In every failing run the
+> survivors are a contiguous **tail** of the serialization order (ids `[6, 8]`;
+> `[8, 2, 4]`; and twice all-but-one), which is the fingerprint of exactly one
+> writer reading an **empty** note mid-sequence and rewriting the ref with only
+> its own line. The write path made that possible: `append_to_git_notes` read
+> the existing note with `git notes show` and treated **any** failure as "no
+> note yet" (`.unwrap_or_default()`), so one transient git failure inside the
+> guarded section wiped every prior entry, while the writer held the lock the
+> whole time, and the lock excluded correctly. The fix distinguishes "no note
+> found" (exit 1) from a failed read (anything else) and fails the writer
+> rather than guessing empty. The identity concern was real hygiene and is
+> hardened anyway (`--path-format=absolute` where git knows it, output-checked
+> because `rev-parse` **echoes** unknown flags with exit 0 rather than
+> rejecting them, then canonicalized), with a regression test pinning that
+> worktree contenders converge on one lock file. But note the OS primitive
+> locks the underlying **file**, not the path string, so two spellings of one
+> path never excluded nothing; only paths resolving to genuinely different
+> files could, and no failing run required that. D8's contention policy is
+> unchanged by this; what it governs was never the loss mechanism observed.
+
 **The rule D6 left implicit, stated:** the contention policy is set by *what is
 lost when the lock is missing*, not by whether the caller is nominally a read or
 a write. Three cases, three answers:

--- a/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
+++ b/docs/adr/069-git-notes-sharing-pre-push-hook-and-tracking-refspec.md
@@ -454,8 +454,10 @@ Added on review of a `windows-latest` CI failure in D6's own regression guard.
 > note yet" (`.unwrap_or_default()`), so one transient git failure inside the
 > guarded section wiped every prior entry, while the writer held the lock the
 > whole time, and the lock excluded correctly. The fix distinguishes "no note
-> found" (exit 1) from a failed read (anything else) and fails the writer
-> rather than guessing empty. The identity concern was real hygiene and is
+> found" (exit 1) from a failed read (anything else); a failed read is retried
+> briefly (it is side-effect free, and every observed failure was transient:
+> the same read succeeded for sibling writers moments apart) and then fails
+> the writer rather than guessing empty. The identity concern was real hygiene and is
 > hardened anyway (`--path-format=absolute` where git knows it, output-checked
 > because `rev-parse` **echoes** unknown flags with exit 0 rather than
 > rejecting them, then canonicalized), with a regression test pinning that

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -615,6 +615,11 @@ and `source_project` / `source_project_path` fields in JSON.
 **git-notes write-through:** when `store_in_git_notes` is true (the default),
 `spelunk memory add` also appends the entry to `refs/notes/spelunk` on `HEAD`,
 so memory travels with the code. Outside a git repo this is a graceful no-op.
+Concurrent writes are serialized by a cross-process lock, and a write that
+cannot take the lock in time fails rather than risk erasing a concurrent
+writer's entry: `memory add` warns on stderr that the entry is stored locally
+but will not travel with the repo (pre-`init`, where git notes is the sole
+store, it fails instead), and retrying the command is the remedy.
 
 **Entry identity:** entries are identified by a SHA-256 over exactly their
 `kind`, `title`, and `body`, so the same decision recorded on two machines

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -67,15 +67,20 @@ search and embed).
 5. No project but inside a git repo: the git-notes write-through carrier (add/list only)
 6. Neither a project nor a git repo: error, *"no spelunk project here, and not inside a git repo. Run 'spelunk init' first, or run inside a git repository."*
 
-**Known limitation:** git-notes writes are not atomic across concurrent `add`
-commands to the same commit (the read-modify-write can lose an entry if two
-agents write simultaneously). This is acceptable for the solo, pre-`init`
-quick-fix case; multi-agent workflows should `spelunk init` and use SQLite. Note
-also that notes under `refs/notes/spelunk` are **not** pushed or fetched by
-default, so pre-`init` entries stay on the machine that wrote them until the
-notes ref is pushed (see [Sharing memory across clones via
-git-notes](#sharing-memory-across-clones-via-git-notes) below, and the
-[git notes](https://git-scm.com/docs/git-notes) documentation).
+**Concurrent `add` commands are serialized.** git-notes writes take a
+cross-process lock (one lock file in the git common dir, shared across
+worktrees), so simultaneous writers append to the note instead of overwriting
+each other. A writer that cannot take the lock in time never writes unlocked,
+since an unserialized write can erase a concurrent writer's entry: pre-`init`,
+where git notes is the sole store, `memory add` fails with an error telling you
+to retry; post-`init` the entry is already in `memory.db`, and `memory add`
+warns on stderr that the carry to git notes failed. On the rare filesystem
+where the lock file cannot be created at all, the write proceeds unserialized
+and warns on stderr. Note also that notes under `refs/notes/spelunk` are
+**not** pushed or fetched by default, so pre-`init` entries stay on the machine
+that wrote them until the notes ref is pushed (see [Sharing memory across
+clones via git-notes](#sharing-memory-across-clones-via-git-notes) below, and
+the [git notes](https://git-scm.com/docs/git-notes) documentation).
 
 See [ADR-067](adr/067-fail-closed-no-local-project.md) for the fail-closed design
 and [ADR-068](adr/068-zero-setup-onboarding-git-notes-memory-fallback.md) for the


### PR DESCRIPTION
**Pipeline complete, QA approved — ready to merge.** Engineer, adversarial Test stage (9 of 19 mutations survived the first suite and were killed; one real defect found and fixed), Docs, and QA have all run; all CI green including 4 consecutive `windows-latest` cells against main's recent 4-red-in-7. Note for the merger: this PR amends ADR-069 D8 in place (superseding its identity sub-diagnosis and its expiry-means-a-bug premise, with CI evidence below), so merging is also the founder sign-off on that amendment. One known residual ships deliberately and is recorded at the bottom.

## What this fixes

Two distinct defects around the `refs/notes/spelunk` lock (#185, ADR-069 D6/D8), plus one hardening, plus the test invariant D8 makes obsolete.

### Defect 1: a failed note read was mistaken for "no note yet" (the actual windows-latest loss mechanism, previously undiagnosed)

`append_to_git_notes` read the existing note with `git notes show` and treated **any** failure as "no note yet" (`.unwrap_or_default()`; same hole in `GitNotesBackend::read_note_blob`). One transient git failure inside the guarded section made that writer rewrite the whole note as just its own line, erasing every prior entry **while it correctly held the lock**. The pre-fix evidence, from `main`:

| run | test | loss | survivors |
|---|---|---|---|
| [57cbb54d1](https://github.com/spelunk-cloud/spelunk/actions/runs/29425343867) | single-repo guard | 6 of 8 | `[6, 8]` |
| [57cbb54d1](https://github.com/spelunk-cloud/spelunk/actions/runs/29425343867) | worktree guard | 5 of 8 | `[8, 2, 4]` |
| [241efbd3e](https://github.com/spelunk-cloud/spelunk/actions/runs/29409485808) | worktree guard | 1 of 8 | all but `[4]` |
| [49a95201a](https://github.com/spelunk-cloud/spelunk/actions/runs/29408116263) | worktree guard | 1 of 8 | all but `[6]` |

Survivors are always a contiguous **tail** of the serialization order: the fingerprint of exactly one mid-sequence writer reading "empty" and clobbering, then later writers appending normally. A lock-identity defect cannot produce the 6-of-8 case (one process, one repo, no worktrees), and the ~13s serialized test durations rule out unlocked stampedes.

**Fix:** the read classifies exit 1 ("no note found") as missing vs anything else as a failed read; a failed read is retried inside the lock with linear backoff (4 attempts, 50/100/150ms pauses, ~300ms added worst case; side-effect free, and every observed pre-fix failure was transient, the same read succeeding for sibling writers moments apart) and then **fails the writer** rather than guessing empty. Deterministic regression tests reproduce the wipe scenario by deleting the note blob object (reads die with exit 128, `git notes add -f` still succeeds), for both the free-function and backend write paths.

### Defect 2: ADR-069 D8 was unimplemented

All three writers discarded the lock outcome (`let _lock = lock_notes(...)`) and proceeded unlocked on contention. Now:

- `lock_notes` returns `LockAttempt::{Acquired, Contended, Unusable}` (`#[must_use]`); `Err` = lock path unresolvable.
- Writers (`append_to_git_notes`, `append_record`, `archive_record`): fail with an actionable error on `Contended`, proceed loudly only on `Unusable` (the one degradation D8 keeps), fail on unresolvable path.
- **"Loudly" is user-visible, not tracing-only** (Test-stage finding, fixed in `5a30d9769`): the first cut logged the `Unusable` degradation via `tracing::warn!`, which reaches nobody without `RUST_LOG` — verified against the real binary as exit 0 + empty stderr. `writer_lock` now returns `WriterLock::Held | Unlocked{path,reason}`, `append_to_git_notes` reports it in `AppendOutcome::lock_degradation`, and `memory add` prints it on stderr. Pinned by `unusable_notes_lock_degradation_is_visible_without_rust_log`, which fails if the warning is dropped (mutation-verified).
- Read-path merge (`merge_tracking_notes`) and publish keep skip-and-report on every non-acquired outcome.
- Pre-D8 pins inverted: `append_to_git_notes_proceeds_when_lock_budget_is_exhausted` is now `append_to_git_notes_fails_when_the_lock_is_contended`; CLI-level `contended_notes_lock_does_not_fail_the_fatal_pre_init_carry` is now `contended_notes_lock_fails_the_pre_init_carry_and_writes_nothing`.

**D8 proven end-to-end on a genuinely contended Windows runner** ([run 29488887058](https://github.com/spelunk-cloud/spelunk/actions/runs/29488887058)): writers lost `[1,5,6,8]` / worktrees lost `[1,2,4,5,7]`, and in both cases the visible failure set was **exactly** the lost set, each failing ~5.4s in with the actionable contention error naming the canonicalized lock path. Zero silent loss; landed and failed sets disjoint and complete. That red also falsified D8's premise that budget expiry "means a bug rather than a busy repo": 8 legitimate serialized writers exceed 5s on a slow runner. The guards therefore now assert the D8 invariant itself (every entry lands or its writer fails visibly; silent loss = red; at least one lands), NOT "all 8 survive" with a raised budget, which would re-hide the behavior.

### Hardening: worktree lock identity

`notes_lock_path` now uses `rev-parse --path-format=absolute --git-common-dir`, **output-validated** (on git < 2.31 `rev-parse` *echoes* unknown flags with exit 0 rather than rejecting them, so exit-code feature detection is a false green), with fallback to the old join logic, then canonicalized. A deterministic test pins that contenders in linked worktrees converge on one lock file; run 29488887058 shows both worktrees resolving the identical canonicalized path on real Windows. Identity divergence was **not** the observed loss mechanism (OS byte-range locks bind to the file, not the path string); ADR-069 D8's identity sub-diagnosis is superseded in place.

## Windows CI sampling

All samples are `Test (windows-latest)` cell conclusions; sampling commits were empty (trees byte-identical within each build) and have been dropped from the branch, so run links are the durable record.

**Build 1 (classification fix, no retry), 6 samples, 6 green:**
[29487862762](https://github.com/spelunk-cloud/spelunk/actions/runs/29487862762) · [29487899197](https://github.com/spelunk-cloud/spelunk/actions/runs/29487899197) · [29487905212](https://github.com/spelunk-cloud/spelunk/actions/runs/29487905212) · [29487912532](https://github.com/spelunk-cloud/spelunk/actions/runs/29487912532)\* · [29487919366](https://github.com/spelunk-cloud/spelunk/actions/runs/29487919366) · [29487923522](https://github.com/spelunk-cloud/spelunk/actions/runs/29487923522)

\* this run's `Check & Lint` job was killed mid-build with no failed step recorded (runner-level infra flake; the byte-identical tree built and linted green in all five sibling runs). Its Windows cell passed and counts as a valid sample.

**Build 2 (+ bounded in-lock read retry), 3 samples, 2 green, 1 red-by-obsolete-invariant:**
[29488887058](https://github.com/spelunk-cloud/spelunk/actions/runs/29488887058) (the D8-proof run above: zero silent loss, old "all survive" assertion tripped by design-correct visible failures) · [29488907705](https://github.com/spelunk-cloud/spelunk/actions/runs/29488907705) · [29488916954](https://github.com/spelunk-cloud/spelunk/actions/runs/29488916954)

**Build 3 (final: guards assert the D8 invariant), 4 samples, 4 green:**
[29489955599](https://github.com/spelunk-cloud/spelunk/actions/runs/29489955599)\*\* · [29489979337](https://github.com/spelunk-cloud/spelunk/actions/runs/29489979337) · [29489986859](https://github.com/spelunk-cloud/spelunk/actions/runs/29489986859) · [29489993560](https://github.com/spelunk-cloud/spelunk/actions/runs/29489993560)

\*\* same `Check & Lint` runner-kill infra flake as build 1 (second occurrence on this branch, unrelated to this change; byte-identical tree linted green in the three sibling runs). Its Windows cell passed and counts as a valid sample.

**Honesty caveats:** the pre-fix flake fired in 3 of 9 windows-latest runs on `main` (Jul 15). Across **13 fixed-code Windows samples, silent loss occurred zero times**; the only red was the obsolete "all survive" invariant, and that run is itself the proof of the designed behavior (lost ids == visibly-failed ids, exactly). Sampling cannot prove absence; the structural guarantees are what changed: the silent-clobber path no longer exists (mutation-verified), and any persistent read failure or contention now fails loudly with the git stderr or lock path in the output. The `Check & Lint` runner-kill flake struck twice on this branch and is a separate, pre-existing CI reliability issue.

## Test plan

- Gates on the final head (`5a30d9769`), all rc=0 locally (macOS), re-run after every commit on this branch: `cargo fmt --all -- --check` · `cargo clippy --all-targets --features rich-formats -- -D warnings` · `cargo nextest run` (1139 passed) · `cargo test --doc` · **full-workspace** `cargo nextest run --no-default-features` (1138 passed, matching the CI ndf cell's scope) · `cargo test --doc --no-default-features`.
- Test stage (`b1e989d06`, tests only): mutation testing found 9 of 19 mutations surviving the Engineer suite (the whole read-retry loop unpinned, both backend writers' lock arms, and the call-site use of the rev-parse output validation); all now killed via a pass-through git shim (unix fault injection), a pacing floor, a backend contended test, and a cross-worktree lock-path identity pin.
- Engineer mutation checks, each killed at the intended assertion, none survived:
  1. Contended writer proceeds unlocked → `append_to_git_notes_fails_when_the_lock_is_contended` fails at its `expect_err`.
  2. Any read failure classified as missing note → both `*_cannot_be_read` guards fail at their `expect_err`s.
  3. Lock keyed on per-worktree `--git-dir` → `lock_notes_contends_across_worktrees` fails, message showing the two divergent lock files.
  4. Writers never take the lock → both `*_land_or_fail_visibly` guards fail at the SILENT LOSS assertion (7 of 8 lost, zero visible failures).
  5. Unusable degradation collapsed to `None` → `unusable_notes_lock_degradation_is_visible_without_rust_log` fails at its stderr assertion.
  - Caveat: the `--path-format`/canonicalize unification itself is not mutation-killable on unix (both branches already converge there); Windows CI exercises the property, see run 29488887058's identical resolved paths.
- The two backend concurrency guards (`git_notes_backend_concurrent_{adds,archives}_*`) now assert the same land-or-fail-visibly invariant as the free-function guards, so a slow runner's legitimate budget expiry cannot flake them.
- Windows validation: sampling tables above.

## Known residuals

- Under heavy concurrent writing on a slow machine, a writer past the 5s budget fails with an actionable retry message (post-`init`: entry kept in SQLite, visible warning; pre-`init`: command fails). That is D8's designed trade: an error the user can see and retry costs a command; the silent clobber it replaces cost the record.
- The backend write paths (`--backend git-notes` add/archive via `MemoryBackend`) still report the `Unusable` degradation only through `tracing`: the trait's signatures have no channel to carry it to the CLI. Same class as the fixed defect, much smaller surface (explicit `--backend git-notes` users), flagged for QA rather than silently absorbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

