### PR TITLE
Carry supersede edges to git notes (ADR-068 A6 retrofit)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -7,8 +7,8 @@ use crate::{
     indexer::secrets::contains_secret,
     server_client::ServerInferenceClient,
     storage::{
-        MemoryBackend, NoteInput, NoteRecord, RewriteRefStatus, append_state_update,
-        append_to_git_notes, now_millis, now_secs, open_memory_backend,
+        GitNotesBackend, MemoryBackend, NoteInput, NoteRecord, RewriteRefStatus,
+        append_state_update, append_to_git_notes, now_millis, now_secs, open_memory_backend,
     },
 };
 
@@ -213,8 +213,22 @@ pub(super) async fn memory_add(
         // record (the one just written above) would be backwards. Best-effort
         // and non-fatal like the write above: SQLite already holds the
         // authoritative archive.
-        if let (Some(old_id), Some(backend)) = (args.supersedes, primary_backend.as_ref()) {
-            match backend.get(old_id).await {
+        //
+        // Pre-`init` there is no SQLite primary to re-read OLD from (`primary_backend`
+        // is `None`), but OLD was never in SQLite anyway — it only ever lived in
+        // git notes, via this same write-through, so a fresh `GitNotesBackend`
+        // (its `get` reads purely off `refs/notes/spelunk`, no SQLite involved)
+        // resolves it the same way. Without this, `--supersedes` pre-init used to
+        // silently drop the edge: the block below never ran because
+        // `primary_backend` was always `None`, yet the command still printed a
+        // plain "Stored" success line.
+        if let Some(old_id) = args.supersedes {
+            let old_lookup = if let Some(backend) = primary_backend.as_ref() {
+                backend.get(old_id).await
+            } else {
+                GitNotesBackend::new().get(old_id).await
+            };
+            match old_lookup {
                 Ok(Some(old_note)) => {
                     let invalid_at = old_note.invalid_at.or_else(|| Some(now_secs()));
                     if let Err(e) = append_state_update(

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -7,8 +7,8 @@ use crate::{
     indexer::secrets::contains_secret,
     server_client::ServerInferenceClient,
     storage::{
-        NoteInput, NoteRecord, RewriteRefStatus, append_to_git_notes, now_millis, now_secs,
-        open_memory_backend,
+        MemoryBackend, NoteInput, NoteRecord, RewriteRefStatus, append_state_update,
+        append_to_git_notes, now_millis, now_secs, open_memory_backend,
     },
 };
 
@@ -106,11 +106,17 @@ pub(super) async fn memory_add(
     // server, or (with `--backend git-notes`) git notes itself. Pre-init there
     // is no primary; the write-through carrier below is the sole writer, so mint
     // an id the same way the backends do (`now_millis`).
+    //
+    // The backend handle is kept (not just its returned id) so that, when
+    // `--supersedes` is given, the write-through carrier below can read back
+    // the OLD entry (now archived by the `add` call) and carry its supersede
+    // edge to git notes too.
+    let mut primary_backend: Option<Box<dyn MemoryBackend + Send>> = None;
     let id = if pre_init_notes {
         now_millis()
     } else {
         let backend = open_memory_backend(cfg, mem_path, backend_override).await?;
-        backend
+        let id = backend
             .add(NoteInput {
                 kind: args.kind.clone(),
                 title: title.clone(),
@@ -122,7 +128,9 @@ pub(super) async fn memory_add(
                 valid_at,
                 supersedes: args.supersedes,
             })
-            .await?
+            .await?;
+        primary_backend = Some(backend);
+        id
     };
 
     // ── Git-notes write-through carrier ──────────────────────────────────────
@@ -135,6 +143,7 @@ pub(super) async fn memory_add(
         pre_init_notes || (cfg.store_in_git_notes && backend_override != Some("git-notes"));
     let mut notes_rewrite_note: Option<&str> = None;
     if write_through {
+        let new_entity_id = crate::storage::entity_id::entity_id(&args.kind, &title, &body);
         let record = NoteRecord {
             schema_version: 1,
             id,
@@ -151,9 +160,7 @@ pub(super) async fn memory_add(
             superseded_by: None,
             // Never-synced local row: no cross-machine id yet.
             remote_id: None,
-            entity_id: Some(crate::storage::entity_id::entity_id(
-                &args.kind, &title, &body,
-            )),
+            entity_id: Some(new_entity_id.clone()),
             superseded_by_entity_id: None,
         };
         // Use process CWD (None) — the CLI is always run from the project root.
@@ -196,6 +203,48 @@ pub(super) async fn memory_add(
                     "Warning: entry stored locally, but the git-notes carry failed, \
                      so it will not travel with the repo: {e:#}"
                 );
+            }
+        }
+
+        // ── Carry the OLD entity's supersede edge too ────────────────────────
+        // `--supersedes` already archived OLD in the primary store above; the
+        // edge itself only travels once a state-update record is appended for
+        // OLD's own entry, pointing at NEW's `entity_id` — writing it on NEW's
+        // record (the one just written above) would be backwards. Best-effort
+        // and non-fatal like the write above: SQLite already holds the
+        // authoritative archive.
+        if let (Some(old_id), Some(backend)) = (args.supersedes, primary_backend.as_ref()) {
+            match backend.get(old_id).await {
+                Ok(Some(old_note)) => {
+                    let invalid_at = old_note.invalid_at.or_else(|| Some(now_secs()));
+                    if let Err(e) = append_state_update(
+                        None,
+                        &old_note,
+                        "archived",
+                        invalid_at,
+                        Some(new_entity_id),
+                    )
+                    .await
+                    {
+                        eprintln!(
+                            "Warning: entry stored locally, but carrying #{old_id}'s \
+                             supersede edge to git notes failed, so it will not travel \
+                             with the repo: {e:#}"
+                        );
+                    }
+                }
+                Ok(None) => {
+                    eprintln!(
+                        "Warning: --supersedes {old_id} not found; no supersede edge was \
+                         carried to git notes."
+                    );
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Warning: could not re-read #{old_id} to carry its supersede edge \
+                         to git notes: {e:#}"
+                    );
+                }
             }
         }
     }

--- a/crates/spelunk-cli/src/cli/cmd/memory/supersede.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/supersede.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 
 use super::{MemorySupersededArgs, backend_err};
-use crate::{config::Config, storage::open_memory_backend};
+use crate::{
+    config::Config,
+    storage::{append_state_update, note_entity_id, now_secs, open_memory_backend},
+};
 
 pub(super) async fn memory_supersede(
     args: MemorySupersededArgs,
@@ -10,9 +13,9 @@ pub(super) async fn memory_supersede(
     backend_override: Option<&str>,
 ) -> Result<()> {
     let backend = open_memory_backend(cfg, mem_path, backend_override).await?;
-    if backend.get(args.new_id).await?.is_none() {
+    let Some(new_note) = backend.get(args.new_id).await? else {
         anyhow::bail!("No memory entry with id {} (new).", args.new_id);
-    }
+    };
     if backend
         .supersede(args.old_id, args.new_id)
         .await
@@ -23,6 +26,54 @@ pub(super) async fn memory_supersede(
             old = args.old_id,
             new = args.new_id
         );
+
+        // ── Git-notes write-through carrier ──────────────────────────────────
+        // Best-effort and non-fatal, matching `memory add`'s contract: SQLite
+        // above already holds the authoritative archive + link, so a failed
+        // carry means only that the edge stays local for now, never that the
+        // command fails. `GitNotesBackend::supersede` stays unsupported
+        // (ADR-068 D3), so this is the sole path that carries the edge when
+        // git notes is the primary store (explicit `--backend git-notes`
+        // never reaches here: `supersede` above already returned `Err`).
+        let write_through = cfg.store_in_git_notes && backend_override != Some("git-notes");
+        if write_through {
+            match backend.get(args.old_id).await {
+                Ok(Some(old_note)) => {
+                    let new_entity_id = note_entity_id(&new_note);
+                    let invalid_at = old_note.invalid_at.or_else(|| Some(now_secs()));
+                    if let Err(e) = append_state_update(
+                        None,
+                        &old_note,
+                        "archived",
+                        invalid_at,
+                        Some(new_entity_id),
+                    )
+                    .await
+                    {
+                        eprintln!(
+                            "Warning: #{old} archived locally, but carrying its supersede \
+                             edge to git notes failed, so it will not travel with the \
+                             repo: {e:#}",
+                            old = args.old_id
+                        );
+                    }
+                }
+                Ok(None) => {
+                    eprintln!(
+                        "Warning: could not re-read #{} after archiving it, so its \
+                         supersede edge was not carried to git notes.",
+                        args.old_id
+                    );
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Warning: could not re-read #{} after archiving it, so its \
+                         supersede edge was not carried to git notes: {e:#}",
+                        args.old_id
+                    );
+                }
+            }
+        }
     } else {
         anyhow::bail!("No active memory entry with id {} (old).", args.old_id);
     }

--- a/crates/spelunk-cli/tests/git_notes_fallback.rs
+++ b/crates/spelunk-cli/tests/git_notes_fallback.rs
@@ -1119,3 +1119,73 @@ fn post_init_supersede_command_carries_edge_to_git_notes() {
         "the edge must never land on NEW's record; got: {new_line}"
     );
 }
+
+/// `memory add --supersedes OLD` run entirely **pre-`init`** (no `.spelunk/`,
+/// carrier-only, as in `memory_add_list_round_trips_via_git_notes_fallback`
+/// above): both OLD and NEW exist only via the git-notes carrier, since there
+/// is no SQLite primary yet. The edge-carry block in `add.rs` ("Carry the OLD
+/// entity's supersede edge too") only runs when a primary backend handle was
+/// opened (`primary_backend.as_ref()`), which is never the case pre-init —
+/// so today the edge is silently dropped: no state-update record is
+/// appended, and no warning is printed, even though the command prints a
+/// plain "Stored" success line as if the `--supersedes` request succeeded.
+///
+/// This currently fails, pinning the gap: `spelunk memory add --supersedes`
+/// pre-init drops the edge exactly the way the pre-fix post-init path used
+/// to (the case this whole task exists to close), just on the other half of
+/// the carrier's supported command surface (ADR-068 D3).
+#[test]
+fn pre_init_add_supersedes_carries_edge_for_old_entry() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+
+    bin(home.path(), repo.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "decision",
+            "--title",
+            "pre-init-old",
+            "--body",
+            "b1",
+        ])
+        .assert()
+        .success();
+    let old_lines = spelunk_note_lines(repo.path());
+    assert_eq!(old_lines.len(), 1, "setup: OLD's own pre-init add");
+    let old_id = record_field(&old_lines[0], "id");
+
+    bin(home.path(), repo.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "decision",
+            "--title",
+            "pre-init-new",
+            "--body",
+            "b2",
+            "--supersedes",
+            &old_id,
+        ])
+        .assert()
+        .success();
+
+    let lines = spelunk_note_lines(repo.path());
+    assert_eq!(
+        lines.len(),
+        3,
+        "expected OLD's untouched original, NEW's record, and a state-update \
+         archiving OLD (mirroring the post-init behaviour proven above); got \
+         only {lines:?} — pre-init, the `--supersedes` edge is being \
+         silently dropped while the command still reports plain success"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| title_and_status(l) == ("pre-init-old".to_string(), "archived".to_string())),
+        "OLD must gain an archived state-update record even pre-init; got: {lines:?}"
+    );
+}

--- a/crates/spelunk-cli/tests/git_notes_fallback.rs
+++ b/crates/spelunk-cli/tests/git_notes_fallback.rs
@@ -944,3 +944,178 @@ fn unusable_notes_lock_degradation_is_visible_without_rust_log() {
         "the degraded write must still land exactly one record; got: {lines:?}"
     );
 }
+
+// ── ADR-068 A6 retrofit: supersede edges travel via the carrier ───────────────
+//
+// Both `memory add --supersedes` and `memory supersede` archive the OLD entry
+// in the SQLite primary already; what was missing is carrying that edge to
+// git notes too, via a second, appended record for OLD (never a rewrite of
+// its original line — see `append_state_update`'s doc in
+// `storage/git_notes/mod.rs`). The gap this closes: `add.rs` already passed
+// `--supersedes` through to the SQLite backend, then wrote
+// `superseded_by_entity_id: None` on the write-through record regardless, so
+// the edge was silently dropped even when explicitly requested.
+
+/// A JSON-Lines record's `title` and `status`, read together since several
+/// assertions below need both to pick the right line out of a note with more
+/// than one record for the same title (the OLD entity's original record and
+/// its later state-update).
+fn title_and_status(line: &str) -> (String, String) {
+    (record_field(line, "title"), record_field(line, "status"))
+}
+
+/// `memory add --supersedes OLD` must carry OLD's edge to git notes, not just
+/// write the NEW entry: OLD's original record stays untouched (append-only),
+/// and a second record for OLD lands with `status: archived` and
+/// `superseded_by_entity_id` pointing at NEW's `entity_id` — never the other
+/// way around.
+#[test]
+fn post_init_add_supersedes_carries_edge_for_old_entry() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+    std::fs::create_dir_all(repo.path().join(".spelunk")).unwrap();
+
+    bin(home.path(), repo.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "decision",
+            "--title",
+            "old-decision",
+            "--body",
+            "b1",
+        ])
+        .assert()
+        .success();
+    let old_lines = spelunk_note_lines(repo.path());
+    assert_eq!(old_lines.len(), 1, "setup: OLD's own add");
+    let old_id = record_field(&old_lines[0], "id");
+    let old_entity_id = record_field(&old_lines[0], "entity_id");
+
+    bin(home.path(), repo.path())
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "decision",
+            "--title",
+            "new-decision",
+            "--body",
+            "b2",
+            "--supersedes",
+            &old_id,
+        ])
+        .assert()
+        .success();
+
+    let lines = spelunk_note_lines(repo.path());
+    assert_eq!(
+        lines.len(),
+        3,
+        "OLD's untouched original, NEW's record, and OLD's state-update; got: {lines:?}"
+    );
+
+    let new_line = lines
+        .iter()
+        .find(|l| title_and_status(l) == ("new-decision".to_string(), "active".to_string()))
+        .unwrap_or_else(|| panic!("no active new-decision record in {lines:?}"));
+    let new_entity_id = record_field(new_line, "entity_id");
+    assert!(
+        !new_line.contains("superseded_by_entity_id"),
+        "the edge must never land on NEW's record; got: {new_line}"
+    );
+
+    let old_original = lines
+        .iter()
+        .find(|l| title_and_status(l) == ("old-decision".to_string(), "active".to_string()))
+        .unwrap_or_else(|| {
+            panic!("OLD's original active record must survive untouched: {lines:?}")
+        });
+    assert_eq!(
+        record_field(old_original, "entity_id"),
+        old_entity_id,
+        "OLD's original record must be byte-identical in identity, never rewritten"
+    );
+
+    let old_update = lines
+        .iter()
+        .find(|l| title_and_status(l) == ("old-decision".to_string(), "archived".to_string()))
+        .unwrap_or_else(|| panic!("OLD's state-update record is missing: {lines:?}"));
+    assert_eq!(
+        record_field(old_update, "entity_id"),
+        old_entity_id,
+        "the state-update record must carry OLD's own entity_id, not NEW's"
+    );
+    assert_eq!(
+        record_field(old_update, "superseded_by_entity_id"),
+        new_entity_id,
+        "the edge must point at NEW's entity_id"
+    );
+    assert!(
+        !record_field(old_update, "invalid_at").is_empty(),
+        "the state-update record must set invalid_at"
+    );
+}
+
+/// `memory supersede OLD NEW` carries the same edge, via the same shared
+/// carrier helper, when both entries already exist as separate `add`s.
+#[test]
+fn post_init_supersede_command_carries_edge_to_git_notes() {
+    let home = TempDir::new().unwrap();
+    let repo = TempDir::new().unwrap();
+    init_git_repo_with_commit(repo.path());
+    std::fs::create_dir_all(repo.path().join(".spelunk")).unwrap();
+
+    let add = |title: &str, body: &str| {
+        bin(home.path(), repo.path())
+            .args([
+                "memory", "add", "--kind", "decision", "--title", title, "--body", body,
+            ])
+            .assert()
+            .success();
+    };
+    add("old-via-supersede", "b1");
+    add("new-via-supersede", "b2");
+
+    let seeded = spelunk_note_lines(repo.path());
+    assert_eq!(seeded.len(), 2, "setup: two independent adds");
+    let old_id = record_field(&seeded[0], "id");
+    let new_id = record_field(&seeded[1], "id");
+    let new_entity_id = record_field(&seeded[1], "entity_id");
+
+    bin(home.path(), repo.path())
+        .args(["memory", "supersede", &old_id, &new_id])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Archived #").and(predicate::str::contains("superseded by #")),
+        );
+
+    let lines = spelunk_note_lines(repo.path());
+    assert_eq!(
+        lines.len(),
+        3,
+        "OLD's untouched original, NEW's record, and OLD's state-update; got: {lines:?}"
+    );
+
+    let old_update = lines
+        .iter()
+        .find(|l| title_and_status(l) == ("old-via-supersede".to_string(), "archived".to_string()))
+        .unwrap_or_else(|| panic!("OLD's state-update record is missing: {lines:?}"));
+    assert_eq!(
+        record_field(old_update, "superseded_by_entity_id"),
+        new_entity_id,
+        "the edge must point at NEW's entity_id"
+    );
+
+    let new_line = lines
+        .iter()
+        .find(|l| title_and_status(l) == ("new-via-supersede".to_string(), "active".to_string()))
+        .unwrap_or_else(|| panic!("NEW's record is missing: {lines:?}"));
+    assert!(
+        !new_line.contains("superseded_by_entity_id"),
+        "the edge must never land on NEW's record; got: {new_line}"
+    );
+}

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -5,8 +5,9 @@ use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
+use super::entity_id::note_entity_id;
 use super::memory::Note;
-use super::note_record::{NoteRecord, record_to_note};
+use super::note_record::{NoteRecord, now_millis, now_secs, record_to_note};
 use fold::fold_records;
 
 mod backend_impl;
@@ -317,6 +318,62 @@ pub async fn append_to_git_notes(
         rewrite_ref,
         lock_degradation,
     })
+}
+
+/// Append a state-update record for an entity that already exists on the
+/// carrier: `base` supplies its content (`kind`/`title`/`body`/`tags`/
+/// `linked_files`/`source_ref`/`valid_at`) unchanged, while `status`,
+/// `invalid_at` and `superseded_by_entity_id` override its mutable state.
+///
+/// **Never rewrites the entity's existing line(s) in place.** A live-git
+/// experiment (three-repo harness) showed why: a rewrite leaves a second
+/// machine, which holds the original line plus a divergent local note of its
+/// own, with both the rewritten and the stale original line after
+/// `cat_sort_uniq` unions them — the entity appears twice, with conflicting
+/// `status`. Appending a new line instead, and folding same-`entity_id` copies
+/// at read time ([`fold_records`]), converges regardless of merge order
+/// (ADR-068 A6): the fold's archival rule is monotonic, so whichever copy
+/// carries `status: "archived"` wins.
+///
+/// This append is **not** the "re-recording an unchanged entry" case ADR-068
+/// A6 calls a no-op — that no-op is scoped to a byte-for-byte-unchanged
+/// re-record, and does not apply here since this call always changes mutable
+/// state. Nothing in this module suppresses same-`entity_id` appends; keep it
+/// that way; a guard that did would silently swallow every state update this
+/// function writes.
+///
+/// Shared by `memory supersede` and `memory add --supersedes` (the two
+/// carriers of a supersede edge); shaped so `memory archive`'s carrier
+/// write-through, tracked as separate follow-up work, can call it too with
+/// `superseded_by_entity_id: None`.
+pub async fn append_state_update(
+    git_root: Option<&std::path::Path>,
+    base: &Note,
+    status: &str,
+    invalid_at: Option<i64>,
+    superseded_by_entity_id: Option<String>,
+) -> Result<AppendOutcome> {
+    let record = NoteRecord {
+        schema_version: 1,
+        id: now_millis(),
+        kind: base.kind.clone(),
+        title: base.title.clone(),
+        body: base.body.clone(),
+        tags: base.tags.clone(),
+        linked_files: base.linked_files.clone(),
+        created_at: now_secs(),
+        status: status.to_string(),
+        source_ref: base.source_ref.clone(),
+        valid_at: base.valid_at,
+        invalid_at,
+        // Machine-local rowid link: never populated by this path, which keys
+        // entities by `entity_id` only (ADR-068 A6).
+        superseded_by: None,
+        remote_id: None,
+        entity_id: Some(note_entity_id(base)),
+        superseded_by_entity_id,
+    };
+    append_to_git_notes(git_root, &record).await
 }
 
 // ── Read-path merge: making fetched notes visible ────────────────────────────

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -23,8 +23,8 @@ pub use entity_id::{entity_id, note_entity_id};
 pub use files::FileRecord;
 pub use git_notes::{
     AppendOutcome, GitNotesBackend, LOCK_WAIT_BUDGET, LockAttempt, NotesLock, NotesMergeOutcome,
-    PublishOutcome, RewriteRefStatus, SkipReason, append_to_git_notes, ensure_notes_rewrite_ref,
-    lock_notes, merge_tracking_notes, publish_notes,
+    PublishOutcome, RewriteRefStatus, SkipReason, append_state_update, append_to_git_notes,
+    ensure_notes_rewrite_ref, lock_notes, merge_tracking_notes, publish_notes,
 };
 pub use graph::GraphEdge;
 pub use memory::{MemoryEdge, MemoryStore, SyncRow};

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -3478,3 +3478,318 @@ async fn three_distinct_entities_stay_three_entries() {
         "distinct entities must not collapse"
     );
 }
+
+// ── ADR-068 A6 retrofit: supersede edges travel via the carrier ─────────────
+//
+// `memory supersede` and `memory add --supersedes` append a state-update
+// record for the OLD entity rather than rewriting it in place — a live-git
+// experiment showed an in-place rewrite does not converge under a genuine
+// merge (a second clone holding the original line plus a divergent note of
+// its own keeps both the stale original and the rewrite after
+// `cat_sort_uniq`). These tests exercise `append_state_update`'s write shape
+// together with the fold above, the way a receiving clone actually sees it.
+
+use spelunk_core::storage::append_state_update;
+use spelunk_core::storage::memory::Note;
+
+/// A `Note` as `backend.get()` would hand back right after an entry is
+/// created — the shape `append_state_update`'s `base` parameter expects.
+fn note_for(title: &str, id: i64, created_at: i64) -> Note {
+    Note {
+        id,
+        kind: "decision".to_string(),
+        title: title.to_string(),
+        body: format!("body for {title}"),
+        tags: vec![],
+        linked_files: vec![],
+        created_at,
+        status: "active".to_string(),
+        superseded_by: None,
+        source_ref: None,
+        valid_at: None,
+        invalid_at: None,
+        distance: None,
+        score: None,
+        source_project: None,
+        source_project_path: None,
+        remote_id: None,
+    }
+}
+
+/// `append_state_update` appends a new line; it never touches the entity's
+/// existing one. Pinning "the original line survives byte-for-byte" is what
+/// rules out the in-place rewrite the spec's live-git experiment showed does
+/// not converge.
+#[tokio::test]
+#[serial]
+async fn append_state_update_appends_never_rewrites() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    append_to_git_notes(Some(root), &make_note_record(1, "decision X"))
+        .await
+        .expect("seed original");
+    let original = read_raw_note(root);
+    let original_line = original
+        .lines()
+        .next()
+        .expect("one seeded line")
+        .to_string();
+
+    let old = note_for("decision X", 1, 100);
+    append_state_update(
+        Some(root),
+        &old,
+        "archived",
+        Some(900),
+        Some("succ-entity".to_string()),
+    )
+    .await
+    .expect("append state update");
+
+    let after = read_raw_note(root);
+    let lines: Vec<&str> = after.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "a state update must be a second line, not a rewrite of the first: {after}"
+    );
+    assert_eq!(
+        lines[0], original_line,
+        "the original line must survive byte-for-byte"
+    );
+
+    let updated: NoteRecord = serde_json::from_str(lines[1]).expect("parse state update");
+    assert_eq!(updated.status, "archived");
+    assert_eq!(updated.invalid_at, Some(900));
+    assert_eq!(
+        updated.superseded_by_entity_id.as_deref(),
+        Some("succ-entity")
+    );
+}
+
+/// The edge direction is the easy mistake to get backwards: it must land on
+/// OLD's appended record, pointing at NEW's `entity_id` — never on NEW's own
+/// record.
+#[tokio::test]
+#[serial]
+async fn supersede_edge_lands_on_old_record_not_new() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    append_to_git_notes(Some(root), &make_note_record(1, "decision X"))
+        .await
+        .expect("seed X");
+    append_to_git_notes(Some(root), &make_note_record(2, "decision Y"))
+        .await
+        .expect("seed Y");
+
+    let old = note_for("decision X", 1, 100);
+    let new = note_for("decision Y", 2, 200);
+    let new_entity_id = spelunk_core::storage::note_entity_id(&new);
+    let old_entity_id = spelunk_core::storage::note_entity_id(&old);
+
+    append_state_update(
+        Some(root),
+        &old,
+        "archived",
+        Some(500),
+        Some(new_entity_id.clone()),
+    )
+    .await
+    .expect("append state update");
+
+    let blob = read_raw_note(root);
+    let records: Vec<NoteRecord> = blob
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("parse"))
+        .collect();
+
+    for r in &records {
+        if r.resolve_entity_id() == new_entity_id {
+            assert!(
+                r.superseded_by_entity_id.is_none(),
+                "the edge must never land on NEW's record: {r:?}"
+            );
+        }
+    }
+    let old_update = records
+        .iter()
+        .find(|r| r.resolve_entity_id() == old_entity_id && r.status == "archived")
+        .expect("OLD's state-update record must exist");
+    assert_eq!(
+        old_update.superseded_by_entity_id.as_deref(),
+        Some(new_entity_id.as_str()),
+        "the edge must land on OLD's record, pointing at NEW's entity_id"
+    );
+}
+
+/// A clone that received X's supersede state-update but never received Y's
+/// own record must still show X archived, never live: `status` travels on
+/// X's own record rather than being inferred from whether the edge resolves
+/// (ADR-068 A3/A6). X is still counted — not silently dropped just because
+/// its successor is unresolvable.
+#[tokio::test]
+#[serial]
+async fn unresolved_successor_never_renders_as_live_and_is_counted() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    append_to_git_notes(Some(root), &make_note_record(1, "decision X"))
+        .await
+        .expect("seed X");
+    let old = note_for("decision X", 1, 100);
+
+    // Y's entity_id, computed the same way a real successor's would be, but Y's
+    // own record never lands on this clone.
+    let missing_successor = entity_id("decision", "decision Y", "body for decision Y");
+
+    append_state_update(
+        Some(root),
+        &old,
+        "archived",
+        Some(900),
+        Some(missing_successor),
+    )
+    .await
+    .expect("append state update");
+
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+
+    let live = backend
+        .list(None, 50, false, None)
+        .await
+        .expect("list live");
+    assert!(
+        live.is_empty(),
+        "X must never render as live once archived, got: {live:?}"
+    );
+
+    let all = backend.list(None, 50, true, None).await.expect("list all");
+    assert_eq!(
+        all.len(),
+        1,
+        "X must still be counted, not silently dropped: {all:?}"
+    );
+    assert_eq!(all[0].status, "archived");
+    assert_eq!(all[0].title, "decision X");
+}
+
+/// The headline test: clone A records X, then supersedes it with Y; clone B —
+/// holding a divergent local note of its own so the merge genuinely unions
+/// rather than fast-forwards — fetches and merges. B's `list` must show X
+/// archived (superseded by Y) exactly once, and Y live exactly once.
+///
+/// A test that fast-forwards here "passes while proving nothing": with no
+/// divergent content on B's side, `git notes merge` never has to invoke
+/// `cat_sort_uniq`'s union at all, so it would never exercise the fold this
+/// task's writes depend on.
+#[tokio::test]
+#[serial]
+async fn supersede_edge_travels_across_a_genuinely_diverging_merge() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    // ── Clone A's history, about to be "fetched" onto B's tracking ref ───────
+    append_to_git_notes(Some(root), &make_note_record(1, "decision X"))
+        .await
+        .expect("A: record X");
+    append_to_git_notes(Some(root), &make_note_record(2, "decision Y"))
+        .await
+        .expect("A: record Y");
+    let old = note_for("decision X", 1, 100);
+    let new = note_for("decision Y", 2, 200);
+    let new_entity_id = spelunk_core::storage::note_entity_id(&new);
+    append_state_update(Some(root), &old, "archived", Some(300), Some(new_entity_id))
+        .await
+        .expect("A: supersede X with Y");
+
+    // "git fetch" lands A's whole history on the tracking ref.
+    park_working_ref_as_tracking(root);
+
+    // B's own, never-pushed local note — genuine divergence: without this the
+    // merge below fast-forwards and the test would prove nothing.
+    append_to_git_notes(Some(root), &make_note_record(3, "decision Z"))
+        .await
+        .expect("B: local decision Z");
+
+    assert_eq!(
+        merge_tracking_notes(Some(root)).await,
+        NotesMergeOutcome::Merged,
+        "setup: the merge must be a genuine union, not a no-op"
+    );
+
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+
+    let live = backend
+        .list(None, 50, false, None)
+        .await
+        .expect("list live");
+    let live_titles: Vec<&str> = live.iter().map(|n| n.title.as_str()).collect();
+    assert_eq!(
+        live_titles.iter().filter(|&&t| t == "decision X").count(),
+        0,
+        "X must not render as live after being superseded: {live_titles:?}"
+    );
+    assert_eq!(
+        live_titles.iter().filter(|&&t| t == "decision Y").count(),
+        1,
+        "Y must be live exactly once: {live_titles:?}"
+    );
+    assert!(
+        live_titles.contains(&"decision Z"),
+        "B's own note must survive the merge: {live_titles:?}"
+    );
+
+    let all = backend.list(None, 50, true, None).await.expect("list all");
+    let x_entries: Vec<_> = all.iter().filter(|n| n.title == "decision X").collect();
+    assert_eq!(
+        x_entries.len(),
+        1,
+        "X must fold to exactly one entry, archived, superseded by Y, not duplicated: {all:?}"
+    );
+    assert_eq!(x_entries[0].status, "archived");
+}
+
+/// Idempotence: the same supersede recorded twice (e.g. a retried carrier
+/// write, or two machines independently linking the same pair) still
+/// converges to one folded entry, never two.
+#[tokio::test]
+#[serial]
+async fn supersede_is_idempotent_across_repeated_state_updates() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+
+    append_to_git_notes(Some(root), &make_note_record(1, "decision X"))
+        .await
+        .expect("record X");
+    append_to_git_notes(Some(root), &make_note_record(2, "decision Y"))
+        .await
+        .expect("record Y");
+    let old = note_for("decision X", 1, 100);
+    let new = note_for("decision Y", 2, 200);
+    let new_entity_id = spelunk_core::storage::note_entity_id(&new);
+
+    for _ in 0..2 {
+        append_state_update(
+            Some(root),
+            &old,
+            "archived",
+            Some(300),
+            Some(new_entity_id.clone()),
+        )
+        .await
+        .expect("append state update");
+    }
+
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+    let all = backend.list(None, 50, true, None).await.expect("list all");
+    let x_entries: Vec<_> = all.iter().filter(|n| n.title == "decision X").collect();
+    assert_eq!(
+        x_entries.len(),
+        1,
+        "repeating the identical state update must still fold to one entry: {all:?}"
+    );
+    assert_eq!(x_entries[0].status, "archived");
+}

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -51,6 +51,15 @@ surviving entry carries the earliest recording time, and the union of the copies
 any copy reads as archived everywhere, so archiving it on one machine does not
 un-archive when a still-active copy arrives from another.
 
+**Superseding travels too.** `--supersedes <old-id>` (on `memory add`) and
+`memory supersede` both append a state-update record for the *old* entry to the
+carrier — archived status, invalidation time, and an edge naming the new
+entry's identity — rather than editing the old entry's line in place, so the
+edge survives a re-`init` renumbering `id` and reaches teammates once the notes
+ref is fetched and merged. This works identically before and after `spelunk
+init`: a clone that never received the new entry still renders the old one as
+archived, just without a name for what replaced it.
+
 **Before `spelunk init`**, `memory add` and `memory list` still work when you are
 inside a git repository: with no `.spelunk/` project, `add` rides the same
 write-through carrier (there is no SQLite primary yet) and `list` reads entries


### PR DESCRIPTION
## Summary

`memory supersede` and `memory add --supersedes` archive the OLD entry in the
SQLite primary, but never carried that edge to `refs/notes/spelunk` - a clone
that only ever received git notes (no SQLite, or a teammate reading the
carrier before this entry syncs) would see the OLD entry still active, with
no record it had been superseded. This PR closes that gap per ADR-068's A6
amendment (edges travel via `entity_id`, not the machine-local rowid).

- New shared helper `append_state_update` (`crates/spelunk-core/src/storage/git_notes/mod.rs`):
  appends a state-update record for an existing entity (never rewrites its
  original line in place - an in-place rewrite does not converge under a
  genuine multi-clone merge, verified live). Shaped so `memory archive`'s
  carrier write-through (tracked separately) can reuse it.
- Both `memory supersede` and `memory add --supersedes` now call it after
  their SQLite write succeeds, putting `superseded_by_entity_id` on the OLD
  entry's appended record, pointing at NEW's `entity_id` (not the reverse -
  the easy mistake here).
- `GitNotesBackend::supersede` stays `BackendUnsupported`; this only uses the
  existing `GitNotesBackend::get`, so ADR-068 D3's pre-init command surface is
  untouched.

**Handback round found and fixed a real gap, worth calling out rather than
hiding:** independent Test Engineer review of the first pass found that
`memory add --supersedes OLD` run entirely pre-`init` silently dropped the
edge - no warning, plain "Stored" success line, no state-update appended -
because the carry-edge block was gated on a SQLite primary handle that is
always `None` pre-init. Fixed by resolving OLD via a fresh `GitNotesBackend`
(it already implements `get` purely off git notes) when there's no SQLite
primary to read from. Re-verified by an independent Test Engineer pass and
confirmed again in this QA review via manual CLI repro.

A separate, pre-existing (not introduced here) gap - double-superseding the
same OLD entry with two different successors resolves the conflict via
lexicographically-smallest id rather than most-recent - was found during
re-verification and filed as its own follow-up rather than blocking this task.

## Test plan

All run from a clean worktree with `CARGO_TARGET_DIR` pointed at the shared
target dir and `SPELUNK_SECRET_STORE=file`:

- `cargo fmt --all -- --check` - clean
- `cargo clippy --workspace --all-targets --features rich-formats -- -D warnings` - clean
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` - clean
- `cargo test --workspace --features rich-formats` - 0 failed
- `cargo test --workspace --no-default-features` - 0 failed
- `cargo test --doc --workspace --features rich-formats` - ok
- Manual CLI repro (pre-init, no `.spelunk/`): `memory add --supersedes <bad-id>`
  prints a warning and exits 0 with no bogus carrier record; a valid
  `--supersedes` archives OLD exactly once in the carrier, with the edge on
  OLD's record pointing at NEW, and `memory list`/`memory list --archived`
  render it correctly (archived, never live, never duplicated).
- Independently re-read `append_state_update`, both call sites, and
  `fold.rs`'s merge rules to confirm the two-clone genuine-diverging-merge
  test (`supersede_edge_travels_across_a_genuinely_diverging_merge`) actually
  forces `git notes merge -s cat_sort_uniq` to union two histories with no
  common ancestor, rather than fast-forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)