### PR TITLE
Add CI guard against internal board-id leaks into commit history/content

### DIFF
--- a/.github/scripts/check-internal-ids.sh
+++ b/.github/scripts/check-internal-ids.sh
@@ -56,7 +56,10 @@ check_text() {
   local label="$1" text="$2"
   local pattern matches line
   for pattern in "${PATTERNS[@]}"; do
-    matches="$(printf '%s\n' "$text" | grep -E "$pattern" || true)"
+    # -i: a differently-cased ref (e.g. "SPELUNK-OSS^250", a PR title with
+    # title-casing, "Task_<HEX>") is still the same leak — nothing about the
+    # patterns below relies on case to disambiguate from legitimate content.
+    matches="$(printf '%s\n' "$text" | grep -Ei "$pattern" || true)"
     if [ -n "$matches" ]; then
       while IFS= read -r line; do
         if [ -n "$line" ]; then

--- a/.github/scripts/check-internal-ids.sh
+++ b/.github/scripts/check-internal-ids.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# .github/scripts/check-internal-ids.sh — reject internal-only task-tracker
+# references from landing in this public repo.
+#
+# spelunk-oss is public; the internal task-tracker board is not. Its
+# shorthand references (a project-slug `^` number, an opaque `task_<hex>`
+# id, and the `task/<persona>-<slug>-<UTC timestamp>` worktree/branch naming
+# convention) have leaked into commit messages and file content before. This
+# guard rejects any commit that introduces one, going forward.
+#
+# It is deliberately NOT a retroactive audit: it only ever looks at lines a
+# commit *adds* (via `git diff`, never a full-file grep) and at commits
+# within an explicit range, so history that already contains a leak is never
+# rescanned or flagged. See docs/security/internal-id-guard.md.
+#
+# Usage:
+#   check-internal-ids.sh --message <file>       # scan a commit message file
+#                                                 #   (commit-msg hook)
+#   check-internal-ids.sh --staged               # scan the staged diff
+#                                                 #   (pre-commit hook)
+#   check-internal-ids.sh --range <rev>..<rev>   # scan added lines + commit
+#                                                 #   messages for a range
+#                                                 #   (CI)
+#
+# Exits 0 if clean, 1 with the offending line(s) on stderr otherwise, 2 on
+# misuse.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Patterns. Keep in sync with docs/security/internal-id-guard.md.
+# Each is `grep -E`, so keep them portable (BSD grep on macOS, GNU grep in
+# CI) — no PCRE-only constructs.
+# ---------------------------------------------------------------------------
+PATTERNS=(
+  '\b(cloud-api|spelunk-oss|oss)\^[0-9]+\b' # project-slug task ref, e.g. a "<slug>^<number>" shorthand
+  '\btask_[0-9a-f]{16,}\b'                  # opaque task id
+  '\btask/[a-z][a-z-]*-[0-9]{8}-[0-9]{4}\b' # task/<persona>-<slug>-<UTC timestamp> branch/worktree name
+)
+
+# The guard's own script + test fixtures necessarily contain placeholder
+# text shaped like the patterns above (to prove the patterns work) or
+# describe them in prose. Neither is a real leak, so both are excluded from
+# every diff this script scans — everything else in the repo stays covered,
+# including this exclusion list itself.
+EXCLUDE_PATHSPEC=(
+  ':(exclude).github/scripts/check-internal-ids.sh'
+  ':(exclude).github/scripts/check-internal-ids.test.sh'
+)
+
+fail=0
+
+# check_text LABEL TEXT — scans (possibly multi-line) TEXT for every
+# pattern, printing and flagging each matching line under LABEL.
+check_text() {
+  local label="$1" text="$2"
+  local pattern matches line
+  for pattern in "${PATTERNS[@]}"; do
+    matches="$(printf '%s\n' "$text" | grep -E "$pattern" || true)"
+    if [ -n "$matches" ]; then
+      while IFS= read -r line; do
+        if [ -n "$line" ]; then
+          echo "internal-id-guard: $label matches an internal reference pattern:" >&2
+          echo "    $line" >&2
+          fail=1
+        fi
+      done <<<"$matches"
+    fi
+  done
+  # Explicit, unconditional success: under `set -e` a bare `[ ... ]` as the
+  # last-executed statement would otherwise make this function's (and thus
+  # any caller-statement's) exit status reflect "no match found" as failure,
+  # aborting the whole script even on clean input.
+  return 0
+}
+
+# scan_added_lines DIFF — scans only '+' lines of a `git diff --unified=0`
+# style patch (never removed or context lines), skipping the '+++' file
+# header. This is what keeps the guard going-forward-only: a line that was
+# already in the repo, or one being deleted, is never inspected.
+scan_added_lines() {
+  local diff="$1" added
+  added="$(printf '%s\n' "$diff" | grep -E '^\+' | grep -Ev '^\+\+\+' | sed -E 's/^\+//' || true)"
+  if [ -n "$added" ]; then
+    check_text "added line" "$added"
+  fi
+  return 0 # see check_text's comment on why this is explicit
+}
+
+mode="${1:-}"
+case "$mode" in
+  --message)
+    file="${2:?usage: check-internal-ids.sh --message <file>}"
+    check_text "commit message" "$(cat "$file")"
+    ;;
+  --staged)
+    diff="$(git diff --cached --unified=0 -- . "${EXCLUDE_PATHSPEC[@]}")"
+    scan_added_lines "$diff"
+    ;;
+  --range)
+    range="${2:?usage: check-internal-ids.sh --range <rev>..<rev> or <rev>...<rev>}"
+    while IFS= read -r sha; do
+      [ -z "$sha" ] && continue
+      check_text "commit $sha message" "$(git log -1 --format=%B "$sha")"
+    done < <(git rev-list "$range") || true # empty range: 0 iterations, `read` fails once
+    diff="$(git diff --unified=0 "$range" -- . "${EXCLUDE_PATHSPEC[@]}")"
+    scan_added_lines "$diff"
+    ;;
+  *)
+    echo "usage: check-internal-ids.sh --message <file> | --staged | --range <rev>..<rev>" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$fail" -ne 0 ]; then
+  echo "" >&2
+  echo "internal-id-guard: rejected — internal task-tracker references must not" >&2
+  echo "ship in spelunk-oss (public repo). See docs/security/internal-id-guard.md" >&2
+  echo "for what matched and why, and how to get an explicit override." >&2
+  exit 1
+fi
+
+exit 0

--- a/.github/scripts/check-internal-ids.test.sh
+++ b/.github/scripts/check-internal-ids.test.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# .github/scripts/check-internal-ids.test.sh — fixture-based tests for
+# check-internal-ids.sh (self-contained: no test framework, matches this
+# repo's other zero-dependency CI scripts).
+#
+# Run: bash .github/scripts/check-internal-ids.test.sh
+#
+# Every fixture below uses placeholder ids that are obviously fake (e.g. an
+# out-of-range `oss^999999`, an all-zero `task_...` hex string, a
+# `task/engineer-faketest-...` branch name with a 9999-in-the-future
+# timestamp) — never a real internal task-tracker reference. These fixtures
+# live inside throwaway git repos created under a tmpdir for the duration of
+# a single test and are never committed to *this* repo, but the literal
+# strings still appear in this file's own source, which is why
+# check-internal-ids.sh excludes this file (and itself) from the scans it
+# runs against spelunk-oss's real history.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-internal-ids.sh"
+
+# Deterministic, config-file-free identity for every synthetic commit —
+# env vars only, so no test ever touches a git config file (local or
+# global).
+export GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="test@example.invalid"
+export GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="test@example.invalid"
+
+pass=0
+fail=0
+
+# ok DESCRIPTION — record a passing case.
+ok() { pass=$((pass + 1)); echo "ok   - $1"; }
+# bad DESCRIPTION DETAIL — record a failing case with why.
+bad() {
+  fail=$((fail + 1))
+  echo "FAIL - $1"
+  echo "       $2"
+}
+
+# new_repo — create and cd into a fresh throwaway repo, print its path.
+new_repo() {
+  local dir
+  dir="$(mktemp -d)"
+  git -C "$dir" init -q -b main
+  echo "$dir"
+}
+
+# assert_status DESCRIPTION EXPECTED_STATUS ACTUAL_STATUS OUTPUT
+assert_status() {
+  local desc="$1" expected="$2" actual="$3" output="$4"
+  if [ "$actual" = "$expected" ]; then
+    ok "$desc"
+  else
+    bad "$desc" "expected exit $expected, got $actual. Output:
+$output"
+  fi
+}
+
+# assert_contains DESCRIPTION HAYSTACK NEEDLE
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    ok "$desc"
+  else
+    bad "$desc" "expected output to contain '$needle'. Output:
+$haystack"
+  fi
+}
+
+# =============================================================================
+# --message mode
+# =============================================================================
+
+run_message_case() {
+  local msg="$1" file status output
+  file="$(mktemp)"
+  printf '%s\n' "$msg" >"$file"
+  set +e
+  output="$("$SCRIPT" --message "$file" 2>&1)"
+  status=$?
+  set -e
+  rm -f "$file"
+  printf '%s\x1f%s' "$status" "$output"
+}
+
+result="$(run_message_case "docs: expand the getting-started guide")"
+status="${result%%$'\x1f'*}"
+assert_status "clean commit message passes --message" 0 "$status" "${result#*$'\x1f'}"
+
+result="$(run_message_case "fix: address feedback from spelunk-oss^999999")"
+status="${result%%$'\x1f'*}"; output="${result#*$'\x1f'}"
+assert_status "project-slug ref in message fails --message" 1 "$status" "$output"
+assert_contains "failing message names the offending line" "$output" "spelunk-oss^999999"
+
+result="$(run_message_case "fix: closes task_00112233445566778899")"
+status="${result%%$'\x1f'*}"; output="${result#*$'\x1f'}"
+assert_status "opaque task id in message fails --message" 1 "$status" "$output"
+
+result="$(run_message_case "chore: picked up in task/engineer-faketest-99990101-0000")"
+status="${result%%$'\x1f'*}"; output="${result#*$'\x1f'}"
+assert_status "worktree-branch ref in message fails --message" 1 "$status" "$output"
+
+result="$(run_message_case "fix: our biggest boss^2 enemy in the game")"
+status="${result%%$'\x1f'*}"
+assert_status "near-miss text (no word boundary) does not false-positive" 0 "$status" "${result#*$'\x1f'}"
+
+# =============================================================================
+# --staged mode
+# =============================================================================
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  printf 'hello world\n' >notes.txt
+  git add notes.txt
+  set +e
+  output="$("$SCRIPT" --staged 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"
+assert_status "clean staged addition passes --staged" 0 "$status" "${result#*$'\x1f'}"
+rm -rf "$repo"
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  printf 'context: relates to cloud-api^999999 (fake, for the test only)\n' >notes.txt
+  git add notes.txt
+  set +e
+  output="$("$SCRIPT" --staged 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"; output="${result#*$'\x1f'}"
+assert_status "leaked ref in staged addition fails --staged" 1 "$status" "$output"
+assert_contains "failing --staged output names the offending line" "$output" "cloud-api^999999"
+rm -rf "$repo"
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  # A short digit-only run after "task_" is well under the 16-char floor —
+  # ordinary variable-ish text, not a task id, must never trip the guard.
+  printf 'task_42 = compute_batch_size()\n' >notes.txt
+  git add notes.txt
+  set +e
+  output="$("$SCRIPT" --staged 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"
+assert_status "short task_-prefixed identifier does not false-positive" 0 "$status" "${result#*$'\x1f'}"
+rm -rf "$repo"
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  # Everything staged is under the guard's own excluded paths, so the diff
+  # is empty after exclusion — the exact shape of the bug this regression
+  # test exists for: an empty-after-exclusion diff must still exit 0, not
+  # abort on the `[ -n "$added" ]` test having nothing to report.
+  mkdir -p .github/scripts
+  printf 'fixture: task_aabbccddeeff00112233\n' >.github/scripts/check-internal-ids.sh
+  printf 'fixture: task_aabbccddeeff00112233\n' >.github/scripts/check-internal-ids.test.sh
+  git add .github/scripts/check-internal-ids.sh .github/scripts/check-internal-ids.test.sh
+  set +e
+  output="$("$SCRIPT" --staged 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"
+assert_status "staging only the guard's own excluded paths passes --staged" 0 "$status" "${result#*$'\x1f'}"
+rm -rf "$repo"
+
+# =============================================================================
+# --range mode: the going-forward-only guarantee
+# =============================================================================
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  # Seed "accepted history": a commit that already contains a leaked-shaped
+  # reference, standing in for real history this guard intentionally never
+  # rewrites or rescans.
+  printf 'legacy note: see spelunk-oss^999998 (fake, pre-existing "history")\n' >history.txt
+  git add history.txt
+  git commit -q -m "seed: pre-existing history"
+  base="$(git rev-parse HEAD)"
+
+  # A later, unrelated commit that touches nothing referencing the pattern.
+  printf 'unrelated change\n' >other.txt
+  git add other.txt
+  git commit -q -m "chore: unrelated follow-up"
+  head="$(git rev-parse HEAD)"
+
+  set +e
+  output="$("$SCRIPT" --range "$base..$head" 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"
+assert_status "pre-existing leak outside the range is not rescanned/flagged" 0 "$status" "${result#*$'\x1f'}"
+rm -rf "$repo"
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  printf 'clean baseline\n' >base.txt
+  git add base.txt
+  git commit -q -m "chore: baseline"
+  base="$(git rev-parse HEAD)"
+
+  printf 'clean baseline\nfollow-up mentioning task_aabbccddeeff00112233\n' >base.txt
+  git add base.txt
+  git commit -q -m "fix: patch a thing"
+  head="$(git rev-parse HEAD)"
+
+  set +e
+  output="$("$SCRIPT" --range "$base..$head" 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"; output="${result#*$'\x1f'}"
+assert_status "a leak newly introduced within the range fails --range" 1 "$status" "$output"
+assert_contains "failing --range output names the offending line" "$output" "task_aabbccddeeff00112233"
+rm -rf "$repo"
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  printf 'a file that already mentions task_ffeeddccbbaa99887766\n' >leaky.txt
+  git add leaky.txt
+  git commit -q -m "seed: pre-existing history with a leak in it"
+  base="$(git rev-parse HEAD)"
+
+  # Remove the leaked line entirely; nothing new is added referencing it.
+  printf 'a file that mentions nothing sensitive\n' >leaky.txt
+  git add leaky.txt
+  git commit -q -m "chore: clean up the note"
+  head="$(git rev-parse HEAD)"
+
+  set +e
+  output="$("$SCRIPT" --range "$base..$head" 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"
+assert_status "a commit that only removes a leaked line passes --range" 0 "$status" "${result#*$'\x1f'}"
+rm -rf "$repo"
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  printf 'clean baseline\n' >base.txt
+  git add base.txt
+  git commit -q -m "chore: baseline"
+  base="$(git rev-parse HEAD)"
+
+  printf 'clean follow-up\n' >other.txt
+  git add other.txt
+  git commit -q -m "picked up in task/engineer-faketest-99990101-0000"
+  head="$(git rev-parse HEAD)"
+
+  set +e
+  output="$("$SCRIPT" --range "$base..$head" 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"
+assert_status "leaked ref in an in-range commit message fails --range" 1 "$status" "${result#*$'\x1f'}"
+rm -rf "$repo"
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  printf 'clean baseline\n' >base.txt
+  git add base.txt
+  git commit -q -m "chore: baseline"
+  base="$(git rev-parse HEAD)"
+
+  mkdir -p .github/scripts
+  printf 'fixture: task_aabbccddeeff00112233\n' >.github/scripts/check-internal-ids.sh
+  git add .github/scripts/check-internal-ids.sh
+  git commit -q -m "chore: only touches the guard's own excluded script"
+  head="$(git rev-parse HEAD)"
+
+  set +e
+  output="$("$SCRIPT" --range "$base..$head" 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"
+assert_status "a range touching only the guard's own excluded paths passes --range" 0 "$status" "${result#*$'\x1f'}"
+rm -rf "$repo"
+
+# =============================================================================
+# misuse
+# =============================================================================
+
+set +e
+output="$("$SCRIPT" 2>&1)"
+status=$?
+set -e
+assert_status "no args exits 2 (misuse, not a false pass/fail)" 2 "$status" "$output"
+
+echo ""
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/.github/scripts/check-internal-ids.test.sh
+++ b/.github/scripts/check-internal-ids.test.sh
@@ -313,6 +313,89 @@ assert_status "a range touching only the guard's own excluded paths passes --ran
 rm -rf "$repo"
 
 # =============================================================================
+# case sensitivity — adversarial hardening (test-engineer pass)
+#
+# A differently-cased ref isn't an adversarial trick, it's ordinary writing
+# variance (a PR title auto-titlecased, someone typing in caps) — it must be
+# caught exactly like the lowercase form.
+# =============================================================================
+
+result="$(run_message_case "fix: SPELUNK-OSS^999999 needs follow-up")"
+status="${result%%$'\x1f'*}"; output="${result#*$'\x1f'}"
+assert_status "uppercase project-slug ref fails --message" 1 "$status" "$output"
+
+result="$(run_message_case "fix: closes task_AABBCCDDEEFF00112233")"
+status="${result%%$'\x1f'*}"
+assert_status "uppercase-hex task id fails --message" 1 "$status" "${result#*$'\x1f'}"
+
+result="$(run_message_case "chore: picked up in task/Engineer-Faketest-99990101-0000")"
+status="${result%%$'\x1f'*}"
+assert_status "title-cased task/ branch ref fails --message" 1 "$status" "${result#*$'\x1f'}"
+
+# =============================================================================
+# regression: verified-safe edge cases the range guard must keep passing
+# =============================================================================
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  # A file containing an already-accepted leak is renamed with no content
+  # change. `git diff` detects this as a 100%-similarity rename (no + lines
+  # at all), so the pre-existing line is correctly never treated as "added".
+  # This locks in real (non-obvious) behavior verified by hand — a rename
+  # with a lower content-similarity would NOT get this protection (git
+  # falls back to representing it as a full delete+add), which is a known,
+  # accepted structural limitation of line-based diffing — see
+  # docs/security/internal-id-guard.md.
+  printf 'legacy note: see spelunk-oss^999998 (fake, pre-existing "history")\n' >legacy.txt
+  git add legacy.txt
+  git commit -q -m "seed: pre-existing accepted history"
+  base="$(git rev-parse HEAD)"
+
+  git mv legacy.txt renamed.txt
+  git commit -q -m "chore: pure rename, no content change"
+  head="$(git rev-parse HEAD)"
+
+  set +e
+  output="$("$SCRIPT" --range "$base..$head" 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"
+assert_status "pure rename of a file with a pre-existing leak passes --range" 0 "$status" "${result#*$'\x1f'}"
+rm -rf "$repo"
+
+repo="$(new_repo)"
+(
+  cd "$repo"
+  # A multi-paragraph commit message (subject + blank line + body) still
+  # gets fully scanned: `git log --format=%B` returns the whole message and
+  # check_text scans it line-by-line, so a leak in the body (not just the
+  # subject) is caught.
+  printf 'baseline\n' >f.txt
+  git add f.txt
+  git commit -q -m "chore: baseline"
+  base="$(git rev-parse HEAD)"
+
+  printf 'baseline\nmore\n' >f.txt
+  git add f.txt
+  git commit -q -m "fix: address review feedback" -m "Follow-up on spelunk-oss^999999 per discussion."
+  head="$(git rev-parse HEAD)"
+
+  set +e
+  output="$("$SCRIPT" --range "$base..$head" 2>&1)"
+  status=$?
+  set -e
+  printf '%s\x1f%s' "$status" "$output"
+) >/tmp/case_out.$$
+result="$(cat /tmp/case_out.$$)"; rm -f /tmp/case_out.$$
+status="${result%%$'\x1f'*}"
+assert_status "leak in a commit message body (not subject) fails --range" 1 "$status" "${result#*$'\x1f'}"
+rm -rf "$repo"
+
+# =============================================================================
 # misuse
 # =============================================================================
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,3 +216,30 @@ jobs:
             echo "Then commit the updated snapshot."
             exit 1
           fi
+
+  internal-id-guard:
+    name: Internal board-id guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The guard needs the base ref (PR) or previous ref (push) present
+          # locally to diff against; a shallow checkout wouldn't have it.
+          fetch-depth: 0
+
+      - name: Run guard self-tests
+        run: bash .github/scripts/check-internal-ids.test.sh
+
+      - name: Scan the introduced commits for internal board-id references
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            range="${{ github.event.pull_request.base.sha }}...${{ github.sha }}"
+          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            range="${{ github.event.before }}...${{ github.event.after }}"
+          else
+            # First push of a new branch: no meaningful "before". Fall back
+            # to just the tip commit rather than skipping the check.
+            range="${{ github.sha }}~1...${{ github.sha }}"
+          fi
+          .github/scripts/check-internal-ids.sh --range "$range"

--- a/docs/security/SECURITY-PROGRAM.md
+++ b/docs/security/SECURITY-PROGRAM.md
@@ -90,6 +90,7 @@ server-specific pre-v1.0 checklist is
 | Dependency advisory scan         | `cargo audit`              | Yes — blocks merge |
 | Dependency license/source policy | `cargo deny`               | Yes — blocks merge |
 | Static analysis                  | `cargo clippy -D warnings` | Yes — blocks merge |
+| Internal task-tracker ID leak guard | `.github/scripts/check-internal-ids.sh` | Yes — blocks merge |
 
 ### Design controls
 

--- a/docs/security/internal-id-guard.md
+++ b/docs/security/internal-id-guard.md
@@ -82,6 +82,28 @@ prior instances), not by extending this guard's scope backwards.
   CI is the enforced gate either way; the local hooks just give faster
   feedback before a push.
 
+## Known limitations (accepted)
+
+This is a hygiene guard, not a security boundary — it isn't hardened against
+someone deliberately evading it:
+
+- **Split across lines.** `grep` matches per line; a ref broken across two
+  lines (or two commits) is invisible to it.
+- **Unicode lookalikes / zero-width characters.** A zero-width space inside
+  the ref, or a Unicode caret lookalike instead of ASCII `^`, doesn't match.
+- **A rewrite with low content-similarity that drags forward an
+  already-accepted leak untouched.** `git diff` represents a rename/rewrite
+  below its similarity threshold as a full delete+add, so an untouched
+  historical line inside it reads as newly "added" — a false positive in the
+  rare case this happens, not a missed leak.
+- **A version-style ref glued to a project slug** — a caret-range dependency
+  pin (no separator between the slug and the caret) reads as the project-slug
+  pattern up through the first `.` and is flagged — a false positive, not a
+  missed leak.
+
+None of these have shown up in practice; noted here so a future change to
+`PATTERNS` or the diff strategy doesn't need to rediscover them.
+
 ## Overriding
 
 There is no bypass flag by design — a match means rewrite the offending line

--- a/docs/security/internal-id-guard.md
+++ b/docs/security/internal-id-guard.md
@@ -1,0 +1,92 @@
+# Internal task-tracker ID guard
+
+**What:** a CI check — `.github/scripts/check-internal-ids.sh`, run by the
+`internal-id-guard` job in `.github/workflows/ci.yml` — that rejects a
+pull request whose introduced commits (message or added diff lines) contain
+a reference to the internal task-tracker board. spelunk-oss is public; that
+board is not.
+
+## Why
+
+The internal board's shorthand references have leaked into this repo's
+history before: a `<project-slug>^<number>` reference (the board's own
+citation shorthand), an opaque `task_<hex>` id, and the
+`task/<persona>-<slug>-<UTC timestamp>` branch/worktree naming convention
+agents use internally have each shown up in commit messages or file content
+on `main`. None of those leaks exposed a secret — they're meaningless
+outside the internal board — but they're noise in public history and a sign
+the internal/public boundary isn't being enforced anywhere. Rewriting
+existing history to remove them was judged not worth the disruption, so
+those specific commits are left alone; this guard exists so the same class
+of leak requires an explicit, deliberate override going forward instead of
+landing silently.
+
+## What it matches
+
+Three patterns, `grep -E`, checked against **only the lines a change
+introduces** — never a whole file, never existing history:
+
+| Pattern | Matches | Example shape (not a real id) |
+| --- | --- | --- |
+| `\b(cloud-api\|spelunk-oss\|oss)\^[0-9]+\b` | a project-slug task-ref shorthand | `PROJECT^NNN` |
+| `\btask_[0-9a-f]{16,}\b` | an opaque task id | `task_<16+ hex chars>` |
+| `\btask/[a-z][a-z-]*-[0-9]{8}-[0-9]{4}\b` | the worktree/branch naming convention | `task/<persona>-<slug>-<UTC timestamp>` |
+
+If you have a project convention this list should also cover, add a pattern
+to the `PATTERNS` array in `check-internal-ids.sh` and a matching row here.
+
+## Scope: going-forward only, by construction
+
+The guard never scans a full file and never re-walks accepted history — only
+`git diff --unified=0` **added** (`+`) lines within an explicit commit range,
+plus the messages of the commits in that range. A pattern match sitting
+untouched in a file, or in a commit already on `main` before the range
+starts, is invisible to it. This isn't a filter bolted on top — the CI job
+only ever hands it `<base>...<head>` for the current pull request, so there
+is no code path that could accidentally rescan history.
+
+This is a deliberate, discussed tradeoff, not an oversight: a leak found in
+existing history is handled case by case (see the repo's change history for
+prior instances), not by extending this guard's scope backwards.
+
+## Where it runs
+
+- **CI (enforced):** the `internal-id-guard` job in `.github/workflows/ci.yml`
+  runs on every push and pull request against `main`. It first runs the
+  guard's own fixture-based test suite
+  (`.github/scripts/check-internal-ids.test.sh`), then runs the guard itself
+  against the range introduced by the change (`base...head` for a PR, or
+  `before...after` for a direct push).
+- **Local (optional convenience):** the same script doubles as a
+  `commit-msg` and/or `pre-commit` git hook — nothing in this repo installs
+  git hooks automatically (see [`docs/commands.md`](../commands.md#spelunk-hooks)
+  for the unrelated `spelunk hooks` product feature, which manages a
+  *project's* hooks, not this repo's own). To opt in on your own clone:
+
+  ```bash
+  # reject a leaked ref in the commit message itself
+  cat > .git/hooks/commit-msg <<'EOF'
+  #!/usr/bin/env bash
+  exec .github/scripts/check-internal-ids.sh --message "$1"
+  EOF
+  chmod +x .git/hooks/commit-msg
+
+  # reject a leaked ref in the lines you're about to commit
+  cat > .git/hooks/pre-commit <<'EOF'
+  #!/usr/bin/env bash
+  exec .github/scripts/check-internal-ids.sh --staged
+  EOF
+  chmod +x .git/hooks/pre-commit
+  ```
+
+  CI is the enforced gate either way; the local hooks just give faster
+  feedback before a push.
+
+## Overriding
+
+There is no bypass flag by design — a match means rewrite the offending line
+so it doesn't cite the board (say what changed instead of citing the
+tracker), then re-commit. If a specific line is a deliberate, reviewed
+exception, get sign-off and adjust the pattern/exclusion list in
+`check-internal-ids.sh` itself, in its own reviewed PR, rather than
+suppressing a single occurrence inline.

--- a/docs/security/internal-id-guard.md
+++ b/docs/security/internal-id-guard.md
@@ -23,8 +23,9 @@ landing silently.
 
 ## What it matches
 
-Three patterns, `grep -E`, checked against **only the lines a change
-introduces** — never a whole file, never existing history:
+Three patterns, `grep -Ei` (case-insensitive — a differently-cased ref, e.g.
+a title-cased PR subject, is the same leak), checked against **only the
+lines a change introduces** — never a whole file, never existing history:
 
 | Pattern | Matches | Example shape (not a real id) |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/check-internal-ids.sh`, a grep-based guard rejecting internal task-tracker references (`<project-slug>^<number>` shorthand, opaque `task_<hex>` ids, `task/<persona>-<slug>-<timestamp>` branch names) that leak into public commit messages or added file content.
- Scoped to introduced diff only (`git diff --unified=0` added lines) plus in-range commit messages — never a full-file scan, never existing history, so it's a going-forward guard, not a retroactive one.
- Wires it into CI as a required `internal-id-guard` job (`.github/workflows/ci.yml`), running the guard's own 23-case self-test suite first, then the guard itself against the PR/push range.
- Case-insensitive matching (`grep -Ei`) after an adversarial hardening pass found a case-sensitivity bypass (differently-cased refs slipped through `grep -E`).
- Documents scope, matched patterns, and 4 accepted residual-risk limitations (line-split refs, unicode lookalikes, low-similarity-rewrite false positive, caret-version-pin false positive) in `docs/security/internal-id-guard.md`, cross-linked from `docs/security/SECURITY-PROGRAM.md`.

## Test plan
- [x] `bash .github/scripts/check-internal-ids.test.sh` — 23/23 pass
- [x] `bash .github/scripts/check-internal-ids.sh --range origin/main...HEAD` — exit 0 (guard passes against its own introducing branch)
- [x] `shellcheck` clean on both scripts
- [x] `git merge-base --is-ancestor origin/main HEAD` — branch is a clean fast-forward of `main`
- [x] Broad grep across added file content and all in-range commit messages for real board-id patterns — no matches (only fake/out-of-range placeholder ids used throughout fixtures and docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)