### PR TITLE
fix(server): dual-mode /memory/since so spelunk sync's pull half works against OSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,8 +162,15 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   on cloud-api, so `spelunk memory push` returned 405 Method Not Allowed against
   a self-hosted `spelunk-server`. The OSS team server now implements the same
   endpoint with idempotent re-push on `external_id`, enabling push-only workflows.
-  Note: the PULL leg of `spelunk sync` remains unsupported against the OSS server
-  due to a separate wire-format mismatch (follow-up planned).
+- **`spelunk sync`'s pull leg now works against OSS team servers.** The
+  pull half spoke a different wire format than the OSS server's
+  `/memory/since` endpoint understood (a UUID cursor and an `{entries,
+  count}` envelope vs. the endpoint's timestamp-only, bare-array contract),
+  so `spelunk sync` could push but not pull against a self-hosted
+  `spelunk-server`. `/memory/since` now accepts an optional `since_id` cursor
+  alongside the existing `t` timestamp parameter and returns the matching
+  envelope shape when it is used; `spelunk memory since` (which still uses
+  `t`) is unaffected.
 - **Concurrent memory writes can no longer silently erase each other's
   entries.** The git-notes write path is a read-modify-write of the note on
   `HEAD`, and nothing serialized it: two simultaneous `memory add` commands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,6 +5244,7 @@ dependencies = [
  "axum-server",
  "blake3",
  "candle-core",
+ "chrono",
  "clap",
  "constant_time_eq 0.5.0",
  "dirs",

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = { workspace = true }
 rusqlite = { workspace = true }
 sqlite-vec = { workspace = true }
 uuid = { workspace = true }
+chrono = { workspace = true }
 reqwest = { workspace = true }
 axum = { version = "0.8", features = ["macros"] }
 axum-server = { workspace = true }

--- a/crates/spelunk-server/migrations/server_007.sql
+++ b/crates/spelunk-server/migrations/server_007.sql
@@ -1,0 +1,13 @@
+-- spelunk-server migration 007
+-- Server-minted, arrival-ordered identity for the delta-pull cursor
+-- (`/memory/since?since_id=`). Distinct from `remote_id` (a pushing client's
+-- own external_id, used only for push idempotency): `sync_id` is minted by
+-- this server at insert time, so it sorts in the order rows actually arrived
+-- here, not whatever local clock/uuid a pushing client used. That is what
+-- keeps cursor pagination monotonic. Additive and nullable at the schema
+-- level; every row is guaranteed one by the backfill in `ServerDb::migrate`.
+
+ALTER TABLE notes ADD COLUMN sync_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_notes_sync_id
+    ON notes(sync_id) WHERE sync_id IS NOT NULL;

--- a/crates/spelunk-server/src/db.rs
+++ b/crates/spelunk-server/src/db.rs
@@ -100,6 +100,23 @@ pub struct ServerNote {
     pub distance: Option<f64>,
 }
 
+/// A row from [`ServerDb::notes_since_id`] — the `since_id` cursor-mode
+/// delta-pull query. Not directly serialized: `handlers::memory_since` shapes
+/// this into the wire-level `SinceIdEntry`, formatting `created_at` as
+/// RFC3339 and using `sync_id` as the entry's public `id` (never the note's
+/// integer `id`, which has no meaning to a puller on a different machine).
+#[derive(Debug)]
+pub struct SinceIdRow {
+    pub sync_id: String,
+    pub kind: String,
+    pub title: String,
+    pub body: String,
+    /// Extracted from a `git:<sha>` tag, the same convention `harvested_shas`
+    /// reads (`source_commit` has no dedicated column on this schema).
+    pub source_commit: Option<String>,
+    pub created_at: i64,
+}
+
 impl ServerDb {
     pub fn open(
         path: &std::path::Path,
@@ -162,6 +179,40 @@ impl ServerDb {
         self.conn
             .execute_batch(include_str!("../migrations/server_006.sql"))
             .context("server migration 006")?;
+        // Migration 007: sync_id (`ALTER TABLE ADD COLUMN`, not idempotent;
+        // tolerate only the already-applied error, same as migration 005).
+        match self
+            .conn
+            .execute_batch(include_str!("../migrations/server_007.sql"))
+        {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => return Err(e).context("server migration 007"),
+        }
+        self.backfill_missing_sync_ids()?;
+        Ok(())
+    }
+
+    /// Assign a fresh `sync_id` to every row that predates migration 007.
+    /// Idempotent and cheap once caught up (the `WHERE sync_id IS NULL` scan
+    /// returns nothing). Runs unconditionally on every open so a legacy
+    /// database is fully backfilled before any `since_id` cursor pull is
+    /// served. Ordered by `id ASC` so the minted ids stay relatively ordered
+    /// among themselves, matching original insertion order.
+    fn backfill_missing_sync_ids(&self) -> Result<()> {
+        let stale_ids: Vec<i64> = {
+            let mut stmt = self
+                .conn
+                .prepare_cached("SELECT id FROM notes WHERE sync_id IS NULL ORDER BY id ASC")?;
+            stmt.query_map([], |row| row.get(0))?
+                .collect::<rusqlite::Result<Vec<_>>>()?
+        };
+        for id in stale_ids {
+            self.conn.execute(
+                "UPDATE notes SET sync_id = ?1 WHERE id = ?2",
+                rusqlite::params![Uuid::now_v7().to_string(), id],
+            )?;
+        }
         Ok(())
     }
 
@@ -313,11 +364,17 @@ impl ServerDb {
         } else {
             Some(linked_files.join(","))
         };
+        // `sync_id` is minted here unconditionally (server-side, arrival
+        // order), independent of the caller-supplied `remote_id` (a pushing
+        // client's own external_id, used only for push idempotency) — see
+        // migration 007. Every insert path (single-note POST and batch push)
+        // goes through this one function, so every new row gets one.
+        let sync_id = Uuid::now_v7().to_string();
         self.conn.execute(
-            "INSERT INTO notes (project_id, kind, title, body, tags, linked_files, remote_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO notes (project_id, kind, title, body, tags, linked_files, remote_id, sync_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             rusqlite::params![
-                project_id, kind, title, body, tags_csv, files_csv, remote_id
+                project_id, kind, title, body, tags_csv, files_csv, remote_id, sync_id
             ],
         )?;
         let note_id = self.conn.last_insert_rowid();
@@ -578,6 +635,38 @@ impl ServerDb {
         Ok(notes)
     }
 
+    /// Return notes whose `sync_id` sorts strictly after `cursor` (a UUIDv7
+    /// string), ordered ASC by `sync_id`. `sync_id` is server-minted at
+    /// insert time (see `add_note`), so this ordering reflects arrival order
+    /// at this server — unlike `remote_id`, which is a pushing client's own
+    /// external_id and cannot be trusted to sort consistently across
+    /// clients. Archived entries are excluded, matching `notes_since`'s
+    /// behaviour: tombstone propagation over a team server is a known,
+    /// separate gap, not covered by this cursor. `limit` is capped at 500.
+    pub fn notes_since_id(
+        &self,
+        project_id: i64,
+        cursor: &str,
+        limit: i64,
+    ) -> Result<Vec<SinceIdRow>> {
+        let limit = limit.clamp(1, 500);
+        let mut stmt = self.conn.prepare_cached(
+            "SELECT sync_id, kind, title, body, tags, created_at
+             FROM notes
+             WHERE project_id = ?1 AND status != 'archived'
+                   AND sync_id IS NOT NULL AND sync_id > ?2
+             ORDER BY sync_id ASC
+             LIMIT ?3",
+        )?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![project_id, cursor, limit],
+                row_to_since_id_row,
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
     pub fn delete_note(&self, project_id: i64, note_id: i64) -> Result<bool> {
         self.conn.execute(
             "DELETE FROM note_embeddings WHERE note_id = ?1",
@@ -668,6 +757,25 @@ fn row_to_note_with_distance(row: &rusqlite::Row<'_>) -> rusqlite::Result<Server
         superseded_by: row.get(8)?,
         remote_id: row.get(9)?,
         distance: Some(row.get(10)?),
+    })
+}
+
+/// Extract a `git:<sha>` tag's sha, mirroring `harvested_shas`'s parsing of
+/// the same tag convention. Returns the first match, if any.
+fn source_commit_from_tags(tags: &[String]) -> Option<String> {
+    tags.iter()
+        .find_map(|t| t.strip_prefix("git:").map(str::to_string))
+}
+
+fn row_to_since_id_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SinceIdRow> {
+    let tags = split_csv(row.get::<_, Option<String>>(4)?.as_deref());
+    Ok(SinceIdRow {
+        sync_id: row.get(0)?,
+        kind: row.get(1)?,
+        title: row.get(2)?,
+        body: row.get(3)?,
+        source_commit: source_commit_from_tags(&tags),
+        created_at: row.get(5)?,
     })
 }
 
@@ -989,5 +1097,190 @@ mod tests {
             .upsert_project("legacy", 4, "model-a")
             .expect("null model lazy-stamps without rejecting");
         assert_eq!(p.embedding_model.as_deref(), Some("model-a"));
+    }
+
+    // ── sync_id backfill + notes_since_id cursoring ─────────────────────────
+
+    /// A note created via `add_note` (the single-note POST path, `remote_id =
+    /// NULL`) still gets a `sync_id` — minted unconditionally at insert time,
+    /// independent of `remote_id` — and is retrievable via the `since_id`
+    /// cursor from the nil cursor.
+    #[test]
+    fn add_note_mints_sync_id_even_with_no_remote_id() {
+        register_sqlite_vec();
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "test-model")
+            .expect("open in-memory server db");
+        let project = db
+            .upsert_project("acme/widget", 4, "test-model")
+            .expect("project");
+        db.add_note(project.id, "note", "T", "B", &[], &[], None, None)
+            .expect("add note with no remote_id");
+
+        let rows = db
+            .notes_since_id(project.id, "00000000-0000-0000-0000-000000000000", 100)
+            .expect("cursor query from nil");
+        assert_eq!(rows.len(), 1, "the remote_id=NULL note must still surface");
+        assert_eq!(rows[0].title, "T");
+        assert_canonical_uuid(&rows[0].sync_id);
+    }
+
+    /// A pre-existing row created before migration 007 (simulated by
+    /// inserting directly with `sync_id` left NULL) is backfilled with a
+    /// fresh `sync_id` on the next open, so legacy data is not stranded
+    /// outside the `since_id` cursor.
+    #[test]
+    fn reopen_backfills_sync_id_for_legacy_rows() {
+        register_sqlite_vec();
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let path = tmp.path().join("server.db");
+
+        {
+            let db = ServerDb::open(&path, 4, "test-model").expect("first open");
+            let project = db
+                .upsert_project("acme/widget", 4, "test-model")
+                .expect("project");
+            // Simulate a genuinely legacy row: insert directly, bypassing
+            // add_note (which now always mints a sync_id), to model a note
+            // written before migration 007 existed.
+            db.conn
+                .execute(
+                    "INSERT INTO notes (project_id, kind, title, body) VALUES (?1, 'note', 'legacy', 'b')",
+                    rusqlite::params![project.id],
+                )
+                .expect("seed legacy row with no sync_id");
+        }
+
+        // Reopening re-runs migrate(), which must backfill the stray NULL.
+        let db = ServerDb::open(&path, 4, "test-model").expect("reopen");
+        let project = db.get_project("acme/widget").expect("get").expect("exists");
+        let rows = db
+            .notes_since_id(project.id, "00000000-0000-0000-0000-000000000000", 100)
+            .expect("cursor query after backfill");
+        assert_eq!(rows.len(), 1, "the backfilled legacy row must surface");
+        assert_eq!(rows[0].title, "legacy");
+        assert_canonical_uuid(&rows[0].sync_id);
+    }
+
+    /// `notes_since_id` orders by `sync_id` (arrival order at this server),
+    /// and the cursor is exclusive: re-querying with the last-seen `sync_id`
+    /// returns nothing further, and paging from an intermediate cursor skips
+    /// exactly the entries already seen.
+    #[test]
+    fn notes_since_id_cursor_is_exclusive_and_orders_by_arrival() {
+        register_sqlite_vec();
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "test-model")
+            .expect("open in-memory server db");
+        let project = db
+            .upsert_project("acme/widget", 4, "test-model")
+            .expect("project");
+        for title in ["first", "second", "third"] {
+            db.add_note(project.id, "note", title, "b", &[], &[], None, None)
+                .expect("add note");
+            // `sync_id` is a UUIDv7 minted per-call with no cross-call
+            // monotonic counter guaranteed; force millisecond separation so
+            // this test's arrival-order assertion isn't a same-millisecond
+            // coin flip.
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+
+        let nil = "00000000-0000-0000-0000-000000000000";
+        let all = db
+            .notes_since_id(project.id, nil, 100)
+            .expect("full catch-up");
+        assert_eq!(all.len(), 3);
+        let titles: Vec<&str> = all.iter().map(|r| r.title.as_str()).collect();
+        assert_eq!(
+            titles,
+            vec!["first", "second", "third"],
+            "must be ordered by arrival (sync_id ASC), matching insertion order"
+        );
+
+        // Cursor on the first entry's sync_id returns only what came after.
+        let after_first = db
+            .notes_since_id(project.id, &all[0].sync_id, 100)
+            .expect("cursor after first");
+        assert_eq!(
+            after_first
+                .iter()
+                .map(|r| r.title.as_str())
+                .collect::<Vec<_>>(),
+            vec!["second", "third"]
+        );
+
+        // Cursor on the last entry's sync_id returns nothing (exclusive, no
+        // re-delivery of the boundary row).
+        let after_last = db
+            .notes_since_id(project.id, &all[2].sync_id, 100)
+            .expect("cursor after last");
+        assert!(
+            after_last.is_empty(),
+            "the boundary entry itself must not be re-delivered: {after_last:?}"
+        );
+    }
+
+    /// `notes_since_id` excludes archived entries, matching `notes_since`'s
+    /// existing behaviour (tombstone propagation over a team server is a
+    /// separate, not-yet-implemented gap).
+    #[test]
+    fn notes_since_id_excludes_archived_entries() {
+        register_sqlite_vec();
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "test-model")
+            .expect("open in-memory server db");
+        let project = db
+            .upsert_project("acme/widget", 4, "test-model")
+            .expect("project");
+        let id = db
+            .add_note(
+                project.id,
+                "note",
+                "will-archive",
+                "b",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .expect("add note");
+        db.archive_note(project.id, id).expect("archive");
+
+        let nil = "00000000-0000-0000-0000-000000000000";
+        let rows = db
+            .notes_since_id(project.id, nil, 100)
+            .expect("cursor query");
+        assert!(
+            rows.is_empty(),
+            "an archived note must not appear in the since_id cursor: {rows:?}"
+        );
+    }
+
+    /// `notes_since_id` surfaces `source_commit` extracted from the
+    /// `git:<sha>` tag convention, mirroring how `push_memory_batch` stores
+    /// it and `harvested_shas` reads it back.
+    #[test]
+    fn notes_since_id_extracts_source_commit_from_git_tag() {
+        register_sqlite_vec();
+        let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "test-model")
+            .expect("open in-memory server db");
+        let project = db
+            .upsert_project("acme/widget", 4, "test-model")
+            .expect("project");
+        db.add_note(
+            project.id,
+            "decision",
+            "T",
+            "B",
+            &["git:deadbeef".to_string()],
+            &[],
+            None,
+            None,
+        )
+        .expect("add note with git tag");
+
+        let nil = "00000000-0000-0000-0000-000000000000";
+        let rows = db
+            .notes_since_id(project.id, nil, 100)
+            .expect("cursor query");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].source_commit.as_deref(), Some("deadbeef"));
     }
 }

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -1097,8 +1097,15 @@ pub async fn harvested_shas(
 
 #[derive(Deserialize, ToSchema, utoipa::IntoParams)]
 pub struct SinceQuery {
-    /// Unix epoch seconds (exclusive lower bound).
-    pub t: i64,
+    /// Unix epoch seconds (exclusive lower bound). Required unless `since_id`
+    /// is given; ignored when `since_id` is present.
+    pub t: Option<i64>,
+    /// UUID cursor (exclusive lower bound, arrival-ordered — see
+    /// `ServerDb::notes_since_id`). Takes precedence over `t` when both are
+    /// supplied. Selects the delta-pull response shape (`{entries, count}`)
+    /// instead of the bare array `t` returns.
+    #[serde(default)]
+    pub since_id: Option<String>,
     /// Maximum number of results (default: 100, max: 500).
     #[serde(default = "default_since_limit")]
     pub limit: i64,
@@ -1107,14 +1114,45 @@ fn default_since_limit() -> i64 {
     100
 }
 
+/// One entry in the `since_id`-cursor response of `/memory/since`. `id` is
+/// the note's server-minted `sync_id` (arrival-ordered), never its integer
+/// `id`, which has no meaning to a puller on a different machine.
+#[derive(Serialize, ToSchema)]
+pub struct SinceIdEntry {
+    pub id: String,
+    pub kind: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_commit: Option<String>,
+    /// RFC 3339 timestamp.
+    pub created_at: String,
+}
+
+/// Response body for the `since_id`-cursor mode of `/memory/since`.
+#[derive(Serialize, ToSchema)]
+pub struct SinceIdResponse {
+    pub entries: Vec<SinceIdEntry>,
+    pub count: usize,
+}
+
 #[derive(Deserialize, ToSchema, utoipa::IntoParams)]
 pub struct StreamQuery {
     /// Unix epoch seconds to start from (inclusive). Defaults to now.
     pub t: Option<i64>,
 }
 
-/// Return notes created after a given Unix timestamp. Archived entries are
-/// excluded. Results are ordered `created_at ASC`.
+/// Return notes newer than a cursor, in one of two modes:
+///
+/// - `?since_id=<uuid>`: delta-pull mode (wire parity with cloud-api;
+///   `CloudSyncClient::pull_since`/`spelunk sync` targets this). Returns
+///   `{entries, count}`, entries ordered by arrival at this server.
+/// - `?t=<unix_secs>`: legacy timestamp mode (`spelunk memory since`
+///   targets this). Returns a bare array, ordered `created_at ASC`.
+///
+/// `since_id` takes precedence when both are supplied. Archived entries are
+/// excluded in both modes.
 #[utoipa::path(
     get,
     path = "/v1/projects/{project_id}/memory/since",
@@ -1123,8 +1161,8 @@ pub struct StreamQuery {
         SinceQuery,
     ),
     responses(
-        (status = 200, description = "Notes newer than `t`", body = Vec<super::db::ServerNote>),
-        (status = 400, description = "Missing or invalid `t` parameter", body = ErrorBody),
+        (status = 200, description = "Notes newer than `t` (bare array) or `since_id` (`{entries, count}`)", body = Vec<super::db::ServerNote>),
+        (status = 400, description = "Neither `t` nor `since_id` given", body = ErrorBody),
         (status = 401, description = "Unauthorized", body = ErrorBody),
         (status = 404, description = "Project not found", body = ErrorBody),
     ),
@@ -1135,11 +1173,34 @@ pub async fn memory_since(
     State(state): State<AppState>,
     Path(project_id): Path<String>,
     Query(params): Query<SinceQuery>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<Response, AppError> {
     let db = state.db.lock().await;
     let project = require_project(&db, &project_id)?;
-    let notes = db.notes_since(project.id, params.t, params.limit)?;
-    Ok(Json(notes))
+
+    if let Some(cursor) = params.since_id.as_deref() {
+        let rows = db.notes_since_id(project.id, cursor, params.limit)?;
+        let entries: Vec<SinceIdEntry> = rows
+            .into_iter()
+            .map(|r| SinceIdEntry {
+                id: r.sync_id,
+                kind: r.kind,
+                title: r.title,
+                body: (!r.body.is_empty()).then_some(r.body),
+                source_commit: r.source_commit,
+                created_at: chrono::DateTime::from_timestamp(r.created_at, 0)
+                    .map(|dt| dt.to_rfc3339())
+                    .unwrap_or_default(),
+            })
+            .collect();
+        let count = entries.len();
+        return Ok(Json(SinceIdResponse { entries, count }).into_response());
+    }
+
+    let t = params
+        .t
+        .ok_or_else(|| AppError::BadRequest("missing `t` or `since_id` query parameter".into()))?;
+    let notes = db.notes_since(project.id, t, params.limit)?;
+    Ok(Json(notes).into_response())
 }
 
 /// Stream new memory entries as Server-Sent Events. Each event carries a
@@ -3070,6 +3131,152 @@ mod tests {
             resp.status(),
             http::StatusCode::OK,
             "GET /memory/{{note_id}} must still resolve for a real numeric id"
+        );
+    }
+
+    // ── GET /memory/since — dual mode (`t` legacy vs `since_id` cursor) ────────
+
+    async fn get_status_and_json(app: axum::Router, uri: &str) -> (http::StatusCode, Value) {
+        let req = Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        (status, json)
+    }
+
+    /// Regression: the pre-existing `?t=` mode must still return a bare
+    /// array, unchanged by the new `since_id` mode.
+    #[tokio::test]
+    async fn memory_since_t_mode_still_returns_bare_array() {
+        let (app, _dim) = make_app(0.92);
+        let (status, body) =
+            post_note(app.clone(), "since-t-proj", "A", vec![1.0, 0.0, 0.0, 0.0]).await;
+        assert_eq!(status, http::StatusCode::CREATED, "seed: {body}");
+
+        let (status, body) =
+            get_status_and_json(app, "/v1/projects/since-t-proj/memory/since?t=0").await;
+        assert_eq!(status, http::StatusCode::OK, "body: {body}");
+        assert!(
+            body.is_array(),
+            "`t` mode must return a bare array, not an object: {body}"
+        );
+        assert_eq!(body.as_array().unwrap().len(), 1);
+        assert_eq!(body[0]["title"], json!("A"));
+        assert!(
+            body[0].get("entries").is_none(),
+            "must not be wrapped in the since_id envelope: {body}"
+        );
+    }
+
+    /// A request with neither `t` nor `since_id` is a 400, matching the
+    /// pre-existing "missing `t`" contract (now generalized to either param).
+    #[tokio::test]
+    async fn memory_since_missing_both_params_returns_400() {
+        let (app, _dim) = make_app(0.92);
+        // Seed the project first: an unknown project 404s before the
+        // t/since_id check ever runs, which would test the wrong thing.
+        let (status, body) = post_note(
+            app.clone(),
+            "since-missing-proj",
+            "A",
+            vec![1.0, 0.0, 0.0, 0.0],
+        )
+        .await;
+        assert_eq!(status, http::StatusCode::CREATED, "seed: {body}");
+
+        let (status, body) =
+            get_status_and_json(app, "/v1/projects/since-missing-proj/memory/since").await;
+        assert_eq!(status, http::StatusCode::BAD_REQUEST, "body: {body}");
+    }
+
+    /// `since_id` mode returns `{entries, count}`, with `id` set to the
+    /// note's `sync_id` (a UUID), not its integer note id — this is the
+    /// shape `CloudSyncClient::pull_since`/`RemoteEntry` expects.
+    #[tokio::test]
+    async fn memory_since_id_mode_returns_entries_envelope() {
+        let (app, _dim) = make_app(0.92);
+        let (status, body) =
+            post_note(app.clone(), "since-id-proj", "A", vec![1.0, 0.0, 0.0, 0.0]).await;
+        assert_eq!(status, http::StatusCode::CREATED, "seed: {body}");
+
+        let (status, body) = get_status_and_json(
+            app,
+            "/v1/projects/since-id-proj/memory/since?since_id=00000000-0000-0000-0000-000000000000",
+        )
+        .await;
+        assert_eq!(status, http::StatusCode::OK, "body: {body}");
+        assert_eq!(body["count"], json!(1), "body: {body}");
+        let entries = body["entries"].as_array().expect("entries array");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["title"], json!("A"));
+        let id = entries[0]["id"].as_str().expect("id must be a string");
+        assert_eq!(
+            id.len(),
+            36,
+            "id must be a UUID (sync_id), not an integer: {id}"
+        );
+    }
+
+    /// `since_id` takes precedence when both `t` and `since_id` are
+    /// supplied: a `t` far in the past must not switch the response back to
+    /// the bare-array shape.
+    #[tokio::test]
+    async fn memory_since_id_takes_precedence_over_t_when_both_given() {
+        let (app, _dim) = make_app(0.92);
+        let (status, body) = post_note(
+            app.clone(),
+            "since-both-proj",
+            "A",
+            vec![1.0, 0.0, 0.0, 0.0],
+        )
+        .await;
+        assert_eq!(status, http::StatusCode::CREATED, "seed: {body}");
+
+        let (status, body) = get_status_and_json(
+            app,
+            "/v1/projects/since-both-proj/memory/since?t=0&since_id=00000000-0000-0000-0000-000000000000",
+        )
+        .await;
+        assert_eq!(status, http::StatusCode::OK, "body: {body}");
+        assert!(
+            body.get("entries").is_some(),
+            "since_id must win over t when both are given: {body}"
+        );
+    }
+
+    /// The `since_id` cursor is exclusive and advances correctly: pulling
+    /// again with the previous response's max id returns nothing further.
+    #[tokio::test]
+    async fn memory_since_id_cursor_advances_and_is_exclusive() {
+        let (app, _dim) = make_app(0.92);
+        let (status, body) = post_note(
+            app.clone(),
+            "since-cursor-proj",
+            "A",
+            vec![1.0, 0.0, 0.0, 0.0],
+        )
+        .await;
+        assert_eq!(status, http::StatusCode::CREATED, "seed: {body}");
+
+        let nil = "/v1/projects/since-cursor-proj/memory/since?since_id=00000000-0000-0000-0000-000000000000";
+        let (status, body) = get_status_and_json(app.clone(), nil).await;
+        assert_eq!(status, http::StatusCode::OK);
+        let cursor = body["entries"][0]["id"].as_str().expect("id").to_string();
+
+        let uri = format!("/v1/projects/since-cursor-proj/memory/since?since_id={cursor}");
+        let (status, body) = get_status_and_json(app, &uri).await;
+        assert_eq!(status, http::StatusCode::OK, "body: {body}");
+        assert_eq!(
+            body["count"],
+            json!(0),
+            "re-querying with the last-seen cursor must return nothing further: {body}"
         );
     }
 

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -249,6 +249,8 @@ pub fn default_conflict_threshold() -> f32 {
         handlers::BatchItemResult,
         handlers::BatchPushResponse,
         handlers::SinceQuery,
+        handlers::SinceIdEntry,
+        handlers::SinceIdResponse,
         handlers::StreamQuery,
         handlers::HealthResponse,
         handlers::EmbedderStatus,

--- a/crates/spelunk-server/tests/cli_sync_e2e.rs
+++ b/crates/spelunk-server/tests/cli_sync_e2e.rs
@@ -12,18 +12,15 @@
 //! - push a batch of local-shaped memories → stored, per-entry "created".
 //! - re-push the same batch → idempotent on `external_id` (server-side
 //!   `remote_id`): all "skipped", zero duplicates.
-//! - since roundtrip: the pushed entries are retrievable via
-//!   `GET /memory/since`, proving the new `/memory/batch` literal route did
-//!   not shadow (or get shadowed by) the pre-existing `/memory/since` route.
-//!
-//! NOT covered here (a separate, pre-existing gap, not this story's bug):
-//! `CloudSyncClient::pull_since`, the half of `spelunk sync` that pulls,
-//! speaks `?since_id=<uuid>` and expects `{entries, count}`; this server's
-//! `/memory/since` (exercised below) speaks `?t=<unix_secs>` and returns a
-//! bare `Vec<ServerNote>` (the contract `spelunk memory since` actually
-//! uses). Those two CLI code paths disagree on this server's own wire
-//! format: `spelunk sync`'s pull half does not work against an OSS team
-//! server today. Flagged for follow-up, out of scope for the batch-push fix.
+//! - since roundtrip (`?t=`, `spelunk memory since`'s contract): the pushed
+//!   entries are retrievable via `GET /memory/since`, proving the
+//!   `/memory/batch` literal route did not shadow (or get shadowed by) the
+//!   pre-existing `/memory/since` route.
+//! - since roundtrip (`?since_id=`, `spelunk sync`'s pull-half contract):
+//!   `CloudSyncClient::pull_since` — the same client code `spelunk sync`
+//!   uses — retrieves pushed entries via the cursor mode, including an entry
+//!   created via the single-note POST route (`remote_id = NULL`), and a
+//!   second pull with the advanced cursor returns nothing further.
 
 mod common;
 
@@ -269,5 +266,104 @@ async fn concurrent_identical_batches_settle_without_duplicates_or_500s() {
         notes.len(),
         1,
         "a race on the same external_id must never produce two rows: {notes:?}"
+    );
+}
+
+// ── `spelunk sync` pull half: CloudSyncClient::pull_since ──────────────────
+
+/// Create a note via the single-note `POST /memory` route (not batch), the
+/// same shape a pre-existing note on an OSS server would have: `remote_id`
+/// stays NULL, since only a batch push (or a future sync) ever sets it.
+async fn post_single_note(base_url: &str, project: &str, title: &str) {
+    let url = format!("{base_url}/v1/projects/{project}/memory");
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&serde_json::json!({"kind": "note", "title": title, "body": ""}))
+        .send()
+        .await
+        .expect("POST /memory");
+    assert!(
+        resp.status().is_success(),
+        "seeding a single note must succeed: {}",
+        resp.status()
+    );
+}
+
+/// The full pull-side round trip through the real CLI client code:
+/// `CloudSyncClient::pull_since` must retrieve entries pushed via
+/// `POST /memory/batch` (this is the bug the batch-push story didn't fix —
+/// pull spoke a different contract than this server's `/memory/since`
+/// handler understood). Also covers the `remote_id = NULL` gap: a note
+/// created via the single-note POST route (predating any batch push, so it
+/// never got a client-supplied `external_id`) must still surface, because
+/// `sync_id` — the identity `pull_since` actually cursors on — is minted
+/// server-side for every note regardless of how it was created.
+#[tokio::test]
+#[serial_test::serial]
+async fn cli_pull_since_retrieves_pushed_and_legacy_entries_then_cursor_advances() {
+    common::register_sqlite_vec();
+    let state = common::make_test_state(4, None);
+    let base_url = spawn_plaintext_server(state).await;
+    let project = "pull-proj";
+
+    // A "legacy" entry: created before any batch push ever touched this
+    // project, so it has no `remote_id` — this is the gap the contract
+    // mismatch left unhandled.
+    post_single_note(&base_url, project, "Legacy note").await;
+
+    let push_client = CloudSyncClient::new(&base_url, project, None, None).unwrap();
+    let res = push_client
+        .push_batch(vec![BatchPushItem {
+            kind: "decision".into(),
+            title: "Pushed decision".into(),
+            body: Some("why we did it".into()),
+            external_id: "uuid-pushed-1".into(),
+            source_commit: Some("cafef00d".into()),
+        }])
+        .await
+        .expect("push_batch must succeed");
+    assert_eq!((res.created, res.skipped, res.failed), (1, 0, 0));
+
+    // ── Pull from scratch (no cursor yet): both entries must come back ─────
+    let pull_client = CloudSyncClient::new(&base_url, project, None, None).unwrap();
+    let entries = pull_client
+        .pull_since(None)
+        .await
+        .expect("pull_since must succeed against the OSS server");
+    assert_eq!(
+        entries.len(),
+        2,
+        "both the legacy (remote_id=NULL) note and the pushed entry must surface: {entries:?}"
+    );
+    let titles: std::collections::HashSet<&str> =
+        entries.iter().map(|e| e.title.as_str()).collect();
+    assert!(titles.contains("Legacy note"), "entries: {entries:?}");
+    assert!(titles.contains("Pushed decision"), "entries: {entries:?}");
+
+    // Every entry's `id` must be a UUID (the sync_id), not a small integer
+    // string — proves the response is the since_id-mode envelope, not the
+    // legacy `?t=` shape.
+    for e in &entries {
+        assert_eq!(e.id.len(), 36, "id must be a UUID: {e:?}");
+    }
+    assert!(!entries.iter().any(|e| e.is_archived()));
+
+    // source_commit round-trips through the git:<sha> tag convention.
+    let pushed = entries
+        .iter()
+        .find(|e| e.title == "Pushed decision")
+        .expect("pushed entry present");
+    assert_eq!(pushed.source_commit.as_deref(), Some("cafef00d"));
+
+    // ── Cursor advances: pulling again with the max id seen returns nothing
+    // further, proving the cursor is exclusive and doesn't loop forever. ───
+    let max_id = entries.iter().map(|e| e.id.as_str()).max().unwrap();
+    let further = pull_client
+        .pull_since(Some(max_id))
+        .await
+        .expect("second pull_since must succeed");
+    assert!(
+        further.is_empty(),
+        "re-pulling from the max already-seen id must return nothing further: {further:?}"
     );
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -691,7 +691,8 @@
         "tags": [
           "memory"
         ],
-        "summary": "Return notes created after a given Unix timestamp. Archived entries are\nexcluded. Results are ordered `created_at ASC`.",
+        "summary": "Return notes newer than a cursor, in one of two modes:",
+        "description": "- `?since_id=<uuid>`: delta-pull mode (wire parity with cloud-api;\n  `CloudSyncClient::pull_since`/`spelunk sync` targets this). Returns\n  `{entries, count}`, entries ordered by arrival at this server.\n- `?t=<unix_secs>`: legacy timestamp mode (`spelunk memory since`\n  targets this). Returns a bare array, ordered `created_at ASC`.\n\n`since_id` takes precedence when both are supplied. Archived entries are\nexcluded in both modes.",
         "operationId": "memory_since",
         "parameters": [
           {
@@ -706,11 +707,26 @@
           {
             "name": "t",
             "in": "query",
-            "description": "Unix epoch seconds (exclusive lower bound).",
-            "required": true,
+            "description": "Unix epoch seconds (exclusive lower bound). Required unless `since_id`\nis given; ignored when `since_id` is present.",
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64"
+            }
+          },
+          {
+            "name": "since_id",
+            "in": "query",
+            "description": "UUID cursor (exclusive lower bound, arrival-ordered — see\n`ServerDb::notes_since_id`). Takes precedence over `t` when both are\nsupplied. Selects the delta-pull response shape (`{entries, count}`)\ninstead of the bare array `t` returns.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
@@ -726,7 +742,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Notes newer than `t`",
+            "description": "Notes newer than `t` (bare array) or `since_id` (`{entries, count}`)",
             "content": {
               "application/json": {
                 "schema": {
@@ -739,7 +755,7 @@
             }
           },
           "400": {
-            "description": "Missing or invalid `t` parameter",
+            "description": "Neither `t` nor `since_id` given",
             "content": {
               "application/json": {
                 "schema": {
@@ -1995,21 +2011,85 @@
           }
         }
       },
+      "SinceIdEntry": {
+        "type": "object",
+        "description": "One entry in the `since_id`-cursor response of `/memory/since`. `id` is\nthe note's server-minted `sync_id` (arrival-ordered), never its integer\n`id`, which has no meaning to a puller on a different machine.",
+        "required": [
+          "id",
+          "kind",
+          "title",
+          "created_at"
+        ],
+        "properties": {
+          "body": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "description": "RFC 3339 timestamp."
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "source_commit": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "SinceIdResponse": {
+        "type": "object",
+        "description": "Response body for the `since_id`-cursor mode of `/memory/since`.",
+        "required": [
+          "entries",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SinceIdEntry"
+            }
+          }
+        }
+      },
       "SinceQuery": {
         "type": "object",
-        "required": [
-          "t"
-        ],
         "properties": {
           "limit": {
             "type": "integer",
             "format": "int64",
             "description": "Maximum number of results (default: 100, max: 500)."
           },
+          "since_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "UUID cursor (exclusive lower bound, arrival-ordered — see\n`ServerDb::notes_since_id`). Takes precedence over `t` when both are\nsupplied. Selects the delta-pull response shape (`{entries, count}`)\ninstead of the bare array `t` returns."
+          },
           "t": {
-            "type": "integer",
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int64",
-            "description": "Unix epoch seconds (exclusive lower bound)."
+            "description": "Unix epoch seconds (exclusive lower bound). Required unless `since_id`\nis given; ignored when `since_id` is present."
           }
         }
       },


### PR DESCRIPTION
## Summary

Stacked on #635 (adds the `notes.remote_id` column and `POST /memory/batch` this PR builds on). Diff shown here is only the delta on top of that branch; once #635 merges this will be retargeted to `main`.

`spelunk sync`'s pull half (`CloudSyncClient::pull_since`) speaks `GET /memory/since?since_id=<uuid>` and expects `{entries, count}` with UUID entry ids, mirroring cloud-api. The OSS server's `/memory/since` only ever understood `?t=<unix_secs>` and returned a bare `Vec<ServerNote>` with integer ids — the contract `spelunk memory since` (a separate, existing CLI subcommand) correctly targets. Net effect: post-#635, `spelunk sync` could push against a self-hosted `spelunk-server` but not pull.

- `/memory/since` is now dual-mode: an optional `since_id` cursor selects the delta-pull envelope (taking precedence when both `since_id` and `t` are supplied), while the existing `t`-mode is untouched byte-for-byte — `spelunk memory since` keeps working exactly as before.
- The cursor identity is a new `sync_id` column, minted server-side at insert time for every note, independent of `remote_id` (a pushing client's own external id, which can't be trusted to sort consistently across machines/clocks) — this is what keeps `since_id` pagination monotonic by arrival order at this server.
- A one-time backfill in `ServerDb::migrate` assigns `sync_id` to any pre-existing row, so notes created before this change (`remote_id = NULL`, single-note POST path) still surface via the cursor.
- Archived entries are excluded from `since_id` mode, matching `t`-mode's existing behavior; tombstone/archive propagation over a team server is a separate, not-yet-implemented gap (would need an `archived_at` timestamp column) and is out of scope here.

## Test plan

- `cargo test --workspace` — full workspace suite green.
- `cargo test -p spelunk-server --no-default-features` — green (CI's non-embed-native matrix cell).
- `cargo test -p spelunk-server --test cli_sync_e2e` — end-to-end push-then-pull round trip through the real `CloudSyncClient`/`BatchPushItem` client code against a bound `spelunk-server`, including a note created via the single-note POST route (`remote_id = NULL`) to cover the legacy-row cursoring gap, and a second pull from the advanced cursor to confirm no re-delivery.
- `cargo test -p spelunk-server --lib` — new unit coverage: `since_id` cursor ordering/exclusivity, archived-entry exclusion, `source_commit` round-trip via the `git:` tag convention, and the legacy-row `sync_id` backfill on reopen.
- `cargo test -p spelunk-server --test integration_server` — regression: `since_endpoint_returns_entries_after_timestamp` (the `t`-mode contract) still passes unchanged.
- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo run -p spelunk-server -- --print-openapi` — regenerated `docs/openapi.json`; a second run against the committed file is byte-identical (stable).