### PR TITLE
ci: split Windows toolchain install into one command per step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,15 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get install -y libdbus-1-dev pkg-config
 
-      - name: Install stable toolchain
-        run: |
-          rustup update stable
-          rustup default stable
+      # One command per step: this job's matrix includes windows-latest, and a
+      # Windows step's exit status does not reflect a failing native
+      # executable (only a failing PowerShell cmdlet), so chaining two rustup
+      # invocations in one run block would mask a failure in the first.
+      - name: Update stable toolchain
+        run: rustup update stable
+
+      - name: Set default toolchain
+        run: rustup default stable
 
       - name: Cache
         uses: actions/cache@v6

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -130,6 +130,16 @@ CI runs `cargo build` + `cargo test` on `ubuntu-latest`, `macos-latest`, and
 
 ### Windows (`windows-latest`) caveats
 
+- **One command per `run:` step.** GitHub wraps a Windows step in PowerShell,
+  which aborts on a failing cmdlet but not on a failing native executable
+  (`rustup`, `cargo`, etc.), since `$ErrorActionPreference='Stop'` +
+  `exit $LASTEXITCODE` doesn't cover native exit codes. A `run:` block
+  chaining two native commands can report success even when the first one
+  failed. Steps in this job's Windows-inclusive matrix keep one command per
+  step for that reason, e.g. the toolchain install is `Update stable
+  toolchain` and `Set default toolchain` as separate steps rather than one
+  `run: |` block.
+
 - **Build time.** Vendored OpenSSL (pulled in transitively by `native-tls`,
   via `hf-hub`/`reqwest` in the `embed-native` stack) compiles from C source.
   Strawberry Perl is pre-installed on `windows-latest` runners so the build


### PR DESCRIPTION
## Summary

- Windows steps in GitHub Actions are wrapped in PowerShell, which aborts on a failing cmdlet but *not* on a failing native executable (`$ErrorActionPreference='Stop'` + `exit $LASTEXITCODE` doesn't cover native exit codes). The `test` job's matrix includes `windows-latest`, and its `Install stable toolchain` step chained `rustup update stable` + `rustup default stable` in one `run:` block — a failure in the first command could be masked by the second command's success, silently continuing CI on an unintended toolchain.
- Splits that step into two single-command steps (`Update stable toolchain`, `Set default toolchain`), matching the pattern already used elsewhere in this repo's `release.yml`.
- Adds a bullet to `docs/testing.md`'s Windows caveats section explaining the hazard and pointing at this step as the concrete example of the one-command-per-step convention.

## Audit scope

Swept every `run:` block with more than one command across all four workflow files (`ci.yml`, `security.yml`, `fuzz.yml`, `release.yml`) for whether it executes on a Windows runner without a `shell:`/`if:` override that would exempt it:

- `ci.yml` `check`, `release-scripts`, `docker-build`, `openapi-snapshot` jobs — `ubuntu-latest` only, safe (bash `-e` aborts on first failure).
- `ci.yml` `test` job — matrix includes `windows-latest`; the fixed step was the only multi-command instance. Rest of the job is already one-command-per-step or `if: runner.os == 'Linux'` gated.
- `security.yml` `audit`/`deny` — `ubuntu-latest` only; their two-command `rustup` blocks are safe under bash.
- `fuzz.yml` — single job, `ubuntu-latest`, no Windows job in the file.
- `release.yml` `build` job — matrix includes `windows-latest`, but its toolchain-install steps were already split (`Install Rust toolchain (runner VM)` / `Add Rust target (runner VM)`) by an unrelated prior commit already on `main`. `Build release binaries` declares `shell: bash` explicitly. `Package zip (Windows)` declares `shell: pwsh` and its two statements (`Compress-Archive`, `Out-File`) are PowerShell cmdlets, not native executables, so PowerShell's `$ErrorActionPreference='Stop'` does abort on their failure — correctly out of scope.
- `release.yml` other jobs — `ubuntu-latest` only.

No other unsafe instances found.

## Test plan

- [x] Independently parsed all four workflow YAML files with a fresh-venv PyYAML (`python3 -m venv`, `pip install pyyaml`, `yaml.safe_load` each file) — all parse cleanly and list the expected job names.
- [x] Ran `actionlint` (v1.7.12) against all four workflow files. The changed file (`ci.yml`) is fully clean. The two shellcheck notes it surfaces (`fuzz.yml:48` SC2012, `release.yml:413` SC2129) are pre-existing style-level findings in files this PR does not touch — confirmed by running `actionlint` against the `origin/main` copies of those two files directly, which reproduce the same findings.
- [x] Confirmed via `git diff --name-only` that only `.github/workflows/ci.yml` and `docs/testing.md` changed — no `.rs` files touched.
- [x] Confirmed via `git merge-base --is-ancestor` that the `release.yml` fix referenced above is already an ancestor of `origin/main`.
- [x] Grepped the full diff and both commit messages for board-id patterns and em-dashes on added lines — none found.
- [ ] **Not execution-verified.** This repo has no `workflow_dispatch` trigger on `ci.yml` yet (checked `origin/main`'s `on:` block directly — only `push`/`pull_request`), so there's no way to exercise the Windows leg without a live PR. This fix is verified by construction, reasoning from GitHub's documented PowerShell step-wrapping behavior. **This PR's own CI run is the first live exercise of the split Windows toolchain-install steps** — watch the `test (windows-latest)` job on this PR to confirm both `Update stable toolchain` and `Set default toolchain` run and pass as expected.