### PR TITLE
feat(init): implement the ADR-070 embed lifecycle and search warmup contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **`spelunk init` starts the server before indexing and detaches the embedding pass.**
+  On a fresh install, the prompt now returns after parsing (typically a few seconds
+  for medium codebases), with embeddings arriving in the background. A detached worker
+  polls the embedder readiness and runs the embed phase, resumable by re-running
+  `spelunk index`. The server is auto-started before parsing begins (rather than after),
+  and a not-yet-ready embedder is a transient condition to wait on rather than a
+  terminal reason to skip indexing. (ADR-070 D1, D2)
+- **Search over a warming index emits coverage-gated notices.** When KNN search runs
+  over an incompletely-embedded corpus, a one-line stderr notice names the coverage
+  percentage and its shape ("front-loaded by indexing order"). In `auto` mode on zero
+  coverage, search falls back to ast-grep with a notice naming embeddings as building
+  in the background; in explicit `semantic`/`hybrid` mode, zero coverage produces an
+  actionable error naming the resume command instead of "No results found." Partial
+  coverage results stay served (KNN order-independence + useful prefix) and are labelled
+  accordingly. (ADR-070 D3)
+- **`spelunk status` reports the embed worker's recorded liveness and token-weighted
+  progress.** A live background worker triggers "Embedding in progress" (not a guess
+  from embedded counts); no live worker + pending work prints "Embedding incomplete"
+  plus the resume command. Coverage (chunks embedded / total chunks) and progress
+  (percentage of work done, measured by token weight) are two separately-named measures,
+  and a measured-this-run ETA derives from the worker's recorded baseline (never cached
+  across runs). The old hedging parenthetical is gone. JSON status gains
+  `embedding_pending`, `embed_worker_alive`, and `embed_tokens` fields. (ADR-070 D4, D6)
+
 - **Memory entries are now identified by their content.** An entry's canonical
   identity is a SHA-256 over exactly its `kind`, `title`, and `body`, so the
   same decision recorded independently on two machines converges on one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - **`spelunk init` starts the server before indexing and detaches the embedding pass.**
-  On a fresh install, the prompt now returns after parsing (typically a few seconds
-  for medium codebases), with embeddings arriving in the background. A detached worker
+  On a fresh install, the prompt now returns after parsing (seconds on small projects,
+  around a minute on large ones), with embeddings arriving in the background. A detached worker
   polls the embedder readiness and runs the embed phase, resumable by re-running
   `spelunk index`. The server is auto-started before parsing begins (rather than after),
   and a not-yet-ready embedder is a transient condition to wait on rather than a
-  terminal reason to skip indexing. (ADR-070 D1, D2)
+  terminal reason to skip the embed pass. (ADR-070 D1, D2)
 - **Search over a warming index emits coverage-gated notices.** When KNN search runs
   over an incompletely-embedded corpus, a one-line stderr notice names the coverage
   percentage and its shape ("front-loaded by indexing order"). In `auto` mode on zero

--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -364,6 +364,26 @@ pub async fn get_tier(cfg: &Config) -> &'static Tier {
     .await
 }
 
+/// One fresh, uncached tier probe, honouring the same explicit-offline
+/// short-circuits as [`get_tier`].
+///
+/// For pollers only: `get_tier`'s process-lifetime cache pins whatever state
+/// the first probe saw, so a caller that must observe a *transition* (the
+/// detached embed worker waiting for the embedder to finish loading) has to
+/// re-probe. Everything else should keep using [`get_tier`].
+pub async fn probe_tier_fresh(cfg: &Config) -> Tier {
+    let explicit_offline = spelunk_core::config::no_server_env_set()
+        || cfg.mode == Some(spelunk_core::config::SyncMode::Offline);
+    if explicit_offline {
+        return Tier::Offline;
+    }
+    probe(
+        cfg.server_url.as_deref(),
+        cfg.server_ca.as_deref().map(std::path::Path::new),
+    )
+    .await
+}
+
 /// Remote-server probe timeout (explicit `server_url` in config/env).
 const REMOTE_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 

--- a/crates/spelunk-cli/src/cli/cmd/embed_worker.rs
+++ b/crates/spelunk-cli/src/cli/cmd/embed_worker.rs
@@ -1,0 +1,277 @@
+//! Liveness and progress-baseline state for the background embed worker, so
+//! `spelunk status` reports what it knows about its own subprocess instead of
+//! guessing from chunk counts (which cannot distinguish a running job from an
+//! abandoned one).
+//!
+//! Mirrors the server's own pid-file shape: one small state file per datum,
+//! written 0600 into the same `~/.local/state/spelunk/` directory (see
+//! `server.rs`), a `pid_is_alive` liveness check, and a foreign-pid
+//! classification so a recycled pid is never misreported as a live worker.
+//! Files are keyed by a hash of the index path because workers are
+//! per-project while the state dir is per-machine.
+//!
+//! Two files per project:
+//! - `embed-worker-<key>.pid` — pid of the process running the embed phase
+//! - `embed-worker-<key>.baseline` — `<started_at_unix> <pending_tokens>` at
+//!   worker start, letting `status` derive a measured-this-run,
+//!   token-weighted ETA (tokens drained since start over elapsed time). The
+//!   rate is never persisted across runs; a cached rate is a defect because
+//!   the token estimate's bias is corpus-dependent.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use super::server::{create_state_dir, pid_is_alive, spelunk_state_dir, write_state_file};
+use crate::storage::Database;
+
+/// Per-project key for the worker state files: hash of the canonicalised
+/// index path (two projects must never share a liveness file).
+fn worker_key(db_path: &Path) -> String {
+    let canonical = spelunk_core::utils::canonicalize(db_path);
+    let hash = blake3::hash(canonical.to_string_lossy().as_bytes());
+    hash.to_hex()[..16].to_string()
+}
+
+fn pid_file(state_dir: &Path, key: &str) -> PathBuf {
+    state_dir.join(format!("embed-worker-{key}.pid"))
+}
+
+fn baseline_file(state_dir: &Path, key: &str) -> PathBuf {
+    state_dir.join(format!("embed-worker-{key}.baseline"))
+}
+
+/// RAII liveness marker held by whichever process runs the embed phase (the
+/// detached worker, or a foreground `spelunk index` resume). Best-effort:
+/// state-file failures must never fail the embed itself.
+///
+/// Dropped on clean exit; a killed worker leaves the files behind, which the
+/// next `status` classifies as a dead pid and cleans up.
+pub(super) struct EmbedWorkerGuard {
+    pid_path: PathBuf,
+    baseline_path: PathBuf,
+}
+
+impl EmbedWorkerGuard {
+    /// Record this process as the live embed worker for `db_path`. `None`
+    /// when the state dir is unusable (embedding proceeds unrecorded).
+    pub(super) fn acquire(db: &Database, db_path: &Path) -> Option<Self> {
+        let state_dir = spelunk_state_dir().ok()?;
+        create_state_dir(&state_dir).ok()?;
+        let key = worker_key(db_path);
+        let pid_path = pid_file(&state_dir, &key);
+        let baseline_path = baseline_file(&state_dir, &key);
+
+        write_state_file(&pid_path, &format!("{}\n", std::process::id())).ok()?;
+
+        // Baseline for the token-weighted ETA. Failure to write it only costs
+        // the ETA, not the liveness record.
+        let pending = db
+            .embed_token_stats()
+            .map(|s| s.pending_tokens)
+            .unwrap_or(0);
+        let now = chrono::Utc::now().timestamp();
+        let _ = write_state_file(&baseline_path, &format!("{now} {pending}\n"));
+
+        Some(Self {
+            pid_path,
+            baseline_path,
+        })
+    }
+}
+
+impl Drop for EmbedWorkerGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.pid_path);
+        let _ = std::fs::remove_file(&self.baseline_path);
+    }
+}
+
+/// What `status` knows about the worker for a project.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorkerLiveness {
+    /// The recorded pid is alive and its command line looks like a spelunk
+    /// index run.
+    Alive,
+    /// No recorded worker, a dead pid, or a pid recycled by an unrelated
+    /// process (foreign). Never reported as running.
+    NotRunning,
+}
+
+/// Classify a recorded worker pid. Pure so the alive/foreign matrix is unit
+/// testable without real processes; `looks_like_worker` is the command-line
+/// identity check (a pid can be recycled by an unrelated process after a
+/// crash, and that must not read as a live embed run).
+fn classify_worker_pid(alive: bool, looks_like_worker: bool) -> WorkerLiveness {
+    if alive && looks_like_worker {
+        WorkerLiveness::Alive
+    } else {
+        WorkerLiveness::NotRunning
+    }
+}
+
+/// Return `true` when `pid`'s command line looks like a spelunk index run
+/// (the detached `--_embed-phases` worker or a foreground resume).
+fn process_looks_like_index_run(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        match std::process::Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "args="])
+            .output()
+        {
+            Ok(out) if out.status.success() => {
+                let args = String::from_utf8_lossy(&out.stdout);
+                args.contains("spelunk") && args.contains("index")
+            }
+            _ => false,
+        }
+    }
+    #[cfg(windows)]
+    {
+        // tasklist exposes only the image name, so match on the binary; the
+        // worst case of the coarser match is reporting another spelunk
+        // process's pid as a live worker, never a foreign process's.
+        match std::process::Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+            .output()
+        {
+            Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+                .to_lowercase()
+                .contains("spelunk"),
+            _ => false,
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+/// Read and classify the recorded worker for `db_path`. Stale state (dead or
+/// foreign pid) is cleaned up so it cannot be re-read as live later.
+pub(super) fn worker_liveness(db_path: &Path) -> WorkerLiveness {
+    let Ok(state_dir) = spelunk_state_dir() else {
+        return WorkerLiveness::NotRunning;
+    };
+    let key = worker_key(db_path);
+    let pid_path = pid_file(&state_dir, &key);
+    let Some(pid) = std::fs::read_to_string(&pid_path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+    else {
+        return WorkerLiveness::NotRunning;
+    };
+    match classify_worker_pid(pid_is_alive(pid), process_looks_like_index_run(pid)) {
+        WorkerLiveness::Alive => WorkerLiveness::Alive,
+        WorkerLiveness::NotRunning => {
+            // Dead or foreign: the recorded state is stale, remove it.
+            let _ = std::fs::remove_file(&pid_path);
+            let _ = std::fs::remove_file(baseline_file(&state_dir, &key));
+            WorkerLiveness::NotRunning
+        }
+    }
+}
+
+/// Token-weighted ETA for a live worker: tokens drained since the recorded
+/// baseline over elapsed wall time, applied to the tokens still pending.
+/// `None` before any measurable progress (calibrating) or without a baseline.
+pub(super) fn worker_eta(db_path: &Path, pending_tokens_now: i64) -> Option<Duration> {
+    let state_dir = spelunk_state_dir().ok()?;
+    let key = worker_key(db_path);
+    let contents = std::fs::read_to_string(baseline_file(&state_dir, &key)).ok()?;
+    let mut parts = contents.split_whitespace();
+    let started_at: i64 = parts.next()?.parse().ok()?;
+    let pending_at_start: i64 = parts.next()?.parse().ok()?;
+    eta_from_baseline(
+        started_at,
+        pending_at_start,
+        chrono::Utc::now().timestamp(),
+        pending_tokens_now,
+    )
+}
+
+/// Pure ETA math over the baseline: measured this run, token-weighted.
+fn eta_from_baseline(
+    started_at: i64,
+    pending_at_start: i64,
+    now: i64,
+    pending_now: i64,
+) -> Option<Duration> {
+    let elapsed = now.checked_sub(started_at)?;
+    let drained = pending_at_start.checked_sub(pending_now)?;
+    if elapsed <= 0 || drained <= 0 || pending_now <= 0 {
+        return None;
+    }
+    let rate = drained as f64 / elapsed as f64; // tokens per second
+    let secs = pending_now as f64 / rate;
+    if !secs.is_finite() {
+        return None;
+    }
+    Some(Duration::from_secs_f64(secs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── classify_worker_pid: liveness × identity matrix ─────────────────────
+
+    #[test]
+    fn alive_and_matching_command_is_a_live_worker() {
+        assert_eq!(classify_worker_pid(true, true), WorkerLiveness::Alive);
+    }
+
+    #[test]
+    fn dead_pid_is_not_running() {
+        assert_eq!(classify_worker_pid(false, true), WorkerLiveness::NotRunning);
+        assert_eq!(
+            classify_worker_pid(false, false),
+            WorkerLiveness::NotRunning
+        );
+    }
+
+    #[test]
+    fn foreign_pid_is_never_reported_as_a_live_worker() {
+        // A pid recycled by an unrelated process after a crash: alive, but the
+        // command line is not a spelunk index run. Reporting it as "Embedding
+        // in progress" is exactly the guess D4 removes.
+        assert_eq!(classify_worker_pid(true, false), WorkerLiveness::NotRunning);
+    }
+
+    // ── worker_key: per-project isolation ───────────────────────────────────
+
+    #[test]
+    fn worker_key_differs_per_project() {
+        let a = worker_key(Path::new("/proj-a/.spelunk/index.db"));
+        let b = worker_key(Path::new("/proj-b/.spelunk/index.db"));
+        assert_ne!(a, b, "two projects must never share a liveness file");
+        assert_eq!(a.len(), 16);
+    }
+
+    // ── eta_from_baseline: measured-this-run token rate ─────────────────────
+
+    #[test]
+    fn eta_scales_with_pending_tokens_at_the_measured_rate() {
+        // 1000 tokens drained in 100 s → 10 tokens/s; 5000 pending → 500 s.
+        let eta = eta_from_baseline(0, 6000, 100, 5000).expect("measurable progress");
+        assert_eq!(eta, Duration::from_secs(500));
+    }
+
+    #[test]
+    fn eta_is_none_while_calibrating() {
+        // No tokens drained yet: no measured rate, no ETA (never a guess).
+        assert!(eta_from_baseline(0, 6000, 100, 6000).is_none());
+        // Zero elapsed time.
+        assert!(eta_from_baseline(100, 6000, 100, 5000).is_none());
+        // Nothing pending.
+        assert!(eta_from_baseline(0, 6000, 100, 0).is_none());
+    }
+
+    #[test]
+    fn eta_tolerates_a_clock_step_or_regressed_baseline() {
+        // A baseline from the future or pending that grew (concurrent
+        // re-index) must yield None, not a negative/panicking duration.
+        assert!(eta_from_baseline(200, 6000, 100, 5000).is_none());
+        assert!(eta_from_baseline(0, 5000, 100, 6000).is_none());
+    }
+}

--- a/crates/spelunk-cli/src/cli/cmd/embed_worker.rs
+++ b/crates/spelunk-cli/src/cli/cmd/embed_worker.rs
@@ -11,8 +11,8 @@
 //! per-project while the state dir is per-machine.
 //!
 //! Two files per project:
-//! - `embed-worker-<key>.pid` — pid of the process running the embed phase
-//! - `embed-worker-<key>.baseline` — `<started_at_unix> <pending_tokens>` at
+//! - `embed-worker-<key>.pid`: pid of the process running the embed phase
+//! - `embed-worker-<key>.baseline`: `<started_at_unix> <pending_tokens>` at
 //!   worker start, letting `status` derive a measured-this-run,
 //!   token-weighted ETA (tokens drained since start over elapsed time). The
 //!   rate is never persisted across runs; a cached rate is a defect because

--- a/crates/spelunk-cli/src/cli/cmd/embed_worker.rs
+++ b/crates/spelunk-cli/src/cli/cmd/embed_worker.rs
@@ -248,6 +248,14 @@ mod tests {
         assert_eq!(a.len(), 16);
     }
 
+    #[test]
+    fn worker_key_is_stable_for_the_same_path() {
+        // Writer (worker) and reader (status) derive the key independently;
+        // any nondeterminism here silently severs status from its worker.
+        let p = Path::new("/proj-a/.spelunk/index.db");
+        assert_eq!(worker_key(p), worker_key(p));
+    }
+
     // ── eta_from_baseline: measured-this-run token rate ─────────────────────
 
     #[test]
@@ -273,5 +281,15 @@ mod tests {
         // re-index) must yield None, not a negative/panicking duration.
         assert!(eta_from_baseline(200, 6000, 100, 5000).is_none());
         assert!(eta_from_baseline(0, 5000, 100, 6000).is_none());
+    }
+
+    #[test]
+    fn eta_survives_extreme_token_counts_without_panicking() {
+        // i64::MAX-scale token sums (a corrupt baseline file is user-writable
+        // input) must not overflow checked_sub or Duration::from_secs_f64.
+        let eta = eta_from_baseline(0, i64::MAX, 1, i64::MAX - 1000);
+        assert!(eta.is_some(), "a huge but finite ETA is still an ETA");
+        // Underflow direction: pending_at_start negative, pending_now MAX.
+        assert!(eta_from_baseline(0, i64::MIN, 1, i64::MAX).is_none());
     }
 }

--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -82,11 +82,19 @@ fn resolve_target_batch_seconds(server_limits: Option<ServerLimits>) -> u64 {
 /// to in one step, so one fast sample can't leap to a size nothing has measured.
 const GROWTH_FACTOR: usize = 8;
 
-/// Choose the next steady-state batch size so a batch takes ~`target_seconds` at
-/// the measured `per_entry` rate. Clamped to `[1, ceiling]` and to at most
-/// `GROWTH_FACTOR × previous_batch_size`.
-fn next_batch_size(
-    per_entry: Duration,
+/// Choose the next steady-state batch length (in chunks) so the batch's
+/// **token** sum fits ~`target_seconds` at the measured `per_token` rate.
+/// `token_tail` is the per-chunk token counts of the queue from the cursor on.
+/// Clamped to `[1, ceiling]` and to at most `GROWTH_FACTOR ×
+/// previous_batch_size` (both in chunks).
+///
+/// Sizing by tokens rather than chunk count is what keeps the derived deadline
+/// honest across a size transition in the queue: per-chunk cost grows ~4x
+/// through an id-ordered queue, so a chunk-count budget calibrated on early
+/// (small) chunks over-fills a batch of late (large) ones.
+fn next_batch_len(
+    per_token: Duration,
+    token_tail: &[usize],
     ceiling: usize,
     previous_batch_size: usize,
     target_seconds: u64,
@@ -96,26 +104,35 @@ fn next_batch_size(
         .saturating_mul(GROWTH_FACTOR)
         .min(ceiling.max(1));
 
-    if per_entry.is_zero() {
-        return growth_cap;
+    if per_token.is_zero() {
+        return growth_cap.min(token_tail.len().max(1));
     }
-    let target = Duration::from_secs(target_seconds).as_secs_f64();
-    let size = (target / per_entry.as_secs_f64()).round();
-    if size < 1.0 {
-        1
-    } else if size >= growth_cap as f64 {
-        growth_cap
-    } else {
-        size as usize
+    let target_tokens = Duration::from_secs(target_seconds).as_secs_f64() / per_token.as_secs_f64();
+
+    // Take chunks while their cumulative token sum stays within the target;
+    // always at least one so progress can't stall.
+    let mut len = 0usize;
+    let mut tokens = 0f64;
+    for &tc in token_tail.iter().take(growth_cap) {
+        tokens += tc.max(1) as f64;
+        if len > 0 && tokens > target_tokens {
+            break;
+        }
+        len += 1;
     }
+    len.max(1)
 }
 
 /// Per-request timeout for a batch: `TIMEOUT_SAFETY_FACTOR ×` its expected
-/// duration at `per_entry`, clamped to `[MIN_REQUEST_TIMEOUT, MAX_REQUEST_TIMEOUT]`.
-fn batch_timeout(per_entry: Duration, batch_size: usize) -> Duration {
-    let expected = per_entry.saturating_mul(batch_size.max(1) as u32);
-    let budget = expected.saturating_mul(TIMEOUT_SAFETY_FACTOR);
-    budget.clamp(MIN_REQUEST_TIMEOUT, MAX_REQUEST_TIMEOUT)
+/// duration at `per_token` over the batch's token sum, clamped to
+/// `[MIN_REQUEST_TIMEOUT, MAX_REQUEST_TIMEOUT]`. The rate and the deadline
+/// share the token unit, so a size transition in the queue moves the deadline
+/// with the batch's real cost instead of consuming the safety margin.
+fn batch_timeout(per_token: Duration, batch_tokens: u64) -> Duration {
+    let expected_secs = per_token.as_secs_f64() * batch_tokens.max(1) as f64;
+    let budget_secs = (expected_secs * TIMEOUT_SAFETY_FACTOR as f64)
+        .clamp(0.0, MAX_REQUEST_TIMEOUT.as_secs_f64());
+    Duration::from_secs_f64(budget_secs).clamp(MIN_REQUEST_TIMEOUT, MAX_REQUEST_TIMEOUT)
 }
 
 /// Timeout for the very first (single-chunk) request, before any rate is known.
@@ -132,14 +149,21 @@ const CALIBRATION_BATCH_1_WEIGHT: f64 = 0.1;
 /// Running estimate of this run's embedding throughput, refined after every
 /// batch so mid-run drift (thermal throttling, GPU contention) is picked up.
 ///
-/// Single authoritative rate source: `next_batch_size`, `batch_timeout`, and the
-/// displayed ETA (`format_eta`) all read `per_entry()` from the same instance so
+/// Single authoritative rate source: `next_batch_len`, `batch_timeout`, and the
+/// displayed ETA (`format_eta`) all read `per_token()` from the same instance so
 /// they can't disagree. Deliberately not indicatif's `{eta}`, which infers rate
 /// from `bar.inc(1)` timing — wrong for this phase's bursty increments (see
 /// `format_eta`).
+///
+/// The rate is **per estimated token**, not per chunk: per-chunk cost is not
+/// stationary through an id-ordered queue (~4x growth), so a per-chunk rate is
+/// systematically biased in one direction across the run. The token estimate's
+/// own corpus-dependent bias cancels here because the rate is calibrated from
+/// estimated tokens and only ever multiplied by estimated tokens — the rate
+/// must stay measured per-run, never cached across runs or repos.
 struct RateEstimate {
-    /// Exponentially-weighted per-entry duration. `None` until the first batch.
-    per_entry: Option<Duration>,
+    /// Exponentially-weighted per-token duration. `None` until the first batch.
+    per_token: Option<Duration>,
     /// Batches folded in so far, so `update` can tell the batch-1 cold sample
     /// (== 1) from later steady-state blends.
     samples_seen: u32,
@@ -148,21 +172,21 @@ struct RateEstimate {
 impl RateEstimate {
     fn new() -> Self {
         Self {
-            per_entry: None,
+            per_token: None,
             samples_seen: 0,
         }
     }
 
-    /// Fold in a batch: `elapsed` for `entries` chunks. First observation seeds
-    /// the estimate; the second de-weights the batch-1 cold sample
-    /// (`CALIBRATION_BATCH_1_WEIGHT`); from the third onward, a 50/50 EMA so
-    /// mid-run rate changes are reflected within a couple of batches.
-    fn update(&mut self, elapsed: Duration, entries: usize) {
-        if entries == 0 {
+    /// Fold in a batch: `elapsed` for `tokens` estimated tokens. First
+    /// observation seeds the estimate; the second de-weights the batch-1 cold
+    /// sample (`CALIBRATION_BATCH_1_WEIGHT`); from the third onward, a 50/50
+    /// EMA so mid-run rate changes are reflected within a couple of batches.
+    fn update(&mut self, elapsed: Duration, tokens: u64) {
+        if tokens == 0 {
             return;
         }
-        let sample = elapsed.div_f64(entries as f64);
-        self.per_entry = Some(match self.per_entry {
+        let sample = elapsed.div_f64(tokens as f64);
+        self.per_token = Some(match self.per_token {
             None => sample,
             Some(prev) if self.samples_seen == 1 => {
                 // Superseding the batch-1 cold sample: de-weight it.
@@ -180,8 +204,8 @@ impl RateEstimate {
     }
 
     /// Current best estimate, or `None` before the first batch has landed.
-    fn per_entry(&self) -> Option<Duration> {
-        self.per_entry
+    fn per_token(&self) -> Option<Duration> {
+        self.per_token
     }
 }
 
@@ -202,22 +226,23 @@ fn embed_progress_style() -> ProgressStyle {
 /// than a literal (possibly absurd) computed duration.
 const ETA_DISPLAY_CAP: Duration = Duration::from_secs(24 * 60 * 60);
 
-/// Render the displayed ETA from the measured `RateEstimate` and chunks remaining.
+/// Render the displayed ETA from the measured `RateEstimate` and estimated
+/// tokens remaining.
 ///
-/// - `None` per_entry (pre-first-batch): a calibrating placeholder, not a guess.
-/// - Else `per_entry * remaining`, computed in f64 and clamped BEFORE converting
-///   back to `Duration` (a pathological `per_entry` can overflow/produce `inf`),
-///   so a bad sample yields the `>24h` string, never a panic.
+/// - `None` per_token (pre-first-batch): a calibrating placeholder, not a guess.
+/// - Else `per_token * remaining tokens`, computed in f64 and clamped BEFORE
+///   converting back to `Duration` (a pathological rate can overflow/produce
+///   `inf`), so a bad sample yields the `>24h` string, never a panic.
 /// - Compact format: seconds / minutes(+seconds) / hours+minutes.
-fn format_eta(remaining: usize, per_entry: Option<Duration>) -> String {
-    let Some(per_entry) = per_entry else {
+fn format_eta(remaining_tokens: u64, per_token: Option<Duration>) -> String {
+    let Some(per_token) = per_token else {
         return "ETA calibrating…".to_string();
     };
-    if remaining == 0 {
+    if remaining_tokens == 0 {
         return "ETA 0s".to_string();
     }
 
-    let seconds = (per_entry.as_secs_f64() * remaining as f64).clamp(0.0, f64::MAX);
+    let seconds = (per_token.as_secs_f64() * remaining_tokens as f64).clamp(0.0, f64::MAX);
     if !seconds.is_finite() || seconds >= ETA_DISPLAY_CAP.as_secs_f64() {
         return "ETA >24h".to_string();
     }
@@ -239,6 +264,13 @@ fn format_eta(remaining: usize, per_entry: Option<Duration>) -> String {
     } else {
         format!("ETA {secs}s")
     }
+}
+
+/// Integer percentage of `done` over `total`, 0 when `total` is 0. Callers
+/// must label the result with its denominator; a bare percentage is banned
+/// from every embedding-state surface.
+fn pct(done: u64, total: u64) -> u64 {
+    done.saturating_mul(100).checked_div(total).unwrap_or(0)
 }
 
 #[derive(Serialize)]
@@ -281,11 +313,15 @@ fn report_embed_failure(
 /// Send pending chunks to `spelunk-server` for embedding and write the returned
 /// vectors into the local DB.
 ///
+/// `chunk_ids_and_texts` items are `(chunk_id, embedding_text, token_count)`;
+/// the token counts weight the progress/ETA display, batch sizing, and request
+/// deadlines (all through the same `RateEstimate`).
+///
 /// Returns the number of chunks successfully embedded.
 ///
 /// Requires `Tier::Server`; returns `Ok(0)` immediately for `Tier::Offline`.
 pub(super) async fn run_embed_phase(
-    chunk_ids_and_texts: Vec<(i64, String)>,
+    chunk_ids_and_texts: Vec<(i64, String, usize)>,
     db: &Database,
     cfg: &Config,
     tier: &Tier,
@@ -358,6 +394,14 @@ pub(super) async fn run_embed_phase(
     let mut batch_num = 0u64;
     let mut previous_batch_size = 1usize;
     let remaining = chunk_ids_and_texts.len();
+    // Token-weighted work totals: the ETA and the "of work done" percentage
+    // run over these, never over chunk counts (chunk fraction is coverage, a
+    // different question — see `status`).
+    let total_tokens: u64 = chunk_ids_and_texts
+        .iter()
+        .map(|(_, _, tc)| (*tc).max(1) as u64)
+        .sum();
+    let mut tokens_done = 0u64;
     // Percent-encode the project_id segment: slugs contain `/`
     // (`local/<hex>`, `github.com/owner/repo`) which would otherwise split the
     // segment and break axum routing → 404.
@@ -377,11 +421,16 @@ pub(super) async fn run_embed_phase(
             1 => CALIBRATION_BATCH_1,
             2 => CALIBRATION_BATCH_2,
             _ => {
-                let per_entry = rate
-                    .per_entry()
+                let per_token = rate
+                    .per_token()
                     .expect("rate is seeded after the first batch completes");
-                next_batch_size(
-                    per_entry,
+                let token_tail: Vec<usize> = chunk_ids_and_texts[cursor..]
+                    .iter()
+                    .map(|(_, _, tc)| *tc)
+                    .collect();
+                next_batch_len(
+                    per_token,
+                    &token_tail,
                     ceiling,
                     previous_batch_size,
                     target_batch_seconds,
@@ -395,25 +444,31 @@ pub(super) async fn run_embed_phase(
         // retry, rather than aborting at 0 embedded. Any other failure aborts.
         let mut escalated_calibration_once = false;
         let bytes = 'retry: loop {
-            let request_timeout = match rate.per_entry() {
-                Some(per_entry) => batch_timeout(per_entry, this_batch_size),
+            let batch_tokens: u64 = chunk_ids_and_texts[cursor..cursor + this_batch_size]
+                .iter()
+                .map(|(_, _, tc)| (*tc).max(1) as u64)
+                .sum();
+            let request_timeout = match rate.per_token() {
+                Some(per_token) => batch_timeout(per_token, batch_tokens),
                 None if escalated_calibration_once => MAX_REQUEST_TIMEOUT,
                 None => FIRST_REQUEST_TIMEOUT,
             };
 
             // Show which chunks are in flight, prefixed with the `RateEstimate`
-            // ETA (not indicatif's `{eta}` — see `format_eta`).
-            let eta_str = format_eta(total.saturating_sub(embedded) as usize, rate.per_entry());
+            // ETA (not indicatif's `{eta}` — see `format_eta`). Work-fraction
+            // percentages are token-weighted and always name their denominator.
+            let eta_str = format_eta(total_tokens.saturating_sub(tokens_done), rate.per_token());
+            let work_pct = pct(tokens_done, total_tokens);
             bar.set_message(format!(
-                "{eta_str}  \u{00b7}  sent {this_batch_size} chunk(s) ({embedded}/{total} done \
-                 so far), awaiting response\u{2026}",
+                "{eta_str}  \u{00b7}  sent {this_batch_size} chunk(s) ({embedded}/{total} chunks, \
+                 {work_pct}% of work done), awaiting response\u{2026}",
             ));
 
             let batch = &chunk_ids_and_texts[cursor..cursor + this_batch_size];
 
             let req_chunks: Vec<ReqChunk> = batch
                 .iter()
-                .map(|(id, text)| ReqChunk {
+                .map(|(id, text, _)| ReqChunk {
                     chunk_id: id.to_string(),
                     content: text.clone(),
                 })
@@ -435,7 +490,7 @@ pub(super) async fn run_embed_phase(
                     // Fold this batch's rate in so later sizes/timeouts track
                     // the current rate. Also what the `bar.inc(1)` loop below
                     // reads for the displayed ETA (via `format_eta`).
-                    rate.update(started.elapsed(), batch.len());
+                    rate.update(started.elapsed(), batch_tokens);
                     break 'retry bytes;
                 }
                 Err(EmbedBatchError::BudgetExceeded(e)) if this_batch_size == 1 => {
@@ -444,7 +499,7 @@ pub(super) async fn run_embed_phase(
                     // (FIRST_REQUEST_TIMEOUT → MAX_REQUEST_TIMEOUT) before
                     // giving up: a cold single chunk on slow hardware may still
                     // finish given the full budget.
-                    if !escalated_calibration_once && rate.per_entry().is_none() {
+                    if !escalated_calibration_once && rate.per_token().is_none() {
                         escalated_calibration_once = true;
                         eprintln!(
                             "First embed request timed out (server request budget \
@@ -474,10 +529,10 @@ pub(super) async fn run_embed_phase(
                         "index/embed batch of {this_batch_size} chunks exceeded the server's \
                          request budget (408) — shrinking to {shrunk} chunk(s) and retrying: {e:#}",
                     );
-                    // Fold in a pessimistic per-entry sample (the failed timeout
-                    // over the batch) so future `next_batch_size` calls don't
-                    // re-derive the same too-large batch.
-                    rate.update(request_timeout, this_batch_size);
+                    // Fold in a pessimistic per-token sample (the failed timeout
+                    // over the batch's tokens) so future `next_batch_len` calls
+                    // don't re-derive the same too-large batch.
+                    rate.update(request_timeout, batch_tokens);
                     this_batch_size = shrunk;
                     continue 'retry;
                 }
@@ -495,16 +550,21 @@ pub(super) async fn run_embed_phase(
         let stride = dim * 4;
         let batch = &chunk_ids_and_texts[cursor..cursor + this_batch_size];
 
-        for (i, (row_id, _text)) in batch.iter().enumerate() {
+        for (i, (row_id, _text, token_count)) in batch.iter().enumerate() {
             let vector =
                 spelunk_core::embeddings::blob_to_vec(&bytes[i * stride..(i + 1) * stride]);
             db.insert_embedding(*row_id, &vector)?;
             embedded += 1;
+            tokens_done += (*token_count).max(1) as u64;
             bar.inc(1);
             // Refresh the displayed ETA from the updated `rate` as each chunk
             // lands, so it counts down through a batch, not once per request.
-            let eta_str = format_eta(total.saturating_sub(embedded) as usize, rate.per_entry());
-            bar.set_message(format!("{eta_str}  \u{00b7}  {embedded}/{total} embedded"));
+            let eta_str = format_eta(total_tokens.saturating_sub(tokens_done), rate.per_token());
+            let work_pct = pct(tokens_done, total_tokens);
+            bar.set_message(format!(
+                "{eta_str}  \u{00b7}  {embedded}/{total} chunks embedded \
+                 ({work_pct}% of work done)"
+            ));
         }
 
         previous_batch_size = this_batch_size;
@@ -676,91 +736,190 @@ mod tests {
         );
     }
 
-    // ── next_batch_size: calibration-driven batch sizing ────────────────────
+    // ── next_batch_len: calibration-driven, token-weighted batch sizing ─────
+    //
+    // A tail of 1-token chunks makes token math equal chunk math, so these
+    // first cases pin the same behaviour the old chunk-count sizing had; the
+    // token-skew cases after them pin what changed.
+
+    /// A uniform queue tail of 1-token chunks.
+    fn unit_tail(n: usize) -> Vec<usize> {
+        vec![1; n]
+    }
 
     #[test]
-    fn next_batch_size_shrinks_for_slow_hardware() {
-        // ~60 s/entry ⇒ a 240 s budget fits ~4 entries per batch.
+    fn next_batch_len_shrinks_for_slow_hardware() {
+        // ~60 s/token over 1-token chunks: a 240 s budget fits ~4 chunks.
         // previous_batch_size=256 so the growth cap doesn't bind here.
         assert_eq!(
-            next_batch_size(Duration::from_secs(60), 256, 256, TARGET_BATCH_SECONDS),
+            next_batch_len(
+                Duration::from_secs(60),
+                &unit_tail(256),
+                256,
+                256,
+                TARGET_BATCH_SECONDS
+            ),
             4
         );
     }
 
     #[test]
-    fn next_batch_size_grows_for_fast_hardware_but_respects_growth_cap() {
-        // ~1 s/entry ⇒ a 240 s budget fits 240 entries, but growth from a
-        // previous batch of 4 is capped to GROWTH_FACTOR (8) × 4 = 32.
+    fn next_batch_len_grows_for_fast_hardware_but_respects_growth_cap() {
+        // ~1 s/token over 1-token chunks: a 240 s budget fits 240 chunks, but
+        // growth from a previous batch of 4 is capped to GROWTH_FACTOR (8) × 4.
         assert_eq!(
-            next_batch_size(Duration::from_secs(1), 256, 4, TARGET_BATCH_SECONDS),
+            next_batch_len(
+                Duration::from_secs(1),
+                &unit_tail(256),
+                256,
+                4,
+                TARGET_BATCH_SECONDS
+            ),
             32
         );
     }
 
     #[test]
-    fn next_batch_size_reaches_ceiling_once_previous_batch_is_already_large() {
-        // Once the previous batch was already large enough that
-        // GROWTH_FACTOR × it exceeds the ceiling, the ceiling (not the growth
-        // cap) is the binding constraint — growth isn't artificially
-        // stalled forever once it has ramped up.
+    fn next_batch_len_reaches_budget_once_previous_batch_is_already_large() {
+        // Once the previous batch was large enough that GROWTH_FACTOR × it
+        // exceeds the ceiling, the token budget (not the growth cap) is the
+        // binding constraint, so growth isn't artificially stalled forever.
         assert_eq!(
-            next_batch_size(Duration::from_secs(1), 256, 64, TARGET_BATCH_SECONDS),
+            next_batch_len(
+                Duration::from_secs(1),
+                &unit_tail(256),
+                256,
+                64,
+                TARGET_BATCH_SECONDS
+            ),
             240 // budget-derived value, below both the 512 growth cap and the 256 ceiling
         );
     }
 
     #[test]
-    fn next_batch_size_clamps_to_ceiling() {
+    fn next_batch_len_clamps_to_ceiling() {
         // A very fast rate would derive a batch above the ceiling; the ceiling
         // wins even when the growth cap would otherwise allow more.
-        let t = next_batch_size(Duration::from_millis(1), 256, 256, TARGET_BATCH_SECONDS);
+        let t = next_batch_len(
+            Duration::from_millis(1),
+            &unit_tail(512),
+            256,
+            256,
+            TARGET_BATCH_SECONDS,
+        );
         assert_eq!(t, 256);
-        let t = next_batch_size(Duration::from_millis(1), 32, 32, TARGET_BATCH_SECONDS);
+        let t = next_batch_len(
+            Duration::from_millis(1),
+            &unit_tail(512),
+            32,
+            32,
+            TARGET_BATCH_SECONDS,
+        );
         assert_eq!(t, 32);
     }
 
     #[test]
-    fn next_batch_size_floors_at_one_for_extremely_slow_hardware() {
-        // If a single entry alone blows the whole per-batch budget, we still
-        // must send at least one entry per request.
-        let t = next_batch_size(Duration::from_secs(10_000), 256, 4, TARGET_BATCH_SECONDS);
+    fn next_batch_len_floors_at_one_for_extremely_slow_hardware() {
+        // If a single chunk alone blows the whole per-batch budget, we still
+        // must send at least one chunk per request.
+        let t = next_batch_len(
+            Duration::from_secs(10_000),
+            &unit_tail(256),
+            256,
+            4,
+            TARGET_BATCH_SECONDS,
+        );
         assert_eq!(t, 1);
     }
 
     #[test]
-    fn next_batch_size_handles_zero_duration_without_panicking() {
+    fn next_batch_len_handles_zero_duration_without_panicking() {
         // A degenerate zero-duration sample (e.g. a clock quirk) must not
         // divide-by-zero; falls back to the growth cap since the rate is
-        // unmeasurably fast (not directly to the ceiling — growth is still
-        // capped per step even in this degenerate case).
-        let t = next_batch_size(Duration::ZERO, 256, 4, TARGET_BATCH_SECONDS);
+        // unmeasurably fast (growth is still capped per step even here).
+        let t = next_batch_len(
+            Duration::ZERO,
+            &unit_tail(256),
+            256,
+            4,
+            TARGET_BATCH_SECONDS,
+        );
         assert_eq!(t, 32); // growth_cap = 4 * GROWTH_FACTOR(8)
     }
 
     #[test]
-    fn next_batch_size_uses_smaller_clamped_target_when_passed() {
+    fn next_batch_len_uses_smaller_clamped_target_when_passed() {
         // A caller passing a smaller target_seconds (e.g. because
         // resolve_target_batch_seconds clamped it down for a small-budget
         // server) must derive a proportionally smaller batch, not always
         // TARGET_BATCH_SECONDS.
-        let t = next_batch_size(Duration::from_secs(1), 256, 256, 20);
+        let t = next_batch_len(Duration::from_secs(1), &unit_tail(256), 256, 256, 20);
         assert_eq!(t, 20);
+    }
+
+    #[test]
+    fn next_batch_len_fills_by_token_sum_not_chunk_count() {
+        // 100-token chunks at 1 s/token: the 240 s budget fits 2 whole chunks
+        // (300 tokens would overshoot), NOT the 240 chunks a chunk-count
+        // budget calibrated on small chunks would have asked for. This is the
+        // sizing half of the D6 wasted-GPU defect.
+        let tail = vec![100usize; 256];
+        let t = next_batch_len(
+            Duration::from_secs(1),
+            &tail,
+            256,
+            256,
+            TARGET_BATCH_SECONDS,
+        );
+        assert_eq!(t, 2);
+    }
+
+    #[test]
+    fn next_batch_len_stops_at_a_size_transition_in_the_queue() {
+        // A queue crossing from tiny chunks into huge ones (the measured 7.4x
+        // jump) must not fill the batch past the transition: three 1-token
+        // chunks fit, and the 1000-token chunk that follows is left for the
+        // next batch instead of silently consuming the deadline's margin.
+        let mut tail = vec![1usize, 1, 1];
+        tail.extend(vec![1000usize; 64]);
+        let t = next_batch_len(
+            Duration::from_secs(1),
+            &tail,
+            256,
+            256,
+            TARGET_BATCH_SECONDS,
+        );
+        assert_eq!(t, 3);
+    }
+
+    #[test]
+    fn next_batch_len_zero_token_chunks_are_floored_not_free() {
+        // A pre-backfill row can carry token_count 0; it must cost at least 1
+        // token so a run of zeros can't derive an unbounded batch.
+        let tail = vec![0usize; 512];
+        let t = next_batch_len(
+            Duration::from_secs(60),
+            &tail,
+            256,
+            256,
+            TARGET_BATCH_SECONDS,
+        );
+        assert_eq!(t, 4); // identical to the 1-token case
     }
 
     // ── batch_timeout: derive a per-request deadline from the measured rate ──
 
     #[test]
     fn batch_timeout_scales_with_expected_batch_duration() {
-        // At 60 s/entry, a batch of 4 is expected to take 240 s; with the 4x
-        // safety factor that's 960 s, clamped to the 1800 s ceiling.
+        // At 60 s/token, a 4-token batch is expected to take 240 s; with the
+        // 4x safety factor that's 960 s, inside the 1800 s ceiling.
         let t = batch_timeout(Duration::from_secs(60), 4);
         assert_eq!(t, Duration::from_secs(960));
     }
 
     #[test]
     fn batch_timeout_clamps_to_floor_for_fast_hardware() {
-        // At 1 s/entry, a batch of 4 is expected to take 4 s; even with the
+        // At 1 s/token, a 4-token batch is expected to take 4 s; even with the
         // 4x safety factor (16 s) that's far below the floor, which must win
         // so transient latency spikes are still absorbed.
         let t = batch_timeout(Duration::from_secs(1), 4);
@@ -779,25 +938,40 @@ mod tests {
         assert!(t >= MIN_REQUEST_TIMEOUT && t <= MAX_REQUEST_TIMEOUT);
     }
 
-    // ── RateEstimate: continuously re-estimate the per-entry rate ───────────
+    #[test]
+    fn batch_timeout_tracks_batch_token_sum_not_chunk_count() {
+        // The deadline is derived from the batch's token sum, so two batches
+        // of equal chunk count but 10x different token weight get 10x
+        // different deadlines. Under chunk-count sizing both would have shared
+        // one deadline and the heavy batch would consume its entire safety
+        // margin (the D6 field failure).
+        let per_token = Duration::from_secs(1);
+        let light = batch_timeout(per_token, 100);
+        let heavy = batch_timeout(per_token, 1000);
+        assert_eq!(light, Duration::from_secs(400));
+        assert_eq!(heavy, MAX_REQUEST_TIMEOUT); // 4000s clamped to 1800s
+        assert!(heavy > light);
+    }
+
+    // ── RateEstimate: continuously re-estimate the per-token rate ───────────
 
     #[test]
     fn rate_estimate_seeds_from_first_observation() {
         let mut r = RateEstimate::new();
-        assert!(r.per_entry().is_none());
+        assert!(r.per_token().is_none());
         r.update(Duration::from_secs(2), 1);
-        assert_eq!(r.per_entry(), Some(Duration::from_secs(2)));
+        assert_eq!(r.per_token(), Some(Duration::from_secs(2)));
     }
 
     #[test]
     fn rate_estimate_deweights_the_batch_1_cold_sample_on_second_observation() {
-        // Batch 1: 1 entry in 10 s ⇒ 10 s/entry (cold). Batch 2 (1 s/entry) must
-        // dominate — only CALIBRATION_BATCH_1_WEIGHT (0.1) of the cold sample
-        // survives, not a 50/50 split.
+        // Batch 1: 1 token in 10 s ⇒ 10 s/token (cold). Batch 2 (1 s/token)
+        // must dominate: only CALIBRATION_BATCH_1_WEIGHT (0.1) of the cold
+        // sample survives, not a 50/50 split.
         let mut r = RateEstimate::new();
         r.update(Duration::from_secs(10), 1);
-        r.update(Duration::from_secs(4), 4); // 1 s/entry
-        let blended = r.per_entry().unwrap();
+        r.update(Duration::from_secs(4), 4); // 1 s/token
+        let blended = r.per_token().unwrap();
         // Exact expected value: 10*0.1 + 1*0.9 = 1.9s.
         assert!(
             (blended.as_secs_f64() - 1.9).abs() < 1e-9,
@@ -814,10 +988,10 @@ mod tests {
         // From the third observation onward (batch-1 cold sample already
         // superseded), later samples blend evenly with the running estimate.
         let mut r = RateEstimate::new();
-        r.update(Duration::from_secs(10), 1); // batch 1 (cold): 10s/entry
-        r.update(Duration::from_secs(4), 4); // batch 2: 1s/entry -> blended 1.9s/entry
-        r.update(Duration::from_secs(3), 1); // batch 3: 3s/entry -> 50/50 blend with 1.9
-        let blended = r.per_entry().unwrap();
+        r.update(Duration::from_secs(10), 1); // batch 1 (cold): 10s/token
+        r.update(Duration::from_secs(4), 4); // batch 2: 1s/token -> blended 1.9s/token
+        r.update(Duration::from_secs(3), 1); // batch 3: 3s/token -> 50/50 blend with 1.9
+        let blended = r.per_token().unwrap();
         let expected = (1.9 + 3.0) / 2.0;
         assert!(
             (blended.as_secs_f64() - expected).abs() < 1e-9,
@@ -827,22 +1001,22 @@ mod tests {
 
     #[test]
     fn rate_estimate_reproduces_field_failure_scenario_with_fix() {
-        // Batch 1 (1 chunk) ~25s cold; batch 2 (4 chunks) ~4.8s (~1.2s/entry
+        // Batch 1 (1 token) ~25s cold; batch 2 (4 tokens) ~4.8s (~1.2s/token
         // warm). The single shared estimate (de-weighted + growth-capped) must
-        // derive a small, internally consistent batch — not the unblended
+        // derive a small, internally consistent batch, not the unblended
         // ~50x leap an earlier build produced.
         let mut r = RateEstimate::new();
         r.update(Duration::from_secs(25), 1); // batch 1: cold
-        r.update(Duration::from_millis(4800), 4); // batch 2: 1.2s/entry warm
-        let per_entry = r.per_entry().unwrap();
-        // 25*0.1 + 1.2*0.9 = 3.58s/entry.
+        r.update(Duration::from_millis(4800), 4); // batch 2: 1.2s/token warm
+        let per_token = r.per_token().unwrap();
+        // 25*0.1 + 1.2*0.9 = 3.58s/token.
         assert!(
-            (per_entry.as_secs_f64() - 3.58).abs() < 1e-9,
-            "expected 3.58s/entry, got {per_entry:?}"
+            (per_token.as_secs_f64() - 3.58).abs() < 1e-9,
+            "expected 3.58s/token, got {per_token:?}"
         );
-        // The same estimate feeds next_batch_size, growth-capped from the
-        // previous batch of 4.
-        let batch_3_size = next_batch_size(per_entry, 256, 4, TARGET_BATCH_SECONDS);
+        // The same estimate feeds next_batch_len, growth-capped from the
+        // previous batch of 4 (1-token chunks keep token math == chunk math).
+        let batch_3_size = next_batch_len(per_token, &unit_tail(256), 256, 4, TARGET_BATCH_SECONDS);
         assert_eq!(
             batch_3_size, 32,
             "growth-capped (GROWTH_FACTOR=8 * previous batch of 4) at 32, not the raw \
@@ -851,19 +1025,67 @@ mod tests {
         );
         // The resulting batch's expected duration must stay well under ~240s;
         // uses the uncapped TARGET_BATCH_SECONDS so the growth cap alone is under test.
-        let expected_duration = per_entry.as_secs_f64() * batch_3_size as f64;
+        let expected_duration = per_token.as_secs_f64() * batch_3_size as f64;
         assert!(
             expected_duration < 150.0,
             "batch 3's expected duration ({expected_duration:.1}s) must be far below the \
-             field failure's ~240s (200 chunks @ ~1.2s/entry)"
+             field failure's ~240s (200 chunks @ ~1.2s/token)"
         );
     }
 
     #[test]
-    fn rate_estimate_ignores_zero_length_batches() {
+    fn rate_estimate_ignores_zero_token_batches() {
         let mut r = RateEstimate::new();
         r.update(Duration::from_secs(1), 0);
-        assert!(r.per_entry().is_none());
+        assert!(r.per_token().is_none());
+    }
+
+    // ── pct + token-weighted progress: work fraction ≠ chunk fraction ───────
+
+    #[test]
+    fn work_fraction_diverges_from_chunk_fraction_on_a_token_skewed_queue() {
+        // The D4/D6 estimator defect in miniature: a queue whose late chunks
+        // are far heavier than its early ones. After the first two of four
+        // chunks land, HALF the chunks are searchable but almost none of the
+        // work is done; the two percentages must diverge, and each must be
+        // computed over its own denominator.
+        let queue: Vec<(i64, String, usize)> = vec![
+            (1, "a".into(), 10),
+            (2, "b".into(), 10),
+            (3, "c".into(), 400),
+            (4, "d".into(), 400),
+        ];
+        let total_tokens: u64 = queue.iter().map(|(_, _, tc)| *tc as u64).sum();
+        let tokens_done: u64 = queue[..2].iter().map(|(_, _, tc)| *tc as u64).sum();
+
+        let chunk_pct = pct(2, queue.len() as u64);
+        let work_pct = pct(tokens_done, total_tokens);
+
+        assert_eq!(chunk_pct, 50);
+        assert_eq!(work_pct, 2); // 20 / 820
+        assert_ne!(
+            chunk_pct, work_pct,
+            "chunk fraction is coverage, token fraction is progress; on a skewed \
+             queue they must not coincide"
+        );
+    }
+
+    #[test]
+    fn pct_is_zero_over_an_empty_denominator() {
+        assert_eq!(pct(0, 0), 0);
+        assert_eq!(pct(5, 0), 0);
+    }
+
+    #[test]
+    fn eta_is_token_weighted_not_chunk_weighted() {
+        // Same rate, same remaining CHUNK count, 100x the remaining tokens:
+        // the displayed ETA must scale with tokens. A chunk-weighted ETA would
+        // print the same string for both (the 3.2x under-report in the field).
+        let per_token = Some(Duration::from_secs(1));
+        let light = format_eta(60, per_token);
+        let heavy = format_eta(6000, per_token);
+        assert_eq!(light, "ETA 1m");
+        assert_eq!(heavy, "ETA 1h40m");
     }
 
     // ── embed_progress_style: the message-only-ETA template must build ──────
@@ -947,7 +1169,7 @@ mod tests {
         // Duration::MAX times a large remaining count would overflow a naive
         // `Duration * u32`/`Duration::saturating_mul` computation; this must
         // still return the capped string without panicking.
-        let eta = format_eta(usize::MAX, Some(Duration::MAX));
+        let eta = format_eta(u64::MAX, Some(Duration::MAX));
         assert_eq!(eta, "ETA >24h");
     }
 
@@ -1060,8 +1282,10 @@ mod tests {
             .await;
 
         let (db, ids) = seed_chunks(6);
-        let chunk_ids_and_texts: Vec<(i64, String)> =
-            ids.iter().map(|id| (*id, format!("text {id}"))).collect();
+        let chunk_ids_and_texts: Vec<(i64, String, usize)> = ids
+            .iter()
+            .map(|id| (*id, format!("text {id}"), 3))
+            .collect();
 
         let cfg = Config::default();
         let tier = server_tier(mock.uri());
@@ -1107,8 +1331,10 @@ mod tests {
             .await;
 
         let (db, ids) = seed_chunks(50);
-        let chunk_ids_and_texts: Vec<(i64, String)> =
-            ids.iter().map(|id| (*id, format!("text {id}"))).collect();
+        let chunk_ids_and_texts: Vec<(i64, String, usize)> = ids
+            .iter()
+            .map(|id| (*id, format!("text {id}"), 3))
+            .collect();
 
         let cfg = Config::default();
         let tier = server_tier(mock.uri());
@@ -1144,8 +1370,10 @@ mod tests {
 
         for n in [1usize, 2, 3] {
             let (db, ids) = seed_chunks(n);
-            let chunk_ids_and_texts: Vec<(i64, String)> =
-                ids.iter().map(|id| (*id, format!("text {id}"))).collect();
+            let chunk_ids_and_texts: Vec<(i64, String, usize)> = ids
+                .iter()
+                .map(|id| (*id, format!("text {id}"), 3))
+                .collect();
 
             let cfg = Config::default();
             let tier = server_tier(mock.uri());
@@ -1221,8 +1449,10 @@ mod tests {
             .await;
 
         let (db, ids) = seed_chunks(3);
-        let chunk_ids_and_texts: Vec<(i64, String)> =
-            ids.iter().map(|id| (*id, format!("text {id}"))).collect();
+        let chunk_ids_and_texts: Vec<(i64, String, usize)> = ids
+            .iter()
+            .map(|id| (*id, format!("text {id}"), 3))
+            .collect();
 
         let cfg = Config::default();
         let tier = server_tier(mock.uri());
@@ -1261,8 +1491,10 @@ mod tests {
             .await;
 
         let (db, ids) = seed_chunks(3);
-        let chunk_ids_and_texts: Vec<(i64, String)> =
-            ids.iter().map(|id| (*id, format!("text {id}"))).collect();
+        let chunk_ids_and_texts: Vec<(i64, String, usize)> = ids
+            .iter()
+            .map(|id| (*id, format!("text {id}"), 3))
+            .collect();
 
         let cfg = Config::default();
         let tier = server_tier(mock.uri());
@@ -1326,8 +1558,10 @@ mod tests {
             .await;
 
         let (db, ids) = seed_chunks(20);
-        let chunk_ids_and_texts: Vec<(i64, String)> =
-            ids.iter().map(|id| (*id, format!("text {id}"))).collect();
+        let chunk_ids_and_texts: Vec<(i64, String, usize)> = ids
+            .iter()
+            .map(|id| (*id, format!("text {id}"), 3))
+            .collect();
 
         let cfg = Config::default();
         let tier = server_tier(mock.uri());
@@ -1397,8 +1631,10 @@ mod tests {
             .await;
 
         let (db, ids) = seed_chunks(30);
-        let chunk_ids_and_texts: Vec<(i64, String)> =
-            ids.iter().map(|id| (*id, format!("text {id}"))).collect();
+        let chunk_ids_and_texts: Vec<(i64, String, usize)> = ids
+            .iter()
+            .map(|id| (*id, format!("text {id}"), 3))
+            .collect();
 
         let cfg = Config::default();
         let limits = ServerLimits {

--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -159,7 +159,7 @@ const CALIBRATION_BATCH_1_WEIGHT: f64 = 0.1;
 /// stationary through an id-ordered queue (~4x growth), so a per-chunk rate is
 /// systematically biased in one direction across the run. The token estimate's
 /// own corpus-dependent bias cancels here because the rate is calibrated from
-/// estimated tokens and only ever multiplied by estimated tokens — the rate
+/// estimated tokens and only ever multiplied by estimated tokens; the rate
 /// must stay measured per-run, never cached across runs or repos.
 struct RateEstimate {
     /// Exponentially-weighted per-token duration. `None` until the first batch.
@@ -396,7 +396,7 @@ pub(super) async fn run_embed_phase(
     let remaining = chunk_ids_and_texts.len();
     // Token-weighted work totals: the ETA and the "of work done" percentage
     // run over these, never over chunk counts (chunk fraction is coverage, a
-    // different question — see `status`).
+    // different question; see `status`).
     let total_tokens: u64 = chunk_ids_and_texts
         .iter()
         .map(|(_, _, tc)| (*tc).max(1) as u64)
@@ -455,7 +455,7 @@ pub(super) async fn run_embed_phase(
             };
 
             // Show which chunks are in flight, prefixed with the `RateEstimate`
-            // ETA (not indicatif's `{eta}` — see `format_eta`). Work-fraction
+            // ETA (not indicatif's `{eta}`; see `format_eta`). Work-fraction
             // percentages are token-weighted and always name their denominator.
             let eta_str = format_eta(total_tokens.saturating_sub(tokens_done), rate.per_token());
             let work_pct = pct(tokens_done, total_tokens);

--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -27,8 +27,8 @@ const CALIBRATION_BATCH_1: usize = 1;
 /// one-off cold-start) before committing to a steady-state size.
 const CALIBRATION_BATCH_2: usize = 4;
 
-/// Wall-clock time each steady-state batch aims to stay under; batch size is
-/// this budget divided by the measured per-entry rate.
+/// Wall-clock time each steady-state batch aims to stay under; a batch is
+/// sized so its token sum fits this budget at the measured token rate.
 const TARGET_BATCH_SECONDS: u64 = 240;
 
 /// Floor for a calibrated per-request timeout, to absorb transient latency spikes.

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -174,17 +174,23 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     // notice rather than letting the embed request 503 out mid-index or
     // silently producing an unembedded index.
     let embed_ready = matches!(tier.caps(), Some(c) if c.index_embed);
-    if tier.is_server() && embed_ready {
-        // ── Detached embed ───────────────────────────────────────────────────
-        // Parsing is done and the chunks are persisted; hand the (usually long)
-        // embedding phase to a background process so the user regains the
-        // prompt now. The subprocess (`--_embed-phases`) rebuilds the embed
-        // queue from the DB, so nothing from `result` needs to cross the
-        // process boundary. Confirm completion later with `spelunk status`.
+
+    // ── Detached embed ────────────────────────────────────────────────────────
+    // Parsing is done and the chunks are persisted; hand the (usually long)
+    // embedding phase to a background process so the user regains the prompt
+    // now. The subprocess (`--_embed-phases`) rebuilds the embed queue from the
+    // DB, so nothing from `result` needs to cross the process boundary. Confirm
+    // completion later with `spelunk status`.
+    //
+    // The spawn is gated on "worth waiting for" (ready OR still loading), not
+    // on ready alone: the worker owns the readiness wait, and a fresh install
+    // arrives here with the embedder still `loading`. Gating the spawn on
+    // `embed_ready` is exactly the no-op that ships a permanently unembedded
+    // index on a cold machine.
+    if args.detach_embed && tier.is_server() && detach_embed_eligible(tier) {
         let embed_log = background_log_path(&db_path);
-        if args.detach_embed
-            && let EmbedSpawn::Detached(log_in_use) =
-                spawn_embed_subprocess(&args, embed_log.as_deref())?
+        if let EmbedSpawn::Detached(log_in_use) =
+            spawn_embed_subprocess(&args, embed_log.as_deref())?
         {
             let stats = db.stats()?;
             let pending = stats.chunk_count - stats.embedding_count;
@@ -192,13 +198,20 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
                 "Index: {} files, {} chunks. Embedding {} chunk(s) in the background\u{2026}",
                 stats.file_count, stats.chunk_count, pending,
             );
+            if !embed_ready {
+                println!("The embedder is still loading; the background worker waits for it.");
+            }
             println!("Run `spelunk status` to check progress.");
             if let Some(p) = log_in_use {
                 println!("  Log: {}", p.display());
             }
             return Ok(());
         }
+        // Spawn failed: fall through to the inline path (embeds now if ready,
+        // else prints the skip notice).
+    }
 
+    if tier.is_server() && embed_ready {
         embed_phase::run_embed_phase(
             result.chunk_ids_and_texts,
             &db,
@@ -321,9 +334,83 @@ fn spawn_embed_subprocess<'a>(
     }
 }
 
+/// True when handing the embed pass to the detached worker can do useful work:
+/// the embedder is `ready`, or still `loading` (the worker owns the readiness
+/// wait, see [`wait_for_embedder`]). `unavailable` and `disabled` are terminal
+/// for this server process, and an older server that never advertises
+/// `index.embed` has nothing to wait for.
+fn detach_embed_eligible(tier: &capability::Tier) -> bool {
+    matches!(tier.caps(), Some(c) if c.index_embed)
+        || matches!(
+            tier.embedder_state(),
+            Some(capability::EmbedderState::Loading)
+        )
+}
+
+/// First delay of the embed worker's readiness-wait backoff.
+const EMBED_WAIT_INITIAL_BACKOFF: std::time::Duration = std::time::Duration::from_secs(1);
+/// Backoff growth is bounded at this interval; the wait itself is not
+/// time-bounded while the embedder reports `loading` (a model download can
+/// legitimately take many minutes, and the queue is durable).
+const EMBED_WAIT_MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(30);
+/// Consecutive offline probes tolerated before the worker concludes the server
+/// is gone (crashed after spawning us) rather than momentarily unreachable.
+const EMBED_WAIT_MAX_OFFLINE_PROBES: u32 = 10;
+
+/// Wait until the server's embedder can serve, polling `/v1/health` with a
+/// bounded backoff. Returns the final observed tier; the caller re-derives
+/// `index_embed` from it.
+///
+/// A not-ready embedder is a transient condition to wait on, not a terminal
+/// condition to skip: `ensure_server_running` waits for liveness only (health
+/// goes live at socket bind, before the model loads), so a fresh machine
+/// reaches the worker with the embedder still `loading`. Only `unavailable`
+/// and `disabled` (or a server with no embedder at all) are terminal; each
+/// keeps its distinct notice via `eprint_embed_skipped_notice`. `loading` is
+/// never a reason to abandon durable queued work.
+async fn wait_for_embedder(
+    cfg: &Config,
+    initial_backoff: std::time::Duration,
+    max_backoff: std::time::Duration,
+) -> capability::Tier {
+    let mut backoff = initial_backoff;
+    let mut offline_probes = 0u32;
+    let mut announced = false;
+    loop {
+        let tier = capability::probe_tier_fresh(cfg).await;
+        match &tier {
+            capability::Tier::Server { .. } => {
+                if matches!(tier.caps(), Some(c) if c.index_embed) {
+                    return tier;
+                }
+                if !matches!(
+                    tier.embedder_state(),
+                    Some(capability::EmbedderState::Loading)
+                ) {
+                    // unavailable / disabled / no embedder: terminal here.
+                    return tier;
+                }
+                offline_probes = 0;
+                if !announced {
+                    eprintln!("Waiting for the embedder to finish loading\u{2026}");
+                    announced = true;
+                }
+            }
+            capability::Tier::Offline => {
+                offline_probes += 1;
+                if offline_probes >= EMBED_WAIT_MAX_OFFLINE_PROBES {
+                    return tier;
+                }
+            }
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(max_backoff);
+    }
+}
+
 /// Embed-only entry point for the detached `--_embed-phases` subprocess: rebuild
-/// the embed queue from the chunks already in the DB (no re-parse), run the
-/// embed phase, then phases 3–5.
+/// the embed queue from the chunks already in the DB (no re-parse), wait for
+/// the embedder to become ready, run the embed phase, then phases 3–5.
 async fn run_embed_phases(
     args: &IndexArgs,
     cfg: &Config,
@@ -332,7 +419,7 @@ async fn run_embed_phases(
     root_canonical: &std::path::Path,
     db_path: &std::path::Path,
 ) -> Result<()> {
-    let tier = capability::get_tier(cfg).await;
+    let tier = wait_for_embedder(cfg, EMBED_WAIT_INITIAL_BACKOFF, EMBED_WAIT_MAX_BACKOFF).await;
     let embed_ready = matches!(tier.caps(), Some(c) if c.index_embed);
     if tier.is_server() && embed_ready {
         let chunk_ids_and_texts = parse_phase::missing_embedding_texts(db)?;
@@ -342,7 +429,7 @@ async fn run_embed_phases(
                 chunk_ids_and_texts,
                 db,
                 cfg,
-                tier,
+                &tier,
                 project_root,
                 args.batch_size,
                 &mp,
@@ -350,7 +437,7 @@ async fn run_embed_phases(
             .await?;
         }
     } else {
-        eprint_embed_skipped_notice(tier, cfg);
+        eprint_embed_skipped_notice(&tier, cfg);
     }
 
     run_phases_3_to_5(args, cfg, db, root_canonical, db_path).await
@@ -546,6 +633,179 @@ mod tests {
         let lines = embed_skipped_lines(None, None);
         let joined = lines.join("\n");
         assert!(joined.contains("spelunk server start"));
+    }
+
+    // ── detach_embed_eligible: the spawn gate must include `loading` ────────────
+
+    fn tier_with(embed_ready: bool, state: capability::EmbedderState) -> capability::Tier {
+        let mut caps = capability::Capabilities::all();
+        caps.index_embed = embed_ready;
+        capability::Tier::Server {
+            url: "http://127.0.0.1:7777".to_string(),
+            caps,
+            auto_discovered: true,
+            embedder_state: state,
+            server_limits: None,
+        }
+    }
+
+    #[test]
+    fn detach_eligible_when_embedder_ready() {
+        assert!(detach_embed_eligible(&tier_with(
+            true,
+            capability::EmbedderState::Ready
+        )));
+    }
+
+    #[test]
+    fn detach_eligible_when_embedder_still_loading() {
+        // The cold-start case ADR-070 D1/D2 exists for: a server started
+        // moments ago advertises no index.embed yet, but the worker can wait
+        // it out. Gating the spawn on readiness alone is the recorded no-op.
+        assert!(detach_embed_eligible(&tier_with(
+            false,
+            capability::EmbedderState::Loading
+        )));
+    }
+
+    #[test]
+    fn detach_not_eligible_for_terminal_embedder_states() {
+        for state in [
+            capability::EmbedderState::Unavailable,
+            capability::EmbedderState::Disabled,
+            capability::EmbedderState::Unknown,
+        ] {
+            assert!(
+                !detach_embed_eligible(&tier_with(false, state)),
+                "state {state:?} is terminal; spawning a worker would wait forever"
+            );
+        }
+    }
+
+    #[test]
+    fn detach_not_eligible_offline() {
+        assert!(!detach_embed_eligible(&capability::Tier::Offline));
+    }
+
+    // ── wait_for_embedder: the worker owns the readiness wait (ADR-070 D2) ────
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// `/v1/health` body for an embedder in `state`. `index.embed` is
+    /// advertised only when ready, mirroring the real server's contract.
+    fn health_body(state: &str) -> serde_json::Value {
+        let (caps, dim) = if state == "ready" {
+            (
+                vec!["memory", "index.embed", "search.semantic"],
+                spelunk_core::embeddings::EMBEDDING_DIM,
+            )
+        } else {
+            (vec!["memory"], 0)
+        };
+        serde_json::json!({
+            "status": "ok",
+            "version": "0.9.3",
+            "capabilities": caps,
+            "instance_id": "00000000-0000-0000-0000-000000000001",
+            "embedding_dim": dim,
+            "embedder": { "state": state, "detail": null }
+        })
+    }
+
+    fn cfg_for(url: String) -> Config {
+        Config {
+            server_url: Some(url),
+            project_id: Some("local/test".to_string()),
+            ..Default::default()
+        }
+    }
+
+    const TEST_BACKOFF: std::time::Duration = std::time::Duration::from_millis(1);
+
+    #[tokio::test]
+    async fn wait_for_embedder_outlasts_a_loading_embedder() {
+        // The readiness gate the cold-start bug lives behind: health reports
+        // `loading` (twice here) before flipping to `ready`. The wait must
+        // keep polling through `loading` and come back with `index.embed`.
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body("loading")))
+            .up_to_n_times(2)
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body("ready")))
+            .mount(&mock)
+            .await;
+
+        let tier = wait_for_embedder(&cfg_for(mock.uri()), TEST_BACKOFF, TEST_BACKOFF).await;
+        assert!(
+            matches!(tier.caps(), Some(c) if c.index_embed),
+            "the wait must return only once the embedder serves; got {tier:?}"
+        );
+        assert_eq!(
+            tier.embedder_state(),
+            Some(capability::EmbedderState::Ready)
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_embedder_treats_unavailable_as_terminal() {
+        // A failed model load is terminal for this server process: return at
+        // the first probe (no retries burned) and preserve the state so the
+        // caller prints the distinct `unavailable` notice.
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body("unavailable")))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let tier = wait_for_embedder(&cfg_for(mock.uri()), TEST_BACKOFF, TEST_BACKOFF).await;
+        assert_eq!(
+            tier.embedder_state(),
+            Some(capability::EmbedderState::Unavailable)
+        );
+        assert!(!matches!(tier.caps(), Some(c) if c.index_embed));
+    }
+
+    #[tokio::test]
+    async fn wait_for_embedder_treats_disabled_as_terminal() {
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body("disabled")))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let tier = wait_for_embedder(&cfg_for(mock.uri()), TEST_BACKOFF, TEST_BACKOFF).await;
+        assert_eq!(
+            tier.embedder_state(),
+            Some(capability::EmbedderState::Disabled)
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_embedder_gives_up_after_bounded_offline_probes() {
+        // A vanished server (crashed after spawning the worker) must not hang
+        // the worker forever: bounded consecutive offline probes, then return
+        // Offline so the skip notice prints and the durable queue stays put.
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let dead_url = format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port());
+        drop(listener); // port is real but nothing serves it
+
+        let started = std::time::Instant::now();
+        let tier = wait_for_embedder(&cfg_for(dead_url), TEST_BACKOFF, TEST_BACKOFF).await;
+        assert!(matches!(tier, capability::Tier::Offline));
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(30),
+            "the offline give-up must be bounded"
+        );
     }
 
     #[test]

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -212,6 +212,9 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     }
 
     if tier.is_server() && embed_ready {
+        // Liveness marker so `spelunk status` from another terminal reports a
+        // foreground embed as running rather than telling the user to resume.
+        let worker_guard = super::embed_worker::EmbedWorkerGuard::acquire(&db, &db_path);
         embed_phase::run_embed_phase(
             result.chunk_ids_and_texts,
             &db,
@@ -222,6 +225,7 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
             &mp,
         )
         .await?;
+        drop(worker_guard);
     } else {
         eprint_embed_skipped_notice(tier, &cfg);
     }
@@ -419,6 +423,12 @@ async fn run_embed_phases(
     root_canonical: &std::path::Path,
     db_path: &std::path::Path,
 ) -> Result<()> {
+    // Liveness marker for `spelunk status` (dropped on exit; a killed worker
+    // leaves it behind for status to classify as a dead pid). Held through the
+    // readiness wait too: a worker waiting on a loading embedder is running,
+    // and status must not advise a resume that would double it up.
+    let worker_guard = super::embed_worker::EmbedWorkerGuard::acquire(db, db_path);
+
     let tier = wait_for_embedder(cfg, EMBED_WAIT_INITIAL_BACKOFF, EMBED_WAIT_MAX_BACKOFF).await;
     let embed_ready = matches!(tier.caps(), Some(c) if c.index_embed);
     if tier.is_server() && embed_ready {
@@ -439,6 +449,7 @@ async fn run_embed_phases(
     } else {
         eprint_embed_skipped_notice(&tier, cfg);
     }
+    drop(worker_guard);
 
     run_phases_3_to_5(args, cfg, db, root_canonical, db_path).await
 }

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -802,6 +802,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn wait_for_embedder_loading_then_unavailable_is_terminal() {
+        // The embedder can flip loading -> unavailable mid-wait (model load
+        // fails after the worker started polling). The wait must exit at the
+        // transition with the terminal state preserved, so the caller prints
+        // the distinct `unavailable` notice; it must not keep polling.
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body("loading")))
+            .up_to_n_times(2)
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body("unavailable")))
+            .mount(&mock)
+            .await;
+
+        let tier = wait_for_embedder(&cfg_for(mock.uri()), TEST_BACKOFF, TEST_BACKOFF).await;
+        assert_eq!(
+            tier.embedder_state(),
+            Some(capability::EmbedderState::Unavailable),
+            "the terminal state observed mid-wait must be returned as-is"
+        );
+        assert!(!matches!(tier.caps(), Some(c) if c.index_embed));
+    }
+
+    #[tokio::test]
+    async fn wait_for_embedder_offline_counter_resets_on_a_reachable_probe() {
+        // The give-up counter is CONSECUTIVE offline probes, not cumulative: a
+        // server that flaps (down, briefly back while loading, down again)
+        // must not have its earlier misses counted against the later ones.
+        // 7 offline + 1 loading + 7 offline = 14 cumulative misses, but never
+        // 10 in a row, so the wait must survive to the final `ready`.
+        // (A non-2xx health response probes as Tier::Offline.)
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(7)
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body("loading")))
+            .up_to_n_times(1)
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(7)
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body("ready")))
+            .mount(&mock)
+            .await;
+
+        let tier = wait_for_embedder(&cfg_for(mock.uri()), TEST_BACKOFF, TEST_BACKOFF).await;
+        assert!(
+            matches!(tier.caps(), Some(c) if c.index_embed),
+            "14 cumulative but never {EMBED_WAIT_MAX_OFFLINE_PROBES} consecutive offline \
+             probes must not trip the give-up; got {tier:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn wait_for_embedder_gives_up_after_bounded_offline_probes() {
         // A vanished server (crashed after spawning the worker) must not hang
         // the worker forever: bounded consecutive offline probes, then return

--- a/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
@@ -48,8 +48,9 @@ fn is_file_too_large(path: &std::path::Path, path_str: &str) -> bool {
 }
 
 pub(super) struct ParseResult {
-    /// (chunk_id, embedding_text) pairs awaiting embedding.
-    pub chunk_ids_and_texts: Vec<(i64, String)>,
+    /// (chunk_id, embedding_text, token_count) tuples awaiting embedding.
+    /// `token_count` mirrors the stored `chunks.token_count` (never 0 here).
+    pub chunk_ids_and_texts: Vec<(i64, String, usize)>,
     pub indexed: u64,
     pub removed: u64,
 }
@@ -57,7 +58,7 @@ pub(super) struct ParseResult {
 /// Mutable accumulators shared across per-file processor functions.
 /// Bundled into one struct so processor signatures stay under 7 arguments.
 struct ParseAcc {
-    out: Vec<(i64, String)>,
+    out: Vec<(i64, String, usize)>,
     indexed: u64,
     skipped: u64,
 }
@@ -151,14 +152,17 @@ pub(super) fn run_parse_phase(
     // appear here too; dedupe against the ids we already queued to avoid
     // embedding them twice.
     let already: std::collections::HashSet<i64> =
-        chunk_ids_and_texts.iter().map(|(id, _)| *id).collect();
-    for (chunk_id, name, metadata, summary, content) in db.chunks_missing_embeddings()? {
+        chunk_ids_and_texts.iter().map(|(id, ..)| *id).collect();
+    for (chunk_id, name, metadata, summary, content, token_count) in
+        db.chunks_missing_embeddings()?
+    {
         if already.contains(&chunk_id) {
             continue;
         }
+        let tokens = effective_token_count(token_count, &content);
         let text =
             reconstruct_embedding_text(name.as_deref(), metadata.as_deref(), summary, content);
-        chunk_ids_and_texts.push((chunk_id, text));
+        chunk_ids_and_texts.push((chunk_id, text, tokens));
     }
 
     Ok(ParseResult {
@@ -174,14 +178,29 @@ pub(super) fn run_parse_phase(
 /// a backfill; exposed separately so a detached embed-only
 /// subprocess can rebuild the embed queue straight from the DB without
 /// re-parsing.
-pub(super) fn missing_embedding_texts(db: &Database) -> Result<Vec<(i64, String)>> {
+pub(super) fn missing_embedding_texts(db: &Database) -> Result<Vec<(i64, String, usize)>> {
     let mut out = Vec::new();
-    for (chunk_id, name, metadata, summary, content) in db.chunks_missing_embeddings()? {
+    for (chunk_id, name, metadata, summary, content, token_count) in
+        db.chunks_missing_embeddings()?
+    {
+        let tokens = effective_token_count(token_count, &content);
         let text =
             reconstruct_embedding_text(name.as_deref(), metadata.as_deref(), summary, content);
-        out.push((chunk_id, text));
+        out.push((chunk_id, text, tokens));
     }
     Ok(out)
+}
+
+/// Token weight for a queue entry: the stored `chunks.token_count`, estimated
+/// on the fly for a pre-backfill row (stored 0), floored at 1 so token-weighted
+/// arithmetic never divides by zero.
+fn effective_token_count(stored: usize, content: &str) -> usize {
+    let tc = if stored == 0 {
+        estimate_tokens(content)
+    } else {
+        stored
+    };
+    tc.max(1)
 }
 
 /// Rebuild the exact document text that `Chunk::embedding_text()` produces,
@@ -480,7 +499,7 @@ fn store_chunks(
             Some(&metadata.to_string()),
             tc,
         )?;
-        acc.out.push((chunk_id, chunk.embedding_text()));
+        acc.out.push((chunk_id, chunk.embedding_text(), tc.max(1)));
     }
     Ok(())
 }
@@ -714,7 +733,7 @@ mod tests {
         let mut queued_run1: Vec<i64> = first
             .chunk_ids_and_texts
             .iter()
-            .map(|(id, _)| *id)
+            .map(|(id, ..)| *id)
             .collect();
         queued_run1.sort();
         let mut missing_after_run1: Vec<i64> = db
@@ -748,7 +767,7 @@ mod tests {
         let mut backfilled: Vec<i64> = second
             .chunk_ids_and_texts
             .iter()
-            .map(|(id, _)| *id)
+            .map(|(id, ..)| *id)
             .collect();
         backfilled.sort();
         assert_eq!(
@@ -758,10 +777,10 @@ mod tests {
 
         // The reconstructed embedding texts must also be byte-identical to what
         // the first (parse-time) run produced for those same chunks.
-        let mut texts_run1: Vec<(i64, String)> = first.chunk_ids_and_texts.clone();
-        texts_run1.sort_by_key(|(id, _)| *id);
-        let mut texts_run2: Vec<(i64, String)> = second.chunk_ids_and_texts.clone();
-        texts_run2.sort_by_key(|(id, _)| *id);
+        let mut texts_run1: Vec<(i64, String, usize)> = first.chunk_ids_and_texts.clone();
+        texts_run1.sort_by_key(|(id, ..)| *id);
+        let mut texts_run2: Vec<(i64, String, usize)> = second.chunk_ids_and_texts.clone();
+        texts_run2.sort_by_key(|(id, ..)| *id);
         assert_eq!(
             texts_run2, texts_run1,
             "backfilled embedding text must match the parse-time embedding text byte-for-byte"
@@ -839,7 +858,7 @@ mod tests {
 
         // Exactly the two un-embedded chunks, in ascending id order, and NOT the
         // embedded one.
-        let got_ids: Vec<i64> = missing.iter().map(|(id, _)| *id).collect();
+        let got_ids: Vec<i64> = missing.iter().map(|(id, ..)| *id).collect();
         assert_eq!(
             got_ids,
             vec![ids[0].0, ids[2].0],
@@ -852,7 +871,7 @@ mod tests {
 
         // Each queued text is reconstructed byte-for-byte to the parse-time
         // `embedding_text()` for that chunk.
-        for (queued_id, queued_text) in &missing {
+        for (queued_id, queued_text, _) in &missing {
             let (_, chunk) = ids.iter().find(|(id, _)| id == queued_id).unwrap();
             assert_eq!(
                 queued_text,

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -105,7 +105,7 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
     // ── 5. Auto-spawn server (TTY only) or probe for a running server ─────────
     //
     // Interactive (stdin is a TTY): attempt to start the server so semantic
-    // search works immediately. Non-interactive (CI / hook): probe only —
+    // search works immediately. Non-interactive (CI / hook): probe only,
     // never auto-spawn; print a skip notice if offline.
     //
     // This runs BEFORE the index step, and the index step below hands the
@@ -133,7 +133,7 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
             match tier {
                 capability::Tier::Server { url, .. } => Some(format!("{url}  \x1b[32m✓\x1b[0m")),
                 capability::Tier::Offline => {
-                    Some("[server not running — semantic search skipped]".to_string())
+                    Some("[server not running - semantic search skipped]".to_string())
                 }
             }
         }

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -102,75 +102,19 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
         "not installed  (run `spelunk hooks install` to add)".to_string()
     };
 
-    // ── 5. Run initial index (unless --no-index) ──────────────────────────────
-    let (file_count, chunk_count) = if args.no_index {
-        println!("Skipping index (--no-index). Run `spelunk index .` when ready.");
-        // If the DB exists already, read its stats; otherwise report zeros.
-        if db_path.exists() {
-            match Database::open(&db_path) {
-                Ok(db) => match db.stats() {
-                    Ok(stats) => (stats.file_count, stats.chunk_count),
-                    Err(_) => (0, 0),
-                },
-                Err(_) => (0, 0),
-            }
-        } else {
-            (0, 0)
-        }
-    } else {
-        // Delegate to the real index command logic.
-        let index_args = super::index::IndexArgs {
-            path: project_root.clone(),
-            db: None,
-            batch_size: 32,
-            force: false,
-            recount: false,
-            no_summaries: true,
-            summary_batch_size: 10,
-            background_phases: false,
-            embed_phases: false,
-            detach: false,
-            detach_embed: false,
-        };
-        super::index::index(index_args, cfg.clone()).await?;
-
-        // Read fresh stats from the just-created DB.
-        match Database::open(&db_path) {
-            Ok(db) => match db.stats() {
-                Ok(stats) => (stats.file_count, stats.chunk_count),
-                Err(_) => (0, 0),
-            },
-            Err(_) => (0, 0),
-        }
-    };
-
-    // ── 5b. Import git-notes memory into the project memory.db ────────────────
-    // Entries recorded on `refs/notes/spelunk` before init (git-notes fallback
-    // or write-through) are invisible to the SQLite-backed `memory list` until
-    // imported. No enclosing git repo → nothing to import. Non-fatal: a failure
-    // here must not sink init.
-    let memory_line: Option<String> = if let Some(git_root) = git_root.as_ref() {
-        let mem_path = spelunk_dir.join("memory.db");
-        // Fold in anything a previous `git fetch` left on the tracking ref
-        // before hydrating, so teammates' entries import too (ADR-069 D5).
-        crate::storage::merge_tracking_notes(Some(git_root)).await;
-        match super::memory::reconcile::import_git_notes_into_memory(git_root, &mem_path).await {
-            Ok(0) => None,
-            Ok(n) => Some(format!("imported {n} entries from git notes")),
-            Err(e) => {
-                tracing::warn!("git-notes memory import skipped (non-fatal): {e}");
-                None
-            }
-        }
-    } else {
-        None
-    };
-
-    // ── 6. Auto-spawn server (TTY only) or probe for a running server ─────────
+    // ── 5. Auto-spawn server (TTY only) or probe for a running server ─────────
     //
     // Interactive (stdin is a TTY): attempt to start the server so semantic
     // search works immediately. Non-interactive (CI / hook): probe only —
     // never auto-spawn; print a skip notice if offline.
+    //
+    // This runs BEFORE the index step, and the index step below hands the
+    // embed pass to the detached worker. The two are one change (ADR-070 D1):
+    // starting the server first is what makes the detached embed reachable on
+    // a fresh machine (otherwise the embed probes for a server this very
+    // command has not started yet and silently ships a zero-embedding index),
+    // and detaching is what keeps the reorder from holding the terminal
+    // through the entire embed pass.
     let server_line: Option<String> = {
         use std::io::IsTerminal;
         if std::io::stdin().is_terminal() {
@@ -193,6 +137,76 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
                 }
             }
         }
+    };
+
+    // ── 6. Run initial index (unless --no-index) ──────────────────────────────
+    let (file_count, chunk_count) = if args.no_index {
+        println!("Skipping index (--no-index). Run `spelunk index .` when ready.");
+        // If the DB exists already, read its stats; otherwise report zeros.
+        if db_path.exists() {
+            match Database::open(&db_path) {
+                Ok(db) => match db.stats() {
+                    Ok(stats) => (stats.file_count, stats.chunk_count),
+                    Err(_) => (0, 0),
+                },
+                Err(_) => (0, 0),
+            }
+        } else {
+            (0, 0)
+        }
+    } else {
+        // Delegate to the real index command logic. `detach_embed: true` hands
+        // the (usually long) embed pass to the detached background worker, so
+        // init returns the prompt after parsing instead of holding the
+        // terminal through the whole embed (ADR-070 D1; on the profiled repo
+        // that wait is ~103 minutes). The worker waits out a still-loading
+        // embedder, so this holds on a cold machine whose server step 5 only
+        // just started.
+        let index_args = super::index::IndexArgs {
+            path: project_root.clone(),
+            db: None,
+            batch_size: 32,
+            force: false,
+            recount: false,
+            no_summaries: true,
+            summary_batch_size: 10,
+            background_phases: false,
+            embed_phases: false,
+            detach: false,
+            detach_embed: true,
+        };
+        super::index::index(index_args, cfg.clone()).await?;
+
+        // Read fresh stats from the just-created DB.
+        match Database::open(&db_path) {
+            Ok(db) => match db.stats() {
+                Ok(stats) => (stats.file_count, stats.chunk_count),
+                Err(_) => (0, 0),
+            },
+            Err(_) => (0, 0),
+        }
+    };
+
+    // ── 6b. Import git-notes memory into the project memory.db ────────────────
+    // Entries recorded on `refs/notes/spelunk` before init (git-notes fallback
+    // or write-through) are invisible to the SQLite-backed `memory list` until
+    // imported. No enclosing git repo → nothing to import. Non-fatal: a failure
+    // here must not sink init.
+    let memory_line: Option<String> = if let Some(git_root) = git_root.as_ref() {
+        let mem_path = spelunk_dir.join("memory.db");
+        // Fold in anything a previous `git fetch` left on the tracking ref
+        // before hydrating, so teammates' entries import too (ADR-069 D5).
+        crate::storage::merge_tracking_notes(Some(git_root)).await;
+        match super::memory::reconcile::import_git_notes_into_memory(git_root, &mem_path).await {
+            Ok(0) => None,
+            Ok(n) => Some(format!("imported {n} entries from git notes")),
+            Err(e) => {
+                tracing::warn!("git-notes memory import skipped (non-fatal): {e}");
+                None
+            }
+        }
+    } else {
+        None
     };
 
     // ── 7. Configure git-notes refspec on `origin` (only inside a git repo) ───

--- a/crates/spelunk-cli/src/cli/cmd/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth_api;
 pub mod check;
 pub mod context;
+mod embed_worker;
 pub mod explore;
 pub mod graph;
 pub mod helpers;

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -173,6 +173,50 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
         return Ok(());
     }
 
+    // ── Embedding coverage is a first-class search input (chunk-shaped) ──────
+    // A just-built, unembedded index is not stale, so the staleness probe can
+    // never see the warmup window; the empty-result path below gates on
+    // coverage instead. Invariant: `No results found.` is only ever printed
+    // when the corpus that was searched was complete; whenever coverage is
+    // partial, the output names what was incomplete. Notices go to stderr so
+    // json/jsonl stdout stays machine-clean. No threshold: "incomplete" is a
+    // fact, the percentage is reported, and the user judges.
+    let coverage: Option<(i64, i64)> = if mode == "text" {
+        // FTS is written at parse time and covers every chunk.
+        None
+    } else {
+        Database::open(&db_path)
+            .and_then(|db| db.stats())
+            .ok()
+            .map(|s| (s.embedding_count, s.chunk_count))
+    };
+
+    if let Some((embedded, total)) = coverage {
+        match coverage_disposition(embedded, total, auto_mode) {
+            CoverageDisposition::Complete => {}
+            CoverageDisposition::PartialNotice => {
+                eprintln!("{}", warmup_notice_partial(embedded, total));
+            }
+            CoverageDisposition::ZeroFallBack => {
+                eprintln!("{}", warmup_notice_zero_auto(total));
+                return search_live(
+                    &args.query,
+                    &args.format,
+                    std::path::Path::new("."),
+                    args.limit,
+                );
+            }
+            CoverageDisposition::ZeroExplicitError => {
+                return Err(anyhow::anyhow!(warmup_error_zero_explicit(mode, total)));
+            }
+        }
+    }
+    let coverage_partial = matches!(coverage, Some((e, t)) if e < t);
+    // Set when an empty semantic result over a partial corpus was re-run as
+    // text search: the FTS corpus is complete, so the plain empty-result line
+    // becomes truthful again.
+    let mut fell_back_to_text = false;
+
     let mut results = if mode == "text" {
         // Text mode: FTS5 only, no embedding model required.
         let sp = spinner("Searching (text)…");
@@ -250,21 +294,42 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
         )?;
         sp.finish_and_clear();
 
-        // Auto mode: stale index + empty results → fall back to ast-grep silently.
-        if auto_mode && res.is_empty() && !args.no_stale_check && index_is_stale(&db_path) {
+        // Auto mode, empty result set:
+        //  - partial coverage → re-run as text search over the complete FTS
+        //    corpus rather than reporting an absence KNN over a partial corpus
+        //    cannot substantiate (the warmup notice already went to stderr);
+        //  - full coverage → today's behaviour: stale index falls back to
+        //    ast-grep.
+        if auto_mode && res.is_empty() && coverage_partial {
+            eprintln!("[no semantic results in the embedded portion; using text search]");
+            fell_back_to_text = true;
+            let db = Database::open(&db_path)?;
+            db.search_text(&args.query, args.limit.min(100))
+                .unwrap_or_default()
+        } else if auto_mode && res.is_empty() && !args.no_stale_check && index_is_stale(&db_path) {
             return search_live(
                 &args.query,
                 &args.format,
                 std::path::Path::new("."),
                 args.limit,
             );
+        } else {
+            res
         }
-
-        res
     };
 
     if results.is_empty() {
-        println!("No results found.");
+        if coverage_partial && !fell_back_to_text {
+            // Explicit semantic/hybrid over a partial corpus: the plain
+            // absence claim is not substantiated, name the incompleteness.
+            let (e, t) = coverage.unwrap_or((0, 0));
+            println!(
+                "No results found in the embedded portion of the index \
+                 (searchable {e}/{t} chunks; the rest is not embedded yet)."
+            );
+        } else {
+            println!("No results found.");
+        }
         return Ok(());
     }
 
@@ -573,6 +638,83 @@ pub(crate) fn search_live(
     Ok(())
 }
 
+/// What the embedding coverage of the index means for this search
+/// (`spelunk search` warmup contract). Three coverage states by two mode
+/// classes, exhaustively; there is deliberately no coverage threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CoverageDisposition {
+    /// Every chunk is embedded (or the index is empty, handled earlier):
+    /// today's behaviour, no notice.
+    Complete,
+    /// `0 < coverage < 100`: run KNN and always emit the one-line warmup
+    /// notice, in auto and explicit modes alike, so a thin result set is
+    /// never mistaken for a complete one.
+    PartialNotice,
+    /// Zero coverage in `auto` mode: fall back to the live search, with a
+    /// notice naming warmup as the reason.
+    ZeroFallBack,
+    /// Zero coverage in an explicit `semantic`/`hybrid` mode: an actionable
+    /// error naming warmup and the resume command. Never `No results found.`.
+    ZeroExplicitError,
+}
+
+/// The three-state coverage table (`0` / partial / `100`, by auto vs explicit
+/// semantic/hybrid). `embedded >= total` covers the defensive over-count case.
+fn coverage_disposition(embedded: i64, total: i64, auto_mode: bool) -> CoverageDisposition {
+    if total <= 0 || embedded >= total {
+        return CoverageDisposition::Complete;
+    }
+    if embedded <= 0 {
+        if auto_mode {
+            CoverageDisposition::ZeroFallBack
+        } else {
+            CoverageDisposition::ZeroExplicitError
+        }
+    } else {
+        CoverageDisposition::PartialNotice
+    }
+}
+
+/// One-line warmup notice for a partially-embedded corpus: carries the
+/// coverage percentage AND its shape. The queue drains in indexing order, so
+/// a prefix is the first N files, not a sample across the repo: the user has
+/// a complete picture of some of the codebase and a systematic blind spot
+/// over the rest, and a bare percentage would read as the opposite failure
+/// mode (a uniformly thinner picture of everything).
+fn warmup_notice_partial(embedded: i64, total: i64) -> String {
+    let pct = if total > 0 {
+        (embedded.max(0) as u64).saturating_mul(100) / total as u64
+    } else {
+        0
+    };
+    format!(
+        "[warmup: searchable {embedded}/{total} chunks ({pct}%), front-loaded by indexing \
+         order; a missing result may mean \"not embedded yet\", not \"not in the codebase\" \
+         (check `spelunk status`)]"
+    )
+}
+
+/// Zero-coverage notice for `auto` mode, printed before the live-search
+/// fallback: names warmup as the reason.
+fn warmup_notice_zero_auto(total: i64) -> String {
+    format!(
+        "[semantic search is warming up: 0/{total} chunks embedded; using ast-grep. \
+         Embeddings build in the background (check `spelunk status`)]"
+    )
+}
+
+/// Zero-coverage error for explicit `semantic`/`hybrid`: actionable, naming
+/// warmup and the resume command.
+fn warmup_error_zero_explicit(mode: &str, total: i64) -> String {
+    format!(
+        "semantic search is still warming up: 0/{total} chunks are embedded, so a {mode} \
+         search would search nothing.\n\
+         Embeddings build in the background; check `spelunk status`. If no embed worker is \
+         running, resume with `spelunk index .`.\n\
+         Use `--mode text` or `--mode ast-grep` in the meantime."
+    )
+}
+
 /// Build the one-line notice explaining why `auto`-mode search is falling back
 /// from semantic to ast-grep, differentiating the cases the readiness contract
 /// exposes.
@@ -621,6 +763,118 @@ fn eprint_semantic_unavailable_notice(tier: &capability::Tier, cfg: &Config) {
 mod tests {
     use super::*;
     use crate::capability::EmbedderState;
+
+    // ── coverage_disposition: the three-state warmup table, all six cells ──────
+
+    #[test]
+    fn coverage_zero_auto_falls_back_with_notice() {
+        assert_eq!(
+            coverage_disposition(0, 100, true),
+            CoverageDisposition::ZeroFallBack
+        );
+    }
+
+    #[test]
+    fn coverage_zero_explicit_is_an_actionable_error() {
+        assert_eq!(
+            coverage_disposition(0, 100, false),
+            CoverageDisposition::ZeroExplicitError
+        );
+    }
+
+    #[test]
+    fn coverage_partial_auto_runs_knn_with_notice() {
+        assert_eq!(
+            coverage_disposition(40, 100, true),
+            CoverageDisposition::PartialNotice
+        );
+    }
+
+    #[test]
+    fn coverage_partial_explicit_runs_knn_with_the_same_notice() {
+        assert_eq!(
+            coverage_disposition(40, 100, false),
+            CoverageDisposition::PartialNotice
+        );
+    }
+
+    #[test]
+    fn coverage_full_auto_is_todays_behaviour_no_notice() {
+        assert_eq!(
+            coverage_disposition(100, 100, true),
+            CoverageDisposition::Complete
+        );
+    }
+
+    #[test]
+    fn coverage_full_explicit_is_todays_behaviour_no_notice() {
+        assert_eq!(
+            coverage_disposition(100, 100, false),
+            CoverageDisposition::Complete
+        );
+    }
+
+    #[test]
+    fn coverage_has_no_threshold() {
+        // "Incomplete" is a fact, not a tunable: 1 missing chunk out of 100k
+        // still notices, and 1 embedded chunk out of 100k still serves KNN.
+        assert_eq!(
+            coverage_disposition(99_999, 100_000, true),
+            CoverageDisposition::PartialNotice
+        );
+        assert_eq!(
+            coverage_disposition(1, 100_000, false),
+            CoverageDisposition::PartialNotice
+        );
+    }
+
+    #[test]
+    fn coverage_defensive_cases_are_complete() {
+        // Empty index (handled by earlier guards) and an over-count must not
+        // produce warmup output.
+        assert_eq!(
+            coverage_disposition(0, 0, true),
+            CoverageDisposition::Complete
+        );
+        assert_eq!(
+            coverage_disposition(120, 100, false),
+            CoverageDisposition::Complete
+        );
+    }
+
+    // ── warmup notices: percentage, shape, and actionability ───────────────────
+
+    #[test]
+    fn partial_notice_names_coverage_and_its_front_loaded_shape() {
+        let n = warmup_notice_partial(11_813, 27_734);
+        assert!(n.contains("11813/27734"), "labelled coverage: {n}");
+        assert!(n.contains("42%"), "carries the percentage: {n}");
+        assert!(
+            n.contains("front-loaded by indexing order"),
+            "names the shape so a subsystem miss reads as a blind spot, not a thin sample: {n}"
+        );
+        assert!(n.contains("spelunk status"), "actionable: {n}");
+    }
+
+    #[test]
+    fn zero_auto_notice_names_warmup_as_the_reason() {
+        let n = warmup_notice_zero_auto(27_734);
+        assert!(n.contains("warming up"));
+        assert!(n.contains("0/27734"));
+        assert!(n.contains("ast-grep"));
+    }
+
+    #[test]
+    fn zero_explicit_error_names_warmup_and_the_resume_command() {
+        let e = warmup_error_zero_explicit("semantic", 27_734);
+        assert!(e.contains("warming up"));
+        assert!(e.contains("spelunk index ."), "resume command: {e}");
+        assert!(e.contains("--mode text"), "usable alternative: {e}");
+        assert!(
+            !e.contains("No results found"),
+            "never the empty-result claim: {e}"
+        );
+    }
 
     // ── semantic_unavailable_message: auto-mode fallback notice (#5) ────────────
 

--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -70,7 +70,7 @@ fn log_path(state_dir: &Path) -> PathBuf {
 /// Create `dir` (and parents) with `0700` permissions on Unix so only the
 /// owner can read the PID/port/log files inside it. A no-op permission
 /// tightening on platforms without Unix perms.
-fn create_state_dir(dir: &Path) -> Result<()> {
+pub(super) fn create_state_dir(dir: &Path) -> Result<()> {
     std::fs::create_dir_all(dir)
         .with_context(|| format!("creating state dir {}", dir.display()))?;
     #[cfg(unix)]
@@ -85,7 +85,7 @@ fn create_state_dir(dir: &Path) -> Result<()> {
 /// Write `contents` to a state file, creating it `0600` and refusing to
 /// follow an existing symlink at `path` (see
 /// [`super::helpers::open_private_file_for_write`]).
-fn write_state_file(path: &Path, contents: &str) -> Result<()> {
+pub(super) fn write_state_file(path: &Path, contents: &str) -> Result<()> {
     use std::io::Write;
     let mut f = super::helpers::open_private_file_for_write(path)?;
     f.write_all(contents.as_bytes())
@@ -132,7 +132,7 @@ fn read_port(state_dir: &Path) -> Option<u16> {
 }
 
 /// Return `true` when `pid` names a currently-running process.
-fn pid_is_alive(pid: u32) -> bool {
+pub(super) fn pid_is_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
         // kill(pid, 0) checks existence without sending a signal.

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -123,6 +123,23 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
             Some(s) => serde_json::Value::String(s.as_str().to_string()),
         };
 
+        // Embed-state extensions: worker liveness is read from the recorded
+        // pid (never inferred from counts) and only meaningful while work is
+        // pending; token sums carry their own denominators.
+        let pending_chunks = stats.chunk_count - stats.embedding_count;
+        let (embed_worker_alive_json, embed_tokens_json) = if pending_chunks > 0 {
+            let alive = super::embed_worker::worker_liveness(&db_path)
+                == super::embed_worker::WorkerLiveness::Alive;
+            let tokens = db
+                .embed_token_stats()
+                .ok()
+                .map(|t| serde_json::to_value(t).unwrap_or(serde_json::Value::Null))
+                .unwrap_or(serde_json::Value::Null);
+            (serde_json::json!(alive), tokens)
+        } else {
+            (serde_json::Value::Null, serde_json::Value::Null)
+        };
+
         // Serialize languages as [{name, file_count}, ...]
         let languages_json: Vec<serde_json::Value> = languages
             .iter()
@@ -156,6 +173,9 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
                 "capabilities": caps_json,
                 "embedder_state": embedder_state_json,
                 "embedding_count": stats.embedding_count,
+                "embedding_pending": pending_chunks,
+                "embed_worker_alive": embed_worker_alive_json,
+                "embed_tokens": embed_tokens_json,
                 "drift_candidates": drift,
                 "usage_7d": {
                     "search": usage_map.get("search").copied().unwrap_or(0),
@@ -281,12 +301,34 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
     println!("Files:      {}", s.file_count);
     println!("Chunks:     {}", s.chunk_count);
     println!("Embeddings: {}", s.embedding_count);
-    // Surface an in-progress (or interrupted) embed pass: when chunks outnumber
-    // embeddings there is embedding work left, e.g. a detached `--detach-embed`
-    // run still working through batches, or an interrupted run to resume. This
-    // is the completion check for a backgrounded embed.
-    if let Some(line) = embedding_progress_line(s.chunk_count, s.embedding_count) {
-        println!("{line}");
+    // Surface remaining embed work from what the process actually knows: the
+    // worker's recorded pid liveness (not a guess from two integers), chunk
+    // coverage, and the token-weighted work fraction. Coverage and progress
+    // are two measures in two units under two names; on a real repo they
+    // diverge by 2x and that divergence is the fact being reported.
+    if s.chunk_count > s.embedding_count {
+        let tokens = db.embed_token_stats().ok();
+        let worker = super::embed_worker::worker_liveness(&db_path);
+        let worker_alive = worker == super::embed_worker::WorkerLiveness::Alive;
+        let eta = match (&tokens, worker_alive) {
+            (Some(t), true) => super::embed_worker::worker_eta(&db_path, t.pending_tokens),
+            _ => None,
+        };
+        let embedder_unavailable = matches!(
+            tier.embedder_state(),
+            Some(capability::EmbedderState::Unavailable)
+        );
+        if let Some(line) = embedding_state_line(
+            worker_alive,
+            embedder_unavailable,
+            s.chunk_count,
+            s.embedding_count,
+            tokens.as_ref().map(|t| t.total_tokens).unwrap_or(0),
+            tokens.as_ref().map(|t| t.pending_tokens).unwrap_or(0),
+            eta,
+        ) {
+            println!("{line}");
+        }
     }
     if let Some(ts) = s.last_indexed {
         println!("Last index: {}", format_age(ts));
@@ -432,21 +474,82 @@ fn embedder_status_line(state: &capability::EmbedderState) -> Option<String> {
     Some(line)
 }
 
-/// Render the "embedding in progress" line for `spelunk status` when the index
-/// has more chunks than embeddings, i.e. an embed pass is still running (e.g. a
-/// detached `--detach-embed` subprocess) or was interrupted and can be resumed.
-/// Returns `None` when every chunk is embedded (or the index is empty), so a
-/// fully-embedded index prints nothing extra. Pure so it can be unit tested.
-fn embedding_progress_line(chunk_count: i64, embedding_count: i64) -> Option<String> {
+/// Integer percentage with an explicit denominator; `None` when the
+/// denominator is empty (the caller omits the clause rather than printing a
+/// made-up number).
+fn labelled_pct(done: i64, total: i64) -> Option<u64> {
+    (done.max(0) as u64)
+        .saturating_mul(100)
+        .checked_div(u64::try_from(total).ok().filter(|t| *t > 0)?)
+}
+
+/// `~54 min left` style rendering for the status ETA.
+fn humanize_eta(eta: std::time::Duration) -> String {
+    let secs = eta.as_secs();
+    if secs < 60 {
+        format!("~{secs}s left")
+    } else if secs < 3600 {
+        format!("~{} min left", secs.div_ceil(60))
+    } else {
+        format!("~{}h{:02}m left", secs / 3600, (secs % 3600) / 60)
+    }
+}
+
+/// Render the embedding-state line for `spelunk status` when the index has
+/// more chunks than embeddings. Pure so the state matrix is unit testable.
+///
+/// The line reports what the process knows, never a guess:
+/// - a live recorded worker: `Embedding in progress`
+/// - no live worker but pending work: `Embedding incomplete` plus the resume
+///   command (or, when the embedder is unavailable, a pointer at the server
+///   logs instead, since resuming cannot help until the server is fixed)
+///
+/// Two measures, two units, two names: `searchable` is chunk coverage (what
+/// KNN can see), `of work done` is token-weighted progress (how much of the
+/// wait is behind you). They are supposed to diverge; a single unlabelled
+/// percentage serving both questions is the defect this replaces. On an index
+/// whose token counts are not backfilled (total 0) the work clause is omitted
+/// rather than fabricated.
+fn embedding_state_line(
+    worker_alive: bool,
+    embedder_unavailable: bool,
+    chunk_count: i64,
+    embedding_count: i64,
+    total_tokens: i64,
+    pending_tokens: i64,
+    eta: Option<std::time::Duration>,
+) -> Option<String> {
     if chunk_count <= 0 || embedding_count >= chunk_count {
         return None;
     }
-    let pending = chunk_count - embedding_count;
-    Some(format!(
-        "  \x1b[33mEmbedding in progress\x1b[0m  {embedding_count}/{chunk_count} embedded \
-         ({pending} pending) \x1b[2m(a background embed may be running; re-run \
-         `spelunk index` to resume if not)\x1b[0m"
-    ))
+    let coverage = labelled_pct(embedding_count, chunk_count).unwrap_or(0);
+    let searchable = format!("searchable {embedding_count}/{chunk_count} chunks ({coverage}%)");
+
+    let mut progress = match labelled_pct(
+        (total_tokens - pending_tokens).clamp(0, total_tokens),
+        total_tokens,
+    ) {
+        Some(work) => format!("{work}% of work done"),
+        None => "work remaining unknown (run `spelunk index --recount` to backfill token counts)"
+            .to_string(),
+    };
+    if worker_alive && let Some(eta) = eta {
+        progress = format!("{progress}, {}", humanize_eta(eta));
+    }
+
+    Some(if worker_alive {
+        format!("  \x1b[33mEmbedding in progress\x1b[0m   {searchable}  \u{00b7}  {progress}")
+    } else if embedder_unavailable {
+        format!(
+            "  \x1b[33mEmbedding incomplete\x1b[0m   {searchable}  \u{00b7}  {progress}; \
+             the embedder is unavailable, see `spelunk server logs`"
+        )
+    } else {
+        format!(
+            "  \x1b[33mEmbedding incomplete\x1b[0m   {searchable}  \u{00b7}  {progress}; \
+             resume with `spelunk index .`"
+        )
+    })
 }
 
 pub(crate) fn format_age(unix_ts: i64) -> String {
@@ -509,26 +612,129 @@ mod tests {
         assert!(embedder_status_line(&EmbedderState::Unknown).is_none());
     }
 
-    // ── embedding_progress_line: detached / interrupted embed signal ────────────
+    // ── embedding_state_line: what status knows about its own worker (no guessing) ──
+
+    /// Numbers mirroring the recorded field repro: 42% of chunks searchable
+    /// while only 21% of the token-weighted work is done.
+    fn skewed_line(worker_alive: bool, embedder_unavailable: bool) -> Option<String> {
+        embedding_state_line(
+            worker_alive,
+            embedder_unavailable,
+            27_734,
+            11_813,
+            10_000_000,
+            7_900_000,
+            None,
+        )
+    }
 
     #[test]
-    fn embedding_progress_shown_when_chunks_outnumber_embeddings() {
-        let line = embedding_progress_line(100, 40).expect("partial embed shows a line");
+    fn live_worker_reports_in_progress_with_both_labelled_measures() {
+        let line = skewed_line(true, false).expect("pending work renders a line");
         assert!(line.contains("Embedding in progress"));
-        assert!(line.contains("40/100"));
-        assert!(line.contains("60 pending"));
+        assert!(
+            line.contains("searchable 11813/27734 chunks (42%)"),
+            "coverage stays chunk-shaped and labelled: {line}"
+        );
+        assert!(
+            line.contains("21% of work done"),
+            "progress is token-weighted and labelled: {line}"
+        );
+        assert!(
+            !line.contains("may be running"),
+            "the hedging parenthetical is deleted, not reworded: {line}"
+        );
+        assert!(
+            !line.contains("resume"),
+            "a live worker needs no resume advice: {line}"
+        );
     }
 
     #[test]
-    fn embedding_progress_hidden_when_fully_embedded() {
-        assert!(embedding_progress_line(100, 100).is_none());
+    fn no_worker_with_pending_work_reports_incomplete_and_the_resume_command() {
+        let line = skewed_line(false, false).expect("pending work renders a line");
+        assert!(
+            line.contains("Embedding incomplete"),
+            "a dead worker is not 'in progress': {line}"
+        );
+        assert!(!line.contains("Embedding in progress"));
+        assert!(
+            line.contains("spelunk index ."),
+            "must name the resume command: {line}"
+        );
+        assert!(!line.contains("may be running"));
+    }
+
+    #[test]
+    fn unavailable_embedder_points_at_server_logs_instead_of_resume() {
+        let line = skewed_line(false, true).expect("pending work renders a line");
+        assert!(line.contains("Embedding incomplete"));
+        assert!(line.contains("unavailable"), "must say so: {line}");
+        assert!(
+            line.contains("spelunk server logs"),
+            "must point at the server logs: {line}"
+        );
+        assert!(
+            !line.contains("resume with"),
+            "resuming cannot help while the embedder is unavailable: {line}"
+        );
+    }
+
+    #[test]
+    fn coverage_and_progress_percentages_diverge_and_are_never_bare() {
+        // The two measures answer different questions and must be rendered
+        // under their own names; the field repro diverges 2x.
+        let line = skewed_line(true, false).unwrap();
+        assert!(line.contains("(42%)") && line.contains("21%"));
+        assert!(line.contains("searchable") && line.contains("of work done"));
+    }
+
+    #[test]
+    fn live_worker_line_carries_the_measured_eta_when_available() {
+        let line = embedding_state_line(
+            true,
+            false,
+            27_734,
+            11_813,
+            10_000_000,
+            7_900_000,
+            Some(std::time::Duration::from_secs(54 * 60)),
+        )
+        .unwrap();
+        assert!(line.contains("~54 min left"), "got: {line}");
+    }
+
+    #[test]
+    fn pre_backfill_index_omits_the_work_clause_instead_of_fabricating_it() {
+        // total_tokens == 0: no denominator to weight work by, so the clause
+        // is omitted (with the backfill hint), never rendered as a fake 0/100%.
+        let line = embedding_state_line(false, false, 100, 40, 0, 0, None).unwrap();
+        assert!(line.contains("searchable 40/100 chunks (40%)"));
+        assert!(!line.contains("% of work done"));
+        assert!(line.contains("--recount"), "hint at the backfill: {line}");
+    }
+
+    #[test]
+    fn embedding_state_hidden_when_fully_embedded() {
+        assert!(embedding_state_line(true, false, 100, 100, 10, 0, None).is_none());
         // Defensive: never render a negative pending count.
-        assert!(embedding_progress_line(100, 120).is_none());
+        assert!(embedding_state_line(true, false, 100, 120, 10, 0, None).is_none());
     }
 
     #[test]
-    fn embedding_progress_hidden_for_empty_index() {
-        assert!(embedding_progress_line(0, 0).is_none());
+    fn embedding_state_hidden_for_empty_index() {
+        assert!(embedding_state_line(false, false, 0, 0, 0, 0, None).is_none());
+    }
+
+    // ── humanize_eta ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn humanize_eta_scales_units() {
+        use std::time::Duration;
+        assert_eq!(humanize_eta(Duration::from_secs(30)), "~30s left");
+        assert_eq!(humanize_eta(Duration::from_secs(54 * 60)), "~54 min left");
+        assert_eq!(humanize_eta(Duration::from_secs(3_300)), "~55 min left");
+        assert_eq!(humanize_eta(Duration::from_secs(6_000)), "~1h40m left");
     }
 
     // ── memory_backend_label: resolved-backend memory line (ADR-067 D3) ─────────

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -983,6 +983,7 @@ fn test_search_explicit_hybrid_no_embedder_falls_back_to_text() {
     // (ADR-004: inference-only routing; fallback is resolved at capability detection,
     // no per-query notice is emitted).
     spelunk_bin()
+        .env("SPELUNK_NO_SERVER", "1") // prevent accidental loopback auto-discovery
         .current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -1682,3 +1682,353 @@ fn test_init_without_git_repo_skips_notes_import() {
         .success()
         .stdout(predicate::str::contains("from git notes").not());
 }
+
+// ── ADR-070 D3/D4: warmup contract + status honesty (adversarial pass) ────────
+
+/// Build an offline-indexed project (chunks stored, zero embeddings, no
+/// recorded worker) under `home`, returning `(project_dir, config_path)`.
+/// The index DB lands at `<project_dir>/.spelunk/index.db` - the same path
+/// `status`/`search` resolve via the project walk, and the one the embed
+/// worker's state files are keyed on.
+fn offline_indexed_project(home: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let project_dir = home.join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(
+        project_dir.join("lib.rs"),
+        "pub fn compute(x: i32) -> i32 { x * 2 }\npub fn helper() -> i32 { 7 }\n",
+    )
+    .unwrap();
+    let config_path = home.join("config.toml");
+    fs::write(
+        &config_path,
+        "api_base_url = \"http://127.0.0.1:19999\"\nembedding_model = \"test\"\nllm_model = \"test\"\n",
+    )
+    .unwrap();
+    spelunk_bin_in(home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+    (project_dir, config_path)
+}
+
+/// Path of the embed worker's pid state file for `db_path`, replicating the
+/// worker's own keying (blake3 of the canonicalised index path, first 16 hex
+/// chars). Deliberately duplicated here: if the writer's keying ever drifts
+/// from this, the reader/writer pair drifts too, and this test fails loudly.
+fn embed_worker_pid_file(home: &std::path::Path, db_path: &std::path::Path) -> std::path::PathBuf {
+    let canonical = spelunk_core::utils::canonicalize(db_path);
+    let key = blake3::hash(canonical.to_string_lossy().as_bytes())
+        .to_hex()
+        .to_string();
+    home.join(".local")
+        .join("state")
+        .join("spelunk")
+        .join(format!("embed-worker-{}.pid", &key[..16]))
+}
+
+/// ADR-070 D4: the `status --format json` embed-state extensions are additive
+/// and truthful. On an offline-built index (pending work, no worker) the new
+/// fields must report pending counts, a non-alive worker, and token sums with
+/// their own denominators - while the stable #269 schema keys survive intact.
+#[test]
+fn test_status_json_embed_state_extensions_when_pending() {
+    let home = tempfile::TempDir::new().unwrap();
+    let (project_dir, config_path) = offline_indexed_project(home.path());
+
+    let output = spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .args(["status", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let body: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+
+    // Stable schema keys must survive the extension (additive-only contract).
+    for key in [
+        "version",
+        "db_path",
+        "indexed_files",
+        "total_chunks",
+        "languages",
+        "embedding_dim",
+        "has_semantic_search",
+        "memory_entries",
+        "memory_backend",
+        "tier",
+        "embedding_count",
+    ] {
+        assert!(
+            body.get(key).is_some(),
+            "stable/extension key `{key}` missing from status JSON"
+        );
+    }
+
+    let total_chunks = body["total_chunks"].as_i64().unwrap();
+    assert!(total_chunks > 0, "fixture must produce chunks");
+    assert_eq!(body["embedding_count"].as_i64(), Some(0));
+    assert_eq!(
+        body["embedding_pending"].as_i64(),
+        Some(total_chunks),
+        "everything is pending on an offline-built index"
+    );
+    assert_eq!(
+        body["embed_worker_alive"].as_bool(),
+        Some(false),
+        "no recorded worker must read as alive=false, never a guess"
+    );
+    let tokens = &body["embed_tokens"];
+    assert!(
+        tokens.is_object(),
+        "embed_tokens must be an object: {tokens}"
+    );
+    let total_tokens = tokens["total_tokens"].as_i64().unwrap();
+    let pending_tokens = tokens["pending_tokens"].as_i64().unwrap();
+    assert!(total_tokens > 0, "token counts are written at parse time");
+    assert_eq!(
+        pending_tokens, total_tokens,
+        "zero embeddings means every token is pending"
+    );
+}
+
+/// ADR-070 D4: with pending work and no recorded worker, text `status` says
+/// `Embedding incomplete` plus the resume command - never `in progress`, and
+/// the deleted hedging parenthetical must not resurface.
+#[test]
+fn test_status_reports_incomplete_when_no_worker_is_recorded() {
+    let home = tempfile::TempDir::new().unwrap();
+    let (project_dir, config_path) = offline_indexed_project(home.path());
+
+    spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Embedding incomplete"))
+        .stdout(predicate::str::contains("resume with `spelunk index .`"))
+        .stdout(predicate::str::contains("Embedding in progress").not())
+        .stdout(predicate::str::contains("may be running").not());
+}
+
+/// ADR-070 D4: a worker that crashed without cleanup leaves a pid file behind;
+/// the next `status` must classify the dead pid as not-running (never
+/// `in progress`) and remove the stale record so it cannot be re-read later.
+#[cfg(unix)]
+#[test]
+fn test_status_cleans_stale_dead_worker_pid_and_reports_incomplete() {
+    let home = tempfile::TempDir::new().unwrap();
+    let (project_dir, config_path) = offline_indexed_project(home.path());
+    let db_path = project_dir.join(".spelunk").join("index.db");
+    assert!(db_path.exists(), "offline index must exist");
+
+    // A pid that was real and is now certainly dead: spawn and reap a child.
+    let mut child = std::process::Command::new("true").spawn().unwrap();
+    let dead_pid = child.id();
+    child.wait().unwrap();
+
+    let pid_file = embed_worker_pid_file(home.path(), &db_path);
+    fs::create_dir_all(pid_file.parent().unwrap()).unwrap();
+    fs::write(&pid_file, format!("{dead_pid}\n")).unwrap();
+    fs::write(pid_file.with_extension("baseline"), "0 1000\n").unwrap();
+
+    spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Embedding incomplete"))
+        .stdout(predicate::str::contains("Embedding in progress").not());
+
+    assert!(
+        !pid_file.exists(),
+        "a dead worker's stale pid record must be cleaned up on read"
+    );
+}
+
+/// ADR-070 D4: a pid recycled by an unrelated live process (here: this test
+/// process itself - alive, but its command line is not a spelunk index run)
+/// must never be reported as a live embed worker, and the foreign record is
+/// cleaned up like a dead one.
+#[cfg(unix)]
+#[test]
+fn test_status_foreign_pid_reuse_never_reads_as_live_worker() {
+    let home = tempfile::TempDir::new().unwrap();
+    let (project_dir, config_path) = offline_indexed_project(home.path());
+    let db_path = project_dir.join(".spelunk").join("index.db");
+
+    // This test process is definitely alive, and its `ps` command line (the
+    // e2e test binary plus a test-name filter) is not a spelunk index run.
+    let foreign_pid = std::process::id();
+
+    let pid_file = embed_worker_pid_file(home.path(), &db_path);
+    fs::create_dir_all(pid_file.parent().unwrap()).unwrap();
+    fs::write(&pid_file, format!("{foreign_pid}\n")).unwrap();
+
+    spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Embedding in progress").not())
+        .stdout(predicate::str::contains("Embedding incomplete"));
+
+    assert!(
+        !pid_file.exists(),
+        "a foreign (recycled) pid record must be cleaned up on read"
+    );
+}
+
+/// ADR-070 D3, zero-coverage auto cell, end to end: an offline-built index has
+/// chunks but no embeddings; `search` in auto mode must fall back to the live
+/// search with a stderr notice naming warmup - never a bare `No results
+/// found.` over a corpus KNN never saw.
+#[test]
+fn test_search_auto_zero_coverage_falls_back_with_warmup_notice() {
+    let home = tempfile::TempDir::new().unwrap();
+    let (project_dir, config_path) = offline_indexed_project(home.path());
+
+    spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .args(["search", "compute"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("semantic search is warming up"))
+        .stderr(predicate::str::contains("0/"))
+        .stderr(predicate::str::contains("ast-grep"));
+}
+
+/// ADR-070 D3, zero-coverage explicit cell, end to end: with a reachable
+/// server but an index whose embeddings have not been built yet, an explicit
+/// `--mode semantic` search must be an actionable error naming warmup and the
+/// resume command - never `No results found.`.
+#[tokio::test]
+async fn test_search_explicit_semantic_zero_coverage_is_actionable_error() {
+    let mock = MockServer::start().await;
+    plumbing_helpers::mount_health(&mock).await;
+
+    let home = tempfile::TempDir::new().unwrap();
+    let (project_dir, _config_path) = offline_indexed_project(home.path());
+
+    // Same project, but a config that names the (mock) server, so the search
+    // runs at Tier 1 and reaches the coverage gate instead of the Tier-0
+    // text fallback.
+    let db_ignored = home.path().join("unused.db");
+    let server_config =
+        write_config_with_server(home.path(), &db_ignored, &mock.uri(), &mock.uri());
+
+    let assert = spelunk_bin_in(home.path())
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&server_config)
+        .args(["search", "--mode", "semantic", "compute"])
+        .assert()
+        .failure();
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stderr.contains("warming up"),
+        "error must name warmup, got stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("spelunk index ."),
+        "error must name the resume command, got stderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("No results found"),
+        "never the empty-result claim over an unsearched corpus, got stdout: {stdout}"
+    );
+}
+
+/// ADR-070 D3, partial-coverage cell, end to end: embed everything, then add a
+/// file and re-index offline so coverage is partial. An auto search must emit
+/// the one-line stderr warmup notice carrying the coverage AND its
+/// front-loaded shape, while `--format json` stdout stays machine-clean.
+#[tokio::test]
+async fn test_search_auto_partial_coverage_emits_warmup_notice_on_stderr() {
+    let mock = MockServer::start().await;
+    plumbing_helpers::mount_health(&mock).await;
+    plumbing_helpers::mount_index_embed(&mock).await;
+
+    let home = tempfile::TempDir::new().unwrap();
+    let project_dir = home.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(
+        project_dir.join("lib.rs"),
+        "pub fn compute(x: i32) -> i32 { x * 2 }\n",
+    )
+    .unwrap();
+    let db_ignored = home.path().join("unused.db");
+    let config_path = write_config_with_server(home.path(), &db_ignored, &mock.uri(), &mock.uri());
+
+    // Pass 1: embed everything via the mock server (full coverage).
+    spelunk_bin_in(home.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    // Pass 2: add a file and re-index offline - its chunks are stored but not
+    // embedded, so coverage drops below 100%.
+    fs::write(
+        project_dir.join("extra.rs"),
+        "pub fn extra_helper() -> i32 { 41 }\npub fn another_helper() -> i32 { 42 }\n",
+    )
+    .unwrap();
+    spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("index")
+        .arg(&project_dir)
+        .assert()
+        .success();
+
+    // Auto search with no reachable embedder: the partial-coverage warmup
+    // notice must land on stderr (percentage + shape + pointer at status),
+    // and the JSON on stdout must stay parseable.
+    let output = spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .args(["search", "compute", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warmup: searchable"),
+        "partial coverage must emit the warmup notice, got stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("front-loaded by indexing order"),
+        "the notice must name the prefix shape, got stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("spelunk status"),
+        "the notice must be actionable, got stderr: {stderr}"
+    );
+    let _: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("stdout must stay machine-clean JSON with all notices on stderr");
+}

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -1136,7 +1136,7 @@ fn test_init_non_tty_prints_skip_notice() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "server not running — semantic search skipped",
+            "server not running - semantic search skipped",
         ));
 }
 

--- a/crates/spelunk-core/src/storage/chunks.rs
+++ b/crates/spelunk-core/src/storage/chunks.rs
@@ -58,8 +58,9 @@ impl Database {
     /// table, i.e. chunks that were parsed/stored but never embedded (e.g. an
     /// `init`/`index` run where the embedder wasn't ready yet, so the embed
     /// phase was skipped). Returns the raw fields needed to reconstruct the
-    /// exact `Chunk::embedding_text()` document format: `(chunk_id, name,
-    /// metadata_json, summary, content)`.
+    /// exact `Chunk::embedding_text()` document format plus the stored token
+    /// estimate: `(chunk_id, name, metadata_json, summary, content,
+    /// token_count)`. `token_count` may be 0 on a pre-backfill index.
     ///
     /// A plain re-`index` skips unchanged files by file-hash, so those chunks
     /// never reach the embed phase on their own; the index command unions the
@@ -68,9 +69,18 @@ impl Database {
     #[allow(clippy::type_complexity)]
     pub fn chunks_missing_embeddings(
         &self,
-    ) -> Result<Vec<(i64, Option<String>, Option<String>, Option<String>, String)>> {
+    ) -> Result<
+        Vec<(
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            String,
+            usize,
+        )>,
+    > {
         let mut stmt = self.conn.prepare_cached(
-            "SELECT c.id, c.name, c.metadata, c.summary, c.content
+            "SELECT c.id, c.name, c.metadata, c.summary, c.content, c.token_count
              FROM chunks c
              LEFT JOIN embeddings e ON e.chunk_id = c.id
              WHERE e.chunk_id IS NULL
@@ -83,6 +93,7 @@ impl Database {
                 row.get::<_, Option<String>>(2)?,
                 row.get::<_, Option<String>>(3)?,
                 row.get::<_, String>(4)?,
+                row.get::<_, i64>(5)? as usize,
             ))
         })?;
         rows.collect::<rusqlite::Result<Vec<_>>>()

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -34,7 +34,9 @@ pub use remote::{
     RemoteMemoryBackend, resolve_cloud_project_uuid,
 };
 pub use specs::{SpecRecord, StaleSpec};
-pub use stats::{DriftCandidate, IndexStats, LanguageStat, StalenessReport, record_usage_at};
+pub use stats::{
+    DriftCandidate, EmbedTokenStats, IndexStats, LanguageStat, StalenessReport, record_usage_at,
+};
 
 use anyhow::Result;
 use std::path::Path;

--- a/crates/spelunk-core/src/storage/stats.rs
+++ b/crates/spelunk-core/src/storage/stats.rs
@@ -12,6 +12,18 @@ pub struct IndexStats {
     pub last_indexed: Option<i64>,
 }
 
+/// Token-weighted view of the embed queue, for progress reporting. Chunk
+/// counts answer "what can search see" (coverage); token sums answer "how much
+/// embed work remains" (progress). The two are different questions and must
+/// never be rendered under one name.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct EmbedTokenStats {
+    /// Sum of `token_count` over all chunks. 0 on an empty or pre-backfill index.
+    pub total_tokens: i64,
+    /// Sum of `token_count` over chunks with no embedding row.
+    pub pending_tokens: i64,
+}
+
 /// Result of a lightweight random-sample staleness probe.
 #[derive(Debug, serde::Serialize)]
 pub struct StalenessReport {
@@ -68,6 +80,27 @@ impl Database {
             chunk_count,
             embedding_count,
             last_indexed,
+        })
+    }
+
+    /// Token-weighted embed-queue totals (see [`EmbedTokenStats`]).
+    pub fn embed_token_stats(&self) -> Result<EmbedTokenStats> {
+        let total_tokens: i64 = self.conn.query_row(
+            "SELECT COALESCE(SUM(token_count), 0) FROM chunks",
+            [],
+            |r| r.get(0),
+        )?;
+        let pending_tokens: i64 = self.conn.query_row(
+            "SELECT COALESCE(SUM(c.token_count), 0)
+             FROM chunks c
+             LEFT JOIN embeddings e ON e.chunk_id = c.id
+             WHERE e.chunk_id IS NULL",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(EmbedTokenStats {
+            total_tokens,
+            pending_tokens,
         })
     }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,10 +15,11 @@ always-available commands (`graph`, text/ast-grep `search`, `memory add/list`,
 
 ## spelunk init
 
-Initialise spelunk for the current project: register it, parse and chunk the
-source tree, start the local server if needed, embed the code, and (when inside
-a git repo with an `origin` remote) configure the fetch refspec so project
-memory notes travel automatically on `git fetch`.
+Initialise spelunk for the current project: register it, start the local server
+if needed, parse and chunk the source tree, hand the embedding pass to a
+detached background worker, and (when inside a git repo with an `origin` remote)
+configure the fetch refspec so project memory notes travel automatically on
+`git fetch`.
 
 ```
 spelunk init [options]
@@ -88,7 +89,7 @@ spelunk index <path> [options]
 | `--no-summaries` | false | Skip LLM summary generation even when `llm_model` is configured |
 | `--summary-batch-size <n>` | 10 | Chunks per LLM summary request |
 | `--detach` | false | Re-exec in the background and return immediately (used by git hooks) |
-| `--detach-embed` | false | Parse in the foreground, then run the embedding phase in a background process and return the prompt |
+| `--detach-embed` | false | Deprecated (parse auto-returns after embedding is handed off); ignored, kept for compatibility |
 
 A plain `spelunk index` (no `--force`) re-indexes changed files (blake3 hash)
 and also backfills embeddings for any already-parsed chunk that has no embedding
@@ -110,13 +111,14 @@ Each batch is written to the database as soon as it completes, so an
 interrupted run (timeout, machine sleep, process kill) never loses
 already-embedded chunks — re-run `spelunk index` to pick up where it left off.
 
-`--detach-embed` is useful when embedding a large codebase on slow hardware:
-parsing finishes in the foreground (so the index is immediately usable for
-text and ast-grep search) and the long embedding pass continues in the
-background. Run `spelunk status` afterwards to check progress; it shows an
-"Embedding in progress" line with the embedded/total count until every chunk
-is embedded. If the background pass is interrupted, re-running `spelunk index`
-resumes it (already-embedded chunks are skipped).
+The embedding pass is always handed off to a detached background worker
+(returned via auto-spawn in `init` or explicit `--detach-embed` in `index`),
+so parsing finishes in the foreground (index is immediately usable for text and
+ast-grep search) and the long embedding pass continues in the background. Run
+`spelunk status` afterwards to check progress; it shows an "Embedding in progress"
+line with searchable chunks and work percentage until every chunk is embedded.
+If the background pass is interrupted, re-running `spelunk index` resumes it
+(already-embedded chunks are skipped).
 
 Add a `.spelunkignore` file (same syntax as `.gitignore`) to any directory to
 exclude files from indexing. It takes higher precedence than `.gitignore`.
@@ -133,8 +135,11 @@ spelunk index ./myproject --force --batch-size 16
 ## spelunk search
 
 Search the index. In `auto` mode (the default) spelunk uses semantic/hybrid
-search when an index and server are available and silently falls back to
-ast-grep otherwise.
+search when an index and server are available. During embeddings warmup, a
+coverage notice is printed to stderr naming the percentage and shape of
+embedded chunks; on zero coverage `auto` falls back to ast-grep. Explicit
+`semantic`/`hybrid` on a warming index returns an actionable error naming the
+resume command instead of an absence claim.
 
 ```
 spelunk search <query> [options]
@@ -226,10 +231,11 @@ spelunk status [options]
 | `-l, --list` | false | One-line-per-project format (implies `--all`) |
 | `--format text\|json` | text | Output format |
 
-When chunks outnumber embeddings, `spelunk status` prints an "Embedding in
-progress" line showing the embedded/total count. This covers both an active
-background embed (e.g. `spelunk index --detach-embed` still running) and an
-interrupted run that can be resumed with `spelunk index`.
+When embeddings are incomplete, `spelunk status` prints an "Embedding in progress"
+line (when a live background worker is detected) or "Embedding incomplete" (when
+no worker is running but chunks remain unembedded). Coverage is shown as searchable
+chunks and percentage; progress is shown as percentage of work done, measured by
+token weight. An incomplete status includes the `spelunk index .` resume command.
 
 **Example:**
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -89,7 +89,7 @@ spelunk index <path> [options]
 | `--no-summaries` | false | Skip LLM summary generation even when `llm_model` is configured |
 | `--summary-batch-size <n>` | 10 | Chunks per LLM summary request |
 | `--detach` | false | Re-exec in the background and return immediately (used by git hooks) |
-| `--detach-embed` | false | Deprecated (parse auto-returns after embedding is handed off); ignored, kept for compatibility |
+| `--detach-embed` | false | Parse in the foreground, then run the embedding phase in a detached background process and return the prompt (`spelunk init` does this automatically) |
 
 A plain `spelunk index` (no `--force`) re-indexes changed files (blake3 hash)
 and also backfills embeddings for any already-parsed chunk that has no embedding
@@ -103,21 +103,24 @@ skips it. Use `--force` to retry those.
 
 The embed phase calibrates its own batch size instead of guessing: it times a
 1-chunk request, then a 4-chunk request, and sizes subsequent requests (and
-their timeouts) from the observed per-chunk rate — smaller batches on slow
+their timeouts) from the observed token-weighted rate: smaller batches on slow
 hardware, larger ones (up to 256 chunks, or your `--batch-size` cap if lower)
-on fast hardware. It keeps re-measuring as the run progresses, so a rate that
+on fast hardware. Sizing by tokens rather than chunk count keeps the deadline
+honest when the queue crosses from small chunks into large ones. It keeps re-measuring as the run progresses, so a rate that
 drifts partway through is picked up rather than locked to the first sample.
 Each batch is written to the database as soon as it completes, so an
 interrupted run (timeout, machine sleep, process kill) never loses
 already-embedded chunks — re-run `spelunk index` to pick up where it left off.
 
-The embedding pass is always handed off to a detached background worker
-(returned via auto-spawn in `init` or explicit `--detach-embed` in `index`),
-so parsing finishes in the foreground (index is immediately usable for text and
-ast-grep search) and the long embedding pass continues in the background. Run
-`spelunk status` afterwards to check progress; it shows an "Embedding in progress"
-line with searchable chunks and work percentage until every chunk is embedded.
-If the background pass is interrupted, re-running `spelunk index` resumes it
+`spelunk init` always hands the embedding pass to a detached background worker,
+and `--detach-embed` opts a manual `spelunk index` run into the same behaviour:
+parsing finishes in the foreground (the index is immediately usable for text and
+ast-grep search) and the long embedding pass continues in the background, with
+the worker waiting out a still-loading embedder rather than skipping. A plain
+`spelunk index` without the flag embeds in the foreground. Run `spelunk status`
+to check a background pass; it shows an "Embedding in progress" line with
+searchable chunks and work percentage until every chunk is embedded. If the
+background pass is interrupted, re-running `spelunk index` resumes it
 (already-embedded chunks are skipped).
 
 Add a `.spelunkignore` file (same syntax as `.gitignore`) to any directory to
@@ -235,7 +238,8 @@ When embeddings are incomplete, `spelunk status` prints an "Embedding in progres
 line (when a live background worker is detected) or "Embedding incomplete" (when
 no worker is running but chunks remain unembedded). Coverage is shown as searchable
 chunks and percentage; progress is shown as percentage of work done, measured by
-token weight. An incomplete status includes the `spelunk index .` resume command.
+token weight. An incomplete status includes the `spelunk index .` resume command
+(or, when the embedder is unavailable, a pointer at the server logs instead).
 
 **Example:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,10 +156,12 @@ cd /path/to/your/project
 spelunk init
 ```
 
-That's the whole setup. `spelunk init` registers the project, parses and chunks
-every source file, starts the bundled `spelunk-server` in the background when run
-interactively (if one isn't already running), and embeds your code so semantic
-search works out of the box:
+That's the whole setup. `spelunk init` registers the project, starts the bundled
+`spelunk-server` in the background when run interactively (if one isn't already running),
+parses and chunks every source file, and hands the embedding pass to a detached background
+worker so the prompt returns after parsing (typically a few seconds) rather than after
+the full embed pass. Embeddings build in the background; full-text and ast-grep search
+work immediately, and semantic search becomes available as embeddings land.
 
 ```bash
 # Search by meaning, not just text

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -159,8 +159,8 @@ spelunk init
 That's the whole setup. `spelunk init` registers the project, starts the bundled
 `spelunk-server` in the background when run interactively (if one isn't already running),
 parses and chunks every source file, and hands the embedding pass to a detached background
-worker so the prompt returns after parsing (typically a few seconds) rather than after
-the full embed pass. Embeddings build in the background; full-text and ast-grep search
+worker so the prompt returns after parsing (seconds on small projects, around a minute on
+large ones) rather than after the full embed pass. Embeddings build in the background; full-text and ast-grep search
 work immediately, and semantic search becomes available as embeddings land.
 
 ```bash


### PR DESCRIPTION
Implements ADR-070 (`docs/adr/070-init-embed-lifecycle-and-search-warmup-contract.md`) decisions D1 through D4, with D6's estimator correction folded into the D4 status work as the ADR directs.

## The measured problem

A fresh `spelunk init` on a machine with no running server shipped an index with **zero embeddings** and a semantic search that answered `No results found.` for every query, forever, with nothing in the output saying the index was unusable. The embed step probed for a server the same command was about to start, treated the not-ready embedder as terminal, and the empty-result fallback was gated on a staleness check that a just-built index can never trip. On the profiled repo (8,226 files / 27,734 chunks) the alternative of embedding inline holds the terminal for ~103 minutes.

## Summary by decision

**D1: server first, embed detached, as one indivisible change** (`crates/spelunk-cli/src/cli/cmd/init.rs`). `init` starts (or probes for) the server before the index step, and hands the embed pass to a detached background worker via the existing `--_embed-phases` subprocess. The reorder is what makes the detach reachable on a fresh machine; the detach is what keeps the reorder from becoming a foreground wall. The prompt returns after parsing.

**D2: a loading embedder is waited on, not skipped** (`crates/spelunk-cli/src/cli/cmd/index/mod.rs`, `wait_for_embedder`). The detached worker owns the readiness wait: it polls `/v1/health` with bounded backoff (1s doubling to a 30s cap). Only `unavailable` and `disabled` are terminal, each keeping its distinct notice; a vanished server gives up after 10 consecutive offline probes. The spawn gate admits a still-loading embedder, because gating on readiness alone skips the spawn on exactly the fresh install that needs it. No new persistence: the worker rebuilds its queue from `chunks_missing_embeddings`.

**D3: search never reports an absence it cannot substantiate** (`crates/spelunk-cli/src/cli/cmd/search.rs`). Embedding coverage replaces the staleness proxy on the empty-result path. Zero coverage: `auto` falls back to live search with a notice naming warmup; explicit `semantic`/`hybrid` is an actionable error naming warmup and the resume command. Partial coverage: KNN runs and a one-line stderr notice always prints, carrying the percentage and its shape (the queue drains in indexing order, so a prefix is a systematic blind spot, not a thin sample); an empty `auto` result re-runs as text over the complete FTS corpus. Full coverage: today's behaviour. All six cells of the 3x2 table are unit-tested by name, plus end-to-end tests that the notices hit stderr while `--format json` stdout stays machine-clean. No coverage threshold exists.

**D4: status reads its worker, it does not guess** (`crates/spelunk-cli/src/cli/cmd/embed_worker.rs`, `status.rs`). The process running the embed phase records a per-project pid liveness file (keyed by index-path hash, mirroring the server's state-file shape), with the foreign-pid classification so a recycled pid never reads as a live worker; stale records are cleaned on read. A live worker renders `Embedding in progress`; no worker with pending work renders `Embedding incomplete` plus the resume command; an unavailable embedder says so and points at the server logs. The hedging parenthetical is deleted. Coverage and progress are two measures in two units under two names, and no percentage is printed bare. The D6 fold: the embed phase's single `RateEstimate` is now seconds per estimated token, so batch sizing, request deadlines, and the ETA share a rate whose unit matches the cost it predicts; the rate is measured per run and never cached across runs (the token estimate's corpus-dependent bias only cancels when calibrated in the units it predicts in).

## New output

Status line (live worker):

```
Embedding in progress   searchable 11813/27734 chunks (42%)  ·  21% of work done, ~54 min left
```

Status line (no worker, work pending), as observed in the cold-start transcript below:

```
Embedding incomplete   searchable 0/4 chunks (0%)  ·  0% of work done; resume with `spelunk index .`
```

Search notices (stderr):

```
[semantic search is warming up: 0/27734 chunks embedded; using ast-grep. Embeddings build in the background (check `spelunk status`)]
[warmup: searchable 11813/27734 chunks (42%), front-loaded by indexing order; a missing result may mean "not embedded yet", not "not in the codebase" (check `spelunk status`)]
```

JSON status gains additive `embedding_pending`, `embed_worker_alive`, and `embed_tokens` fields.

## Honest limits

- **Spawn-to-pid-write transient.** Between the foreground process spawning the detached worker and the worker writing its pid file (process startup plus DB open, roughly a couple of seconds on a slow machine), a concurrent `spelunk status` reports `Embedding incomplete` with resume advice. Benign by construction: the advised resume drains the same durable queue with per-chunk commits, so the worst case is briefly duplicated work, never corruption, and the window closes as soon as the worker acquires its guard (held through the readiness wait, so a worker waiting on a loading embedder does read as running).
- **State-dir cleanup is read-triggered.** Stale worker records (dead or foreign pid) are cleaned up when `status` next reads that project. Records for projects that are deleted and never inspected again linger in the state dir; a small GC sweep is a reasonable follow-up.
- Worker diagnostics ride the existing `index-background.log` routing (#624); this change adds liveness, not log plumbing, per the ADR's D4 boundary.
- The server still computes an abandoned batch to completion on client disconnect; that is an independent fault tracked as #631 and out of scope here, though the token-weighted deadline should make spurious timeouts rarer (the 37% wasted-GPU repro in the ADR is the case that should stop reproducing).

## Test plan

All with `SPELUNK_SECRET_STORE=file`, real exit codes:

- `cargo fmt --check`: clean
- `cargo clippy --features rich-formats -- -D warnings`: clean
- `cargo nextest run`: 1189/1189 passed, 9 skipped
- `cargo test --doc`: pass
- `cargo nextest run --no-default-features`: 1188/1188 passed, 4 skipped
- The six D3 disposition-table tests run by name: 6/6
- Cold-start spot check on a tiny fixture in an isolated `HOME` with `SPELUNK_NO_SERVER=1` (no contact with any live server): `init` returned in ~2.6s with `0 embeddings` stated and the server-start hint printed; `status` rendered `Embedding incomplete   searchable 0/4 chunks (0%)` with the resume command and the JSON extensions (`embed_worker_alive: false`, token sums); `auto` search printed the zero-coverage warmup notice on stderr and fell back to live search; explicit `--mode semantic` with no server at all took the pre-existing Tier-0 text fallback over the complete FTS corpus (a different, deliberately preserved contract from the D3 warming cell, which presumes a reachable server and is covered end-to-end by `test_search_explicit_semantic_zero_coverage_is_actionable_error` against a mock server). The full detach-and-wait path with a live embedder was not exercised in this spot check, since it needs a TTY plus a real server; it is covered by the branch's unit tests (`wait_for_embedder` transitions, spawn-gate matrix) and mock-server e2e tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
