### PR TITLE
Fix memory push/sync honesty: attempted count, remote_id stamping, and result reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,31 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   alongside the existing `t` timestamp parameter and returns the matching
   envelope shape when it is used; `spelunk memory since` (which still uses
   `t`) is unaffected.
+- **`spelunk memory push` and `spelunk memory sync` no longer claim to have
+  pushed entries that were never sent, never durably persisted, or that the
+  server rejected.** Three bugs in the same push path could each make "Done.
+  Pushed N entries" (or `sync`'s equivalent) print when nothing meaningful had
+  happened. The reported count was the number of sync-eligible rows rather
+  than the rows actually included in the batch request, so a push where every
+  row was already synced — no HTTP request sent at all — still printed
+  "Pushed N entries." Separately, a batch item was stamped with the local
+  `remote_id` that permanently excludes a row from all future pushes as soon
+  as the server's response carried an id for it, without checking the item's
+  own reported status first; a response that returned an id for an entry it
+  had not actually persisted would silently and permanently take that row out
+  of every future retry. And the summary trusted the server's aggregate
+  `created`/`skipped` counters instead of the authoritative per-item
+  `results[]` list, so a batch whose aggregate counters understated what
+  happened (observed: a server reporting `created: 0` for entries it had in
+  fact persisted) was reported exactly as understated, not as what actually
+  happened. All three are fixed: the reported count now reflects rows
+  actually sent, a row is only stamped as synced when its own status
+  affirmatively means the server durably has it, and created/skipped/failed
+  counts are reconciled from per-item results (the aggregate counters are used
+  only as a fallback when the server sends no per-item detail at all). A push
+  where nothing was sent now reads "Nothing to push — N entries already
+  synced." instead of implying work was done, and a batch with a partial
+  failure reports the real successes and failures instead of masking them.
 - **Concurrent memory writes can no longer silently erase each other's
   entries.** The git-notes write path is a read-modify-write of the note on
   `HEAD`, and nothing serialized it: two simultaneous `memory add` commands

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -61,7 +61,14 @@ pub async fn memory_push(
     println!("Pushing local memory to {base_url}…");
     let summary = push_local_oneway(&local, &client, args.include_archived).await?;
     if summary.attempted == 0 {
-        println!("No local memory entries to push.");
+        if summary.already_synced > 0 {
+            println!(
+                "Nothing to push — {} entries already synced.",
+                summary.already_synced
+            );
+        } else {
+            println!("No local memory entries to push.");
+        }
     } else {
         println!(
             "Done. Pushed {} entries (created {}, skipped {}).",

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -69,6 +69,11 @@ pub async fn memory_push(
         } else {
             println!("No local memory entries to push.");
         }
+    } else if summary.failed > 0 {
+        println!(
+            "Done. Pushed {} entries (created {}, skipped {}, {} failed).",
+            summary.attempted, summary.created, summary.skipped, summary.failed
+        );
     } else {
         println!(
             "Done. Pushed {} entries (created {}, skipped {}).",

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -229,7 +229,17 @@ async fn push_local(
         // Record cloud ids for created entries so a later pull dedupes them and
         // a later archive can tombstone them by id.
         for item in &res.results {
-            if let (Some(ext), Some(cloud_id)) = (item.external_id.as_deref(), item.id.as_deref())
+            // Stamping `remote_id` is permanent (it's what excludes a row from
+            // `live` on every future push), so only do it for a status that
+            // affirmatively means the cloud durably has this row: `created`
+            // (just persisted) or `skipped` (already persisted — dedup on
+            // identity). Any other status — `failed`, or an id riding along
+            // with a status that doesn't mean persisted — must not stamp, or
+            // that row can never be retried again.
+            let durably_persisted = item.status == "created" || item.status == "skipped";
+            if durably_persisted
+                && let (Some(ext), Some(cloud_id)) =
+                    (item.external_id.as_deref(), item.id.as_deref())
                 && let Some(row) = chunk.iter().find(|r| r.uuid == ext)
             {
                 local.set_remote_id(row.local_id, cloud_id)?;
@@ -529,5 +539,63 @@ mod tests {
         );
         // No duplicate local rows introduced by the round trip.
         assert_eq!(store.count().unwrap(), 2);
+    }
+
+    // ── stamping must not trust a non-persisted status ─────────────────────
+    // Reproduces the reopened cloud-api^109 incident: the server returned a
+    // per-item `id` for an entry alongside a status that does not affirm
+    // durable persistence (aggregate `created: 0`). Stamping `remote_id`
+    // anyway would permanently exclude the row from `live` on every future
+    // push — the data could never be retried. Only `created`/`skipped` may
+    // stamp; a `failed` item carrying an `id` must be left unstamped.
+    #[tokio::test]
+    async fn push_local_does_not_stamp_remote_id_for_a_failed_status_item() {
+        use tempfile::TempDir;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        store
+            .add_note("decision", "One", "first", &[], &[], None, None)
+            .unwrap();
+
+        let rows = store.rows_for_sync(false).unwrap();
+        assert_eq!(rows.len(), 1);
+        let ext_a = rows[0].uuid.clone();
+        // The server hands back an `id` even though the entry was not
+        // durably persisted (`created: 0`, status "failed") — exactly the
+        // shape of the reopened cloud-api^109 bug.
+        let cloud_a = "01890000-0000-7000-8000-0000000000b1";
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 0, "skipped": 0, "failed": 1,
+                "results": [
+                    {"status": "failed", "external_id": ext_a, "id": cloud_a},
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        let s1 = push_local(&store, &client, false).await.unwrap();
+        assert_eq!((s1.attempted, s1.created, s1.skipped), (1, 0, 0));
+
+        // The row must NOT carry the id the server handed back — it stays
+        // retryable on the next push.
+        assert_eq!(store.note_id_for_remote_id(cloud_a).unwrap(), None);
+        let rows_after = store.rows_for_sync(false).unwrap();
+        assert_eq!(rows_after[0].remote_id, None);
+
+        // A re-push must still consider this row live (not already-synced).
+        let live_again: Vec<_> = rows_after
+            .iter()
+            .filter(|r| !r.archived && r.remote_id.is_none())
+            .collect();
+        assert_eq!(live_again.len(), 1, "unstamped row must remain retryable");
     }
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -133,18 +133,32 @@ pub async fn memory_sync(
     // ── Pull cloud → local (delta after the UUID cursor, keep-both) ─────────
     let pulled = pull_and_apply(&local, &client).await?;
 
-    println!(
-        "Sync complete. Pushed {} entries (created {}, skipped {}), applied {} new remote entries.",
-        pushed.attempted, pushed.created, pushed.skipped, pulled
-    );
+    if pushed.attempted == 0 {
+        println!(
+            "Nothing to push — {} entries already synced. Applied {} new remote entries.",
+            pushed.already_synced, pulled
+        );
+    } else {
+        println!(
+            "Sync complete. Pushed {} entries (created {}, skipped {}), applied {} new remote entries.",
+            pushed.attempted, pushed.created, pushed.skipped, pulled
+        );
+    }
     Ok(())
 }
 
 /// Outcome of a push pass (shared by `sync` and the one-way `memory push`).
 pub(super) struct PushSummary {
+    /// Rows actually sent to `push_batch` (the `live` set) — not the raw
+    /// pre-filter row count, which would over-report when rows are already
+    /// synced (`remote_id` already set) and no request is made at all.
     pub attempted: usize,
     pub created: u32,
     pub skipped: u32,
+    /// Non-archived rows already carrying a `remote_id` — i.e. previously
+    /// synced and excluded from `attempted`. Lets callers report an honest
+    /// "nothing to push" message instead of implying a push happened.
+    pub already_synced: usize,
 }
 
 /// One-way push entry point reused by `spelunk memory push`.
@@ -164,12 +178,12 @@ async fn push_local(
     include_archived: bool,
 ) -> Result<PushSummary> {
     let rows = local.rows_for_sync(include_archived)?;
-    let attempted = rows.len();
     if rows.is_empty() {
         return Ok(PushSummary {
             attempted: 0,
             created: 0,
             skipped: 0,
+            already_synced: 0,
         });
     }
 
@@ -186,6 +200,11 @@ async fn push_local(
         .iter()
         .filter(|r| !r.archived && r.remote_id.is_none())
         .collect();
+    let already_synced = rows
+        .iter()
+        .filter(|r| !r.archived && r.remote_id.is_some())
+        .count();
+    let attempted = live.len();
     // Map external_id (local uuid) → local_id so we can record the cloud-minted
     // id returned in the 207 result back onto the local row.
     for chunk in live.chunks(200) {
@@ -239,6 +258,7 @@ async fn push_local(
         attempted,
         created,
         skipped,
+        already_synced,
     })
 }
 
@@ -497,9 +517,11 @@ mod tests {
         assert_eq!(store.max_remote_id().unwrap().as_deref(), Some(cloud_b));
 
         // Second push: every row carries a `remote_id`, so the live set is empty
-        // and no batch request is sent — the re-sync is a no-op.
+        // and no batch request is sent — the re-sync is a no-op. `attempted` must
+        // reflect that (not the raw row count), so callers never report "Pushed
+        // N" when nothing was sent.
         let s2 = push_local(&store, &client, false).await.unwrap();
-        assert_eq!(s2.created, 0);
+        assert_eq!((s2.attempted, s2.created, s2.already_synced), (0, 0, 2));
         assert_eq!(
             server.received_requests().await.unwrap().len(),
             1,

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -138,6 +138,11 @@ pub async fn memory_sync(
             "Nothing to push — {} entries already synced. Applied {} new remote entries.",
             pushed.already_synced, pulled
         );
+    } else if pushed.failed > 0 {
+        println!(
+            "Sync complete. Pushed {} entries (created {}, skipped {}, {} failed), applied {} new remote entries.",
+            pushed.attempted, pushed.created, pushed.skipped, pushed.failed, pulled
+        );
     } else {
         println!(
             "Sync complete. Pushed {} entries (created {}, skipped {}), applied {} new remote entries.",
@@ -153,8 +158,20 @@ pub(super) struct PushSummary {
     /// pre-filter row count, which would over-report when rows are already
     /// synced (`remote_id` already set) and no request is made at all.
     pub attempted: usize,
+    /// Tallied from `results[].status`, not the server's own aggregate
+    /// `created`/`skipped` ints — the two are independent wire fields
+    /// (`BatchPushResult`) and can diverge (a server has been observed
+    /// reporting aggregate `created: 0` for a batch whose per-item results
+    /// showed entries durably persisted). `results[]` is the reconciled
+    /// signal.
     pub created: u32,
     pub skipped: u32,
+    /// Items whose status did not affirmatively mean "durably persisted"
+    /// — anything other than `created`/`skipped` (`failed`, or an
+    /// unrecognized status riding along with a result). Kept separate so a
+    /// partial-failure batch still reports its real successes instead of
+    /// reading as "nothing happened".
+    pub failed: u32,
     /// Non-archived rows already carrying a `remote_id` — i.e. previously
     /// synced and excluded from `attempted`. Lets callers report an honest
     /// "nothing to push" message instead of implying a push happened.
@@ -183,6 +200,7 @@ async fn push_local(
             attempted: 0,
             created: 0,
             skipped: 0,
+            failed: 0,
             already_synced: 0,
         });
     }
@@ -191,6 +209,7 @@ async fn push_local(
     // archived entries already known to the cloud (tombstoned via DELETE).
     let mut created = 0u32;
     let mut skipped = 0u32;
+    let mut failed = 0u32;
 
     // Push set (decision #183): live entries not yet on the cloud — i.e.
     // `WHERE remote_id IS NULL`. Already-synced rows carry a `remote_id` and are
@@ -223,12 +242,32 @@ async fn push_local(
             })
             .collect();
         let res = client.push_batch(items).await?;
-        created += res.created;
-        skipped += res.skipped;
+
+        // `created`/`skipped`/`failed` (aggregate ints) and `results[]`
+        // (per-item) are independent fields on `BatchPushResult` — nothing on
+        // the wire guarantees they agree, and a server can send an aggregate
+        // `created: 0` for a batch whose `results[]` shows the entries
+        // durably persisted. The aggregate ints are NOT trusted here: tally
+        // from `results[].status`, the reconciled signal, and only fall back
+        // to the aggregate when the server sent no per-item detail at all to
+        // reconcile against.
+        if res.results.is_empty() {
+            created += res.created;
+            skipped += res.skipped;
+            failed += res.failed;
+        }
 
         // Record cloud ids for created entries so a later pull dedupes them and
         // a later archive can tombstone them by id.
         for item in &res.results {
+            match item.status.as_str() {
+                "created" => created += 1,
+                "skipped" => skipped += 1,
+                // Anything else — `"failed"`, or an unrecognized status — did
+                // not affirmatively land; count it as failed rather than
+                // silently dropping it from every tally.
+                _ => failed += 1,
+            }
             // Stamping `remote_id` is permanent (it's what excludes a row from
             // `live` on every future push), so only do it for a status that
             // affirmatively means the cloud durably has this row: `created`
@@ -268,6 +307,7 @@ async fn push_local(
         attempted,
         created,
         skipped,
+        failed,
         already_synced,
     })
 }
@@ -542,12 +582,12 @@ mod tests {
     }
 
     // ── stamping must not trust a non-persisted status ─────────────────────
-    // Reproduces the reopened cloud-api^109 incident: the server returned a
-    // per-item `id` for an entry alongside a status that does not affirm
-    // durable persistence (aggregate `created: 0`). Stamping `remote_id`
-    // anyway would permanently exclude the row from `live` on every future
-    // push — the data could never be retried. Only `created`/`skipped` may
-    // stamp; a `failed` item carrying an `id` must be left unstamped.
+    // A server can return a per-item `id` for an entry alongside a status
+    // that does not affirm durable persistence (aggregate `created: 0`).
+    // Stamping `remote_id` anyway would permanently exclude the row from
+    // `live` on every future push — the data could never be retried. Only
+    // `created`/`skipped` may stamp; a `failed` item carrying an `id` must be
+    // left unstamped.
     #[tokio::test]
     async fn push_local_does_not_stamp_remote_id_for_a_failed_status_item() {
         use tempfile::TempDir;
@@ -565,8 +605,7 @@ mod tests {
         assert_eq!(rows.len(), 1);
         let ext_a = rows[0].uuid.clone();
         // The server hands back an `id` even though the entry was not
-        // durably persisted (`created: 0`, status "failed") — exactly the
-        // shape of the reopened cloud-api^109 bug.
+        // durably persisted (`created: 0`, status "failed").
         let cloud_a = "01890000-0000-7000-8000-0000000000b1";
 
         let server = MockServer::start().await;
@@ -597,5 +636,128 @@ mod tests {
             .filter(|r| !r.archived && r.remote_id.is_none())
             .collect();
         assert_eq!(live_again.len(), 1, "unstamped row must remain retryable");
+    }
+
+    // ── counts must reconcile against results[], not the aggregate ints ────
+    // `BatchPushResult`'s `created`/`skipped` ints and its `results[]` array
+    // are independent wire fields — a server can send an aggregate
+    // `created: 0` for a batch whose `results[]` shows every entry durably
+    // persisted. A push summary built from the aggregate ints alone would
+    // read as "nothing landed"; it must instead read the true outcome off
+    // `results[].status`.
+    #[tokio::test]
+    async fn push_local_reconciles_counts_from_results_not_aggregate_ints() {
+        use tempfile::TempDir;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        store
+            .add_note("decision", "One", "first", &[], &[], None, None)
+            .unwrap();
+        store
+            .add_note("note", "Two", "second", &[], &[], None, None)
+            .unwrap();
+
+        let rows = store.rows_for_sync(false).unwrap();
+        let (ext_a, ext_b) = (rows[0].uuid.clone(), rows[1].uuid.clone());
+        let cloud_a = "01890000-0000-7000-8000-0000000000c1";
+        let cloud_b = "01890000-0000-7000-8000-0000000000c2";
+
+        let server = MockServer::start().await;
+        // The aggregate ints understate what happened (`created: 0, skipped:
+        // 0`), but `results[]` shows both entries durably persisted.
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 0, "skipped": 0, "failed": 0,
+                "results": [
+                    {"status": "created", "external_id": ext_a, "id": cloud_a},
+                    {"status": "skipped", "external_id": ext_b, "id": cloud_b},
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        let s1 = push_local(&store, &client, false).await.unwrap();
+        // Reconciled from `results[]`, not the misleading aggregate zeros.
+        assert_eq!(
+            (s1.attempted, s1.created, s1.skipped, s1.failed),
+            (2, 1, 1, 0)
+        );
+        assert_eq!(
+            store.note_id_for_remote_id(cloud_a).unwrap(),
+            Some(rows[0].local_id)
+        );
+        assert_eq!(
+            store.note_id_for_remote_id(cloud_b).unwrap(),
+            Some(rows[1].local_id)
+        );
+    }
+
+    // ── a failed item must not mask other successes in the same batch ─────
+    // Mixed outcome: one entry lands, one doesn't. The failed item must stay
+    // unstamped (retryable) while the successful one is recorded — and the
+    // summary must show the real partial success, not a false "nothing
+    // happened" (which is what reading only the aggregate `created` count
+    // for a batch containing any failure could produce).
+    #[tokio::test]
+    async fn push_local_partial_failure_reports_the_real_successes() {
+        use tempfile::TempDir;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        store
+            .add_note("decision", "One", "first", &[], &[], None, None)
+            .unwrap();
+        store
+            .add_note("note", "Two", "second", &[], &[], None, None)
+            .unwrap();
+
+        let rows = store.rows_for_sync(false).unwrap();
+        let (ext_a, ext_b) = (rows[0].uuid.clone(), rows[1].uuid.clone());
+        let cloud_a = "01890000-0000-7000-8000-0000000000d1";
+        let cloud_b = "01890000-0000-7000-8000-0000000000d2";
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 1, "skipped": 0, "failed": 1,
+                "results": [
+                    {"status": "created", "external_id": ext_a, "id": cloud_a},
+                    {"status": "failed", "external_id": ext_b, "id": cloud_b},
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        let s1 = push_local(&store, &client, false).await.unwrap();
+        assert_eq!(
+            (s1.attempted, s1.created, s1.skipped, s1.failed),
+            (2, 1, 0, 1),
+            "attempted must stay 2 (not read as nothing-to-push) and the \
+             genuine success must be visible alongside the failure"
+        );
+        // The successful row is stamped...
+        assert_eq!(
+            store.note_id_for_remote_id(cloud_a).unwrap(),
+            Some(rows[0].local_id)
+        );
+        // ...the failed one is not, and remains retryable.
+        assert_eq!(store.note_id_for_remote_id(cloud_b).unwrap(), None);
+        let rows_after = store.rows_for_sync(false).unwrap();
+        let live_again: Vec<_> = rows_after
+            .iter()
+            .filter(|r| !r.archived && r.remote_id.is_none())
+            .collect();
+        assert_eq!(live_again.len(), 1, "failed row must remain retryable");
     }
 }


### PR DESCRIPTION
## Summary
- `push_local`'s reported \`attempted\` count now reflects rows actually sent (the live set), not the raw pre-filter row count, so a push where every row is already synced no longer prints "Pushed N entries" when nothing was sent.
- \`remote_id\` stamping is now gated on the batch result's per-item status: only \`created\`/\`skipped\` (both mean the server durably has the row) may stamp. A response that hands back an id for an item whose status doesn't affirm persistence (e.g. \`failed\`) leaves the row unstamped and retryable, instead of permanently locking it out of future pushes.
- Created/skipped/failed counts are now reconciled from the per-item \`results[]\` array rather than trusted from the response's aggregate integers, which can diverge from what \`results[]\` actually shows.
- \`memory push\` and \`memory sync\` messaging updated to say "Nothing to push — N entries already synced" instead of implying a push happened, and to surface partial-failure counts honestly.

## Test plan
- \`cargo test --workspace --features rich-formats\` — 285+ tests, 0 failures (new tests: \`push_local_does_not_stamp_remote_id_for_a_failed_status_item\`, \`push_local_reconciles_counts_from_results_not_aggregate_ints\`, \`push_local_partial_failure_reports_the_real_successes\`, plus the updated idempotent-repush assertion).
- \`cargo test --workspace --no-default-features\` — 285 tests, 0 failures.
- \`cargo clippy --workspace --features rich-formats --all-targets -- -D warnings\` — clean.
- Note: two unrelated pre-existing tests in \`capability.rs\` (\`probe_url_explicit_non_success_status_does_not_set_any_probe_failure\`, \`probe_url_auto_discovered_connection_refused_leaves_probe_failure_unset\`) are order-dependent on a \`OnceCell\` global and fail nondeterministically depending on test run order regardless of this change — filed separately, excluded from the runs above with \`--skip\`.