### PR TITLE
fix(cli): scope remote-server log hints to the actually-failing server

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -1081,6 +1081,31 @@ mod tests {
         assert_eq!(Tier::Offline.explicit_remote_url(), None);
     }
 
+    #[test]
+    fn tier_explicit_remote_url_is_explicit_even_when_host_is_loopback() {
+        // `explicit_remote_url` keys off *how the URL was reached*
+        // (`auto_discovered`), never off the host it resolves to. An operator
+        // can hand-configure `server_url = http://127.0.0.1:PORT`; it is
+        // still `auto_discovered: false` because it went through the
+        // `Some(url)` probe branch, not loopback auto-discovery (see
+        // `probe()`). `spelunk server logs` only ever reads the fixed
+        // auto-daemon log path and has no idea this loopback address was
+        // hand-configured, so the hint must still name it rather than assume
+        // "loopback implies safe to point at the local log".
+        let explicit_loopback = Tier::Server {
+            url: "http://127.0.0.1:9797".to_string(),
+            caps: Capabilities::all(),
+            auto_discovered: false,
+            embedder_state: EmbedderState::Ready,
+            server_limits: None,
+        };
+        assert_eq!(
+            explicit_loopback.explicit_remote_url(),
+            Some("http://127.0.0.1:9797"),
+            "an explicitly configured server_url must count as explicit even when its host is loopback"
+        );
+    }
+
     // ── effective_config (ADR-004 inference-vs-memory routing) ───────────────
 
     #[test]

--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -423,6 +423,27 @@ impl Tier {
         )
     }
 
+    /// `Some(url)` when this tier reached `Server` via an **explicit**
+    /// `server_url` (not loopback auto-discovery); `None` for `Offline` and
+    /// for the auto-discovered loopback case.
+    ///
+    /// `spelunk server logs` only ever reads the local auto-daemon's log
+    /// file. A command-output hint that names a server to check must use
+    /// this instead of unconditionally pointing at that command: with an
+    /// explicit remote `server_url`, `spelunk server logs` reads a healthy
+    /// local daemon's log while the real failure lives on the named server
+    /// (the pattern `embedder_status_line` in `status.rs` established).
+    pub fn explicit_remote_url(&self) -> Option<&str> {
+        match self {
+            Tier::Server {
+                url,
+                auto_discovered: false,
+                ..
+            } => Some(url),
+            _ => None,
+        }
+    }
+
     /// Return a `Config` whose server fields reflect this tier, so that
     /// server-backed helpers (`ServerInferenceClient::from_config`,
     /// `open_memory_backend`) work the same whether the server was configured
@@ -1034,6 +1055,30 @@ mod tests {
         assert!(auto.is_auto_discovered());
         assert!(!explicit.is_auto_discovered());
         assert!(!Tier::Offline.is_auto_discovered());
+    }
+
+    #[test]
+    fn tier_explicit_remote_url_only_for_explicit_server() {
+        let auto = Tier::Server {
+            url: "http://127.0.0.1:7777".to_string(),
+            caps: Capabilities::all(),
+            auto_discovered: true,
+            embedder_state: EmbedderState::Ready,
+            server_limits: None,
+        };
+        let explicit = Tier::Server {
+            url: "http://server.example.com:7777".to_string(),
+            caps: Capabilities::all(),
+            auto_discovered: false,
+            embedder_state: EmbedderState::Ready,
+            server_limits: None,
+        };
+        assert_eq!(auto.explicit_remote_url(), None);
+        assert_eq!(
+            explicit.explicit_remote_url(),
+            Some("http://server.example.com:7777")
+        );
+        assert_eq!(Tier::Offline.explicit_remote_url(), None);
     }
 
     // ── effective_config (ADR-004 inference-vs-memory routing) ───────────────

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -486,9 +486,16 @@ async fn run_embed_phases(
 /// skipped, so an unembedded index is never a silent surprise. Pure so it can
 /// be unit-tested; the four cases mirror the server's readiness contract.
 /// `server_url` is `cfg.server_url` (used only for the offline case).
+///
+/// `remote_url` is `Some` when the probed server came from an explicit
+/// `server_url` (not loopback auto-discovery). The unavailable-embedder
+/// notice must then name that server instead of pointing at `spelunk server
+/// logs`, which only reads the local auto-daemon's log and would show clean
+/// logs for a failure that lives on the remote server.
 fn embed_skipped_lines(
     embedder_state: Option<capability::EmbedderState>,
     server_url: Option<&str>,
+    remote_url: Option<&str>,
 ) -> Vec<String> {
     use capability::EmbedderState;
     match embedder_state {
@@ -498,12 +505,23 @@ fn embed_skipped_lines(
             "Re-run `spelunk index` in a moment to add embeddings (check `spelunk server status`)."
                 .to_string(),
         ],
-        Some(EmbedderState::Unavailable) => vec![
-            "Warning: the embedder failed to load — chunks indexed for text/ast-grep search only."
-                .to_string(),
-            "See `spelunk server logs` for the load error, then re-run `spelunk index`."
-                .to_string(),
-        ],
+        Some(EmbedderState::Unavailable) => match remote_url {
+            Some(url) => vec![
+                format!(
+                    "Warning: the embedder failed to load on team server {url}; chunks indexed \
+                     for text/ast-grep search only."
+                ),
+                "Check that server's own logs for the load error, then re-run `spelunk index`."
+                    .to_string(),
+            ],
+            None => vec![
+                "Warning: the embedder failed to load; chunks indexed for text/ast-grep search \
+                 only."
+                    .to_string(),
+                "See `spelunk server logs` for the load error, then re-run `spelunk index`."
+                    .to_string(),
+            ],
+        },
         // Reachable server without a ready embedder for any other reason
         // (`disabled`, or an older server that never advertised `index.embed`).
         Some(_) => vec![
@@ -534,7 +552,11 @@ fn embed_skipped_lines(
 
 /// Print the embed-skipped notice to stderr.
 fn eprint_embed_skipped_notice(tier: &capability::Tier, cfg: &Config) {
-    for line in embed_skipped_lines(tier.embedder_state(), cfg.server_url.as_deref()) {
+    for line in embed_skipped_lines(
+        tier.embedder_state(),
+        cfg.server_url.as_deref(),
+        tier.explicit_remote_url(),
+    ) {
         eprintln!("{line}");
     }
 }
@@ -754,7 +776,7 @@ mod tests {
 
     #[test]
     fn embed_skipped_loading_advises_retry() {
-        let lines = embed_skipped_lines(Some(capability::EmbedderState::Loading), None);
+        let lines = embed_skipped_lines(Some(capability::EmbedderState::Loading), None, None);
         assert!(!lines.is_empty(), "notice must not be silent");
         let joined = lines.join("\n");
         assert!(joined.contains("warming up"));
@@ -762,11 +784,35 @@ mod tests {
     }
 
     #[test]
-    fn embed_skipped_unavailable_points_at_logs() {
-        let lines = embed_skipped_lines(Some(capability::EmbedderState::Unavailable), None);
+    fn embed_skipped_unavailable_loopback_points_at_logs() {
+        // Loopback auto-discovery: the failing embedder IS the local daemon,
+        // so `spelunk server logs` is the right place to look.
+        let lines = embed_skipped_lines(Some(capability::EmbedderState::Unavailable), None, None);
         let joined = lines.join("\n");
         assert!(joined.contains("failed to load"));
         assert!(joined.contains("spelunk server logs"));
+    }
+
+    #[test]
+    fn embed_skipped_unavailable_remote_names_that_server_never_local_logs() {
+        // Explicit server_url: `spelunk server logs` reads the LOCAL daemon's
+        // log, which is clean when the failure lives on the team server. The
+        // notice must name the probed server instead.
+        let lines = embed_skipped_lines(
+            Some(capability::EmbedderState::Unavailable),
+            None,
+            Some("https://team.example:7777"),
+        );
+        let joined = lines.join("\n");
+        assert!(joined.contains("failed to load"));
+        assert!(
+            joined.contains("https://team.example:7777"),
+            "got: {joined}"
+        );
+        assert!(
+            !joined.contains("spelunk server logs"),
+            "must not point a remote failure at local logs: {joined}"
+        );
     }
 
     #[test]
@@ -774,7 +820,7 @@ mod tests {
         // Offline (no reachable server) with a configured server_url: the notice
         // names the URL and the Windows firewall cause, replacing the old silent
         // 0-chunk embed.
-        let lines = embed_skipped_lines(None, Some("http://127.0.0.1:7777"));
+        let lines = embed_skipped_lines(None, Some("http://127.0.0.1:7777"), None);
         let joined = lines.join("\n");
         assert!(joined.contains("http://127.0.0.1:7777"));
         assert!(joined.contains("unreachable"));
@@ -783,7 +829,7 @@ mod tests {
 
     #[test]
     fn embed_skipped_no_server_suggests_starting_one() {
-        let lines = embed_skipped_lines(None, None);
+        let lines = embed_skipped_lines(None, None, None);
         let joined = lines.join("\n");
         assert!(joined.contains("spelunk server start"));
     }
@@ -1040,10 +1086,12 @@ mod tests {
             None,
         ] {
             for url in [Some("http://x:1"), None] {
-                assert!(
-                    !embed_skipped_lines(state, url).is_empty(),
-                    "state {state:?} url {url:?} produced no notice"
-                );
+                for remote_url in [None, Some("https://team.example:7777")] {
+                    assert!(
+                        !embed_skipped_lines(state, url, remote_url).is_empty(),
+                        "state {state:?} url {url:?} remote_url {remote_url:?} produced no notice"
+                    );
+                }
             }
         }
     }

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -721,20 +721,31 @@ fn warmup_error_zero_explicit(mode: &str, total: i64) -> String {
 ///
 /// Pure so it can be unit-tested without capturing stderr; `has_server_url` is
 /// `cfg.server_url.is_some()`.
+///
+/// `remote_url` is `Some` when the probed server came from an explicit
+/// `server_url` (not loopback auto-discovery). The unavailable-embedder
+/// notice must then name that server instead of pointing at `spelunk server
+/// logs`, which only reads the local auto-daemon's log and would show clean
+/// logs for a failure that lives on the remote server.
 fn semantic_unavailable_message(
     embedder_state: Option<capability::EmbedderState>,
     has_server_url: bool,
+    remote_url: Option<&str>,
 ) -> String {
     use capability::EmbedderState;
     match embedder_state {
         Some(EmbedderState::Loading) => "[semantic search unavailable: model still warming up — \
              retry shortly (`spelunk server status`); using ast-grep]"
             .to_string(),
-        Some(EmbedderState::Unavailable) => {
-            "[semantic search unavailable: embedder failed to load — \
-             see `spelunk server logs`; using ast-grep]"
-                .to_string()
-        }
+        Some(EmbedderState::Unavailable) => match remote_url {
+            Some(url) => format!(
+                "[semantic search unavailable: embedder failed to load on team server {url}; \
+                 check that server's own logs; using ast-grep]"
+            ),
+            None => "[semantic search unavailable: embedder failed to load; \
+                 see `spelunk server logs`; using ast-grep]"
+                .to_string(),
+        },
         Some(_) => "[semantic search unavailable on this server; using ast-grep]".to_string(),
         None => {
             if has_server_url {
@@ -755,7 +766,11 @@ fn semantic_unavailable_message(
 fn eprint_semantic_unavailable_notice(tier: &capability::Tier, cfg: &Config) {
     eprintln!(
         "{}",
-        semantic_unavailable_message(tier.embedder_state(), cfg.server_url.is_some())
+        semantic_unavailable_message(
+            tier.embedder_state(),
+            cfg.server_url.is_some(),
+            tier.explicit_remote_url(),
+        )
     );
 }
 
@@ -880,30 +895,50 @@ mod tests {
 
     #[test]
     fn notice_loading_advises_retry() {
-        let msg = semantic_unavailable_message(Some(EmbedderState::Loading), true);
+        let msg = semantic_unavailable_message(Some(EmbedderState::Loading), true, None);
         assert!(msg.contains("warming up"));
         assert!(msg.contains("ast-grep"));
     }
 
     #[test]
-    fn notice_unavailable_points_at_logs() {
-        let msg = semantic_unavailable_message(Some(EmbedderState::Unavailable), true);
+    fn notice_unavailable_loopback_points_at_logs() {
+        // Loopback auto-discovery: the failing embedder IS the local daemon,
+        // so `spelunk server logs` is the right place to look.
+        let msg = semantic_unavailable_message(Some(EmbedderState::Unavailable), true, None);
         assert!(msg.contains("failed to load"));
         assert!(msg.contains("spelunk server logs"));
+    }
+
+    #[test]
+    fn notice_unavailable_remote_names_that_server_never_local_logs() {
+        // Explicit server_url: `spelunk server logs` reads the LOCAL daemon's
+        // log, which is clean when the failure lives on the team server. The
+        // notice must name the probed server instead.
+        let msg = semantic_unavailable_message(
+            Some(EmbedderState::Unavailable),
+            true,
+            Some("https://team.example:7777"),
+        );
+        assert!(msg.contains("failed to load"));
+        assert!(msg.contains("https://team.example:7777"), "got: {msg}");
+        assert!(
+            !msg.contains("spelunk server logs"),
+            "must not point a remote failure at local logs: {msg}"
+        );
     }
 
     #[test]
     fn notice_no_server_with_configured_url_mentions_firewall() {
         // Offline (no reachable server) but a server_url was configured →
         // the likely Windows cause is a blocked loopback listener.
-        let msg = semantic_unavailable_message(None, true);
+        let msg = semantic_unavailable_message(None, true, None);
         assert!(msg.contains("no server reachable"));
         assert!(msg.contains("Firewall"));
     }
 
     #[test]
     fn notice_no_server_no_url_suggests_starting_one() {
-        let msg = semantic_unavailable_message(None, false);
+        let msg = semantic_unavailable_message(None, false, None);
         assert!(msg.contains("spelunk server start"));
     }
 
@@ -920,7 +955,9 @@ mod tests {
             None,
         ] {
             for has_url in [true, false] {
-                assert!(!semantic_unavailable_message(state, has_url).is_empty());
+                for remote_url in [None, Some("https://team.example:7777")] {
+                    assert!(!semantic_unavailable_message(state, has_url, remote_url).is_empty());
+                }
             }
         }
     }

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -971,6 +971,33 @@ mod tests {
         assert_eq!(guard.bearer.as_deref(), Some("sk-legacy"));
     }
 
+    /// `is_explicit_remote` keys off whether `server_url` was set by the
+    /// operator, never off what host it resolves to: an explicitly
+    /// configured `server_url = http://127.0.0.1:PORT` is still "explicit"
+    /// even though the host is loopback. `spelunk server logs` only ever
+    /// reads the fixed auto-daemon log path and cannot tell this loopback
+    /// address was hand-configured, so the inference-error hint must still
+    /// name it. Mirrors `capability::tests::
+    /// tier_explicit_remote_url_is_explicit_even_when_host_is_loopback`,
+    /// which pins the same invariant on the `Tier` side of this contract.
+    #[test]
+    #[serial_test::serial]
+    fn from_config_is_explicit_remote_true_for_explicitly_configured_loopback_url() {
+        unsafe {
+            std::env::remove_var("SPELUNK_SERVER_KEY");
+        }
+        let cfg = crate::config::Config {
+            server_url: Some("http://127.0.0.1:9797".to_string()),
+            project_id: Some("proj".to_string()),
+            ..Default::default()
+        };
+        let client = ServerInferenceClient::from_config(&cfg).expect("client builds");
+        assert!(
+            client.is_explicit_remote,
+            "an explicitly configured server_url must count as explicit even when it is loopback"
+        );
+    }
+
     /// `derive_local_fallback` produces `local/<blake3-hex>` slugs — the `/`
     /// must become `%2F` so the whole slug occupies one URL path segment
     /// (IMP-1 / spelunk decision #106).

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -109,6 +109,13 @@ pub struct ServerInferenceClient {
     client: reqwest::Client,
     base_url: String,
     project_id: String,
+    /// `true` when `base_url` came from an explicitly configured team
+    /// `server_url` rather than loopback auto-discovery (which populates
+    /// `inference_url` while leaving `server_url` unset, ADR-004). An
+    /// inference error against an explicit remote must name `base_url`
+    /// instead of pointing at `spelunk server logs`, which only reads the
+    /// local auto-daemon's log.
+    is_explicit_remote: bool,
     /// Current bearer token + refresh state. `RwLock`-free `Mutex` is fine:
     /// contention is nil (refresh happens at most once per request) and the
     /// critical section is a cheap clone / swap.
@@ -189,6 +196,10 @@ impl ServerInferenceClient {
             client,
             base_url,
             project_id,
+            // `effective_config` only ever sets `inference_url` when
+            // `server_url` is unset (ADR-004), so a set `server_url` here
+            // means `base_url` resolved from it, i.e. an explicit remote.
+            is_explicit_remote: cfg.server_url.is_some(),
             auth: Mutex::new(BearerState {
                 bearer: cfg.server_key.clone(),
                 refresh,
@@ -210,6 +221,7 @@ impl ServerInferenceClient {
             client: reqwest::Client::new(),
             base_url: base_url.trim_end_matches('/').to_string(),
             project_id: project_id.to_string(),
+            is_explicit_remote: false,
             auth: Mutex::new(BearerState {
                 bearer,
                 // `workos_url` is the second tuple element (tests point it at a
@@ -222,6 +234,15 @@ impl ServerInferenceClient {
                 }),
             }),
         }
+    }
+
+    /// Mark this test client as reached via an explicit remote `server_url`
+    /// (not loopback auto-discovery), for tests covering the scoped
+    /// inference-error hint.
+    #[cfg(test)]
+    fn with_explicit_remote(mut self) -> Self {
+        self.is_explicit_remote = true;
+        self
     }
 
     /// Current bearer token, if any.
@@ -467,7 +488,11 @@ impl ServerInferenceClient {
         let status = resp.status();
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
-            anyhow::bail!("{}", server_inference_error("/index/embed", status, &text));
+            let remote_url = self.is_explicit_remote.then_some(self.base_url.as_str());
+            anyhow::bail!(
+                "{}",
+                server_inference_error("/index/embed", status, &text, remote_url)
+            );
         }
         let bytes = resp
             .bytes()
@@ -588,7 +613,18 @@ impl spelunk_core::llm::LlmBackend for ServerLlmAdapter {
 /// embedder (state `loading`/`unavailable`). `reqwest::error_for_status` throws
 /// that body away and yields a bare "HTTP status 503", so we parse it here and
 /// append a next-step hint.
-fn server_inference_error(endpoint: &str, status: reqwest::StatusCode, body: &str) -> String {
+///
+/// `remote_url` is `Some` when this client reached the server via an explicit
+/// `server_url` (not loopback auto-discovery). The `unavailable` hint must
+/// then name that server instead of pointing at `spelunk server logs`, which
+/// only reads the local auto-daemon's log and would show clean logs for a
+/// failure that lives on the remote server.
+fn server_inference_error(
+    endpoint: &str,
+    status: reqwest::StatusCode,
+    body: &str,
+    remote_url: Option<&str>,
+) -> String {
     let parsed: Option<serde_json::Value> = serde_json::from_str(body).ok();
     let field = |k: &str| {
         parsed
@@ -599,9 +635,12 @@ fn server_inference_error(endpoint: &str, status: reqwest::StatusCode, body: &st
     };
     let reason = field("detail").or_else(|| field("error"));
     let hint = match field("state") {
-        Some("loading") => " Retry shortly (`spelunk server status`).",
-        Some("unavailable") => " See `spelunk server logs`.",
-        _ => "",
+        Some("loading") => " Retry shortly (`spelunk server status`).".to_string(),
+        Some("unavailable") => match remote_url {
+            Some(url) => format!(" Check the logs for team server {url}."),
+            None => " See `spelunk server logs`.".to_string(),
+        },
+        _ => String::new(),
     };
     match reason {
         Some(reason) => format!("spelunk-server {endpoint} returned {status}: {reason}.{hint}"),
@@ -1058,6 +1097,7 @@ mod tests {
             "/index/embed",
             reqwest::StatusCode::SERVICE_UNAVAILABLE,
             &body,
+            None,
         );
         assert!(msg.contains("downloading model (42%)"), "got: {msg}");
         assert!(msg.contains("spelunk server status"), "got: {msg}");
@@ -1066,7 +1106,9 @@ mod tests {
     }
 
     #[test]
-    fn inference_error_surfaces_unavailable_points_at_logs() {
+    fn inference_error_surfaces_unavailable_loopback_points_at_logs() {
+        // Loopback auto-discovery: the failing embedder IS the local daemon,
+        // so `spelunk server logs` is the right place to look.
         let body = serde_json::json!({
             "error": "embedder unavailable",
             "state": "unavailable",
@@ -1077,9 +1119,35 @@ mod tests {
             "/index/embed",
             reqwest::StatusCode::SERVICE_UNAVAILABLE,
             &body,
+            None,
         );
         assert!(msg.contains("OOM loading GGUF"), "got: {msg}");
         assert!(msg.contains("spelunk server logs"), "got: {msg}");
+    }
+
+    #[test]
+    fn inference_error_surfaces_unavailable_remote_names_that_server_never_local_logs() {
+        // Explicit server_url: `spelunk server logs` reads the LOCAL daemon's
+        // log, which is clean when the failure lives on the team server. The
+        // error must name the probed server instead.
+        let body = serde_json::json!({
+            "error": "embedder unavailable",
+            "state": "unavailable",
+            "detail": "OOM loading GGUF",
+        })
+        .to_string();
+        let msg = server_inference_error(
+            "/index/embed",
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            &body,
+            Some("https://team.example:7777"),
+        );
+        assert!(msg.contains("OOM loading GGUF"), "got: {msg}");
+        assert!(msg.contains("https://team.example:7777"), "got: {msg}");
+        assert!(
+            !msg.contains("spelunk server logs"),
+            "must not point a remote failure at local logs: {msg}"
+        );
     }
 
     #[test]
@@ -1089,6 +1157,7 @@ mod tests {
             "/index/embed",
             reqwest::StatusCode::BAD_GATEWAY,
             "<html>502</html>",
+            None,
         );
         assert!(msg.contains("/index/embed"), "got: {msg}");
         assert!(msg.contains("502"), "got: {msg}");
@@ -1118,6 +1187,38 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("loading F2LLM weights"), "got: {msg}");
         assert!(msg.contains("spelunk server status"), "got: {msg}");
+    }
+
+    /// End-to-end: a 503 `unavailable` from `/index/embed` against an
+    /// explicit team `server_url` must name that server, never `spelunk
+    /// server logs` (which would read a healthy local daemon's log instead).
+    #[tokio::test]
+    async fn embed_text_remote_names_that_server_never_local_logs() {
+        let inference = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/index/embed"))
+            .respond_with(ResponseTemplate::new(503).set_body_json(serde_json::json!({
+                "error": "embedder unavailable",
+                "state": "unavailable",
+                "detail": "OOM loading GGUF",
+            })))
+            .mount(&inference)
+            .await;
+
+        let client =
+            ServerInferenceClient::for_test(&inference.uri(), "proj", Some("sk".into()), None)
+                .with_explicit_remote();
+        let err = client
+            .embed_text("hello")
+            .await
+            .expect_err("503 must surface as an error");
+        let msg = err.to_string();
+        assert!(msg.contains("OOM loading GGUF"), "got: {msg}");
+        assert!(msg.contains(&inference.uri()), "got: {msg}");
+        assert!(
+            !msg.contains("spelunk server logs"),
+            "must not point a remote failure at local logs: {msg}"
+        );
     }
 
     /// `/v1/health`-style probes aside, inference requests built via


### PR DESCRIPTION
## Summary
- `search.rs::semantic_unavailable_message`, `index/mod.rs::embed_skipped_lines`, and `server_client.rs::server_inference_error` all pointed embedder failures at `spelunk server logs`, which only ever reads the local auto-daemon's log file.
- With an explicit remote `server_url` configured, a healthy local daemon means those logs are clean even when the real failure is on the team server, so the hint was actively misleading.
- Extends the scope-aware pattern already used by `status.rs::embedder_status_line`: an explicit remote `server_url` now names that server and points at its own logs; loopback auto-discovery keeps the original hint unchanged.
- Added a `Tier::explicit_remote_url()` helper (`capability.rs`) and an `is_explicit_remote` field on `ServerInferenceClient`, both keyed off "was `server_url` set explicitly", not the resolved host — an explicitly-configured loopback URL is still treated as explicit, matching the existing `status.rs` precedent, with tests locking in that edge case.

## Test plan
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --features rich-formats -- -D warnings`
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
- `cargo test --workspace --features rich-formats` (60/60 binaries green)
- `cargo test --workspace --no-default-features` (60/60 binaries green)
- `cargo test --doc --workspace`
- Manually built the CLI and exercised all three message-construction functions directly with loopback vs. explicit-remote inputs, confirming the printed text differs and the remote case names the specific server, e.g.:
  - `[semantic search unavailable: embedder failed to load on team server https://team.example.com:7777; check that server's own logs; using ast-grep]`
  - `spelunk-server /index/embed returned 503 Service Unavailable: OOM loading GGUF. Check the logs for team server https://team.example.com:7777.`