### PR TITLE
fix(cli): consolidate three divergent state-dir resolvers behind SPELUNK_STATE_DIR

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -26,7 +26,17 @@ use tokio::sync::OnceCell;
 
 use crate::config::Config;
 
-/// State file directory: `~/.local/state/spelunk/`.
+/// The single state file directory resolver for the whole CLI:
+/// `~/.local/state/spelunk/`, or `SPELUNK_STATE_DIR` when set.
+///
+/// Every reader and writer of runtime state goes through this one function:
+/// `spelunk server start/stop/status/logs` (server pid/port/log/db-path
+/// files, `cli/cmd/server.rs`), the embed worker's liveness files
+/// (`cli/cmd/embed_worker.rs`), and this module's own loopback
+/// auto-discovery probe below. A second, independent resolution here was a
+/// real bug: it let the override apply to some readers/writers and not
+/// others, so a status reader could miss a worker's pid file written to a
+/// different directory (or vice versa) and misreport liveness.
 ///
 /// On all platforms we use `~/.local/state` rather than the OS-native state dir.
 /// This mirrors the deliberate choice made for the config dir
@@ -37,27 +47,30 @@ use crate::config::Config;
 /// It also sidesteps a concrete portability bug: `dirs::state_dir()` returns
 /// `None` on macOS (dirs v6 has no XDG_STATE_HOME equivalent there), which
 /// silently disabled loopback auto-discovery on the primary dev platform
-/// (spelunk#316). Returns `None` only when the home directory can't be resolved.
+/// (spelunk#316).
 ///
-/// NOTE for spelunk#317 (writer side, `spelunk server start`): the writer MUST
-/// write `server.port` into this exact directory so reader and writer agree.
-/// Use the same `~/.local/state/spelunk/` path on every platform.
+/// `SPELUNK_STATE_DIR` is a supported override of the entire path, not
+/// dev-only cruft: it is load-bearing on Windows CI, where `dirs::home_dir()`
+/// 6.x calls `SHGetKnownFolderPath` (a Windows Registry lookup) rather than
+/// reading `USERPROFILE`, making per-process environment overrides of `HOME`
+/// ineffective. It is also used directly by end users who want state files
+/// somewhere other than the default (e.g. an ephemeral or sandboxed HOME).
 ///
-/// `SPELUNK_STATE_DIR` overrides the entire path. Useful in tests and on
-/// Windows CI where `dirs::home_dir()` 6.x calls `SHGetKnownFolderPath` (a
-/// Windows Registry lookup) rather than reading `USERPROFILE`, making
-/// per-process environment overrides ineffective.
-fn spelunk_state_dir() -> Option<std::path::PathBuf> {
+/// Errors only when the home directory can't be resolved and no override is
+/// set.
+pub(crate) fn spelunk_state_dir() -> anyhow::Result<std::path::PathBuf> {
     if let Some(p) = std::env::var_os("SPELUNK_STATE_DIR") {
-        return Some(std::path::PathBuf::from(p));
+        return Ok(std::path::PathBuf::from(p));
     }
-    dirs::home_dir().map(|home| home.join(".local").join("state").join("spelunk"))
+    dirs::home_dir()
+        .map(|home| home.join(".local").join("state").join("spelunk"))
+        .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))
 }
 
 /// Read the port written by `spelunk server start` into
 /// `~/.local/state/spelunk/server.port`. Returns `None` if absent or unreadable.
 fn read_server_port_file() -> Option<u16> {
-    let path = spelunk_state_dir()?.join("server.port");
+    let path = spelunk_state_dir().ok()?.join("server.port");
     let content = std::fs::read_to_string(&path).ok()?;
     content.trim().parse::<u16>().ok()
 }

--- a/crates/spelunk-cli/src/cli/cmd/embed_worker.rs
+++ b/crates/spelunk-cli/src/cli/cmd/embed_worker.rs
@@ -4,11 +4,13 @@
 //! abandoned one).
 //!
 //! Mirrors the server's own pid-file shape: one small state file per datum,
-//! written 0600 into the same `~/.local/state/spelunk/` directory (see
-//! `server.rs`), a `pid_is_alive` liveness check, and a foreign-pid
-//! classification so a recycled pid is never misreported as a live worker.
-//! Files are keyed by a hash of the index path because workers are
-//! per-project while the state dir is per-machine.
+//! written 0600 into the same state directory as the server's pid/port files
+//! (`capability::spelunk_state_dir`, the single resolver both share, so an
+//! `SPELUNK_STATE_DIR` override applies to worker and server files alike), a
+//! `pid_is_alive` liveness check, and a foreign-pid classification so a
+//! recycled pid is never misreported as a live worker. Files are keyed by a
+//! hash of the index path because workers are per-project while the state
+//! dir is per-machine.
 //!
 //! Two files per project:
 //! - `embed-worker-<key>.pid`: pid of the process running the embed phase
@@ -21,7 +23,8 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use super::server::{create_state_dir, pid_is_alive, spelunk_state_dir, write_state_file};
+use super::server::{create_state_dir, pid_is_alive, write_state_file};
+use crate::capability::spelunk_state_dir;
 use crate::storage::Database;
 
 /// Per-project key for the worker state files: hash of the canonicalised

--- a/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
@@ -25,6 +25,7 @@ use std::path::PathBuf;
 
 use super::MemoryReconcileArgs;
 use crate::{
+    capability::spelunk_state_dir,
     config::Config,
     server_client::ServerInferenceClient,
     storage::{MemoryStore, entity_id, note_entity_id},
@@ -463,13 +464,18 @@ async fn reconcile_project(
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/// Default path for the daemon's server.db: `~/.local/state/spelunk/server.db`.
+/// Default path for the daemon's server.db: `~/.local/state/spelunk/server.db`,
+/// or `SPELUNK_STATE_DIR` when set.
+///
+/// Must go through the shared `capability::spelunk_state_dir` resolver, not
+/// reconstruct the path from `dirs::home_dir()` independently: the daemon
+/// (`spelunk server start`) writes `server.db` via that same resolver, so a
+/// second, hardcoded reconstruction here would silently stop finding it
+/// under `SPELUNK_STATE_DIR` while still reporting reconcile as a no-op
+/// success (the "server.db doesn't exist" branch) instead of an error.
 fn default_server_db_path() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".local")
-        .join("state")
-        .join("spelunk")
+    spelunk_state_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
         .join("server.db")
 }
 

--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -10,13 +10,16 @@
 //!
 //! ## State directory
 //!
-//! All runtime state lives under `~/.local/state/spelunk/`:
+//! All runtime state lives under `~/.local/state/spelunk/` (or
+//! `SPELUNK_STATE_DIR` when set; see `capability::spelunk_state_dir`, the
+//! single resolver every reader and writer of this directory shares):
 //! - `server.pid`  — PID of the running daemon process
 //! - `server.port` — TCP port the daemon is listening on (read by `capability.rs`)
 //! - `server.log`  — stdout + stderr of the daemon process
 //!
 //! The port file is read by `capability.rs` for loopback auto-discovery
-//! (spelunk#316).  The writer here **must** use the same path.
+//! (spelunk#316).  The writer here **must** use the same path, enforced by
+//! both going through the shared resolver rather than each defining their own.
 //!
 //! ## Spawned-binary resolution (PATH vs. sibling/absolute)
 //!
@@ -45,17 +48,9 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 
-// ── State dir helpers ─────────────────────────────────────────────────────────
+use crate::capability::spelunk_state_dir;
 
-/// `~/.local/state/spelunk/` on all platforms.
-///
-/// Mirrors `spelunk_state_dir()` in `capability.rs` — both reader and writer
-/// must use the same path.
-pub fn spelunk_state_dir() -> Result<PathBuf> {
-    dirs::home_dir()
-        .map(|h| h.join(".local").join("state").join("spelunk"))
-        .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))
-}
+// ── State dir helpers ─────────────────────────────────────────────────────────
 
 fn pid_path(state_dir: &Path) -> PathBuf {
     state_dir.join("server.pid")

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -1808,19 +1808,26 @@ fn offline_indexed_project(home: &std::path::Path) -> (std::path::PathBuf, std::
     (project_dir, config_path)
 }
 
-/// Path of the embed worker's pid state file for `db_path`, replicating the
-/// worker's own keying (blake3 of the canonicalised index path, first 16 hex
-/// chars). Deliberately duplicated here: if the writer's keying ever drifts
-/// from this, the reader/writer pair drifts too, and this test fails loudly.
-fn embed_worker_pid_file(home: &std::path::Path, db_path: &std::path::Path) -> std::path::PathBuf {
+/// Path of the embed worker's pid state file for `db_path` under a given
+/// state directory, replicating the worker's own keying (blake3 of the
+/// canonicalised index path, first 16 hex chars). Deliberately duplicated
+/// here: if the writer's keying ever drifts from this, the reader/writer
+/// pair drifts too, and this test fails loudly.
+fn embed_worker_pid_file_in(
+    state_dir: &std::path::Path,
+    db_path: &std::path::Path,
+) -> std::path::PathBuf {
     let canonical = spelunk_core::utils::canonicalize(db_path);
     let key = blake3::hash(canonical.to_string_lossy().as_bytes())
         .to_hex()
         .to_string();
-    home.join(".local")
-        .join("state")
-        .join("spelunk")
-        .join(format!("embed-worker-{}.pid", &key[..16]))
+    state_dir.join(format!("embed-worker-{}.pid", &key[..16]))
+}
+
+/// Same as [`embed_worker_pid_file_in`], for the default (no
+/// `SPELUNK_STATE_DIR`) state dir derived from `home`.
+fn embed_worker_pid_file(home: &std::path::Path, db_path: &std::path::Path) -> std::path::PathBuf {
+    embed_worker_pid_file_in(&home.join(".local").join("state").join("spelunk"), db_path)
 }
 
 /// ADR-070 D4: the `status --format json` embed-state extensions are additive
@@ -1983,6 +1990,60 @@ fn test_status_foreign_pid_reuse_never_reads_as_live_worker() {
     assert!(
         !pid_file.exists(),
         "a foreign (recycled) pid record must be cleaned up on read"
+    );
+}
+
+/// Regression: writer and reader of runtime state must agree on
+/// `SPELUNK_STATE_DIR`. `HOME` and `SPELUNK_STATE_DIR` are pointed at two
+/// *different* directories; the embed worker's pid file is written only into
+/// the override directory (as the writer does once it honours the override),
+/// never under `HOME`. `status` - the reader - must resolve the same
+/// override to find and clean it up. Before the fix, `status`'s read path
+/// (`cli/cmd/embed_worker.rs` -> `cli/cmd/server.rs::spelunk_state_dir()`)
+/// ignored `SPELUNK_STATE_DIR` and only ever looked under `HOME`, so a file
+/// written to the override would never be found.
+#[cfg(unix)]
+#[test]
+fn test_status_honors_state_dir_override_for_embed_worker_pid() {
+    let home = tempfile::TempDir::new().unwrap();
+    let state_override = tempfile::TempDir::new().unwrap();
+    let (project_dir, config_path) = offline_indexed_project(home.path());
+    let db_path = project_dir.join(".spelunk").join("index.db");
+    assert!(db_path.exists(), "offline index must exist");
+
+    // A pid that was real and is now certainly dead.
+    let mut child = std::process::Command::new("true").spawn().unwrap();
+    let dead_pid = child.id();
+    child.wait().unwrap();
+
+    // Write directly into the override dir - NOT `<home>/.local/state/spelunk`.
+    let pid_file = embed_worker_pid_file_in(state_override.path(), &db_path);
+    fs::create_dir_all(pid_file.parent().unwrap()).unwrap();
+    fs::write(&pid_file, format!("{dead_pid}\n")).unwrap();
+    fs::write(pid_file.with_extension("baseline"), "0 1000\n").unwrap();
+
+    // Sanity: nothing was written under the HOME-derived default location.
+    let home_pid_file = embed_worker_pid_file(home.path(), &db_path);
+    assert!(
+        !home_pid_file.exists(),
+        "fixture bug: pid file must only exist under the override"
+    );
+
+    spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .env("SPELUNK_STATE_DIR", state_override.path())
+        .current_dir(&project_dir)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Embedding incomplete"))
+        .stdout(predicate::str::contains("Embedding in progress").not());
+
+    assert!(
+        !pid_file.exists(),
+        "the reader must resolve SPELUNK_STATE_DIR (not HOME) to find and clean up the stale pid record"
     );
 }
 

--- a/crates/spelunk-cli/tests/memory_reconcile.rs
+++ b/crates/spelunk-cli/tests/memory_reconcile.rs
@@ -1695,7 +1695,7 @@ fn sql_injection_payload_in_body_does_not_break_import() {
 /// `capability::spelunk_state_dir` resolver, which honors `SPELUNK_STATE_DIR`.
 /// Reconcile's default source path (used whenever `--source-db` is omitted)
 /// must resolve through that same function rather than reconstructing
-/// `~/.local/state/spelunk/` from `dirs::home_dir()` on its own — otherwise a
+/// `~/.local/state/spelunk/` from `dirs::home_dir()` on its own. Otherwise a
 /// daemon run under a `SPELUNK_STATE_DIR` override is invisible to reconcile:
 /// it hits the "server.db absent" no-op branch instead of importing.
 #[test]

--- a/crates/spelunk-cli/tests/memory_reconcile.rs
+++ b/crates/spelunk-cli/tests/memory_reconcile.rs
@@ -14,7 +14,7 @@
 //! 8. Exit codes: 0 on success and on no-op; non-zero only on real fault.
 
 mod plumbing_helpers;
-use plumbing_helpers::spelunk_bin;
+use plumbing_helpers::{spelunk_bin, spelunk_bin_in};
 
 use assert_cmd::Command;
 use rusqlite::Connection;
@@ -1687,4 +1687,71 @@ fn sql_injection_payload_in_body_does_not_break_import() {
 
     assert_eq!(title, injection_title, "title stored verbatim");
     assert_eq!(body, injection_body, "body stored verbatim");
+}
+
+// ── Regression: default source path must honor SPELUNK_STATE_DIR ────────────
+
+/// `spelunk server start` writes `server.db` through the shared
+/// `capability::spelunk_state_dir` resolver, which honors `SPELUNK_STATE_DIR`.
+/// Reconcile's default source path (used whenever `--source-db` is omitted)
+/// must resolve through that same function rather than reconstructing
+/// `~/.local/state/spelunk/` from `dirs::home_dir()` on its own — otherwise a
+/// daemon run under a `SPELUNK_STATE_DIR` override is invisible to reconcile:
+/// it hits the "server.db absent" no-op branch instead of importing.
+#[test]
+fn default_source_db_honors_state_dir_override() {
+    let home = TempDir::new().unwrap();
+    let state_override = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let db_path = project.path().join("spelunk.db");
+    let (config_path, mem_path) = write_config(project.path(), &db_path);
+
+    // Write server.db directly into the override dir, NOT under
+    // `<home>/.local/state/spelunk/`.
+    let (server_db, project_id) = create_server_db(state_override.path(), "override-project");
+    let conn = Connection::open(&server_db).unwrap();
+    insert_server_note(
+        &conn,
+        project_id,
+        "decision",
+        "Use SQLite for storage",
+        "SQLite is the right choice because it is zero-infrastructure.",
+        None,
+        None,
+        1_700_000_000,
+        "active",
+        None,
+    );
+    drop(conn);
+
+    // Sanity: nothing exists under HOME's default location.
+    let home_default = home
+        .path()
+        .join(".local")
+        .join("state")
+        .join("spelunk")
+        .join("server.db");
+    assert!(
+        !home_default.exists(),
+        "fixture bug: server.db must only exist under the override"
+    );
+
+    // No --source-db: exercises default_server_db_path().
+    let mut cmd = spelunk_bin_in(home.path());
+    cmd.current_dir(project.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .env("SPELUNK_NO_RECONCILE_NUDGE", "1")
+        .env("SPELUNK_STATE_DIR", state_override.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("reconcile")
+        .arg("--all-projects");
+    cmd.assert().success();
+
+    assert_eq!(
+        count_memory_notes(&mem_path),
+        1,
+        "reconcile must resolve server.db through SPELUNK_STATE_DIR when --source-db is omitted"
+    );
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -822,5 +822,6 @@ and publish on your next push.
 | `SPELUNK_SERVER_KEY` | Static credential for a team/self-hosted server; takes precedence over the keychain-stored credential and `login` tokens (the non-interactive escape hatch for CI / headless) |
 | `SPELUNK_SERVER_CA` | Path to a PEM CA bundle to trust for a `SPELUNK_SERVER_URL` whose certificate is signed by an internal or self-signed CA. Added as a trust anchor on top of the built-in roots; TLS verification stays on (no insecure mode). Overrides `server_ca` in `config.toml`. |
 | `SPELUNK_SECRET_STORE` | Secret-store backend: `auto` (default — keychain, file fallback), `keychain` (require the OS keychain), or `file` (force `~/.config/spelunk/secrets.toml`) |
+| `SPELUNK_STATE_DIR` | Override the runtime state directory (default `~/.local/state/spelunk/`) that holds the server's pid/port/log/db files and the embed worker's pid/baseline files. Every reader and writer resolves through this same variable, so it is safe to redirect wholesale (useful for test isolation, containers, or a non-default `HOME`). |
 | `RUST_LOG=debug` | Enable verbose logging |
 | `EDITOR` / `VISUAL` | Editor opened by `spelunk memory add` when `--body` is omitted |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -139,10 +139,12 @@ CI runs `cargo build` + `cargo test` on `ubuntu-latest`, `macos-latest`, and
 - **State-dir isolation.** E2E tests that set `.env("HOME", tmp)` to redirect
   spelunk's runtime state directory (`~/.local/state/spelunk/`) do not achieve
   full isolation on Windows because `dirs::home_dir()` uses the Windows Shell
-  API (`SHGetKnownFolderPath`) rather than the `HOME` environment variable. On
-  a clean CI runner (no pre-existing server state) these tests still pass, but
-  they may flake if parallel test workers race on the shared state directory.
-  A future improvement is a `SPELUNK_STATE_DIR` override environment variable.
+  API (`SHGetKnownFolderPath`) rather than the `HOME` environment variable.
+  Tests that need deterministic isolation should set `SPELUNK_STATE_DIR`
+  directly instead of relying on `HOME`: it is a supported override of the
+  entire state directory, read by the single resolver
+  (`capability::spelunk_state_dir`) every reader and writer of runtime state
+  goes through, so it bypasses the Windows `HOME` gap entirely.
 
 - **`pid_is_alive` on Windows.** The Windows implementation uses
   `OpenProcess` + `GetExitCodeProcess` to check whether a process with a given


### PR DESCRIPTION
## Summary

Two functions independently resolved the runtime state directory (`~/.local/state/spelunk/`) and disagreed about honoring the `SPELUNK_STATE_DIR` override: `capability.rs`'s resolver honored it, `server.rs`'s (used by the server's own pid/port/log/db writers and the embed worker's pid/baseline files) did not. A reader honoring the override could miss a writer's files under the default dir, or vice versa, causing worker-liveness misreports.

While hardening the fix, a third independent resolver was found and fixed: `memory/reconcile.rs::default_server_db_path()` reconstructed the same directory directly via `dirs::home_dir()`, bypassing the override entirely. Under `SPELUNK_STATE_DIR`, `spelunk memory reconcile` (default source path) would silently treat the daemon's `server.db` as absent instead of importing it.

- Consolidated all three onto a single `pub(crate) fn spelunk_state_dir()` in `capability.rs`; `server.rs`, `embed_worker.rs`, and `reconcile.rs` now all resolve through it. No other function builds the base state-dir path (verified via grep for `state_dir`/`STATE_DIR`/`join(".local")` across the workspace).
- Decided `SPELUNK_STATE_DIR` is a **supported override**, not dev-only cruft: it's the only hermetic-test lever on Windows (`dirs` 6.x resolves `home_dir()` via `SHGetKnownFolderPath`, which ignores a per-process `HOME` override) and is already exercised by existing e2e tests. Documented it in `docs/commands.md`'s environment-variable reference table and refreshed the existing note in `docs/testing.md`.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace --no-fail-fast` and the same with `--no-default-features`: both green except the two known-flaky, pre-existing `capability::tests::probe_url_*` failures (order-dependent `OnceCell` state leak, tracked separately in PR #660, still open/unmerged — confirmed not a regression introduced here).
- Two new regression tests added and mutation-tested (red against the pre-fix code, green after):
  - `crates/spelunk-cli/tests/e2e_cli.rs::test_status_honors_state_dir_override_for_embed_worker_pid` — writes an embed-worker pid file only under a `SPELUNK_STATE_DIR` override and asserts `spelunk status` finds it there.
  - `crates/spelunk-cli/tests/memory_reconcile.rs::default_source_db_honors_state_dir_override` — writes `server.db` only under the override and asserts `spelunk memory reconcile` (no `--source-db`) imports it.
- `cargo fmt --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`, both feature configs: clean.
- `cargo audit`: only the two pre-existing `unmaintained` advisories (`paste`, `proc-macro-error2`); no new advisories; no `Cargo.toml` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)