### PR TITLE
test(git): isolate ambient core.hooksPath from src/ unit tests too

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/hooks.rs
+++ b/crates/spelunk-cli/src/cli/cmd/hooks.rs
@@ -433,7 +433,14 @@ mod tests {
 
     /// A repo with a real identity and one commit, isolated from the
     /// developer's ambient git config.
+    ///
+    /// The isolation has to be process-wide (see
+    /// `cli::cmd::test_support::isolate_git_config`), not just set on the
+    /// setup `Command`s here: `resolve_hooks_dir` (the function under test)
+    /// spawns its own git via `git_output`, uninstrumented, and inherits
+    /// whatever the process environment holds at that point.
     fn init_repo(dir: &Path) {
+        crate::cli::cmd::test_support::isolate_git_config();
         let run = |args: &[&str]| {
             let status = std::process::Command::new("git")
                 .args(args)
@@ -442,8 +449,6 @@ mod tests {
                 .env("GIT_AUTHOR_EMAIL", "t@example.com")
                 .env("GIT_COMMITTER_NAME", "t")
                 .env("GIT_COMMITTER_EMAIL", "t@example.com")
-                .env("GIT_CONFIG_GLOBAL", "/dev/null")
-                .env("GIT_CONFIG_SYSTEM", "/dev/null")
                 .status()
                 .expect("run git");
             assert!(status.success(), "git {args:?} failed");

--- a/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
@@ -801,6 +801,10 @@ mod init_import_tests {
     }
 
     fn make_temp_git_repo() -> tempfile::TempDir {
+        // Process-wide: this repo's own `commit` below runs through the
+        // ambient global git config if it isn't neutralized first, so an
+        // ambient `core.hooksPath` fires a foreign pre-commit hook here.
+        crate::cli::cmd::test_support::isolate_git_config();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let p = dir.path();
         let run = |args: &[&str]| {

--- a/crates/spelunk-cli/src/cli/cmd/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/mod.rs
@@ -19,6 +19,8 @@ pub mod plumbing;
 pub mod search;
 pub mod server;
 pub mod status;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod ui;
 
 pub use check::check;

--- a/crates/spelunk-cli/src/cli/cmd/test_support.rs
+++ b/crates/spelunk-cli/src/cli/cmd/test_support.rs
@@ -1,0 +1,33 @@
+//! Shared helper for unit tests under `cli::cmd`.
+//!
+//! `tests/plumbing_helpers.rs` carries the same helper for the `tests/`
+//! integration binaries, but a unit test compiled into `src/` cannot reach a
+//! file under `tests/`, so this is the `src/`-side counterpart.
+
+/// Drop the machine's global/system git config for every git this process
+/// spawns: a setup git a test runs directly, and any git the code under
+/// test spawns for itself. Must be process-wide, not per-`Command`: a
+/// helper that only sets env on the `Command` it builds itself never
+/// reaches a git spawned inside the function under test.
+///
+/// A temp repo's local config does not shadow an ambient value the repo
+/// never sets, so an ambient `core.hooksPath` (husky, lefthook, the
+/// pre-commit framework) fires a foreign hook inside a test's throwaway
+/// repo, and an ambient `commit.gpgsign` signs as an identity no
+/// contributor holds a key for.
+///
+/// `/dev/null` is not a Windows path, but git skips a scope whenever its
+/// var is set, whatever the path resolves to, so this isolates on Windows
+/// too.
+pub(crate) fn isolate_git_config() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: every caller here calls this first and `Once` blocks the
+        // rest until it returns, so no thread can be spawning git (reading
+        // environ) while these run.
+        unsafe {
+            std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
+            std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
+        }
+    });
+}

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -1607,9 +1607,10 @@ async fn test_memory_timeline_reads_local_store_with_auto_discovered_server() {
 // re-run imports nothing (dedup by the same content key as `memory reconcile`).
 
 /// Init a git repo at `dir` with a committer identity AND one commit, so
-/// `refs/notes/spelunk` can be attached — git notes hang off a commit object,
+/// `refs/notes/spelunk` can be attached - git notes hang off a commit object,
 /// so the no-commit `git_init_repo` helper above is not enough here.
 fn git_init_repo_with_commit(dir: &std::path::Path) {
+    plumbing_helpers::isolate_git_config();
     for args in [
         &["init", "-q"][..],
         &["config", "user.email", "test@test.com"][..],

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -944,8 +944,33 @@ mod cat_file_batch {
         );
     }
 
+    /// Drop the machine's global/system git config for every git this
+    /// process spawns, including a setup git this test module runs
+    /// directly. Must be process-wide, not per-`Command`: a helper that
+    /// only sets env on the `Command` it builds itself never reaches git
+    /// spawned by the code under test (`run_git`/`run_git_with_stdin`
+    /// inherit the process environment like any other `Command`).
+    ///
+    /// A temp repo's local config does not shadow an ambient value the
+    /// repo never sets, so an ambient `core.hooksPath` (husky, lefthook,
+    /// the pre-commit framework) fires a foreign pre-commit hook on the
+    /// commit below.
+    fn isolate_git_config() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            // SAFETY: every caller here calls this first and `Once` blocks
+            // the rest until it returns, so no thread can be spawning git
+            // (reading environ) while these run.
+            unsafe {
+                std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
+                std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
+            }
+        });
+    }
+
     /// A repo carrying one note, and that note's blob sha.
     fn repo_with_one_note() -> (tempfile::TempDir, String) {
+        isolate_git_config();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let run = |args: &[&str]| {
             let out = std::process::Command::new("git")

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -92,6 +92,39 @@ Tests that open a database call `common::open_test_db()` and are annotated
 
 ---
 
+## Ambient git config in tests
+
+Tests that shell out to `git` in a temp repo do not start from a clean
+slate: git also reads the contributor's real **global** and **system**
+config. A repo's local config does not shadow a global value it never
+sets, so an ambient `core.hooksPath` (husky, lefthook, the `pre-commit`
+framework), `commit.gpgsign`, or `notes.rewriteRef` can make git behave
+differently inside a test's throwaway repo than it does in CI, where no
+ambient config exists.
+
+Every test that spawns git must call an `isolate_git_config()` helper
+first. It sets `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `/dev/null`
+for the whole process, guarded by `std::sync::Once` so it is safe to call
+from every test. The isolation must be process-wide, not scoped to one
+`Command`: a helper that only sets env on the `Command` it builds itself
+never reaches git that the code under test spawns for itself.
+
+Three call sites carry a copy of the same helper, because a unit test
+compiled into `src/` cannot reach a file under `tests/`:
+
+| Location | Covers |
+|------|---------------|
+| `crates/spelunk-cli/tests/plumbing_helpers.rs` | `tests/` integration binaries for `spelunk-cli` |
+| `crates/spelunk-cli/src/cli/cmd/test_support.rs` | `src/` unit tests for `spelunk-cli` |
+| `crates/spelunk-core/src/storage/git_notes/mod.rs` (local to the `cat_file_batch` test module) | `spelunk-core` unit tests |
+
+CI runners carry no ambient global config, so a missing call here never
+fails CI. It only surfaces as a local test failure for a contributor who
+has one of these settings configured globally, with no indication of the
+cause.
+
+---
+
 ## Running the tests
 
 ```bash


### PR DESCRIPTION
## Summary

A global `core.hooksPath` (husky, lefthook, the `pre-commit` framework — a mainstream pattern) makes a foreign `pre-commit` hook fire inside this repo's temp-repo tests, turning them red on a clean checkout. Same defect class as #620 (`notes.rewriteRef`) and the earlier `commit.gpgsign` fix: the suite isn't hermetic against the contributor's ambient global git config.

The originally-scoped repro found 7 tests. Re-deriving it from scratch during this pass turned up an **8th**: `cli::cmd::hooks::tests::resolve_hooks_dir_defaults_to_dot_git_hooks_when_core_hooks_path_is_unset`. Its setup helper already neutralized `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`, but only on the setup `Command`s — the function under test (`resolve_hooks_dir`) spawns its own git and inherited the ambient value anyway. That's the exact per-`Command` anti-pattern #620 flagged; the other 5 tests in that file set an explicit local `core.hooksPath` that shadows the ambient one, so only the "unset default" case was exposed.

Most of the affected tests are unit tests compiled into `src/`, which can't reach `tests/plumbing_helpers.rs::isolate_git_config()` — a `tests/`-only helper can't be imported by a `src/` unit test. This PR adds the same isolation mechanism (`Once`-guarded, process-wide `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`) reachable from `src/`:

- `crates/spelunk-cli/src/cli/cmd/test_support.rs` (new, `#[cfg(test)]`-gated) — used by `reconcile.rs::make_temp_git_repo()` and `hooks.rs::init_repo()`.
- `crates/spelunk-core/src/storage/git_notes/mod.rs` — a local copy in the `cat_file_batch` test module, used by `repo_with_one_note()`.
- `crates/spelunk-cli/tests/e2e_cli.rs::git_init_repo_with_commit` — now calls the existing `plumbing_helpers::isolate_git_config()` (one-line fix).

Also adds an "Ambient git config in tests" section to `docs/testing.md` documenting the pattern and its three call sites, since this is now the third instance of this defect class.

**Test-hermeticity only — no production behaviour change.** `test_support.rs` is `#[cfg(test)]`-gated and never compiled into a release build; `run_git`/`run_git_with_stdin` in `spelunk-core` are untouched.

## Test plan

All commands run directly in the branch worktree, real (unpiped) `$?`, `SPELUNK_SECRET_STORE=file`:

- Branch rebased onto latest `origin/main` (was 5 commits behind); rebase was clean, no conflicts.
- `git diff origin/main..HEAD` reviewed end-to-end — confirmed test-only (3 test files + 1 new `#[cfg(test)]` module + docs), no production code path touched.
- `cargo fmt --check` → exit 0.
- `cargo clippy --workspace --tests --features rich-formats -- -D warnings` → exit 0, clean.
- `cargo nextest run --workspace --no-fail-fast` (default features) → 1319 passed, exit 0.
- `cargo nextest run --workspace --no-fail-fast --features rich-formats` → 1319 passed, exit 0.
- `cargo test --doc --workspace` (default features) → exit 0.
- `cargo test --doc --workspace --features rich-formats` → exit 0.
- Independent repro spot-check: built a scratch `GIT_CONFIG_GLOBAL` pointing `core.hooksPath` at a foreign failing `pre-commit` hook (never touched the real global config; sanity-checked the poison itself blocks a plain `git commit` with exit 1). Ran the 8 affected tests by name under that poisoned config against this fixed tree: all 12 matched tests (8 affected + a few adjacent no-op variants) passed, exit 0.
- Grepped the full diff for board-id references and em-dashes on added lines: none found.

Repro-before-fix (8 red under the poisoned config) and the mutation check proving the isolation call load-bearing (reverted, re-ran individually, confirmed red again) were independently verified by the Test Engineer stage on this task; see board thread for detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)