### PR TITLE
Forward the parent's resolved config and index flags to detached child processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -408,6 +408,21 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   or warning. Anything pushed after that point landed in the wrong org.
   Refreshes now re-send the durably stored active org, so a switched org
   survives rotation and stays in effect until you switch again.
+- **`spelunk index` on repos over 100 files could summarize against the wrong
+  config, or silently ignore `--no-summaries`/`--summary-batch-size`, once
+  indexing continued in its detached background phase.** Above the 100-file
+  threshold, indexing hands graph rank, spec discovery, and LLM summaries to a
+  detached child process; that child (and the separate one spawned by
+  `--detach-embed`) rebuilt its own command line from scratch instead of
+  forwarding the parent's, so it re-resolved the default config in place of
+  whatever `--config` the parent had resolved (summarizing against the wrong
+  config, or skipping the pass entirely if that default config has no chat
+  model configured), and dropped `--summary-batch-size` from both spawns and
+  `--no-summaries` from the background-phases spawn (so a run given
+  `--no-summaries` could still generate them in the background). All three are
+  now forwarded through one shared argv-building function used by both spawn
+  sites. `spelunk index` still exits 0 if summarization fails in the child;
+  this only changes what the child is given, not what it does with a failure.
 
 ## [0.9.3] — 2026-07-08
 

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -664,6 +664,92 @@ mod tests {
         );
     }
 
+    #[test]
+    fn detached_child_command_forwards_config_path_when_resolved() {
+        // Before the fix, `IndexArgs` had no config-path field at all, so
+        // neither spawn could forward a resolved `--config` override and the
+        // child re-resolved the default config instead.
+        let mut args = sample_index_args();
+        args.config_path = Some(std::path::PathBuf::from("/tmp/custom-config.toml"));
+        let cmd = build_detached_child_command(
+            std::path::Path::new("/usr/bin/spelunk"),
+            "--_background-phases",
+            &args,
+        );
+        let argv: Vec<_> = cmd.get_args().collect();
+        let pos = argv
+            .iter()
+            .position(|a| *a == "--config")
+            .expect("--config must be forwarded when the parent resolved an override");
+        assert_eq!(argv[pos + 1], "/tmp/custom-config.toml");
+    }
+
+    #[test]
+    fn detached_child_command_omits_config_flag_when_not_resolved() {
+        // A default-config run must not force an explicit `--config` onto the
+        // child: `config_path` is `None` when the user passed no override, and
+        // an unconditional `--config` would stop the child from resolving its
+        // own default the way the parent did.
+        let args = sample_index_args();
+        assert!(args.config_path.is_none());
+        let cmd = build_detached_child_command(
+            std::path::Path::new("/usr/bin/spelunk"),
+            "--_background-phases",
+            &args,
+        );
+        let argv: Vec<_> = cmd.get_args().collect();
+        assert!(
+            !argv.iter().any(|a| *a == "--config"),
+            "must not add --config when the parent had no override"
+        );
+    }
+
+    #[test]
+    fn detached_child_command_forwards_no_summaries_to_both_spawn_sites() {
+        // Before the fix the phases-3-5 background spawn built its argv
+        // independently and never included `--no-summaries` at all (only the
+        // embed-phase spawn did), so disabling summaries still let the
+        // background child generate them.
+        let mut args = sample_index_args();
+        args.no_summaries = true;
+        for mode_flag in ["--_background-phases", "--_embed-phases"] {
+            let cmd = build_detached_child_command(
+                std::path::Path::new("/usr/bin/spelunk"),
+                mode_flag,
+                &args,
+            );
+            let argv: Vec<_> = cmd.get_args().collect();
+            assert!(
+                argv.iter().any(|a| *a == "--no-summaries"),
+                "--no-summaries must reach the {mode_flag} child"
+            );
+        }
+    }
+
+    #[test]
+    fn detached_child_command_forwards_configured_summary_batch_size_to_both_spawn_sites() {
+        // Before the fix neither spawn forwarded `--summary-batch-size`, so a
+        // custom value silently reset to the default (10) in whichever child
+        // ran phase 4.
+        let args = TestCli::try_parse_from(["spelunk", "some/path", "--summary-batch-size", "42"])
+            .expect("parse")
+            .index;
+        assert_eq!(args.summary_batch_size, 42);
+        for mode_flag in ["--_background-phases", "--_embed-phases"] {
+            let cmd = build_detached_child_command(
+                std::path::Path::new("/usr/bin/spelunk"),
+                mode_flag,
+                &args,
+            );
+            let argv: Vec<_> = cmd.get_args().collect();
+            let pos = argv
+                .iter()
+                .position(|a| *a == "--summary-batch-size")
+                .expect("--summary-batch-size must be forwarded");
+            assert_eq!(argv[pos + 1], "42");
+        }
+    }
+
     // ── embed_skipped_lines: 0-chunks / offline notice (#5) ─────────────────────
 
     #[test]

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -58,6 +58,14 @@ pub struct IndexArgs {
     /// detached run has chunks left to embed).
     #[arg(long, default_value_t = false)]
     pub detach_embed: bool,
+
+    /// The `--config` override this process itself resolved, if any. Not part
+    /// of the `index` subcommand's own argv: `--config` is a global `Cli`-level
+    /// flag, so `main` fills this in after parsing. Threaded through so the
+    /// detached-child spawns below can forward the same override rather than
+    /// have the child re-resolve the default config.
+    #[arg(skip)]
+    pub config_path: Option<PathBuf>,
 }
 
 use crate::{capability, config::Config, registry::Registry, storage::Database};
@@ -242,14 +250,8 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     if result.indexed > 100 {
         eprintln!("Spawning background job for graph rank, spec discovery, and summaries\u{2026}");
         let log = background_log_path(&db_path);
-        let mut cmd = std::process::Command::new(std::env::current_exe()?);
-        cmd.arg("index");
-        cmd.arg(&args.path);
-        cmd.arg("--_background-phases");
-        if let Some(db_arg) = &args.db {
-            cmd.args(["--db", &db_arg.to_string_lossy()]);
-        }
-        cmd.stdin(std::process::Stdio::null());
+        let mut cmd =
+            build_detached_child_command(&std::env::current_exe()?, "--_background-phases", &args);
         let in_use = redirect_to_background_log(&mut cmd, log.as_deref());
         if let Some(p) = in_use {
             eprintln!("  Log: {}", p.display());
@@ -308,6 +310,42 @@ enum EmbedSpawn<'a> {
     Detached(Option<&'a std::path::Path>),
 }
 
+/// Build the argv shared by every detached re-exec that continues indexing in
+/// a child process: the child parses its own fresh `IndexArgs`/`Config` from
+/// this argv rather than inheriting the parent's already-parsed values, so
+/// anything the parent resolved that isn't a plain pass-through of `args`
+/// itself (the global `--config` override) or on this list (`--no-summaries`,
+/// `--summary-batch-size`) would otherwise silently reset to its default in
+/// the child. `mode_flag` selects which internal phase-only mode the child
+/// runs (`--_background-phases` or `--_embed-phases`); callers append any
+/// mode-specific flags (e.g. `--batch-size` for the embed phase) afterwards.
+///
+/// Env vars and cwd are not part of this contract: `std::process::Command`
+/// inherits both by default and nothing here calls `.env_clear()` or
+/// `.current_dir()` to opt out (see the regression test below).
+fn build_detached_child_command(
+    exe: &std::path::Path,
+    mode_flag: &str,
+    args: &IndexArgs,
+) -> std::process::Command {
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("index");
+    cmd.arg(&args.path);
+    cmd.arg(mode_flag);
+    if let Some(db_arg) = &args.db {
+        cmd.args(["--db", &db_arg.to_string_lossy()]);
+    }
+    if let Some(cfg_path) = &args.config_path {
+        cmd.args(["--config", &cfg_path.to_string_lossy()]);
+    }
+    if args.no_summaries {
+        cmd.arg("--no-summaries");
+    }
+    cmd.args(["--summary-batch-size", &args.summary_batch_size.to_string()]);
+    cmd.stdin(std::process::Stdio::null());
+    cmd
+}
+
 /// Spawn a detached background process to run the embed phase (plus phases 3–5)
 /// against the chunks the foreground run just parsed, reusing the internal
 /// `--_embed-phases` mode. Mirrors the phases-3–5 background spawn: the parent
@@ -316,18 +354,8 @@ fn spawn_embed_subprocess<'a>(
     args: &IndexArgs,
     log: Option<&'a std::path::Path>,
 ) -> Result<EmbedSpawn<'a>> {
-    let mut cmd = std::process::Command::new(std::env::current_exe()?);
-    cmd.arg("index");
-    cmd.arg(&args.path);
-    cmd.arg("--_embed-phases");
+    let mut cmd = build_detached_child_command(&std::env::current_exe()?, "--_embed-phases", args);
     cmd.args(["--batch-size", &args.batch_size.to_string()]);
-    if args.no_summaries {
-        cmd.arg("--no-summaries");
-    }
-    if let Some(db_arg) = &args.db {
-        cmd.args(["--db", &db_arg.to_string_lossy()]);
-    }
-    cmd.stdin(std::process::Stdio::null());
     let in_use = redirect_to_background_log(&mut cmd, log);
     match cmd.spawn() {
         Ok(_) => Ok(EmbedSpawn::Detached(in_use)),
@@ -606,6 +634,34 @@ mod tests {
         // `resolve_batch_ceiling` in embed_phase.rs).
         let cli = TestCli::try_parse_from(["spelunk", "some/path"]).expect("parse");
         assert_eq!(cli.index.batch_size, 0);
+    }
+
+    // ── build_detached_child_command: shared re-exec contract ───────────────────
+
+    fn sample_index_args() -> IndexArgs {
+        TestCli::try_parse_from(["spelunk", "some/path"])
+            .expect("parse")
+            .index
+    }
+
+    #[test]
+    fn detached_child_command_inherits_cwd_and_env() {
+        // `std::process::Command` inherits both by default; this only breaks
+        // if a future edit adds `.current_dir(...)` or `.env_clear()`/`.env(...)`
+        // to the shared builder.
+        let cmd = build_detached_child_command(
+            std::path::Path::new("/usr/bin/spelunk"),
+            "--_background-phases",
+            &sample_index_args(),
+        );
+        assert!(
+            cmd.get_current_dir().is_none(),
+            "must inherit the parent's cwd rather than pin one"
+        );
+        assert!(
+            cmd.get_envs().next().is_none(),
+            "must inherit the parent's environment rather than clear or override it"
+        );
     }
 
     // ── embed_skipped_lines: 0-chunks / offline notice (#5) ─────────────────────

--- a/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
@@ -669,6 +669,7 @@ mod tests {
             embed_phases: false,
             detach: false,
             detach_embed: false,
+            config_path: None,
         }
     }
 

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -174,6 +174,11 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
             embed_phases: false,
             detach: false,
             detach_embed: true,
+            // `init` has no global `--config` override of its own to forward
+            // (it isn't threaded through `InitArgs`); a detached embed child
+            // spawned from here falls back to the default config, same as
+            // before this field existed.
+            config_path: None,
         };
         super::index::index(index_args, cfg.clone()).await?;
 

--- a/crates/spelunk-cli/src/main.rs
+++ b/crates/spelunk-cli/src/main.rs
@@ -54,6 +54,7 @@ async fn main() -> Result<()> {
     // still fails loudly on a config it cannot load.
     let best_effort_publish = matches!(&cli.command, Command::Plumbing(p)
         if matches!(&p.command, PlumbingCommand::PublishNotes(a) if a.best_effort));
+    let cli_config_path = cli.config.clone();
     let cfg = match config::Config::load(cli.config.as_deref()) {
         Ok(c) => c,
         Err(e) if best_effort_publish => {
@@ -65,7 +66,10 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Command::Init(args) => cli::cmd::init(args, cfg).await,
-        Command::Index(args) => cli::cmd::index(args, cfg).await,
+        Command::Index(mut args) => {
+            args.config_path = cli_config_path;
+            cli::cmd::index(args, cfg).await
+        }
         Command::Search(args) => cli::cmd::search(args, cfg).await,
         Command::Status(args) => cli::cmd::status(args, cfg).await,
         Command::Check(args) => cli::cmd::check(args, cfg).await,


### PR DESCRIPTION
## Summary
Both internal re-exec points that continue \`spelunk index\` in a detached child (the phases-3-5 background job, and the embed-phase subprocess) reconstructed their argv from named fields instead of forwarding what the parent actually resolved:
- The resolved \`--config\` path never reached either child at all, so a detached child on a large repo re-resolved the DEFAULT config instead of the one the parent loaded.
- \`--no-summaries\` was forwarded to only one of the two spawn sites.
- \`--summary-batch-size\` was forwarded by neither.

Both spawns now build their argv from one shared \`build_detached_child_command\` contract. \`--config\` is only forwarded when the parent itself resolved an explicit override (never unconditionally, since the parent may have used the default). \`spelunk index\` still exits 0 when summarization fails in a detached child — this change affects what the child is given, not what it does with a failure. Env vars and cwd were already correctly inherited (no \`.env_clear()\`/\`.current_dir()\` anywhere); added a regression test guarding that going forward.

## Test plan
- New tests in \`crates/spelunk-cli/src/cli/cmd/index/mod.rs\`: \`detached_child_command_forwards_config_path_when_resolved\`, \`detached_child_command_omits_config_flag_when_not_resolved\`, \`detached_child_command_forwards_no_summaries_to_both_spawn_sites\`, \`detached_child_command_forwards_configured_summary_batch_size_to_both_spawn_sites\`, \`detached_child_command_inherits_cwd_and_env\`.
- Verified regression validity by temporarily reverting the argv builder to the old per-site shape — all four non-cwd/env tests failed as expected, then restored.
- \`cargo test --workspace --features rich-formats\`: 364+ passed, 0 failed (two unrelated pre-existing order-dependent tests in \`capability.rs\`, filed separately, excluded via \`--skip\`).
- \`cargo clippy --workspace --features rich-formats --all-targets -- -D warnings\`: clean.