### PR TITLE
fix: org switch now survives token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,15 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   ```bash
   echo "*.log" >> .spelunk/.gitignore
   ```
+- **`spelunk org switch` now stays in effect after the access token expires.**
+  The switched-to org lived only in the short-lived (~5 minute) WorkOS access
+  token; nothing re-applied it when that token was refreshed. The first token
+  refresh after any `org switch` — triggered by the next `spelunk memory push`,
+  `sync`, or other cloud-api/team-server call — silently reverted the session
+  to the account's default org and persisted the reverted token, with no error
+  or warning. Anything pushed after that point landed in the wrong org.
+  Refreshes now re-send the durably stored active org, so a switched org
+  survives rotation and stays in effect until you switch again.
 
 ## [0.9.3] — 2026-07-08
 

--- a/crates/spelunk-cli/src/cli/cmd/auth_api.rs
+++ b/crates/spelunk-cli/src/cli/cmd/auth_api.rs
@@ -363,7 +363,8 @@ pub async fn poll_token(
 /// `POST /user_management/authenticate` with the refresh-token grant.
 ///
 /// With `organization_id` set this is a silent org-switch; without it, a plain
-/// refresh. A non-member / unknown organisation surfaces as a clear error.
+/// refresh reverts to the account's default org. A non-member / unknown
+/// organisation surfaces as a clear error.
 pub async fn refresh_token(
     client: &reqwest::Client,
     workos_url: &str,
@@ -400,6 +401,11 @@ pub async fn refresh_token(
 /// WorkOS (refresh grant, ADR-047), persists the rotated tokens to `[auth]`, and
 /// returns the tokens to use.
 ///
+/// The refresh re-sends `auth.org_id` as `organization_id` so a prior `org
+/// switch` survives rotation — WorkOS's refresh grant otherwise reverts to the
+/// account's default org when `organization_id` is omitted, silently undoing
+/// the switch on every expiry (see [`refresh_token`]).
+///
 /// When the token is still valid, `auth` is returned unchanged (no network
 /// call). A refresh failure (revoked/expired refresh token) surfaces a clear
 /// "run `spelunk login`" error rather than a raw 401 from the downstream call.
@@ -417,12 +423,26 @@ pub async fn ensure_fresh_token(
         return Ok(auth.clone());
     }
 
-    let rotated = refresh_token(client, workos_url, client_id, &auth.refresh_token, None)
-        .await
-        .map_err(|e| e.context("session expired and token refresh failed — run `spelunk login`"))?
-        .into_auth_tokens();
+    let rotated = refresh_token(
+        client,
+        workos_url,
+        client_id,
+        &auth.refresh_token,
+        org_id_for_refresh(&auth.org_id),
+    )
+    .await
+    .map_err(|e| e.context("session expired and token refresh failed — run `spelunk login`"))?
+    .into_auth_tokens();
     persist(&rotated)?;
     Ok(rotated)
+}
+
+/// The `organization_id` to re-request on a plain refresh: `auth.org_id` when
+/// set, `None` when empty (an orgless account, or tokens predating org
+/// tracking) so the refresh grant falls back to its default-org behaviour
+/// instead of sending an empty `organization_id` form field.
+pub(crate) fn org_id_for_refresh(org_id: &str) -> Option<&str> {
+    (!org_id.is_empty()).then_some(org_id)
 }
 
 /// Resolve the bearer token to send to cloud-api, refreshing the stored WorkOS
@@ -684,7 +704,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_fresh_token_refreshes_and_persists_when_expired() {
         use std::sync::{Arc, Mutex};
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{body_string_contains, method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
@@ -692,6 +712,7 @@ mod tests {
             fake_jwt(&serde_json::json!({ "exp": 5_000_000_000_i64, "org_id": "org_1" }));
         Mock::given(method("POST"))
             .and(path("/user_management/authenticate"))
+            .and(body_string_contains("organization_id=org_1"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "access_token": fresh_jwt,
                 "refresh_token": "rt-rotated",
@@ -725,6 +746,108 @@ mod tests {
             "rt-rotated",
             "rotated tokens must be persisted"
         );
+    }
+
+    /// Regression test for the org-switch-doesn't-stick bug: a refresh of an
+    /// expired token scoped to a switched-to org (`auth.org_id`) must re-send
+    /// that same org as `organization_id`, so the session stays scoped to it
+    /// instead of silently reverting to the account's default org.
+    #[tokio::test]
+    async fn ensure_fresh_token_preserves_switched_org_across_refresh() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let fresh_jwt =
+            fake_jwt(&serde_json::json!({ "exp": 5_000_000_000_i64, "org_id": "org_switched" }));
+        // The mock only answers a request whose form body names the switched
+        // org; a plain refresh (no organization_id) would 404 here instead.
+        Mock::given(method("POST"))
+            .and(path("/user_management/authenticate"))
+            .and(body_string_contains("organization_id=org_switched"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": fresh_jwt,
+                "refresh_token": "rt-rotated",
+                "organization_id": "org_switched",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Simulates state right after `org switch org_switched`: the access
+        // token has since expired, but auth.org_id still names the switched org.
+        let expired_after_switch = AuthTokens {
+            access_token: "at-expired".into(),
+            refresh_token: "rt-old".into(),
+            expires_at: 0,
+            org_id: "org_switched".into(),
+        };
+
+        let client = build_client().unwrap();
+        let out = ensure_fresh_token(
+            &client,
+            &server.uri(),
+            "client_test",
+            &expired_after_switch,
+            |_| Ok(()),
+        )
+        .await
+        .expect("refresh scoped to the switched org should succeed");
+
+        assert_eq!(
+            out.org_id, "org_switched",
+            "the rotated token must stay scoped to the switched org, not revert to the default"
+        );
+    }
+
+    /// An account with no active org (`org_id` empty — e.g. tokens from before
+    /// `org switch` was ever used) falls back to a plain refresh: no
+    /// `organization_id` field is sent at all, matching prior behaviour.
+    #[tokio::test]
+    async fn ensure_fresh_token_empty_org_id_sends_plain_refresh() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+        struct AssertNoOrgId;
+        impl Respond for AssertNoOrgId {
+            fn respond(&self, request: &Request) -> ResponseTemplate {
+                let body = String::from_utf8_lossy(&request.body);
+                assert!(
+                    !body.contains("organization_id"),
+                    "an empty org_id must not send organization_id at all, got body: {body}"
+                );
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "access_token": fake_jwt(&serde_json::json!({ "exp": 5_000_000_000_i64 })),
+                    "refresh_token": "rt-rotated",
+                }))
+            }
+        }
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/user_management/authenticate"))
+            .respond_with(AssertNoOrgId)
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let expired_no_org = AuthTokens {
+            access_token: "at-expired".into(),
+            refresh_token: "rt-old".into(),
+            expires_at: 0,
+            org_id: String::new(),
+        };
+
+        let client = build_client().unwrap();
+        ensure_fresh_token(
+            &client,
+            &server.uri(),
+            "client_test",
+            &expired_no_org,
+            |_| Ok(()),
+        )
+        .await
+        .expect("plain refresh with no org should still succeed");
     }
 
     /// When the refresh grant is rejected (revoked/expired refresh token), the

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -259,11 +259,12 @@ impl ServerInferenceClient {
     /// is no refresh state (a bare `server_key` — nothing to refresh). Errors
     /// carry a clear "re-run `spelunk login`" message.
     async fn refresh_access_token(&self) -> Result<bool> {
-        let (refresh_token, workos_url, client_id, config_path) = {
+        let (refresh_token, org_id, workos_url, client_id, config_path) = {
             let guard = self.auth.lock().expect("auth mutex poisoned");
             match &guard.refresh {
                 Some(r) => (
                     r.tokens.refresh_token.clone(),
+                    r.tokens.org_id.clone(),
                     r.workos_url.clone(),
                     r.client_id.clone(),
                     r.config_path.clone(),
@@ -272,12 +273,20 @@ impl ServerInferenceClient {
             }
         };
 
-        let rotated =
-            auth_api::refresh_token(&self.client, &workos_url, &client_id, &refresh_token, None)
-                .await
-                .map_err(|e| {
-                    e.context("session expired and token refresh failed — re-run `spelunk login`")
-                })?;
+        // Re-send the active org so a prior `org switch` survives rotation
+        // instead of reverting to the account's default org (see auth_api::
+        // ensure_fresh_token, which has the same requirement).
+        let rotated = auth_api::refresh_token(
+            &self.client,
+            &workos_url,
+            &client_id,
+            &refresh_token,
+            auth_api::org_id_for_refresh(&org_id),
+        )
+        .await
+        .map_err(|e| {
+            e.context("session expired and token refresh failed — re-run `spelunk login`")
+        })?;
         let new_tokens = rotated.into_auth_tokens();
 
         // Persist rotated tokens so the next process starts authenticated.
@@ -616,7 +625,7 @@ pub fn harvest_requires_server() -> anyhow::Error {
 mod tests {
     use super::*;
     use spelunk_core::config::AuthTokens;
-    use wiremock::matchers::{header, method, path};
+    use wiremock::matchers::{body_string_contains, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn expiring_tokens(expires_at: i64) -> AuthTokens {
@@ -740,8 +749,11 @@ mod tests {
 
         let at_fresh = jwt("fresh", "org_1", 5_000_000_000);
 
+        // The refresh request must carry the stored `org_1` scope, so it never
+        // silently reverts to the account's default org on rotation.
         Mock::given(method("POST"))
             .and(path("/user_management/authenticate"))
+            .and(body_string_contains("organization_id=org_1"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "access_token": at_fresh,
                 "refresh_token": "rt-fresh",


### PR DESCRIPTION
## Summary

`spelunk org switch <org>` re-scopes the session by rotating the WorkOS access token with an `organization_id`, but that switched-to org lived only inside the short-lived (~5 minute) access token. Nothing re-applied it when that token was refreshed. Both places in the CLI that perform a token refresh (`ensure_fresh_token` in `auth_api.rs`, used for cloud-api calls, and `ServerInferenceClient::refresh_access_token` in `server_client.rs`, used for the team/loopback server bearer) hardcoded `organization_id: None` on the refresh-grant request. WorkOS's refresh grant with no `organization_id` reverts the session to the account's default org.

Net effect: the first token refresh after any `org switch` — triggered by the next `memory push`, `sync`, or other cloud-api/team-server call — silently reverted the session to the default org and persisted the reverted token, with no error or warning. Anything pushed after that point landed in the wrong org (cross-tenant misrouting in the multi-org / consultant scenario).

The durable state needed to fix this already existed — `AuthTokens.org_id` is persisted on disk by both `login` and `org switch` — it just wasn't being read back out at the refresh call sites.

## Fix

- `auth_api.rs`: `ensure_fresh_token` now passes the persisted `auth.org_id` through to `refresh_token` via a new shared helper, `org_id_for_refresh()`, instead of hardcoding `None`.
- `server_client.rs`: the second, independent refresh implementation (`ServerInferenceClient::refresh_access_token`) had the identical bug and gets the same fix.
- `org_id_for_refresh(org_id: &str) -> Option<&str>` maps an empty `org_id` (orgless account, or tokens predating org tracking) to `None`, preserving the prior plain-refresh wire behavior for that case; a non-empty `org_id` is sent as `organization_id`, so a switched org survives rotation.

## Test plan

Verified in this review, from a fresh worktree on this branch:

- `git fetch origin && git log origin/main..HEAD --oneline` / `git log HEAD..origin/main --oneline` — branch is 2 commits ahead, some commits behind main; confirmed via `git merge-tree` that there are no merge conflicts, and the new main commits touch only embed/search/status/init code, disjoint from the two files this PR changes.
- Read the full diff end-to-end: both refresh call sites now thread the persisted org id through instead of hardcoding `None`; `org_id_for_refresh` is shared and correctly falls back to a plain refresh for empty org ids.
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` (whole workspace) — clean.
- `SPELUNK_SECRET_STORE=file cargo test` (whole workspace, default features) — 1174 passed, 0 failed, across all crates and test binaries.
- `SPELUNK_SECRET_STORE=file cargo test --no-default-features` (whole workspace) — 1173 passed, 0 failed.
- Ran the two new regression tests (`ensure_fresh_token_preserves_switched_org_across_refresh`, `ensure_fresh_token_empty_org_id_sends_plain_refresh`) and the two updated ones (`ensure_fresh_token_refreshes_and_persists_when_expired`, `proactive_refresh_when_locally_expired`) — each asserts the actual request body sent to the mock WorkOS server carries (or omits) `organization_id` as expected.
- Manual acceptance check of the described scenario: `org switch X` followed by a forced-expiry refresh now keeps the rotated token's org scoped to `X` (exercised at the unit level via wiremock, since this repo has no existing integration harness that mocks cloud-api's ingest endpoint).

## Not this PR

A separate, unrelated 500 on first-ingest to a genuinely fresh org (no existing project) is a distinct lead tracked elsewhere.