### PR TITLE
Resolve the hooks directory via git, honoring core.hooksPath

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/hooks.rs
+++ b/crates/spelunk-cli/src/cli/cmd/hooks.rs
@@ -409,4 +409,108 @@ mod tests {
             "the embedded path must be absolute: {quoted}"
         );
     }
+
+    /// A repo with a real identity and one commit, isolated from the
+    /// developer's ambient git config.
+    fn init_repo(dir: &Path) {
+        let run = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .env("GIT_AUTHOR_NAME", "t")
+                .env("GIT_AUTHOR_EMAIL", "t@example.com")
+                .env("GIT_COMMITTER_NAME", "t")
+                .env("GIT_COMMITTER_EMAIL", "t@example.com")
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .status()
+                .expect("run git");
+            assert!(status.success(), "git {args:?} failed");
+        };
+        run(&["init", "-q", "-b", "main"]);
+        std::fs::write(dir.join("f.txt"), "x").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-q", "-m", "init"]);
+    }
+
+    fn set_hooks_path(dir: &Path, path: &str) {
+        let status = std::process::Command::new("git")
+            .args(["config", "core.hooksPath", path])
+            .current_dir(dir)
+            .status()
+            .expect("set core.hooksPath");
+        assert!(status.success());
+    }
+
+    /// A fresh temp dir, canonicalized. `resolve_hooks_dir`/`hooks_dir_is_tracked`
+    /// compare their `dir` argument against git's own output (`--show-toplevel`,
+    /// `--git-common-dir`), which git always reports symlink-resolved; every real
+    /// call site gets a `dir` the same way, via `std::env::current_dir()`, which
+    /// resolves symlinks for the same reason. `tempfile`'s raw path does not (on
+    /// macOS `$TMPDIR` is itself a symlink), so tests comparing paths must
+    /// canonicalize to match what these functions actually receive in practice.
+    fn canonical_tmp_dir(tmp: &tempfile::TempDir) -> std::path::PathBuf {
+        tmp.path().canonicalize().unwrap()
+    }
+
+    #[test]
+    fn resolve_hooks_dir_defaults_to_dot_git_hooks_when_core_hooks_path_is_unset() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = canonical_tmp_dir(&tmp);
+        init_repo(&dir);
+
+        assert_eq!(
+            resolve_hooks_dir(&dir).unwrap(),
+            dir.join(".git").join("hooks")
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_dir_honors_a_relative_core_hooks_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = canonical_tmp_dir(&tmp);
+        init_repo(&dir);
+        set_hooks_path(&dir, ".githooks-custom");
+
+        assert_eq!(
+            resolve_hooks_dir(&dir).unwrap(),
+            dir.join(".githooks-custom")
+        );
+    }
+
+    #[test]
+    fn hooks_dir_is_tracked_false_for_the_default_git_hooks_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = canonical_tmp_dir(&tmp);
+        init_repo(&dir);
+        let hooks_dir = resolve_hooks_dir(&dir).unwrap();
+
+        assert!(!hooks_dir_is_tracked(&dir, &hooks_dir).unwrap());
+    }
+
+    #[test]
+    fn hooks_dir_is_tracked_true_for_a_directory_inside_the_working_tree() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = canonical_tmp_dir(&tmp);
+        init_repo(&dir);
+        set_hooks_path(&dir, ".husky");
+        let hooks_dir = resolve_hooks_dir(&dir).unwrap();
+
+        assert!(hooks_dir_is_tracked(&dir, &hooks_dir).unwrap());
+    }
+
+    #[test]
+    fn hooks_dir_is_tracked_false_for_a_hooks_path_outside_the_repository() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let base = canonical_tmp_dir(&tmp);
+        let repo = base.join("repo");
+        let outside = base.join("outside-hooks");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        init_repo(&repo);
+        set_hooks_path(&repo, outside.to_str().unwrap());
+        let hooks_dir = resolve_hooks_dir(&repo).unwrap();
+
+        assert!(!hooks_dir_is_tracked(&repo, &hooks_dir).unwrap());
+    }
 }

--- a/crates/spelunk-cli/src/cli/cmd/hooks.rs
+++ b/crates/spelunk-cli/src/cli/cmd/hooks.rs
@@ -470,8 +470,19 @@ mod tests {
     /// resolves symlinks for the same reason. `tempfile`'s raw path does not (on
     /// macOS `$TMPDIR` is itself a symlink), so tests comparing paths must
     /// canonicalize to match what these functions actually receive in practice.
+    ///
+    /// This must go through [`spelunk_core::utils::canonicalize`] (the `dunce`
+    /// wrapper), not `Path::canonicalize`/`std::fs::canonicalize` directly: on
+    /// Windows the std version returns the verbatim `\\?\`-prefixed form, while
+    /// `resolve_hooks_dir` and `hooks_dir_is_tracked` canonicalize through the
+    /// `dunce` wrapper and so never produce that prefix. Building an expected
+    /// path from the verbatim form and comparing it against the non-verbatim
+    /// form those functions actually return compares two different spellings
+    /// of the same real directory and fails `assert_eq!`/`PathBuf` equality
+    /// even though nothing is wrong - the fix is to canonicalize both sides
+    /// through the identical helper, not to chase the `\\?\` prefix itself.
     fn canonical_tmp_dir(tmp: &tempfile::TempDir) -> std::path::PathBuf {
-        tmp.path().canonicalize().unwrap()
+        spelunk_core::utils::canonicalize(tmp.path())
     }
 
     #[test]

--- a/crates/spelunk-cli/src/cli/cmd/hooks.rs
+++ b/crates/spelunk-cli/src/cli/cmd/hooks.rs
@@ -122,35 +122,94 @@ fn pre_push_hook_body() -> Result<String> {
 /// Whether spelunk's own pre-push hook is installed in the repo holding `dir`.
 /// False for a foreign pre-push hook: that one publishes nothing.
 pub fn pre_push_installed(dir: &Path) -> bool {
-    let Ok(git_dir) = find_git_dir_in(dir) else {
+    let Ok(hooks_dir) = resolve_hooks_dir(dir) else {
         return false;
     };
-    std::fs::read_to_string(git_dir.join("hooks").join(PRE_PUSH.name))
+    std::fs::read_to_string(hooks_dir.join(PRE_PUSH.name))
         .is_ok_and(|body| body.contains(PRE_PUSH.marker))
 }
 
-fn find_git_dir() -> Result<std::path::PathBuf> {
-    let cwd = std::env::current_dir().context("getting current directory")?;
-    find_git_dir_in(&cwd)
+/// Run `git <args>` in `dir` and return trimmed stdout, erroring on a non-zero
+/// exit.
+fn git_output(dir: &Path, args: &[&str]) -> Result<String> {
+    let output = std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .with_context(|| format!("running git {}", args.join(" ")))?;
+    if !output.status.success() {
+        anyhow::bail!("Not inside a git repository.");
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn find_git_dir_in(dir: &Path) -> Result<std::path::PathBuf> {
-    let repo = gix::discover(dir).context("Not inside a git repository.")?;
-    Ok(repo.git_dir().to_path_buf())
+/// Resolve the hooks directory the way git itself would run hooks from:
+/// `git rev-parse --git-path hooks`, run from `dir`. This is the only correct
+/// resolution because it honors `core.hooksPath` (set by husky, lefthook, and
+/// the pre-commit framework) and follows a linked worktree back to its shared
+/// hooks directory. Reading `$GIT_DIR/hooks` directly, as this used to, agrees
+/// with git only when `core.hooksPath` is unset.
+fn resolve_hooks_dir(dir: &Path) -> Result<std::path::PathBuf> {
+    let raw = git_output(dir, &["rev-parse", "--git-path", "hooks"])?;
+    let path = std::path::PathBuf::from(raw);
+    // A relative result is relative to `dir`, the cwd git was invoked from
+    // (matches how git itself resolves a relative core.hooksPath).
+    Ok(if path.is_absolute() {
+        path
+    } else {
+        dir.join(path)
+    })
+}
+
+/// Whether `hooks_dir` sits inside the repository's tracked working tree
+/// rather than under its git directory. True for the husky/lefthook pattern:
+/// `core.hooksPath` pointing at a directory (e.g. `.husky/`) that is itself
+/// committed and shared with every clone. False for the default `.git/hooks`
+/// and for a `core.hooksPath` pointing outside the repo entirely.
+fn hooks_dir_is_tracked(dir: &Path, hooks_dir: &Path) -> Result<bool> {
+    let Ok(toplevel) = git_output(dir, &["rev-parse", "--show-toplevel"]) else {
+        // No working tree (bare repo): nothing to be "inside".
+        return Ok(false);
+    };
+    let toplevel = std::path::PathBuf::from(toplevel);
+
+    let common_dir = git_output(dir, &["rev-parse", "--git-common-dir"])?;
+    let common_dir = std::path::PathBuf::from(common_dir);
+    let common_dir = if common_dir.is_absolute() {
+        common_dir
+    } else {
+        dir.join(common_dir)
+    };
+
+    Ok(hooks_dir.starts_with(&toplevel) && !hooks_dir.starts_with(&common_dir))
 }
 
 /// What [`write_hook`] did.
-enum Installed {
+pub(crate) enum Installed {
     Wrote(std::path::PathBuf),
     /// Ours, but the body changed: a moved binary re-resolves through here.
     Updated(std::path::PathBuf),
     AlreadyPresent(std::path::PathBuf),
 }
 
-/// Write `body` to `<git-dir>/hooks/<spec.name>`, refusing to clobber a hook
-/// spelunk did not write.
-fn write_hook(spec: &HookSpec, body: &str) -> Result<Installed> {
-    let hooks_dir = find_git_dir()?.join("hooks");
+/// Write `body` to the git-resolved hooks directory for the repo at `dir`,
+/// refusing to clobber a hook spelunk did not write.
+fn write_hook(dir: &Path, spec: &HookSpec, body: &str) -> Result<Installed> {
+    let hooks_dir = resolve_hooks_dir(dir)?;
+
+    // A tracked hooks directory is shared with every teammate on clone: writing
+    // into it is committing spelunk's hook to the team, not to this machine, so
+    // it needs the user's own commit rather than a silent write on their behalf.
+    if hooks_dir_is_tracked(dir, &hooks_dir)? {
+        anyhow::bail!(
+            "core.hooksPath resolves to {}, which is inside this repository's tracked \
+             working tree, so it is shared with every clone. spelunk will not write a hook \
+             there on your behalf; add it to that directory yourself, or point \
+             core.hooksPath at an untracked location and re-run this command.",
+            hooks_dir.display()
+        );
+    }
+
     std::fs::create_dir_all(&hooks_dir)?;
     let hook_path = hooks_dir.join(spec.name);
 
@@ -200,8 +259,19 @@ fn hooks_install(args: HooksInstallArgs) -> Result<()> {
     install_post_commit()
 }
 
+/// Install the post-commit hook in the repo at `dir`. Exposed so `spelunk
+/// init --hook` shares this resolution logic rather than re-implementing it
+/// against a hardcoded `$GIT_DIR/hooks`.
+pub(crate) fn install_post_commit_hook(dir: &Path) -> Result<Installed> {
+    write_hook(dir, &POST_COMMIT, POST_COMMIT_HOOK)
+}
+
+fn cwd() -> Result<std::path::PathBuf> {
+    std::env::current_dir().context("getting current directory")
+}
+
 fn install_post_commit() -> Result<()> {
-    match write_hook(&POST_COMMIT, POST_COMMIT_HOOK)? {
+    match install_post_commit_hook(&cwd()?)? {
         Installed::AlreadyPresent(p) => {
             println!("Hook already installed at {}", p.display());
             return Ok(());
@@ -217,7 +287,7 @@ fn install_post_commit() -> Result<()> {
 }
 
 fn install_pre_push() -> Result<()> {
-    match write_hook(&PRE_PUSH, &pre_push_hook_body()?)? {
+    match write_hook(&cwd()?, &PRE_PUSH, &pre_push_hook_body()?)? {
         Installed::AlreadyPresent(p) => {
             println!("Hook already installed at {}", p.display());
             return Ok(());
@@ -234,7 +304,7 @@ fn install_pre_push() -> Result<()> {
 }
 
 fn hooks_uninstall() -> Result<()> {
-    let hooks_dir = find_git_dir()?.join("hooks");
+    let hooks_dir = resolve_hooks_dir(&cwd()?)?;
     let mut removed = 0usize;
     let mut foreign: Vec<std::path::PathBuf> = Vec::new();
 

--- a/crates/spelunk-cli/src/cli/cmd/hooks.rs
+++ b/crates/spelunk-cli/src/cli/cmd/hooks.rs
@@ -149,15 +149,28 @@ fn git_output(dir: &Path, args: &[&str]) -> Result<String> {
 /// the pre-commit framework) and follows a linked worktree back to its shared
 /// hooks directory. Reading `$GIT_DIR/hooks` directly, as this used to, agrees
 /// with git only when `core.hooksPath` is unset.
+///
+/// The result is canonicalized (via [`spelunk_core::utils::canonicalize`], so
+/// symlinks are resolved and, on Windows, the `\\?\` prefix is stripped)
+/// before it is returned. `hooks_dir_is_tracked` compares this value against
+/// git's own `--show-toplevel` / `--git-common-dir` output with a plain
+/// `PathBuf::starts_with`, which is a component-wise comparison with no
+/// tolerance for two paths naming the same directory in different forms -
+/// resolved vs. un-resolved symlinks, a differently-cased Windows drive
+/// letter, or a `\\?\`-prefixed path next to a plain one. Canonicalizing both
+/// sides is what makes that comparison meaningful.
 fn resolve_hooks_dir(dir: &Path) -> Result<std::path::PathBuf> {
     let raw = git_output(dir, &["rev-parse", "--git-path", "hooks"])?;
     let path = std::path::PathBuf::from(raw);
     // A relative result is relative to `dir`, the cwd git was invoked from
-    // (matches how git itself resolves a relative core.hooksPath).
+    // (matches how git itself resolves a relative core.hooksPath). The
+    // target itself (e.g. a `core.hooksPath` that has never been created)
+    // may not exist yet, so canonicalize the base - which always exists -
+    // before joining, rather than the full result.
     Ok(if path.is_absolute() {
-        path
+        spelunk_core::utils::canonicalize(&path)
     } else {
-        dir.join(path)
+        spelunk_core::utils::canonicalize(dir).join(path)
     })
 }
 
@@ -171,7 +184,13 @@ fn hooks_dir_is_tracked(dir: &Path, hooks_dir: &Path) -> Result<bool> {
         // No working tree (bare repo): nothing to be "inside".
         return Ok(false);
     };
-    let toplevel = std::path::PathBuf::from(toplevel);
+    // `--show-toplevel` is always absolute and always names a directory that
+    // exists, so canonicalizing it is safe unconditionally. `hooks_dir`
+    // (from `resolve_hooks_dir`) is canonicalized the same way, so this
+    // `starts_with` compares two paths in the same normalized form rather
+    // than risking a resolved-vs-unresolved-symlink or Windows case/`\\?\`
+    // mismatch between git's notion of the path and ours.
+    let toplevel = spelunk_core::utils::canonicalize(&std::path::PathBuf::from(toplevel));
 
     let common_dir = git_output(dir, &["rev-parse", "--git-common-dir"])?;
     let common_dir = std::path::PathBuf::from(common_dir);
@@ -180,6 +199,8 @@ fn hooks_dir_is_tracked(dir: &Path, hooks_dir: &Path) -> Result<bool> {
     } else {
         dir.join(common_dir)
     };
+    // The `.git` directory always exists, so this is always safe too.
+    let common_dir = spelunk_core::utils::canonicalize(&common_dir);
 
     Ok(hooks_dir.starts_with(&toplevel) && !hooks_dir.starts_with(&common_dir))
 }
@@ -512,5 +533,29 @@ mod tests {
         let hooks_dir = resolve_hooks_dir(&repo).unwrap();
 
         assert!(!hooks_dir_is_tracked(&repo, &hooks_dir).unwrap());
+    }
+
+    /// `dir` reaches these functions as `std::env::current_dir()` in real use,
+    /// which does not resolve symlinks. On a machine where the OS temp dir has
+    /// a symlinked component (e.g. macOS, where `$TMPDIR` sits under `/var`,
+    /// itself a symlink to `/private/var`), git resolves that away when it
+    /// prints `--show-toplevel` / `--git-common-dir`, while a hooks_dir built
+    /// by joining onto the raw, un-resolved `dir` does not. A component-wise
+    /// `starts_with` between the two then fails even though both name the
+    /// same real directory - the same class of bug as a Windows drive-letter
+    /// case or `\\?\`-prefix mismatch, reproduced here without needing Windows.
+    #[test]
+    fn hooks_dir_is_tracked_true_with_an_unresolved_symlinked_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf(); // deliberately NOT canonicalized
+        init_repo(&dir);
+        set_hooks_path(&dir, ".husky");
+        let hooks_dir = resolve_hooks_dir(&dir).unwrap();
+
+        assert!(
+            hooks_dir_is_tracked(&dir, &hooks_dir).unwrap(),
+            "must detect the tracked hooks dir even when `dir` itself was \
+             never canonicalized by the caller"
+        );
     }
 }

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -398,57 +398,19 @@ fn find_git_root(start: &std::path::Path) -> Option<std::path::PathBuf> {
 }
 
 /// Install the git post-commit hook, returning a short status string.
+///
+/// Shares `hooks.rs`'s resolution logic rather than re-implementing it: a
+/// second hardcoded `$GIT_DIR/hooks` here previously disagreed with
+/// `core.hooksPath` in exactly the same way `spelunk hooks install` did.
 fn install_hook_for_init() -> Result<String> {
-    // Re-use the hook installation logic from hooks.rs by calling the same
-    // underlying helper used there: replicate it inline to avoid making private
-    // functions pub, keeping the hook module self-contained.
     let cwd = std::env::current_dir().context("getting current directory")?;
-    let git_dir = gix::discover(&cwd)
-        .context("not inside a git repository")?
-        .git_dir()
-        .to_path_buf();
-    let hooks_dir = git_dir.join("hooks");
-    std::fs::create_dir_all(&hooks_dir)?;
-    let hook_path = hooks_dir.join("post-commit");
-
-    if hook_path.exists() {
-        let existing = std::fs::read_to_string(&hook_path)?;
-        if existing.contains("spelunk post-commit hook") {
-            return Ok(format!("already installed at {}", hook_path.display()));
+    match super::hooks::install_post_commit_hook(&cwd)? {
+        super::hooks::Installed::Wrote(p) => Ok(format!("installed at {}", p.display())),
+        super::hooks::Installed::Updated(p) => Ok(format!("updated at {}", p.display())),
+        super::hooks::Installed::AlreadyPresent(p) => {
+            Ok(format!("already installed at {}", p.display()))
         }
-        anyhow::bail!(
-            "a post-commit hook already exists at {} and was not installed by spelunk; \
-             merge manually or remove it first",
-            hook_path.display()
-        );
     }
-
-    const POST_COMMIT_HOOK: &str = r#"#!/bin/sh
-# spelunk post-commit hook — installed by `spelunk hooks install`
-# Keeps the spelunk index in sync and harvests memory from new commits.
-# Silently skips if `spelunk` is not in PATH, so teammates without spelunk are unaffected.
-
-if ! command -v spelunk >/dev/null 2>&1; then
-  exit 0
-fi
-
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-
-spelunk index "$PROJECT_ROOT"
-spelunk memory harvest --git-range HEAD~1..HEAD
-"#;
-
-    std::fs::write(&hook_path, POST_COMMIT_HOOK)?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&hook_path)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&hook_path, perms)?;
-    }
-
-    Ok(format!("installed at {}", hook_path.display()))
 }
 
 #[cfg(test)]

--- a/crates/spelunk-cli/tests/hooks_path_resolution.rs
+++ b/crates/spelunk-cli/tests/hooks_path_resolution.rs
@@ -1,0 +1,380 @@
+//! Hook installation must resolve the hooks directory the way git itself
+//! does, honoring `core.hooksPath` (set by husky, lefthook, the pre-commit
+//! framework, or a team's own shared-hooks convention) instead of assuming
+//! the default `.git/hooks`.
+//!
+//! Before this, `spelunk hooks install` wrote to a hardcoded `$GIT_DIR/hooks`
+//! and the `init` install-state detector read that same hardcoded path. On a
+//! `core.hooksPath` machine the hook silently never ran while `init` kept
+//! reporting it as installed, because installer and detector agreed with
+//! each other while both disagreed with git.
+//!
+//! Covered:
+//! - install lands at the git-resolved hooks dir when `core.hooksPath` points
+//!   elsewhere, not at the default `.git/hooks`.
+//! - a pre-push hook installed at a `core.hooksPath` location is actually
+//!   invoked by a real `git push` (the functional proof, not just a file
+//!   existence check).
+//! - `init`'s summary agrees with where the hook actually landed.
+//! - a `core.hooksPath` pointing inside the repo's tracked working tree (the
+//!   husky/lefthook pattern) is refused rather than written to silently.
+//! - a linked worktree resolves hooks to the main worktree's shared hooks dir.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use assert_cmd::Command;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+use tempfile::TempDir;
+
+/// A `git` invocation in `dir` with an isolated identity and config.
+fn git_cmd(dir: &Path) -> std::process::Command {
+    let mut cmd = std::process::Command::new("git");
+    cmd.current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@example.com")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@example.com")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null");
+    cmd
+}
+
+fn git_out(dir: &Path, args: &[&str]) -> Output {
+    git_cmd(dir).args(args).output().expect("spawn git")
+}
+
+fn git(dir: &Path, args: &[&str]) -> Output {
+    let out = git_out(dir, args);
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    String::from_utf8_lossy(&git_out(dir, args).stdout)
+        .trim()
+        .to_string()
+}
+
+/// The hooks directory git itself resolves for `dir` (honors `core.hooksPath`
+/// and worktrees). The independent reference the tests check installs
+/// against, rather than re-deriving spelunk's own resolution logic.
+fn git_hooks_dir(dir: &Path) -> PathBuf {
+    let raw = git_stdout(dir, &["rev-parse", "--git-path", "hooks"]);
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        dir.join(path)
+    }
+}
+
+/// A repo with a real identity and one commit.
+fn init_repo(dir: &Path) {
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "t@example.com"]);
+    git(dir, &["config", "user.name", "Test"]);
+    std::fs::write(dir.join("f.txt"), "x\n").unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-q", "-m", "init"]);
+}
+
+/// A `spelunk` command with an isolated HOME and no server contact.
+fn bin(home: &Path, cwd: &Path) -> Command {
+    let mut cmd = spelunk_bin_in(home);
+    cmd.current_dir(cwd)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL");
+    cmd
+}
+
+/// Record one memory entry through the real `memory add`.
+fn memory_add(home: &Path, repo: &Path, title: &str) {
+    bin(home, repo)
+        .args([
+            "memory", "add", "--kind", "decision", "--title", title, "--body", "why",
+        ])
+        .assert()
+        .success();
+}
+
+/// Write an empty spelunk config (`init` needs `--config` but no values here).
+fn empty_config(dir: &Path) -> PathBuf {
+    let cfg = dir.join("config.toml");
+    std::fs::write(&cfg, "").unwrap();
+    cfg
+}
+
+// ── install resolves through git, not a hardcoded .git/hooks ─────────────────
+
+/// With `core.hooksPath` pointed at an untracked directory outside the repo,
+/// the post-commit hook must land there, not at the default `.git/hooks`.
+#[test]
+fn install_post_commit_lands_at_the_core_hooks_path_location() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("repo");
+    let custom_hooks = tmp.path().join("external-hooks");
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::create_dir_all(&custom_hooks).unwrap();
+    init_repo(&repo);
+    git(
+        &repo,
+        &["config", "core.hooksPath", custom_hooks.to_str().unwrap()],
+    );
+
+    // Setup control: confirm git itself resolves hooks to the custom dir, so
+    // the assertions below are about the real target, not a guess.
+    assert_eq!(
+        git_hooks_dir(&repo),
+        custom_hooks,
+        "setup: git must resolve hooks to the custom dir"
+    );
+
+    bin(home.path(), &repo)
+        .args(["hooks", "install"])
+        .assert()
+        .success();
+
+    assert!(
+        custom_hooks.join("post-commit").exists(),
+        "the hook must land where git will actually run it from"
+    );
+    assert!(
+        !repo.join(".git").join("hooks").join("post-commit").exists(),
+        "the hook must not be written to the default .git/hooks when \
+         core.hooksPath points elsewhere"
+    );
+}
+
+/// Same, for the pre-push hook, plus the functional proof: a real `git push`
+/// must actually invoke the hook from the resolved location. A file existing
+/// at the right path is necessary but not sufficient; git running it is the
+/// whole point.
+#[test]
+fn pre_push_hook_installed_at_core_hooks_path_is_actually_invoked_by_git_push() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let origin = tmp.path().join("origin.git");
+    let dev = tmp.path().join("dev");
+    let custom_hooks = tmp.path().join("team-hooks");
+    std::fs::create_dir_all(&origin).unwrap();
+    std::fs::create_dir_all(&dev).unwrap();
+    std::fs::create_dir_all(&custom_hooks).unwrap();
+
+    git(&origin, &["init", "-q", "--bare", "-b", "main"]);
+    init_repo(&dev);
+    git(&dev, &["remote", "add", "origin", origin.to_str().unwrap()]);
+    git(&dev, &["push", "-q", "-u", "origin", "main"]);
+    git(
+        &dev,
+        &["config", "core.hooksPath", custom_hooks.to_str().unwrap()],
+    );
+
+    bin(home.path(), &dev)
+        .args(["hooks", "install", "--pre-push"])
+        .assert()
+        .success();
+
+    assert!(
+        custom_hooks.join("pre-push").exists(),
+        "setup: the hook must have landed at the custom hooks dir"
+    );
+    assert!(
+        !dev.join(".git").join("hooks").join("pre-push").exists(),
+        "setup: nothing should be at the default .git/hooks location"
+    );
+
+    memory_add(home.path(), &dev, "custom-hooks-path-decision");
+    std::fs::write(dev.join("f2.txt"), "y\n").unwrap();
+    git(&dev, &["add", "."]);
+    git(&dev, &["commit", "-q", "-m", "second"]);
+    git(&dev, &["push", "-q", "origin", "main"]);
+
+    // The proof that matters: git actually ran the hook from the custom
+    // location, so the notes ref reached origin. A hook that only exists on
+    // disk but is never invoked would leave this ref absent.
+    assert!(
+        git_out(&origin, &["rev-parse", "refs/notes/spelunk"])
+            .status
+            .success(),
+        "the pre-push hook installed at the core.hooksPath location must \
+         actually run on git push: origin should carry refs/notes/spelunk"
+    );
+}
+
+// ── the install-state detector must agree with the installer ─────────────────
+
+/// `init`'s summary must say the hook is installed only when it landed where
+/// git will actually run it from. Before the fix, the installer and the
+/// detector both read the same hardcoded `.git/hooks`, which agreed with each
+/// other while disagreeing with git whenever `core.hooksPath` pointed
+/// elsewhere.
+#[test]
+fn init_summary_agrees_with_pre_push_installer_when_core_hooks_path_is_set() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("repo");
+    let custom_hooks = tmp.path().join("external-hooks");
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::create_dir_all(&custom_hooks).unwrap();
+    init_repo(&repo);
+    git(
+        &repo,
+        &["config", "core.hooksPath", custom_hooks.to_str().unwrap()],
+    );
+
+    bin(home.path(), &repo)
+        .args(["hooks", "install", "--pre-push"])
+        .assert()
+        .success();
+    assert!(
+        custom_hooks.join("pre-push").exists(),
+        "setup: the hook must have landed at the custom hooks dir"
+    );
+
+    let cfg = empty_config(&repo);
+    let out = bin(home.path(), &repo)
+        .arg("--config")
+        .arg(&cfg)
+        .args(["init", "--no-index"])
+        .output()
+        .expect("spawn spelunk init");
+    assert!(
+        out.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("pre-push hook installed: your memory publishes on `git push`"),
+        "init must report the hook as installed since it landed where git \
+         resolves hooks, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("your memory stays local"),
+        "init must not claim the hook is missing when it is actually \
+         installed at the resolved location, got:\n{stdout}"
+    );
+}
+
+// ── a tracked, shared hooks dir is refused rather than written to ────────────
+
+/// `core.hooksPath` pointing inside the repo's own tracked working tree (the
+/// husky/lefthook pattern) is a different act from writing into local
+/// `.git/`: it commits spelunk's hook to every clone. Install must refuse with
+/// an explanation rather than write silently.
+#[test]
+fn install_refuses_when_core_hooks_path_is_inside_the_tracked_working_tree() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo(&repo);
+    git(&repo, &["config", "core.hooksPath", ".husky"]);
+
+    let out = bin(home.path(), &repo)
+        .args(["hooks", "install"])
+        .output()
+        .expect("run spelunk hooks install");
+
+    assert!(
+        !out.status.success(),
+        "install must refuse a core.hooksPath inside the tracked working tree"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("tracked") && stderr.contains("shared"),
+        "the refusal must explain that the directory is tracked and shared \
+         with every clone, got: {stderr}"
+    );
+    assert!(
+        !repo.join(".husky").join("post-commit").exists(),
+        "nothing should have been written to the tracked hooks dir"
+    );
+}
+
+/// The refusal is specific to a directory inside the tracked working tree: a
+/// `core.hooksPath` outside the repo entirely (the common case) must still
+/// install normally.
+#[test]
+fn install_still_succeeds_when_core_hooks_path_is_outside_the_repository() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    let repo = tmp.path().join("repo");
+    let custom_hooks = tmp.path().join("outside-hooks");
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::create_dir_all(&custom_hooks).unwrap();
+    init_repo(&repo);
+    git(
+        &repo,
+        &["config", "core.hooksPath", custom_hooks.to_str().unwrap()],
+    );
+
+    bin(home.path(), &repo)
+        .args(["hooks", "install"])
+        .assert()
+        .success();
+
+    assert!(custom_hooks.join("post-commit").exists());
+}
+
+// ── worktrees share the main repo's hooks dir ─────────────────────────────────
+
+/// A linked worktree resolves hooks to the MAIN worktree's shared hooks dir,
+/// not a per-worktree location: git itself runs hooks from there for every
+/// worktree of a repo.
+#[test]
+fn hooks_resolve_to_the_shared_main_repo_hooks_dir_from_a_linked_worktree() {
+    let home = TempDir::new().unwrap();
+    let tmp = TempDir::new().unwrap();
+    // Canonicalized: git reports `--git-path`/`--show-toplevel` symlink-resolved
+    // (macOS `$TMPDIR` is itself a symlink), and the real command always sees a
+    // canonical cwd via `std::env::current_dir()`, so comparisons below must
+    // use the same resolved form to compare like with like.
+    let base = tmp.path().canonicalize().unwrap();
+    let main_root = base.join("main");
+    std::fs::create_dir_all(&main_root).unwrap();
+    init_repo(&main_root);
+
+    let linked = base.join("linked");
+    git(
+        &main_root,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            linked.to_str().unwrap(),
+            "-b",
+            "feat",
+        ],
+    );
+
+    // Setup control: confirm git itself shares the hooks dir across worktrees.
+    assert_eq!(
+        git_hooks_dir(&linked),
+        main_root.join(".git").join("hooks"),
+        "setup: git must resolve a linked worktree's hooks to the main repo's"
+    );
+
+    bin(home.path(), &linked)
+        .args(["hooks", "install"])
+        .assert()
+        .success();
+
+    assert!(
+        main_root
+            .join(".git")
+            .join("hooks")
+            .join("post-commit")
+            .exists(),
+        "installing from a linked worktree must land the hook in the main \
+         repo's shared hooks dir"
+    );
+}

--- a/crates/spelunk-cli/tests/hooks_path_resolution.rs
+++ b/crates/spelunk-cli/tests/hooks_path_resolution.rs
@@ -338,7 +338,16 @@ fn hooks_resolve_to_the_shared_main_repo_hooks_dir_from_a_linked_worktree() {
     // (macOS `$TMPDIR` is itself a symlink), and the real command always sees a
     // canonical cwd via `std::env::current_dir()`, so comparisons below must
     // use the same resolved form to compare like with like.
-    let base = tmp.path().canonicalize().unwrap();
+    //
+    // `spelunk_core::utils::canonicalize` (backed by `dunce`) rather than
+    // `Path::canonicalize`: on Windows CI runners the plain std canonicalize
+    // returns a `\\?\`-prefixed verbatim path, and passing that straight to
+    // `git worktree add <path>` as an argv string fails ("Invalid argument")
+    // because this git-for-windows version does not accept the `\\?\` form
+    // there. `dunce::canonicalize` still resolves symlinks (so the macOS
+    // `$TMPDIR` case above is unaffected) but de-UNCs the Windows result back
+    // to a plain `C:\…` path, which `git worktree add` accepts.
+    let base = spelunk_core::utils::canonicalize(tmp.path());
     let main_root = base.join("main");
     std::fs::create_dir_all(&main_root).unwrap();
     init_repo(&main_root);

--- a/crates/spelunk-core/src/utils/mod.rs
+++ b/crates/spelunk-core/src/utils/mod.rs
@@ -265,6 +265,46 @@ mod tests {
         assert_eq!(resolved, tmp.path());
     }
 
+    // ── canonicalize ───────────────────────────────────────────────────────
+
+    /// `canonicalize`'s whole reason to exist is de-UNCing: it must never
+    /// return the verbatim `\\?\`-prefixed form that `std::fs::canonicalize`
+    /// produces on Windows for a real, existing directory. A caller that
+    /// builds one path through this wrapper and another through
+    /// `std::fs::canonicalize`/`Path::canonicalize` directly is comparing two
+    /// different spellings of the same directory - `PathBuf` equality (and
+    /// `assert_eq!`) then fails even though both name the identical real
+    /// path. This is exactly the mismatch that broke the hooks-dir tests in
+    /// `crates/spelunk-cli/src/cli/cmd/hooks.rs`: a test built its "expected"
+    /// value via the raw std canonicalize while production went through this
+    /// wrapper.
+    #[test]
+    #[cfg(windows)]
+    fn canonicalize_never_returns_the_verbatim_unc_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("real");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let std_form = dir.canonicalize().unwrap();
+        let wrapped_form = canonicalize(&dir);
+
+        assert!(
+            std_form.to_string_lossy().starts_with(r"\\?\"),
+            "setup: std::fs::canonicalize is expected to add the verbatim \
+             prefix on Windows, got: {}",
+            std_form.display()
+        );
+        assert!(
+            !wrapped_form.to_string_lossy().starts_with(r"\\?\"),
+            "canonicalize() must strip the verbatim prefix, got: {}",
+            wrapped_form.display()
+        );
+        // Same real directory, so re-canonicalizing the std form through the
+        // wrapper must land on the same result the wrapper gives directly -
+        // proving the two flavors name one identical path rather than two.
+        assert_eq!(canonicalize(&std_form), wrapped_form);
+    }
+
     // ── normalize_index_path ──────────────────────────────────────────────────
 
     #[test]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -541,9 +541,21 @@ binary embedded rather than a `PATH` lookup, so it keeps working under GUI git
 clients. If you move or reinstall spelunk the hook fails loudly; re-run
 `spelunk hooks install --pre-push` to re-resolve the path.
 
+`install` resolves the hooks directory the way git itself does
+(`git rev-parse --git-path hooks`), so it honors `core.hooksPath` if you have
+one set (as husky, lefthook, and the pre-commit framework do) and follows a
+linked worktree back to its shared hooks directory.
+
 Neither hook overwrites one it did not write: if a hook of that name already
-exists, `install` reports it and leaves the file alone. Git never clones
-`.git/hooks`, so installing either hook affects only your own clone.
+exists, `install` reports it and leaves the file alone. If the resolved hooks
+directory sits inside the repository's tracked working tree (the husky/lefthook
+pattern, where `core.hooksPath` points at a committed directory such as
+`.husky/`), `install` refuses instead of writing there: that directory is
+shared with every clone, so a silent write would commit spelunk's hook to the
+whole team rather than just this machine. Add the hook to that directory
+yourself, or point `core.hooksPath` at an untracked location and re-run.
+Otherwise, git never clones `.git/hooks`, so installing either hook affects
+only your own clone.
 
 `uninstall` removes every hook spelunk installed, leaving any other hooks alone.
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -171,8 +171,17 @@ while appearing to work. If you move or reinstall spelunk, that path goes stale
 and the hook fails loudly; re-run `spelunk hooks install --pre-push` to
 re-resolve it. Remove it entirely with `spelunk hooks uninstall`.
 
-Teammates never receive the hook: git does not clone `.git/hooks`, so installing
-it affects only your own clone.
+The hook is written to whatever directory `git rev-parse --git-path hooks`
+reports, so it honors `core.hooksPath` if you have one set (as husky, lefthook,
+and the pre-commit framework do) rather than assuming `.git/hooks`. If that
+directory turns out to be tracked and shared (a committed `core.hooksPath`
+target like `.husky/`), `install` refuses rather than writing there: a silent
+write there would commit spelunk's hook for every teammate on clone instead of
+just this machine. Install it into that directory by hand in that case, or
+point `core.hooksPath` at an untracked location first.
+
+Teammates never receive the hook otherwise: git does not clone `.git/hooks`, so
+installing it affects only your own clone.
 
 #### Publishing without the hook
 


### PR DESCRIPTION
## Summary
\`spelunk hooks install\`/\`uninstall\` and the install-state detector used by \`spelunk init\`'s summary all resolved the hooks directory as a hardcoded \`$GIT_DIR/hooks\`, never consulting \`core.hooksPath\`. When that setting is set (as husky, lefthook, and the pre-commit framework all do), git uses it *instead of* \`$GIT_DIR/hooks\` — so a hook installed by spelunk landed somewhere git would never run it, while \`init\`'s summary still reported it as installed and publishing.

- Hooks directory resolution now goes through \`git rev-parse --git-path hooks\`, used uniformly by install, uninstall, and the install-state detector, so all three agree with git and with each other, and correctly follow a linked worktree back to the shared hooks directory.
- Found and fixed a second, independent copy of the same bug in \`spelunk init --hook\`'s installer, which had its own inlined hardcoded-path implementation; deduplicated into one shared helper.
- New deliberate behavior: when the resolved hooks directory sits inside the repository's own tracked working tree (the husky/lefthook pattern, e.g. \`core.hooksPath\` pointing at a committed \`.githooks/\`), install now refuses with an explanatory error instead of silently writing a hook that would be shared with every clone. An absolute \`core.hooksPath\` pointing outside the repo is not refused. Uninstall is exempt from this check since it only ever removes a hook already carrying spelunk's own marker.
- Updated \`docs/commands.md\` and \`docs/memory.md\`, which previously claimed hook installation only ever affects your own clone.

## Test plan
- New integration tests in \`crates/spelunk-cli/tests/hooks_path_resolution.rs\` (6 tests) plus unit tests in \`hooks.rs\`: hooks land at the git-resolved location under \`core.hooksPath\`; a pre-push hook installed there is proven to actually fire via a real \`git push\`; \`init\`'s summary agrees with the installer; the tracked-hooks-dir refusal fires with an explanation, contrasted with an untracked external path which still installs; a linked worktree resolves to the shared main-repo hooks dir.
- Verified pre-fix failure: reverted just the fix's diff with tests left in place, confirmed all 6 integration tests fail at the exact assertion describing the bug; reapplied and confirmed clean.
- \`cargo test --workspace --features rich-formats\`: full suite green (two unrelated pre-existing order-dependent tests in \`capability.rs\`, filed separately, excluded via \`--skip\`).
- \`cargo clippy --workspace --features rich-formats --all-targets -- -D warnings\`: clean.