### PR TITLE
fix(ci): build the .deb with -Zxz (zstd members unreadable on the debian:11 floor)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,7 +255,12 @@ jobs:
 
       - name: Build .deb
         run: |
-          dpkg-deb --build BUILD "spelunk_${{ env.DEB_VERSION }}_amd64.deb"
+          # -Zxz: this runner is ubuntu-24.04, whose dpkg-deb defaults to zstd
+          # (control.tar.zst / data.tar.zst). debian:11's dpkg (1.20) cannot read
+          # zstd members, so a default-built .deb fails to install on the
+          # glibc-2.31 floor with "unknown compression for member 'control.tar.zst'".
+          # xz members install everywhere from the floor up.
+          dpkg-deb --build -Zxz BUILD "spelunk_${{ env.DEB_VERSION }}_amd64.deb"
 
       # apt-get install SUCCEEDS on a .deb whose Depends omits a linked library;
       # only executing real subcommands (a git-backed memory round trip


### PR DESCRIPTION
## What broke (fourth tag-time failure, same class)

With #651 (pipefail) and #652 (libc6 floor) merged, the release reached the `.deb` smoke-test and failed on **compression**:

```
dpkg-deb: error: archive 'spelunk_0.9.4_amd64.deb' uses unknown compression for member 'control.tar.zst', giving up
```

The `.deb` is built with `dpkg-deb --build` on **ubuntu-24.04**, whose dpkg-deb defaults to **zstd** (`control.tar.zst` / `data.tar.zst`). `debian:11`'s dpkg (1.20) cannot read zstd members, so the `.deb` fails to install on the glibc-2.31 floor.

## Fix
`dpkg-deb --build -Zxz` → xz members, which the floor's dpkg reads.

## Validated locally (exact repro + fix)
Built the `.deb` on `ubuntu:24.04` (matching CI) from the failed run's own binaries:
- default → members `control.tar.zst` + `data.tar.zst` → install on `debian:11` fails with the **exact** CI error.
- `-Zxz` → members `control.tar.xz` + `data.tar.xz` → **INSTALL OK** on `debian:11`, `spelunk --version` → `spelunk-cli 0.9.4`.

## After merge
Re-tag `v0.9.4` at the new main HEAD (delete + recreate).

---
_Fourth failure surfaced only at tag time (pipefail #651, libc6 floor #652, now zstd). The durable fix is a PR-triggered release dry-run (container build + `.deb` assemble/install on the floor) so `release.yml` is exercised before tagging, not after. Strongly recommend filing it as a fast-follow — it's the recurring root cause of this whole sequence._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
