### PR TITLE
fix(storage): INSERT OR REPLACE does not replace on vec0 embedding tables

### DIFF
--- a/crates/spelunk-core/src/storage/db.rs
+++ b/crates/spelunk-core/src/storage/db.rs
@@ -1054,4 +1054,187 @@ mod tests {
             "the last write in the batch must win"
         );
     }
+
+    /// Replacing a `chunk_id` that has never been inserted must be a harmless
+    /// no-op DELETE followed by a normal INSERT — not an error. This is the
+    /// overwhelmingly common real-world call pattern (indexing a chunk for the
+    /// first time), so it must not regress under the delete-then-insert fix.
+    #[test]
+    fn insert_embedding_of_nonexistent_chunk_id_is_a_harmless_delete_no_op() {
+        register_sqlite_vec();
+        let db = Database::open(std::path::Path::new(":memory:")).expect("open");
+        let dim = crate::embeddings::EMBEDDING_DIM;
+
+        let mut vector = vec![0f32; dim];
+        vector[3] = 1.0;
+
+        db.insert_embedding(42, &vector)
+            .expect("inserting a never-before-seen chunk_id must succeed");
+
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM embeddings WHERE chunk_id = 42",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "the first insert for a fresh id must land exactly once"
+        );
+
+        let stored: Vec<u8> = db
+            .conn
+            .query_row(
+                "SELECT embedding FROM embeddings WHERE chunk_id = 42",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, crate::embeddings::vec_to_int8_blob(&vector));
+    }
+
+    /// The strongest test of "joins the existing transaction" vs. "just happens
+    /// not to error": call `insert_embedding` for a repeated `chunk_id` from
+    /// WITHIN a transaction the caller already opened, then roll that outer
+    /// transaction back. If the delete+insert genuinely joined the caller's
+    /// transaction (rather than, say, silently nesting a SAVEPOINT that
+    /// commits independently), rolling back the outer transaction must undo
+    /// both the delete and the insert, restoring the pre-transaction row
+    /// exactly.
+    #[test]
+    fn insert_embedding_joins_callers_transaction_and_rolls_back_with_it() {
+        register_sqlite_vec();
+        let db = Database::open(std::path::Path::new(":memory:")).expect("open");
+        let dim = crate::embeddings::EMBEDDING_DIM;
+
+        let mut first = vec![0f32; dim];
+        first[0] = 1.0;
+        db.insert_embedding(1, &first)
+            .expect("seed row (autocommit)");
+
+        let mut second = vec![0f32; dim];
+        second[1] = 1.0;
+
+        {
+            let tx = db
+                .conn
+                .unchecked_transaction()
+                .expect("caller opens an outer transaction");
+            assert!(
+                !db.conn.is_autocommit(),
+                "precondition: connection must be mid-transaction, exercising the \
+                 is_autocommit() guard's join branch rather than its own-BEGIN branch"
+            );
+
+            // Must not attempt a nested BEGIN (vec0/SQLite would reject it) —
+            // simply not erroring here already covers that. The real test is
+            // below: did it join *this* transaction, or silently commit on its
+            // own?
+            db.insert_embedding(1, &second)
+                .expect("replacing inside the caller's open transaction must not nest a BEGIN");
+
+            tx.rollback().expect("roll back the outer transaction");
+        }
+
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM embeddings WHERE chunk_id = 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "rollback must not leave the row deleted — the DELETE half of the \
+             replace was part of the outer transaction and must roll back with it"
+        );
+
+        let stored: Vec<u8> = db
+            .conn
+            .query_row(
+                "SELECT embedding FROM embeddings WHERE chunk_id = 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stored,
+            crate::embeddings::vec_to_int8_blob(&first),
+            "rollback must restore the pre-transaction (first) vector — if the \
+             delete+insert had committed independently of the caller's \
+             transaction, the row would still hold `second` here"
+        );
+    }
+
+    /// The `embeddings` table runs in WAL mode (`Database::open`). A repeated
+    /// `chunk_id` replace is delete-then-insert; if those two statements were
+    /// not wrapped in one atomic transaction, a concurrent reader (e.g. a
+    /// search query racing an index refresh) could observe a window with zero
+    /// rows for that id between the DELETE committing and the INSERT
+    /// committing. Drive many replaces on one connection while a second,
+    /// independent connection continuously polls the row count, and assert
+    /// the reader never observes zero.
+    #[test]
+    fn insert_embedding_replace_has_no_zero_row_window_visible_to_a_concurrent_reader() {
+        register_sqlite_vec();
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let path = tmp.path().to_path_buf();
+        let db = Database::open(&path).expect("open file-backed db (WAL mode)");
+        let dim = crate::embeddings::EMBEDDING_DIM;
+
+        let mut seed = vec![0f32; dim];
+        seed[0] = 1.0;
+        db.insert_embedding(1, &seed).expect("seed row");
+
+        let reader = Connection::open(&path).expect("independent reader connection");
+        reader
+            .execute_batch("PRAGMA busy_timeout = 5000;")
+            .expect("reader busy timeout");
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let saw_zero = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let iterations_observed = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let stop_reader = stop.clone();
+        let saw_zero_reader = saw_zero.clone();
+        let iterations_reader = iterations_observed.clone();
+
+        let reader_thread = std::thread::spawn(move || {
+            while !stop_reader.load(std::sync::atomic::Ordering::Relaxed) {
+                let count: i64 = reader
+                    .query_row(
+                        "SELECT COUNT(*) FROM embeddings WHERE chunk_id = 1",
+                        [],
+                        |r| r.get(0),
+                    )
+                    .expect("reader query must not error under WAL");
+                iterations_reader.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if count == 0 {
+                    saw_zero_reader.store(true, std::sync::atomic::Ordering::Relaxed);
+                }
+            }
+        });
+
+        let mut v = vec![0f32; dim];
+        for i in 0..500 {
+            v[i % dim] = 1.0;
+            db.insert_embedding(1, &v).expect("replace");
+        }
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        reader_thread.join().expect("reader thread must not panic");
+
+        assert!(
+            iterations_observed.load(std::sync::atomic::Ordering::Relaxed) > 0,
+            "sanity check: the reader must actually have raced the writer"
+        );
+        assert!(
+            !saw_zero.load(std::sync::atomic::Ordering::Relaxed),
+            "a concurrent WAL reader must never observe zero rows for chunk_id=1 \
+             mid-replace — the delete+insert must commit atomically as one \
+             transaction, not as two independently-visible statements"
+        );
+    }
 }

--- a/crates/spelunk-core/src/storage/db.rs
+++ b/crates/spelunk-core/src/storage/db.rs
@@ -410,21 +410,45 @@ impl Database {
     /// `embeddings` `int8[896]` column (see `embeddings::vec_to_int8_blob`).
     pub fn insert_embedding(&self, chunk_id: i64, vector: &[f32]) -> Result<()> {
         let blob = crate::embeddings::vec_to_int8_blob(vector);
+        // The `embeddings` table is a sqlite-vec `vec0` virtual table, which does
+        // not honour `INSERT OR REPLACE`/`ON CONFLICT`: a second insert for an
+        // existing `chunk_id` raises a hard UNIQUE-constraint error instead of
+        // overwriting. Emulate replace with an explicit delete-then-insert, kept
+        // atomic under one transaction so a repeated `chunk_id` is genuine
+        // last-write-wins (re-embed-on-change, `index --force`). When a caller
+        // already holds a transaction (batch flush) we join it rather than
+        // nesting a BEGIN, which vec0/SQLite would reject.
         // sqlite-vec treats a raw BLOB as float32; vec_int8() reinterprets the
         // bytes as the int8 vector the column expects.
-        self.conn.execute(
-            "INSERT OR REPLACE INTO embeddings (chunk_id, embedding) VALUES (?1, vec_int8(?2))",
-            rusqlite::params![chunk_id, blob],
-        )?;
+        let write = |conn: &Connection| -> rusqlite::Result<()> {
+            conn.execute(
+                "DELETE FROM embeddings WHERE chunk_id = ?1",
+                rusqlite::params![chunk_id],
+            )?;
+            conn.execute(
+                "INSERT INTO embeddings (chunk_id, embedding) VALUES (?1, vec_int8(?2))",
+                rusqlite::params![chunk_id, blob],
+            )?;
+            Ok(())
+        };
+        if self.conn.is_autocommit() {
+            let tx = self.conn.unchecked_transaction()?;
+            write(&tx)?;
+            tx.commit()?;
+        } else {
+            write(&self.conn)?;
+        }
         Ok(())
     }
 
     /// Insert or replace a whole batch of embeddings in a single transaction.
     ///
-    /// Same per-row statement as [`insert_embedding`], but one commit for the
-    /// batch instead of one implicit autocommit per row (mirrors the
-    /// `update_graph_ranks` batch pattern). The embed phase already holds the
-    /// whole batch's vectors in memory by the time it writes them, so the
+    /// Same per-row replace shape as [`insert_embedding`] (the `embeddings`
+    /// vec0 table doesn't honour `INSERT OR REPLACE`, so a repeated
+    /// `chunk_id` is emulated with delete-then-insert), but one commit for
+    /// the whole batch instead of one implicit autocommit per row (mirrors
+    /// the `update_graph_ranks` batch pattern). The embed phase already holds
+    /// the whole batch's vectors in memory by the time it writes them, so the
     /// commit boundary is the batch: on an untimely kill the transaction is
     /// rolled back atomically and `chunks_missing_embeddings` re-queues the
     /// entire batch, never a partial one.
@@ -433,7 +457,11 @@ impl Database {
         for (chunk_id, vector) in rows {
             let blob = crate::embeddings::vec_to_int8_blob(vector);
             tx.execute(
-                "INSERT OR REPLACE INTO embeddings (chunk_id, embedding) VALUES (?1, vec_int8(?2))",
+                "DELETE FROM embeddings WHERE chunk_id = ?1",
+                rusqlite::params![chunk_id],
+            )?;
+            tx.execute(
+                "INSERT INTO embeddings (chunk_id, embedding) VALUES (?1, vec_int8(?2))",
                 rusqlite::params![chunk_id, blob],
             )?;
         }
@@ -669,28 +697,16 @@ mod tests {
         assert_eq!(embedding_count(&db), 1);
     }
 
-    /// BUG, pre-existing and NOT introduced by this story (found during
-    /// test-hardening; not fixed here — see the story's handback comment):
-    /// `insert_embedding`'s own doc-comment promises "insert or replace", but
-    /// `INSERT OR REPLACE` against the `embeddings` vec0 virtual table does
-    /// not actually replace anything — even here, across two separate,
-    /// fully-autocommitted calls with nothing else in flight, the second call
-    /// raises `UNIQUE constraint failed on embeddings primary key` instead of
-    /// overwriting the first row. sqlite-vec's vec0 module does not honour
-    /// `OR REPLACE` conflict resolution against an already-committed row
-    /// either. This has no observed production impact today only because
-    /// every real caller (`embed_phase.rs`, `parse_phase.rs`) inserts
-    /// exclusively for `chunk_id`s drawn from `chunks_missing_embeddings`
-    /// (never-yet-embedded) or after `delete_embeddings_for_file`, so a
-    /// same-key collision never actually reaches this call. It matters to
-    /// *this* story specifically because the run-level resume test's own
-    /// comment ("`INSERT OR REPLACE` keyed on chunk_id is what makes a
-    /// re-embed idempotent") and the batch engineer's handoff note both cite
-    /// OR-REPLACE idempotency as a safety property to lean on — it is not
-    /// actually true at the DB layer, so neither should keep relying on it as
-    /// stated. Left failing deliberately; do not weaken this assertion.
+    /// Was a bug (see `git blame`/ADR-070): `insert_embedding`'s doc-comment
+    /// promises "insert or replace", but plain `INSERT OR REPLACE` against the
+    /// `embeddings` vec0 virtual table does not honour the conflict clause —
+    /// a second call for the same `chunk_id` raised `UNIQUE constraint
+    /// failed` instead of overwriting. This mattered because the run-level
+    /// resume test's own comment and the batch engineer's handoff note both
+    /// cited OR-REPLACE idempotency as a safety property to lean on. Fixed by
+    /// emulating replace with an explicit delete-then-insert (see
+    /// `insert_embedding`); this test now pins the fixed, promised behaviour.
     #[test]
-    #[ignore = "known bug: INSERT OR REPLACE does not replace on the embeddings vec0 table, tracked separately"]
     fn insert_embedding_single_row_path_does_not_actually_replace_a_repeated_chunk_id() {
         register_sqlite_vec();
         let db = Database::open(std::path::Path::new(":memory:")).expect("open");
@@ -707,15 +723,13 @@ mod tests {
     /// Same underlying bug as the test above, exercised through the batch
     /// path this story added: a batch containing the same `chunk_id` twice
     /// (still legitimate input — nothing in `insert_embeddings`'s contract
-    /// forbids it) hits the identical `UNIQUE constraint failed` error,
-    /// because it is the same OR-REPLACE-against-vec0 gap, not something the
-    /// transaction wrapper introduced. Left failing deliberately; do not
-    /// weaken this assertion to match the buggy behaviour — the fix belongs
-    /// in `insert_embedding`/`insert_embeddings` (e.g. dedup a batch's rows
-    /// keeping the last write, or an explicit delete-then-insert), not in a
-    /// relaxed test.
+    /// forbids it) used to hit the identical `UNIQUE constraint failed`
+    /// error, because it was the same OR-REPLACE-against-vec0 gap, not
+    /// something the transaction wrapper introduced. `insert_embeddings` now
+    /// applies the same delete-then-insert-per-row fix inside its batch
+    /// transaction, so a repeated id within one batch collapses to a single
+    /// last-write-wins row instead of erroring.
     #[test]
-    #[ignore = "known bug: INSERT OR REPLACE does not replace on the embeddings vec0 table, tracked separately"]
     fn insert_embeddings_duplicate_chunk_id_within_one_batch_last_write_wins() {
         register_sqlite_vec();
         let db = Database::open(std::path::Path::new(":memory:")).expect("open");
@@ -940,6 +954,104 @@ mod tests {
             0,
             "a batch abandoned by a hard process exit before commit must leave zero rows — the \
              literal 'kill mid-batch' scenario, not just an in-process Err short-circuit"
+        );
+    }
+
+    /// Two independent, fully-committed `insert_embedding` calls for the same
+    /// `chunk_id` must leave exactly one row holding the *second* vector — the
+    /// re-embed-on-content-change idempotency the resume/`index --force` paths
+    /// assume. On a `vec0` virtual table plain `INSERT OR REPLACE` silently
+    /// fails to do this (the conflict clause isn't honoured), so this pins the
+    /// delete-then-insert fix.
+    #[test]
+    fn insert_embedding_single_row_path_replaces_a_repeated_chunk_id() {
+        register_sqlite_vec();
+        let db = Database::open(std::path::Path::new(":memory:")).expect("open");
+        let dim = crate::embeddings::EMBEDDING_DIM;
+
+        let mut first = vec![0f32; dim];
+        first[0] = 1.0;
+        let mut second = vec![0f32; dim];
+        second[10] = 1.0;
+
+        db.insert_embedding(1, &first).expect("first insert");
+        db.insert_embedding(1, &second)
+            .expect("second insert (replace)");
+
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM embeddings WHERE chunk_id = 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "a repeated chunk_id must leave exactly one row");
+
+        let stored: Vec<u8> = db
+            .conn
+            .query_row(
+                "SELECT embedding FROM embeddings WHERE chunk_id = 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stored,
+            crate::embeddings::vec_to_int8_blob(&second),
+            "the second insert must overwrite the first (last-write-wins)"
+        );
+    }
+
+    /// The same duplicate-`chunk_id` sequence inside a single explicit
+    /// transaction (mirroring a batch embed that flushes many rows under one
+    /// `BEGIN`) must also collapse to one last-write-wins row.
+    #[test]
+    fn insert_embedding_duplicate_chunk_id_within_one_transaction_last_write_wins() {
+        register_sqlite_vec();
+        let db = Database::open(std::path::Path::new(":memory:")).expect("open");
+        let dim = crate::embeddings::EMBEDDING_DIM;
+
+        let mut a = vec![0f32; dim];
+        a[1] = 1.0;
+        let mut b = vec![0f32; dim];
+        b[2] = 1.0;
+        let mut c = vec![0f32; dim];
+        c[3] = 1.0;
+
+        {
+            let tx = db.conn.unchecked_transaction().unwrap();
+            db.insert_embedding(7, &a).unwrap();
+            db.insert_embedding(7, &b).unwrap();
+            db.insert_embedding(7, &c).unwrap();
+            tx.commit().unwrap();
+        }
+
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM embeddings WHERE chunk_id = 7",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "duplicate chunk_ids in one batch collapse to one row"
+        );
+
+        let stored: Vec<u8> = db
+            .conn
+            .query_row(
+                "SELECT embedding FROM embeddings WHERE chunk_id = 7",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stored,
+            crate::embeddings::vec_to_int8_blob(&c),
+            "the last write in the batch must win"
         );
     }
 }

--- a/crates/spelunk-core/src/storage/memory/notes.rs
+++ b/crates/spelunk-core/src/storage/memory/notes.rs
@@ -213,10 +213,30 @@ impl MemoryStore {
     }
 
     pub fn insert_embedding(&self, note_id: i64, blob: &[u8]) -> Result<()> {
-        self.conn.execute(
-            "INSERT OR REPLACE INTO note_embeddings (note_id, embedding) VALUES (?1, ?2)",
-            rusqlite::params![note_id, blob],
-        )?;
+        // `note_embeddings` is a sqlite-vec `vec0` virtual table, which does not
+        // honour `INSERT OR REPLACE`/`ON CONFLICT` — a repeated `note_id` raises
+        // a hard UNIQUE-constraint error instead of overwriting. Emulate replace
+        // with an atomic delete-then-insert so re-embedding a note is genuine
+        // last-write-wins. When a caller already holds a transaction we join it
+        // rather than nesting a BEGIN, which vec0/SQLite would reject.
+        let write = |conn: &rusqlite::Connection| -> rusqlite::Result<()> {
+            conn.execute(
+                "DELETE FROM note_embeddings WHERE note_id = ?1",
+                rusqlite::params![note_id],
+            )?;
+            conn.execute(
+                "INSERT INTO note_embeddings (note_id, embedding) VALUES (?1, ?2)",
+                rusqlite::params![note_id, blob],
+            )?;
+            Ok(())
+        };
+        if self.conn.is_autocommit() {
+            let tx = self.conn.unchecked_transaction()?;
+            write(&tx)?;
+            tx.commit()?;
+        } else {
+            write(&self.conn)?;
+        }
         Ok(())
     }
 

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -472,3 +472,52 @@ fn entity_id_migration_is_additive_on_a_store_with_duplicates() {
     drop(store);
     MemoryStore::open(&path).expect("re-open must be idempotent");
 }
+
+/// `note_embeddings` is a `vec0` virtual table, so like the code `embeddings`
+/// table it does not honour `INSERT OR REPLACE`: re-embedding an existing
+/// `note_id` must overwrite in place (one last-write-wins row), not error or
+/// duplicate.
+#[test]
+fn insert_embedding_replaces_a_repeated_note_id() {
+    let store = open_store();
+    let id = store
+        .add_note("note", "N", "b", &[], &[], None, None)
+        .unwrap();
+
+    let dim = crate::embeddings::EMBEDDING_DIM;
+    let mut first = vec![0f32; dim];
+    first[0] = 1.0;
+    let mut second = vec![0f32; dim];
+    second[5] = 1.0;
+
+    store
+        .insert_embedding(id, &crate::embeddings::vec_to_blob(&first))
+        .expect("first note embedding");
+    store
+        .insert_embedding(id, &crate::embeddings::vec_to_blob(&second))
+        .expect("second note embedding (replace)");
+
+    let count: i64 = store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM note_embeddings WHERE note_id = ?1",
+            rusqlite::params![id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 1, "a repeated note_id must leave exactly one row");
+
+    let stored: Vec<u8> = store
+        .conn
+        .query_row(
+            "SELECT embedding FROM note_embeddings WHERE note_id = ?1",
+            rusqlite::params![id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        stored,
+        crate::embeddings::vec_to_blob(&second),
+        "the second embedding must overwrite the first"
+    );
+}

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -521,3 +521,107 @@ fn insert_embedding_replaces_a_repeated_note_id() {
         "the second embedding must overwrite the first"
     );
 }
+
+/// Replacing a `note_id` that has never been embedded must be a harmless
+/// no-op DELETE followed by a normal INSERT, not an error — the common case
+/// of embedding a note for the first time.
+#[test]
+fn insert_embedding_of_nonexistent_note_id_is_a_harmless_delete_no_op() {
+    let store = open_store();
+    let id = store
+        .add_note("note", "N", "b", &[], &[], None, None)
+        .unwrap();
+
+    let dim = crate::embeddings::EMBEDDING_DIM;
+    let mut vector = vec![0f32; dim];
+    vector[7] = 1.0;
+
+    store
+        .insert_embedding(id, &crate::embeddings::vec_to_blob(&vector))
+        .expect("embedding a never-before-embedded note must succeed");
+
+    let count: i64 = store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM note_embeddings WHERE note_id = ?1",
+            rusqlite::params![id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        count, 1,
+        "the first embed for a fresh note must land exactly once"
+    );
+}
+
+/// The strongest test of "joins the existing transaction" vs. "just happens
+/// not to error": call `insert_embedding` for a repeated `note_id` from
+/// WITHIN a transaction the caller already opened, then roll that outer
+/// transaction back. If the delete+insert genuinely joined the caller's
+/// transaction, rolling it back must undo both halves, restoring the
+/// pre-transaction row exactly.
+#[test]
+fn insert_embedding_joins_callers_transaction_and_rolls_back_with_it() {
+    let store = open_store();
+    let id = store
+        .add_note("note", "N", "b", &[], &[], None, None)
+        .unwrap();
+
+    let dim = crate::embeddings::EMBEDDING_DIM;
+    let mut first = vec![0f32; dim];
+    first[0] = 1.0;
+    store
+        .insert_embedding(id, &crate::embeddings::vec_to_blob(&first))
+        .expect("seed row (autocommit)");
+
+    let mut second = vec![0f32; dim];
+    second[1] = 1.0;
+
+    {
+        let tx = store
+            .conn
+            .unchecked_transaction()
+            .expect("caller opens an outer transaction");
+        assert!(
+            !store.conn.is_autocommit(),
+            "precondition: connection must be mid-transaction, exercising the \
+             is_autocommit() guard's join branch rather than its own-BEGIN branch"
+        );
+
+        store
+            .insert_embedding(id, &crate::embeddings::vec_to_blob(&second))
+            .expect("replacing inside the caller's open transaction must not nest a BEGIN");
+
+        tx.rollback().expect("roll back the outer transaction");
+    }
+
+    let count: i64 = store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM note_embeddings WHERE note_id = ?1",
+            rusqlite::params![id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        count, 1,
+        "rollback must not leave the row deleted — the DELETE half of the \
+         replace was part of the outer transaction and must roll back with it"
+    );
+
+    let stored: Vec<u8> = store
+        .conn
+        .query_row(
+            "SELECT embedding FROM note_embeddings WHERE note_id = ?1",
+            rusqlite::params![id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        stored,
+        crate::embeddings::vec_to_blob(&first),
+        "rollback must restore the pre-transaction (first) vector — if the \
+         delete+insert had committed independently of the caller's \
+         transaction, the row would still hold `second` here"
+    );
+}

--- a/docs/adr/070-init-embed-lifecycle-and-search-warmup-contract.md
+++ b/docs/adr/070-init-embed-lifecycle-and-search-warmup-contract.md
@@ -134,13 +134,18 @@ The recovery path has always worked. It was only ever undiscoverable.
 
 Resume granularity is **per batch, not per chunk**. `insert_embeddings` writes
 each batch's rows in a single transaction (matching the `update_graph_ranks`
-batch pattern), so a batch either lands whole or not at all. The queue-durability
-argument holds unchanged: a worker killed mid-batch keeps every batch it had
-already committed, the interrupted batch commits nothing, and the `LEFT JOIN`
-re-queues exactly that batch on the next run, with no duplicate row (the insert
-is keyed on `chunk_id`) and no silent gap. The trade this buys is bounded: the
-worst case on an untimely kill is recomputing one batch's embeddings, capped by
-the calibrated batch size (at most 256 chunks, and usually the smaller
+batch pattern), so a batch either lands whole or not at all. Each row within
+that transaction is written via an atomic delete-then-insert, not a bare
+`INSERT OR REPLACE` — the `embeddings` table is a `vec0` virtual table, which
+does not honour that conflict clause, so a repeated `chunk_id` (within or
+across batches) genuinely replaces the existing row instead of raising a
+UNIQUE-constraint error. The queue-durability argument holds unchanged: a
+worker killed mid-batch keeps every batch it had already committed, the
+interrupted batch commits nothing, and the `LEFT JOIN` re-queues exactly that
+batch on the next run, with no duplicate row (the insert is keyed on
+`chunk_id`) and no silent gap. The trade this buys is bounded: the worst case
+on an untimely kill is recomputing one batch's embeddings, capped by the
+calibrated batch size (at most 256 chunks, and usually the smaller
 duration-calibrated size rather than the ceiling), not unbounded work. This
 supersedes an earlier per-chunk autocommit whose per-row transaction commit
 bought finer resumability than this ADR requires; batching the commits trades


### PR DESCRIPTION
## Severity

**Correctness bug, data-loss/error class.** `INSERT OR REPLACE` (and by extension `ON CONFLICT`) does not work against a sqlite-vec `vec0` virtual table. A second insert for an existing primary key (`chunk_id` / `note_id`) does not silently keep the old row either — it raises a hard `UNIQUE constraint failed` error on the connection. Any re-embed of a previously-embedded chunk or note (content change + re-index, `spelunk index --force`, re-embedding a note) would have hit this error at runtime. No production impact observed to date because real callers have so far only ever inserted for never-yet-embedded ids, but the assumption of idempotent replace was false and baked into ADR-070's resume-granularity argument.

## Root cause

vec0's shadow-table-backed `xUpdate` treats a primary-key collision as a plain UNIQUE violation and does not honour SQLite's normal `OR REPLACE` / `ON CONFLICT` conflict-resolution clauses. This is a property of the vec0 extension, not of these particular queries.

## Fix

Emulate replace with an explicit, atomic **delete-then-insert**:
- `Database::insert_embedding` (`crates/spelunk-core/src/storage/db.rs`) — `embeddings` table.
- `MemoryStore::insert_embedding` (`crates/spelunk-core/src/storage/memory/notes.rs`) — `note_embeddings` table.

Both check `conn.is_autocommit()`: if the connection is idle, the function opens and commits its own transaction around the delete+insert; if a caller already holds an open transaction (e.g. a batch flush), it joins that transaction instead of nesting a `BEGIN` (which vec0/SQLite would reject). This keeps the replace atomic in both call shapes with no window where a crash could leave the row permanently missing.

## Audit of other INSERT OR REPLACE / ON CONFLICT usage against vec0 tables

- `snapshot_embeddings` (vec0): no live insert path — the feature was removed and the table dropped in migration `021_drop_snapshots.sql`. Not affected.
- Server-side `note_embeddings` (`crates/spelunk-server/src/db.rs`): `add_note` only ever does a plain `INSERT` for a freshly-minted `note_id` (never a repeated id), and `delete_note` explicitly `DELETE`s before removing the note. Already correct, no change needed.
- All other `ON CONFLICT` usage in the codebase (`registry.rs`, `storage/specs.rs`, `storage/files.rs`) targets ordinary (non-vec0) tables, where `ON CONFLICT` works as normal SQLite. Not affected.
- `index_meta` (`db.rs`) uses `INSERT OR REPLACE` but is also an ordinary table, not vec0. Not affected.

## Tests added

`crates/spelunk-core/src/storage/db.rs` (embeddings) and `crates/spelunk-core/src/storage/memory/tests.rs` (note_embeddings):
- Repeated id across two independent committed calls collapses to one last-write-wins row.
- Repeated id within one caller-held transaction (batch-style) collapses to one last-write-wins row.
- Replacing a never-seen id is a harmless no-op delete + normal insert.
- **Nested-transaction-join proof**: call `insert_embedding` for a repeated id from inside a transaction the caller already opened, then roll that outer transaction back — asserts the row is restored to its pre-transaction state, proving the delete+insert genuinely joined the caller's transaction rather than independently committing.
- **WAL concurrent-reader proof** (embeddings only, file-backed WAL-mode db): drives 500 replaces on one connection while an independent connection polls the row count on a background thread; asserts the reader never observes a zero-row window. (`note_embeddings` does not run in WAL mode, so this specific race class doesn't apply there — noted in the code, not a gap.)

Also corrected one stale paragraph in `docs/adr/070-init-embed-lifecycle-and-search-warmup-contract.md` (D2) that described `insert_embedding` as a bare `INSERT OR REPLACE` committing in its own implicit transaction — the decision itself (per-chunk resume granularity) is unaffected, only the mechanism description was wrong.

## Known follow-up (not in this PR)

spelunk-oss^216 (PR #674, separate/unmerged) adds a new batch `insert_embeddings` function with the same vec0-replace bug — that PR has its own `#[ignore]`d characterization tests. Already flagged on the board; will need the same delete-then-insert idiom applied there once merged.

## Test plan

- `cargo fmt --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — 0 failed, all new tests pass (`insert_embedding_single_row_path_replaces_a_repeated_chunk_id`, `insert_embedding_duplicate_chunk_id_within_one_transaction_last_write_wins`, `insert_embedding_of_nonexistent_chunk_id_is_a_harmless_delete_no_op`, `insert_embedding_joins_callers_transaction_and_rolls_back_with_it`, `insert_embedding_replace_has_no_zero_row_window_visible_to_a_concurrent_reader`, plus the `note_embeddings` equivalents).
- `cargo test --workspace --no-default-features` — same result, 0 failed.
- `cargo audit` — clean; no new dependencies (`Cargo.lock`/`Cargo.toml` untouched by this diff).
- Confirmed no board/internal references leaked into the diff.