### PR TITLE
docs(dockerfile): fix broken sibling-DNS dev recipe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # this repo does not ship a proxy to pair with it.
 #
 # Run (dev, no compose): the server binds loopback only (see above), so a
-# sibling container on its own network can't reach it — sibling-container DNS
+# sibling container on its own network can't reach it: sibling-container DNS
 # resolves to the bridge IP, and nothing listens there. A sidecar has to share
 # the server's network namespace instead, then reach it at 127.0.0.1:
 #   docker run -d --name spelunk-server -v spelunk-data:/data spelunk-server
@@ -25,8 +25,8 @@
 #
 # Run (local scaffold, with API key): see docker-compose.yml. It runs this
 # image with a persistent volume, wired up with the same
-# `--network container:spelunk-server` + 127.0.0.1 pattern above — nothing
-# more. It does not publish a host-reachable port.
+# `--network container:spelunk-server` + 127.0.0.1 pattern above. Nothing
+# more; it does not publish a host-reachable port.
 #
 # For a team-reachable deployment, don't containerize this at all: run the
 # binary bare-metal/systemd on a host, with your own TLS terminator (nginx,

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,18 @@
 # docs/server.md#non-loopback-plaintext-binds-are-refused-no-override), and
 # this repo does not ship a proxy to pair with it.
 #
-# Run (dev, reachable only from other containers on the same Docker network):
-#   docker network create spelunk-dev
-#   docker run --rm --network spelunk-dev --name spelunk-server \
-#     -v spelunk-data:/data spelunk-server
-#   docker run --rm --network spelunk-dev curlimages/curl \
-#     curl http://spelunk-server:7777/v1/health
+# Run (dev, no compose): the server binds loopback only (see above), so a
+# sibling container on its own network can't reach it — sibling-container DNS
+# resolves to the bridge IP, and nothing listens there. A sidecar has to share
+# the server's network namespace instead, then reach it at 127.0.0.1:
+#   docker run -d --name spelunk-server -v spelunk-data:/data spelunk-server
+#   docker run --rm --network container:spelunk-server curlimages/curl \
+#     curl http://127.0.0.1:7777/v1/health
 #
 # Run (local scaffold, with API key): see docker-compose.yml. It runs this
-# image with a persistent volume — nothing more. It does not publish a
-# host-reachable port; reach the server from a separate container sharing
-# this one's network namespace (`--network container:spelunk-server`), the
-# same pattern as the dev recipe above but pointed at 127.0.0.1.
+# image with a persistent volume, wired up with the same
+# `--network container:spelunk-server` + 127.0.0.1 pattern above — nothing
+# more. It does not publish a host-reachable port.
 #
 # For a team-reachable deployment, don't containerize this at all: run the
 # binary bare-metal/systemd on a host, with your own TLS terminator (nginx,


### PR DESCRIPTION
## Summary
- The Dockerfile's "Run (dev)" recipe told readers to reach the server via sibling-container DNS on a shared bridge network — but the file's own lines above (and `docker-compose.yml`) state the server binds loopback-only inside its own network namespace, so that DNS name resolves to nothing listening. The recipe could never have worked.
- Replaced it with the `--network container:<name>` + `127.0.0.1` pattern `docker-compose.yml` already documents as working, and fixed a now-inaccurate cross-reference ("same pattern as the dev recipe above") a few lines down.
- Comment-only change: no CMD/behavior change.

## Test plan
- Reproduced both topologies with `busybox httpd -f -p 127.0.0.1:7777` standing in for the real server (avoids a multi-GB Rust image build): the old sibling-DNS + separate-bridge-network pattern gets connection refused; the replacement `--network container:<name>` + `127.0.0.1` pattern reaches the server and gets a response.
- Ran the new recipe's literal command shape end-to-end — succeeds.
- Repo-wide grep confirmed no other file (README, docs/*.md, docker-compose.yml) repeats the old broken pattern.