### PR TITLE
docs: drop fabricated init return-time estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,7 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   declares `libdbus-1-3` as a dependency; tarball users on minimal images must
   install `libdbus-1-3` separately.
 - **`spelunk init` starts the server before indexing and detaches the embedding pass.**
-  On a fresh install, the prompt now returns after parsing (seconds on small projects,
-  around a minute on large ones), with embeddings arriving in the background. A detached worker
+  On a fresh install, the prompt now returns after parsing, with embeddings arriving in the background. A detached worker
   polls the embedder readiness and runs the embed phase, resumable by re-running
   `spelunk index`. The server is auto-started before parsing begins (rather than after),
   and a not-yet-ready embedder is a transient condition to wait on rather than a

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -159,8 +159,7 @@ spelunk init
 That's the whole setup. `spelunk init` registers the project, starts the bundled
 `spelunk-server` in the background when run interactively (if one isn't already running),
 parses and chunks every source file, and hands the embedding pass to a detached background
-worker so the prompt returns after parsing (seconds on small projects, around a minute on
-large ones) rather than after the full embed pass. Embeddings build in the background; full-text and ast-grep search
+worker so the prompt returns after parsing rather than after the full embed pass. Embeddings build in the background; full-text and ast-grep search
 work immediately, and semantic search becomes available as embeddings land.
 
 ```bash


### PR DESCRIPTION
## What

Removes the parenthetical `(seconds on small projects, around a minute on large ones)` from two places:
- `CHANGELOG.md` — the 0.9.4 `spelunk init` entry
- `docs/getting-started.md` — the same claim, propagated into the onboarding doc

## Why

The figure is inaccurate: real `init` runs take multiple minutes, not seconds. It also contradicts the measured timings recorded in ADR-070 (init ~104 min on the test repo, embed ~99% of it), the very ADR the changelog entry cites. Surfaced while drafting the v0.9.4 release note; flagged by the founder, who has never seen init return in under multiple minutes.

The surrounding claim is left intact and is the real, verified change: `init` returns after parsing and detaches the embedding pass to the background, rather than blocking on the full embed. No timing number is asserted in its place.

## Scope

Docs/changelog only, no code change. ADR-070 is left as-is (its measured numbers are correct). Marketing-site mirror already carries no timing number, so nothing to change there.

## Test plan

- `grep -rniE 'seconds on small|minute on large ones'` over the repo returns no matches after the change.
- Both edited sentences read correctly without the parenthetical (verified in the diff).
- Docs-only change; pre-push `cargo check` passed.

Preview / merge is the founder's call.