### PR TITLE
fix(cli): default local cargo runs to the file-backed secret store

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,7 +7,7 @@
 # `run_embed_phase`) reaches the real OS keychain on first run. On macOS in a
 # headless/non-interactive session (CI runners, sandboxed agent shells) that
 # keychain access blocks indefinitely waiting for an authorisation prompt
-# that will never appear — surfacing as a "hung" test rather than a failure.
+# that will never appear, surfacing as a "hung" test rather than a failure.
 # `force = false` (the default for a plain string) lets a developer still
 # opt into the real keychain by exporting SPELUNK_SECRET_STORE=keychain in
 # their own shell; this only supplies a default.

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+[env]
+# Local `cargo test`/`cargo run` invoked from within this workspace default to
+# the file-backed secret store, mirroring `SPELUNK_SECRET_STORE: file` in
+# .github/workflows/ci.yml. Without this, any code path that resolves a
+# bearer via `Config::bearer_for` (e.g. `server_client.rs`'s
+# `ServerInferenceClient::from_config`, or `index/embed_phase.rs`'s
+# `run_embed_phase`) reaches the real OS keychain on first run. On macOS in a
+# headless/non-interactive session (CI runners, sandboxed agent shells) that
+# keychain access blocks indefinitely waiting for an authorisation prompt
+# that will never appear — surfacing as a "hung" test rather than a failure.
+# `force = false` (the default for a plain string) lets a developer still
+# opt into the real keychain by exporting SPELUNK_SECRET_STORE=keychain in
+# their own shell; this only supplies a default.
+SPELUNK_SECRET_STORE = "file"

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -1023,7 +1023,7 @@ mod tests {
         // comment above and config.rs tests). This test previously called
         // the production `from_config` entry point directly, which resolves
         // the bearer via `Config::bearer_for` against the *real* default
-        // secret store — on macOS in a headless session that keychain
+        // secret store; on macOS in a headless session that keychain
         // lookup blocks indefinitely instead of failing fast, which is what
         // made this test (and the whole module) appear to hang "even in
         // isolation" without `SPELUNK_SECRET_STORE=file` set in the

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -1018,7 +1018,19 @@ mod tests {
             project_id: Some("proj".to_string()),
             ..Default::default()
         };
-        let client = ServerInferenceClient::from_config(&cfg).expect("client builds");
+        // Inject an in-memory secret store so this test never touches the
+        // real OS keychain (DI; cf. the `refresh_on_401_retries_once_and_persists`
+        // comment above and config.rs tests). This test previously called
+        // the production `from_config` entry point directly, which resolves
+        // the bearer via `Config::bearer_for` against the *real* default
+        // secret store — on macOS in a headless session that keychain
+        // lookup blocks indefinitely instead of failing fast, which is what
+        // made this test (and the whole module) appear to hang "even in
+        // isolation" without `SPELUNK_SECRET_STORE=file` set in the
+        // environment.
+        let store = spelunk_core::config::secret_store::MemoryStore::default();
+        let client =
+            ServerInferenceClient::from_config_with_store(&cfg, &store).expect("client builds");
         assert!(
             client.is_explicit_remote,
             "an explicitly configured server_url must count as explicit even when it is loopback"


### PR DESCRIPTION
## Root cause (corrected framing)

The original bug title said `embed_phase` and `server_client` tests "hang under concurrent worktree load, even in isolation" and was investigated as a concurrency issue. That framing was wrong. The real cause: a plain `cargo test`/`cargo run` invoked locally resolves a bearer via `Config::bearer_for` against a non-cloud origin (a loopback `wiremock` URL in these tests), which reaches the **real macOS Keychain** unless `SPELUNK_SECRET_STORE=file` is set. In a headless/non-interactive shell (exactly what an agent session or a plain terminal without an unlocked keychain session looks like), that keychain lookup blocks indefinitely waiting for an authorization prompt that never comes. `.github/workflows/ci.yml` already works around this with `SPELUNK_SECRET_STORE: file` at the workflow level; nothing propagated that default to a plain local invocation.

This is not a concurrency/shared-resource bug. Reproduced deterministically in a single process with zero concurrent load.

## Fix

1. **`.cargo/config.toml`** — new file, `[env] SPELUNK_SECRET_STORE = "file"`. Non-forcing default (a contributor can still opt into the real keychain by exporting `SPELUNK_SECRET_STORE=keychain` themselves), mirrors what CI already sets. This is the actual fix for `embed_phase.rs`'s `run_embed_phase`, which has no store-injection seam.
2. **`crates/spelunk-cli/src/server_client.rs`** — fixed one test (`from_config_is_explicit_remote_true_for_explicitly_configured_loopback_url`) that called the production `ServerInferenceClient::from_config` entry point directly instead of the established `from_config_with_store` + `MemoryStore` DI pattern its sibling tests already use.

## Test plan

- `env -u SPELUNK_SECRET_STORE cargo test -p spelunk-cli --bin spelunk server_client::` — 22/22 pass in 0.02s (previously hung indefinitely).
- `env -u SPELUNK_SECRET_STORE cargo test -p spelunk-cli --bin spelunk embed_phase::` — 49/49 pass in 0.08s (previously hung indefinitely).
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean (run against an isolated `CARGO_TARGET_DIR` to avoid a build-cache race with concurrently-building sibling worktrees on this machine; unrelated to the change itself).
- Full `cargo test -p spelunk-cli` green (404 unit tests + all integration binaries).