### PR TITLE
fix(ci): install libdbus in the Fuzz workflow so the fuzz build links

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,6 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # The fuzz targets link spelunk-core, which pulls keyring's
+      # sync-secret-service backend (libdbus-sys); without this its build script
+      # fails when pkg-config can't find dbus-1. Every Linux job in ci.yml
+      # installs the same package for this reason.
+      - name: Install libdbus (keyring sync-secret-service backend)
+        run: sudo apt-get install -y libdbus-1-dev pkg-config
+
       - name: Install Rust nightly
         run: |
           rustup update nightly


### PR DESCRIPTION
## Problem

The scheduled **Fuzz** workflow has failed the last three runs ([28374547093](https://github.com/spelunk-cloud/spelunk/actions/runs/28374547093), [28793005756](https://github.com/spelunk-cloud/spelunk/actions/runs/28793005756), [29248991410](https://github.com/spelunk-cloud/spelunk/actions/runs/29248991410)), all with the same root cause — and not a fuzzing crash (no crash artifacts were ever uploaded).

The failure is at **build time**. The fuzz targets link `spelunk-core`, which depends on `keyring` with the `sync-secret-service` backend. That backend links `libdbus-sys`, whose build script shells out to `pkg-config` for `dbus-1`. On a bare `ubuntu-latest` runner the dev package is absent, so the build script panics:

```
The system library `dbus-1` required by crate `libdbus-sys` was not found.
error: failed to run custom build command for `libdbus-sys v0.2.7`
Error: failed to build fuzz script: ... "cargo" "build" ... "--bin" "fuzz_parser"
```

`cargo fuzz run` never reaches the fuzzer, so the job exits 1 before any fuzzing happens.

## Fix

Every Linux job in `ci.yml` already installs `libdbus-1-dev pkg-config` for exactly this reason (the check/lint, test, and openapi-snapshot jobs). The Fuzz workflow was the only Linux job missing it. This adds the identical step right after checkout.

## Test plan

- `workflow_dispatch` run of the Fuzz workflow on this branch confirms the fuzz target now builds and the 60s fuzz run completes (link added in a comment below once it finishes).
- No product-code change; the CLI/library keyring behaviour is untouched.