### PR TITLE
Scope server-key resolution per origin (ADR-071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+
+- **Self-hosted server bearer credentials are now scoped per server, not
+  global.** Previously a single flat `server_key` served every configured
+  `server_url`, so a developer working on two projects that each point at a
+  different self-hosted server (the topology [ADR-056](docs/adr/056-oss-server-tenancy-model.md)
+  recommends over multi-tenancy) had one key slot for two servers, with
+  whichever key lost getting 401s. The bearer for a request is now resolved
+  per the target server's origin, so keys for distinct self-hosted servers
+  coexist without collision or manual env-var juggling. A pre-existing flat
+  key migrates into the new per-server store automatically the first time
+  it's needed. See [ADR-071](docs/adr/071-per-server-client-bearer-scoping.md).
+
+### Added
+
+- **`spelunk auth set-key --server <url>` and `spelunk auth list-servers`.**
+  `set-key` stores a bearer key for a self-hosted server, scoped to its
+  origin; the key is read from stdin or an interactive prompt only, never
+  from a flag or positional argument, so it never lands in shell history or
+  `ps` output. `list-servers` prints the origins with a stored key (never the
+  key material itself). (ADR-071)
+- **`spelunk logout --servers` / `spelunk logout --server <url>`.** Clearing
+  self-hosted server keys is now an explicit, separate action from clearing
+  the spelunk.cloud login: bare `spelunk logout` clears only the `[auth]`
+  token pair, so recovering from a broken cloud login no longer has the side
+  effect of deleting server keys used on other projects. (ADR-071 D3)
+
+### Removed
+
+- **`server_key` is no longer read from a project's committed
+  `.spelunk/config.toml`.** That field let a plaintext credential live in a
+  file the docs otherwise say is safe to commit. It is now silently ignored
+  (matching the earlier `memory_server_*` alias removal precedent) rather
+  than migrated or warned about; use `spelunk auth set-key --server <url>` to
+  store the key per-developer instead. If a key was ever committed under the
+  old model, treat it as compromised: rotate it on the server and re-set it
+  on every machine that used the old one. (ADR-071 D4)
+
 ## [0.9.4] — 2026-07-17
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ config/
   predicates.rs  — URL/UUID/env predicates
   tls.rs         — custom CA trust-anchor application
   secret_store.rs — OS keychain / file secret-store backend
+  server_keys.rs — per-origin server-key map + bearer_for() resolution (ADR-071)
 utils/
   mod.rs         — strip_ansi(), misc helpers
   dates.rs       — date parsing helpers
@@ -170,6 +171,7 @@ cli/
   mod.rs         — clap structs (Cli, Command, *Args)
   cmd/
     mod.rs       — re-exports one pub fn per subcommand
+    auth.rs      — `spelunk auth set-key/list-servers` handlers (ADR-071)
     check.rs     — `spelunk check` handler
     context.rs   — `spelunk context` handler (agent session entry point)
     explore.rs   — `spelunk explore` handler

--- a/crates/spelunk-cli/src/cli/cmd/auth.rs
+++ b/crates/spelunk-cli/src/cli/cmd/auth.rs
@@ -1,0 +1,108 @@
+//! `spelunk auth set-key` / `spelunk auth list-servers`: manage the
+//! per-server bearer credentials a self-hosted `server_url` resolves through
+//! (ADR-071 D1/D3).
+//!
+//! These are the credential's front door: the key is read from stdin or an
+//! interactive prompt, never from argv (a positional or flag-valued secret
+//! lands in shell history and `ps` output). `set-key` stores it in the
+//! per-origin map (`spelunk_core::config::server_keys`); `list-servers`
+//! prints only origins, never key material.
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use std::io::{IsTerminal, Write};
+
+use spelunk_core::config::server_keys;
+
+#[derive(Args, Debug)]
+pub struct AuthArgs {
+    #[command(subcommand)]
+    pub command: AuthCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AuthCommand {
+    /// Store a bearer key for a self-hosted spelunk-server, read from stdin/prompt
+    SetKey(AuthSetKeyArgs),
+    /// List servers with a stored key (origins only, never prints key material)
+    ListServers,
+}
+
+#[derive(Args, Debug)]
+pub struct AuthSetKeyArgs {
+    /// Server URL this key belongs to (normalized to its origin before storage)
+    #[arg(long)]
+    pub server: String,
+}
+
+pub async fn auth(args: AuthArgs) -> Result<()> {
+    match args.command {
+        AuthCommand::SetKey(set_key_args) => set_key(&set_key_args.server),
+        AuthCommand::ListServers => list_servers(),
+    }
+}
+
+fn set_key(server: &str) -> Result<()> {
+    let key = read_secret_from_stdin_or_prompt()?;
+    let store = spelunk_core::config::default_secret_store()?;
+    let origin = server_keys::set_key_for_origin(server, &key, store.as_ref())
+        .context("storing the server key")?;
+    println!("Stored a server key for {origin}.");
+    Ok(())
+}
+
+fn list_servers() -> Result<()> {
+    let store = spelunk_core::config::default_secret_store()?;
+    let (origins, legacy) = server_keys::list_origins(store.as_ref())?;
+    if origins.is_empty() && !legacy {
+        println!("No server keys stored.");
+        return Ok(());
+    }
+    for origin in &origins {
+        println!("{origin}");
+    }
+    if legacy {
+        println!(
+            "(a legacy server key is also stored; it migrates automatically the next \
+             time it resolves for a server)"
+        );
+    }
+    Ok(())
+}
+
+/// Read a secret from stdin: piped input if present, else an interactive
+/// prompt. Never accepted via a CLI flag/argv (D3).
+fn read_secret_from_stdin_or_prompt() -> Result<String> {
+    if std::io::stdin().is_terminal() {
+        eprint!("Server key: ");
+        std::io::stderr().flush().ok();
+    }
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .context("reading server key from stdin")?;
+    let key = line.trim().to_string();
+    if key.is_empty() {
+        anyhow::bail!("no server key provided (empty input)");
+    }
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spelunk_core::config::secret_store::MemoryStore;
+
+    #[test]
+    fn set_key_then_list_servers_round_trip_via_store() {
+        let store = MemoryStore::default();
+        let origin =
+            server_keys::set_key_for_origin("https://team.example:7777/ignored", "sk-1", &store)
+                .unwrap();
+        assert_eq!(origin, "https://team.example:7777");
+
+        let (origins, legacy) = server_keys::list_origins(&store).unwrap();
+        assert_eq!(origins, vec!["https://team.example:7777".to_string()]);
+        assert!(!legacy);
+    }
+}

--- a/crates/spelunk-cli/src/cli/cmd/auth_api.rs
+++ b/crates/spelunk-cli/src/cli/cmd/auth_api.rs
@@ -24,8 +24,13 @@ use serde::Deserialize;
 
 use spelunk_core::config::{AuthTokens, Config};
 
-/// Default cloud API base URL (used only for `GET /v1/me`).
-pub const DEFAULT_CLOUD_URL: &str = "https://api.spelunk.cloud";
+/// Default cloud API base URL (used for `GET /v1/me`, and as the cloud-vs-
+/// self-hosted origin boundary for bearer resolution, ADR-071 D2). Single
+/// source of truth lives in `spelunk_core::config::server_keys`, which also
+/// reads it (and its `SPELUNK_CLOUD_URL` override) when deciding credential
+/// kind; re-exported here so every existing `auth_api::DEFAULT_CLOUD_URL`
+/// call site keeps working unchanged.
+pub use spelunk_core::config::server_keys::DEFAULT_CLOUD_URL;
 
 /// Default WorkOS User Management API base URL.
 pub const DEFAULT_WORKOS_URL: &str = "https://api.workos.com";
@@ -445,36 +450,42 @@ pub(crate) fn org_id_for_refresh(org_id: &str) -> Option<&str> {
     (!org_id.is_empty()).then_some(org_id)
 }
 
-/// Resolve the bearer token to send to cloud-api, refreshing the stored WorkOS
-/// access token first if it has expired.
+/// Resolve the bearer token to send to `server_url`, refreshing the stored
+/// WorkOS access token first if it has expired.
 ///
-/// The CLI's effective bearer (`cfg.server_key`) is the `[auth]` access token
-/// when the user logged in via WorkOS. Because access tokens are short-lived,
-/// commands that hit cloud-api directly (e.g. `spelunk sync`, `spelunk memory
-/// pull`) must guard against using an already-expired token, which would 401.
+/// Resolution goes through [`Config::bearer_for`] (ADR-071 D2): only a
+/// cloud-origin `server_url` can ever resolve to the `[auth]` access token,
+/// so a self-hosted `server_url` never mistakes an unrelated cloud login for
+/// its own credential. Because access tokens are short-lived, commands that
+/// hit cloud-api directly (e.g. `spelunk sync`, `spelunk memory pull`) must
+/// guard against using an already-expired token, which would 401.
 ///
 /// Behaviour:
-///   - When `[auth]` tokens are present AND the bearer was derived from them
-///     (the WorkOS-login case) AND they are expired, refresh directly against
-///     WorkOS, persist the rotated tokens, and return the fresh access token.
-///   - Otherwise return `cfg.server_key` unchanged — a bare/team `server_key`
-///     or an env override is not refreshable here, and a still-valid token needs
-///     no network round-trip.
+///   - When `[auth]` tokens are present AND the resolved bearer was derived
+///     from them (i.e. `server_url` is the cloud origin) AND they are
+///     expired, refresh directly against WorkOS, persist the rotated tokens,
+///     and return the fresh access token.
+///   - Otherwise return the resolved bearer unchanged: a self-hosted
+///     server-key or an env override is not refreshable here, and a
+///     still-valid token needs no network round-trip.
 ///
 /// A refresh failure surfaces a clear "run `spelunk login`" error.
-pub async fn ensure_fresh_server_key(cfg: &Config) -> Result<Option<String>> {
-    // Only the WorkOS-login bearer (server_key derived from [auth].access_token)
-    // is refreshable; a team/env key is returned as-is.
+pub async fn ensure_fresh_server_key(cfg: &Config, server_url: &str) -> Result<Option<String>> {
+    let resolved = cfg.bearer_for(server_url)?;
+
+    // Only the WorkOS-login bearer (the cloud kind, resolved from
+    // [auth].access_token) is refreshable; a self-hosted server-key is
+    // returned as-is.
     let Some(auth) = cfg
         .auth
         .as_ref()
-        .filter(|a| Some(a.access_token.as_str()) == cfg.server_key.as_deref())
+        .filter(|a| Some(a.access_token.as_str()) == resolved.as_deref())
     else {
-        return Ok(cfg.server_key.clone());
+        return Ok(resolved);
     };
 
     if !auth.is_expired() {
-        return Ok(cfg.server_key.clone());
+        return Ok(resolved);
     }
 
     let client = build_client()?;

--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -330,7 +330,7 @@ pub(super) async fn run_embed_phase(
     mp: &MultiProgress,
 ) -> Result<u64> {
     let (server_url, server_key) = match tier {
-        Tier::Server { url, .. } => (url.clone(), cfg.server_key.clone()),
+        Tier::Server { url, .. } => (url.clone(), cfg.bearer_for(url)?),
         Tier::Offline => return Ok(0),
     };
     // Refuse to append vectors from a different model into an existing index;

--- a/crates/spelunk-cli/src/cli/cmd/logout.rs
+++ b/crates/spelunk-cli/src/cli/cmd/logout.rs
@@ -1,18 +1,57 @@
-//! `spelunk logout` — clear stored spelunk.cloud credentials.
+//! `spelunk logout`: clear stored spelunk.cloud credentials.
 //!
-//! Removes both the WorkOS `[auth]` tokens written by `spelunk login` and the
-//! legacy bare `server_key`, so a logout fully de-authenticates regardless of
-//! which credential the user last logged in with.
+//! Bare `spelunk logout` clears **only** the `[auth]` WorkOS token pair
+//! written by `spelunk login`: the credential logout exists to undo. It no
+//! longer touches self-hosted server keys as a side effect (ADR-071 D3,
+//! founder-review correction): a developer recovering from a broken cloud
+//! login should not silently lose the server key(s) they use on other
+//! projects. Clearing those is an explicit, separate action via `--servers`
+//! (all of them) or `--server <url>` (just one).
 
 use anyhow::{Context as _, Result};
+use clap::Args;
 
-use spelunk_core::config;
+use spelunk_core::config::{self, server_keys};
 
-pub async fn logout() -> Result<()> {
+#[derive(Args, Debug)]
+pub struct LogoutArgs {
+    /// Also clear every stored self-hosted server key (the per-origin map
+    /// and any legacy entry).
+    #[arg(long, conflicts_with = "server")]
+    pub servers: bool,
+
+    /// Also clear the stored server key for this one server origin.
+    #[arg(long)]
+    pub server: Option<String>,
+}
+
+pub async fn logout(args: LogoutArgs) -> Result<()> {
     config::remove_auth_tokens()
         .context("removing [auth] tokens from ~/.config/spelunk/config.toml")?;
-    config::remove_server_key()
-        .context("removing server_key from ~/.config/spelunk/config.toml")?;
-    println!("Logged out. Stored credentials have been removed from ~/.config/spelunk/config.toml");
+    println!("Logged out. Stored spelunk.cloud credentials have been removed.");
+
+    let store = config::default_secret_store()?;
+
+    if args.servers {
+        server_keys::clear_all(store.as_ref()).context("clearing the server_keys map")?;
+        // Belt-and-braces: also clear the legacy flat entry and any plaintext
+        // remnant still in config.toml (config::remove_server_key's job).
+        config::remove_server_key().context("clearing the legacy server_key entry")?;
+        println!("Cleared all stored server keys.");
+    } else if let Some(url) = &args.server {
+        let origin = server_keys::clear_origin(url, store.as_ref())
+            .context("clearing the stored server key")?;
+        println!("Cleared the stored server key for {origin}.");
+    } else {
+        let n = server_keys::count(store.as_ref())?;
+        if n > 0 {
+            println!(
+                "{n} server key(s) are still stored (unaffected by this logout). \
+                 Run `spelunk logout --servers` to remove them all, or \
+                 `spelunk logout --server <url>` for just one."
+            );
+        }
+    }
+
     Ok(())
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -50,7 +50,7 @@ pub async fn memory_push(
     let local = MemoryStore::open(src_path)
         .with_context(|| format!("opening local memory at {}", src_path.display()))?;
     // Refresh a stale WorkOS access token before the cloud-api call.
-    let key = auth_api::ensure_fresh_server_key(cfg).await?;
+    let key = auth_api::ensure_fresh_server_key(cfg, &base_url).await?;
     let client = CloudSyncClient::new(
         &base_url,
         &project_id,

--- a/crates/spelunk-cli/src/cli/cmd/memory/since.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/since.rs
@@ -47,7 +47,8 @@ pub(super) async fn memory_since(
         let mut req = client
             .get(&url)
             .query(&[("t", args.since.to_string()), ("limit", limit.to_string())]);
-        if let Some(key) = cfg.server_key.as_deref() {
+        let bearer = cfg.bearer_for(base_url)?;
+        if let Some(key) = bearer.as_deref() {
             req = req.header("Authorization", format!("Bearer {key}"));
         }
         let notes: Vec<NoteResponse> = req

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -79,7 +79,7 @@ async fn sync_target(
         )
     })?;
     let project_id = resolve_sync_project(cli_project, cfg)?;
-    let key = auth_api::ensure_fresh_server_key(cfg).await?;
+    let key = auth_api::ensure_fresh_server_key(cfg, &base_url).await?;
     Ok((base_url, project_id, key))
 }
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/watch.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/watch.rs
@@ -72,7 +72,8 @@ pub(super) async fn memory_watch(args: MemoryWatchArgs, cfg: &Config) -> Result<
         .build()
         .context("building HTTP client for memory watch")?;
         let mut req = client.get(&url);
-        if let Some(key) = cfg.server_key.as_deref() {
+        let bearer = cfg.bearer_for(base_url)?;
+        if let Some(key) = bearer.as_deref() {
             req = req.header("Authorization", format!("Bearer {key}"));
         }
         if let Some(ref id) = last_event_id {

--- a/crates/spelunk-cli/src/cli/cmd/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod auth_api;
 pub mod check;
 pub mod context;
@@ -23,6 +24,7 @@ pub mod status;
 pub(crate) mod test_support;
 mod ui;
 
+pub use auth::auth;
 pub use check::check;
 pub use context::context;
 pub use explore::explore;

--- a/crates/spelunk-cli/src/cli/mod.rs
+++ b/crates/spelunk-cli/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod cmd;
 // Re-export top-level Args types so callers can use `crate::cli::XxxArgs`.
 // Sub-command Args types (Memory*Args, Plumbing*Args, etc.) are accessed via
 // their owning modules (e.g. `crate::cli::cmd::memory::MemoryAddArgs`) when needed.
+pub use cmd::auth::AuthArgs;
 pub use cmd::check::CheckArgs;
 pub use cmd::context::ContextArgs;
 pub use cmd::explore::ExploreArgs;
@@ -15,6 +16,7 @@ pub use cmd::init::InitArgs;
 pub use cmd::link::{LinkArgs, UnlinkArgs};
 pub use cmd::links::LinksArgs;
 pub use cmd::login::LoginArgs;
+pub use cmd::logout::LogoutArgs;
 pub use cmd::memory::MemoryArgs;
 pub use cmd::memory::MemorySyncArgs as SyncArgs;
 pub use cmd::misc::ChunksArgs;
@@ -84,8 +86,10 @@ pub enum Command {
     Server(ServerArgs),
     /// Authenticate with spelunk.cloud (WorkOS device authorization)
     Login(LoginArgs),
-    /// Remove stored spelunk.cloud credentials
-    Logout,
+    /// Remove stored spelunk.cloud credentials (see `--servers`/`--server` for self-hosted keys)
+    Logout(LogoutArgs),
     /// Manage the active organization (e.g. `spelunk org switch <org>`)
     Org(OrgArgs),
+    /// Manage per-server bearer credentials (`set-key`, `list-servers`)
+    Auth(AuthArgs),
 }

--- a/crates/spelunk-cli/src/main.rs
+++ b/crates/spelunk-cli/src/main.rs
@@ -104,7 +104,8 @@ async fn main() -> Result<()> {
         }
         Command::Server(args) => cli::cmd::server(args).await,
         Command::Login(args) => cli::cmd::login(args).await,
-        Command::Logout => cli::cmd::logout().await,
+        Command::Logout(args) => cli::cmd::logout(args).await,
         Command::Org(args) => cli::cmd::org(args).await,
+        Command::Auth(args) => cli::cmd::auth(args).await,
     }
 }

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -154,11 +154,42 @@ impl ServerInferenceClient {
     /// loopback server sets `inference_url` while leaving `server_url` unset, so
     /// inference reaches the server even though memory stays local. An explicit
     /// team `server_url` is used for both.
+    ///
+    /// The bearer is resolved per-origin via `Config::bearer_for` (ADR-071
+    /// D2): a self-hosted server never receives a cloud `[auth]` token meant
+    /// for a different origin, and vice versa.
     pub fn from_config(cfg: &Config) -> Option<Self> {
         let base_url = cfg
             .resolve_inference_url()?
             .trim_end_matches('/')
             .to_string();
+        let bearer = cfg
+            .bearer_for(&base_url)
+            .expect("resolving per-server bearer credential");
+        Some(Self::build(cfg, base_url, bearer))
+    }
+
+    /// Same as [`from_config`](Self::from_config) but with an injected
+    /// [`SecretStore`](spelunk_core::config::secret_store::SecretStore), so
+    /// in-process tests can exercise bearer resolution without touching the
+    /// real default secret store.
+    #[cfg(test)]
+    fn from_config_with_store(
+        cfg: &Config,
+        store: &dyn spelunk_core::config::secret_store::SecretStore,
+    ) -> Option<Self> {
+        let base_url = cfg
+            .resolve_inference_url()?
+            .trim_end_matches('/')
+            .to_string();
+        let bearer = cfg
+            .bearer_for_with_store(&base_url, store)
+            .expect("resolving per-server bearer credential");
+        Some(Self::build(cfg, base_url, bearer))
+    }
+
+    /// Shared construction once `base_url` and `bearer` are resolved.
+    fn build(cfg: &Config, base_url: String, bearer: Option<String>) -> Self {
         if let Err(msg) = spelunk_core::config::validate_transport_url(&base_url) {
             // Fail loudly and immediately: the alternative is silently sending a
             // bearer token in the clear. No opt-out: the fix is always "use
@@ -176,15 +207,16 @@ impl ServerInferenceClient {
         .build()
         .expect("building HTTP client for server inference");
 
-        // Carry WorkOS refresh state only when the bearer comes from `[auth]`
-        // (i.e. `server_key` was resolved from the access token). A bare
-        // `server_key` / env token is not refreshable here. Refresh targets
-        // WorkOS directly (ADR-047): the WorkOS base URL and the embedded public
-        // client_id (derived from the default cloud host) are captured here.
+        // Carry WorkOS refresh state only when the resolved bearer came from
+        // `[auth]`, i.e. `base_url`'s origin is the cloud kind (ADR-071 D2).
+        // A self-hosted server-key / env token is not refreshable here.
+        // Refresh targets WorkOS directly (ADR-047): the WorkOS base URL and
+        // the embedded public client_id (derived from the default cloud
+        // host) are captured here.
         let refresh = cfg
             .auth
             .as_ref()
-            .filter(|a| Some(a.access_token.as_str()) == cfg.server_key.as_deref())
+            .filter(|a| Some(a.access_token.as_str()) == bearer.as_deref())
             .map(|tokens| RefreshState {
                 tokens: tokens.clone(),
                 workos_url: auth_api::workos_url(),
@@ -192,7 +224,7 @@ impl ServerInferenceClient {
                 config_path: None,
             });
 
-        Some(Self {
+        Self {
             client,
             base_url,
             project_id,
@@ -200,11 +232,8 @@ impl ServerInferenceClient {
             // `server_url` is unset (ADR-004), so a set `server_url` here
             // means `base_url` resolved from it, i.e. an explicit remote.
             is_explicit_remote: cfg.server_url.is_some(),
-            auth: Mutex::new(BearerState {
-                bearer: cfg.server_key.clone(),
-                refresh,
-            }),
-        })
+            auth: Mutex::new(BearerState { bearer, refresh }),
+        }
     }
 
     /// Test-only constructor wiring an explicit base URL, bearer, and refresh
@@ -907,7 +936,9 @@ mod tests {
     }
 
     /// `from_config` carries refresh state ONLY when the bearer was resolved from
-    /// the `[auth]` access token — so a `spelunk login` session can refresh.
+    /// the `[auth]` access token, so a `spelunk login` session can refresh. That
+    /// only happens for a cloud-origin target (ADR-071 D2); a self-hosted origin
+    /// never resolves to the cloud token, whatever `[auth]` holds.
     #[test]
     #[serial_test::serial]
     fn from_config_attaches_refresh_state_for_auth_token_bearer() {
@@ -924,14 +955,12 @@ mod tests {
         };
         spelunk_core::config::save_auth_tokens_to(&tokens, &path).unwrap();
 
-        let mut cfg = crate::config::Config::load_with_store(
-            Some(&path),
-            &spelunk_core::config::secret_store::MemoryStore::default(),
-        )
-        .unwrap();
-        // from_config needs an inference URL to build a client at all.
-        cfg.inference_url = Some("http://127.0.0.1:7777".into());
-        let client = ServerInferenceClient::from_config(&cfg).expect("client builds");
+        let store = spelunk_core::config::secret_store::MemoryStore::default();
+        let mut cfg = crate::config::Config::load_with_store(Some(&path), &store).unwrap();
+        // The cloud kind only applies for the cloud origin (ADR-071 D2).
+        cfg.inference_url = Some(auth_api::DEFAULT_CLOUD_URL.to_string());
+        let client =
+            ServerInferenceClient::from_config_with_store(&cfg, &store).expect("client builds");
 
         let guard = client.auth.lock().unwrap();
         assert!(
@@ -955,13 +984,11 @@ mod tests {
         let path = tmp.path().join("config.toml");
         std::fs::write(&path, "server_key = \"sk-legacy\"\n").unwrap();
 
-        let mut cfg = crate::config::Config::load_with_store(
-            Some(&path),
-            &spelunk_core::config::secret_store::MemoryStore::default(),
-        )
-        .unwrap();
+        let store = spelunk_core::config::secret_store::MemoryStore::default();
+        let mut cfg = crate::config::Config::load_with_store(Some(&path), &store).unwrap();
         cfg.inference_url = Some("http://127.0.0.1:7777".into());
-        let client = ServerInferenceClient::from_config(&cfg).expect("client builds");
+        let client =
+            ServerInferenceClient::from_config_with_store(&cfg, &store).expect("client builds");
 
         let guard = client.auth.lock().unwrap();
         assert!(
@@ -1078,14 +1105,11 @@ mod tests {
         }
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
-        let mut cfg = crate::config::Config::load_with_store(
-            Some(&path),
-            &spelunk_core::config::secret_store::MemoryStore::default(),
-        )
-        .unwrap();
+        let store = spelunk_core::config::secret_store::MemoryStore::default();
+        let mut cfg = crate::config::Config::load_with_store(Some(&path), &store).unwrap();
         cfg.inference_url = Some("http://127.0.0.1:7777".into());
         assert!(
-            ServerInferenceClient::from_config(&cfg).is_some(),
+            ServerInferenceClient::from_config_with_store(&cfg, &store).is_some(),
             "loopback http:// inference URL must be accepted"
         );
     }
@@ -1098,14 +1122,11 @@ mod tests {
         }
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
-        let mut cfg = crate::config::Config::load_with_store(
-            Some(&path),
-            &spelunk_core::config::secret_store::MemoryStore::default(),
-        )
-        .unwrap();
+        let store = spelunk_core::config::secret_store::MemoryStore::default();
+        let mut cfg = crate::config::Config::load_with_store(Some(&path), &store).unwrap();
         cfg.inference_url = Some("https://team-server:7777".into());
         assert!(
-            ServerInferenceClient::from_config(&cfg).is_some(),
+            ServerInferenceClient::from_config_with_store(&cfg, &store).is_some(),
             "https:// inference URL (any host) must be accepted"
         );
     }

--- a/crates/spelunk-cli/tests/auth_server_keys.rs
+++ b/crates/spelunk-cli/tests/auth_server_keys.rs
@@ -1,0 +1,175 @@
+//! `spelunk auth set-key` / `spelunk auth list-servers` / the `spelunk logout`
+//! server-key scoping correction (ADR-071 D1/D3).
+//!
+//! Drives the real binary end to end against an isolated `HOME` (via
+//! `spelunk_bin_in`, `SPELUNK_SECRET_STORE=file`) so these tests never touch
+//! the developer's real `~/.config/spelunk` or the OS keychain, and so
+//! `auth set-key`'s persisted key survives across the separate process spawns
+//! each assertion below makes.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// Pipe `key` to `spelunk auth set-key --server <server>` over stdin: the
+/// only supported way to set a key (never argv).
+fn set_key(home: &std::path::Path, server: &str, key: &str) {
+    spelunk_bin_in(home)
+        .arg("auth")
+        .arg("set-key")
+        .arg("--server")
+        .arg(server)
+        .write_stdin(format!("{key}\n"))
+        .assert()
+        .success();
+}
+
+#[test]
+fn set_key_then_list_servers_shows_the_origin_not_the_secret() {
+    let home = TempDir::new().unwrap();
+    set_key(
+        home.path(),
+        "https://team.example:7777/ignored/path",
+        "sk-team-secret",
+    );
+
+    spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("list-servers")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("https://team.example:7777"))
+        .stdout(predicate::str::contains("sk-team-secret").not());
+}
+
+#[test]
+fn list_servers_with_nothing_stored_says_so() {
+    let home = TempDir::new().unwrap();
+    spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("list-servers")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No server keys stored"));
+}
+
+#[test]
+fn set_key_rejects_empty_stdin() {
+    let home = TempDir::new().unwrap();
+    spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("set-key")
+        .arg("--server")
+        .arg("https://team.example:7777")
+        .write_stdin("")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn set_key_normalizes_origin_so_a_second_call_overwrites_not_duplicates() {
+    let home = TempDir::new().unwrap();
+    set_key(home.path(), "https://team.example:7777/a/b?x=1", "sk-1");
+    set_key(home.path(), "https://team.example:7777/", "sk-2");
+
+    let out = spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("list-servers")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    // Exactly one origin line, not two.
+    assert_eq!(
+        text.lines().filter(|l| l.contains("team.example")).count(),
+        1,
+        "two URL forms of the same origin must collapse to one entry, got:\n{text}"
+    );
+}
+
+// ── `spelunk logout` server-key scoping (D3 founder correction) ────────────
+
+#[test]
+fn bare_logout_does_not_clear_stored_server_keys() {
+    let home = TempDir::new().unwrap();
+    set_key(home.path(), "https://team.example:7777", "sk-team-secret");
+
+    spelunk_bin_in(home.path()).arg("logout").assert().success();
+
+    // The server key must survive a bare logout: only the cloud [auth] pair
+    // is an unconditional clear target.
+    spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("list-servers")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("https://team.example:7777"));
+}
+
+#[test]
+fn logout_servers_flag_clears_all_stored_server_keys() {
+    let home = TempDir::new().unwrap();
+    set_key(home.path(), "https://a.example:7777", "sk-a");
+    set_key(home.path(), "https://b.example:7777", "sk-b");
+
+    spelunk_bin_in(home.path())
+        .arg("logout")
+        .arg("--servers")
+        .assert()
+        .success();
+
+    spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("list-servers")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No server keys stored"));
+}
+
+#[test]
+fn logout_server_flag_clears_only_that_one_origin() {
+    let home = TempDir::new().unwrap();
+    set_key(home.path(), "https://a.example:7777", "sk-a");
+    set_key(home.path(), "https://b.example:7777", "sk-b");
+
+    spelunk_bin_in(home.path())
+        .arg("logout")
+        .arg("--server")
+        .arg("https://a.example:7777")
+        .assert()
+        .success();
+
+    let out = spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("list-servers")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    assert!(
+        !text.contains("a.example"),
+        "cleared origin still listed:\n{text}"
+    );
+    assert!(
+        text.contains("b.example"),
+        "untouched origin missing:\n{text}"
+    );
+}
+
+#[test]
+fn logout_servers_and_server_flags_are_mutually_exclusive() {
+    let home = TempDir::new().unwrap();
+    spelunk_bin_in(home.path())
+        .arg("logout")
+        .arg("--servers")
+        .arg("--server")
+        .arg("https://a.example")
+        .assert()
+        .failure();
+}

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -104,6 +104,16 @@ pub fn spelunk_bin_in(home: &Path) -> Command {
         // XDG_CONFIG_HOME so the file store lands under `<home>/.config/spelunk`
         // and never the developer's real config dir.
         .env_remove("XDG_CONFIG_HOME")
+        // `dirs::home_dir()` 6.x on Windows calls `SHGetKnownFolderPath` (a
+        // Registry lookup) rather than reading `HOME`/`USERPROFILE`, so the
+        // `HOME` redirect above is a no-op there: every subprocess this spawns
+        // would otherwise land on the same real `%USERPROFILE%\.config\spelunk`,
+        // and concurrent tests racing on one `secrets.toml` corrupt it (see the
+        // identical, already-documented gap on `SPELUNK_STATE_DIR` in
+        // `capability.rs` and `SPELUNK_SCRIPTS_DIR` in `memory/add.rs`).
+        // `SPELUNK_CONFIG_DIR` bypasses `dirs::home_dir()` entirely and works
+        // identically on every platform.
+        .env("SPELUNK_CONFIG_DIR", home.join(".config").join("spelunk"))
         // The HOME redirect above hides `~/.gitconfig` from the git this child
         // spawns, but an exported GIT_CONFIG_GLOBAL outranks HOME and would
         // still reach it. Not a Windows path, but git skips a scope whenever

--- a/crates/spelunk-cli/tests/server_key_resolution_e2e.rs
+++ b/crates/spelunk-cli/tests/server_key_resolution_e2e.rs
@@ -1,0 +1,224 @@
+//! Test-engineer coverage: drive per-origin bearer resolution (ADR-071 D1/D2)
+//! through the real binary, over the real wire, against two independent mock
+//! servers standing in for the motivating multi-server case: two projects,
+//! two `server_url`s, two keys, resolving correctly with no env-juggling.
+//!
+//! The Engineer's own suite (`crates/spelunk-core/src/config/server_keys.rs`,
+//! `crates/spelunk-cli/tests/auth_server_keys.rs`) verifies resolution at the
+//! unit level and the command surface (`set-key`/`list-servers`/`logout`)
+//! end to end, but nothing exercises the actual `Authorization` header a real
+//! request carries to a real (mocked) origin. That is the one place a
+//! same-string-comparison or map-mixup bug would actually manifest as a
+//! credential going to the wrong server, so this file inspects the header
+//! wiremock received rather than trusting the CLI's own stdout/exit code.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use std::path::Path;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const PROJECT_ID: &str = "test-org/test-project";
+
+async fn mount_health_and_since(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/v1/health$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "version": "test",
+            "capabilities": ["memory"],
+        })))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/v1/projects/.+/memory/since$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(server)
+        .await;
+}
+
+fn write_server_config(dir: &Path, name: &str, server_url: &str) -> std::path::PathBuf {
+    let config_path = dir.join(format!("{name}.toml"));
+    std::fs::write(
+        &config_path,
+        format!(
+            "server_url = {server_url:?}\nproject_id = {PROJECT_ID:?}\nembedding_model = \"test-model\"\n"
+        ),
+    )
+    .unwrap();
+    config_path
+}
+
+fn set_key(home: &Path, server: &str, key: &str) {
+    spelunk_bin_in(home)
+        .arg("auth")
+        .arg("set-key")
+        .arg("--server")
+        .arg(server)
+        .write_stdin(format!("{key}\n"))
+        .assert()
+        .success();
+}
+
+/// The multi-server acceptance case, driven for real: two `server_url`s
+/// under the *same* HOME (so they share one secret-store map, D1's whole
+/// point), each with its own key set via the real `auth set-key` command,
+/// then two separate `spelunk memory since` invocations, one per origin,
+/// each inspected for the literal `Authorization` header wiremock received.
+/// Each origin must get exactly its own key, never the other's, and never
+/// an env var (none is set at any point in this test).
+#[tokio::test]
+async fn two_servers_two_keys_each_gets_only_its_own_bearer_over_the_wire() {
+    let server_a = MockServer::start().await;
+    let server_b = MockServer::start().await;
+    mount_health_and_since(&server_a).await;
+    mount_health_and_since(&server_b).await;
+
+    let home = TempDir::new().unwrap();
+    let cfg_dir = TempDir::new().unwrap();
+
+    set_key(home.path(), &server_a.uri(), "sk-project-a-secret");
+    set_key(home.path(), &server_b.uri(), "sk-project-b-secret");
+
+    let config_a = write_server_config(cfg_dir.path(), "a", &server_a.uri());
+    let config_b = write_server_config(cfg_dir.path(), "b", &server_b.uri());
+
+    let mem_db = cfg_dir.path().join("memory.db");
+
+    spelunk_bin_in(home.path())
+        .env_remove("SPELUNK_SERVER_KEY")
+        .arg("--config")
+        .arg(&config_a)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_db)
+        .arg("since")
+        .arg("0")
+        .assert()
+        .success();
+
+    spelunk_bin_in(home.path())
+        .env_remove("SPELUNK_SERVER_KEY")
+        .arg("--config")
+        .arg(&config_b)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_db)
+        .arg("since")
+        .arg("0")
+        .assert()
+        .success();
+
+    let requests_a = server_a.received_requests().await.unwrap();
+    let since_req_a = requests_a
+        .iter()
+        .find(|r| r.url.path().ends_with("/memory/since"))
+        .expect("server A received a /memory/since request");
+    assert_eq!(
+        since_req_a
+            .headers
+            .get("authorization")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer sk-project-a-secret"),
+        "server A must receive exactly its own key"
+    );
+
+    let requests_b = server_b.received_requests().await.unwrap();
+    let since_req_b = requests_b
+        .iter()
+        .find(|r| r.url.path().ends_with("/memory/since"))
+        .expect("server B received a /memory/since request");
+    assert_eq!(
+        since_req_b
+            .headers
+            .get("authorization")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer sk-project-b-secret"),
+        "server B must receive exactly its own key, never A's"
+    );
+}
+
+/// Migration end-to-end through the real binary and the real (file-backed)
+/// secret store: a legacy flat key planted the way a pre-ADR-071 client
+/// would have left it (raw `KEY_SERVER_KEY` entry, no map) is picked up
+/// transparently on first use against a self-hosted `server_url`: the
+/// request still succeeds, and `auth list-servers` afterward shows it
+/// migrated into the per-origin map with the legacy tier gone. This is the
+/// "continues to work transparently on first use" claim from the ADR,
+/// verified by actually running the binary against a live (mock) server
+/// rather than only asserting on `Config::bearer_for`'s return value.
+#[tokio::test]
+async fn legacy_flat_key_migrates_transparently_on_first_real_request() {
+    let server = MockServer::start().await;
+    mount_health_and_since(&server).await;
+
+    let home = TempDir::new().unwrap();
+    let cfg_dir = TempDir::new().unwrap();
+
+    // Plant a legacy flat key exactly where a pre-ADR-071 `spelunk login`/
+    // plaintext-config migration would have left it: the file-backed
+    // secret-store entry named by `KEY_SERVER_KEY` ("server_key"), under the
+    // same isolated HOME `spelunk_bin_in` points every child process at.
+    // `auth set-key` itself only ever writes the new per-origin map, so
+    // there is no CLI surface to plant this pre-migration state: writing
+    // the secrets.toml file directly is the only way to simulate an
+    // upgrading (not fresh) install.
+    let secrets_path = home.path().join(".config").join("spelunk");
+    std::fs::create_dir_all(&secrets_path).unwrap();
+    std::fs::write(
+        secrets_path.join("secrets.toml"),
+        "server_key = \"sk-legacy-preupgrade\"\n",
+    )
+    .unwrap();
+
+    let config_path = write_server_config(cfg_dir.path(), "legacy", &server.uri());
+    let mem_db = cfg_dir.path().join("memory.db");
+
+    spelunk_bin_in(home.path())
+        .env_remove("SPELUNK_SERVER_KEY")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_db)
+        .arg("since")
+        .arg("0")
+        .assert()
+        .success();
+
+    let requests = server.received_requests().await.unwrap();
+    let since_req = requests
+        .iter()
+        .find(|r| r.url.path().ends_with("/memory/since"))
+        .expect("server received a /memory/since request");
+    assert_eq!(
+        since_req
+            .headers
+            .get("authorization")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer sk-legacy-preupgrade"),
+        "the legacy key must be sent transparently on first use"
+    );
+
+    // And it must now be visible as a migrated per-origin entry, with the
+    // legacy tier gone (D3/D1's "migrate, don't dual-read forever").
+    let out = spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("list-servers")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    assert!(
+        text.contains(server.uri().as_str()) || text.contains(&server.address().to_string()),
+        "migrated origin must be listed:\n{text}"
+    );
+    assert!(
+        !text.contains("a legacy server key is also stored"),
+        "legacy tier must be gone after migration:\n{text}"
+    );
+}

--- a/crates/spelunk-core/src/config/mod.rs
+++ b/crates/spelunk-core/src/config/mod.rs
@@ -10,6 +10,7 @@ mod sync_mode;
 mod tls;
 
 pub mod secret_store;
+pub mod server_keys;
 
 use paths::{find_project_config, spelunk_config_dir};
 use secret_store::{KEY_SERVER_KEY, SecretStore};
@@ -76,13 +77,17 @@ struct ProjectIndexConfig {
 
 /// Fields that can be set in `.spelunk/config.toml` (project-level, checked-in).
 /// Only contains fields safe to share with the team (no secrets).
+///
+/// `server_key` is deliberately absent (ADR-071 D4): a credential in a
+/// committed file is in the repo's history for good and readable by anyone
+/// with repo access. A file that still has a `server_key` line keeps working
+/// for its other fields: serde silently drops the unrecognized key, the
+/// same way the removed `memory_server_*` aliases are dropped. Use
+/// `spelunk auth set-key --server <url>` instead.
 #[derive(Debug, Default, Deserialize)]
 struct ProjectConfig {
     /// Canonical server URL (preferred).
     server_url: Option<String>,
-    /// Shared API key — acceptable if the server is behind a VPN/firewall.
-    /// For secrets, prefer `SPELUNK_SERVER_KEY` env var instead.
-    server_key: Option<String>,
     project_id: Option<String>,
     /// Path to a PEM CA bundle to trust in addition to the built-in roots, for a
     /// team server presenting a self-signed / internal-CA certificate.
@@ -116,11 +121,14 @@ pub struct Config {
     #[serde(default)]
     pub server_url: Option<String>,
 
-    /// Bearer token for cloud/spelunk-server auth — the single token every auth
-    /// path sends as `Authorization: Bearer …`.
-    /// Set in `~/.config/spelunk/config.toml` (personal), written by
-    /// `spelunk login`, or overridden via `SPELUNK_SERVER_KEY`.
-    /// Do NOT commit this to `.spelunk/config.toml`.
+    /// The **cloud-kind** bearer only (ADR-071 D2): `SPELUNK_SERVER_KEY` env
+    /// override, else the `[auth].access_token` written by `spelunk login`.
+    /// Resolved once at load time because both tiers are origin-independent.
+    ///
+    /// This is NOT the effective bearer for a self-hosted `server_url`:
+    /// that credential is scoped per server origin and resolved lazily via
+    /// [`Config::bearer_for`], which also branches to this same field for the
+    /// cloud origin. Do NOT commit any bearer to `.spelunk/config.toml`.
     #[serde(default)]
     pub server_key: Option<String>,
 
@@ -183,12 +191,12 @@ pub struct Config {
     /// `[auth]` table in the global config.
     ///
     /// When present and the access token is unexpired, it is the source of the
-    /// `Authorization: Bearer` token every cloud request sends — [`Config::load`]
-    /// copies the access token into [`Config::server_key`] so existing call
-    /// sites keep working unchanged. The `refresh_token` is used to rotate an
-    /// expired access token and to silently switch organisations. Read the
-    /// effective bearer through [`Config::server_key`]; reach for the refresh
-    /// token via this field only in the token-refresh path.
+    /// `Authorization: Bearer` token every cloud-origin request sends.
+    /// [`Config::load`] copies the access token into [`Config::server_key`]
+    /// (the cloud-kind bearer). A self-hosted `server_url` never consults
+    /// this field (ADR-071 D2); use [`Config::bearer_for`] there. The
+    /// `refresh_token` is used to rotate an expired access token and to
+    /// silently switch organisations.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth: Option<AuthTokens>,
 
@@ -327,10 +335,10 @@ impl Config {
         let global_bare_server_key = cfg.server_key.clone();
 
         // ── 2. Merge project-level config (.spelunk/config.toml) ─────────────
-        // A `server_key` here is a *shared team* key (acceptable behind a VPN);
-        // it is intentionally NOT migrated to the keychain — it lives in a
-        // checked-in file by design and is not personal to this user.
-        let mut project_server_key: Option<String> = None;
+        // `ProjectConfig` has no `server_key` field (ADR-071 D4): a checked-in
+        // file never carries a credential. A file that still has a
+        // `server_key` line keeps working for its other fields: the parse
+        // above silently drops the unrecognized key.
         if let Ok(cwd) = std::env::current_dir()
             && let Some(proj_path) = find_project_config(&cwd)
         {
@@ -341,10 +349,6 @@ impl Config {
 
             if let Some(v) = proj.server_url {
                 cfg.server_url = Some(v);
-            }
-            if let Some(v) = proj.server_key {
-                project_server_key = Some(v.clone());
-                cfg.server_key = Some(v);
             }
             if let Some(v) = proj.project_id {
                 cfg.project_id = Some(v);
@@ -375,9 +379,8 @@ impl Config {
         if let Some(bare) = &global_bare_server_key {
             let already_in_store = store.get(KEY_SERVER_KEY)?.is_some();
             if !already_in_store {
-                store.set(KEY_SERVER_KEY, bare).with_context(|| {
-                    "migrating plaintext server_key into the secret store".to_string()
-                })?;
+                save_server_key_with(bare, store)
+                    .context("migrating plaintext server_key into the secret store")?;
             }
             // Strip the plaintext key from the personal config regardless: it is
             // now in the store (or was already there), so it must not linger in
@@ -417,32 +420,61 @@ impl Config {
             cfg.mode = Some(parsed);
         }
 
-        // ── 4. Resolve the effective Bearer token ────────────────────────────
-        // Precedence for `Authorization: Bearer` (highest first):
+        // ── 4. Resolve the cloud-kind bearer (ADR-071 D2) ────────────────────
+        // `cfg.server_key` is now the **cloud-kind** bearer only:
         //   1. `SPELUNK_SERVER_KEY` env var (CI / headless escape hatch) — wins.
         //   2. `[auth].access_token` from `spelunk login` (WorkOS device flow).
-        //   3. Secret-store `server_key` (the migrated home for the personal
-        //      bearer — keychain by default, file fallback when headless).
-        //   4. Project-level team `server_key` from `.spelunk/config.toml`.
-        // The `[auth]` tokens are kept in `cfg.auth` so the refresh-on-expiry /
-        // org-switch paths can reach the refresh token; every other call site
-        // only ever reads the resolved `cfg.server_key`.
-        //
-        // Tiers 1-2 resolve without the secret store at all, so the store is
-        // only actually read when neither is present: a value that would be
-        // discarded anyway is never fetched, which spares a keychain prompt
-        // on every `spelunk login`'d or `SPELUNK_SERVER_KEY` invocation.
+        // Both tiers are origin-independent, so resolving them once here (with
+        // no secret-store read at all) is correct and cheap. A self-hosted
+        // `server_url`'s bearer is a *different* credential, scoped to that
+        // server's origin, resolved lazily via [`Config::bearer_for`]. It is
+        // never derived from this field, so a cloud login can never leak to a
+        // self-hosted server (the bug this ADR fixes).
         cfg.server_key = if let Some(v) = env_server_key {
             Some(v)
-        } else if let Some(auth) = &cfg.auth {
-            Some(auth.access_token.clone())
         } else {
-            store.get(KEY_SERVER_KEY)?.or(project_server_key)
+            cfg.auth.as_ref().map(|auth| auth.access_token.clone())
         };
 
         Ok(cfg)
     }
 
+    /// Resolve the effective bearer for a request to `server_url` (ADR-071
+    /// D2), using the host's default secret store. See
+    /// [`Config::bearer_for_with_store`] for the resolution rules and the
+    /// testable, store-injected form.
+    pub fn bearer_for(&self, server_url: &str) -> Result<Option<String>> {
+        let store = secret_store::default_store(&spelunk_config_dir())?;
+        self.bearer_for_with_store(server_url, store.as_ref())
+    }
+
+    /// Same as [`Config::bearer_for`] but with an injected [`SecretStore`]
+    /// (tests, and callers that already resolved a store).
+    ///
+    /// Branches on credential kind by `server_url`'s origin before touching
+    /// any store (cloud vs. self-hosted server-key: see
+    /// [`server_keys::bearer_for`] for the full precedence and the legacy
+    /// migration it performs).
+    pub fn bearer_for_with_store(
+        &self,
+        server_url: &str,
+        store: &dyn SecretStore,
+    ) -> Result<Option<String>> {
+        server_keys::bearer_for(self.auth.as_ref(), server_url, store)
+    }
+}
+
+/// Resolve the host's default [`SecretStore`], honouring [`secret_store::ENV_SECRET_STORE`].
+///
+/// The public entry point for CLI commands that need to read or write the
+/// per-origin key map directly (`spelunk auth set-key` / `list-servers` /
+/// `logout --servers`), the same resolution [`Config::load`] and
+/// [`Config::bearer_for`] use internally.
+pub fn default_secret_store() -> Result<Box<dyn SecretStore>> {
+    secret_store::default_store(&spelunk_config_dir())
+}
+
+impl Config {
     /// Validate cross-field constraints. Call after `load()`.
     ///
     /// When `server_url` points to a loopback address (`127.0.0.1`, `localhost`, `::1`),
@@ -696,8 +728,14 @@ project_id = "my-proj"
     #[test]
     #[serial_test::serial]
     fn mixed_config_live_key_wins_over_deprecated() {
-        // Both the live key and its removed alias present: the live key resolves
-        // and the deprecated key is silently dropped (no error, no override).
+        // Both the live key and its removed alias present: the live server_url
+        // resolves and the deprecated alias is silently dropped (no error, no
+        // override). `server_key` is the legacy personal bearer (a bare
+        // `server_key` in the *global* config, not a `.spelunk/config.toml`
+        // credential; D4 is about the latter): it no longer feeds
+        // `cfg.server_key` (cloud-kind only, ADR-071 D2), but the migration
+        // into the secret store still runs and the value is still reachable
+        // through `bearer_for_with_store` for a self-hosted origin.
         clear_spelunk_env();
         let tmp = TempDir::new().unwrap();
         let config_path = tmp.path().join("config.toml");
@@ -712,12 +750,19 @@ memory_server_key = "old-token"
         )
         .unwrap();
 
-        let cfg = load_hermetic(&config_path).unwrap();
+        let store = MemoryStore::default();
+        let cfg = Config::load_with_store(Some(&config_path), &store).unwrap();
         assert_eq!(
             cfg.server_url,
             Some("http://new.example.com:7777".to_string())
         );
-        assert_eq!(cfg.server_key, Some("new-token".to_string()));
+        assert_eq!(cfg.server_key, None);
+        assert_eq!(
+            cfg.bearer_for_with_store("http://new.example.com:7777", &store)
+                .unwrap()
+                .as_deref(),
+            Some("new-token")
+        );
     }
 
     #[test]
@@ -1083,33 +1128,54 @@ project_id = "team/proj"
         unsafe { std::env::remove_var("SPELUNK_SERVER_KEY") };
     }
 
-    /// A legacy bare `server_key` keeps working when no `[auth]` table exists.
+    /// A legacy bare `server_key` no longer feeds `cfg.server_key` (cloud-kind
+    /// only, ADR-071 D2) when no `[auth]` table exists, but it is still
+    /// migrated into the store and resolves via `bearer_for` for a
+    /// self-hosted origin.
     #[test]
     #[serial_test::serial]
-    fn legacy_server_key_used_when_no_auth_table() {
+    fn legacy_server_key_migrates_but_no_longer_feeds_server_key_field() {
         clear_spelunk_env();
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
         std::fs::write(&path, "server_key = \"sk-legacy\"\n").unwrap();
 
-        let cfg = load_hermetic(&path).unwrap();
-        assert_eq!(cfg.server_key.as_deref(), Some("sk-legacy"));
+        let store = MemoryStore::default();
+        let cfg = Config::load_with_store(Some(&path), &store).unwrap();
+        assert_eq!(cfg.server_key, None);
         assert!(cfg.auth.is_none());
+        assert_eq!(
+            cfg.bearer_for_with_store("https://team.example:7777", &store)
+                .unwrap()
+                .as_deref(),
+            Some("sk-legacy")
+        );
     }
 
-    /// `[auth]` access token takes precedence over a legacy bare `server_key`
-    /// present in the same file.
+    /// The `[auth]` access token (cloud kind) and a legacy bare `server_key`
+    /// (self-hosted kind) resolve independently by target origin (ADR-071
+    /// D2): they no longer compete in a single flat precedence chain.
     #[test]
     #[serial_test::serial]
-    fn auth_token_precedence_over_legacy_server_key() {
+    fn auth_token_and_legacy_server_key_resolve_by_kind_not_precedence() {
         clear_spelunk_env();
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
         std::fs::write(&path, "server_key = \"sk-legacy\"\n").unwrap();
         save_auth_tokens_to(&sample_tokens(), &path).unwrap();
 
-        let cfg = load_hermetic(&path).unwrap();
+        let store = MemoryStore::default();
+        let cfg = Config::load_with_store(Some(&path), &store).unwrap();
+        // Cloud-kind field resolves from [auth], unaffected by the legacy key.
         assert_eq!(cfg.server_key.as_deref(), Some("at-sample"));
+        // The legacy key is still migrated and reachable for a self-hosted
+        // origin; the cloud token never leaks to it.
+        assert_eq!(
+            cfg.bearer_for_with_store("https://team.example:7777", &store)
+                .unwrap()
+                .as_deref(),
+            Some("sk-legacy")
+        );
     }
 
     /// Writing auth tokens preserves other top-level keys (e.g. `server_url`).
@@ -1139,10 +1205,17 @@ project_id = "team/proj"
         save_auth_tokens_to(&sample_tokens(), &path).unwrap();
 
         remove_auth_tokens_from(&path).unwrap();
-        let cfg = load_hermetic(&path).unwrap();
+        let store = MemoryStore::default();
+        let cfg = Config::load_with_store(Some(&path), &store).unwrap();
         assert!(cfg.auth.is_none());
-        // Legacy key still present and now resolves as the bearer fallback.
-        assert_eq!(cfg.server_key.as_deref(), Some("sk-legacy"));
+        assert_eq!(cfg.server_key, None);
+        // Legacy key still present in the store, reachable via bearer_for.
+        assert_eq!(
+            cfg.bearer_for_with_store("https://team.example:7777", &store)
+                .unwrap()
+                .as_deref(),
+            Some("sk-legacy")
+        );
     }
 
     /// On Unix, the config file is written `0600` after persisting tokens.
@@ -1243,8 +1316,9 @@ project_id = "team/new"
     // no real keychain or Secret Service daemon is required (CI-safe).
 
     /// Migration: a bare `server_key` in the personal global config is moved
-    /// into the secret store and stripped from the file on next load. It still
-    /// resolves as the bearer (transparent to the user).
+    /// into the secret store and stripped from the file on next load. It no
+    /// longer feeds `cfg.server_key` (cloud-kind only, ADR-071 D2); it
+    /// resolves via `bearer_for` for a self-hosted origin instead.
     #[test]
     #[serial_test::serial]
     fn migration_moves_bare_server_key_into_store_and_strips_file() {
@@ -1260,11 +1334,17 @@ project_id = "team/new"
         let store = MemoryStore::default();
         let cfg = Config::load_with_store(Some(&path), &store).unwrap();
 
-        // Still resolves transparently as the bearer.
-        assert_eq!(cfg.server_key.as_deref(), Some("sk-sp-legacy"));
+        assert_eq!(cfg.server_key, None);
         // Moved into the store.
         assert_eq!(
             store.get(KEY_SERVER_KEY).unwrap().as_deref(),
+            Some("sk-sp-legacy")
+        );
+        // Resolves transparently through bearer_for for the configured server.
+        assert_eq!(
+            cfg.bearer_for_with_store("http://team:7777", &store)
+                .unwrap()
+                .as_deref(),
             Some("sk-sp-legacy")
         );
         // Stripped from the file, but other keys preserved.
@@ -1289,12 +1369,19 @@ project_id = "team/new"
 
         let store = MemoryStore::default();
         let first = Config::load_with_store(Some(&path), &store).unwrap();
-        assert_eq!(first.server_key.as_deref(), Some("sk-sp-legacy"));
+        assert_eq!(first.server_key, None);
 
         let second = Config::load_with_store(Some(&path), &store).unwrap();
-        assert_eq!(second.server_key.as_deref(), Some("sk-sp-legacy"));
+        assert_eq!(second.server_key, None);
         assert_eq!(
             store.get(KEY_SERVER_KEY).unwrap().as_deref(),
+            Some("sk-sp-legacy")
+        );
+        assert_eq!(
+            second
+                .bearer_for_with_store("https://team.example:7777", &store)
+                .unwrap()
+                .as_deref(),
             Some("sk-sp-legacy")
         );
     }
@@ -1314,9 +1401,15 @@ project_id = "team/new"
         store.set(KEY_SERVER_KEY, "sk-fresh-store").unwrap();
 
         let cfg = Config::load_with_store(Some(&path), &store).unwrap();
-        assert_eq!(cfg.server_key.as_deref(), Some("sk-fresh-store"));
+        assert_eq!(cfg.server_key, None);
         assert_eq!(
             store.get(KEY_SERVER_KEY).unwrap().as_deref(),
+            Some("sk-fresh-store")
+        );
+        assert_eq!(
+            cfg.bearer_for_with_store("https://team.example:7777", &store)
+                .unwrap()
+                .as_deref(),
             Some("sk-fresh-store")
         );
         let on_disk = std::fs::read_to_string(&path).unwrap();
@@ -1345,9 +1438,15 @@ project_id = "team/new"
         assert!(!on_disk.contains("sk-sp-new"));
         assert!(!on_disk.contains("server_key"));
 
-        // Resolves from the store on load.
+        // Resolves from the store via bearer_for, not the eager server_key field.
         let cfg = Config::load_with_store(Some(&path), &store).unwrap();
-        assert_eq!(cfg.server_key.as_deref(), Some("sk-sp-new"));
+        assert_eq!(cfg.server_key, None);
+        assert_eq!(
+            cfg.bearer_for_with_store("http://team:7777", &store)
+                .unwrap()
+                .as_deref(),
+            Some("sk-sp-new")
+        );
     }
 
     /// `logout` (remove_server_key_with) clears the store entry AND any legacy
@@ -1411,19 +1510,22 @@ project_id = "team/new"
         assert_eq!(cfg.server_key.as_deref(), Some("at-sample"));
     }
 
-    /// Precedence: a stored `server_key` wins over a project-level team key in
-    /// `.spelunk/config.toml`.
+    /// ADR-071 D4: a `server_key` line in the project-level, checked-in
+    /// `.spelunk/config.toml` is dropped entirely: no read, no warning, no
+    /// effect on the resolved bearer at any tier. Mirrors the
+    /// `memory_server_*` silent-drop precedent.
     #[test]
     #[serial_test::serial]
-    fn store_key_wins_over_project_team_key() {
+    fn project_config_server_key_field_is_silently_dropped() {
         clear_spelunk_env();
         let tmp = TempDir::new().unwrap();
         let proj_dir = tmp.path().join("project");
         let spelunk_dir = proj_dir.join(".spelunk");
         std::fs::create_dir_all(&spelunk_dir).unwrap();
+        let proj_cfg = spelunk_dir.join("config.toml");
         std::fs::write(
-            spelunk_dir.join("config.toml"),
-            "server_key = \"team-shared-key\"\n",
+            &proj_cfg,
+            "server_url = \"https://team.example:7777\"\nserver_key = \"team-shared-key\"\nproject_id = \"team/proj\"\n",
         )
         .unwrap();
 
@@ -1431,34 +1533,6 @@ project_id = "team/new"
         std::fs::write(&global_config, "").unwrap();
 
         let store = MemoryStore::default();
-        store.set(KEY_SERVER_KEY, "personal-store-key").unwrap();
-
-        let original_cwd = std::env::current_dir().ok();
-        std::env::set_current_dir(&proj_dir).unwrap();
-        let cfg = Config::load_with_store(Some(&global_config), &store).unwrap();
-        if let Some(d) = original_cwd {
-            std::env::set_current_dir(d).unwrap();
-        }
-        assert_eq!(cfg.server_key.as_deref(), Some("personal-store-key"));
-    }
-
-    /// A project-level team `server_key` is the lowest-precedence fallback and
-    /// is NOT migrated to the store (it lives in a checked-in file by design).
-    #[test]
-    #[serial_test::serial]
-    fn project_team_key_used_as_fallback_and_not_migrated() {
-        clear_spelunk_env();
-        let tmp = TempDir::new().unwrap();
-        let proj_dir = tmp.path().join("project");
-        let spelunk_dir = proj_dir.join(".spelunk");
-        std::fs::create_dir_all(&spelunk_dir).unwrap();
-        let proj_cfg = spelunk_dir.join("config.toml");
-        std::fs::write(&proj_cfg, "server_key = \"team-shared-key\"\n").unwrap();
-
-        let global_config = tmp.path().join("global.toml");
-        std::fs::write(&global_config, "").unwrap();
-
-        let store = MemoryStore::default();
         let original_cwd = std::env::current_dir().ok();
         std::env::set_current_dir(&proj_dir).unwrap();
         let cfg = Config::load_with_store(Some(&global_config), &store).unwrap();
@@ -1466,10 +1540,23 @@ project_id = "team/new"
             std::env::set_current_dir(d).unwrap();
         }
 
-        assert_eq!(cfg.server_key.as_deref(), Some("team-shared-key"));
-        // The team key must NOT have been migrated into the personal store.
+        // The file's other fields still load fine (no parse error from the
+        // now-unrecognized `server_key` key).
+        assert_eq!(
+            cfg.server_url,
+            Some("https://team.example:7777".to_string())
+        );
+        assert_eq!(cfg.project_id, Some("team/proj".to_string()));
+        // No credential resolves anywhere: not eagerly, not per-origin.
+        assert_eq!(cfg.server_key, None);
+        assert_eq!(
+            cfg.bearer_for_with_store("https://team.example:7777", &store)
+                .unwrap(),
+            None
+        );
+        // Never touches the personal secret store.
         assert_eq!(store.get(KEY_SERVER_KEY).unwrap(), None);
-        // …and the checked-in file is left untouched.
+        // The checked-in file itself is left untouched (D4 does not rewrite it).
         assert!(
             std::fs::read_to_string(&proj_cfg)
                 .unwrap()
@@ -1478,7 +1565,7 @@ project_id = "team/new"
     }
 
     /// No-keychain fallback contract: the file-backed store stands in for a
-    /// keychain when none exists, so `load_with_store` resolves the credential
+    /// keychain when none exists, so `bearer_for` resolves the credential
     /// identically. This mirrors what `default_store` does on a headless host.
     #[test]
     #[serial_test::serial]
@@ -1492,7 +1579,12 @@ project_id = "team/new"
         save_server_key_with("sk-headless", &file_store).unwrap();
 
         let cfg = Config::load_with_store(Some(&path), &file_store).unwrap();
-        assert_eq!(cfg.server_key.as_deref(), Some("sk-headless"));
+        assert_eq!(
+            cfg.bearer_for_with_store("https://team.example:7777", &file_store)
+                .unwrap()
+                .as_deref(),
+            Some("sk-headless")
+        );
     }
 
     /// No credential anywhere (empty config, empty store, no env) ⇒ no bearer,

--- a/crates/spelunk-core/src/config/paths.rs
+++ b/crates/spelunk-core/src/config/paths.rs
@@ -1,13 +1,27 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
-/// Returns `~/.config/spelunk/`.
+/// Returns `~/.config/spelunk/`, or `SPELUNK_CONFIG_DIR` when set.
 ///
 /// On all platforms we use `~/.config` rather than the OS-native config dir
 /// (e.g. `~/Library/Application Support` on macOS) so that the path matches
 /// what the CLI documentation and error messages say, and so that config files
 /// work the same way across Linux and macOS.
+///
+/// `SPELUNK_CONFIG_DIR` is a supported override of the entire path, not
+/// dev-only cruft: it is load-bearing on Windows, where `dirs::home_dir()` 6.x
+/// calls `SHGetKnownFolderPath` (a Registry lookup) rather than reading
+/// `HOME`/`USERPROFILE`, making a per-process environment override of `HOME`
+/// ineffective (the identical portability gap documented on
+/// `spelunk_state_dir` in the CLI's `capability.rs` and on
+/// `web_to_md_script_path` in `memory/add.rs`). Tests that need an isolated
+/// config/secret-store location (this crate's own `config::mod::tests`, and
+/// the CLI integration tests via `spelunk_bin_in`) set this instead of relying
+/// on `HOME` alone.
 pub(in crate::config) fn spelunk_config_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("SPELUNK_CONFIG_DIR") {
+        return PathBuf::from(dir);
+    }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".config")
@@ -115,6 +129,34 @@ pub fn resolve_db(explicit: Option<&Path>, cfg_default: &Path) -> PathBuf {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    // ── spelunk_config_dir / SPELUNK_CONFIG_DIR override ─────────────────────
+
+    /// `SPELUNK_CONFIG_DIR` wins over `dirs::home_dir()`-derived resolution.
+    /// This is the override that makes per-test isolation possible on
+    /// Windows, where `dirs::home_dir()` does not read `HOME`.
+    #[test]
+    #[serial_test::serial(spelunk_config_dir_env)]
+    fn spelunk_config_dir_honors_env_override() {
+        let tmp = TempDir::new().unwrap();
+        let override_dir = tmp.path().join("custom-config-dir");
+        unsafe { std::env::set_var("SPELUNK_CONFIG_DIR", &override_dir) };
+        let got = spelunk_config_dir();
+        unsafe { std::env::remove_var("SPELUNK_CONFIG_DIR") };
+        assert_eq!(got, override_dir);
+    }
+
+    #[test]
+    #[serial_test::serial(spelunk_config_dir_env)]
+    fn spelunk_config_dir_falls_back_to_home_when_unset() {
+        unsafe { std::env::remove_var("SPELUNK_CONFIG_DIR") };
+        let got = spelunk_config_dir();
+        assert!(
+            got.ends_with(Path::new(".config").join("spelunk")),
+            "got: {}",
+            got.display()
+        );
+    }
 
     // ── find_project_dir / require_project_db_at (ADR-067) ───────────────────
 

--- a/crates/spelunk-core/src/config/persist.rs
+++ b/crates/spelunk-core/src/config/persist.rs
@@ -33,9 +33,12 @@ pub fn save_server_key_with(key: &str, store: &dyn SecretStore) -> Result<()> {
 
 /// Remove the CLI bearer credential everywhere it might live.
 ///
-/// What `spelunk logout` clears: the secret-store entry **and** any legacy
-/// plaintext `server_key` left in `~/.config/spelunk/config.toml`. No-op for any
-/// location where the credential is absent.
+/// What `spelunk logout --servers` clears (ADR-071 D3): the secret-store
+/// entry **and** any legacy plaintext `server_key` left in
+/// `~/.config/spelunk/config.toml`. Bare `spelunk logout` no longer calls
+/// this — it only clears the `[auth]` cloud token pair (see
+/// [`remove_auth_tokens`]). No-op for any location where the credential is
+/// absent.
 pub fn remove_server_key() -> Result<()> {
     let store = secret_store::default_store(&spelunk_config_dir())?;
     remove_server_key_with(store.as_ref(), &spelunk_config_dir().join("config.toml"))
@@ -107,8 +110,11 @@ pub fn save_auth_tokens_to(tokens: &AuthTokens, config_path: &Path) -> Result<()
 
 /// Remove the `[auth]` table from `~/.config/spelunk/config.toml`.
 ///
-/// What `spelunk logout` clears (alongside the legacy `server_key`). No-op if
-/// the file or the table is absent. Other keys are preserved.
+/// What bare `spelunk logout` clears (ADR-071 D3): only the `[auth]` cloud
+/// token pair. It no longer touches self-hosted server keys as a side
+/// effect — clearing those requires the explicit `--servers` or
+/// `--server <url>` flag (see [`remove_server_key`]). No-op if the file or
+/// the table is absent. Other keys are preserved.
 pub fn remove_auth_tokens() -> Result<()> {
     remove_auth_tokens_from(&spelunk_config_dir().join("config.toml"))
 }

--- a/crates/spelunk-core/src/config/persist.rs
+++ b/crates/spelunk-core/src/config/persist.rs
@@ -36,7 +36,7 @@ pub fn save_server_key_with(key: &str, store: &dyn SecretStore) -> Result<()> {
 /// What `spelunk logout --servers` clears (ADR-071 D3): the secret-store
 /// entry **and** any legacy plaintext `server_key` left in
 /// `~/.config/spelunk/config.toml`. Bare `spelunk logout` no longer calls
-/// this — it only clears the `[auth]` cloud token pair (see
+/// this; it only clears the `[auth]` cloud token pair (see
 /// [`remove_auth_tokens`]). No-op for any location where the credential is
 /// absent.
 pub fn remove_server_key() -> Result<()> {
@@ -112,7 +112,7 @@ pub fn save_auth_tokens_to(tokens: &AuthTokens, config_path: &Path) -> Result<()
 ///
 /// What bare `spelunk logout` clears (ADR-071 D3): only the `[auth]` cloud
 /// token pair. It no longer touches self-hosted server keys as a side
-/// effect — clearing those requires the explicit `--servers` or
+/// effect; clearing those requires the explicit `--servers` or
 /// `--server <url>` flag (see [`remove_server_key`]). No-op if the file or
 /// the table is absent. Other keys are preserved.
 pub fn remove_auth_tokens() -> Result<()> {

--- a/crates/spelunk-core/src/config/persist.rs
+++ b/crates/spelunk-core/src/config/persist.rs
@@ -5,16 +5,20 @@ use super::AuthTokens;
 use super::paths::spelunk_config_dir;
 use super::secret_store::{self, KEY_SERVER_KEY, SecretStore};
 
-/// Persist the CLI bearer credential (`server_key`) into the OS secret store.
+/// Persist a bearer into the **legacy flat** secret-store entry
+/// (`KEY_SERVER_KEY`, superseded by the per-origin map in
+/// [`super::server_keys`], ADR-071 D1).
 ///
-/// This is the token `spelunk login` persists. It is stored in the OS keychain
-/// (macOS Keychain / Linux Secret Service / Windows Credential Manager) by
-/// default, falling back to an owner-only file when no keychain backend is
-/// available (CI / headless). The credential is **never** written to
-/// `config.toml`.
-///
-/// The store is credential-format-agnostic, so the same call path serves a
-/// future WorkOS-token migration.
+/// `spelunk login` does NOT call this: it writes the `[auth]` table via
+/// [`save_auth_tokens`], and `cfg.server_key` derives from that at load time.
+/// The only production caller left is [`super::Config::load_with_store`]'s
+/// plaintext-file migration (moving a bare `server_key` out of
+/// `config.toml`); `spelunk auth set-key` writes the per-origin map instead
+/// (see [`super::server_keys::set_key_for_origin`]), never this flat entry. It
+/// is stored in the OS keychain (macOS Keychain / Linux Secret Service /
+/// Windows Credential Manager) by default, falling back to an owner-only file
+/// when no keychain backend is available (CI / headless). The credential is
+/// **never** written to `config.toml`.
 pub fn save_server_key(key: &str) -> Result<()> {
     let store = secret_store::default_store(&spelunk_config_dir())?;
     save_server_key_with(key, store.as_ref())

--- a/crates/spelunk-core/src/config/server_keys.rs
+++ b/crates/spelunk-core/src/config/server_keys.rs
@@ -1,0 +1,481 @@
+//! Per-origin server-key map (ADR-071 D1/D2).
+//!
+//! The client's bearer credential used to be a single flat `server_key`
+//! (`secret_store::KEY_SERVER_KEY`), which cannot represent a developer who
+//! holds keys for two different self-hosted `server_url`s (ADR-056's
+//! recommended multi-server topology). This module gives the credential a
+//! home keyed by the server it belongs to: a single secret-store entry
+//! (`KEY_SERVER_KEYS_MAP`) whose payload is a JSON object mapping normalized
+//! origin to key. One entry, not one per host, so granting keychain access
+//! once covers every server (see the module-level rationale in ADR-071 D1).
+//!
+//! [`bearer_for`] is the resolution entry point: it decides the credential
+//! *kind* (cloud vs. self-hosted) from the target `server_url`'s origin
+//! before touching any store, so a given request only ever consults the
+//! tier(s) its own kind uses (ADR-071 D2). The legacy flat entry is migrated
+//! into the map lazily: the first time server-key-kind resolution needs a
+//! credential for an origin the map does not yet have.
+
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+
+use super::AuthTokens;
+use super::secret_store::{KEY_SERVER_KEY, SecretStore};
+
+/// Key name for the per-origin server-key map: a single secret-store entry
+/// distinct from the legacy flat [`KEY_SERVER_KEY`] (ADR-071 D1).
+pub const KEY_SERVER_KEYS_MAP: &str = "server_keys";
+
+/// Default spelunk.cloud API origin. Overridable via `SPELUNK_CLOUD_URL`,
+/// which is read directly here (and by every cloud-api call site) so bearer
+/// resolution, `/v1/me`, and WorkOS client-id selection all agree on the same
+/// value. Single source of truth for the constant: `spelunk-cli`'s
+/// `auth_api` module re-exports this rather than defining its own copy.
+pub const DEFAULT_CLOUD_URL: &str = "https://api.spelunk.cloud";
+
+/// Normalize `url` to its origin: scheme, lowercased host, and explicit
+/// port (default port applied for comparison, omitted from the canonical
+/// form when it matches the scheme default). This is the WHATWG origin
+/// concept. Path, query, trailing slash, and host case do not participate
+/// (ADR-071 D1).
+pub fn normalize_origin(url: &str) -> Result<String> {
+    let parsed =
+        reqwest::Url::parse(url.trim()).with_context(|| format!("{url:?} is not a valid URL"))?;
+    let origin = parsed.origin();
+    if !origin.is_tuple() {
+        anyhow::bail!("{url:?} has no origin (must be an http(s) URL)");
+    }
+    Ok(origin.ascii_serialization())
+}
+
+/// The cloud origin bearer resolution branches against (D2).
+fn cloud_origin() -> Result<String> {
+    let raw = std::env::var("SPELUNK_CLOUD_URL")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_CLOUD_URL.to_string());
+    normalize_origin(&raw)
+}
+
+fn read_map(store: &dyn SecretStore) -> Result<HashMap<String, String>> {
+    match store.get(KEY_SERVER_KEYS_MAP)? {
+        Some(raw) if !raw.trim().is_empty() => {
+            serde_json::from_str(&raw).context("parsing the server_keys map from the secret store")
+        }
+        _ => Ok(HashMap::new()),
+    }
+}
+
+fn write_map(store: &dyn SecretStore, map: &HashMap<String, String>) -> Result<()> {
+    let raw = serde_json::to_string(map).context("serialising the server_keys map")?;
+    store.set(KEY_SERVER_KEYS_MAP, &raw)
+}
+
+/// Resolve (and lazily migrate) the server-key-kind credential for `origin`
+/// (D2 tiers 2-3, non-cloud): a map hit wins; otherwise a legacy flat entry
+/// is migrated into the map and deleted in one step, then returned. Migration
+/// runs at most once per origin: once the map has an entry, the legacy tier
+/// is never consulted again for it.
+fn server_key_for_origin(origin: &str, store: &dyn SecretStore) -> Result<Option<String>> {
+    let mut map = read_map(store)?;
+    if let Some(key) = map.get(origin) {
+        return Ok(Some(key.clone()));
+    }
+    let Some(legacy) = store.get(KEY_SERVER_KEY)? else {
+        return Ok(None);
+    };
+    map.insert(origin.to_string(), legacy.clone());
+    write_map(store, &map)?;
+    store.delete(KEY_SERVER_KEY)?;
+    eprintln!(
+        "spelunk: migrated a legacy server key into the per-server key map for {origin}. \
+         Run `spelunk auth set-key --server <url>` for any other server you use."
+    );
+    Ok(Some(legacy))
+}
+
+/// Resolve the effective bearer for a request to `server_url` (ADR-071 D2).
+///
+/// Branches on credential kind by origin before touching any store:
+/// * **Cloud kind** (origin matches [`DEFAULT_CLOUD_URL`] /
+///   `SPELUNK_CLOUD_URL`): `SPELUNK_SERVER_KEY` env, then `[auth]`'s access
+///   token. The map and the legacy entry are never consulted.
+/// * **Server-key kind** (any other origin): `SPELUNK_SERVER_KEY` env, then
+///   the per-origin map, then (migrating on read) the legacy flat entry.
+///   `[auth]` is never consulted.
+pub fn bearer_for(
+    auth: Option<&AuthTokens>,
+    server_url: &str,
+    store: &dyn SecretStore,
+) -> Result<Option<String>> {
+    if let Ok(v) = std::env::var("SPELUNK_SERVER_KEY") {
+        return Ok(Some(v));
+    }
+    let origin = normalize_origin(server_url)?;
+    if origin == cloud_origin()? {
+        return Ok(auth.map(|a| a.access_token.clone()));
+    }
+    server_key_for_origin(&origin, store)
+}
+
+/// `spelunk auth set-key --server <url>`: store `key` for `url`'s origin.
+/// Returns the normalized origin it was stored under.
+pub fn set_key_for_origin(server_url: &str, key: &str, store: &dyn SecretStore) -> Result<String> {
+    let origin = normalize_origin(server_url)?;
+    let mut map = read_map(store)?;
+    map.insert(origin.clone(), key.to_string());
+    write_map(store, &map)?;
+    Ok(origin)
+}
+
+/// `spelunk auth list-servers`: origins with a stored key (sorted), plus
+/// whether a legacy (not-yet-migrated) flat key is also present. Never
+/// returns key material.
+pub fn list_origins(store: &dyn SecretStore) -> Result<(Vec<String>, bool)> {
+    let map = read_map(store)?;
+    let mut origins: Vec<String> = map.into_keys().collect();
+    origins.sort();
+    let legacy = store.get(KEY_SERVER_KEY)?.is_some();
+    Ok((origins, legacy))
+}
+
+/// Count of stored server-key credentials: map entries plus one if a legacy
+/// entry is still present (used by bare `spelunk logout` to report what it
+/// left untouched, D3).
+pub fn count(store: &dyn SecretStore) -> Result<usize> {
+    let (origins, legacy) = list_origins(store)?;
+    Ok(origins.len() + usize::from(legacy))
+}
+
+/// `spelunk logout --servers`: clear the per-origin map.
+///
+/// Only the map. The legacy flat entry (and any plaintext remnant still in
+/// `config.toml`) is a separate concern with its own belt-and-braces cleanup
+/// in [`super::remove_server_key`]; callers that want both call both (see
+/// `spelunk logout`'s `--servers` handling).
+pub fn clear_all(store: &dyn SecretStore) -> Result<()> {
+    store
+        .delete(KEY_SERVER_KEYS_MAP)
+        .context("clearing the server_keys map")
+}
+
+/// `spelunk logout --server <url>`: clear only that origin's credential.
+/// Returns the normalized origin that was cleared.
+///
+/// A map entry for the origin is removed if present. Otherwise, when a
+/// legacy flat entry still exists, it is removed too: pre-migration the
+/// legacy entry is the fallback for *every* unmapped origin (see
+/// [`server_key_for_origin`]), so it may be serving this very one.
+pub fn clear_origin(server_url: &str, store: &dyn SecretStore) -> Result<String> {
+    let origin = normalize_origin(server_url)?;
+    let mut map = read_map(store)?;
+    if map.remove(&origin).is_some() {
+        write_map(store, &map)?;
+    } else {
+        store
+            .delete(KEY_SERVER_KEY)
+            .context("clearing the legacy server_key entry")?;
+    }
+    Ok(origin)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::secret_store::MemoryStore;
+
+    fn tokens(access_token: &str) -> AuthTokens {
+        AuthTokens {
+            access_token: access_token.to_string(),
+            refresh_token: "rt".to_string(),
+            expires_at: 4_000_000_000,
+            org_id: "org_1".to_string(),
+        }
+    }
+
+    fn clear_env() {
+        unsafe {
+            std::env::remove_var("SPELUNK_SERVER_KEY");
+            std::env::remove_var("SPELUNK_CLOUD_URL");
+        }
+    }
+
+    // ── normalize_origin ──────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_origin_omits_default_port_and_lowercases_host() {
+        assert_eq!(
+            normalize_origin("https://Spelunk.Internal.Example.Com/foo?x=1#y").unwrap(),
+            "https://spelunk.internal.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_origin_keeps_explicit_non_default_port() {
+        assert_eq!(
+            normalize_origin("https://other.example.net:8443/").unwrap(),
+            "https://other.example.net:8443"
+        );
+    }
+
+    #[test]
+    fn normalize_origin_ignores_path_query_and_trailing_slash() {
+        let a = normalize_origin("http://team.example:7777/a/b?x=1").unwrap();
+        let b = normalize_origin("http://team.example:7777/").unwrap();
+        let c = normalize_origin("http://team.example:7777").unwrap();
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+    }
+
+    #[test]
+    fn normalize_origin_rejects_invalid_url() {
+        assert!(normalize_origin("not a url").is_err());
+    }
+
+    // ── bearer_for: env always wins, no store touch ─────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn bearer_for_env_wins_over_everything_and_skips_store() {
+        clear_env();
+        unsafe { std::env::set_var("SPELUNK_SERVER_KEY", "sk-from-env") };
+
+        let store = MemoryStore::default();
+        store.set(KEY_SERVER_KEY, "sk-legacy").unwrap();
+        let auth = tokens("at-cloud");
+
+        // Even for the cloud origin, env wins and the map/legacy tiers are
+        // untouched by the resolution (no side effect on the store).
+        let result = bearer_for(Some(&auth), DEFAULT_CLOUD_URL, &store).unwrap();
+        assert_eq!(result.as_deref(), Some("sk-from-env"));
+        assert_eq!(
+            store.get(KEY_SERVER_KEY).unwrap().as_deref(),
+            Some("sk-legacy")
+        );
+
+        unsafe { std::env::remove_var("SPELUNK_SERVER_KEY") };
+    }
+
+    // ── bearer_for: cloud kind ───────────────────────────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn bearer_for_cloud_origin_uses_auth_token() {
+        clear_env();
+        let store = MemoryStore::default();
+        let auth = tokens("at-cloud");
+
+        let result = bearer_for(Some(&auth), DEFAULT_CLOUD_URL, &store).unwrap();
+        assert_eq!(result.as_deref(), Some("at-cloud"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bearer_for_cloud_origin_without_auth_is_none() {
+        clear_env();
+        let store = MemoryStore::default();
+        assert_eq!(bearer_for(None, DEFAULT_CLOUD_URL, &store).unwrap(), None);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bearer_for_cloud_origin_never_touches_map_or_legacy() {
+        clear_env();
+        let store = MemoryStore::default();
+        store.set(KEY_SERVER_KEY, "sk-legacy").unwrap();
+        let auth = tokens("at-cloud");
+
+        let result = bearer_for(Some(&auth), DEFAULT_CLOUD_URL, &store).unwrap();
+        assert_eq!(result.as_deref(), Some("at-cloud"));
+        // The legacy entry must be untouched: cloud-kind resolution never
+        // migrates or reads it.
+        assert_eq!(
+            store.get(KEY_SERVER_KEY).unwrap().as_deref(),
+            Some("sk-legacy")
+        );
+    }
+
+    // ── bearer_for: server-key kind ──────────────────────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn bearer_for_non_cloud_origin_uses_map_entry_ignoring_auth() {
+        clear_env();
+        let store = MemoryStore::default();
+        set_key_for_origin("https://team.example:7777", "sk-team", &store).unwrap();
+        let auth = tokens("at-cloud");
+
+        // A cloud [auth] token must never leak to a self-hosted origin.
+        let result = bearer_for(Some(&auth), "https://team.example:7777", &store).unwrap();
+        assert_eq!(result.as_deref(), Some("sk-team"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bearer_for_non_cloud_origin_migrates_legacy_entry_on_first_use() {
+        clear_env();
+        let store = MemoryStore::default();
+        store.set(KEY_SERVER_KEY, "sk-legacy").unwrap();
+
+        let result = bearer_for(None, "https://team.example:7777", &store).unwrap();
+        assert_eq!(result.as_deref(), Some("sk-legacy"));
+
+        // Migrated into the map...
+        let (origins, legacy) = list_origins(&store).unwrap();
+        assert_eq!(origins, vec!["https://team.example:7777".to_string()]);
+        // ...and removed from the legacy tier.
+        assert!(!legacy, "legacy entry must be deleted after migration");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bearer_for_non_cloud_origin_no_credential_anywhere_is_none() {
+        clear_env();
+        let store = MemoryStore::default();
+        assert_eq!(
+            bearer_for(None, "https://team.example:7777", &store).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn bearer_for_legacy_migration_does_not_leak_to_a_second_unmapped_origin() {
+        clear_env();
+        let store = MemoryStore::default();
+        store.set(KEY_SERVER_KEY, "sk-legacy").unwrap();
+
+        // First origin migrates and consumes the legacy entry.
+        let first = bearer_for(None, "https://a.example:7777", &store).unwrap();
+        assert_eq!(first.as_deref(), Some("sk-legacy"));
+
+        // A second, still-unmapped origin must fail closed, not silently
+        // reuse the first origin's now-migrated key.
+        let second = bearer_for(None, "https://b.example:7777", &store).unwrap();
+        assert_eq!(second, None);
+    }
+
+    // ── D1: the map's on-the-wire JSON shape ─────────────────────────────────
+
+    /// D1: the payload behind the single `KEY_SERVER_KEYS_MAP` entry is a
+    /// flat JSON object of `origin -> key`, nothing more (no envelope, no
+    /// metadata). Verified against the raw string the store holds, not just
+    /// through the read helpers that would mask a shape drift.
+    #[test]
+    fn map_entry_payload_is_a_flat_json_object_of_origin_to_key() {
+        let store = MemoryStore::default();
+        set_key_for_origin("https://a.example:7777", "sk-a", &store).unwrap();
+        set_key_for_origin("https://b.example", "sk-b", &store).unwrap();
+
+        let raw = store.get(KEY_SERVER_KEYS_MAP).unwrap().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            parsed,
+            serde_json::json!({
+                "https://a.example:7777": "sk-a",
+                "https://b.example": "sk-b",
+            })
+        );
+        // A single entry, not one per origin (D1's whole point).
+        assert_eq!(store.get(KEY_SERVER_KEY).unwrap(), None);
+    }
+
+    #[test]
+    fn empty_map_leaves_no_entry_rather_than_an_empty_json_object() {
+        // Before any set_key_for_origin call, the entry must not exist at all
+        // (read_map treats "absent" and "{}" the same, but nothing should
+        // write an empty object pre-emptively).
+        let store = MemoryStore::default();
+        assert_eq!(list_origins(&store).unwrap(), (vec![], false));
+        assert_eq!(store.get(KEY_SERVER_KEYS_MAP).unwrap(), None);
+    }
+
+    // ── set_key_for_origin / list_origins ────────────────────────────────────
+
+    #[test]
+    fn set_key_for_origin_normalizes_and_overwrites() {
+        let store = MemoryStore::default();
+        set_key_for_origin("https://Team.Example:7777/ignored/path", "sk-1", &store).unwrap();
+        set_key_for_origin("https://team.example:7777", "sk-2", &store).unwrap();
+
+        let (origins, _) = list_origins(&store).unwrap();
+        assert_eq!(origins, vec!["https://team.example:7777".to_string()]);
+        assert_eq!(
+            bearer_for(None, "https://team.example:7777", &store)
+                .unwrap()
+                .as_deref(),
+            Some("sk-2")
+        );
+    }
+
+    #[test]
+    fn list_origins_reports_legacy_flag_independently_of_map() {
+        let store = MemoryStore::default();
+        assert_eq!(list_origins(&store).unwrap(), (vec![], false));
+
+        store.set(KEY_SERVER_KEY, "sk-legacy").unwrap();
+        set_key_for_origin("https://a.example", "sk-a", &store).unwrap();
+        let (origins, legacy) = list_origins(&store).unwrap();
+        assert_eq!(origins, vec!["https://a.example".to_string()]);
+        assert!(legacy);
+    }
+
+    // ── clear_all / clear_origin / count ─────────────────────────────────────
+
+    #[test]
+    fn clear_all_removes_the_map_but_not_the_legacy_entry() {
+        // The legacy entry is a separate concern (config::remove_server_key
+        // handles it, including the plaintext config.toml remnant); see
+        // `clear_all`'s doc comment.
+        let store = MemoryStore::default();
+        set_key_for_origin("https://a.example", "sk-a", &store).unwrap();
+        store.set(KEY_SERVER_KEY, "sk-legacy").unwrap();
+
+        clear_all(&store).unwrap();
+
+        let (origins, legacy) = list_origins(&store).unwrap();
+        assert_eq!(origins, Vec::<String>::new());
+        assert!(legacy, "clear_all must not touch the legacy entry");
+    }
+
+    #[test]
+    fn clear_origin_removes_only_that_origin() {
+        let store = MemoryStore::default();
+        set_key_for_origin("https://a.example", "sk-a", &store).unwrap();
+        set_key_for_origin("https://b.example", "sk-b", &store).unwrap();
+
+        clear_origin("https://a.example", &store).unwrap();
+
+        let (origins, _) = list_origins(&store).unwrap();
+        assert_eq!(origins, vec!["https://b.example".to_string()]);
+    }
+
+    #[test]
+    fn clear_origin_falls_back_to_legacy_when_origin_not_yet_mapped() {
+        let store = MemoryStore::default();
+        store.set(KEY_SERVER_KEY, "sk-legacy").unwrap();
+
+        // This origin was never resolved (so never migrated), but the legacy
+        // entry might be serving it: clear_origin removes it defensively.
+        clear_origin("https://never-resolved.example", &store).unwrap();
+
+        assert_eq!(store.get(KEY_SERVER_KEY).unwrap(), None);
+    }
+
+    #[test]
+    fn clear_origin_is_a_no_op_when_nothing_is_stored() {
+        let store = MemoryStore::default();
+        clear_origin("https://nothing.example", &store).unwrap();
+        assert_eq!(list_origins(&store).unwrap(), (vec![], false));
+    }
+
+    #[test]
+    fn count_reflects_map_size_plus_legacy() {
+        let store = MemoryStore::default();
+        assert_eq!(count(&store).unwrap(), 0);
+        set_key_for_origin("https://a.example", "sk-a", &store).unwrap();
+        assert_eq!(count(&store).unwrap(), 1);
+        store.set(KEY_SERVER_KEY, "sk-legacy").unwrap();
+        assert_eq!(count(&store).unwrap(), 2);
+    }
+}

--- a/crates/spelunk-core/src/config/server_keys.rs
+++ b/crates/spelunk-core/src/config/server_keys.rs
@@ -478,4 +478,179 @@ mod tests {
         store.set(KEY_SERVER_KEY, "sk-legacy").unwrap();
         assert_eq!(count(&store).unwrap(), 2);
     }
+
+    // ── adversarial: independent test-engineer coverage ──────────────────────
+    //
+    // The tests above are the Engineer's own suite. These probe cases their
+    // own tests don't: a corrupted store payload, and a map entry coexisting
+    // with the legacy tier for a *different* origin than the one already
+    // migrated (the scenario the ADR's "no cross-origin leak" claim rests on
+    // but the Engineer's `..._does_not_leak_to_a_second_unmapped_origin` test
+    // only exercises with an *empty* map, not a map that already has an
+    // unrelated origin in it).
+
+    /// A corrupted `server_keys` payload must fail resolution loudly (`Err`),
+    /// never silently fall through to "no credential" or, worse, to the
+    /// legacy tier. A silent fallthrough here would be the dangerous case: an
+    /// operator could believe a server is unauthenticated-safe (loopback,
+    /// firewalled) when in fact resolution swallowed a real error and just
+    /// returned `None`, or could get a stale/wrong key from the legacy tier
+    /// instead of a clear "your credential store is broken" signal.
+    #[test]
+    #[serial_test::serial]
+    fn corrupted_map_json_fails_resolution_loudly_not_silently() {
+        clear_env();
+        let store = MemoryStore::default();
+        // Not valid JSON at all.
+        store.set(KEY_SERVER_KEYS_MAP, "{not valid json").unwrap();
+        // A legacy entry is also present: a silent-fallthrough implementation
+        // could mistakenly hand this out instead of surfacing the corruption.
+        store
+            .set(KEY_SERVER_KEY, "sk-legacy-should-not-be-returned")
+            .unwrap();
+
+        let result = bearer_for(None, "https://team.example:7777", &store);
+        assert!(
+            result.is_err(),
+            "a corrupted map must fail loudly, not resolve to Some/None silently; got {result:?}"
+        );
+
+        // Same for the JSON tools directly: a valid JSON value of the wrong
+        // shape (an array, not an object) must also fail, not deserialize
+        // into an empty/default map.
+        store
+            .set(KEY_SERVER_KEYS_MAP, "[\"not\", \"a\", \"map\"]")
+            .unwrap();
+        let result2 = bearer_for(None, "https://team.example:7777", &store);
+        assert!(
+            result2.is_err(),
+            "a wrong-shaped-but-valid-JSON map must also fail loudly; got {result2:?}"
+        );
+    }
+
+    /// `set_key_for_origin` / `list_origins` must likewise surface a
+    /// corrupted map rather than silently treating it as empty and
+    /// overwriting it (which would quietly discard whatever the corrupted
+    /// payload's other origins were, destroying credentials for servers the
+    /// corruption didn't even touch).
+    #[test]
+    fn corrupted_map_json_fails_set_and_list_loudly() {
+        let store = MemoryStore::default();
+        store.set(KEY_SERVER_KEYS_MAP, "{not valid json").unwrap();
+
+        assert!(set_key_for_origin("https://a.example", "sk-a", &store).is_err());
+        assert!(list_origins(&store).is_err());
+    }
+
+    /// Both a per-origin map entry AND the legacy flat key exist
+    /// simultaneously (the realistic post-partial-migration state: one
+    /// origin was already explicitly `auth set-key`'d while another is still
+    /// waiting on its first-use migration). Resolving the *already-mapped*
+    /// origin must return the map's value and must NOT touch or delete the
+    /// legacy entry, since it isn't this origin's to consume. Resolving the
+    /// *unmapped* origin afterward must migrate the legacy entry, and must
+    /// leave the first origin's map entry untouched (no cross-origin
+    /// overwrite of an unrelated key while writing the map back).
+    #[test]
+    #[serial_test::serial]
+    fn mapped_origin_and_legacy_entry_coexist_without_leaking_or_clobbering() {
+        clear_env();
+        let store = MemoryStore::default();
+        // Origin A was explicitly set via `auth set-key`.
+        set_key_for_origin("https://a.example:7777", "sk-a-explicit", &store).unwrap();
+        // A legacy flat key also still exists (not yet migrated, so it belongs
+        // to whichever origin first resolves through the fallback tier).
+        store.set(KEY_SERVER_KEY, "sk-legacy").unwrap();
+
+        // Resolving A must return A's own key, untouched by the legacy tier.
+        let a = bearer_for(None, "https://a.example:7777", &store).unwrap();
+        assert_eq!(a.as_deref(), Some("sk-a-explicit"));
+        assert_eq!(
+            store.get(KEY_SERVER_KEY).unwrap().as_deref(),
+            Some("sk-legacy"),
+            "resolving an already-mapped origin must not touch the legacy entry"
+        );
+
+        // Resolving a second, unmapped origin B migrates the legacy entry
+        // into B's slot...
+        let b = bearer_for(None, "https://b.example:7777", &store).unwrap();
+        assert_eq!(b.as_deref(), Some("sk-legacy"));
+        assert_eq!(store.get(KEY_SERVER_KEY).unwrap(), None, "legacy consumed");
+
+        // ...and A's own key must be exactly what it was before, not
+        // overwritten by the read-modify-write that added B.
+        let (mut origins, legacy) = list_origins(&store).unwrap();
+        origins.sort();
+        assert_eq!(
+            origins,
+            vec![
+                "https://a.example:7777".to_string(),
+                "https://b.example:7777".to_string(),
+            ]
+        );
+        assert!(!legacy);
+        assert_eq!(
+            bearer_for(None, "https://a.example:7777", &store)
+                .unwrap()
+                .as_deref(),
+            Some("sk-a-explicit"),
+            "A's key must survive B's migration write unchanged"
+        );
+    }
+
+    /// `clear_origin` on an origin that is present in the map must remove
+    /// only the map entry, even when a legacy entry also still exists
+    /// (serving some *other*, not-yet-migrated origin); it must not
+    /// mistakenly delete the legacy entry too, which would strand whichever
+    /// other origin is still relying on it.
+    #[test]
+    fn clear_origin_on_mapped_origin_does_not_touch_an_unrelated_legacy_entry() {
+        let store = MemoryStore::default();
+        set_key_for_origin("https://a.example:7777", "sk-a", &store).unwrap();
+        store
+            .set(KEY_SERVER_KEY, "sk-legacy-for-someone-else")
+            .unwrap();
+
+        clear_origin("https://a.example:7777", &store).unwrap();
+
+        assert_eq!(
+            store.get(KEY_SERVER_KEY).unwrap().as_deref(),
+            Some("sk-legacy-for-someone-else"),
+            "clearing a mapped origin must leave an unrelated legacy entry intact"
+        );
+        let (origins, _) = list_origins(&store).unwrap();
+        assert!(origins.is_empty());
+    }
+
+    /// The two-server, two-key motivating case (task's acceptance sketch),
+    /// driven purely through the public resolution/storage API with no env
+    /// var involved at any point: both origins resolve to their own key on
+    /// repeated, interleaved lookups, with no state that could cause a
+    /// second read to see the first origin's key.
+    #[test]
+    #[serial_test::serial]
+    fn two_projects_two_origins_two_keys_resolve_independently_interleaved() {
+        clear_env();
+        let store = MemoryStore::default();
+        set_key_for_origin("https://proj-a.example:7777", "sk-proj-a", &store).unwrap();
+        set_key_for_origin("https://proj-b.example:9443", "sk-proj-b", &store).unwrap();
+
+        // Interleave lookups (A, B, A, B) to catch any accidental
+        // last-write-wins / shared-mutable-state bug a naive cache could
+        // introduce.
+        for _ in 0..3 {
+            assert_eq!(
+                bearer_for(None, "https://proj-a.example:7777", &store)
+                    .unwrap()
+                    .as_deref(),
+                Some("sk-proj-a")
+            );
+            assert_eq!(
+                bearer_for(None, "https://proj-b.example:9443", &store)
+                    .unwrap()
+                    .as_deref(),
+                Some("sk-proj-b")
+            );
+        }
+    }
 }

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -124,20 +124,51 @@ pub async fn open_memory_backend(
 }
 
 /// Build the cloud-routing memory backend (slug→UUID resolution + REST client)
-/// for an already **transport-validated** `url`.
+/// for an already **transport-validated** `url`, using the host's default
+/// secret store to resolve the bearer (see [`open_remote_memory_backend_with_store`]
+/// for the store-injectable seam tests use).
 ///
 /// Split out of [`open_memory_backend`] as the test seam for the cloud-routing
 /// branch. Production reaches it only after `open_memory_backend` has enforced
 /// [`crate::config::validate_transport_url`], so a non-loopback plaintext
-/// `http://` url is rejected before any bearer is sent. Integration tests that
-/// must drive resolution against a plaintext-http mock addressed as a
-/// non-loopback host (wiremock via `0.0.0.0`) call this directly — the same
-/// reason [`remote::resolve_cloud_project_uuid`]'s `_inner` half exists, to
-/// bypass a guard the production entry point enforces.
+/// `http://` url is rejected before any bearer is sent.
 async fn open_remote_memory_backend(
     cfg: &crate::config::Config,
     mem_path: &Path,
     url: &str,
+) -> Result<Box<dyn MemoryBackend + Send>> {
+    // Bearer resolved per-origin (ADR-071 D2): `url` may be a self-hosted team
+    // server (`cloud_first` mode routes any configured `server_url`, not only
+    // the cloud one), so `cfg.server_key` (cloud-kind only) is not the right
+    // credential here: a cloud login must never leak to a self-hosted server.
+    let bearer = cfg.bearer_for(url)?;
+    open_remote_memory_backend_with_bearer(cfg, mem_path, url, bearer).await
+}
+
+/// Same as [`open_remote_memory_backend`] but with an injected
+/// [`SecretStore`](crate::config::secret_store::SecretStore), so tests can
+/// drive the cloud-routing seam without touching the real default secret
+/// store. Integration tests that must drive resolution against a
+/// plaintext-http mock addressed as a non-loopback host (wiremock via
+/// `0.0.0.0`) call this directly, the same reason
+/// [`remote::resolve_cloud_project_uuid`]'s `_inner` half exists, to bypass a
+/// guard the production entry point enforces.
+#[cfg(test)]
+async fn open_remote_memory_backend_with_store(
+    cfg: &crate::config::Config,
+    mem_path: &Path,
+    url: &str,
+    store: &dyn crate::config::secret_store::SecretStore,
+) -> Result<Box<dyn MemoryBackend + Send>> {
+    let bearer = cfg.bearer_for_with_store(url, store)?;
+    open_remote_memory_backend_with_bearer(cfg, mem_path, url, bearer).await
+}
+
+async fn open_remote_memory_backend_with_bearer(
+    cfg: &crate::config::Config,
+    mem_path: &Path,
+    url: &str,
+    bearer: Option<String>,
 ) -> Result<Box<dyn MemoryBackend + Send>> {
     let project_id = cfg.project_id.clone().ok_or_else(|| {
         anyhow::anyhow!(
@@ -166,7 +197,7 @@ async fn open_remote_memory_backend(
             let uuid = remote::resolve_cloud_project_uuid(
                 &project_id,
                 url,
-                cfg.server_key.as_deref(),
+                bearer.as_deref(),
                 cfg.server_ca.as_deref().map(std::path::Path::new),
                 spelunk_dir,
             )
@@ -183,7 +214,7 @@ async fn open_remote_memory_backend(
         client,
         base_url: url.to_string(),
         project_id,
-        api_key: cfg.server_key.clone(),
+        api_key: bearer,
     }))
 }
 
@@ -294,6 +325,17 @@ mod backend_selection_tests {
     #[serial_test::serial]
     async fn cloud_first_mode_routes_remote() {
         clear_env();
+        // This goes through the PUBLIC `open_memory_backend`, which resolves
+        // the bearer via `Config::bearer_for`: the host's *default* secret
+        // store. Isolate `HOME` + force the file backend so this never reads
+        // or writes the developer's real `~/.config/spelunk`.
+        let home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        unsafe {
+            std::env::set_var("HOME", home.path());
+            std::env::set_var("SPELUNK_SECRET_STORE", "file");
+        }
+
         // ADR-005 D5: a `project_id` that is already a UUID is used directly,
         // so the remote backend is constructed without any slug→UUID lookup
         // (no network call against the unreachable team.example.com host).
@@ -309,6 +351,15 @@ mod backend_selection_tests {
         let be = open_memory_backend(&cfg, std::path::Path::new(":memory:"), None)
             .await
             .unwrap();
+
+        unsafe {
+            match original_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            std::env::remove_var("SPELUNK_SECRET_STORE");
+        }
+
         assert_eq!(
             be.backend_kind(),
             "remote",
@@ -392,7 +443,6 @@ mod backend_selection_tests {
         let cfg = Config {
             server_url: Some(url),
             project_id: Some("spelunk".to_string()),
-            server_key: Some("k".to_string()),
             mode: Some(SyncMode::CloudFirst),
             ..Default::default()
         };
@@ -401,8 +451,11 @@ mod backend_selection_tests {
         // only after `open_memory_backend`'s transport guard passes, which this
         // non-loopback `http://` url would not (that guard is covered
         // separately). The seam exercises the same resolution + keying logic.
+        // The store-injecting variant keeps this hermetic (no real secret
+        // store touch); the mocks below don't assert on the bearer.
         let url = cfg.server_url.clone().unwrap();
-        let be = super::open_remote_memory_backend(&cfg, &mem_path, &url)
+        let store = crate::config::secret_store::MemoryStore::default();
+        let be = super::open_remote_memory_backend_with_store(&cfg, &mem_path, &url, &store)
             .await
             .unwrap();
         assert_eq!(be.backend_kind(), "remote");

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -624,31 +624,35 @@ resolves one for you instead of leaving a session that needs a follow-up
   no-org session is persisted.
 
 Tokens are written to the `[auth]` table of `~/.config/spelunk/config.toml`
-(file mode `0600`). Existing setups that use a static `server_key` (or the
-`SPELUNK_SERVER_KEY` environment variable) keep working unchanged until you next
-run `spelunk login`; `SPELUNK_SERVER_KEY` continues to take precedence, which is
-handy for CI.
+(file mode `0600`). Existing setups that use a self-hosted server key (stored via
+`spelunk auth set-key`, or the `SPELUNK_SERVER_KEY` environment variable) keep
+working unchanged; `SPELUNK_SERVER_KEY` continues to take precedence, which is
+handy for CI. See `spelunk auth` below for the self-hosted credential itself;
+`spelunk login` only ever manages the `[auth]` cloud token pair.
 
-### Where the `server_key` credential is stored
+### Where the self-hosted server key is stored
 
-The static `server_key` bearer credential is **not** kept in plaintext in
-`config.toml`. It lives in your operating system's secret store:
+See [`spelunk auth`](#spelunk-auth) below for the full per-server credential
+story (ADR-071). In short: a self-hosted server's bearer key is **not** kept in
+plaintext anywhere. It lives in your operating system's secret store:
 
-- **macOS** — Keychain
-- **Linux** — Secret Service (libsecret / `org.freedesktop.secrets`)
-- **Windows** — Credential Manager
+- **macOS**: Keychain
+- **Linux**: Secret Service (libsecret / `org.freedesktop.secrets`)
+- **Windows**: Credential Manager
 
-The first time you run any command after upgrading, a `server_key` previously
-written to `~/.config/spelunk/config.toml` is migrated into the OS keychain and
-removed from the file automatically — no action required. (A shared
-`server_key` set in a project's checked-in `.spelunk/config.toml` is left as-is;
-it is a team key by design, not a personal credential.)
+keyed by the server's origin, so keys for two different self-hosted servers
+never collide. A flat `server_key` from an install predating this scheme is
+migrated in automatically the first time it's needed for a given server; no
+action required. A `server_key` line in a project's checked-in
+`.spelunk/config.toml` is no longer read at all (it was a plaintext-in-a-committed-file
+footgun); if a project config still has that line, remove it and have each
+developer run `spelunk auth set-key --server <url>` instead.
 
 **Headless / CI / containers.** When no OS keychain backend is available, the
 credential never causes a hard failure:
 
 - `SPELUNK_SERVER_KEY` remains the non-interactive escape hatch and always takes
-  precedence — set it in CI and you never touch the keychain.
+  precedence: set it in CI and you never touch the keychain.
 - Otherwise spelunk falls back to an owner-only (`0600`) file at
   `~/.config/spelunk/secrets.toml`.
 
@@ -661,6 +665,36 @@ credential never causes a hard failure:
 | `file` | Always use the `secrets.toml` file store (e.g. a container that mounts secrets from elsewhere). |
 
 The credential is never logged.
+
+---
+
+## spelunk auth
+
+Manage the per-server bearer credentials a self-hosted `server_url` resolves
+through (ADR-071). Distinct from `spelunk login`, which manages the
+spelunk.cloud `[auth]` token pair.
+
+```
+spelunk auth set-key --server <url>
+spelunk auth list-servers
+```
+
+| Subcommand | Notes |
+|------------|-------|
+| `set-key --server <url>` | Store a bearer key for the given server, keyed by its origin (scheme + host + non-default port). The key is read from stdin if piped, otherwise from an interactive prompt; it is never accepted as a flag value or positional argument. |
+| `list-servers` | Print every server origin with a stored key, one per line. Never prints key material. Notes if a legacy flat key is still present and pending migration. |
+
+```bash
+echo "$SERVER_KEY" | spelunk auth set-key --server https://spelunk.internal.example.com
+spelunk auth list-servers
+```
+
+Resolution precedence for a given request's `server_url`: the `SPELUNK_SERVER_KEY`
+environment variable (if set, always wins, regardless of origin) takes priority
+over the per-origin store; a spelunk.cloud origin instead resolves through the
+`[auth]` token pair from `spelunk login`. This lets CI pin a single key for the
+one server it talks to without touching the keychain, while a developer's
+machine holds separate keys per self-hosted server.
 
 ---
 
@@ -684,13 +718,26 @@ spelunk org switch acme
 
 ## spelunk logout
 
-Remove stored spelunk.cloud credentials. Clears the `[auth]` tokens written by
-`spelunk login` from `~/.config/spelunk/config.toml`, the `server_key` from the
-OS keychain (or `secrets.toml` fallback), and any legacy plaintext `server_key`
-still left in `config.toml`.
+Remove stored spelunk.cloud credentials. Bare `spelunk logout` clears **only**
+the `[auth]` token pair written by `spelunk login`; it does not touch any
+self-hosted server key, so recovering from a broken cloud login never costs
+you the keys you use on other projects (ADR-071 D3). Clearing server keys is a
+separate, explicit action:
 
 ```
+spelunk logout [--servers | --server <url>]
+```
+
+| Flag | Notes |
+|------|-------|
+| (none) | Clears only the `[auth]` cloud token pair. If any server keys are still stored, prints how many and how to clear them. |
+| `--servers` | Also clears every stored server key: the per-origin map and any legacy flat entry. |
+| `--server <url>` | Also clears just the stored key for that one server's origin. Mutually exclusive with `--servers`. |
+
+```bash
 spelunk logout
+spelunk logout --server https://spelunk.internal.example.com
+spelunk logout --servers
 ```
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -451,21 +451,31 @@ project_id = "my-awesome-app"
 > token to these requests. See [Self-hosting](self-hosting.md) for putting TLS
 > in front of a deployed server.
 
-Each developer provides their API key. Prefer the `SPELUNK_SERVER_KEY`
-environment variable, which works everywhere (including CI / headless):
+Each developer provides their own key with `spelunk auth set-key`, scoped to
+this server's URL:
+
+```bash
+spelunk auth set-key --server https://spelunk.internal.example.com
+```
+
+The key is stored in your OS keychain (macOS Keychain, Linux Secret Service,
+Windows Credential Manager) rather than in plaintext, keyed by the server's
+origin so a second project's server key never collides with this one. For CI /
+headless use, the `SPELUNK_SERVER_KEY` environment variable works everywhere
+and takes precedence over the stored key:
 
 ```bash
 export SPELUNK_SERVER_KEY="your-shared-api-key"
 ```
 
-The credential is otherwise stored in your OS keychain (macOS Keychain, Linux
-Secret Service, Windows Credential Manager) rather than in plaintext. If you
-have an old personal `~/.config/spelunk/config.toml` with a bare
-`server_key = "…"`, it is migrated into the keychain and stripped from the file
-automatically on the next run. On a host with no keychain, spelunk falls back to
-an owner-only `~/.config/spelunk/secrets.toml`. For the full credential-storage
-rules and the `SPELUNK_SECRET_STORE` override, see the
-[Commands reference](commands.md#spelunk-login).
+If you have an old personal `~/.config/spelunk/config.toml` with a bare
+`server_key = "..."`, it is picked up and migrated into the per-server store
+automatically the first time it's needed; no action required. A `server_key`
+line in a project's checked-in `.spelunk/config.toml` is no longer read at all,
+so remove it if one is still there. On a host with no keychain, spelunk falls
+back to an owner-only `~/.config/spelunk/secrets.toml`. For the full
+credential-storage rules and the `SPELUNK_SECRET_STORE` override, see the
+[Commands reference](commands.md#spelunk-auth).
 
 `project_id` stays a human-readable slug. If the server routes projects by an
 internal UUID (as a team/cloud memory server does), the CLI resolves the slug

--- a/docs/server.md
+++ b/docs/server.md
@@ -156,11 +156,35 @@ project_id = "my-awesome-app"
 > TLS endpoint. Loopback `http://` (e.g. while developing against a server on
 > your own machine) is fine.
 
-Personal config (`~/.config/spelunk/config.toml` — never commit):
+Personal credential: set it with `spelunk auth set-key`, not a config file:
 
-```toml
-# ~/.config/spelunk/config.toml
-server_key = "your-shared-api-key"
+```bash
+spelunk auth set-key --server https://spelunk.internal.example.com
+```
+
+The key is read from stdin (piped, or an interactive prompt if you're on a
+terminal) and is never accepted as a command argument, so it never lands in
+shell history or `ps` output. It's stored in your OS secret store (Keychain /
+Secret Service / Credential Manager), keyed by the server's *origin*: see
+[ADR-071](adr/071-per-server-client-bearer-scoping.md). That means a
+developer working on two projects, each pointing at a different self-hosted
+server (the topology [ADR-056](adr/056-oss-server-tenancy-model.md)
+recommends over multi-tenancy), holds both keys at once with no collision and
+no env-var juggling between them.
+
+Check what's stored with `spelunk auth list-servers` (origins only, never key
+material):
+
+```
+$ spelunk auth list-servers
+https://spelunk.internal.example.com
+```
+
+For CI / headless use, the environment variable still works and takes
+precedence over any stored key:
+
+```bash
+export SPELUNK_SERVER_KEY=your-shared-api-key
 ```
 
 `project_id` is a human-readable slug. If the server routes projects by an
@@ -171,11 +195,20 @@ The cache is keyed on the slug, so renaming the project re-resolves it
 automatically; set `SPELUNK_NO_SLUG_CACHE=1` to force a fresh lookup. A raw UUID
 in `project_id` is used as-is. (See [ADR-005](adr/005-cli-slug-uuid-resolution.md).)
 
-Or use the environment variable:
-
-```bash
-export SPELUNK_SERVER_KEY=your-shared-api-key
-```
+> **Rotating a key you committed under the old model.** Earlier versions of
+> this doc suggested a plaintext `server_key = "..."` line in the personal
+> `~/.config/spelunk/config.toml`, and a committed project `.spelunk/config.toml`
+> used to accept the same field as a "shared team key". Neither path exists
+> any more: the personal file never stores the key in plaintext, and
+> `.spelunk/config.toml` silently ignores a `server_key` line if one is still
+> present. If a key was ever written to either file, especially if it reached
+> git history, treat it as compromised: issue a new key on the server (e.g.
+> `openssl rand -hex 32` for a self-managed instance, see
+> [Self-hosting](self-hosting.md)) and run `spelunk auth set-key --server
+> <url>` with the new value on every machine that had the old one. A flat key
+> from an even older install is picked up and migrated into the per-server
+> store automatically the first time it's needed; `auth list-servers` notes
+> when one is still pending migration.
 
 By default a configured `server_url` runs in `local_first` mode: reads and
 writes stay in each developer's local `memory.db` and the server is a


### PR DESCRIPTION
## Summary

Implements ADR-071 (per-server client bearer scoping), closing spelunk-oss #225. A single flat `server_key` used to serve every configured `server_url`, so a developer on two projects each pointing at a different self-hosted server (the topology ADR-056 recommends over multi-tenancy) had one key slot for two servers, with whichever key lost getting 401s.

- **D1/D2**: new `crates/spelunk-core/src/config/server_keys.rs` module — a single secret-store entry (`server_keys`) holding a JSON map of normalized origin to key. `Config::bearer_for(server_url)` resolves the effective bearer per request by branching on credential kind (cloud vs. self-hosted) by the target origin *before* touching any store, so a cloud login can never leak to a self-hosted server and vice versa. A legacy flat key migrates into the map lazily, once per origin, on first use.
- **D3**: new `spelunk auth set-key --server <url>` / `spelunk auth list-servers` commands (key read from stdin/prompt only, never argv). `spelunk logout` is rescoped: bare `logout` clears only the `[auth]` cloud token pair; clearing self-hosted server keys now requires the explicit `--servers` (all) or `--server <url>` (one) flag, so recovering from a broken cloud login no longer has the side effect of deleting keys used on other projects.
- **D4**: `server_key` is dropped entirely from `ProjectConfig` (committed `.spelunk/config.toml` never carries a credential — serde silently drops the unrecognized key, same precedent as the `memory_server_*` alias removal).

All production call sites that used to read the now cloud-only `cfg.server_key` (`server_client.rs`, `auth_api::ensure_fresh_server_key`, the `memory since/watch/push/sync` commands, `index/embed_phase.rs`, and `storage/mod.rs::open_remote_memory_backend` — the last one backing `cloud_first` memory sync for *any* configured `server_url`, found and fixed during implementation) now resolve per-origin via `bearer_for`.

Docs updated in the same PR per the ADR's requirement: `docs/server.md`, `docs/commands.md`, `docs/getting-started.md`, `CHANGELOG.md`, `CLAUDE.md` (module map). `docs/self-hosting.md` needed no change (its `SPELUNK_SERVER_KEY` mentions are unaffected).

## Fast-follow (non-blocking, noted for a future pass)

- `auth set-key`'s interactive prompt (used only when stdin isn't piped) doesn't suppress terminal echo of the typed key. No argv/shell-history/`ps` exposure either way; low severity, worth a `termion`-style fix pre-v1.0 if it bothers anyone.

## Test plan

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --features rich-formats -- -D warnings` and `--no-default-features` — both clean.
- `cargo test --workspace` for both `--features rich-formats` and `--no-default-features` (real exit codes captured, not piped) — all green, including the two new integration test files (`auth_server_keys.rs`: 8 tests exercising the command surface end-to-end; `server_key_resolution_e2e.rs`: real two-`wiremock`-server test asserting on the literal `Authorization` header each server receives, proving no cross-origin credential leakage over the wire). The documented pre-existing `capability::tests::probe_url_explicit_non_success_status_does_not_set_any_probe_failure` flake did not reproduce after rebasing onto current `main` (fixed upstream by `ef1922f79`).
- `cargo test --doc` — clean.
- `cargo audit` — same 2 pre-existing allowed warnings, no new advisories; `Cargo.lock` unchanged (no new dependency).
- Rebased cleanly onto current `origin/main` (12 commits landed since this branch's base), no conflicts.