### PR TITLE
scoop: publish v0.9.4 manifest (release job blocked by branch protection)

### DIFF
--- a/bucket/spelunk.json
+++ b/bucket/spelunk.json
@@ -1,12 +1,12 @@
 {
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Code intelligence for AI agents - persistent memory, code graph, search",
   "homepage": "https://github.com/spelunk-cloud/spelunk",
   "license": "MIT",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/spelunk-cloud/spelunk/releases/download/v0.9.3/spelunk-v0.9.3-x86_64-pc-windows-msvc.zip",
-      "hash": "9c1691dc700c67af0c63ba0c61b20c1f51e02bdb80da07ae3c24fea04d7a0161"
+      "url": "https://github.com/spelunk-cloud/spelunk/releases/download/v0.9.4/spelunk-v0.9.4-x86_64-pc-windows-msvc.zip",
+      "hash": "c86a215ed0436a5db3d4c0e98f059f0f52dcd59519b245d6bb274603e9b274c3"
     }
   },
   "bin": [


### PR DESCRIPTION
The `update-scoop-manifest` release job failed to publish v0.9.4: it commits `bucket/spelunk.json` and `git push origin main` **directly**, which `main`'s branch-protection rule now rejects ("changes must be made through a pull request", GH013). v0.9.4 shipped on every other channel (platform binaries, `.deb`, Homebrew) — only the scoop bucket was left at 0.9.3.

This PR is the manifest the job would have pushed, regenerated with the same script:

```
node .github/scripts/update-scoop-manifest.js --version 0.9.4 \
  --sha-x86_64-windows <sha256 of the published spelunk-v0.9.4-x86_64-pc-windows-msvc.zip>
```

Merging it brings the scoop bucket to 0.9.4.

The durable fix — so the scoop job works on future releases without a manual PR — is tracked separately (make the job open a PR, use a bypass token, or move the bucket to a separate repo like the Homebrew tap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
