### PR TITLE
fix(ci): run Linux-container release steps under bash (set -o pipefail fails under dash)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
       # keyring crate's sync-secret-service feature (links libdbus, a C lib).
       - name: Install build dependencies (Linux container)
         if: matrix.container != ''
+        shell: bash
         run: |
           set -euo pipefail
           apt-get update
@@ -64,6 +65,7 @@ jobs:
 
       - name: Install Rust stable (Linux container)
         if: matrix.container != ''
+        shell: bash
         run: |
           set -euo pipefail
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
@@ -108,6 +110,7 @@ jobs:
 
       - name: Strip binaries (Linux)
         if: contains(matrix.target, 'linux')
+        shell: bash
         run: |
           set -euo pipefail
           strip "target/${{ matrix.target }}/release/spelunk"
@@ -121,6 +124,7 @@ jobs:
       # GLIBC_ symbols at all, would otherwise slip through as a false pass).
       - name: Enforce glibc ceiling (Linux)
         if: matrix.container != ''
+        shell: bash
         run: |
           set -euo pipefail
           for bin in spelunk spelunk-server; do


### PR DESCRIPTION
## What broke

The v0.9.4 release run failed on **both Linux builds** (macOS passed, Windows unaffected). Root cause from the job log:

```
/__w/_temp/….sh: 1: set: Illegal option -o pipefail
##[error]Process completed with exit code 2.
```

Inside the `debian:11` container, GitHub Actions defaults the step shell to **`sh` (dash)**, which has no `pipefail`. So `set -euo pipefail` aborted the **first** container step (`Install build dependencies`) before `apt-get` even ran — failing the build immediately. Non-container runners (macOS/Windows) default to `bash`/`pwsh`, so they were fine.

This rode in with the `debian:11` container (glibc-2.31 floor) and was never caught because the release workflow only runs on **tag push**, never on a PR.

## Fix

Add `shell: bash` to the four Linux-container steps that were missing it — build deps, rustup install, strip, and the glibc-ceiling check. The `Build release binaries` and `Package tarball` steps already had `shell: bash`; this just makes the rest consistent. `bash` is present in `debian:11`, and this preserves `pipefail` semantics (the rustup `curl | sh` step relies on it).

## Verification note

PR CI (`ci.yml`) does **not** exercise `release.yml` (that only runs on a tag), so a green PR here doesn't prove the fix — the proof is a clean re-tagged release run. Follow-up worth considering: a PR-triggered container smoke build so the release path stops failing only at tag time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
