### PR TITLE
ADR-053 #4b: CLI sync sends locally-computed fp32/896 vector when server accepts it

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -298,6 +298,14 @@ pub struct Capabilities {
     #[serde(skip_serializing)]
     #[allow(dead_code)]
     pub plan: bool,
+    /// The server accepts a client-pushed embedding vector on `POST
+    /// /memory/batch` (ADR-053 #4b), advertised as a top-level `bool` in
+    /// `/v1/health` (NOT an entry in the `capabilities` array). When set, the
+    /// sync push may send the locally-computed fp32/896 vector instead of making
+    /// the server re-embed; when unset (older server / OSS team server) the push
+    /// stays text-only. Not surfaced in user-facing output.
+    #[serde(skip_serializing)]
+    pub accepts_pushed_vectors: bool,
 }
 
 impl Capabilities {
@@ -313,6 +321,9 @@ impl Capabilities {
             memory_harvest: memory,
             explore: has("explore"),
             plan: has("plan"),
+            // Not derivable from the `capabilities` array — it is a separate
+            // top-level bool set by `parse_health` from the health body.
+            accepts_pushed_vectors: false,
         }
     }
 
@@ -328,6 +339,8 @@ impl Capabilities {
             memory_harvest: false,
             explore: false,
             plan: false,
+            // A legacy plain-text server pre-dates the pushed-vector accept side.
+            accepts_pushed_vectors: false,
         }
     }
 
@@ -343,6 +356,7 @@ impl Capabilities {
             memory_harvest: true,
             explore: true,
             plan: true,
+            accepts_pushed_vectors: true,
         }
     }
 }
@@ -783,6 +797,12 @@ async fn parse_health(
         /// Absent on older servers → `server_limits` stays `None`.
         #[serde(default)]
         limits: Option<ServerLimits>,
+        /// Whether the server accepts a client-pushed embedding vector on
+        /// `POST /memory/batch` (ADR-053 #4b). Top-level bool, not a
+        /// `capabilities` entry. Absent on servers without the accept side
+        /// (older servers, the OSS team server) → defaults false.
+        #[serde(default)]
+        accepts_pushed_vectors: bool,
     }
 
     match resp.json::<HealthBody>().await {
@@ -809,12 +829,11 @@ async fn parse_health(
                 tracing::debug!("server instance_id: {id}");
             }
             let cap_strs: Vec<&str> = body.capabilities.iter().map(String::as_str).collect();
-            (
-                Capabilities::from_server_caps(&cap_strs),
-                body.embedding_dim,
-                embedder_state,
-                body.limits,
-            )
+            let mut caps = Capabilities::from_server_caps(&cap_strs);
+            // `accepts_pushed_vectors` is a top-level health bool, not a
+            // `capabilities` array entry, so it is applied after the array parse.
+            caps.accepts_pushed_vectors = body.accepts_pushed_vectors;
+            (caps, body.embedding_dim, embedder_state, body.limits)
         }
         Err(_) => {
             // Legacy server returns plain-text "ok" — conservative fallback.
@@ -1379,6 +1398,61 @@ mod tests {
         assert!(
             matches!(result, Ok(Tier::Server { .. })),
             "auto-discovered loopback with correct dim must return Server; got {result:?}"
+        );
+    }
+
+    // ── accepts_pushed_vectors (top-level health bool, ADR-053 #4b) ────────────
+
+    /// A server advertising `accepts_pushed_vectors: true` must parse into
+    /// `caps.accepts_pushed_vectors == true` — the gate the sync push reads
+    /// before attaching a client-computed vector.
+    #[tokio::test]
+    async fn probe_url_parses_accepts_pushed_vectors_true() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let mut body = health_body(&["memory"], spelunk_core::embeddings::EMBEDDING_DIM);
+        body["accepts_pushed_vectors"] = serde_json::json!(true);
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+
+        let tier = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, true, None)
+            .await
+            .expect("probe must succeed");
+        assert!(
+            tier.caps().unwrap().accepts_pushed_vectors,
+            "health `accepts_pushed_vectors: true` must set the capability"
+        );
+    }
+
+    /// A server that omits the field (older server, or the OSS team server)
+    /// must default to `false` — the push stays text-only there.
+    #[tokio::test]
+    async fn probe_url_accepts_pushed_vectors_defaults_false_when_absent() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // `health_body` carries no `accepts_pushed_vectors` field.
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body(
+                &["memory"],
+                spelunk_core::embeddings::EMBEDDING_DIM,
+            )))
+            .mount(&server)
+            .await;
+
+        let tier = probe_url(&server.uri(), REMOTE_PROBE_TIMEOUT, true, None)
+            .await
+            .expect("probe must succeed");
+        assert!(
+            !tier.caps().unwrap().accepts_pushed_vectors,
+            "absent `accepts_pushed_vectors` must default to false (text-only)"
         );
     }
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -1,10 +1,15 @@
 //! `spelunk memory push` — one-way push of local memory to the cloud.
 //!
 //! ADR-037 D2/D3 changes vs. the MVP placeholder:
-//! - **Text-only.** The client never ships a vector; the server backfills the
-//!   embedding with its configured model (ADR-010/ADR-020). The old
-//!   `local.get_embedding(...)` send path is gone — it carried the *local*
-//!   model's vectors into the cloud's space and broke KNN over synced rows.
+//! - **Text-only by default; optional pushed vector.** The client ships no
+//!   vector and the server backfills the embedding with its configured model
+//!   (ADR-010/ADR-020) — unless the server advertises `accepts_pushed_vectors`
+//!   (ADR-053 #4b), in which case an entry with a local fp32/896 embedding
+//!   carries it (same model + dim as the server), so the server stores it as-is
+//!   instead of re-embedding. The old unconditional `get_embedding` send path
+//!   (which carried a *mismatched* local model's vectors into the cloud's space
+//!   and broke KNN) stays gone; the gated path only sends a vector the server
+//!   has said it will accept for its own space.
 //! - **Batched.** Entries go via `POST /memory/batch`, not N single POSTs.
 //! - **Idempotent.** Each entry carries its stable UUID as the cloud
 //!   `external_id`, so re-pushing skips already-present entries instead of
@@ -59,7 +64,16 @@ pub async fn memory_push(
     )?;
 
     println!("Pushing local memory to {base_url}…");
-    let summary = push_local_oneway(&local, &client, args.include_archived).await?;
+    // Attach the local fp32/896 vector only when the server advertises it
+    // (ADR-053 #4b); otherwise the push is text-only and the server re-embeds.
+    let accepts_pushed_vectors = tier.caps().is_some_and(|c| c.accepts_pushed_vectors);
+    let summary = push_local_oneway(
+        &local,
+        &client,
+        args.include_archived,
+        accepts_pushed_vectors,
+    )
+    .await?;
     if summary.attempted == 0 {
         if summary.already_synced > 0 {
             println!(

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -19,8 +19,11 @@
 //!   ones; semantic-dup detection is the server's job (it flags `contradicts`).
 //! - **Lifecycle propagation.** `supersedes` and archive/tombstone state travel
 //!   in both directions (previously hard-coded `None`/dropped).
-//! - **Text-only.** Pushes never ship a vector; the server backfills embeddings
-//!   (ADR-010/ADR-020).
+//! - **Text-only by default; optional pushed vector.** A push ships no vector
+//!   and the server backfills the embedding (ADR-010/ADR-020) — unless the
+//!   server advertises `accepts_pushed_vectors` (ADR-053 #4b), in which case an
+//!   entry with a local fp32/896 embedding carries it so the server stores it
+//!   as-is instead of re-embedding.
 
 use anyhow::{Context, Result};
 
@@ -127,8 +130,17 @@ pub async fn memory_sync(
         cfg.server_ca.as_deref().map(std::path::Path::new),
     )?;
 
-    // ── Push local → cloud (batched, text-only, idempotent on UUID) ─────────
-    let pushed = push_local(&local, &client, args.include_archived).await?;
+    // ── Push local → cloud (batched, idempotent on UUID). Attaches the local
+    // fp32/896 vector when the server advertises `accepts_pushed_vectors`,
+    // otherwise text-only and the server re-embeds. ────────────────────────
+    let accepts_pushed_vectors = tier.caps().is_some_and(|c| c.accepts_pushed_vectors);
+    let pushed = push_local(
+        &local,
+        &client,
+        args.include_archived,
+        accepts_pushed_vectors,
+    )
+    .await?;
 
     // ── Pull cloud → local (delta after the UUID cursor, keep-both) ─────────
     let pulled = pull_and_apply(&local, &client).await?;
@@ -193,20 +205,30 @@ pub(super) struct PushSummary {
 }
 
 /// One-way push entry point reused by `spelunk memory push`.
+///
+/// `accepts_pushed_vectors` mirrors the destination server's `/v1/health`
+/// capability (ADR-053 #4b): when true, each entry that has a local embedding
+/// carries its fp32/896 vector so the server stores it as-is; when false the
+/// push is text-only and the server re-embeds.
 pub(super) async fn push_local_oneway(
     local: &MemoryStore,
     client: &CloudSyncClient,
     include_archived: bool,
+    accepts_pushed_vectors: bool,
 ) -> Result<PushSummary> {
-    push_local(local, client, include_archived).await
+    push_local(local, client, include_archived, accepts_pushed_vectors).await
 }
 
-/// Push local entries to the cloud as text-only batches, then propagate
-/// tombstones for any archived rows that exist cloud-side.
+/// Push local entries to the cloud in batches, then propagate tombstones for any
+/// archived rows that exist cloud-side. Each entry is text-only unless
+/// `accepts_pushed_vectors` is set and the row has a local fp32/896 embedding,
+/// in which case that vector is attached (the server stores it without
+/// re-embedding).
 async fn push_local(
     local: &MemoryStore,
     client: &CloudSyncClient,
     include_archived: bool,
+    accepts_pushed_vectors: bool,
 ) -> Result<PushSummary> {
     let rows = local.rows_for_sync(include_archived)?;
     if rows.is_empty() {
@@ -241,20 +263,39 @@ async fn push_local(
     // Map external_id (local uuid) → local_id so we can record the cloud-minted
     // id returned in the 207 result back onto the local row.
     for chunk in live.chunks(200) {
-        let items: Vec<BatchPushItem> = chunk
-            .iter()
-            .map(|r| BatchPushItem {
-                kind: r.kind.clone(),
-                title: r.title.clone(),
-                body: if r.body.is_empty() {
-                    None
-                } else {
-                    Some(r.body.clone())
-                },
-                external_id: r.uuid.clone(),
-                source_commit: r.source_ref.clone(),
-            })
-            .collect();
+        let mut items: Vec<BatchPushItem> = Vec::with_capacity(chunk.len());
+        for r in chunk {
+            // Only read the local embedding when the server can accept it. The
+            // stored blob is raw little-endian fp32 (`vec_to_blob`); decode it
+            // and only attach a correctly-dimensioned (896) vector — a
+            // wrong-length or missing embedding falls back to text-only rather
+            // than poisoning the whole batch with a 4xx.
+            let vector = if accepts_pushed_vectors {
+                local
+                    .get_embedding(r.local_id)?
+                    .map(|blob| spelunk_core::embeddings::blob_to_vec(&blob))
+                    .filter(|v| v.len() == spelunk_core::embeddings::EMBEDDING_DIM)
+            } else {
+                None
+            };
+            items.push(
+                BatchPushItem {
+                    kind: r.kind.clone(),
+                    title: r.title.clone(),
+                    body: if r.body.is_empty() {
+                        None
+                    } else {
+                        Some(r.body.clone())
+                    },
+                    external_id: r.uuid.clone(),
+                    source_commit: r.source_ref.clone(),
+                    vector: None,
+                    vector_model: None,
+                    vector_precision: None,
+                }
+                .maybe_attach_vector(accepts_pushed_vectors, vector),
+            );
+        }
         let res = client.push_batch(items).await?;
 
         // `created`/`skipped`/`failed` (aggregate ints) and `results[]`
@@ -498,6 +539,9 @@ mod tests {
                 body: Some("B".into()),
                 external_id: "e1".into(),
                 source_commit: None,
+                vector: None,
+                vector_model: None,
+                vector_precision: None,
             }])
             .await
             .expect("push to the lazily-created project must succeed");
@@ -567,7 +611,7 @@ mod tests {
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
         // First push: creates both, persists the server-minted id on each row.
-        let s1 = push_local(&store, &client, false).await.unwrap();
+        let s1 = push_local(&store, &client, false, false).await.unwrap();
         assert_eq!((s1.attempted, s1.created, s1.skipped), (2, 2, 0));
         assert_eq!(
             store.note_id_for_remote_id(cloud_a).unwrap(),
@@ -584,7 +628,7 @@ mod tests {
         // and no batch request is sent — the re-sync is a no-op. `attempted` must
         // reflect that (not the raw row count), so callers never report "Pushed
         // N" when nothing was sent.
-        let s2 = push_local(&store, &client, false).await.unwrap();
+        let s2 = push_local(&store, &client, false, false).await.unwrap();
         assert_eq!((s2.attempted, s2.created, s2.already_synced), (0, 0, 2));
         assert_eq!(
             server.received_requests().await.unwrap().len(),
@@ -593,6 +637,99 @@ mod tests {
         );
         // No duplicate local rows introduced by the round trip.
         assert_eq!(store.count().unwrap(), 2);
+    }
+
+    // ── pushed-vector fast path (ADR-053 #4b) ──────────────────────────────
+    // A note with a local fp32/896 embedding carries that vector (+ model tag
+    // + precision "fp32") to a server advertising `accepts_pushed_vectors`, so
+    // the server stores it as-is; against a server without the capability the
+    // same note is pushed text-only even though the vector is available. This
+    // exercises the full `push_local` wiring: it reads the local embedding and
+    // consults the gate, which the `maybe_attach_vector` unit test cannot.
+
+    /// Insert an active note plus a valid L2-normalised fp32/896 embedding,
+    /// returning its local id + external uuid.
+    fn note_with_embedding(store: &MemoryStore) -> (i64, String) {
+        store
+            .add_note("decision", "One", "first", &[], &[], None, None)
+            .unwrap();
+        let dim = spelunk_core::embeddings::EMBEDDING_DIM;
+        let vec: Vec<f32> = vec![1.0 / (dim as f32).sqrt(); dim];
+        let blob = spelunk_core::embeddings::vec_to_blob(&vec);
+        let rows = store.rows_for_sync(false).unwrap();
+        assert_eq!(rows.len(), 1);
+        store.insert_embedding(rows[0].local_id, &blob).unwrap();
+        (rows[0].local_id, rows[0].uuid.clone())
+    }
+
+    #[tokio::test]
+    async fn push_local_attaches_vector_when_server_accepts() {
+        use tempfile::TempDir;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        let (_id, uuid) = note_with_embedding(&store);
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 1, "skipped": 0, "failed": 0,
+                "results": [{"status": "created", "external_id": uuid, "id": "cloud-1"}]
+            })))
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        // accepts_pushed_vectors = true → the fp32/896 vector reaches the wire.
+        push_local(&store, &client, false, true).await.unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        let entry = &json["entries"][0];
+        assert_eq!(
+            entry["vector"].as_array().map(Vec::len),
+            Some(spelunk_core::embeddings::EMBEDDING_DIM),
+            "server that accepts vectors must receive the 896-dim vector: {entry}"
+        );
+        assert_eq!(entry["vector_model"], "F2LLM-v2-330M");
+        assert_eq!(entry["vector_precision"], "fp32");
+    }
+
+    #[tokio::test]
+    async fn push_local_stays_text_only_when_server_declines() {
+        use tempfile::TempDir;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        let (_id, uuid) = note_with_embedding(&store);
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 1, "skipped": 0, "failed": 0,
+                "results": [{"status": "created", "external_id": uuid, "id": "cloud-1"}]
+            })))
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        // accepts_pushed_vectors = false → text-only, despite a local vector.
+        push_local(&store, &client, false, false).await.unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        let body = String::from_utf8(reqs[0].body.clone()).unwrap();
+        assert!(
+            !body.contains("vector"),
+            "server without the capability must get a text-only push: {body}"
+        );
     }
 
     // ── stamping must not trust a non-persisted status ─────────────────────
@@ -635,7 +772,7 @@ mod tests {
             .await;
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-        let s1 = push_local(&store, &client, false).await.unwrap();
+        let s1 = push_local(&store, &client, false, false).await.unwrap();
         assert_eq!((s1.attempted, s1.created, s1.skipped), (1, 0, 0));
 
         // The row must NOT carry the id the server handed back — it stays
@@ -696,7 +833,7 @@ mod tests {
             .await;
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-        let s1 = push_local(&store, &client, false).await.unwrap();
+        let s1 = push_local(&store, &client, false, false).await.unwrap();
         // Reconciled from `results[]`, not the misleading aggregate zeros.
         assert_eq!(
             (s1.attempted, s1.created, s1.skipped, s1.failed),
@@ -753,7 +890,7 @@ mod tests {
             .await;
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-        let s1 = push_local(&store, &client, false).await.unwrap();
+        let s1 = push_local(&store, &client, false, false).await.unwrap();
         assert_eq!(
             (s1.attempted, s1.created, s1.skipped, s1.failed),
             (2, 1, 0, 1),
@@ -817,7 +954,7 @@ mod tests {
             .await;
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-        let s1 = push_local(&store, &client, false).await.unwrap();
+        let s1 = push_local(&store, &client, false, false).await.unwrap();
         assert_eq!(
             (s1.attempted, s1.created, s1.skipped, s1.failed),
             (2, 0, 0, 2),

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -732,6 +732,134 @@ mod tests {
         );
     }
 
+    /// A note queued for push with NO `note_embeddings` row at all (never
+    /// embedded locally, or embedding failed) must fall back to a text-only
+    /// push for that row — not crash, and not send an empty/malformed
+    /// `vector` field — even though the server accepts pushed vectors.
+    #[tokio::test]
+    async fn push_local_falls_back_to_text_only_when_local_embedding_missing() {
+        use tempfile::TempDir;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        // Deliberately no `insert_embedding` call — this note has never been
+        // embedded.
+        store
+            .add_note("decision", "Unembedded", "first", &[], &[], None, None)
+            .unwrap();
+        let rows = store.rows_for_sync(false).unwrap();
+        assert_eq!(rows.len(), 1);
+        let uuid = rows[0].uuid.clone();
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 1, "skipped": 0, "failed": 0,
+                "results": [{"status": "created", "external_id": uuid, "id": "cloud-1"}]
+            })))
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        // accepts_pushed_vectors = true, but no local embedding exists.
+        let summary = push_local(&store, &client, false, true).await.unwrap();
+        assert_eq!(
+            (summary.attempted, summary.created, summary.failed),
+            (1, 1, 0)
+        );
+
+        let reqs = server.received_requests().await.unwrap();
+        let body = String::from_utf8(reqs[0].body.clone()).unwrap();
+        assert!(
+            !body.contains("vector"),
+            "a note with no local embedding must fall back to text-only, \
+             not error or send a malformed vector: {body}"
+        );
+    }
+
+    /// `note_embeddings` is a `vec0` virtual table with a `FLOAT[896]` column
+    /// (migration `004_memory.sql`) — sqlite-vec enforces that exact
+    /// dimension AT INSERT TIME, for every write path (there is only one:
+    /// `insert_embedding`). So a "leftover pre-896 768-dim row" — unlike the
+    /// code-chunk `embeddings` table, which DID have a legacy 768-dim era
+    /// with an explicit recreate-on-open migration in `db.rs` — can never
+    /// actually be written for memory notes: there was never a 768-dim
+    /// memory-embedding vintage to migrate from, and the store itself
+    /// refuses the write. Confirmed here rather than assumed, since it is
+    /// exactly the scenario `push_local`'s dimension guard names in its
+    /// comment.
+    #[tokio::test]
+    async fn insert_embedding_rejects_wrong_dimension_vector() {
+        use tempfile::TempDir;
+
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        store
+            .add_note("decision", "One", "first", &[], &[], None, None)
+            .unwrap();
+        let rows = store.rows_for_sync(false).unwrap();
+
+        let stale_768_blob = spelunk_core::embeddings::vec_to_blob(&vec![1.0f32; 768]);
+        let err = store
+            .insert_embedding(rows[0].local_id, &stale_768_blob)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("896") && err.to_string().contains("768"),
+            "the vec0 FLOAT[896] column must refuse a 768-dim insert outright \
+             (this is what makes a wrong-dimension row unreachable via any \
+             application write path): {err}"
+        );
+    }
+
+    /// Since a wrong-dimension row can never be *written* (previous test),
+    /// the only way `push_local`'s guard (`blob_to_vec` decode + a length
+    /// check against `EMBEDDING_DIM` — the same two building blocks
+    /// exercised inline at `sync.rs`'s vector-resolution site) could ever
+    /// see a wrong-length vector is an on-disk blob corrupted or torn
+    /// independently of any insert (disk fault, a crash mid-write). This
+    /// pins that composed guard logic directly: it must never panic on a
+    /// short/truncated/empty blob, and must always filter such a decode out
+    /// rather than accept a spurious length or garbage-padded 896 vector.
+    #[test]
+    fn dim_guard_logic_rejects_short_truncated_and_empty_blobs() {
+        use spelunk_core::embeddings::{EMBEDDING_DIM, blob_to_vec, vec_to_blob};
+
+        let guarded = |blob: &[u8]| -> Option<Vec<f32>> {
+            Some(blob_to_vec(blob)).filter(|v| v.len() == EMBEDDING_DIM)
+        };
+
+        // A stale 768-float blob (wrong dimension, but cleanly decodable).
+        let stale_768 = vec_to_blob(&vec![1.0f32; 768]);
+        assert!(
+            guarded(&stale_768).is_none(),
+            "a 768-float blob must be filtered out, not accepted"
+        );
+
+        // A torn write: a valid 896-dim blob with its last few bytes cut off.
+        let full = vec_to_blob(&vec![1.0f32; EMBEDDING_DIM]);
+        let truncated = &full[..full.len() - 10];
+        assert_ne!(
+            blob_to_vec(truncated).len(),
+            EMBEDDING_DIM,
+            "sanity: a truncated blob must decode to a non-896 length"
+        );
+        assert!(
+            guarded(truncated).is_none(),
+            "a truncated blob must never pass the dimension guard"
+        );
+
+        // A zero-length blob (e.g. corrupted read).
+        assert!(
+            guarded(&[]).is_none(),
+            "an empty blob must be filtered out, not treated as a valid vector"
+        );
+    }
+
     // ── stamping must not trust a non-persisted status ─────────────────────
     // A server can return a per-item `id` for an entry alongside a status
     // that does not affirm durable persistence (aggregate `created: 0`).

--- a/crates/spelunk-core/src/storage/remote/sync.rs
+++ b/crates/spelunk-core/src/storage/remote/sync.rs
@@ -16,19 +16,45 @@
 //! entries carry the cloud `id` (a UUID), which we record as the local
 //! `remote_id` and dedupe on, so a subsequent push of the same entry is a no-op.
 //!
-//! Embedding conformance (ADR-010/ADR-020, ADR-037 D3): pushes are **text only**
-//! — the `vector` field is always omitted and the server backfills with its
-//! configured model. There is deliberately no client-vector send path here.
+//! Embedding conformance (ADR-010/ADR-020, ADR-053): a push is **text-only by
+//! default** — the `vector` field is omitted and the server backfills the
+//! embedding with its configured model. As a compute/bandwidth optimization,
+//! when the destination advertises the `accepts_pushed_vectors` capability the
+//! CLI MAY attach the locally-computed full-precision (fp32/896) vector it
+//! already holds, tagged with the model and precision the accept side
+//! validates. A server without the capability (an older server, or the OSS team
+//! server) never receives a vector and re-embeds — so text-only remains the
+//! universal fallback.
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use super::encode_project_id;
 
+/// Precision tag sent alongside a client-pushed memory vector. Memory vectors
+/// cross to the cloud, so they are ALWAYS full-precision fp32 — never the
+/// int8/halfvec quantisation used for the local code index. The accept side
+/// rejects (4xx) any other precision, so it is never sent.
+const PUSHED_VECTOR_PRECISION: &str = "fp32";
+
+/// The `vector_model` tag a vector-accepting server validates for exact string
+/// equality. It is the model *family* portion of [`crate::embeddings::MODEL_ID`]
+/// (`"F2LLM-v2-330M@896"`) with the `@<dim>` suffix stripped — the dimension is
+/// carried by the fixed 896-dim contract, and the accept side compares only the
+/// family string (its own model constant has no `@<dim>` suffix). Deriving it
+/// from `MODEL_ID` keeps a single source of truth for the model identity.
+fn pushed_vector_model_tag() -> &'static str {
+    let id = crate::embeddings::MODEL_ID;
+    id.split('@').next().unwrap_or(id)
+}
+
 /// One entry pushed to `POST /memory/batch`.
 ///
 /// `external_id` carries the local entry's stable UUID — the server's
-/// idempotency key. `vector` is intentionally absent (text-only; ADR-037 D3).
+/// idempotency key. `vector`/`vector_model`/`vector_precision` are the optional
+/// client-pushed embedding fast path (ADR-053 #4b): omitted for a text-only
+/// push (the default), populated only for a server advertising
+/// `accepts_pushed_vectors` via [`BatchPushItem::maybe_attach_vector`].
 #[derive(Debug, Serialize)]
 pub struct BatchPushItem {
     pub kind: String,
@@ -39,6 +65,45 @@ pub struct BatchPushItem {
     pub external_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_commit: Option<String>,
+    /// Locally-computed full-precision (fp32) embedding. Present only when the
+    /// destination advertises `accepts_pushed_vectors`; otherwise omitted so the
+    /// server re-embeds (text-only fallback).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector: Option<Vec<f32>>,
+    /// Model tag for a pushed `vector` (accept-side field `vector_model`).
+    /// Required by the server whenever `vector` is present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector_model: Option<String>,
+    /// Precision of a pushed `vector` (accept-side field `vector_precision`);
+    /// always `"fp32"` when present. Required by the server whenever `vector`
+    /// is present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector_precision: Option<String>,
+}
+
+impl BatchPushItem {
+    /// Attach a locally-computed embedding to this item, gated on the
+    /// destination server advertising `accepts_pushed_vectors`.
+    ///
+    /// When `server_accepts_vectors` is false (an older server, or the OSS team
+    /// server) or `vector` is `None` (the local row has no embedding), the item
+    /// is left text-only — the server re-embeds. When both hold, the fp32 vector
+    /// is attached alongside its model tag and `vector_precision = "fp32"`, and
+    /// the server stores it verbatim (no re-embed). Precision is ALWAYS fp32;
+    /// reduced precision is never sent because memory vectors cross to the
+    /// cloud.
+    pub fn maybe_attach_vector(
+        mut self,
+        server_accepts_vectors: bool,
+        vector: Option<Vec<f32>>,
+    ) -> Self {
+        if let (true, Some(v)) = (server_accepts_vectors, vector) {
+            self.vector = Some(v);
+            self.vector_model = Some(pushed_vector_model_tag().to_string());
+            self.vector_precision = Some(PUSHED_VECTOR_PRECISION.to_string());
+        }
+        self
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -240,13 +305,28 @@ mod tests {
             body: Some("B".into()),
             external_id: ext.into(),
             source_commit: None,
+            vector: None,
+            vector_model: None,
+            vector_precision: None,
         }
     }
 
+    /// A valid L2-normalised fp32/896 vector (norm == 1.0), the shape a local
+    /// `note_embeddings` row holds.
+    fn unit_vec_896() -> Vec<f32> {
+        let n = spelunk_core_embedding_dim();
+        vec![1.0 / (n as f32).sqrt(); n]
+    }
+
+    fn spelunk_core_embedding_dim() -> usize {
+        crate::embeddings::EMBEDDING_DIM
+    }
+
+    /// The push is text-only by default, and carries the fp32/896 vector + model
+    /// tag ONLY for a server advertising `accepts_pushed_vectors` (ADR-053 #4b).
     #[tokio::test]
     async fn push_batch_is_text_only_no_vector() {
         let server = MockServer::start().await;
-        // The pushed body must NOT contain a vector/embedding field (ADR-037 D3).
         Mock::given(method("POST"))
             .and(path("/v1/projects/proj/memory/batch"))
             .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
@@ -255,21 +335,54 @@ mod tests {
             })))
             .mount(&server)
             .await;
-
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
-        let res = client.push_batch(vec![item("e1")]).await.unwrap();
-        assert_eq!(res.created, 1);
 
-        // Inspect the recorded request body — it must carry external_id but no
-        // vector/embedding key at all.
+        // ── Case A: server WITHOUT the capability → text-only, no vector at all,
+        // even though a local vector is available to attach. ──────────────────
+        let text_only = item("e1").maybe_attach_vector(false, Some(unit_vec_896()));
+        client.push_batch(vec![text_only]).await.unwrap();
+
+        // ── Case B: server WITH the capability → fp32/896 vector + model tag. ──
+        let with_vec = item("e2").maybe_attach_vector(true, Some(unit_vec_896()));
+        client.push_batch(vec![with_vec]).await.unwrap();
+
         let reqs = server.received_requests().await.unwrap();
-        let body = String::from_utf8(reqs[0].body.clone()).unwrap();
-        assert!(body.contains("\"external_id\":\"e1\""), "body: {body}");
-        assert!(!body.contains("vector"), "push must be text-only: {body}");
+        assert_eq!(reqs.len(), 2);
+
+        // Case A body: external_id present, no vector/model/precision keys.
+        let body_a = String::from_utf8(reqs[0].body.clone()).unwrap();
+        assert!(body_a.contains("\"external_id\":\"e1\""), "body: {body_a}");
         assert!(
-            !body.contains("embedding"),
-            "push must be text-only: {body}"
+            !body_a.contains("vector"),
+            "no-capability push must be text-only: {body_a}"
         );
+
+        // Case B body: fp32/896 vector + exact model tag + precision "fp32".
+        let json_b: serde_json::Value =
+            serde_json::from_slice(&reqs[1].body).expect("valid JSON body");
+        let entry = &json_b["entries"][0];
+        let vec = entry["vector"]
+            .as_array()
+            .expect("vector must be a JSON array when the server accepts it");
+        assert_eq!(
+            vec.len(),
+            spelunk_core_embedding_dim(),
+            "pushed vector must be 896-dim"
+        );
+        assert!(
+            vec.iter().all(|v| v.is_number()),
+            "vector components must be fp32 numbers: {entry}"
+        );
+        // The tag is the model family with no `@<dim>` suffix (accept-side
+        // contract); the dim travels separately.
+        assert_eq!(entry["vector_model"], "F2LLM-v2-330M");
+        assert!(
+            entry["vector_model"]
+                .as_str()
+                .is_some_and(|s| !s.contains('@')),
+            "model tag must not carry the @<dim> suffix: {entry}"
+        );
+        assert_eq!(entry["vector_precision"], "fp32");
     }
 
     #[tokio::test]

--- a/crates/spelunk-server/tests/cli_sync_e2e.rs
+++ b/crates/spelunk-server/tests/cli_sync_e2e.rs
@@ -110,6 +110,9 @@ async fn cli_push_then_repush_is_idempotent_then_since_roundtrips() {
                 body: Some("why we did it".into()),
                 external_id: format!("uuid-a-{suffix}"),
                 source_commit: Some("deadbeef".into()),
+                vector: None,
+                vector_model: None,
+                vector_precision: None,
             },
             BatchPushItem {
                 kind: "note".into(),
@@ -117,6 +120,9 @@ async fn cli_push_then_repush_is_idempotent_then_since_roundtrips() {
                 body: None,
                 external_id: format!("uuid-b-{suffix}"),
                 source_commit: None,
+                vector: None,
+                vector_model: None,
+                vector_precision: None,
             },
         ]
     };
@@ -206,6 +212,9 @@ async fn cli_push_lazily_creates_the_project() {
             body: None,
             external_id: "uuid-first".into(),
             source_commit: None,
+            vector: None,
+            vector_model: None,
+            vector_precision: None,
         }])
         .await
         .expect("push to a not-yet-existing project must succeed (lazy create)");
@@ -233,6 +242,9 @@ async fn concurrent_identical_batches_settle_without_duplicates_or_500s() {
             body: None,
             external_id: "race-1".into(),
             source_commit: None,
+            vector: None,
+            vector_model: None,
+            vector_precision: None,
         }]
     };
 
@@ -319,6 +331,9 @@ async fn cli_pull_since_retrieves_pushed_and_legacy_entries_then_cursor_advances
             body: Some("why we did it".into()),
             external_id: "uuid-pushed-1".into(),
             source_commit: Some("cafef00d".into()),
+            vector: None,
+            vector_model: None,
+            vector_precision: None,
         }])
         .await
         .expect("push_batch must succeed");


### PR DESCRIPTION
## Summary
- Optional client-pushed-vector fast path for `spelunk sync` / `spelunk memory push`: when the server advertises `accepts_pushed_vectors` (top-level bool in `/v1/health`), the CLI attaches the locally-computed fp32/896 embedding to `BatchPushItem` (`vector` / `vector_model` / `vector_precision`) instead of leaving the push text-only for the server to re-embed.
- Model tag is derived from the CLI's own `MODEL_ID` constant by stripping the `@<dim>` suffix, matching the cloud-api accept side's bare family string (`F2LLM-v2-330M`), verified directly against `cloud-api/src/embedding.rs` and `routes/memory.rs`.
- Text-only fallback is preserved for servers without the flag (older servers, the OSS team server) and for local rows with no embedding or a dimension mismatch.
- This branch was rebased onto current `main` to pick up #663's consolidated `spelunk_state_dir()` resolver; the feature diff itself is unchanged by the rebase (still 5 files, 534/53 lines).

## Test plan
- `SPELUNK_SECRET_STORE=file cargo fmt --all --check` — clean
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` — clean
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets --no-default-features -- -D warnings` — clean
- `SPELUNK_SECRET_STORE=file cargo test --workspace` — 0 failures (396 unit + all integration suites, 58 test binaries)
- `SPELUNK_SECRET_STORE=file cargo test --workspace --no-default-features` — 0 failures (same counts)
- Verified `merge-base HEAD origin/main` equals `origin/main` HEAD (branch is current, not stale)
- Verified exactly one `spelunk_state_dir()` definition repo-wide, matching #663's consolidated form; diffed all previously-flagged files against `origin/main` — only `capability.rs` differs, scoped entirely to the `accepts_pushed_vectors` field/tests
- No new dependencies (Cargo.toml/Cargo.lock unchanged)