### PR TITLE
ci: fix Check & Lint runner disk exhaustion (ENOSPC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,17 @@ jobs:
     name: Check & Lint
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      # clippy/check/build in this job need no debug info from the dev
+      # profile; the full workspace build (all-targets, rich-formats, incl.
+      # the embedder dep tree) has been observed to exhaust runner disk
+      # (ENOSPC) with debug info on. Mirrors CARGO_PROFILE_TEST_DEBUG below.
+      CARGO_PROFILE_DEV_DEBUG: 0
     steps:
       - uses: actions/checkout@v7
+
+      - name: Disk usage (baseline)
+        run: df -h
 
       - name: Install libdbus (keyring sync-secret-service backend)
         run: sudo apt-get install -y libdbus-1-dev pkg-config
@@ -46,6 +55,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Disk usage (after cache restore)
+        run: df -h
+
       - name: Rustfmt
         run: cargo fmt --all -- --check
 
@@ -57,6 +69,10 @@ jobs:
 
       - name: Build (rich-formats)
         run: cargo build --all-targets --features rich-formats
+
+      - name: Disk usage (after build)
+        if: always()
+        run: df -h
 
   test:
     name: Test

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -154,6 +154,16 @@ CI runs `cargo build` + `cargo test` on `ubuntu-latest`, `macos-latest`, and
   at runtime on first use, not at build time. No model is downloaded during
   `cargo build` or `cargo test` (tests use `embedder: None`).
 
+### Ubuntu (`ubuntu-latest`) caveats
+
+- **`check` job disk pressure.** The `check`/lint job builds the full
+  workspace (`--all-targets --features rich-formats`, which pulls in the
+  embedder dependency tree) and has intermittently exhausted the runner's
+  free disk space. The job sets `CARGO_PROFILE_DEV_DEBUG: 0` to drop
+  dev-profile debug info, and runs `df -h` before toolchain install, after
+  cache restore, and after the final build, so a recurrence is diagnosable
+  from the job log instead of vanishing with the runner.
+
 ---
 
 ## Planned additions


### PR DESCRIPTION
## Summary

Founder-confirmed root cause: the intermittent `Check & Lint` job failures (no failed step recorded, log unavailable, same tree passes on sibling runs) are the GitHub-hosted runner running out of disk space during the full-workspace debug build (`--all-targets --features rich-formats`, which pulls in the embedder dependency tree).

- Adds `CARGO_PROFILE_DEV_DEBUG: 0` to the `check` job's env (scoped to that job only), dropping dev-profile debug info from clippy/check/build output. Mirrors the existing `CARGO_PROFILE_TEST_DEBUG: 0` pattern already used by the `test` job.
- Adds three `df -h` instrumentation steps in the `check` job: baseline (post-checkout), after cache restore, and after the final build (`if: always()`, so it still reports if an earlier step failed). This isolates the cache-restore contribution from build-time growth and gives a peak-usage reading, so a recurrence is diagnosable from the job log instead of vanishing with the runner.
- The lint command itself is untouched: `cargo clippy --all-targets --features rich-formats -- -D warnings`, byte-for-byte identical to `main`.
- Adds a short "Ubuntu (`ubuntu-latest`) caveats" subsection to `docs/testing.md`, matching the existing "Windows caveats" subsection's style, documenting the symptom and the mitigation for future readers of the job log.

## Test plan

What was actually run pre-PR (worktree, no CI access):

- [x] `git fetch origin` + ancestor check: branch is not behind `origin/main` (based on `80beee72d`).
- [x] `git diff origin/main..HEAD` reviewed end-to-end: exactly 2 commits, 26 insertions, 0 deletions, touching only `.github/workflows/ci.yml` (16 lines) and `docs/testing.md` (10 lines). No `.rs` files touched.
- [x] Confirmed the `clippy` line is byte-identical between `origin/main` and `HEAD` (`git show <ref>:.github/workflows/ci.yml | grep clippy` on both sides) — the lint gate itself is unchanged, only instrumentation/env was added.
- [x] Independent YAML parse (`ruby -ryaml`) confirms `CARGO_PROFILE_DEV_DEBUG: 0` is scoped to the `check` job's `env:` only — `test` (`CARGO_PROFILE_TEST_DEBUG: 0`), `release-scripts`, `docker-build`, and `openapi-snapshot` all report no such key.
- [x] Confirmed the workflow has no `workflow_dispatch` trigger (`on:` is `push`/`pull_request` to `main` only), so this PR's own `pull_request`-triggered CI run is the only way to get a live disk-usage reading — it could not be produced pre-PR.
- [x] Grepped the diff for board-tracker references (`spelunk-oss^NNN`, `task_[hex]`) and em-dashes on added lines: none found. Public-repo hygiene clean.
- [x] Read `docs/testing.md` diff in context against the existing "Windows caveats" subsection: consistent style/tone.

**Not yet verified, and can only be verified by this PR's own CI run:** the actual `df -h` disk-usage numbers (baseline / after-cache-restore / after-build) and whether the ENOSPC recurrence is actually resolved. Please check this PR's own `Check & Lint` job log for the three `df -h` outputs before merging, and ideally watch for a couple of green runs afterward since a single green proves little for an intermittent failure.