### PR TITLE
fix(oss): scrub private cloud-api ADR-number citations from public content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -978,13 +978,13 @@ to re-embed. (#439, #441)
   machines are preserved. A new `spelunk memory pull` does a one-way delta pull.
   Sync is identity-keyed on a time-ordered UUID carried by each entry, so it is
   idempotent (re-running never duplicates) and drift-free across machine clocks;
-  archived entries propagate as tombstones. (ADR-037 P1, #425)
+  archived entries propagate as tombstones. (#425)
 
 - **Sync modes (`mode = offline | local_first | cloud_first`).** A new `mode`
   config field (and `SPELUNK_MODE` env override) controls how the CLI reconciles
   local and cloud memory. The default preserves existing behaviour: with no
   `server_url` the CLI is `offline`; with a `server_url` set it is `local_first`.
-  `SPELUNK_NO_SERVER=1` remains a hard kill-switch. (ADR-037 P1, #425)
+  `SPELUNK_NO_SERVER=1` remains a hard kill-switch. (#425)
 - **Sync-mode indicator and state-scoped capability hints.** `spelunk status`
   gains a neutral one-word `mode` line reporting the active sync mode
   (`local_first`, `cloud_first`, or `offline`) whenever a `server_url` or an
@@ -995,7 +995,7 @@ to re-embed. (#439, #441)
   instead of suggesting to set one that is already set. `cloud_first` mode pins
   hard-error behavior: reads and writes fail loudly when the server is
   unreachable or untrusted, and local data is never silently substituted as a
-  fallback. (ADR-037)
+  fallback.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Full reference: `SKILL.md` and `docs/agent-guide.md`.
 
 **Semantic search via spelunk-server:** from v0.9.0 the default UX runs a local `spelunk-server` (auto-bound on `127.0.0.1`). The server bundles a native embedder (codefuse-ai/F2LLM-v2-330M, 896-dim, candle runtime, Metal/GPU on macOS) — no external embedding endpoint required. Semantic search, `spelunk explore`, `spelunk memory harvest`, and LLM summaries all route through the server's inference endpoints; the CLI talks to it via `server_client.rs`. Manage the daemon with `spelunk server start|stop|status|logs`. This **auto-discovered loopback server is an inference backend only** — it embeds queries and runs LLM calls, but it is **never** a memory store. A project's memory always lives in its local `memory.db`; the loopback server holds no authoritative memory.
 
-**Optional: team memory server** (`server_url` *explicitly* set in config, pointing at a shared instance): share memory (decisions, requirements) across a team. Setting an explicit `server_url` is the **only** way memory moves off the local `memory.db`, and how it moves is governed by the `mode` config (ADR-037): the default `local_first` keeps reads and writes in the local store with the server as a converging replica; `mode = "cloud_first"` relocates the store of record to the shared server, and reads/writes fail loudly when it is unreachable (no silent local fallback). Each developer's code stays local. (Note the distinction: an auto-discovered loopback server provides inference and never owns memory; an explicit team `server_url` does own memory. They must not be conflated.) When a team server routes projects by an internal UUID, a human `project_id` slug is auto-resolved to that UUID on first use and cached in `.spelunk/cloud-project-id.lock` (see ADR-005); a raw UUID `project_id` is used directly.
+**Optional: team memory server** (`server_url` *explicitly* set in config, pointing at a shared instance): share memory (decisions, requirements) across a team. Setting an explicit `server_url` is the **only** way memory moves off the local `memory.db`, and how it moves is governed by the `mode` config (see `SyncMode` in `sync_mode.rs`): the default `local_first` keeps reads and writes in the local store with the server as a converging replica; `mode = "cloud_first"` relocates the store of record to the shared server, and reads/writes fail loudly when it is unreachable (no silent local fallback). Each developer's code stays local. (Note the distinction: an auto-discovered loopback server provides inference and never owns memory; an explicit team `server_url` does own memory. They must not be conflated.) When a team server routes projects by an internal UUID, a human `project_id` slug is auto-resolved to that UUID on first use and cached in `.spelunk/cloud-project-id.lock` (see ADR-005); a raw UUID `project_id` is used directly.
 
 You search with spelunk, then reason over the results yourself.
 
@@ -78,7 +78,7 @@ lib.rs           — crate root; re-exports public modules
 error.rs         — SpelunkError enum
 config/
   mod.rs         — Config struct; load from ~/.config/spelunk/config.toml
-  sync_mode.rs   — SyncMode enum (ADR-037 D1)
+  sync_mode.rs   — SyncMode enum: offline / local_first / cloud_first mode selection
   project_id.rs  — project-id derivation from git remote / local fallback
   paths.rs       — config-dir + project/db discovery
   persist.rs     — config.toml / secret-store read-write

--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -299,7 +299,7 @@ pub struct Capabilities {
     #[allow(dead_code)]
     pub plan: bool,
     /// The server accepts a client-pushed embedding vector on `POST
-    /// /memory/batch` (ADR-053 #4b), advertised as a top-level `bool` in
+    /// /memory/batch`, advertised as a top-level `bool` in
     /// `/v1/health` (NOT an entry in the `capabilities` array). When set, the
     /// sync push may send the locally-computed fp32/896 vector instead of making
     /// the server re-embed; when unset (older server / OSS team server) the push
@@ -533,7 +533,7 @@ impl Tier {
 /// = one config), but unsuitable for long-running daemons that may use multiple
 /// configs — they would always see the tier determined by the first call.
 pub async fn get_tier(cfg: &Config) -> &'static Tier {
-    // ADR-037 D1: an *explicit* offline mode (config `mode = "offline"`,
+    // An *explicit* offline mode (config `mode = "offline"`,
     // `SPELUNK_MODE=offline`, or the `SPELUNK_NO_SERVER=1` kill-switch) skips all
     // server probes — the user has asked for a provable no-cloud run.
     //
@@ -798,7 +798,7 @@ async fn parse_health(
         #[serde(default)]
         limits: Option<ServerLimits>,
         /// Whether the server accepts a client-pushed embedding vector on
-        /// `POST /memory/batch` (ADR-053 #4b). Top-level bool, not a
+        /// `POST /memory/batch`. Top-level bool, not a
         /// `capabilities` entry. Absent on servers without the accept side
         /// (older servers, the OSS team server) → defaults false.
         #[serde(default)]
@@ -1401,7 +1401,7 @@ mod tests {
         );
     }
 
-    // ── accepts_pushed_vectors (top-level health bool, ADR-053 #4b) ────────────
+    // ── accepts_pushed_vectors (top-level health bool) ──────────────────────────
 
     /// A server advertising `accepts_pushed_vectors: true` must parse into
     /// `caps.accepts_pushed_vectors == true` — the gate the sync push reads

--- a/crates/spelunk-cli/src/cli/cmd/auth_api.rs
+++ b/crates/spelunk-cli/src/cli/cmd/auth_api.rs
@@ -1,6 +1,6 @@
-//! HTTP client for WorkOS-direct device-flow auth (ADR-047).
+//! HTTP client for WorkOS-direct device-flow auth.
 //!
-//! Supersedes the cloud-api `/v1/auth/*` proxy (ADR-045). A live multi-org
+//! Supersedes the cloud-api `/v1/auth/*` proxy. A live multi-org
 //! device login proved every token leg the CLI needs is a WorkOS PUBLIC-CLIENT
 //! exchange — `client_id` only, no secret — so the CLI talks to WorkOS directly
 //! and no longer routes auth through cloud-api.
@@ -403,7 +403,7 @@ pub async fn refresh_token(
 /// runs — every cloud-api call would then `401`. This guard refreshes proactively
 /// when the token is at/past expiry (with a small skew window, see
 /// [`AuthTokens::is_expired`]) using the stored refresh token directly against
-/// WorkOS (refresh grant, ADR-047), persists the rotated tokens to `[auth]`, and
+/// WorkOS (refresh grant), persists the rotated tokens to `[auth]`, and
 /// returns the tokens to use.
 ///
 /// The refresh re-sends `auth.org_id` as `organization_id` so a prior `org

--- a/crates/spelunk-cli/src/cli/cmd/login.rs
+++ b/crates/spelunk-cli/src/cli/cmd/login.rs
@@ -1,4 +1,4 @@
-//! `spelunk login` — WorkOS device-authorization grant, direct (ADR-047).
+//! `spelunk login` — WorkOS device-authorization grant, direct.
 //!
 //! Flow
 //! ----

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -1,15 +1,15 @@
 //! `spelunk memory push` — one-way push of local memory to the cloud.
 //!
-//! ADR-037 D2/D3 changes vs. the MVP placeholder:
+//! Changes vs. the MVP placeholder:
 //! - **Text-only by default; optional pushed vector.** The client ships no
 //!   vector and the server backfills the embedding with its configured model
-//!   (ADR-010/ADR-020) — unless the server advertises `accepts_pushed_vectors`
-//!   (ADR-053 #4b), in which case an entry with a local fp32/896 embedding
-//!   carries it (same model + dim as the server), so the server stores it as-is
-//!   instead of re-embedding. The old unconditional `get_embedding` send path
-//!   (which carried a *mismatched* local model's vectors into the cloud's space
-//!   and broke KNN) stays gone; the gated path only sends a vector the server
-//!   has said it will accept for its own space.
+//!   — unless the server advertises `accepts_pushed_vectors`, in which case an
+//!   entry with a local fp32/896 embedding carries it (same model + dim as the
+//!   server), so the server stores it as-is instead of re-embedding. The old
+//!   unconditional `get_embedding` send path (which carried a *mismatched*
+//!   local model's vectors into the cloud's space and broke KNN) stays gone;
+//!   the gated path only sends a vector the server has said it will accept for
+//!   its own space.
 //! - **Batched.** Entries go via `POST /memory/batch`, not N single POSTs.
 //! - **Idempotent.** Each entry carries its stable UUID as the cloud
 //!   `external_id`, so re-pushing skips already-present entries instead of
@@ -64,8 +64,8 @@ pub async fn memory_push(
     )?;
 
     println!("Pushing local memory to {base_url}…");
-    // Attach the local fp32/896 vector only when the server advertises it
-    // (ADR-053 #4b); otherwise the push is text-only and the server re-embeds.
+    // Attach the local fp32/896 vector only when the server advertises it;
+    // otherwise the push is text-only and the server re-embeds.
     let accepts_pushed_vectors = tier.caps().is_some_and(|c| c.accepts_pushed_vectors);
     let summary = push_local_oneway(
         &local,

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -1,5 +1,4 @@
-//! `spelunk sync` and `spelunk memory pull` — two-way local↔cloud memory sync
-//! (ADR-037 D2/D3).
+//! `spelunk sync` and `spelunk memory pull` — two-way local↔cloud memory sync.
 //!
 //! - `pull`: delta-pull from `GET /memory/since?since_id=<cursor>` and apply
 //!   locally. The cursor is the max cloud `remote_id` already synced
@@ -9,7 +8,7 @@
 //!   (batched, not N single POSTs), then pull everything after the cursor and
 //!   apply both.
 //!
-//! Properties (ADR-037 + ADR-005):
+//! Properties:
 //! - **Idempotent.** Identity is the stable UUID; pushes carry it as the cloud
 //!   `external_id` and pulls record the cloud UUID as the local `remote_id` and
 //!   dedupe on it, so re-running never duplicates. Same-millisecond boundary
@@ -20,8 +19,8 @@
 //! - **Lifecycle propagation.** `supersedes` and archive/tombstone state travel
 //!   in both directions (previously hard-coded `None`/dropped).
 //! - **Text-only by default; optional pushed vector.** A push ships no vector
-//!   and the server backfills the embedding (ADR-010/ADR-020) — unless the
-//!   server advertises `accepts_pushed_vectors` (ADR-053 #4b), in which case an
+//!   and the server backfills the embedding (embedding-model conformance) —
+//!   unless the server advertises `accepts_pushed_vectors`, in which case an
 //!   entry with a local fp32/896 embedding carries it so the server stores it
 //!   as-is instead of re-embedding.
 
@@ -207,7 +206,7 @@ pub(super) struct PushSummary {
 /// One-way push entry point reused by `spelunk memory push`.
 ///
 /// `accepts_pushed_vectors` mirrors the destination server's `/v1/health`
-/// capability (ADR-053 #4b): when true, each entry that has a local embedding
+/// capability: when true, each entry that has a local embedding
 /// carries its fp32/896 vector so the server stores it as-is; when false the
 /// push is text-only and the server re-embeds.
 pub(super) async fn push_local_oneway(
@@ -639,7 +638,7 @@ mod tests {
         assert_eq!(store.count().unwrap(), 2);
     }
 
-    // ── pushed-vector fast path (ADR-053 #4b) ──────────────────────────────
+    // ── pushed-vector fast path ─────────────────────────────────────────────
     // A note with a local fp32/896 embedding carries that vector (+ model tag
     // + precision "fp32") to a server advertising `accepts_pushed_vectors`, so
     // the server stores it as-is; against a server without the capability the

--- a/crates/spelunk-cli/src/cli/cmd/org.rs
+++ b/crates/spelunk-cli/src/cli/cmd/org.rs
@@ -1,5 +1,5 @@
 //! `spelunk org switch <org>` — silently re-scope the session to another
-//! organisation without a new device login (ADR-047).
+//! organisation without a new device login.
 //!
 //! Resolves the org argument to its **WorkOS org id** (`org_…`) — that is what
 //! WorkOS's `/authenticate` refresh grant expects in `organization_id`, NOT the
@@ -234,7 +234,7 @@ mod tests {
         );
     }
 
-    // ── switch_org wire-level tests (WorkOS-direct, ADR-047) ──────────────────
+    // ── switch_org wire-level tests (WorkOS-direct) ────────────────────────────
     //
     // `switch_org` makes two calls: cloud-api `GET /v1/me` (slug → UUID) and
     // WorkOS `POST /user_management/authenticate` (refresh grant). Both are

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -134,7 +134,7 @@ struct BearerState {
 
 /// State needed to rotate an expired/rejected WorkOS access token.
 ///
-/// Refresh now goes DIRECTLY to WorkOS (ADR-047), so the WorkOS base URL and the
+/// Refresh now goes DIRECTLY to WorkOS, so the WorkOS base URL and the
 /// embedded public `client_id` are carried here alongside the rotating tokens.
 struct RefreshState {
     tokens: AuthTokens,
@@ -210,9 +210,9 @@ impl ServerInferenceClient {
         // Carry WorkOS refresh state only when the resolved bearer came from
         // `[auth]`, i.e. `base_url`'s origin is the cloud kind (ADR-071 D2).
         // A self-hosted server-key / env token is not refreshable here.
-        // Refresh targets WorkOS directly (ADR-047): the WorkOS base URL and
-        // the embedded public client_id (derived from the default cloud
-        // host) are captured here.
+        // Refresh targets WorkOS directly: the WorkOS base URL and the
+        // embedded public client_id (derived from the default cloud host)
+        // are captured here.
         let refresh = cfg
             .auth
             .as_ref()
@@ -302,7 +302,7 @@ impl ServerInferenceClient {
     }
 
     /// Rotate the WorkOS access token DIRECTLY via WorkOS `/authenticate`
-    /// (refresh grant, ADR-047), persist the rotated tokens, and update the
+    /// (refresh grant), persist the rotated tokens, and update the
     /// in-memory bearer.
     ///
     /// Returns `Ok(true)` when a refresh was performed, `Ok(false)` when there
@@ -755,7 +755,7 @@ mod tests {
             .mount(&inference)
             .await;
 
-        // The WorkOS refresh exchange rotates the tokens (ADR-047).
+        // The WorkOS refresh exchange rotates the tokens.
         Mock::given(method("POST"))
             .and(path("/user_management/authenticate"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -548,7 +548,7 @@ async fn test_status_json_includes_tier_fields() {
     assert!(body["capabilities"]["plan"].is_null());
     assert!(!body["capabilities"]["explore"].as_bool().unwrap());
     // With an explicit server_url and no `mode` override, the default is
-    // local_first (ADR-037 D1) even though the tier probe found the server
+    // local_first even though the tier probe found the server
     // reachable: tier and sync mode are independent axes.
     assert_eq!(body["mode"], "local_first", "got: {body}");
 }

--- a/crates/spelunk-cli/tests/memory_read_mode_notice.rs
+++ b/crates/spelunk-cli/tests/memory_read_mode_notice.rs
@@ -1,4 +1,4 @@
-//! Read commands under a configured team `server_url` (ADR-037).
+//! Read commands under a configured team `server_url`.
 //!
 //! With `server_url` set, the default `local_first` mode serves reads from the
 //! local store. That is by design (offline-resilient; the background reconciler

--- a/crates/spelunk-core/migrations/020_memory_uuid.sql
+++ b/crates/spelunk-core/migrations/020_memory_uuid.sql
@@ -1,4 +1,4 @@
--- ADR-037 D2: stable cross-store identity for memory entries.
+-- Stable cross-store identity for memory entries.
 --
 -- Local IDs are autoincrement i64 and are NOT stable across machines, so they
 -- cannot correlate a local row with its cloud-api counterpart. We add two
@@ -14,7 +14,7 @@
 --                   `remote_id` so an entry that originated locally is never
 --                   re-inserted when it comes back down the `since` feed.
 --
--- cloud-api defaults to UUIDv7 for both identifiers (ADR-032); we match it. The
+-- cloud-api defaults to UUIDv7 for both identifiers; we match it. The
 -- local i64 `id` stays the in-process primary key. Both columns are nullable
 -- (legacy rows get a `uuid` lazily on first sync; `remote_id` is set only after
 -- a row has been seen on the server), with partial UNIQUE indexes so non-NULL

--- a/crates/spelunk-core/src/config/mod.rs
+++ b/crates/spelunk-core/src/config/mod.rs
@@ -146,7 +146,7 @@ pub struct Config {
     #[serde(default)]
     pub server_ca: Option<String>,
 
-    /// Sync mode (ADR-037 D1): `offline` / `local_first` / `cloud_first`.
+    /// Sync mode: `offline` / `local_first` / `cloud_first`.
     ///
     /// Stored as `Option` so the serde default can preserve today's behaviour:
     /// when absent, [`Config::resolve_mode`] derives the effective mode from
@@ -216,7 +216,7 @@ pub struct AuthTokens {
     /// Short-lived WorkOS access token, sent as `Authorization: Bearer`.
     pub access_token: String,
     /// Long-lived rotating refresh token. Exchanged directly at WorkOS
-    /// `/user_management/authenticate` (refresh grant, ADR-047) to rotate the
+    /// `/user_management/authenticate` (refresh grant) to rotate the
     /// access token or switch organisation.
     pub refresh_token: String,
     /// Absolute expiry of `access_token`, as a Unix timestamp (seconds).
@@ -406,7 +406,7 @@ impl Config {
         if let Ok(v) = std::env::var("SPELUNK_SERVER_CA") {
             cfg.server_ca = Some(v);
         }
-        // ADR-037 D1: SPELUNK_MODE overrides the configured sync mode. An
+        // SPELUNK_MODE overrides the configured sync mode. An
         // unrecognised value is a hard error — silently falling back to a
         // default would defeat the deterministic-mode guarantee the Founder
         // needs to separate OSS-local test runs from cloud dogfood runs.
@@ -529,7 +529,7 @@ impl Config {
         self.inference_url.as_deref().or(self.server_url.as_deref())
     }
 
-    /// Resolve the effective sync mode (ADR-037 D1).
+    /// Resolve the effective sync mode.
     ///
     /// Precedence (highest first):
     /// 1. `SPELUNK_NO_SERVER=1` (or `true`/`yes`) → [`SyncMode::Offline`] — a hard
@@ -549,7 +549,7 @@ impl Config {
         if let Some(mode) = self.mode {
             return mode;
         }
-        // Default mirrors the pre-ADR-037 implicit behaviour.
+        // Default mirrors the original implicit behaviour, from before the `mode` field existed.
         if self.server_url.is_some() {
             SyncMode::LocalFirst
         } else {
@@ -580,7 +580,7 @@ mod tests {
         }
     }
 
-    // ── resolve_mode defaults (ADR-037 D1) ───────────────────────────────────
+    // ── resolve_mode defaults ─────────────────────────────────────────────────
 
     #[test]
     #[serial_test::serial]
@@ -1083,7 +1083,7 @@ project_id = "team/proj"
         }
     }
 
-    // ── [auth] WorkOS tokens (ADR-045) ───────────────────────────────────────
+    // ── [auth] WorkOS tokens ───────────────────────────────────────────────────
 
     fn sample_tokens() -> AuthTokens {
         AuthTokens {

--- a/crates/spelunk-core/src/config/persist.rs
+++ b/crates/spelunk-core/src/config/persist.rs
@@ -81,7 +81,7 @@ pub fn remove_server_key_from(config_path: &Path) -> Result<()> {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// `[auth]` table persistence (WorkOS device-flow tokens, ADR-045)
+// `[auth]` table persistence (WorkOS device-flow tokens)
 // ───────────────────────────────────────────────────────────────────────────
 
 /// Persist WorkOS tokens to the `[auth]` table of `~/.config/spelunk/config.toml`.

--- a/crates/spelunk-core/src/config/sync_mode.rs
+++ b/crates/spelunk-core/src/config/sync_mode.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
-// Sync mode (ADR-037 D1)
+// Sync mode
 // ---------------------------------------------------------------------------
 
 /// Persistent, per-project control over where memory reads/writes go and whether
-/// the CLI ever contacts the cloud (ADR-037 D1).
+/// the CLI ever contacts the cloud.
 ///
 /// Replaces the implicit "is the server reachable" branch that previously drove
 /// backend selection. The mode is resolved once from config + environment (see
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 /// | `cloud_first` | server (error if unreachable) | server (error if unreachable) | required |
 ///
 /// `cloud_first` is the **server-authoritative** option: it is a deliberate
-/// override of ADR-005's local-as-source-of-truth invariant, and an
+/// override of ADR-004's local-as-source-of-truth invariant, and an
 /// unreachable or untrusted server is a hard error. There is no silent local
 /// fallback and no local write queue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -74,7 +74,7 @@ impl SyncMode {
 mod tests {
     use super::*;
 
-    // ── SyncMode parse / as_str (ADR-037 D1) ─────────────────────────────────
+    // ── SyncMode parse / as_str ───────────────────────────────────────────────
 
     #[test]
     fn sync_mode_parse_accepts_canonical_and_variant_forms() {

--- a/crates/spelunk-core/src/storage/memory/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/mod.rs
@@ -125,7 +125,7 @@ impl MemoryStore {
         self.conn
             .execute_batch(include_str!("../../../migrations/015_memory_edges.sql"))
             .context("running memory edges migration")?;
-        // Migration 020 (ADR-037): UUID identity columns (`uuid`, `remote_id`).
+        // Migration 020: UUID identity columns (`uuid`, `remote_id`) for cloud sync.
         // ALTER TABLE can't be IF NOT EXISTS; guard the duplicate-column case so
         // re-opening an already-migrated store is a no-op. The unique indexes are
         // CREATE … IF NOT EXISTS and safe to run unconditionally.

--- a/crates/spelunk-core/src/storage/memory/sync.rs
+++ b/crates/spelunk-core/src/storage/memory/sync.rs
@@ -1,4 +1,4 @@
-//! Sync support for the local memory store (ADR-037 D2).
+//! Sync support for the local memory store.
 //!
 //! Identity model. Two stable identifiers bridge the local and cloud stores:
 //!
@@ -20,12 +20,12 @@ use uuid::Uuid;
 
 use super::MemoryStore;
 
-/// A local note prepared for push to the cloud (ADR-037 D2/D3).
+/// A local note prepared for push to the cloud.
 ///
 /// Carries the stable `uuid` (used as the cloud `external_id` / idempotency key)
 /// and **text only** — no embedding vector. The server backfills the embedding
-/// with its configured model (ADR-010/ADR-020 conformance); shipping a local
-/// vector would reintroduce the embedding-space mismatch ADR-020 removed.
+/// with its configured model (embedding-model conformance); shipping a local
+/// vector would reintroduce the embedding-space mismatch that conformance removed.
 #[derive(Debug, Clone)]
 pub struct SyncRow {
     /// Local autoincrement id (for recording the cloud id after a push).
@@ -46,7 +46,7 @@ impl MemoryStore {
     /// Assign a fresh UUIDv7 to `note_id` if it lacks one; return the entry's
     /// UUID. Idempotent. This is the Founder-decided backfill (§3) — a *fresh*
     /// UUIDv7 minted on first sync, not a content-derived UUIDv5 — so identity is
-    /// uniform with cloud-api's UUIDv7 default (ADR-032).
+    /// uniform with cloud-api's UUIDv7 default.
     pub fn ensure_uuid(&self, note_id: i64) -> Result<String> {
         if let Some(existing) = self.uuid_for(note_id)? {
             return Ok(existing);
@@ -103,7 +103,7 @@ impl MemoryStore {
     /// (`push_local`) partitions on `remote_id`/`archived`.
     ///
     /// `include_archived` mirrors the caller's flag; archived rows are still
-    /// returned (as tombstones) when requested so deletes propagate (ADR-037 D2).
+    /// returned (as tombstones) when requested so deletes propagate.
     pub fn rows_for_sync(&self, include_archived: bool) -> Result<Vec<SyncRow>> {
         let status_clause = if include_archived {
             ""
@@ -175,7 +175,7 @@ impl MemoryStore {
     ///
     /// - If a local note already carries this `remote_id` (we pushed it, or we
     ///   pulled it before), reconcile lifecycle only — a cloud tombstone archives
-    ///   the local copy. Content is append-only and never mutated (ADR-005).
+    ///   the local copy. Content is append-only and never mutated.
     /// - Otherwise insert a new local row carrying `remote_id`. Add-Wins /
     ///   keep-both: pulled entries are added, never overwriting local ones.
     ///
@@ -226,7 +226,7 @@ impl MemoryStore {
     }
 
     /// The pull cursor: the max cloud `remote_id` already synced locally
-    /// (ADR-037 D2, decision #183).
+    /// (decision #183).
     ///
     /// `remote_id` holds the cloud-minted UUIDv7 `id`. Because UUIDv7 strings
     /// sort lexically the same as their byte/time order, `MAX(remote_id)` is the

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -149,7 +149,7 @@ fn add_edge_duplicate_silently_ignored() {
     );
 }
 
-// ── ADR-037 D2: UUID identity + cursor + idempotent apply ────────────────────
+// ── UUID identity + cursor + idempotent apply ────────────────────────────────
 
 #[test]
 fn ensure_uuid_backfills_and_is_idempotent() {
@@ -185,7 +185,7 @@ fn rows_for_sync_assigns_uuids_and_is_text_only() {
     let rows = store.rows_for_sync(false).unwrap();
     assert_eq!(rows.len(), 2);
     // Every row carries a freshly-assigned UUID; SyncRow has no embedding field
-    // at all (text-only by construction — ADR-037 D3).
+    // at all (text-only by construction).
     for r in &rows {
         assert_eq!(r.uuid.len(), 36);
         assert!(r.remote_id.is_none());

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -74,7 +74,7 @@ pub(super) fn escape_like(s: &str) -> String {
 
 /// Open the appropriate memory backend.
 ///
-/// Selection rule (ADR-004 — one canonical store per project; ADR-037 D1 — the
+/// Selection rule (ADR-004 — one canonical store per project; the
 /// resolved sync mode replaces the implicit "is `server_url` set" branch):
 /// 1. `backend_override = Some("git-notes")` → `GitNotesBackend`.
 /// 2. [`SyncMode::CloudFirst`](crate::config::SyncMode::CloudFirst) **and** an
@@ -85,7 +85,7 @@ pub(super) fn escape_like(s: &str) -> String {
 ///    [`SyncMode::Offline`] (provable no-cloud, even when `server_url` is set;
 ///    the `SPELUNK_NO_SERVER=1` kill-switch resolves here) and the default
 ///    [`SyncMode::LocalFirst`], where reads and writes stay local and the cloud
-///    replica is converged explicitly by `spelunk sync` (ADR-037 D2).
+///    replica is converged explicitly by `spelunk sync`.
 ///
 /// This function keys on the resolved mode plus `cfg.server_url`. An
 /// auto-discovered loopback server is inference-only and routes through
@@ -259,7 +259,7 @@ mod tests {
     }
 }
 
-// ── ADR-037 D1: backend selection honours the resolved sync mode ──────────────
+// ── Backend selection honours the resolved sync mode ──────────────────────────
 
 #[cfg(test)]
 mod backend_selection_tests {

--- a/crates/spelunk-core/src/storage/remote/sync.rs
+++ b/crates/spelunk-core/src/storage/remote/sync.rs
@@ -1,4 +1,4 @@
-//! Cloud two-way sync wire client (ADR-037 D2/D3).
+//! Cloud two-way sync wire client.
 //!
 //! Wires the CLI's `sync` / `memory pull` commands to cloud-api primitives that
 //! already exist server-side but were previously unreachable from the CLI:
@@ -16,15 +16,15 @@
 //! entries carry the cloud `id` (a UUID), which we record as the local
 //! `remote_id` and dedupe on, so a subsequent push of the same entry is a no-op.
 //!
-//! Embedding conformance (ADR-010/ADR-020, ADR-053): a push is **text-only by
-//! default** — the `vector` field is omitted and the server backfills the
-//! embedding with its configured model. As a compute/bandwidth optimization,
-//! when the destination advertises the `accepts_pushed_vectors` capability the
-//! CLI MAY attach the locally-computed full-precision (fp32/896) vector it
-//! already holds, tagged with the model and precision the accept side
-//! validates. A server without the capability (an older server, or the OSS team
-//! server) never receives a vector and re-embeds — so text-only remains the
-//! universal fallback.
+//! Embedding conformance: a push is **text-only by default** — the `vector`
+//! field is omitted and the server backfills the embedding with its
+//! configured model. As a compute/bandwidth optimization, when the
+//! destination advertises the `accepts_pushed_vectors` capability the CLI MAY
+//! attach the locally-computed full-precision (fp32/896) vector it already
+//! holds, tagged with the model and precision the accept side validates. A
+//! server without the capability (an older server, or the OSS team server)
+//! never receives a vector and re-embeds — so text-only remains the universal
+//! fallback.
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -52,9 +52,9 @@ fn pushed_vector_model_tag() -> &'static str {
 ///
 /// `external_id` carries the local entry's stable UUID — the server's
 /// idempotency key. `vector`/`vector_model`/`vector_precision` are the optional
-/// client-pushed embedding fast path (ADR-053 #4b): omitted for a text-only
-/// push (the default), populated only for a server advertising
-/// `accepts_pushed_vectors` via [`BatchPushItem::maybe_attach_vector`].
+/// client-pushed embedding fast path: omitted for a text-only push (the
+/// default), populated only for a server advertising `accepts_pushed_vectors`
+/// via [`BatchPushItem::maybe_attach_vector`].
 #[derive(Debug, Serialize)]
 pub struct BatchPushItem {
     pub kind: String,
@@ -251,7 +251,7 @@ impl CloudSyncClient {
 
     /// Tombstone a cloud entry by its cloud-minted id (`DELETE /memory/{id}`).
     ///
-    /// Propagates a local archive to the cloud (ADR-037 D2). Already-archived or
+    /// Propagates a local archive to the cloud. Already-archived or
     /// missing entries return 404 server-side, which we treat as success (the
     /// desired end state — gone — already holds), keeping the call idempotent.
     pub async fn delete_remote(&self, remote_id: &str) -> Result<()> {
@@ -323,7 +323,7 @@ mod tests {
     }
 
     /// The push is text-only by default, and carries the fp32/896 vector + model
-    /// tag ONLY for a server advertising `accepts_pushed_vectors` (ADR-053 #4b).
+    /// tag ONLY for a server advertising `accepts_pushed_vectors`.
     #[tokio::test]
     async fn push_batch_is_text_only_no_vector() {
         let server = MockServer::start().await;

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -618,9 +618,9 @@ pub async fn add_note(
 
 /// One entry in a `POST /memory/batch` request. Field-for-field match of the
 /// CLI's `BatchPushItem` (`spelunk-core/src/storage/remote/sync.rs`): the CLI
-/// never sends `embedding` today (its push is text-only, ADR-037 D3), but the
-/// field is accepted when present for forward compatibility with a future
-/// pushed-vector optimization (ADR-053 #4b): the server must not require it.
+/// never sends `embedding` today (its push is text-only), but the
+/// field is accepted when present for forward compatibility with a possible
+/// future pushed-vector optimization: the server must not require it.
 #[derive(Deserialize, ToSchema)]
 pub struct BatchNoteItem {
     pub kind: String,

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -92,8 +92,8 @@ struct Args {
     embedding_url: Option<String>,
 
     /// Deprecated and ignored. The embedding model is fixed to F2LLM-v2-330M@896
-    /// product-wide (ADR-053); a mismatched model silently corrupts the shared
-    /// vector space (ADR-010). Retained hidden only so a legacy
+    /// product-wide; a mismatched model silently corrupts the shared
+    /// vector space. Retained hidden only so a legacy
     /// `SPELUNK_EMBEDDING_MODEL` / `--embedding-model` warns and is ignored
     /// instead of hard-failing an old deployment on upgrade. Never selects a model.
     #[arg(long, env = "SPELUNK_EMBEDDING_MODEL", hide = true)]
@@ -466,7 +466,7 @@ fn resolve_embed_thread_budget() -> ThreadBudget {
 
 /// Warning to emit when a legacy `SPELUNK_EMBEDDING_MODEL` / `--embedding-model`
 /// is set. The embedding model is fixed to `NATIVE_MODEL_ID` product-wide
-/// (ADR-053) and can no longer be selected; a non-blank value is ignored, not
+/// and can no longer be selected; a non-blank value is ignored, not
 /// honoured. Returns `None` when unset/blank so upgrades stay quiet.
 fn legacy_embedding_model_warning(model: Option<&str>) -> Option<String> {
     let value = model.map(str::trim).filter(|m| !m.is_empty())?;

--- a/docs/adr/005-cli-slug-uuid-resolution.md
+++ b/docs/adr/005-cli-slug-uuid-resolution.md
@@ -3,7 +3,7 @@
 **Status:** Proposed  
 **Date:** 2026-06-19  
 **Deciders:** Architect  
-**Trigger:** ADR-037 P1 implementer flag #2 — cloud-api routes all projects by `Uuid` in path
+**Trigger:** cloud-api routes all projects by `Uuid` in path
 params (`/v1/projects/{project_id}`), but the CLI config carries a human slug
 (`project_id = "my-project"` in `.spelunk/config.toml`). The Founder cannot
 dogfood against `api.spelunk.cloud` without either (a) hand-pasting the UUID

--- a/docs/adr/059-git-notes-v1-format-freeze.md
+++ b/docs/adr/059-git-notes-v1-format-freeze.md
@@ -186,7 +186,7 @@ Backward-compatibility rules, uniform across all three surfaces:
   consumer exists today; D1 only fixes the existing manual `--backend git-notes`
   read/write and the write-through append, and D2 only adds a field.
 - **No new identity minting policy.** How and when `remote_id` is assigned on
-  sync is already defined by migration 020 / ADR-037 and is unchanged. This ADR
+  sync is already defined by migration 020 and the project's sync/reconciliation design, and is unchanged. This ADR
   only carries the existing column onto the distributed formats.
 - **No semantic-search or graph capability** is added to `GitNotesBackend`; its
   unsupported methods stay unsupported.

--- a/docs/adr/070-init-embed-lifecycle-and-search-warmup-contract.md
+++ b/docs/adr/070-init-embed-lifecycle-and-search-warmup-contract.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-15
 **Deciders:** founder (Johan); architect
-**Relationship to prior ADRs:** operates strictly inside ADR-010's embedding
+**Relationship to prior ADRs:** operates strictly inside the existing embedding
 split (the server computes vectors, the CLI is the only persistent store for
 index data) and does not reopen it. Extends
 [ADR-068](068-zero-setup-onboarding-git-notes-memory-fallback.md)'s honesty
@@ -51,7 +51,7 @@ tree, and two of them are not what the intake ticket recorded.
    does not store them. The server has no access to the project's SQLite
    database, no notion of which chunks lack embeddings, and no project path. A
    server-side drain loop is not missing, it is **not expressible** without
-   inverting ADR-010. The idle server is correct behaviour, not a bug.
+   inverting that split. The idle server is correct behaviour, not a bug.
 
 4. **Search then declines to fall back.** In `auto` mode the fallback to
    ast-grep on an empty result set is gated on `index_is_stale(&db_path)`, which
@@ -524,7 +524,7 @@ observation, read by every consumer. That was the right design and it stays.
   work is explicitly the `Device::Cpu` path, where these constants are live.
 - **Cloud or remote embedding.** Trades a GPU-bound constraint for a metered
   network one with no wall-clock win.
-- **Reopening ADR-010.** The server stays stateless with respect to index data.
+- **Reopening the embedding split.** The server stays stateless with respect to index data.
   Every alternative that "just has the server finish the job" is a rewrite of
   the storage boundary, and none of them is needed: the CLI-side worker already
   has the database, the queue, and the resume path.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ src/
 
   config/
     mod.rs             Config struct, loads from ~/.config/spelunk/config.toml
-    sync_mode.rs       SyncMode enum (ADR-037 D1)
+    sync_mode.rs       SyncMode enum: offline / local_first / cloud_first mode selection
     project_id.rs      project-id derivation from git remote / local fallback
     paths.rs           config-dir + project/db discovery
     persist.rs         config.toml / secret-store read-write

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1355,7 +1355,7 @@
       },
       "BatchNoteItem": {
         "type": "object",
-        "description": "One entry in a `POST /memory/batch` request. Field-for-field match of the\nCLI's `BatchPushItem` (`spelunk-core/src/storage/remote/sync.rs`): the CLI\nnever sends `embedding` today (its push is text-only, ADR-037 D3), but the\nfield is accepted when present for forward compatibility with a future\npushed-vector optimization (ADR-053 #4b): the server must not require it.",
+        "description": "One entry in a `POST /memory/batch` request. Field-for-field match of the\nCLI's `BatchPushItem` (`spelunk-core/src/storage/remote/sync.rs`): the CLI\nnever sends `embedding` today (its push is text-only), but the\nfield is accepted when present for forward compatibility with a possible\nfuture pushed-vector optimization: the server must not require it.",
         "required": [
           "kind",
           "title",


### PR DESCRIPTION
## Summary

The OSS/cloud-api public-repo boundary (nothing in `spelunk-oss` may cite cloud-api ADR/issue/PR numbers or workstream names) was leaking private cloud-api ADR numbers into public content. Started as a 5-spot fix for a flagged `ADR-037` citation, but a full-repo sweep turned up a much larger set of leaked private ADR numbers.

**Private cloud-api ADR numbers removed:** 010, 020, 032, 037, 045, 047, 053 — none of these correspond to a file in this repo's own `docs/adr/`, confirming they were all leaked private references. Each citation was replaced with an implementation-agnostic description of the mechanism (e.g. "the embedding-model conformance" instead of "ADR-010/ADR-020"), preserving meaning without naming a private doc.

**Mismatched ADR-005 citations (3 spots):** this repo's own local `ADR-005` is "CLI slug→UUID resolution" (`docs/adr/005-cli-slug-uuid-resolution.md`). Three citations of "ADR-005" were actually describing CRDT/append-only-sync semantics that match cloud-api's *differently-numbered* ADR-005 ("local-first-crdt-sync"), not this repo's own ADR-005:
- `crates/spelunk-core/src/storage/memory/sync.rs` ("content is append-only and never mutated") — citation dropped, meaning preserved without a doc reference.
- `crates/spelunk-cli/src/cli/cmd/memory/sync.rs` ("Properties (ADR-037 + ADR-005)") — both private citations dropped.
- `crates/spelunk-core/src/config/sync_mode.rs` ("override of ADR-005's local-as-source-of-truth invariant") — repointed to this repo's own `ADR-004` (`docs/adr/004-unified-memory-storage.md`), which already establishes that same local-as-source-of-truth invariant ("local stays source of truth", decisions #76/#77) as its actual Decision.

Legitimate local self-references to this repo's own ADR-005 (e.g. `CLAUDE.md`'s "see ADR-005" for slug→UUID caching, `CHANGELOG.md`'s "(ADR-005, #428)" for cloud-api routing) were left untouched — their subject matter genuinely matches the local ADR-005 topic.

**Scope:** 27 files touched, all comment/doc/string edits — no `.rs` logic changed. `docs/openapi.json`'s 1-line diff is the `BatchNoteItem` doc-comment text flowing through regeneration (`cargo test -p spelunk-server write_openapi_snapshot -- --nocapture`), not a schema/contract change.

## Test plan

- [x] `git diff --stat` against merge-base with `origin/main`: 27 files, all `.rs`/`.sql`/`.md`/`.json` comment/doc/string lines — verified mechanically that every changed `.rs`/`.sql` line starts with `///`, `//!`, `//`, or `--` (no functional code changed).
- [x] Read every changed file in the diff; independently verified each ADR-005 disambiguation against the actual topic of both this repo's `docs/adr/005-cli-slug-uuid-resolution.md` and the citing context — confirmed all 3 repoints/removals correct, no legitimate self-reference was wrongly rewritten.
- [x] Fresh full-repo sweep: `rg -oi 'ADR-0[0-9]+' --no-filename | sort -u` → exactly 17 surviving numbers, each cross-checked 1:1 against `ls docs/adr/` (001,002,003,004,005,050,052,056,058,059,062,066,067,068,069,070,071 — all real local ADR files). Separately confirmed zero remaining hits for `rg -i 'ADR-0(10|20|32|37|45|47|53)'`.
- [x] Diffed `docs/openapi.json` against the new `handlers.rs` `BatchNoteItem` doc comment — text matches exactly, confirming pure regeneration.
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace` (default features, `SPELUNK_SECRET_STORE=file`) — all green.
- [x] `cargo test --workspace --no-default-features` (spelunk-server without `embed-native`) — all green.