### PR TITLE
release: 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.4] — 2026-07-17
+
 ### Changed
 
+- **`spelunk index` skips generated, vendored, and minified files.** Build output,
+  vendored dependencies, and minified assets are no longer parsed, chunked, or
+  embedded, so the index reflects source you wrote rather than machine-generated files.
 - **Linux release binaries now target glibc 2.31 as the support floor.** Builds
   run in a `debian:11` (Bullseye) container to ensure compatibility with Debian
   11+ and Ubuntu 20.04+. Previously, releases silently required glibc 2.39
@@ -187,6 +192,10 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`spelunk hooks install` honors `core.hooksPath`.** Hooks were previously written
+  to `.git/hooks` even when `core.hooksPath` pointed elsewhere, so git never ran them
+  while `init` reported them installed. Install now resolves the hooks directory via
+  git and writes where git will invoke them.
 - **A TLS certificate failure against a configured `server_url` no longer
   reports "unreachable".** When the capability probe's TLS handshake failed,
   the WARN printed only reqwest's flattened top-level message ("error sending
@@ -478,6 +487,14 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   now forwarded through one shared argv-building function used by both spawn
   sites. `spelunk index` still exits 0 if summarization fails in the child;
   this only changes what the child is given, not what it does with a failure.
+
+### Known issues
+
+- **`memory archive` and `supersede` do not yet travel via the git-notes carrier.**
+  Archiving or superseding an entry updates your local `memory.db`, but that state
+  change is not yet propagated through `refs/notes/spelunk` to teammates: entries
+  sync, their archived/superseded state does not. A fix is tracked for a follow-up
+  release.
 
 ## [0.9.3] — 2026-07-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-embed"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-embed/Cargo.toml
+++ b/crates/spelunk-embed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-embed"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 description = "Native F2LLM-v2-330M embedder (candle) for spelunk"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"


### PR DESCRIPTION
Release-prep for **v0.9.4**. This PR is release metadata only — every functional fix in 0.9.4 is already merged to `main`.

## Changes
- Bump the workspace version `0.9.3 → 0.9.4` (4 crates + `Cargo.lock`).
- Finalize the changelog: rename `[Unreleased]` → `[0.9.4]`, and backfill the two entries whose PRs skipped `CHANGELOG.md`:
  - `spelunk index` skips generated/vendored/minified files (#642)
  - `spelunk hooks install` honors `core.hooksPath` (#647)
- Add a **Known issues** note: `memory archive` / `supersede` don't yet travel via the git-notes carrier (deferred to a follow-up).

## Not in this PR
The 0.9.4 fixes themselves already landed: honest `memory push`/`sync` counting (#643 / #648), `memory watch` panic on a loopback-only server (#644), detached-index flag propagation (#645), dead `read-conventions` removal (#646), `core.hooksPath` resolution (#647), macOS Keychain prompt de-duplication (#649) — plus the git-notes carrier, embed-lifecycle, and glibc-floor work already recorded under `[Unreleased]`.

## After merge
Tag `v0.9.4` to trigger `.github/workflows/release.yml` (platform binaries, `.deb`, GitHub Release, Homebrew formula).

---
_Process note: two of the six gate PRs skipped their own `CHANGELOG.md` update, so those entries are backfilled here. Worth nudging that changelog updates ride their PRs going forward. The Known-issues block is easy to drop if you'd rather keep it only in the GitHub release notes._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
