### PR TITLE
fix(ci): derive .deb Depends inside debian:11 (correct glibc floor)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,16 +225,24 @@ jobs:
           install -m 644 packaging/spelunk-server.service \
             BUILD/usr/lib/systemd/user/spelunk-server.service
 
-          # Depends is derived from the packaged binaries, never hardcoded.
-          # dpkg-shlibdeps needs a debian/control in its working dir, and errors
-          # out if a linked library maps to no installed package.
-          mkdir -p shlibdeps/debian
-          printf 'Source: spelunk\nMaintainer: spelunk-cloud <hello@spelunk.cloud>\n\nPackage: spelunk\nArchitecture: amd64\nDescription: placeholder\n placeholder\n' \
-            > shlibdeps/debian/control
-          DEB_DEPENDS="$(cd shlibdeps && dpkg-shlibdeps -O \
-            ../BUILD/usr/bin/spelunk \
-            ../BUILD/usr/bin/spelunk-server)"
-          rm -rf shlibdeps
+          # Depends is derived from the packaged binaries, never hardcoded, and
+          # derived INSIDE debian:11 (the build floor), not on the ubuntu runner.
+          # On ubuntu-24.04 (glibc 2.39) the binaries' link against the pre-merge
+          # libpthread.so.0 / libdl.so.2 resolves to libc's merged (>= 2.34)
+          # symbols, so dpkg-shlibdeps derives libc6 (>= 2.34) — which then cannot
+          # install on the glibc-2.31 floor the release targets. debian:11 derives
+          # libc6 (>= 2.30). The container needs dpkg-dev plus every linked
+          # library's package (libdbus-1-3); libc6/libgcc-s1 are in the base
+          # image. dpkg-shlibdeps needs a debian/control in its working dir.
+          DEB_DEPENDS="$(docker run --rm -v "$PWD:/w:ro" debian:11 bash -c '
+            set -euo pipefail
+            apt-get update -qq >/dev/null
+            apt-get install -y -qq --no-install-recommends dpkg-dev libdbus-1-3 >/dev/null
+            mkdir -p /tmp/sd/debian
+            printf "Source: spelunk\nMaintainer: spelunk-cloud <hello@spelunk.cloud>\n\nPackage: spelunk\nArchitecture: amd64\nDescription: placeholder\n placeholder\n" > /tmp/sd/debian/control
+            cd /tmp/sd
+            dpkg-shlibdeps -O /w/BUILD/usr/bin/spelunk /w/BUILD/usr/bin/spelunk-server
+          ')"
           echo "Derived ${DEB_DEPENDS}"
 
           # DEBIAN/control — written via JS to avoid YAML heredoc issues


### PR DESCRIPTION
## What broke (one layer past #651)

With the `pipefail` fix in, the release build got further and failed in the **`.deb` smoke-test**:

```
E: Unable to correct problems, you have held broken packages.
Error: Process completed with exit code 100.
```

The `.deb` job runs `dpkg-shlibdeps` on **ubuntu-24.04** (glibc 2.39). There, the binaries' (harmless) link against the pre-merge `libpthread.so.0` / `libdl.so.2` resolves to libc's **merged** symbols (merged at glibc 2.34), so it derives `Depends: libc6 (>= 2.34)`. The smoke-test then installs that `.deb` on `debian:11` (glibc 2.31) → `2.34 > 2.31` → held broken packages. The `.deb` over-declared its own floor, against the whole point of the debian:11 build.

## Fix

Derive `Depends` inside a `debian:11` container (the build floor) instead of on the ubuntu runner — the same binaries resolve to `libc6 (>= 2.30)` there.

## Validated locally (not just reasoned)

Using the failed run's own x86_64 artifact, in an amd64 `debian:11` container:
- ubuntu-24.04 derivation → `libc6 (>= 2.34)` (reproduces the failure)
- debian:11 derivation → `libc6 (>= 2.30), libdbus-1-3 (>= 1.9.14), libgcc-s1 (>= 4.2)`
- assembled the `.deb` with the debian:11-derived Depends and `apt-get install`ed it on `debian:11` → **INSTALL OK**; `spelunk --version` → `spelunk-cli 0.9.4`.

## After merge
Re-tag `v0.9.4` at the new main HEAD (delete + recreate the tag) to re-run the release with this fix.

---
_This is the third tag-time-only failure in this release path (pipefail in #651, now the `.deb` floor). The `tarball-smoke` and homebrew/scoop jobs still haven't run end-to-end. A PR-triggered dry-run of the release path (or at least the container build + `.deb` install) would stop this class of "only fails at tag time" bug — worth a follow-up._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
