### PR TITLE
Exit non-zero when a push/sync attempt fully fails (follow-up to #643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,15 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   where nothing was sent now reads "Nothing to push — N entries already
   synced." instead of implying work was done, and a batch with a partial
   failure reports the real successes and failures instead of masking them.
+  A fourth gap in the same path is also fixed: a push where every attempted
+  entry failed (nothing created, nothing skipped) previously still printed
+  "Done."/"Sync complete." with a failed count appended and exited 0. Both
+  commands now treat a total failure as a hard error — the message leads
+  with "Push failed"/"Sync failed" instead of success framing, and the
+  process exits non-zero, so a caller checking the exit code or skimming
+  for "Done" can no longer mistake a fully-failed batch for a completed one.
+  `spelunk sync`'s pull step still runs and its results are still reported
+  even when the push half fails outright.
 - **Concurrent memory writes can no longer silently erase each other's
   entries.** The git-notes write path is a read-modify-write of the note on
   `HEAD`, and nothing serialized it: two simultaneous `memory add` commands

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -69,6 +69,16 @@ pub async fn memory_push(
         } else {
             println!("No local memory entries to push.");
         }
+    } else if summary.created == 0 && summary.skipped == 0 {
+        // Total failure: nothing durably landed. Must not read as success —
+        // a caller skimming for "Done" or checking only the exit code would
+        // otherwise miss a fully-failed batch (this is the data-loss shape
+        // the bug was filed over).
+        anyhow::bail!(
+            "Push failed: 0 of {} entries reached the server ({} failed).",
+            summary.attempted,
+            summary.failed
+        );
     } else if summary.failed > 0 {
         println!(
             "Done. Pushed {} entries (created {}, skipped {}, {} failed).",

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -138,6 +138,20 @@ pub async fn memory_sync(
             "Nothing to push — {} entries already synced. Applied {} new remote entries.",
             pushed.already_synced, pulled
         );
+    } else if pushed.created == 0 && pushed.skipped == 0 {
+        // Total push failure: nothing durably landed cloud-side. The pull
+        // already ran (it's an independent, unconditionally useful step —
+        // there's no reason to withhold remote changes just because the push
+        // half failed), but the command must still fail loud: a caller
+        // skimming for "Sync complete" or checking only the exit code must
+        // not read this as success.
+        anyhow::bail!(
+            "Sync failed: 0 of {} push entries reached the server ({} failed); \
+             pull still applied {} new remote entries.",
+            pushed.attempted,
+            pushed.failed,
+            pulled
+        );
     } else if pushed.failed > 0 {
         println!(
             "Sync complete. Pushed {} entries (created {}, skipped {}, {} failed), applied {} new remote entries.",
@@ -759,5 +773,93 @@ mod tests {
             .filter(|r| !r.archived && r.remote_id.is_none())
             .collect();
         assert_eq!(live_again.len(), 1, "failed row must remain retryable");
+    }
+
+    // ── total push failure must surface as an error, not a success message ─
+    // `push_local` itself just reports honest counts (that's Bug 1/3's fix);
+    // it's the command layer (`memory_push` / `memory_sync`) that decides
+    // whether those counts mean "Done"/"Sync complete" or a hard failure. A
+    // batch where every attempted row comes back `failed` (nothing created,
+    // nothing skipped) must make the command return `Err`, which is what
+    // gives the CLI a non-zero exit — `push_local` returning `Ok` with
+    // `failed == attempted` is the correct, honest signal for the command
+    // layer to act on, not a bug in `push_local` itself.
+    #[tokio::test]
+    async fn push_local_total_failure_reports_zero_created_and_skipped() {
+        use tempfile::TempDir;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        store
+            .add_note("decision", "One", "first", &[], &[], None, None)
+            .unwrap();
+        store
+            .add_note("note", "Two", "second", &[], &[], None, None)
+            .unwrap();
+
+        let rows = store.rows_for_sync(false).unwrap();
+        let (ext_a, ext_b) = (rows[0].uuid.clone(), rows[1].uuid.clone());
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 0, "skipped": 0, "failed": 2,
+                "results": [
+                    {"status": "failed", "external_id": ext_a, "id": serde_json::Value::Null},
+                    {"status": "failed", "external_id": ext_b, "id": serde_json::Value::Null},
+                ]
+            })))
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        let s1 = push_local(&store, &client, false).await.unwrap();
+        assert_eq!(
+            (s1.attempted, s1.created, s1.skipped, s1.failed),
+            (2, 0, 0, 2),
+            "total failure: attempted > 0 but nothing durably landed"
+        );
+        // Neither row is stamped — both remain retryable.
+        let rows_after = store.rows_for_sync(false).unwrap();
+        assert!(rows_after.iter().all(|r| r.remote_id.is_none()));
+    }
+
+    // ── memory push / memory sync: total failure must exit non-zero ───────
+    // `memory_push` and `memory_sync` are the command-layer callers of
+    // `push_local`; this exercises the message-and-exit-code decision they
+    // make on top of an all-failed `PushSummary`, using the same shape as
+    // the test above (built directly, no need to re-hit the mock server).
+    fn all_failed_summary(attempted: usize) -> PushSummary {
+        PushSummary {
+            attempted,
+            created: 0,
+            skipped: 0,
+            failed: attempted as u32,
+            already_synced: 0,
+        }
+    }
+
+    #[test]
+    fn command_layer_treats_total_failure_summary_as_error_condition() {
+        // Mirrors the exact predicate `memory_push` / `memory_sync` use to
+        // decide "total failure": attempted work happened, but nothing was
+        // durably created or deduped as a skip.
+        let summary = all_failed_summary(3);
+        assert!(summary.attempted > 0 && summary.created == 0 && summary.skipped == 0);
+
+        // A partial failure (something landed) must NOT trip the same
+        // predicate — Bug 3's honest partial-failure reporting stays intact.
+        let partial = PushSummary {
+            attempted: 2,
+            created: 1,
+            skipped: 0,
+            failed: 1,
+            already_synced: 0,
+        };
+        assert!(!(partial.attempted > 0 && partial.created == 0 && partial.skipped == 0));
     }
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -775,15 +775,15 @@ mod tests {
         assert_eq!(live_again.len(), 1, "failed row must remain retryable");
     }
 
-    // ── total push failure must surface as an error, not a success message ─
-    // `push_local` itself just reports honest counts (that's Bug 1/3's fix);
-    // it's the command layer (`memory_push` / `memory_sync`) that decides
-    // whether those counts mean "Done"/"Sync complete" or a hard failure. A
-    // batch where every attempted row comes back `failed` (nothing created,
-    // nothing skipped) must make the command return `Err`, which is what
-    // gives the CLI a non-zero exit — `push_local` returning `Ok` with
-    // `failed == attempted` is the correct, honest signal for the command
-    // layer to act on, not a bug in `push_local` itself.
+    // ── push_local's counting stays honest on a total-failure batch ────────
+    // `push_local` itself just reports honest counts (Bug 1/3's fix); it is
+    // the command layer (`memory_push` / `memory_sync`) that decides whether
+    // those counts mean "Done"/"Sync complete" or a hard failure, and that
+    // command-layer decision (the `bail!` that gives the CLI its non-zero
+    // exit) is covered end to end by the subprocess tests in
+    // `crates/spelunk-cli/tests/memory_push_sync_total_failure.rs`, not here.
+    // This test only pins `push_local`'s own return value for the all-failed
+    // shape those command-layer tests depend on.
     #[tokio::test]
     async fn push_local_total_failure_reports_zero_created_and_skipped() {
         use tempfile::TempDir;
@@ -826,40 +826,5 @@ mod tests {
         // Neither row is stamped — both remain retryable.
         let rows_after = store.rows_for_sync(false).unwrap();
         assert!(rows_after.iter().all(|r| r.remote_id.is_none()));
-    }
-
-    // ── memory push / memory sync: total failure must exit non-zero ───────
-    // `memory_push` and `memory_sync` are the command-layer callers of
-    // `push_local`; this exercises the message-and-exit-code decision they
-    // make on top of an all-failed `PushSummary`, using the same shape as
-    // the test above (built directly, no need to re-hit the mock server).
-    fn all_failed_summary(attempted: usize) -> PushSummary {
-        PushSummary {
-            attempted,
-            created: 0,
-            skipped: 0,
-            failed: attempted as u32,
-            already_synced: 0,
-        }
-    }
-
-    #[test]
-    fn command_layer_treats_total_failure_summary_as_error_condition() {
-        // Mirrors the exact predicate `memory_push` / `memory_sync` use to
-        // decide "total failure": attempted work happened, but nothing was
-        // durably created or deduped as a skip.
-        let summary = all_failed_summary(3);
-        assert!(summary.attempted > 0 && summary.created == 0 && summary.skipped == 0);
-
-        // A partial failure (something landed) must NOT trip the same
-        // predicate — Bug 3's honest partial-failure reporting stays intact.
-        let partial = PushSummary {
-            attempted: 2,
-            created: 1,
-            skipped: 0,
-            failed: 1,
-            already_synced: 0,
-        };
-        assert!(!(partial.attempted > 0 && partial.created == 0 && partial.skipped == 0));
     }
 }

--- a/crates/spelunk-cli/tests/memory_push_sync_total_failure.rs
+++ b/crates/spelunk-cli/tests/memory_push_sync_total_failure.rs
@@ -1,0 +1,212 @@
+//! Subprocess-level regression coverage: a total-failure `spelunk memory push`
+//! / `spelunk sync` batch must exit non-zero and never print success framing.
+//!
+//! `memory_push`/`memory_sync` (`crates/spelunk-cli/src/cli/cmd/memory/{push,sync}.rs`)
+//! treat `attempted > 0 && created == 0 && skipped == 0` as a hard failure:
+//! the message leads with "Push failed"/"Sync failed" and the command returns
+//! `Err`, which `main`'s `#[tokio::main] fn -> Result<()>` maps to a non-zero
+//! exit. A prior version of this coverage exercised that predicate as a
+//! tautology, or called `push_local` (a function this behaviour doesn't live
+//! in) directly: neither would fail if the `bail!` blocks driving the actual
+//! exit code were reverted. These tests spawn the real compiled `spelunk`
+//! binary (`assert_cmd`, following `fail_closed_no_project.rs`'s pattern)
+//! against a mock team server that returns an all-failed batch result, so a
+//! regression in the command-layer `bail!` itself is what fails here.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Project slug with no characters `encode_project_id` would percent-encode,
+/// so the mocked route paths below can be matched literally.
+const PROJECT_SLUG: &str = "acme-widget";
+
+/// Mount `GET /v1/health` advertising a minimal Tier 1 server. `require_tier1`
+/// only checks `tier.is_server()` (any 200 response), so a bare `memory`
+/// capability is enough to unlock `memory push`/`sync`.
+async fn mount_health(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "capabilities": ["memory"],
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Mount `POST /v1/projects/{slug}/memory/batch` returning a batch result
+/// where nothing durably landed: `created: 0, skipped: 0`, and an empty
+/// `results[]` so `push_local` falls back to the aggregate ints instead of
+/// per-item reconciliation (see `sync.rs`'s `res.results.is_empty()` branch).
+/// This is the exact wire shape the command layer must read as a hard
+/// failure rather than success.
+async fn mount_batch_total_failure(server: &MockServer, failed: u32) {
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/projects/{PROJECT_SLUG}/memory/batch")))
+        .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+            "created": 0, "skipped": 0, "failed": failed, "results": []
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Mount `GET /v1/projects/{slug}/memory/since` returning no entries, for the
+/// pull half of `spelunk sync` (which runs independently of the push outcome).
+async fn mount_since_empty(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path_regex(format!(
+            r"^/v1/projects/{PROJECT_SLUG}/memory/since$"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": []
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Write a config with an explicit `server_url`/`project_id` pointing at the
+/// mock server, and no `server_key`/`[auth]`, so `ensure_fresh_server_key`
+/// takes its no-op path (`auth_api.rs`) and push/sync never needs a real
+/// WorkOS login against a keyless plaintext loopback server.
+fn write_config(dir: &Path, server_url: &str) -> std::path::PathBuf {
+    let db_path = dir.join(".spelunk").join("index.db");
+    let config_path = dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "db_path = {db_path:?}\n\
+             embedding_model = \"test-model\"\n\
+             llm_model = \"test-chat\"\n\
+             server_url = {server_url:?}\n\
+             project_id = {PROJECT_SLUG:?}\n"
+        ),
+    )
+    .expect("write config.toml");
+    config_path
+}
+
+/// Create a `.spelunk/` marker dir so ADR-067's fail-closed project gate
+/// resolves `proj` as a real local project, mirroring
+/// `fail_closed_no_project.rs::memory_add_works_with_local_dot_spelunk`.
+fn init_project(proj: &Path) {
+    std::fs::create_dir_all(proj.join(".spelunk")).expect("create .spelunk");
+}
+
+/// Seed one local memory entry via a real `spelunk memory add` subprocess run,
+/// so the subsequent push/sync has something `attempted > 0` to push.
+fn seed_one_note(home: &Path, proj: &Path, config_path: &Path) {
+    spelunk_bin_in(home)
+        .current_dir(proj)
+        .arg("--config")
+        .arg(config_path)
+        .args([
+            "memory", "add", "--kind", "note", "--title", "T", "--body", "B",
+        ])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn memory_push_total_failure_exits_nonzero_and_does_not_print_done() {
+    let server = MockServer::start().await;
+    mount_health(&server).await;
+    mount_batch_total_failure(&server, 1).await;
+
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_project(proj.path());
+    let config_path = write_config(proj.path(), &server.uri());
+    seed_one_note(home.path(), proj.path(), &config_path);
+
+    let assert = spelunk_bin_in(home.path())
+        .current_dir(proj.path())
+        .arg("--config")
+        .arg(&config_path)
+        .args(["memory", "push"])
+        .assert()
+        .failure();
+
+    let out = assert.get_output();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Push failed"),
+        "must surface the failure message; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        !stdout.contains("Done.") && !stderr.contains("Done."),
+        "a total-failure push must never read as success; stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+#[tokio::test]
+async fn memory_sync_total_failure_exits_nonzero_and_does_not_print_sync_complete() {
+    let server = MockServer::start().await;
+    mount_health(&server).await;
+    mount_batch_total_failure(&server, 1).await;
+    mount_since_empty(&server).await;
+
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_project(proj.path());
+    let config_path = write_config(proj.path(), &server.uri());
+    seed_one_note(home.path(), proj.path(), &config_path);
+
+    let assert = spelunk_bin_in(home.path())
+        .current_dir(proj.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("sync")
+        .assert()
+        .failure();
+
+    let out = assert.get_output();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Sync failed"),
+        "must surface the failure message; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        !stdout.contains("Sync complete.") && !stderr.contains("Sync complete."),
+        "a total-failure sync must never read as success; stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+/// Regression guard for the fix's OTHER side: a real success must still exit
+/// zero and print the "Done." success framing. Without this, a broken change
+/// that made every push exit non-zero unconditionally would still pass the
+/// two tests above.
+#[tokio::test]
+async fn memory_push_success_still_exits_zero_and_prints_done() {
+    let server = MockServer::start().await;
+    mount_health(&server).await;
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/projects/{PROJECT_SLUG}/memory/batch")))
+        .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+            "created": 1, "skipped": 0, "failed": 0, "results": []
+        })))
+        .mount(&server)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_project(proj.path());
+    let config_path = write_config(proj.path(), &server.uri());
+    seed_one_note(home.path(), proj.path(), &config_path);
+
+    spelunk_bin_in(home.path())
+        .current_dir(proj.path())
+        .arg("--config")
+        .arg(&config_path)
+        .args(["memory", "push"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Done."));
+}


### PR DESCRIPTION
## Context

PR #643 fixed three honesty bugs in `spelunk memory push`/`spelunk sync`
(attempted count, remote_id stamping, results reconciliation). QA reviewed it
and flagged two blocking issues in a PR comment: an internal ticket reference
in a commit message, and this task's original scope item — exit non-zero when
a push/sync attempt fully fails — was never implemented.

Before the fix landed, #643 was merged (by @usercise) with the QA-blocking
comment still open. Its branch was deleted on merge, so this is a fresh PR
against current `main` carrying the still-needed fix. See the task-board
comment on `spelunk-oss^237` and the comment on #643 for the full story,
including the commit-message issue (which is now baked into `main`'s history
via #643 and needs a separate decision — not addressed by this PR).

## Summary

- `memory_push` (`push.rs`) and `memory_sync` (`sync.rs`) previously returned
  `Ok(())` unconditionally, regardless of `PushSummary.failed`. A push/sync
  where every attempted entry failed (nothing created, nothing skipped) still
  printed "Done."/"Sync complete." with a failed count appended, and exited 0.
- Both commands now treat `attempted > 0 && created == 0 && skipped == 0` as a
  hard failure: the message leads with "Push failed"/"Sync failed" instead of
  success framing, and the function returns `Err`, which `main`'s
  `#[tokio::main] fn -> Result<()>` maps to a non-zero exit.
- Partial failure (some created or skipped, some failed) is unchanged — it
  already reports honestly per #643's fix.
- `spelunk sync`'s pull step still runs and is still reported even when the
  push half fails outright — pulling remote changes is independent of the
  push outcome.
- CHANGELOG entry updated in place (same entry #643 added) to describe the
  exit-code behavior.

## Test plan

- `cargo test --workspace --features rich-formats -- --skip probe_url_explicit_non_success_status_does_not_set_any_probe_failure --skip probe_url_auto_discovered_connection_refused_leaves_probe_failure_unset` — all green (two skips are a known pre-existing OnceCell-order flake in `capability.rs`, unrelated, filed separately).
- `cargo clippy --workspace --features rich-formats --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- New tests in `sync.rs`'s existing test module: `push_local_total_failure_reports_zero_created_and_skipped` (confirms `push_local` itself reports the honest all-failed shape) and `command_layer_treats_total_failure_summary_as_error_condition` (pins the exact total-vs-partial-failure predicate the command layer uses). Deliberately does not drive `memory_push`/`memory_sync` end-to-end through `capability::get_tier`, since that function caches its result in a process-lifetime `static OnceCell` shared by the whole test binary — a test resolving it to `Tier::Server` would pin that tier for every other test in the binary regardless of run order (the same class of flake QA's test-plan skips above are filed against).