### PR TITLE
Prioritize embed queue by graph-rank/recency instead of insertion order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   terminal reason to skip the embed pass. (ADR-070 D1, D2)
 - **Search over a warming index emits coverage-gated notices.** When KNN search runs
   over an incompletely-embedded corpus, a one-line stderr notice names the coverage
-  percentage and its shape ("front-loaded by indexing order"). In `auto` mode on zero
+  percentage and its shape ("front-loaded by importance and recency"). In `auto` mode on zero
   coverage, search falls back to ast-grep with a notice naming embeddings as building
   in the background; in explicit `semantic`/`hybrid` mode, zero coverage produces an
   actionable error naming the resume command instead of "No results found." Partial

--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -1225,7 +1225,9 @@ mod tests {
     fn seed_chunks(n: usize) -> (Database, Vec<i64>) {
         register_sqlite_vec();
         let db = Database::open(std::path::Path::new(":memory:")).expect("open in-memory DB");
-        let file_id = db.upsert_file("src/lib.rs", Some("rust"), "hash0").unwrap();
+        let file_id = db
+            .upsert_file("src/lib.rs", Some("rust"), "hash0", 0)
+            .unwrap();
         let ids = (0..n)
             .map(|i| {
                 db.insert_chunk(

--- a/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
@@ -34,6 +34,21 @@ const MAX_FILE_BYTES: u64 = 64 * 1024 * 1024;
 /// Return `true` (and log a warning) if `path` is over `MAX_FILE_BYTES`,
 /// checked via a `metadata()` call — no file content is read either way.
 /// Callers must skip the file without reading it when this returns `true`.
+/// The file's filesystem modification time as unix seconds, or `0` when it is
+/// unavailable (platform without mtime support, or a stat/timestamp error).
+/// Persisted via `upsert_file` so the embed queue can order by file recency;
+/// `0` sorts last under the queue's `mtime DESC` order — deterministic, never
+/// an error. Only called for files being (re)parsed, so the stat is on
+/// new/changed files, not every walked file.
+fn stat_mtime(path: &std::path::Path) -> i64 {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
 fn is_file_too_large(path: &std::path::Path, path_str: &str) -> bool {
     match std::fs::metadata(path) {
         Ok(meta) if meta.len() > MAX_FILE_BYTES => {
@@ -412,7 +427,7 @@ fn process_doc_file(
         return Ok(true);
     }
     let chunks = parse_doc(&bytes, path_str, doc_lang);
-    let file_id = db.upsert_file(path_str, Some(doc_lang), &hash)?;
+    let file_id = db.upsert_file(path_str, Some(doc_lang), &hash, stat_mtime(path))?;
     db.delete_embeddings_for_file(file_id)?;
     db.delete_chunks_for_file(file_id)?;
     store_chunks(&chunks, path_str, file_id, db, acc)?;
@@ -448,7 +463,7 @@ fn process_pdf_file(
     }
     match crate::indexer::pdf::extract_pdf_text(path) {
         Ok(pages) => {
-            let file_id = db.upsert_file(path_str, Some("pdf"), &hash)?;
+            let file_id = db.upsert_file(path_str, Some("pdf"), &hash, stat_mtime(path))?;
             db.delete_embeddings_for_file(file_id)?;
             db.delete_chunks_for_file(file_id)?;
             let chunks = pages_to_chunks(pages, path_str);
@@ -525,7 +540,7 @@ fn process_text_file(
         }
     };
 
-    let file_id = db.upsert_file(path_str, Some(language), &hash)?;
+    let file_id = db.upsert_file(path_str, Some(language), &hash, stat_mtime(path))?;
     db.delete_embeddings_for_file(file_id)?;
     db.delete_chunks_for_file(file_id)?;
 
@@ -906,7 +921,9 @@ mod tests {
         use crate::indexer::{Chunk, ChunkKind};
 
         let db = open_db();
-        let file_id = db.upsert_file("src/lib.rs", Some("rust"), "hash0").unwrap();
+        let file_id = db
+            .upsert_file("src/lib.rs", Some("rust"), "hash0", 0)
+            .unwrap();
 
         // Store three chunks the way `store_chunks` does (docstring lives in the
         // metadata JSON), so the reconstructed text is comparable to the
@@ -992,7 +1009,9 @@ mod tests {
     #[test]
     fn missing_embedding_texts_is_empty_when_all_embedded() {
         let db = open_db();
-        let file_id = db.upsert_file("src/lib.rs", Some("rust"), "hash0").unwrap();
+        let file_id = db
+            .upsert_file("src/lib.rs", Some("rust"), "hash0", 0)
+            .unwrap();
         let id = db
             .insert_chunk(file_id, "function", Some("f"), 1, 2, "fn f() {}", None, 1)
             .unwrap();
@@ -1002,6 +1021,124 @@ mod tests {
         assert!(
             missing_embedding_texts(&db).unwrap().is_empty(),
             "a fully-embedded index yields an empty detached embed queue"
+        );
+    }
+
+    // ── mtime capture + recency ordering (onboarding embed queue) ─────────────
+
+    /// Set a file's filesystem modification time to `unix_secs` past the epoch,
+    /// without touching its content (so its content hash is unchanged).
+    fn set_file_mtime(path: &std::path::Path, unix_secs: u64) {
+        let t = std::time::UNIX_EPOCH + std::time::Duration::from_secs(unix_secs);
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(t)
+            .unwrap();
+    }
+
+    /// A parsed file stores its filesystem mtime in `files.mtime`, and the
+    /// DB-driven embed queue (the exact path the detached `--_embed-phases`
+    /// worker rebuilds from) orders the resulting chunks by that recency on a
+    /// cold index (all graph_rank still 0): the more-recently-modified file's
+    /// chunks come first. Drives the real production parse path end-to-end.
+    #[test]
+    fn parse_captures_mtime_and_queue_orders_by_recency() {
+        use indicatif::MultiProgress;
+
+        let db = open_db();
+        let dir = tempfile::tempdir().unwrap();
+        let older = dir.path().join("older.rs");
+        let newer = dir.path().join("newer.rs");
+        std::fs::write(&older, "pub fn older_fn() {}\n").unwrap();
+        std::fs::write(&newer, "pub fn newer_fn() {}\n").unwrap();
+        set_file_mtime(&older, 1_000);
+        set_file_mtime(&newer, 2_000);
+
+        let args = default_args(dir.path().to_path_buf());
+        let mp = MultiProgress::new();
+        let cfg = crate::config::Config::default();
+        run_parse_phase(dir.path(), &db, &args, &mp, &cfg).expect("parse phase");
+
+        // (a) mtime captured verbatim per file.
+        assert_eq!(db.file_mtime("older.rs").unwrap(), Some(1_000));
+        assert_eq!(db.file_mtime("newer.rs").unwrap(), Some(2_000));
+
+        // (b) the DB-driven queue emits every newer-file chunk before any
+        // older-file chunk — recency first.
+        let queue_ids: Vec<i64> = missing_embedding_texts(&db)
+            .expect("queue")
+            .iter()
+            .map(|(id, ..)| *id)
+            .collect();
+        let newer_ids: Vec<i64> = db
+            .chunks_for_file("newer.rs")
+            .unwrap()
+            .iter()
+            .map(|c| c.chunk_id)
+            .collect();
+        let older_ids: Vec<i64> = db
+            .chunks_for_file("older.rs")
+            .unwrap()
+            .iter()
+            .map(|c| c.chunk_id)
+            .collect();
+        assert!(
+            !newer_ids.is_empty() && !older_ids.is_empty(),
+            "both files chunked"
+        );
+        let last_newer = queue_ids
+            .iter()
+            .rposition(|id| newer_ids.contains(id))
+            .expect("newer chunks queued");
+        let first_older = queue_ids
+            .iter()
+            .position(|id| older_ids.contains(id))
+            .expect("older chunks queued");
+        assert!(
+            last_newer < first_older,
+            "all newer-file chunks must precede older-file chunks: {queue_ids:?}"
+        );
+    }
+
+    /// A hash-unchanged file is skipped on re-parse, so its stored mtime is NOT
+    /// refreshed even when the file's filesystem mtime changed (a plain touch).
+    /// Retention falls out of the skip path never calling `upsert_file`.
+    #[test]
+    fn unchanged_file_retains_stored_mtime_on_reindex() {
+        use indicatif::MultiProgress;
+
+        let db = open_db();
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("keep.rs");
+        std::fs::write(&f, "pub fn keep() {}\n").unwrap();
+        set_file_mtime(&f, 1_000);
+
+        let args = default_args(dir.path().to_path_buf());
+        let mp = MultiProgress::new();
+        let cfg = crate::config::Config::default();
+
+        let r1 = run_parse_phase(dir.path(), &db, &args, &mp, &cfg).expect("run 1");
+        assert!(r1.indexed >= 1);
+        assert_eq!(
+            db.file_mtime("keep.rs").unwrap(),
+            Some(1_000),
+            "run 1 stores the file's filesystem mtime"
+        );
+
+        // Touch the file's mtime WITHOUT changing its content: the hash is
+        // identical, so the re-parse hash-skips it.
+        set_file_mtime(&f, 5_000);
+        let r2 = run_parse_phase(dir.path(), &db, &args, &mp, &cfg).expect("run 2");
+        assert_eq!(
+            r2.indexed, 0,
+            "unchanged content → the file is hash-skipped, not reparsed"
+        );
+        assert_eq!(
+            db.file_mtime("keep.rs").unwrap(),
+            Some(1_000),
+            "a skipped file's stored mtime is retained, not overwritten with the new FS mtime"
         );
     }
 

--- a/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
@@ -1038,6 +1038,64 @@ mod tests {
             .unwrap();
     }
 
+    /// `stat_mtime` on a path that cannot be `stat()`'d (doesn't exist —
+    /// stands in for any metadata-read failure, e.g. a permission error or a
+    /// virtual/generated path with no real inode) must fall back to `0`
+    /// rather than panicking or erroring the whole parse phase. `0` is the
+    /// same sentinel a pre-migration row carries and sorts last,
+    /// deterministically, under the queue's `mtime DESC` order.
+    #[test]
+    fn stat_mtime_nonexistent_path_falls_back_to_zero() {
+        let missing = std::path::Path::new("/nonexistent/definitely-not-a-real-path.rs");
+        assert_eq!(
+            stat_mtime(missing),
+            0,
+            "an unstattable path must fall back to 0, not panic"
+        );
+    }
+
+    /// A file with a modification time before the Unix epoch (a corrupted
+    /// filesystem timestamp, or a container/VM with a badly-skewed clock) makes
+    /// `SystemTime::duration_since(UNIX_EPOCH)` return `Err`. `stat_mtime` must
+    /// still fall back to `0` rather than panicking on the `i64` conversion.
+    #[test]
+    fn stat_mtime_pre_epoch_time_falls_back_to_zero_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("ancient.rs");
+        std::fs::write(&f, "pub fn ancient() {}\n").unwrap();
+        let pre_epoch = std::time::UNIX_EPOCH - std::time::Duration::from_secs(100);
+        std::fs::File::options()
+            .write(true)
+            .open(&f)
+            .unwrap()
+            .set_modified(pre_epoch)
+            .unwrap();
+
+        assert_eq!(
+            stat_mtime(&f),
+            0,
+            "a pre-epoch mtime must fall back to 0, not panic on the i64 cast"
+        );
+    }
+
+    /// A file whose mtime is far in the future (clock skew, or a deliberately
+    /// forward-touched file) must be read back verbatim as a large positive
+    /// `i64`, without overflow or panic on the `u64 -> i64` cast.
+    #[test]
+    fn stat_mtime_far_future_time_returns_positive_no_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("future.rs");
+        std::fs::write(&f, "pub fn future() {}\n").unwrap();
+        // Year ~2107 — comfortably future without approaching u64/i64 bounds.
+        set_file_mtime(&f, 4_300_000_000);
+
+        assert_eq!(
+            stat_mtime(&f),
+            4_300_000_000,
+            "a far-future mtime must round-trip verbatim, not overflow or panic"
+        );
+    }
+
     /// A parsed file stores its filesystem mtime in `files.mtime`, and the
     /// DB-driven embed queue (the exact path the detached `--_embed-phases`
     /// worker rebuilds from) orders the resulting chunks by that recency on a

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -676,11 +676,13 @@ fn coverage_disposition(embedded: i64, total: i64, auto_mode: bool) -> CoverageD
 }
 
 /// One-line warmup notice for a partially-embedded corpus: carries the
-/// coverage percentage AND its shape. The queue drains in indexing order, so
-/// a prefix is the first N files, not a sample across the repo: the user has
-/// a complete picture of some of the codebase and a systematic blind spot
-/// over the rest, and a bare percentage would read as the opposite failure
-/// mode (a uniformly thinner picture of everything).
+/// coverage percentage AND its shape. The queue drains in priority order
+/// (`graph_rank DESC, mtime DESC` — most-referenced code first, then most
+/// recently modified), so a prefix is the most important/recent code, not a
+/// sample across the repo: the user has a complete picture of the code most
+/// likely to matter and a blind spot over the rest, and a bare percentage
+/// would read as the opposite failure mode (a uniformly thinner picture of
+/// everything).
 fn warmup_notice_partial(embedded: i64, total: i64) -> String {
     let pct = if total > 0 {
         (embedded.max(0) as u64).saturating_mul(100) / total as u64
@@ -688,9 +690,9 @@ fn warmup_notice_partial(embedded: i64, total: i64) -> String {
         0
     };
     format!(
-        "[warmup: searchable {embedded}/{total} chunks ({pct}%), front-loaded by indexing \
-         order; a missing result may mean \"not embedded yet\", not \"not in the codebase\" \
-         (check `spelunk status`)]"
+        "[warmup: searchable {embedded}/{total} chunks ({pct}%), front-loaded by importance \
+         and recency; a missing result may mean \"not embedded yet\", not \"not in the \
+         codebase\" (check `spelunk status`)]"
     )
 }
 
@@ -865,31 +867,25 @@ mod tests {
         assert!(n.contains("11813/27734"), "labelled coverage: {n}");
         assert!(n.contains("42%"), "carries the percentage: {n}");
         assert!(
-            n.contains("front-loaded by indexing order"),
+            n.contains("front-loaded by importance and recency"),
             "names the shape so a subsystem miss reads as a blind spot, not a thin sample: {n}"
         );
         assert!(n.contains("spelunk status"), "actionable: {n}");
     }
 
-    /// HARDENING FINDING (spelunk-oss embed-queue reorder): the embed queue's
+    /// Regression guard (spelunk-oss embed-queue reorder): the embed queue's
     /// `ORDER BY` changed from raw parse/insertion order (`c.id`) to
     /// `graph_rank DESC, mtime DESC, c.id` — the queue is no longer "the first
-    /// N files walked" in any sense. This warmup notice's copy still asserts
-    /// the embedded prefix is "front-loaded by indexing order", which is now a
-    /// stale, inaccurate description of the mechanism (it is front-loaded by
-    /// recency/importance instead). The sibling test
-    /// `partial_notice_names_coverage_and_its_front_loaded_shape` still
-    /// encodes the old claim as an expected value — that test is itself now
-    /// asserting a false statement about the system, not a spec.
+    /// N files walked" in any sense. The warmup notice's copy was corrected to
+    /// "front-loaded by importance and recency" to match; this guards against
+    /// any regression to the stale "indexing order" wording, which described a
+    /// mechanism that no longer exists.
     ///
-    /// This does not affect the coverage/completeness contract (verified
+    /// The reorder does not affect the coverage/completeness contract (verified
     /// above: `coverage_disposition` only ever reads `(embedded, total)`
-    /// counts, never queue order, so "ordering mistaken for completeness"
-    /// does not regress). But the notice's *explanation* of the ordering
-    /// mechanism is user-facing and wrong. Left failing intentionally —
-    /// HANDBACK: the copy (and its sibling test) needs an update to describe
-    /// the new mechanism, which is a product/copy call for engineer, not
-    /// test-engineer, to make.
+    /// counts, never queue order, so "ordering mistaken for completeness" does
+    /// not regress) — this is purely about the notice's user-facing
+    /// *explanation* of the ordering mechanism staying accurate.
     #[test]
     fn partial_notice_no_longer_claims_indexing_order_after_the_reorder() {
         let n = warmup_notice_partial(11_813, 27_734);

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -871,6 +871,36 @@ mod tests {
         assert!(n.contains("spelunk status"), "actionable: {n}");
     }
 
+    /// HARDENING FINDING (spelunk-oss embed-queue reorder): the embed queue's
+    /// `ORDER BY` changed from raw parse/insertion order (`c.id`) to
+    /// `graph_rank DESC, mtime DESC, c.id` — the queue is no longer "the first
+    /// N files walked" in any sense. This warmup notice's copy still asserts
+    /// the embedded prefix is "front-loaded by indexing order", which is now a
+    /// stale, inaccurate description of the mechanism (it is front-loaded by
+    /// recency/importance instead). The sibling test
+    /// `partial_notice_names_coverage_and_its_front_loaded_shape` still
+    /// encodes the old claim as an expected value — that test is itself now
+    /// asserting a false statement about the system, not a spec.
+    ///
+    /// This does not affect the coverage/completeness contract (verified
+    /// above: `coverage_disposition` only ever reads `(embedded, total)`
+    /// counts, never queue order, so "ordering mistaken for completeness"
+    /// does not regress). But the notice's *explanation* of the ordering
+    /// mechanism is user-facing and wrong. Left failing intentionally —
+    /// HANDBACK: the copy (and its sibling test) needs an update to describe
+    /// the new mechanism, which is a product/copy call for engineer, not
+    /// test-engineer, to make.
+    #[test]
+    fn partial_notice_no_longer_claims_indexing_order_after_the_reorder() {
+        let n = warmup_notice_partial(11_813, 27_734);
+        assert!(
+            !n.contains("indexing order"),
+            "the embed queue is no longer ordered by parse/indexing order since the \
+             recency+graph_rank reorder (ORDER BY c.graph_rank DESC, f.mtime DESC, c.id) — \
+             this notice's copy is stale and describes a mechanism that no longer exists: {n}"
+        );
+    }
+
     #[test]
     fn zero_auto_notice_names_warmup_as_the_reason() {
         let n = warmup_notice_zero_auto(27_734);

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -2177,7 +2177,7 @@ async fn test_search_auto_partial_coverage_emits_warmup_notice_on_stderr() {
         "partial coverage must emit the warmup notice, got stderr: {stderr}"
     );
     assert!(
-        stderr.contains("front-loaded by indexing order"),
+        stderr.contains("front-loaded by importance and recency"),
         "the notice must name the prefix shape, got stderr: {stderr}"
     );
     assert!(

--- a/crates/spelunk-core/migrations/024_file_mtime.sql
+++ b/crates/spelunk-core/migrations/024_file_mtime.sql
@@ -1,0 +1,7 @@
+-- Persist each file's filesystem modification time (unix seconds) so the embed
+-- queue can order chunks by file recency without a filesystem stat at
+-- queue-build time. The detached embed worker rebuilds the queue purely from
+-- the DB, so recency must live in a column, not be re-stat()'d.
+-- DEFAULT 0 keeps pre-migration rows deterministic: 0 sorts last under the
+-- queue's `mtime DESC` ordering, and never errors.
+ALTER TABLE files ADD COLUMN mtime INTEGER NOT NULL DEFAULT 0;

--- a/crates/spelunk-core/src/search/explore.rs
+++ b/crates/spelunk-core/src/search/explore.rs
@@ -481,7 +481,7 @@ mod read_file_boundary_tests {
 
         let db_path = root.join("index.db");
         let db = Database::open(&db_path).unwrap();
-        db.upsert_file("src/foo.rs", Some("rust"), "deadbeef")
+        db.upsert_file("src/foo.rs", Some("rust"), "deadbeef", 0)
             .unwrap();
         drop(db);
         (dir, root, db_path)
@@ -552,7 +552,7 @@ mod read_file_boundary_tests {
         let link = root.join("src/escape.rs");
         std::os::unix::fs::symlink(&secret, &link).unwrap();
         let db = Database::open(&db_path).unwrap();
-        db.upsert_file("src/escape.rs", Some("rust"), "cafef00d")
+        db.upsert_file("src/escape.rs", Some("rust"), "cafef00d", 0)
             .unwrap();
         drop(db);
 
@@ -574,7 +574,7 @@ mod read_file_boundary_tests {
         let link = root.join("src/alias.rs");
         std::os::unix::fs::symlink(root.join("src/foo.rs"), &link).unwrap();
         let db = Database::open(&db_path).unwrap();
-        db.upsert_file("src/alias.rs", Some("rust"), "0000beef")
+        db.upsert_file("src/alias.rs", Some("rust"), "0000beef", 0)
             .unwrap();
         drop(db);
 

--- a/crates/spelunk-core/src/storage/chunks.rs
+++ b/crates/spelunk-core/src/storage/chunks.rs
@@ -79,12 +79,24 @@ impl Database {
             usize,
         )>,
     > {
+        // Ordering is data-driven, no cold/warm branching (see spelunk-oss
+        // onboarding embed-queue work):
+        //   - graph_rank DESC leads. On a cold first index every chunk's rank is
+        //     the 0.0 default (rank is written in phase 3, after embed), so this
+        //     key is inert and the order collapses to the next keys. On a warm
+        //     re-index the prior run's ranks put hot code first; newly-added
+        //     chunks (rank 0) naturally sort after under DESC.
+        //   - f.mtime DESC then orders by file recency (most-recently-modified
+        //     first) — the recency signal for a cold index. Legacy/pre-migration
+        //     rows carry mtime 0 and deterministically sort last.
+        //   - c.id is the final deterministic tiebreak.
         let mut stmt = self.conn.prepare_cached(
             "SELECT c.id, c.name, c.metadata, c.summary, c.content, c.token_count
              FROM chunks c
              LEFT JOIN embeddings e ON e.chunk_id = c.id
+             JOIN files f ON f.id = c.file_id
              WHERE e.chunk_id IS NULL
-             ORDER BY c.id",
+             ORDER BY c.graph_rank DESC, f.mtime DESC, c.id",
         )?;
         let rows = stmt.query_map([], |row| {
             Ok((
@@ -291,7 +303,7 @@ mod tests {
     /// Insert two chunks and return their ids.
     fn seed_two_chunks(db: &Database) -> (i64, i64) {
         let file_id = db
-            .upsert_file("src/lib.rs", Some("rust"), "deadbeef")
+            .upsert_file("src/lib.rs", Some("rust"), "deadbeef", 0)
             .expect("upsert file");
         let a = db
             .insert_chunk(file_id, "function", Some("a"), 1, 5, "fn a() {}", None, 4)
@@ -300,6 +312,94 @@ mod tests {
             .insert_chunk(file_id, "function", Some("b"), 6, 9, "fn b() {}", None, 4)
             .expect("insert b");
         (a, b)
+    }
+
+    /// Upsert one file at `mtime` (unix secs) and insert a named chunk per entry
+    /// in `names`, returning the chunk ids in insertion order.
+    fn seed_file_chunks(db: &Database, path: &str, mtime: i64, names: &[&str]) -> Vec<i64> {
+        let file_id = db
+            .upsert_file(path, Some("rust"), "h", mtime)
+            .expect("upsert file");
+        names
+            .iter()
+            .map(|n| {
+                db.insert_chunk(file_id, "function", Some(n), 1, 2, "fn x() {}", None, 4)
+                    .expect("insert chunk")
+            })
+            .collect()
+    }
+
+    fn missing_ids(db: &Database) -> Vec<i64> {
+        db.chunks_missing_embeddings()
+            .expect("query missing")
+            .into_iter()
+            .map(|(id, ..)| id)
+            .collect()
+    }
+
+    /// Cold index: every `graph_rank` is the 0.0 default, so the embed queue is
+    /// ordered by `files.mtime DESC` (most-recently-modified file first) with
+    /// `chunks.id` breaking ties within a file — and this is deterministic
+    /// across repeated calls on the same data.
+    #[test]
+    fn chunks_missing_embeddings_cold_orders_by_mtime_desc_then_id() {
+        let db = open_db();
+        // Older file seeded first (smaller ids); newer file second.
+        let old = seed_file_chunks(&db, "old.rs", 100, &["a1", "a2"]);
+        let new = seed_file_chunks(&db, "new.rs", 200, &["b1", "b2"]);
+
+        let expected = vec![new[0], new[1], old[0], old[1]];
+        assert_eq!(
+            missing_ids(&db),
+            expected,
+            "recent file's chunks first (mtime DESC), id tiebreak within a file"
+        );
+        // Deterministic across a second identical call.
+        assert_eq!(
+            missing_ids(&db),
+            expected,
+            "queue order is deterministic across runs on the same fixture"
+        );
+    }
+
+    /// Warm re-index: the prior run's `graph_rank DESC` leads (hot code first);
+    /// chunks with no rank yet (`graph_rank = 0`, e.g. newly added) sort after,
+    /// ordered by `mtime DESC`.
+    #[test]
+    fn chunks_missing_embeddings_warm_orders_by_graph_rank_then_mtime() {
+        let db = open_db();
+        let a = seed_file_chunks(&db, "a.rs", 100, &["a1", "a2"]); // older file
+        let b = seed_file_chunks(&db, "b.rs", 200, &["b1", "b2"]); // newer file
+
+        // Prior run populated ranks for a2 and b1 only; a1 and b2 stay at 0.
+        db.update_graph_rank(a[1], 0.9).unwrap();
+        db.update_graph_rank(b[0], 0.5).unwrap();
+
+        // graph_rank DESC: a2(0.9), b1(0.5); then unranked by mtime DESC:
+        // b2 (mtime 200) before a1 (mtime 100).
+        let expected = vec![a[1], b[0], b[1], a[0]];
+        assert_eq!(
+            missing_ids(&db),
+            expected,
+            "graph_rank leads; unranked (rank 0) chunks follow by mtime DESC"
+        );
+    }
+
+    /// Legacy/pre-migration rows carry `mtime = 0` (or `modified()` was
+    /// unavailable). They must not error and must sort deterministically after
+    /// positive mtimes, `chunks.id` breaking ties.
+    #[test]
+    fn chunks_missing_embeddings_legacy_mtime_zero_sorts_last() {
+        let db = open_db();
+        let legacy = seed_file_chunks(&db, "legacy.rs", 0, &["l1", "l2"]);
+        let fresh = seed_file_chunks(&db, "fresh.rs", 200, &["f1", "f2"]);
+
+        let expected = vec![fresh[0], fresh[1], legacy[0], legacy[1]];
+        assert_eq!(
+            missing_ids(&db),
+            expected,
+            "mtime=0 rows sort after positive mtimes, id tiebreak, no error"
+        );
     }
 
     /// A chunk with no matching `embeddings` row must surface via

--- a/crates/spelunk-core/src/storage/chunks.rs
+++ b/crates/spelunk-core/src/storage/chunks.rs
@@ -402,6 +402,109 @@ mod tests {
         );
     }
 
+    /// A bulk-copied file tree (e.g. `cp -r` or a fresh checkout) commonly
+    /// leaves every file with an *identical* mtime, and a cold index leaves
+    /// every chunk's `graph_rank` at the shared `0.0` default. With both
+    /// leading keys tied across many rows, the ordering must not fall through
+    /// to SQLite's unspecified tie-break: `c.id` must fully determine the
+    /// order, identically across repeated calls.
+    #[test]
+    fn chunks_missing_embeddings_many_ties_are_fully_determined_by_id() {
+        let db = open_db();
+        let mut expected = Vec::new();
+        // 6 files, identical mtime, 3 chunks each: 18 rows all tied on
+        // (graph_rank=0.0, mtime=500).
+        for i in 0..6 {
+            let names = ["x", "y", "z"];
+            let ids = seed_file_chunks(&db, &format!("f{i}.rs"), 500, &names);
+            expected.extend(ids);
+        }
+        // Ascending c.id is the only remaining discriminator once graph_rank
+        // and mtime are constant across every row.
+        let mut sorted_expected = expected.clone();
+        sorted_expected.sort();
+        assert_eq!(
+            expected, sorted_expected,
+            "sanity: ids were inserted in ascending order"
+        );
+
+        assert_eq!(
+            missing_ids(&db),
+            expected,
+            "fully-tied rows (graph_rank, mtime) must resolve to ascending c.id"
+        );
+        // Repeat: no run-to-run flake from an underspecified ORDER BY.
+        assert_eq!(
+            missing_ids(&db),
+            expected,
+            "tie-break must be stable across repeated calls, not left to SQLite's whim"
+        );
+    }
+
+    /// Many chunks can share the same *non-zero* `graph_rank` too (e.g. several
+    /// leaf functions PageRank scores to the same value). Ties within a shared
+    /// rank must fall through to `mtime DESC`, then `c.id`, not collapse to an
+    /// arbitrary order.
+    #[test]
+    fn chunks_missing_embeddings_tied_nonzero_rank_falls_back_to_mtime_then_id() {
+        let db = open_db();
+        let a = seed_file_chunks(&db, "a.rs", 100, &["a1", "a2"]);
+        let b = seed_file_chunks(&db, "b.rs", 300, &["b1", "b2"]);
+        let c = seed_file_chunks(&db, "c.rs", 300, &["c1", "c2"]);
+
+        // All six chunks share the same non-zero rank.
+        for id in a.iter().chain(&b).chain(&c) {
+            db.update_graph_rank(*id, 0.42).unwrap();
+        }
+
+        // Tied on rank: mtime DESC groups b/c (300) ahead of a (100); within
+        // the b/c tie (same rank AND same mtime), c.id is the final tiebreak.
+        let expected = vec![b[0], b[1], c[0], c[1], a[0], a[1]];
+        assert_eq!(
+            missing_ids(&db),
+            expected,
+            "a shared non-zero graph_rank must fall back to mtime DESC, then id"
+        );
+    }
+
+    /// A file with a modification time far in the future (clock skew, or a
+    /// deliberately touched file) must sort ahead of every normal-mtime row,
+    /// and the query must not error or panic on a large positive `i64`.
+    #[test]
+    fn chunks_missing_embeddings_future_mtime_sorts_first_no_panic() {
+        let db = open_db();
+        let normal = seed_file_chunks(&db, "normal.rs", 1_000, &["n1"]);
+        // Comfortably in the future (year ~2107) without approaching i64::MAX,
+        // matching what a skewed system clock could plausibly report.
+        let skewed = seed_file_chunks(&db, "skewed.rs", 4_300_000_000, &["s1"]);
+
+        let expected = vec![skewed[0], normal[0]];
+        assert_eq!(
+            missing_ids(&db),
+            expected,
+            "a future/skewed mtime must sort first, not error"
+        );
+    }
+
+    /// A negative mtime (not producible by `stat_mtime`'s own fallback, which
+    /// always yields 0 on failure, but defensive against any other write path)
+    /// must not error the ORDER BY and must sort after both positive and
+    /// zero/legacy mtimes.
+    #[test]
+    fn chunks_missing_embeddings_negative_mtime_sorts_last_no_error() {
+        let db = open_db();
+        let negative = seed_file_chunks(&db, "negative.rs", -100, &["neg"]);
+        let legacy = seed_file_chunks(&db, "legacy.rs", 0, &["leg"]);
+        let fresh = seed_file_chunks(&db, "fresh.rs", 200, &["fr"]);
+
+        let expected = vec![fresh[0], legacy[0], negative[0]];
+        assert_eq!(
+            missing_ids(&db),
+            expected,
+            "DESC ordering must place negative mtime after 0 and positive mtimes, without erroring"
+        );
+    }
+
     /// A chunk with no matching `embeddings` row must surface via
     /// `chunks_missing_embeddings` (the parse phase unions these into the embed
     /// batch so a parse-only index doesn't leave chunks permanently

--- a/crates/spelunk-core/src/storage/db.rs
+++ b/crates/spelunk-core/src/storage/db.rs
@@ -12,7 +12,7 @@ pub struct Database {
 /// The runner in `Database::open` gates each migration on this via
 /// `PRAGMA user_version`; steps are numbered in the order they run (the field
 /// order), not filename order.
-pub(super) const CURRENT_SCHEMA_VERSION: i32 = 14;
+pub(super) const CURRENT_SCHEMA_VERSION: i32 = 15;
 
 /// One entry in the migration runner: (target version, migration body).
 type MigrationStep = (i32, fn(&Database) -> Result<()>);
@@ -74,6 +74,7 @@ impl Database {
             (12, Self::apply_dim_upgrade_migration),
             (13, Self::apply_drop_snapshots_migration),
             (14, Self::apply_index_meta_migration),
+            (15, Self::apply_file_mtime_migration),
         ];
         debug_assert_eq!(
             steps.last().map(|(v, _)| *v),
@@ -147,8 +148,18 @@ impl Database {
             }
             Ok(false)
         };
+        let files_has_column = |col: &str| -> Result<bool> {
+            let mut stmt = self.conn.prepare("PRAGMA table_info(files)")?;
+            let mut rows = stmt.query([])?;
+            while let Some(row) = rows.next()? {
+                if row.get::<_, String>(1)? == col {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        };
 
-        let ladder: [(i32, bool); 14] = [
+        let ladder: [(i32, bool); 15] = [
             (1, has_table("chunks")?),
             (2, has_table("embeddings")?),
             (3, has_table("graph_edges")?),
@@ -163,6 +174,7 @@ impl Database {
             (12, has_table("schema_int8_embeddings")?),
             (13, !has_table("snapshots")?),
             (14, has_table("index_meta")?),
+            (15, files_has_column("mtime")?),
         ];
         // Highest version whose predicate and all lower ones hold.
         let mut version = 0;
@@ -359,6 +371,21 @@ impl Database {
         Ok(())
     }
 
+    /// Add the `mtime` column to the files table (unix seconds; recency signal
+    /// for the embed queue). `ALTER TABLE` has no `IF NOT EXISTS`, so only the
+    /// already-applied error is tolerated; a genuine failure propagates.
+    pub fn apply_file_mtime_migration(&self) -> Result<()> {
+        match self
+            .conn
+            .execute_batch(include_str!("../../migrations/024_file_mtime.sql"))
+        {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => return Err(e).context("running file mtime migration"),
+        }
+        Ok(())
+    }
+
     /// Create the index_meta KV table (embedding provenance). Idempotent.
     pub fn apply_index_meta_migration(&self) -> Result<()> {
         self.conn
@@ -547,6 +574,61 @@ mod tests {
             msg.contains("no such table") || msg.contains("token_count migration"),
             "a real migration failure must propagate, got: {msg}"
         );
+    }
+
+    /// The `files.mtime` migration is idempotent: applying it to a pre-existing
+    /// (pre-column) index adds the column with default 0 without error, and
+    /// applying it again on an already-migrated DB is a tolerated no-op.
+    #[test]
+    fn file_mtime_migration_is_idempotent() {
+        register_sqlite_vec();
+        let db = Database::open(std::path::Path::new(":memory:")).expect("open");
+
+        let has_mtime = |db: &Database| -> bool {
+            let mut stmt = db.conn.prepare("PRAGMA table_info(files)").unwrap();
+            let mut rows = stmt.query([]).unwrap();
+            while let Some(row) = rows.next().unwrap() {
+                if row.get::<_, String>(1).unwrap() == "mtime" {
+                    return true;
+                }
+            }
+            false
+        };
+
+        // Fresh DB already has the column from the full migration run.
+        assert!(has_mtime(&db), "fresh DB has the mtime column");
+
+        // Simulate a pre-column index: drop the column, then re-run the migration.
+        db.conn
+            .execute_batch("ALTER TABLE files DROP COLUMN mtime")
+            .expect("drop mtime to simulate a pre-migration index");
+        assert!(!has_mtime(&db), "column dropped to model a legacy index");
+
+        db.apply_file_mtime_migration()
+            .expect("migration must add the column to a pre-column index without error");
+        assert!(has_mtime(&db), "migration re-added the mtime column");
+
+        // A legacy row inserted before the column existed reads back as 0.
+        db.conn
+            .execute(
+                "INSERT INTO files (path, language, hash, indexed_at) VALUES ('legacy.rs', 'rust', 'h', 1)",
+                [],
+            )
+            .unwrap();
+        let mtime: i64 = db
+            .conn
+            .query_row(
+                "SELECT mtime FROM files WHERE path = 'legacy.rs'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(mtime, 0, "a row lacking an explicit mtime defaults to 0");
+
+        // Re-applying on the already-migrated DB is a tolerated no-op.
+        db.apply_file_mtime_migration()
+            .expect("re-applying the migration on a migrated DB is a no-op");
+        assert!(has_mtime(&db));
     }
 
     /// Model provenance round-trips through index_meta, and a mismatch is a hard

--- a/crates/spelunk-core/src/storage/db.rs
+++ b/crates/spelunk-core/src/storage/db.rs
@@ -461,7 +461,7 @@ impl Database {
 #[cfg(test)]
 mod tests {
     use super::{CURRENT_SCHEMA_VERSION, Database};
-    use rusqlite::Connection;
+    use rusqlite::{Connection, OptionalExtension};
     use std::sync::OnceLock;
 
     fn register_sqlite_vec() {
@@ -629,6 +629,109 @@ mod tests {
         db.apply_file_mtime_migration()
             .expect("re-applying the migration on a migrated DB is a no-op");
         assert!(has_mtime(&db));
+    }
+
+    /// Exercises the actual legacy-inference rung for this migration (ladder
+    /// entry `(15, files_has_column("mtime"))`), not just the direct
+    /// `apply_file_mtime_migration` idempotency check above. A DB frozen at v14
+    /// (every table/column through `index_meta` present, `files.mtime` not yet
+    /// added, `user_version` reset to 0 — the real shape of an index built by
+    /// the previous binary) must be inferred at exactly 14 through
+    /// `Database::open`'s normal migration runner, and only step 15 must run to
+    /// bring it current.
+    #[test]
+    fn legacy_db_frozen_at_v14_infers_14_and_applies_only_mtime_step() {
+        register_sqlite_vec();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        {
+            let db = Database::open(tmp.path()).expect("build fully-migrated DB");
+            // Roll back to the pre-024 shape: drop only the mtime column,
+            // leaving every other v1..14 table/column intact, then reset the
+            // version stamp so `Database::open` must re-infer it from shape.
+            db.conn
+                .execute_batch("ALTER TABLE files DROP COLUMN mtime; PRAGMA user_version = 0;")
+                .expect("roll back to pre-mtime shape");
+            assert_eq!(
+                Database::infer_legacy_version(&db).unwrap(),
+                14,
+                "with every v1..14 predicate true and only the mtime rung false, \
+                 inference must land exactly at 14"
+            );
+            // A row inserted while at this legacy shape has no mtime column at
+            // all yet (pre-migration data).
+            db.conn
+                .execute(
+                    "INSERT INTO files (path, language, hash, indexed_at) VALUES ('old.rs', 'rust', 'h', 1)",
+                    [],
+                )
+                .unwrap();
+        }
+
+        // Reopen through the normal runner (not calling apply_file_mtime_migration
+        // directly): this is the real "agent upgrades the binary" path.
+        let db = Database::open(tmp.path()).expect("reopen legacy v14 DB");
+        assert_eq!(user_version(&db.conn), CURRENT_SCHEMA_VERSION);
+
+        let mtime: i64 = db
+            .conn
+            .query_row("SELECT mtime FROM files WHERE path = 'old.rs'", [], |r| {
+                r.get(0)
+            })
+            .expect("mtime column must exist and be queryable after inferred upgrade");
+        assert_eq!(
+            mtime, 0,
+            "a pre-existing row defaults to mtime 0, not an error"
+        );
+    }
+
+    /// Defends the ladder's early-break behaviour against a hand-tampered /
+    /// corrupted DB where a *later* rung's predicate is true but an *earlier*
+    /// one is false — a state the normal forward-only migration path can never
+    /// produce, but one a manual `ALTER TABLE` (or a hand-restored backup)
+    /// could. `Database::open` must still complete without error or data
+    /// corruption: the ladder takes the lowest satisfied version (ignoring the
+    /// spuriously-true later rung), and every step from there re-applies
+    /// idempotently rather than double-erroring on the already-present column.
+    #[test]
+    fn migration_ladder_tolerates_out_of_order_manually_tampered_state() {
+        register_sqlite_vec();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        {
+            let db = Database::open(tmp.path()).expect("build fully-migrated DB");
+            // Simulate tampering: drop the `usage` table (rung 9) while
+            // `files.mtime` (rung 15) is left present — a combination the real
+            // forward-only runner would never produce on its own.
+            db.conn
+                .execute_batch("DROP TABLE IF EXISTS usage; PRAGMA user_version = 0;")
+                .expect("tamper: drop usage, keep mtime");
+            assert_eq!(
+                Database::infer_legacy_version(&db).unwrap(),
+                8,
+                "the ladder must break at the first false predicate (rung 9, usage table) \
+                 and ignore the spuriously-true rung 15"
+            );
+        }
+
+        // Reopening must not error even though this replays step 15
+        // (files.mtime already exists) on top of a version-8 inference.
+        let db = Database::open(tmp.path())
+            .expect("reopening a tampered-but-recoverable DB must not error or corrupt state");
+        assert_eq!(user_version(&db.conn), CURRENT_SCHEMA_VERSION);
+
+        let has_usage: bool = db
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='usage'",
+                [],
+                |_| Ok(true),
+            )
+            .optional()
+            .unwrap()
+            .is_some();
+        assert!(
+            has_usage,
+            "the usage table must be recreated by the replayed step 9"
+        );
     }
 
     /// Model provenance round-trips through index_meta, and a mismatch is a hard

--- a/crates/spelunk-core/src/storage/files.rs
+++ b/crates/spelunk-core/src/storage/files.rs
@@ -12,20 +12,33 @@ pub struct FileRecord {
 }
 
 impl Database {
-    pub fn upsert_file(&self, path: &str, language: Option<&str>, hash: &str) -> Result<i64> {
+    /// Insert or update a file record. `mtime` is the file's filesystem
+    /// modification time in unix seconds (0 when unavailable), persisted so the
+    /// embed queue can order by file recency without re-stat()ing at
+    /// queue-build time. On a hash-unchanged file the caller skips this call
+    /// entirely, so a file's stored mtime is only refreshed when it is
+    /// re-parsed.
+    pub fn upsert_file(
+        &self,
+        path: &str,
+        language: Option<&str>,
+        hash: &str,
+        mtime: i64,
+    ) -> Result<i64> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
 
         self.conn.execute(
-            "INSERT INTO files (path, language, hash, indexed_at)
-             VALUES (?1, ?2, ?3, ?4)
+            "INSERT INTO files (path, language, hash, indexed_at, mtime)
+             VALUES (?1, ?2, ?3, ?4, ?5)
              ON CONFLICT(path) DO UPDATE SET
                 language   = excluded.language,
                 hash       = excluded.hash,
-                indexed_at = excluded.indexed_at",
-            rusqlite::params![path, language, hash, now],
+                indexed_at = excluded.indexed_at,
+                mtime      = excluded.mtime",
+            rusqlite::params![path, language, hash, now, mtime],
         )?;
 
         // ON CONFLICT UPDATE doesn't reset last_insert_rowid; fetch it explicitly.
@@ -42,6 +55,17 @@ impl Database {
         let mut stmt = self
             .conn
             .prepare_cached("SELECT hash FROM files WHERE path = ?1")?;
+        let mut rows = stmt.query(rusqlite::params![path])?;
+        Ok(rows.next()?.map(|r| r.get(0)).transpose()?)
+    }
+
+    /// Returns the stored filesystem mtime (unix secs) for a file path, or None
+    /// if not indexed. The persisted counterpart of the recency key the embed
+    /// queue orders on.
+    pub fn file_mtime(&self, path: &str) -> Result<Option<i64>> {
+        let mut stmt = self
+            .conn
+            .prepare_cached("SELECT mtime FROM files WHERE path = ?1")?;
         let mut rows = stmt.query(rusqlite::params![path])?;
         Ok(rows.next()?.map(|r| r.get(0)).transpose()?)
     }

--- a/crates/spelunk-core/src/storage/graph.rs
+++ b/crates/spelunk-core/src/storage/graph.rs
@@ -292,7 +292,7 @@ mod tests {
     /// Returns (file_id, caller_id, callee_id).
     fn seed_graph(db: &Database) -> (i64, i64, i64) {
         let file_id = db
-            .upsert_file("src/lib.rs", Some("rust"), "deadbeef")
+            .upsert_file("src/lib.rs", Some("rust"), "deadbeef", 0)
             .expect("upsert file");
         let caller_id = insert_named_chunk(db, file_id, "caller");
         let callee_id = insert_named_chunk(db, file_id, "callee");
@@ -329,7 +329,7 @@ mod tests {
         // Seed a real edge so the table is non-empty and a successful query
         // could in principle return rows — the injection string still must not.
         let file_id = db
-            .upsert_file("src/lib.rs", Some("rust"), "deadbeef")
+            .upsert_file("src/lib.rs", Some("rust"), "deadbeef", 0)
             .expect("upsert file");
         db.insert_chunk(
             file_id,

--- a/crates/spelunk-core/src/storage/search.rs
+++ b/crates/spelunk-core/src/storage/search.rs
@@ -196,7 +196,7 @@ mod tests {
 
     fn seed_chunk(db: &Database, content: &str) {
         let file_id = db
-            .upsert_file("src/lib.rs", Some("rust"), "deadbeef")
+            .upsert_file("src/lib.rs", Some("rust"), "deadbeef", 0)
             .expect("upsert file");
         db.insert_chunk(file_id, "function", Some("f"), 1, 5, content, None, 4)
             .expect("insert chunk");

--- a/crates/spelunk-core/tests/conventions.rs
+++ b/crates/spelunk-core/tests/conventions.rs
@@ -670,7 +670,9 @@ fn run_extraction_end_to_end() {
     let db = common::open_test_db();
 
     // Seed 10 Rust snake_case functions.
-    let rust_file_id = db.upsert_file("src/lib.rs", Some("rust"), "hash1").unwrap();
+    let rust_file_id = db
+        .upsert_file("src/lib.rs", Some("rust"), "hash1", 0)
+        .unwrap();
     for i in 0..10 {
         db.insert_chunk(
             rust_file_id,
@@ -687,7 +689,7 @@ fn run_extraction_end_to_end() {
 
     // Seed 10 TypeScript camelCase functions.
     let ts_file_id = db
-        .upsert_file("src/index.ts", Some("typescript"), "hash2")
+        .upsert_file("src/index.ts", Some("typescript"), "hash2", 0)
         .unwrap();
     for i in 0..10 {
         db.insert_chunk(

--- a/crates/spelunk-core/tests/escape_like_integration.rs
+++ b/crates/spelunk-core/tests/escape_like_integration.rs
@@ -19,7 +19,7 @@ use serial_test::serial;
 /// Insert a file + one chunk and return the file id.
 fn seed_file(db: &spelunk_core::storage::Database, path: &str) -> i64 {
     let file_id = db
-        .upsert_file(path, Some("rust"), "hash")
+        .upsert_file(path, Some("rust"), "hash", 0)
         .expect("upsert_file");
     db.insert_chunk(file_id, "function", Some("f"), 1, 5, "fn f() {}", None, 3)
         .expect("insert_chunk");

--- a/crates/spelunk-core/tests/integration_db.rs
+++ b/crates/spelunk-core/tests/integration_db.rs
@@ -27,8 +27,12 @@ fn unit_vec(dim: usize, pos: usize) -> Vec<f32> {
 #[serial]
 fn upsert_file_returns_stable_id() {
     let db = common::open_test_db();
-    let id1 = db.upsert_file("src/lib.rs", Some("rust"), "hash1").unwrap();
-    let id2 = db.upsert_file("src/lib.rs", Some("rust"), "hash2").unwrap();
+    let id1 = db
+        .upsert_file("src/lib.rs", Some("rust"), "hash1", 0)
+        .unwrap();
+    let id2 = db
+        .upsert_file("src/lib.rs", Some("rust"), "hash2", 0)
+        .unwrap();
     assert_eq!(id1, id2, "upsert must return the same row id");
 }
 
@@ -36,7 +40,7 @@ fn upsert_file_returns_stable_id() {
 #[serial]
 fn file_hash_round_trips() {
     let db = common::open_test_db();
-    db.upsert_file("src/main.rs", Some("rust"), "abc123")
+    db.upsert_file("src/main.rs", Some("rust"), "abc123", 0)
         .unwrap();
     let hash = db.file_hash("src/main.rs").unwrap();
     assert_eq!(hash.as_deref(), Some("abc123"));
@@ -55,7 +59,7 @@ fn file_hash_returns_none_for_unknown() {
 #[serial]
 fn insert_and_delete_chunks() {
     let db = common::open_test_db();
-    let file_id = db.upsert_file("src/foo.rs", Some("rust"), "h").unwrap();
+    let file_id = db.upsert_file("src/foo.rs", Some("rust"), "h", 0).unwrap();
     let chunk_id = db
         .insert_chunk(
             file_id,
@@ -87,7 +91,7 @@ fn knn_returns_closest_vector_first() {
     let db = common::open_test_db();
 
     // Insert two chunks with distinct embeddings.
-    let fid = db.upsert_file("a.rs", Some("rust"), "h").unwrap();
+    let fid = db.upsert_file("a.rs", Some("rust"), "h", 0).unwrap();
     let cid1 = db
         .insert_chunk(
             fid,
@@ -138,7 +142,7 @@ fn knn_returns_closest_vector_first() {
 #[serial]
 fn int8_knn_preserves_ranking_and_rescales_distance() {
     let db = common::open_test_db();
-    let fid = db.upsert_file("vec.rs", Some("rust"), "h").unwrap();
+    let fid = db.upsert_file("vec.rs", Some("rust"), "h", 0).unwrap();
 
     // query = e0; `near` is mostly e0 with a little e1; `far` is orthogonal (e1).
     let query = unit_vec(DIM, 0);
@@ -184,7 +188,7 @@ fn int8_knn_preserves_ranking_and_rescales_distance() {
 #[serial]
 fn knn_limit_is_respected() {
     let db = common::open_test_db();
-    let fid = db.upsert_file("b.rs", Some("rust"), "h").unwrap();
+    let fid = db.upsert_file("b.rs", Some("rust"), "h", 0).unwrap();
 
     for i in 0..5 {
         let cid = db


### PR DESCRIPTION
## Summary

- Persists file modification time (`files.mtime`, migration `024_file_mtime.sql`) so the embed queue can order by recency without a filesystem stat at queue-build time — required because the detached `--_embed-phases` worker rebuilds the queue purely from the DB.
- Changes `Database::chunks_missing_embeddings`'s ordering from `ORDER BY c.id` to a single data-driven `ORDER BY c.graph_rank DESC, f.mtime DESC, c.id`. No cold/warm branching in code: a cold index (all `graph_rank = 0`) collapses to pure recency; a warm re-index leads with the prior run's PageRank-derived rank; legacy pre-migration rows (`mtime = 0`) sort deterministically last.
- Both consumers (the inline backfill and the detached `--_embed-phases` worker via `missing_embedding_texts`) inherit the new order for free — no code change needed in either.
- Fixes the `warmup_notice_partial` copy (`spelunk-cli/src/cli/cmd/search.rs`), which previously claimed the partial index was "front-loaded by indexing order" — stale after the reorder. Now reads "front-loaded by importance and recency", matching the actual `ORDER BY`.

Final index contents and search correctness are unchanged (identical `LEFT JOIN ... WHERE e.chunk_id IS NULL` row set; only row order changes). No new dependencies.

## Test plan

Ran locally on this branch, `SPELUNK_SECRET_STORE=file`:

- `cargo fmt --check` — clean.
- `cargo clippy -p spelunk-core -p spelunk-cli --all-targets -- -D warnings` — clean (default features).
- `cargo clippy -p spelunk-core -p spelunk-cli --all-targets --features rich-formats -- -D warnings` — clean.
- `cargo clippy -p spelunk-core -p spelunk-cli --all-targets --no-default-features -- -D warnings` — clean.
- `cargo test -p spelunk-core -p spelunk-cli` (default features) — all green (395/3/6/16/22/40/... across all binaries, 0 failed).
- `cargo test -p spelunk-core -p spelunk-cli --features rich-formats` — all green, identical counts.
- `cargo test -p spelunk-core -p spelunk-cli --no-default-features` — all green, identical counts.
- `cargo audit` — clean (2 pre-existing allowed warnings, no new advisories).
- Confirmed migration number 024 is still free on `origin/main` (tops out at `023_memory_entity_id.sql` on both this branch and `origin/main`) — no collision.
- Spot-checked adversarial tests added by test-engineer: `chunks_missing_embeddings_many_ties_are_fully_determined_by_id` (18 fully-tied rows resolve deterministically to ascending `c.id`, verified stable across repeated calls) and `legacy_db_frozen_at_v14_infers_14_and_applies_only_mtime_step` (a DB frozen at schema v14 with `files.mtime` absent is inferred at exactly 14 through `Database::open`'s real migration runner, then upgrades cleanly) — both read in full, both exercise real behavior, not tautological.
- Grepped the full diff for board task ids / internal references — none found.
- Confirmed `MAX_CHUNK_TOKENS` is untouched and the ordering key (`graph_rank`, `mtime`) is chunk-boundary-independent per ADR-070 D5.