### PR TITLE
feat(memory): backfill entity_id and add spelunk memory dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`spelunk memory dedupe` collapses duplicate-`entity_id` groups already
+  resident in a project's `memory.db`.** A store can already hold rows that
+  share the same content identity (`kind`/`title`/`body`) while differing in
+  `created_at`, `tags`, `linked_files`, or `status`, for example a decision
+  recorded twice by a repeated `memory harvest` run, or one merged in from
+  another machine. Opening the store now backfills each row's `entity_id` but
+  never deletes an existing row on its own, so this new command is the
+  explicit, dry-runnable way to clean duplicates up: `--dry-run` reports
+  duplicate groups and does nothing, otherwise the earliest-created row in
+  each group survives, the others' `tags` and `linked_files` merge onto it,
+  and any `supersedes` edge pointing at a removed row is repointed to the
+  survivor. It is a one-time backfill you run when you want to, not a step
+  `init` or `memory add` perform for you. See [ADR-068's third
+  amendment](docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md).
+
 ### Changed
 
 - **Chunk re-windowing is now token-aware, and windowed chunks keep their identity.**

--- a/crates/spelunk-cli/src/cli/cmd/memory/dedupe.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/dedupe.rs
@@ -1,0 +1,60 @@
+//! `spelunk memory dedupe`: collapse duplicate-`entity_id` groups already
+//! resident in the local `memory.db`.
+//!
+//! Existing duplicate rows under the ADR-068 canonical `entity_id` (rows with
+//! byte-identical `{kind, title, body}` but differing `created_at`, `tags`,
+//! `linked_files`, or `status`) are never collapsed automatically: opening
+//! the store only backfills `entity_id` and, once zero duplicate groups
+//! remain, promotes `idx_notes_entity_id` to UNIQUE (see
+//! `spelunk_core::storage::memory::entity_id_migration`). This command is the
+//! first place in the codebase that deletes existing local memory rows, so
+//! it is explicit and dry-run-able rather than riding along on that
+//! migration. See ADR-068's third amendment for the merge rule.
+
+use anyhow::{Context, Result};
+
+use super::MemoryDedupeArgs;
+use crate::storage::{DedupeSummary, MemoryStore};
+
+pub(super) async fn memory_dedupe(
+    args: MemoryDedupeArgs,
+    mem_path: &std::path::Path,
+) -> Result<()> {
+    let json = crate::utils::effective_format(&args.format) == "json";
+
+    let store = MemoryStore::open(mem_path)
+        .with_context(|| format!("opening memory.db at {}", mem_path.display()))?;
+
+    let summary = store
+        .dedupe_entity_ids(args.dry_run)
+        .context("collapsing duplicate entity_id groups")?;
+
+    emit_summary(&summary, json, args.dry_run);
+    Ok(())
+}
+
+fn emit_summary(summary: &DedupeSummary, json: bool, dry_run: bool) {
+    if json {
+        println!("{}", serde_json::to_string(summary).unwrap_or_default());
+        return;
+    }
+    if dry_run {
+        eprintln!(
+            "[spelunk] dedupe (dry-run): total_notes={} duplicate_groups={} rows_would_collapse={}",
+            summary.total_notes, summary.duplicate_groups, summary.rows_collapsed
+        );
+        return;
+    }
+    eprintln!(
+        "[spelunk] dedupe: total_notes={} duplicate_groups={} rows_collapsed={} \
+         tags_merged={} linked_files_merged={} supersede_edges_repointed={} \
+         supersede_self_edges_dropped={}",
+        summary.total_notes,
+        summary.duplicate_groups,
+        summary.rows_collapsed,
+        summary.tags_merged,
+        summary.linked_files_merged,
+        summary.supersede_edges_repointed,
+        summary.supersede_self_edges_dropped,
+    );
+}

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -50,6 +50,8 @@ pub enum MemoryCommand {
     Failures(MemoryFailuresArgs),
     /// Import unique notes from server.db into the local memory.db (recovery / migration tool)
     Reconcile(MemoryReconcileArgs),
+    /// Collapse duplicate-entity_id groups already resident in local memory.db (recovery tool)
+    Dedupe(MemoryDedupeArgs),
 }
 
 #[derive(Args, Debug)]
@@ -350,11 +352,23 @@ pub struct MemoryReconcileArgs {
     pub format: String,
 }
 
+#[derive(Args, Debug)]
+pub struct MemoryDedupeArgs {
+    /// Detect and report duplicate entity_id groups without collapsing anything
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Output format: text or json (NDJSON summary object)
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
 use super::status::format_age;
 
 mod add;
 mod archive;
 pub(crate) mod cross_project;
+mod dedupe;
 mod failures;
 mod graph_cmd;
 mod harvest;
@@ -397,6 +411,7 @@ pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> 
         MemoryCommand::Watch(a) => watch::memory_watch(a, &cfg).await,
         MemoryCommand::Failures(a) => failures::memory_failures(a, &mem_path, &cfg, be).await,
         MemoryCommand::Reconcile(a) => reconcile::memory_reconcile(a, &mem_path, &cfg).await,
+        MemoryCommand::Dedupe(a) => dedupe::memory_dedupe(a, &mem_path).await,
     }
 }
 

--- a/crates/spelunk-cli/tests/memory_dedupe.rs
+++ b/crates/spelunk-cli/tests/memory_dedupe.rs
@@ -1,0 +1,240 @@
+//! Integration tests for `spelunk memory dedupe`.
+//!
+//! Covers the CLI-facing acceptance criteria (see ADR-068's third amendment):
+//! - `--dry-run` reports counts and makes no writes (AC9).
+//! - Without `--dry-run`, duplicate groups collapse and row count drops by
+//!   exactly `rows_collapsed` (AC10).
+//! - Zero duplicate groups: all-zero counts, no writes, either mode (AC22).
+//! - `--format json` emits one JSON summary object (AC23).
+//!
+//! Storage-layer mechanics (survivor selection, tag/file union, archived
+//! sticks, supersede adoption/rewrite/self-edge-guard, embedding cleanup,
+//! transactional rollback) are covered directly against `MemoryStore` in
+//! `spelunk_core::storage::memory::dedupe`; these tests exercise the command
+//! surface end to end instead of re-proving that mechanics.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
+use assert_cmd::Command;
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use tempfile::TempDir;
+
+fn ensure_sqlite_vec() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite_vec::sqlite3_vec_init as *const (),
+            )));
+        }
+    });
+}
+
+/// Write a minimal spelunk config and make `dir` a real project, mirroring
+/// `memory_reconcile.rs`'s `write_config`. Returns `(config_path, mem_path)`.
+fn write_config(dir: &Path) -> (PathBuf, PathBuf) {
+    let spelunk_dir = dir.join(".spelunk");
+    std::fs::create_dir_all(&spelunk_dir).expect("create .spelunk");
+    let index_db = spelunk_dir.join("index.db");
+    let config_path = dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "db_path = {:?}\nllm_model = \"test-model\"\n",
+            index_db.display().to_string()
+        ),
+    )
+    .expect("write config");
+    let mem_path = index_db.with_file_name("memory.db");
+    (config_path, mem_path)
+}
+
+/// Seed `mem_path` with two rows sharing `{kind, title, body}` (a duplicate
+/// entity_id group) via a schema-only connection, bypassing the CLI's own
+/// `MemoryStore::open` pipeline so the seed isn't rejected: a fresh,
+/// zero-duplicate store would otherwise already have promoted the index to
+/// UNIQUE by the time we try to insert the second row.
+fn seed_duplicate_group(mem_path: &Path) {
+    ensure_sqlite_vec();
+    std::fs::create_dir_all(mem_path.parent().unwrap()).expect("create .spelunk dir");
+    let conn = Connection::open(mem_path).expect("open memory.db");
+    conn.execute_batch(include_str!("../../spelunk-core/migrations/004_memory.sql"))
+        .expect("base memory schema");
+    conn.execute_batch(
+        "ALTER TABLE notes ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
+         ALTER TABLE notes ADD COLUMN superseded_by INTEGER REFERENCES notes(id);
+         ALTER TABLE notes ADD COLUMN source_ref TEXT;
+         ALTER TABLE notes ADD COLUMN valid_at INTEGER;
+         ALTER TABLE notes ADD COLUMN invalid_at INTEGER;
+         ALTER TABLE notes ADD COLUMN uuid TEXT;
+         ALTER TABLE notes ADD COLUMN remote_id TEXT;
+         ALTER TABLE notes ADD COLUMN entity_id TEXT;
+         CREATE INDEX IF NOT EXISTS idx_notes_entity_id ON notes(entity_id) WHERE entity_id IS NOT NULL;",
+    )
+    .expect("lifecycle/uuid/entity_id columns");
+
+    for created_at in [1_700_000_001_i64, 1_700_000_002_i64] {
+        conn.execute(
+            "INSERT INTO notes (kind, title, body, created_at) VALUES ('decision', 'dup', 'body', ?1)",
+            rusqlite::params![created_at],
+        )
+        .expect("seed duplicate row");
+    }
+}
+
+fn count_memory_notes(mem_path: &Path) -> i64 {
+    ensure_sqlite_vec();
+    let conn = Connection::open(mem_path).expect("open memory.db");
+    conn.query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap_or(0)
+}
+
+fn dedupe_cmd(config_path: &Path) -> Command {
+    let tmp_dir = config_path
+        .parent()
+        .expect("config_path must have a parent");
+    let mut cmd = spelunk_bin();
+    cmd.current_dir(tmp_dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(config_path)
+        .arg("memory")
+        .arg("dedupe");
+    cmd
+}
+
+// ── AC9: --dry-run reports counts, makes no writes ───────────────────────────
+
+#[test]
+fn dry_run_reports_counts_and_writes_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let (config_path, mem_path) = write_config(tmp.path());
+    seed_duplicate_group(&mem_path);
+    let before = count_memory_notes(&mem_path);
+    assert_eq!(before, 2, "precondition: two duplicate rows seeded");
+
+    let output = dedupe_cmd(&config_path)
+        .arg("--dry-run")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8(output).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(text.trim()).expect("stdout should be valid JSON");
+    assert_eq!(value["duplicate_groups"].as_i64(), Some(1));
+    assert_eq!(value["rows_collapsed"].as_i64(), Some(1));
+
+    assert_eq!(
+        count_memory_notes(&mem_path),
+        before,
+        "dry-run must write nothing"
+    );
+}
+
+// ── AC10: without --dry-run, duplicates collapse and row count drops exactly ─
+
+#[test]
+fn real_run_collapses_and_row_count_drops_by_rows_collapsed() {
+    let tmp = TempDir::new().unwrap();
+    let (config_path, mem_path) = write_config(tmp.path());
+    seed_duplicate_group(&mem_path);
+    let before = count_memory_notes(&mem_path);
+
+    let output = dedupe_cmd(&config_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8(output).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(text.trim()).expect("stdout should be valid JSON");
+    let rows_collapsed = value["rows_collapsed"].as_i64().expect("rows_collapsed");
+    assert_eq!(rows_collapsed, 1);
+
+    assert_eq!(count_memory_notes(&mem_path), before - rows_collapsed);
+}
+
+// ── AC22: zero duplicate groups -> all-zero counts, no writes ───────────────
+
+#[test]
+fn zero_duplicates_reports_all_zero_and_writes_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let (config_path, mem_path) = write_config(tmp.path());
+
+    // A single `memory add` seeds one unique row and, on its own `open()`,
+    // the empty-store Step B promotes the index: no duplicates ever exist.
+    spelunk_bin()
+        .current_dir(tmp.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("add")
+        .arg("--title")
+        .arg("solo")
+        .arg("--body")
+        .arg("only entry")
+        .assert()
+        .success();
+
+    let before = count_memory_notes(&mem_path);
+    assert_eq!(before, 1);
+
+    let output = dedupe_cmd(&config_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    let value: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+    assert_eq!(value["duplicate_groups"].as_i64(), Some(0));
+    assert_eq!(value["rows_collapsed"].as_i64(), Some(0));
+    assert_eq!(value["tags_merged"].as_i64(), Some(0));
+    assert_eq!(value["linked_files_merged"].as_i64(), Some(0));
+    assert_eq!(value["supersede_edges_repointed"].as_i64(), Some(0));
+    assert_eq!(value["supersede_self_edges_dropped"].as_i64(), Some(0));
+
+    assert_eq!(
+        count_memory_notes(&mem_path),
+        before,
+        "no writes on zero groups"
+    );
+}
+
+// ── AC23: default/text format emits a human-readable line, not JSON ─────────
+
+#[test]
+fn default_format_emits_human_readable_line() {
+    let tmp = TempDir::new().unwrap();
+    let (config_path, mem_path) = write_config(tmp.path());
+    seed_duplicate_group(&mem_path);
+
+    let assert = dedupe_cmd(&config_path).arg("--dry-run").assert().success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "text-format summary goes to stderr, not stdout: {stdout}"
+    );
+    assert!(
+        stderr.contains("dedupe") && stderr.contains("duplicate_groups=1"),
+        "expected a human-readable dedupe summary line, got: {stderr}"
+    );
+}

--- a/crates/spelunk-core/src/storage/memory/dedupe/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/mod.rs
@@ -1,62 +1,26 @@
 //! Collapse duplicate-`entity_id` groups already resident in `memory.db`.
 //!
 //! Backs the `spelunk memory dedupe` command. See ADR-068's third amendment
-//! for the merge rule this implements: survivor = earliest `created_at`;
-//! `tags`/`linked_files` union add-wins; archived sticks.
+//! for the merge rule: survivor = earliest `created_at`; `tags`/`linked_files`
+//! union add-wins; archived sticks.
 //!
-//! `superseded_by` handling treats any reference to a row this *run* is
-//! about to delete or collapse away — whether the referring row and the
-//! referenced row belong to the *same* duplicate group or to two *different*
-//! groups both being collapsed in this same run — as a single, first-class,
-//! whole-run fact, established once up front, before any group is
-//! processed and before any transaction begins. Such a value is never worth
-//! keeping as written: its target is either some group's survivor (the
-//! referring row's resolved value is that survivor, not the doomed id) or,
-//! when that target is the referring row's *own* group's survivor, the
-//! referring row itself — a self-loop, dropped.
+//! Invariant: by the time any loser row is deleted, no live row anywhere in
+//! `notes` may still reference it, whether the reference is within the same
+//! duplicate group or crosses into a different group collapsing in the same
+//! run. To guarantee that without a live re-read mid-run, `loser_to_survivor`
+//! (every id being deleted this run, mapped to its group's survivor) is
+//! computed once, up front, from the immutable pre-transaction snapshot, then
+//! used in two passes before any deletion: each group's own survivor resolves
+//! its final `superseded_by` (self-referential redirects are dropped), then
+//! every other row in the table is rewritten the same way. Only after both
+//! passes complete are losers deleted, in any order.
 //!
-//! Five rounds of adversarial testing each found a wider-scope symptom of
-//! handling this reactively, or at too narrow a scope, instead: a self-loop
-//! from blind adoption; adoption racing the external-rewrite loop over the
-//! same field; the loser-deletion loop hitting a live foreign-key reference
-//! from a not-yet-deleted fellow loser (both a directional and a two-cycle
-//! shape); and finally a reference that crosses into a *different*
-//! duplicate group being collapsed in the same run — invisible to every
-//! prior fix, because each was scoped to "within one group" rather than to
-//! the actual invariant, which is whole-run: by the time any loser is
-//! deleted, no live row anywhere in `notes` may still reference it,
-//! regardless of which group it, or the referencing row, belongs to.
+//! The whole run is one transaction: any error rolls back, leaving
+//! `memory.db` unchanged.
 //!
-//! The whole-run fix, computed once before any group is processed:
-//!   - `loser_to_survivor` maps every id that will be deleted this run,
-//!     across *every* duplicate group, to the survivor its own group
-//!     collapses into. This is purely structural — derived only from group
-//!     membership (earliest `created_at` per `entity_id` group) — so it is
-//!     identical regardless of processing order and never depends on a live
-//!     read, closing the cross-group snapshot staleness the fifth round
-//!     found;
-//!   - each group's own survivor resolves its final value by scanning every
-//!     group member's original value (survivor's own included, in
-//!     `created_at` order) and redirecting any doomed id through
-//!     `loser_to_survivor`; a value that redirects to *this* group's own
-//!     survivor is self-referential and dropped, the same rule rounds 1-2
-//!     established for the single-group case, now applied after redirect
-//!     rather than only to a raw, un-redirected id;
-//!   - every *other* row in the table — an ordinary note, or a loser
-//!     belonging to *any* group — whose own field still points at a doomed
-//!     id is rewritten the same way, once, globally, before any loser is
-//!     deleted. This is what makes the deletion loop safe in any order,
-//!     intra-group (round 3) or cross-group (round 4), without a live query:
-//!     every write target comes from `loser_to_survivor`, so it can only
-//!     ever be a surviving row's id, never another doomed one.
-//!
-//! Losers and their `note_embeddings` row are then deleted. The whole run is
-//! one transaction: any error rolls back, leaving `memory.db` exactly as it
-//! was.
-//!
-//! This is deliberately never called from `Database`/`MemoryStore::open` or
-//! any other automatic path (`init`, `add`, …): collapsing is destructive,
-//! so it only happens when the user explicitly asks for it.
+//! Never called from `Database`/`MemoryStore::open` or any other automatic
+//! path (`init`, `add`, ...): collapsing is destructive, so it only happens
+//! when the user explicitly runs `spelunk memory dedupe`.
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -82,8 +46,8 @@ pub struct DedupeSummary {
 thread_local! {
     /// Test-only fault injection: when set to `Some(n)`, the run fails right
     /// after the (0-indexed) n-th group has been fully applied, before COMMIT.
-    /// Used to prove the whole-run rollback guarantee under a real multi-group
-    /// transaction rather than only the empty/no-op case.
+    /// Proves the whole-run rollback guarantee under a real multi-group
+    /// transaction, not just the empty/no-op case.
     static FAULT_AFTER_GROUP: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
 }
 
@@ -109,11 +73,11 @@ fn fault_due(_i: usize) -> bool {
 
 #[cfg(test)]
 thread_local! {
-    /// Test-only fault injection at a finer grain than `FAULT_AFTER_GROUP`:
-    /// fires after the (0-indexed) n-th loser *within the current group* has
-    /// been fully deleted (embedding + edges + note row), but before any
-    /// later loser in the same group is touched. Used to prove the whole-run
-    /// rollback guarantee holds mid-group, not only at a group boundary.
+    /// Finer-grained fault injection than `FAULT_AFTER_GROUP`: fires after
+    /// the (0-indexed) n-th loser *within the current group* has been fully
+    /// deleted (embedding + edges + note row), before any later loser in the
+    /// same group is touched. Proves the rollback guarantee holds mid-group,
+    /// not only at a group boundary.
     static FAULT_AFTER_LOSER: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
 }
 
@@ -147,12 +111,10 @@ impl MemoryStore {
             .context("reading notes for dedupe")?;
         let total_notes = all.len();
 
-        // Group by entity_id, keeping each note's *index* into `all` rather
-        // than moving the `Note` itself: `all`, in full — every singleton,
-        // non-duplicate note included — is needed again below, for the
-        // whole-run reference-rewrite pass. `all_notes_for_dedup` orders by
-        // created_at ASC, so each group's first element is the
-        // earliest-created row: the survivor, with no separate sort needed.
+        // Index into `all` rather than moving the `Note`: `all` (including
+        // non-duplicate notes) is needed again below for the cross-reference
+        // rewrite pass. `all_notes_for_dedup` orders by created_at ASC, so
+        // each group's first element is already the survivor.
         let mut group_indices: Vec<Vec<usize>> = Vec::new();
         let mut index: HashMap<String, usize> = HashMap::new();
         for (i, n) in all.iter().enumerate() {
@@ -183,17 +145,12 @@ impl MemoryStore {
             .map(|idxs| idxs.iter().map(|&i| &all[i]).collect())
             .collect();
 
-        // ── whole-run facts, computed once, up front, before any group is
-        // processed or any transaction begins (see the module doc) ────────
-        //
-        // `loser_to_survivor` names every id that will be deleted this run,
-        // across *every* duplicate group, mapped to the survivor its own
-        // group collapses into. Purely structural — derived only from group
-        // membership — so it is identical regardless of processing order and
-        // never depends on a live read. `note_group_of` names, for every id
-        // that is a member of *any* duplicate group (survivor or loser),
-        // which group; used only to decide whether a rewrite counts as
-        // "genuinely external" for reporting, never for correctness.
+        // Whole-run facts, computed once up front (see module doc).
+        // loser_to_survivor: every id deleted this run -> its group's
+        // survivor. Purely structural (derived from group membership), so
+        // it's identical regardless of processing order.
+        // note_group_of: id -> group index, used only to classify a rewrite
+        // as "external" for reporting, not for correctness.
         let mut loser_to_survivor: HashMap<i64, i64> = HashMap::new();
         let mut note_group_of: HashMap<i64, usize> = HashMap::new();
         let mut survivor_ids: HashSet<i64> = HashSet::new();
@@ -227,24 +184,17 @@ impl MemoryStore {
             .context("beginning dedupe transaction")?;
         let result: Result<()> = (|| {
             // Phase 1: per group, merge tags/linked_files/status and resolve
-            // the survivor's own final `superseded_by`. Every candidate
-            // value is drawn from the immutable pre-transaction snapshot and
-            // resolved through the whole-run map above, never a live read,
-            // so groups may be processed in any order with an identical
-            // result.
+            // the survivor's final superseded_by, from the pre-transaction
+            // snapshot only (never a live read) so group order doesn't matter.
             for (i, group) in duplicate_groups.iter().enumerate() {
                 self.collapse_group_survivor(group, &loser_to_survivor, &mut summary, true)?;
                 if fault_due(i) {
                     anyhow::bail!("injected test fault after group {i}");
                 }
             }
-            // Phase 2: rewrite every *other* row in the whole table — an
-            // ordinary note, or a loser belonging to any group in this run —
-            // whose own field still refers to a doomed id, before any loser
-            // is deleted. This is what makes the deletion loop safe
-            // regardless of order, both within a group (round 3) and across
-            // groups (round 4): by the time phase 3 runs, no live row
-            // anywhere still references an id phase 3 is about to delete.
+            // Phase 2: rewrite every other row (ordinary note or loser of any
+            // group) whose field still points at a doomed id, before any
+            // loser is deleted, so phase 3 can delete in any order safely.
             self.rewrite_cross_references(
                 &all,
                 &survivor_ids,
@@ -253,9 +203,8 @@ impl MemoryStore {
                 &mut summary,
                 true,
             )?;
-            // Phase 3: delete every loser, from every group. Safe in any
-            // order — intra-group or cross-group — because phase 2 already
-            // cleared every live reference to every id being deleted here.
+            // Phase 3: delete every loser, any order - phase 2 already
+            // cleared every live reference to these ids.
             for group in &duplicate_groups {
                 for (li, loser) in group[1..].iter().enumerate() {
                     self.delete_note_embedding(loser.id)?;
@@ -285,19 +234,16 @@ impl MemoryStore {
     }
 
     /// Plan (and, when `apply`, execute) one duplicate group's
-    /// tags/linked_files/status merge and its survivor's own final
-    /// `superseded_by`. `group` is ordered `created_at` ASC; `group[0]` is
-    /// the survivor.
+    /// tags/linked_files/status merge and its survivor's final
+    /// `superseded_by`. `group` is created_at-ASC ordered; `group[0]` is the
+    /// survivor.
     ///
-    /// Counting and mutation share this one path so a dry-run summary and a
-    /// real run always agree: every count here is derived the same way in
-    /// both modes, only the trailing writes are skipped when `!apply`.
+    /// Dry-run and real-run share this path so their counts always agree;
+    /// only the trailing writes are skipped when `!apply`.
     ///
-    /// Does *not* touch any other row's field (see `rewrite_cross_references`
-    /// for that) and does *not* delete anything: both now happen once,
-    /// globally, after every group's own survivor has been resolved, so that
-    /// no group's own processing can race or interact with another group's —
-    /// see the module doc for why that used to be exactly the gap.
+    /// Does not touch any other row or delete anything (see
+    /// `rewrite_cross_references` and phase 3 in `dedupe_entity_ids`) - kept
+    /// separate so no group's processing can interact with another's.
     fn collapse_group_survivor(
         &self,
         group: &[&Note],
@@ -309,7 +255,7 @@ impl MemoryStore {
         let losers = &group[1..];
         let survivor_id = survivor.id;
 
-        // ── tags / linked_files: union, add-wins ────────────────────────────
+        // tags / linked_files: union, add-wins
         let mut new_tags: Vec<String> = Vec::new();
         let mut new_files: Vec<String> = Vec::new();
         for loser in losers {
@@ -327,25 +273,14 @@ impl MemoryStore {
         summary.tags_merged += new_tags.len();
         summary.linked_files_merged += new_files.len();
 
-        // ── status: archived sticks ──────────────────────────────────────────
+        // status: archived sticks
         let any_archived = group.iter().any(|n| n.status == "archived");
 
-        // ── superseded_by: resolve the survivor's final value against every
-        // id doomed anywhere in this run, not just this group ───────────────
-        //
-        // A candidate value redirects through `loser_to_survivor` to the
-        // survivor its own group collapses into (a no-op redirect when the
-        // value isn't doomed at all this run). If that resolved target is
-        // *this* group's own survivor, the candidate is self-referential —
-        // whether the raw value pointed at this survivor directly, at a
-        // fellow loser of this same group, or at a loser of some other group
-        // (never actually possible to redirect back to *this* survivor,
-        // since groups partition disjointly, but the check does not need to
-        // assume that) — and must be dropped, exactly as rounds 1-2
-        // established for the single-group case. Otherwise it's a genuinely
-        // resolved external candidate, whether that candidate lives entirely
-        // outside every duplicate group or is itself the survivor of a
-        // *different* group being collapsed in this same run (round 4).
+        // superseded_by: resolve against every id doomed this run, not just
+        // this group. A candidate redirects through loser_to_survivor to its
+        // group's survivor (no-op if not doomed). If that target is *this*
+        // group's own survivor, it's self-referential and dropped; otherwise
+        // it's a genuine external value (possibly another group's survivor).
         let resolve = |v: i64| -> Option<i64> {
             let target = loser_to_survivor.get(&v).copied().unwrap_or(v);
             if target == survivor_id {
@@ -371,14 +306,9 @@ impl MemoryStore {
                 );
             }
         }
-        // Did the survivor's *own* pre-existing value resolve to nothing —
-        // i.e. was it self-referential, per the check above? That's what
-        // `supersede_self_edges_dropped` reports, regardless of whether a
-        // fall-through external candidate replaces it or it lands `None`.
-        // (Losers' own doomed references are handled by
-        // `rewrite_cross_references` and aren't counted here: those rows are
-        // about to be deleted, so the field's value is not user-visible
-        // state.)
+        // supersede_self_edges_dropped counts only the survivor's own value
+        // resolving to nothing; losers' references are handled (and not
+        // counted) by rewrite_cross_references, since those rows are deleted.
         let survivor_self_edge_dropped = matches!(survivor.superseded_by.map(resolve), Some(None));
         if survivor_self_edge_dropped {
             summary.supersede_self_edges_dropped += 1;
@@ -390,7 +320,7 @@ impl MemoryStore {
             return Ok(());
         }
 
-        // ── apply phase (real run only) ─────────────────────────────────────
+        // apply phase (real run only)
         if !new_tags.is_empty() || !new_files.is_empty() {
             self.union_tags_and_files(survivor.id, &new_tags, &new_files)?;
         }
@@ -402,11 +332,8 @@ impl MemoryStore {
                 self.set_superseded_by(survivor.id, val)?;
             }
             None if survivor.superseded_by.is_some() => {
-                // The survivor's own original value must have resolved to
-                // nothing (self-referential, per the check above) with no
-                // external fallback anywhere in the group: clear it
-                // explicitly rather than leaving the stale original value
-                // in place.
+                // Resolved to nothing (self-referential) with no external
+                // fallback in the group: clear rather than leave stale.
                 self.clear_superseded_by(survivor.id)?;
             }
             _ => {}
@@ -415,21 +342,13 @@ impl MemoryStore {
         Ok(())
     }
 
-    /// Rewrite every note that is *not* itself a duplicate-group survivor —
-    /// an ordinary note untouched by dedup, or a loser belonging to *any*
-    /// group in this run — whose own `superseded_by` still refers to an id
-    /// that will be deleted this run. Every write target is looked up
-    /// through `loser_to_survivor`, so it can only ever resolve to a
-    /// surviving row's id, never to another doomed id.
+    /// Rewrite every row that is not itself a survivor (an ordinary note or
+    /// a loser of any group) whose `superseded_by` still points at an id
+    /// being deleted this run. Targets resolve through `loser_to_survivor`,
+    /// so a rewrite can only land on a surviving id, never another doomed one.
     ///
-    /// Runs once, globally, over the full pre-transaction snapshot
-    /// (`all_notes`), after every group's own survivor has been resolved
-    /// (`collapse_group_survivor`) and before any loser is deleted: this is
-    /// what guarantees no live row anywhere still references a
-    /// soon-to-be-deleted id by the time deletion happens, regardless of
-    /// group processing order or whether the reference crosses group
-    /// boundaries — the actual invariant five rounds of adversarial testing
-    /// converged on (see the module doc).
+    /// Runs once, globally, before any loser is deleted (see module doc for
+    /// why this ordering is the actual invariant).
     fn rewrite_cross_references(
         &self,
         all_notes: &[Note],
@@ -449,12 +368,8 @@ impl MemoryStore {
             let Some(&target) = loser_to_survivor.get(&v) else {
                 continue; // not a doomed id: nothing to do
             };
-            // Only count as a "repoint" when the referencing row isn't
-            // itself a fellow member of the very group the doomed id
-            // belongs to: that in-group case is inert clean-up (its target
-            // is being deleted regardless of this write), the same
-            // distinction `supersede_self_edges_dropped` draws for the
-            // survivor's own field.
+            // In-group rewrites are inert clean-up (target is deleted
+            // regardless), so only cross-group rewrites count as a "repoint".
             let same_group = matches!(
                 (note_group_of.get(&note.id), note_group_of.get(&v)),
                 (Some(a), Some(b)) if a == b

--- a/crates/spelunk-core/src/storage/memory/dedupe/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/mod.rs
@@ -1,0 +1,478 @@
+//! Collapse duplicate-`entity_id` groups already resident in `memory.db`.
+//!
+//! Backs the `spelunk memory dedupe` command. See ADR-068's third amendment
+//! for the merge rule this implements: survivor = earliest `created_at`;
+//! `tags`/`linked_files` union add-wins; archived sticks.
+//!
+//! `superseded_by` handling treats any reference to a row this *run* is
+//! about to delete or collapse away — whether the referring row and the
+//! referenced row belong to the *same* duplicate group or to two *different*
+//! groups both being collapsed in this same run — as a single, first-class,
+//! whole-run fact, established once up front, before any group is
+//! processed and before any transaction begins. Such a value is never worth
+//! keeping as written: its target is either some group's survivor (the
+//! referring row's resolved value is that survivor, not the doomed id) or,
+//! when that target is the referring row's *own* group's survivor, the
+//! referring row itself — a self-loop, dropped.
+//!
+//! Five rounds of adversarial testing each found a wider-scope symptom of
+//! handling this reactively, or at too narrow a scope, instead: a self-loop
+//! from blind adoption; adoption racing the external-rewrite loop over the
+//! same field; the loser-deletion loop hitting a live foreign-key reference
+//! from a not-yet-deleted fellow loser (both a directional and a two-cycle
+//! shape); and finally a reference that crosses into a *different*
+//! duplicate group being collapsed in the same run — invisible to every
+//! prior fix, because each was scoped to "within one group" rather than to
+//! the actual invariant, which is whole-run: by the time any loser is
+//! deleted, no live row anywhere in `notes` may still reference it,
+//! regardless of which group it, or the referencing row, belongs to.
+//!
+//! The whole-run fix, computed once before any group is processed:
+//!   - `loser_to_survivor` maps every id that will be deleted this run,
+//!     across *every* duplicate group, to the survivor its own group
+//!     collapses into. This is purely structural — derived only from group
+//!     membership (earliest `created_at` per `entity_id` group) — so it is
+//!     identical regardless of processing order and never depends on a live
+//!     read, closing the cross-group snapshot staleness the fifth round
+//!     found;
+//!   - each group's own survivor resolves its final value by scanning every
+//!     group member's original value (survivor's own included, in
+//!     `created_at` order) and redirecting any doomed id through
+//!     `loser_to_survivor`; a value that redirects to *this* group's own
+//!     survivor is self-referential and dropped, the same rule rounds 1-2
+//!     established for the single-group case, now applied after redirect
+//!     rather than only to a raw, un-redirected id;
+//!   - every *other* row in the table — an ordinary note, or a loser
+//!     belonging to *any* group — whose own field still points at a doomed
+//!     id is rewritten the same way, once, globally, before any loser is
+//!     deleted. This is what makes the deletion loop safe in any order,
+//!     intra-group (round 3) or cross-group (round 4), without a live query:
+//!     every write target comes from `loser_to_survivor`, so it can only
+//!     ever be a surviving row's id, never another doomed one.
+//!
+//! Losers and their `note_embeddings` row are then deleted. The whole run is
+//! one transaction: any error rolls back, leaving `memory.db` exactly as it
+//! was.
+//!
+//! This is deliberately never called from `Database`/`MemoryStore::open` or
+//! any other automatic path (`init`, `add`, …): collapsing is destructive,
+//! so it only happens when the user explicitly asks for it.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+
+use super::{MemoryStore, Note};
+use crate::storage::entity_id::note_entity_id;
+
+/// Summary of one `dedupe_entity_ids` run (or dry-run estimate).
+#[derive(Debug, Default, Serialize, PartialEq, Eq)]
+pub struct DedupeSummary {
+    pub total_notes: usize,
+    pub duplicate_groups: usize,
+    /// Losers collapsed (rows removed).
+    pub rows_collapsed: usize,
+    pub tags_merged: usize,
+    pub linked_files_merged: usize,
+    pub supersede_edges_repointed: usize,
+    pub supersede_self_edges_dropped: usize,
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only fault injection: when set to `Some(n)`, the run fails right
+    /// after the (0-indexed) n-th group has been fully applied, before COMMIT.
+    /// Used to prove the whole-run rollback guarantee under a real multi-group
+    /// transaction rather than only the empty/no-op case.
+    static FAULT_AFTER_GROUP: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+fn inject_fault_after_group(n: usize) {
+    FAULT_AFTER_GROUP.with(|f| f.set(Some(n)));
+}
+
+#[cfg(test)]
+fn clear_fault() {
+    FAULT_AFTER_GROUP.with(|f| f.set(None));
+}
+
+#[cfg(test)]
+fn fault_due(i: usize) -> bool {
+    FAULT_AFTER_GROUP.with(|f| f.get() == Some(i))
+}
+
+#[cfg(not(test))]
+fn fault_due(_i: usize) -> bool {
+    false
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only fault injection at a finer grain than `FAULT_AFTER_GROUP`:
+    /// fires after the (0-indexed) n-th loser *within the current group* has
+    /// been fully deleted (embedding + edges + note row), but before any
+    /// later loser in the same group is touched. Used to prove the whole-run
+    /// rollback guarantee holds mid-group, not only at a group boundary.
+    static FAULT_AFTER_LOSER: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+fn inject_fault_after_loser(n: usize) {
+    FAULT_AFTER_LOSER.with(|f| f.set(Some(n)));
+}
+
+#[cfg(test)]
+fn clear_loser_fault() {
+    FAULT_AFTER_LOSER.with(|f| f.set(None));
+}
+
+#[cfg(test)]
+fn loser_fault_due(i: usize) -> bool {
+    FAULT_AFTER_LOSER.with(|f| f.get() == Some(i))
+}
+
+#[cfg(not(test))]
+fn loser_fault_due(_i: usize) -> bool {
+    false
+}
+
+impl MemoryStore {
+    /// Collapse every duplicate `entity_id` group in one all-or-nothing
+    /// transaction. `dry_run` computes the same summary via read-only queries
+    /// and writes nothing.
+    pub fn dedupe_entity_ids(&self, dry_run: bool) -> Result<DedupeSummary> {
+        let all = self
+            .all_notes_for_dedup()
+            .context("reading notes for dedupe")?;
+        let total_notes = all.len();
+
+        // Group by entity_id, keeping each note's *index* into `all` rather
+        // than moving the `Note` itself: `all`, in full — every singleton,
+        // non-duplicate note included — is needed again below, for the
+        // whole-run reference-rewrite pass. `all_notes_for_dedup` orders by
+        // created_at ASC, so each group's first element is the
+        // earliest-created row: the survivor, with no separate sort needed.
+        let mut group_indices: Vec<Vec<usize>> = Vec::new();
+        let mut index: HashMap<String, usize> = HashMap::new();
+        for (i, n) in all.iter().enumerate() {
+            let eid = note_entity_id(n);
+            match index.get(&eid) {
+                Some(&gi) => group_indices[gi].push(i),
+                None => {
+                    index.insert(eid, group_indices.len());
+                    group_indices.push(vec![i]);
+                }
+            }
+        }
+        let duplicate_group_indices: Vec<Vec<usize>> =
+            group_indices.into_iter().filter(|g| g.len() > 1).collect();
+
+        let mut summary = DedupeSummary {
+            total_notes,
+            duplicate_groups: duplicate_group_indices.len(),
+            ..Default::default()
+        };
+
+        if duplicate_group_indices.is_empty() {
+            return Ok(summary);
+        }
+
+        let duplicate_groups: Vec<Vec<&Note>> = duplicate_group_indices
+            .iter()
+            .map(|idxs| idxs.iter().map(|&i| &all[i]).collect())
+            .collect();
+
+        // ── whole-run facts, computed once, up front, before any group is
+        // processed or any transaction begins (see the module doc) ────────
+        //
+        // `loser_to_survivor` names every id that will be deleted this run,
+        // across *every* duplicate group, mapped to the survivor its own
+        // group collapses into. Purely structural — derived only from group
+        // membership — so it is identical regardless of processing order and
+        // never depends on a live read. `note_group_of` names, for every id
+        // that is a member of *any* duplicate group (survivor or loser),
+        // which group; used only to decide whether a rewrite counts as
+        // "genuinely external" for reporting, never for correctness.
+        let mut loser_to_survivor: HashMap<i64, i64> = HashMap::new();
+        let mut note_group_of: HashMap<i64, usize> = HashMap::new();
+        let mut survivor_ids: HashSet<i64> = HashSet::new();
+        for (gi, group) in duplicate_groups.iter().enumerate() {
+            let survivor_id = group[0].id;
+            survivor_ids.insert(survivor_id);
+            for n in group {
+                note_group_of.insert(n.id, gi);
+            }
+            for loser in &group[1..] {
+                loser_to_survivor.insert(loser.id, survivor_id);
+            }
+        }
+
+        if dry_run {
+            for group in &duplicate_groups {
+                self.collapse_group_survivor(group, &loser_to_survivor, &mut summary, false)?;
+            }
+            self.rewrite_cross_references(
+                &all,
+                &survivor_ids,
+                &loser_to_survivor,
+                &note_group_of,
+                &mut summary,
+                false,
+            )?;
+            return Ok(summary);
+        }
+
+        self.execute_batch("BEGIN IMMEDIATE")
+            .context("beginning dedupe transaction")?;
+        let result: Result<()> = (|| {
+            // Phase 1: per group, merge tags/linked_files/status and resolve
+            // the survivor's own final `superseded_by`. Every candidate
+            // value is drawn from the immutable pre-transaction snapshot and
+            // resolved through the whole-run map above, never a live read,
+            // so groups may be processed in any order with an identical
+            // result.
+            for (i, group) in duplicate_groups.iter().enumerate() {
+                self.collapse_group_survivor(group, &loser_to_survivor, &mut summary, true)?;
+                if fault_due(i) {
+                    anyhow::bail!("injected test fault after group {i}");
+                }
+            }
+            // Phase 2: rewrite every *other* row in the whole table — an
+            // ordinary note, or a loser belonging to any group in this run —
+            // whose own field still refers to a doomed id, before any loser
+            // is deleted. This is what makes the deletion loop safe
+            // regardless of order, both within a group (round 3) and across
+            // groups (round 4): by the time phase 3 runs, no live row
+            // anywhere still references an id phase 3 is about to delete.
+            self.rewrite_cross_references(
+                &all,
+                &survivor_ids,
+                &loser_to_survivor,
+                &note_group_of,
+                &mut summary,
+                true,
+            )?;
+            // Phase 3: delete every loser, from every group. Safe in any
+            // order — intra-group or cross-group — because phase 2 already
+            // cleared every live reference to every id being deleted here.
+            for group in &duplicate_groups {
+                for (li, loser) in group[1..].iter().enumerate() {
+                    self.delete_note_embedding(loser.id)?;
+                    self.delete_edges_for_note(loser.id)?;
+                    self.delete_note(loser.id)?;
+                    if loser_fault_due(li) {
+                        anyhow::bail!(
+                            "injected test fault after deleting loser index {li} within group"
+                        );
+                    }
+                }
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => {
+                self.execute_batch("COMMIT")
+                    .context("committing dedupe transaction")?;
+                Ok(summary)
+            }
+            Err(e) => {
+                let _ = self.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
+    /// Plan (and, when `apply`, execute) one duplicate group's
+    /// tags/linked_files/status merge and its survivor's own final
+    /// `superseded_by`. `group` is ordered `created_at` ASC; `group[0]` is
+    /// the survivor.
+    ///
+    /// Counting and mutation share this one path so a dry-run summary and a
+    /// real run always agree: every count here is derived the same way in
+    /// both modes, only the trailing writes are skipped when `!apply`.
+    ///
+    /// Does *not* touch any other row's field (see `rewrite_cross_references`
+    /// for that) and does *not* delete anything: both now happen once,
+    /// globally, after every group's own survivor has been resolved, so that
+    /// no group's own processing can race or interact with another group's —
+    /// see the module doc for why that used to be exactly the gap.
+    fn collapse_group_survivor(
+        &self,
+        group: &[&Note],
+        loser_to_survivor: &HashMap<i64, i64>,
+        summary: &mut DedupeSummary,
+        apply: bool,
+    ) -> Result<()> {
+        let survivor = group[0];
+        let losers = &group[1..];
+        let survivor_id = survivor.id;
+
+        // ── tags / linked_files: union, add-wins ────────────────────────────
+        let mut new_tags: Vec<String> = Vec::new();
+        let mut new_files: Vec<String> = Vec::new();
+        for loser in losers {
+            for t in &loser.tags {
+                if !survivor.tags.contains(t) && !new_tags.contains(t) {
+                    new_tags.push(t.clone());
+                }
+            }
+            for f in &loser.linked_files {
+                if !survivor.linked_files.contains(f) && !new_files.contains(f) {
+                    new_files.push(f.clone());
+                }
+            }
+        }
+        summary.tags_merged += new_tags.len();
+        summary.linked_files_merged += new_files.len();
+
+        // ── status: archived sticks ──────────────────────────────────────────
+        let any_archived = group.iter().any(|n| n.status == "archived");
+
+        // ── superseded_by: resolve the survivor's final value against every
+        // id doomed anywhere in this run, not just this group ───────────────
+        //
+        // A candidate value redirects through `loser_to_survivor` to the
+        // survivor its own group collapses into (a no-op redirect when the
+        // value isn't doomed at all this run). If that resolved target is
+        // *this* group's own survivor, the candidate is self-referential —
+        // whether the raw value pointed at this survivor directly, at a
+        // fellow loser of this same group, or at a loser of some other group
+        // (never actually possible to redirect back to *this* survivor,
+        // since groups partition disjointly, but the check does not need to
+        // assume that) — and must be dropped, exactly as rounds 1-2
+        // established for the single-group case. Otherwise it's a genuinely
+        // resolved external candidate, whether that candidate lives entirely
+        // outside every duplicate group or is itself the survivor of a
+        // *different* group being collapsed in this same run (round 4).
+        let resolve = |v: i64| -> Option<i64> {
+            let target = loser_to_survivor.get(&v).copied().unwrap_or(v);
+            if target == survivor_id {
+                None
+            } else {
+                Some(target)
+            }
+        };
+
+        let external_values: Vec<i64> = group
+            .iter()
+            .filter_map(|n| n.superseded_by.and_then(resolve))
+            .collect();
+        let resolved_survivor_target = external_values.first().copied();
+        if let Some(val) = resolved_survivor_target {
+            let conflicting = external_values.iter().any(|v| *v != val);
+            if conflicting {
+                tracing::warn!(
+                    "memory dedupe: duplicate-entity_id group for survivor #{} carries \
+                     conflicting superseded_by values; the earliest-created row's value \
+                     ({val}) wins",
+                    survivor.id
+                );
+            }
+        }
+        // Did the survivor's *own* pre-existing value resolve to nothing —
+        // i.e. was it self-referential, per the check above? That's what
+        // `supersede_self_edges_dropped` reports, regardless of whether a
+        // fall-through external candidate replaces it or it lands `None`.
+        // (Losers' own doomed references are handled by
+        // `rewrite_cross_references` and aren't counted here: those rows are
+        // about to be deleted, so the field's value is not user-visible
+        // state.)
+        let survivor_self_edge_dropped = matches!(survivor.superseded_by.map(resolve), Some(None));
+        if survivor_self_edge_dropped {
+            summary.supersede_self_edges_dropped += 1;
+        }
+
+        summary.rows_collapsed += losers.len();
+
+        if !apply {
+            return Ok(());
+        }
+
+        // ── apply phase (real run only) ─────────────────────────────────────
+        if !new_tags.is_empty() || !new_files.is_empty() {
+            self.union_tags_and_files(survivor.id, &new_tags, &new_files)?;
+        }
+        if any_archived {
+            self.archive(survivor.id)?;
+        }
+        match resolved_survivor_target {
+            Some(val) if survivor.superseded_by != Some(val) => {
+                self.set_superseded_by(survivor.id, val)?;
+            }
+            None if survivor.superseded_by.is_some() => {
+                // The survivor's own original value must have resolved to
+                // nothing (self-referential, per the check above) with no
+                // external fallback anywhere in the group: clear it
+                // explicitly rather than leaving the stale original value
+                // in place.
+                self.clear_superseded_by(survivor.id)?;
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    /// Rewrite every note that is *not* itself a duplicate-group survivor —
+    /// an ordinary note untouched by dedup, or a loser belonging to *any*
+    /// group in this run — whose own `superseded_by` still refers to an id
+    /// that will be deleted this run. Every write target is looked up
+    /// through `loser_to_survivor`, so it can only ever resolve to a
+    /// surviving row's id, never to another doomed id.
+    ///
+    /// Runs once, globally, over the full pre-transaction snapshot
+    /// (`all_notes`), after every group's own survivor has been resolved
+    /// (`collapse_group_survivor`) and before any loser is deleted: this is
+    /// what guarantees no live row anywhere still references a
+    /// soon-to-be-deleted id by the time deletion happens, regardless of
+    /// group processing order or whether the reference crosses group
+    /// boundaries — the actual invariant five rounds of adversarial testing
+    /// converged on (see the module doc).
+    fn rewrite_cross_references(
+        &self,
+        all_notes: &[Note],
+        survivor_ids: &HashSet<i64>,
+        loser_to_survivor: &HashMap<i64, i64>,
+        note_group_of: &HashMap<i64, usize>,
+        summary: &mut DedupeSummary,
+        apply: bool,
+    ) -> Result<()> {
+        for note in all_notes {
+            if survivor_ids.contains(&note.id) {
+                continue; // the survivor's own field is resolved separately
+            }
+            let Some(v) = note.superseded_by else {
+                continue;
+            };
+            let Some(&target) = loser_to_survivor.get(&v) else {
+                continue; // not a doomed id: nothing to do
+            };
+            // Only count as a "repoint" when the referencing row isn't
+            // itself a fellow member of the very group the doomed id
+            // belongs to: that in-group case is inert clean-up (its target
+            // is being deleted regardless of this write), the same
+            // distinction `supersede_self_edges_dropped` draws for the
+            // survivor's own field.
+            let same_group = matches!(
+                (note_group_of.get(&note.id), note_group_of.get(&v)),
+                (Some(a), Some(b)) if a == b
+            );
+            if !same_group {
+                summary.supersede_edges_repointed += 1;
+            }
+            if apply {
+                self.set_superseded_by(note.id, target)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod superseded_by_tests;
+#[cfg(test)]
+mod test_support;
+#[cfg(test)]
+mod tests;

--- a/crates/spelunk-core/src/storage/memory/dedupe/superseded_by_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/superseded_by_tests.rs
@@ -6,14 +6,10 @@
 use super::test_support::{note_count, open_store};
 use super::*;
 
-// ── Adversarial: the survivor's adoption of a group member's
-// `superseded_by` value does not validate that the value isn't itself a
-// member of the same duplicate group. When a loser's own `superseded_by`
-// points directly at the survivor, adoption creates SURVIVOR -> SURVIVOR
-// (a self-loop), unlike the *rewrite* path (AC19), which explicitly
-// guards against exactly this and drops to NULL instead. This is a
-// genuine bug, not a documented scope gap: a self-referencing
-// `superseded_by` is nonsensical regardless of the ADR's text. ─────────
+// Adversarial: adoption of a loser's superseded_by does not guard against
+// the value pointing at the survivor itself, unlike the rewrite path
+// (AC19), which drops self-loops to NULL. A self-referencing
+// superseded_by is nonsensical regardless of the ADR's text.
 #[test]
 fn adoption_must_not_selfloop_when_a_loser_points_at_the_survivor() {
     let store = open_store();
@@ -39,22 +35,12 @@ fn adoption_must_not_selfloop_when_a_loser_points_at_the_survivor() {
     );
 }
 
-// ── Adversarial: a chained loser->loser `superseded_by` pointer (one
-// loser's `superseded_by` points at *another* loser in the same group,
-// not at the survivor) gets blindly adopted onto the survivor by value,
-// even though that target row is about to be deleted in this very
-// transaction. The rewrite loop (which repoints external dependents)
-// never sees this adoption write, because `rewrites` is computed from a
-// read taken *before* the adoption write happens.
-//
-// The practical symptom is even sharper than "a dangling pointer": this
-// SQLite build enforces `foreign_keys` ON by default (verified directly),
-// and `notes` (`superseded_by INTEGER REFERENCES notes(id)`) has no
-// `ON DELETE` clause, so once the survivor's adoption write leaves it
-// pointing at loser_b, the later `DELETE FROM notes WHERE id = loser_b` in
-// the same transaction is rejected outright with a FOREIGN KEY constraint
-// error: the whole dedupe run fails (and correctly rolls back) for a
-// duplicate shape it should handle cleanly. ─────────────────────────────
+// Adversarial: a loser's superseded_by pointing at a FELLOW loser (not
+// the survivor) gets blindly adopted onto the survivor, even though that
+// target is deleted later in the same transaction. `notes.superseded_by`
+// has a live FK (no ON DELETE clause), so the adoption write leaves the
+// survivor pointing at a row this same transaction then deletes: FOREIGN
+// KEY constraint error, whole run fails instead of collapsing cleanly.
 #[test]
 fn adoption_must_not_dangle_when_a_loser_points_at_a_fellow_loser() {
     let store = open_store();
@@ -67,8 +53,7 @@ fn adoption_must_not_dangle_when_a_loser_points_at_a_fellow_loser() {
     let loser_b = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    // loser_a claims to be "superseded by" loser_b, a fellow member of
-    // the very same duplicate group, not an external note.
+    // loser_a points at fellow loser loser_b: in-group, not external.
     store.set_superseded_by(loser_a, loser_b).unwrap();
 
     let result = store.dedupe_entity_ids(false);
@@ -84,8 +69,8 @@ fn adoption_must_not_dangle_when_a_loser_points_at_a_fellow_loser() {
          then tries to delete.",
         result.as_ref().err()
     );
-    // If a future fix makes this succeed, it must not merely trade the
-    // hard error for a silent dangling pointer.
+    // A future fix must not merely trade the hard error for a silent
+    // dangling pointer.
     if result.is_ok() {
         let note = store.get(survivor).unwrap().unwrap();
         if let Some(target) = note.superseded_by {
@@ -98,19 +83,15 @@ fn adoption_must_not_dangle_when_a_loser_points_at_a_fellow_loser() {
     }
 }
 
-// ── Adversarial (re-verification pass): the survivor's OWN pre-existing
-// `superseded_by` pointed at a fellow in-group loser (not itself, and not
-// the "loser points at survivor" shape already covered above — this is
-// the third permutation: *survivor* points at a *loser*). The adoption
-// fix correctly filters this in-group value out of `external_values` and
-// falls through to a genuinely-external candidate elsewhere in the group
-// (mirroring the "3+ losers, first candidate intra-group-dangling, later
-// candidate valid" check). But the *rewrite* loop below adoption computes
-// `notes_pointing_at(loser_x.id)` against the ORIGINAL pre-transaction
-// state, which still shows survivor -> loser_x, so it independently
-// re-discovers this same edge, treats it as a self-edge case (`ref_id ==
-// survivor.id`), and clears it back to NULL *after* the adoption write
-// already ran — clobbering the correctly-adopted external value.
+// Adversarial (re-verification): the survivor's OWN pre-existing
+// superseded_by points at a fellow in-group loser (survivor -> loser,
+// the third permutation after loser -> survivor and loser -> loser
+// above). Adoption correctly filters the in-group value and falls
+// through to a genuine external candidate. But the rewrite loop below
+// recomputes notes_pointing_at(loser_x) against the stale
+// pre-transaction snapshot, re-discovers the same edge as a self-edge,
+// and clears it to NULL *after* adoption already set the correct
+// external value, clobbering it.
 #[test]
 fn adoption_survivor_own_in_group_pointer_does_not_clobber_fallthrough_adoption() {
     let store = open_store();
@@ -126,12 +107,11 @@ fn adoption_survivor_own_in_group_pointer_does_not_clobber_fallthrough_adoption(
     let loser_y = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    // Survivor's own pre-existing value points at a fellow duplicate
-    // (loser_x), an in-group reference that must not be adopted verbatim.
+    // Survivor's own value points at fellow duplicate loser_x: in-group,
+    // must not be adopted verbatim.
     store.set_superseded_by(survivor, loser_x).unwrap();
-    // loser_y carries a genuinely-external candidate: once the in-group
-    // value is filtered out, this should be what the survivor ends up
-    // pointing at (fall-through adoption), not NULL.
+    // loser_y's value is genuinely external: the fall-through adoption
+    // target once the in-group value is filtered out.
     store.set_superseded_by(loser_y, external).unwrap();
 
     store.dedupe_entity_ids(false).unwrap();
@@ -151,10 +131,10 @@ fn adoption_survivor_own_in_group_pointer_does_not_clobber_fallthrough_adoption(
     );
 }
 
-// ── Adversarial (re-verification pass): 3+ losers, first candidate in
-// iteration order is intra-group-dangling (points at a fellow loser), a
-// later candidate is genuinely external. Confirms fall-through works when
-// the in-group pointer is on a *loser*, not the survivor. ───────────────
+// Adversarial (re-verification): 3+ losers, first candidate in iteration
+// order is intra-group-dangling, a later candidate is genuinely
+// external. Confirms fall-through works when the in-group pointer is on
+// a loser, not the survivor.
 #[test]
 fn fallthrough_adoption_skips_intragroup_dangling_candidate_and_adopts_later_external_one() {
     let store = open_store();
@@ -173,8 +153,8 @@ fn fallthrough_adoption_skips_intragroup_dangling_candidate_and_adopts_later_ext
     let loser_c = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
         .unwrap();
-    // loser_a (earliest loser, first candidate in iteration order) points
-    // at a fellow loser: intra-group-dangling, must be skipped.
+    // loser_a (first candidate in iteration order) points at a fellow
+    // loser: intra-group-dangling, must be skipped.
     store.set_superseded_by(loser_a, loser_b).unwrap();
     // loser_c (later in iteration order) carries the only valid external
     // candidate.
@@ -191,10 +171,9 @@ fn fallthrough_adoption_skips_intragroup_dangling_candidate_and_adopts_later_ext
     );
 }
 
-// ── Adversarial (re-verification pass): only intra-group candidates
-// exist anywhere in the group (no genuinely external value at all).
-// Confirms adoption correctly resolves to None rather than erroring or
-// keeping a bad in-group value. ─────────────────────────────────────────
+// Adversarial (re-verification): only intra-group candidates exist (no
+// external value at all). Adoption must resolve to None, not error or
+// keep a bad in-group value.
 #[test]
 fn adoption_resolves_to_none_when_every_candidate_is_intragroup() {
     let store = open_store();
@@ -207,8 +186,8 @@ fn adoption_resolves_to_none_when_every_candidate_is_intragroup() {
     let loser_b = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    // loser_a -> loser_b and loser_b -> survivor: every candidate value
-    // in the group resolves to a fellow group member, none external.
+    // loser_a -> loser_b -> survivor: every candidate resolves to a
+    // fellow group member, none external.
     store.set_superseded_by(loser_a, loser_b).unwrap();
     store.set_superseded_by(loser_b, survivor).unwrap();
 
@@ -226,21 +205,13 @@ fn adoption_resolves_to_none_when_every_candidate_is_intragroup() {
     );
 }
 
-// ── Adversarial (round 3): a LATER-created loser's own `superseded_by`
-// points at an EARLIER-created fellow loser (not the survivor). Neither
-// adoption nor the rewrite loop ever touches this value — it's correctly
-// excluded from both, per the "a fellow loser's own field doesn't matter
-// since that row is being deleted" comment above the rewrite loop — so it
-// sits untouched on loser_late's own row until deletion time. But the
-// deletion loop deletes losers in `created_at` ASC order (loser_early,
-// then loser_late), i.e. it tries to delete loser_early — the row
-// loser_late still references — *before* loser_late (the referencing
-// row) is gone. Under live FK enforcement (empirically confirmed active
-// on this connection: `notes.superseded_by` has no `ON DELETE` clause)
-// this must fail with a FOREIGN KEY constraint error on the delete of
-// loser_early, exactly the same user-visible symptom as the two
-// previously-fixed bugs, but via the deletion loop's ordering rather than
-// the adoption/rewrite write paths. ──────────────────────────────────────
+// Adversarial (round 3): a LATER-created loser's own superseded_by points
+// at an EARLIER-created fellow loser. Neither adoption nor the rewrite
+// loop touches this value (correctly excluded from both), so it sits
+// until deletion time. Deletion runs in created_at ASC order, so it
+// tries to delete loser_early - still referenced by loser_late - before
+// loser_late (the referencing row) is gone: live FK enforcement rejects
+// it with a constraint error.
 #[test]
 fn later_loser_pointing_at_earlier_fellow_loser_must_not_break_deletion_order() {
     let store = open_store();
@@ -253,8 +224,8 @@ fn later_loser_pointing_at_earlier_fellow_loser_must_not_break_deletion_order() 
     let loser_late = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    // loser_late (deleted SECOND, per created_at ASC order) points at
-    // loser_early (deleted FIRST) — the referencing row outlives, in
+    // loser_late (deleted second, per created_at ASC) points at
+    // loser_early (deleted first): the referencing row outlives, in
     // deletion order, the row it references.
     store.set_superseded_by(loser_late, loser_early).unwrap();
 
@@ -264,7 +235,7 @@ fn later_loser_pointing_at_earlier_fellow_loser_must_not_break_deletion_order() 
         result.is_ok(),
         "BUG: a later-created loser pointing at an earlier-created \
          fellow loser breaks the deletion loop's naive created_at-ASC \
-         order — deleting loser_early while loser_late (not yet \
+         order - deleting loser_early while loser_late (not yet \
          deleted) still references it via superseded_by triggers a \
          live FOREIGN KEY constraint error and the whole run fails \
          instead of collapsing cleanly: {:?}",
@@ -272,16 +243,12 @@ fn later_loser_pointing_at_earlier_fellow_loser_must_not_break_deletion_order() 
     );
 }
 
-// ── Adversarial (round 3): the same deletion-order hazard as above, but
-// with the roles swapped per the story's own round-2-repro-swap
-// instruction: two losers point AT EACH OTHER (a 2-cycle among fellow
-// losers), survivor points at nothing. Neither value is external, so
-// nothing is adopted onto the survivor and nothing is queued in
-// `rewrites` — same as the one-directional case above — but now
-// *whichever* loser the deletion loop tries to delete first is still
-// referenced by the other (not-yet-deleted) loser, so this must fail
-// regardless of `created_at` order, not just in the "later points at
-// earlier" direction. ────────────────────────────────────────────────────
+// Adversarial (round 3): the same deletion-order hazard, roles swapped -
+// two losers point AT EACH OTHER (a 2-cycle), survivor points at
+// nothing. Neither value is external, so nothing is adopted or
+// rewritten, but whichever loser is deleted first is still referenced by
+// the other, not-yet-deleted loser: fails regardless of created_at
+// order, not just the "later points at earlier" direction.
 #[test]
 fn mutually_referencing_fellow_losers_must_not_break_deletion_order() {
     let store = open_store();
@@ -302,7 +269,7 @@ fn mutually_referencing_fellow_losers_must_not_break_deletion_order() {
     assert!(
         result.is_ok(),
         "BUG: two fellow losers pointing at each other (a 2-cycle) \
-         breaks the deletion loop regardless of created_at order — \
+         breaks the deletion loop regardless of created_at order - \
          whichever is deleted first is still referenced by the other, \
          not-yet-deleted loser, triggering a FOREIGN KEY constraint \
          error: {:?}",
@@ -310,13 +277,11 @@ fn mutually_referencing_fellow_losers_must_not_break_deletion_order() {
     );
 }
 
-// ── Adversarial (round 3): a 4-note group where multiple members carry
-// non-null superseded_by pointing at a mix of intra-group and external
-// targets, including a chain (loser -> loser -> external). Confirms the
-// unified resolution still picks a sensible, deterministic external
-// value, the counts stay accurate, AND — this is the actual failure mode
-// this round found — the deletion loop must not choke on the in-group
-// chain reference along the way. ─────────────────────────────────────────
+// Adversarial (round 3): a 4-note group with a mix of intra-group and
+// external superseded_by values, including a chain (loser -> loser ->
+// external). Confirms resolution still picks a deterministic external
+// value, counts stay accurate, and the deletion loop doesn't choke on
+// the in-group chain reference.
 #[test]
 fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_deterministically() {
     let store = open_store();
@@ -338,8 +303,7 @@ fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_determin
     let loser3 = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
         .unwrap();
-    // loser1 (earliest loser, first candidate in iteration order) chains
-    // to a fellow loser: intra-group, must be skipped for adoption AND
+    // loser1 chains to fellow loser2: in-group, skipped for adoption,
     // must not break deletion order.
     store.set_superseded_by(loser1, loser2).unwrap();
     // loser2 itself carries a genuinely-external value.
@@ -348,10 +312,9 @@ fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_determin
     store.set_superseded_by(loser3, external_b).unwrap();
 
     let summary = store.dedupe_entity_ids(false).unwrap();
-    // Resolution order is group order (created_at ASC): survivor(None),
-    // loser1(->loser2, in-group, dropped), loser2(->external_a, first
-    // surviving external candidate), loser3(->external_b, conflicting).
-    // external_a must win.
+    // Resolution order (created_at ASC): loser1's in-group edge is
+    // dropped, loser2's external_a wins over loser3's conflicting
+    // external_b.
     let note = store.get(_survivor).unwrap().unwrap();
     assert_eq!(
         note.superseded_by,
@@ -361,9 +324,8 @@ fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_determin
     );
     assert_eq!(summary.rows_collapsed, 3);
 
-    // Re-run determinism: rebuild an identical store and confirm the same
-    // resolution and counts on a second, independent run (not just
-    // repeatable within one process — a genuinely fresh grouping pass).
+    // Re-run on an independent store to confirm determinism, not just
+    // repeatability within one process.
     let store2 = open_store();
     let external_a2 = store2
         .add_note("note", "external a", "b", &[], &[], None, None)
@@ -397,42 +359,16 @@ fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_determin
     );
 }
 
-// ── Adversarial (round-4 re-verification): TWO duplicate groups in the
-// SAME `dedupe_entity_ids` call, where a member of the *second* group
-// (processed later) has its own `superseded_by` pointing at a member of
-// the *first* group (processed earlier). This probes whether "the
-// current group" is scoped correctly when the run collapses more than
-// one group.
-//
-// `group: &[Note]` passed into `collapse_group` is a fixed snapshot taken
-// by `all_notes_for_dedup()` once, before the transaction begins and
-// before any group is processed. The external-rewrite loop reads live via
-// `notes_pointing_at`, so it sees every prior group's writes. But the
-// in-group/adoption resolution reads a group member's `superseded_by`
-// straight off that same stale, pre-transaction `Note` snapshot — it has
-// no way to know a *different* group, processed earlier in this same
-// run, already rewrote that value or deleted its target.
-//
-// Group A (survivor_a, loser_a) is processed first (created_at 100/200).
-// Group B (survivor_b, external_x) is processed second (created_at
-// 150/250). `external_x` is itself group B's loser, but its own
-// `superseded_by` points at `loser_a` — a member of group A, unrelated to
-// group B's identity.
-//
-// Processing group A: the external-rewrite loop's live query correctly
-// finds external_x pointing at loser_a and repoints it to survivor_a
-// (external_x is not a member of group A, so this is legitimate), then
-// deletes loser_a.
-//
-// Processing group B: survivor_b's adoption resolution reads external_x's
-// *stale* snapshot value (still `loser_a`, not survivor_a) and treats it
-// as a genuinely-external candidate (loser_a isn't a member of group B's
-// `group_ids`), so it tries to write `survivor_b.superseded_by =
-// loser_a.id` — a row deleted by group A moments earlier in the very
-// same transaction. Under live FK enforcement this fails outright instead
-// of collapsing cleanly, the same user-visible symptom as rounds 1-3, but
-// via cross-group snapshot staleness rather than a single group's own
-// internal bookkeeping.
+// Adversarial (round-4 re-verification): TWO groups in the same call,
+// where group B's member has its own superseded_by pointing at a member
+// of group A (processed earlier). `group: &[Note]` is a fixed
+// pre-transaction snapshot; the rewrite loop reads live (via
+// notes_pointing_at), so it sees prior groups' writes, but adoption
+// resolution reads the group member's superseded_by off that same stale
+// snapshot - it can't see that group A's earlier processing already
+// repointed/deleted its target. Result: group B's adoption tries to
+// write a value pointing at a row group A already deleted in this same
+// transaction, causing an FK error.
 #[test]
 fn external_row_that_is_itself_a_duplicate_in_a_different_group_is_resolved_correctly_across_groups()
  {
@@ -479,7 +415,7 @@ fn external_row_that_is_itself_a_duplicate_in_a_different_group_is_resolved_corr
     }
 }
 
-// ── AC24 (structural): dedupe is never reachable except via this method ─
+// AC24 (structural): dedupe is never reachable except via this method.
 // Covered by construction: `MemoryStore::open` only ever calls
 // `backfill_entity_ids`/`promote_entity_id_unique_index` (see
 // `entity_id_migration.rs`), never `dedupe_entity_ids`. See also
@@ -487,17 +423,14 @@ fn external_row_that_is_itself_a_duplicate_in_a_different_group_is_resolved_corr
 // which proves opening a store with duplicates present does not collapse
 // them.
 
-// ── Adversarial (round-5 re-verification, whole-run restructuring):
-// a CHAINED cross-group reference. Group A's survivor's own field points
-// at a *loser* of group B; group B's survivor's own field independently
-// points at a *loser* of group C. `loser_to_survivor` is a flat, one-hop
-// map (every doomed id maps directly to its own group's survivor, never
-// to another doomed id, since group membership partitions disjointly),
-// so each edge should resolve in exactly one redirect to the concrete
-// target group's survivor — never a raw loser id, and never chasing
-// through what the *target* survivor's own field happens to point at
-// (that would be a different, unrelated edge). This test proves both
-// hops resolve independently and correctly in the same run. ────────────
+// Adversarial (round-5 re-verification, whole-run restructuring): a
+// CHAINED cross-group reference. Group A's survivor points at a loser of
+// group B; group B's survivor independently points at a loser of group
+// C. `loser_to_survivor` is a flat one-hop map (group membership
+// partitions disjointly, so no doomed id maps to another doomed id), so
+// each edge must resolve in exactly one redirect to the concrete target
+// group's survivor, never chasing through what that survivor's own
+// field happens to point at.
 #[test]
 fn chained_cross_group_reference_resolves_one_hop_not_to_intermediate_loser() {
     let store = open_store();
@@ -516,8 +449,8 @@ fn chained_cross_group_reference_resolves_one_hop_not_to_intermediate_loser() {
     let loser_c = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 275)
         .unwrap();
-    // A's survivor points at B's loser; B's survivor independently points
-    // at C's loser. Two separate edges, not a transitive chain.
+    // A's survivor points at B's loser; B's survivor independently
+    // points at C's loser. Two separate edges, not a transitive chain.
     store.set_superseded_by(survivor_a, loser_b).unwrap();
     store.set_superseded_by(survivor_b, loser_c).unwrap();
 
@@ -547,23 +480,21 @@ fn chained_cross_group_reference_resolves_one_hop_not_to_intermediate_loser() {
     );
 }
 
-// ── Adversarial (round-5 re-verification): an ordinary note that is a
-// member of *no* duplicate group at all (not a survivor, not a loser of
-// any group) whose `superseded_by` points at a loser belonging to some
-// *other* group being collapsed in this same run. `rewrite_cross_references`'s
-// "every non-survivor row" framing must genuinely include this row: its
-// id is absent from `note_group_of` entirely (unlike a fellow loser's,
-// which *is* present), so the `same_group` check must not accidentally
-// treat "absent from the map" as "same group" (e.g. via a mismatched
-// default or an `unwrap_or` that coerces both sides to a shared
-// sentinel). Three unrelated duplicate groups are present simultaneously
-// so there's a real chance for the ordinary note's id or the target's id
-// to collide with map bookkeeping if the None-handling were wrong. ─────
+// Adversarial (round-5 re-verification): an ordinary note that is a
+// member of no duplicate group at all, whose superseded_by points at a
+// loser belonging to some other group being collapsed in this same run.
+// `rewrite_cross_references`'s "every non-survivor row" framing must
+// genuinely include this row: its id is absent from `note_group_of`
+// entirely (unlike a fellow loser's, which is present), so the
+// `same_group` check must not mistake "absent from the map" for "same
+// group" (e.g. via a mismatched default or an `unwrap_or` that coerces
+// both sides to a shared sentinel). Three unrelated duplicate groups are
+// present so there's a real chance for an id collision to expose that
+// bug.
 #[test]
 fn ordinary_note_outside_every_group_pointing_at_a_loser_is_rewritten_and_counted() {
     let store = open_store();
-    // Three unrelated duplicate groups, present purely as bookkeeping
-    // noise / potential id-collision surface for note_group_of.
+    // Bookkeeping noise: unrelated groups to stress note_group_of lookups.
     let _survivor_a = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
@@ -606,23 +537,18 @@ fn ordinary_note_outside_every_group_pointing_at_a_loser_is_rewritten_and_counte
     );
 }
 
-// ── Adversarial (round-5 re-verification): three duplicate groups whose
+// Adversarial (round-5 re-verification): three duplicate groups whose
 // survivors form a reference CYCLE through each other's losers (A -> B's
-// loser, B -> C's loser, C -> A's loser). `loser_to_survivor` is computed
-// once, structurally, before any group is processed, so no group's
-// resolution can depend on another group having been processed first —
-// this test constructs the identical relational shape under two
-// different physical `created_at` orderings (which changes
-// `duplicate_groups`' internal vector order, since that order follows
-// each group's earliest-member `created_at`) and confirms the resulting
-// graph is the same in both cases, proving the whole-run map's
-// construction is genuinely order-independent rather than accidentally
-// relying on processing group A before B before C. ──────────────────────
+// loser, B -> C's loser, C -> A's loser). `loser_to_survivor` is
+// computed once, structurally, before any group is processed, so no
+// group's resolution can depend on processing order. The identical
+// relational shape is built under two different physical created_at
+// orderings (which changes `duplicate_groups`' vector order, since that
+// follows each group's earliest-member created_at) to prove the map's
+// construction is genuinely order-independent.
 #[test]
 fn three_group_reference_cycle_resolves_identically_under_two_processing_orders() {
-    // Variant 1: groups created in A, B, C order (duplicate_groups will
-    // be ordered A, B, C, since that's each group's earliest-created_at
-    // order too).
+    // Variant 1: groups created in A, B, C order.
     let store1 = open_store();
     let survivor_a1 = store1
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
@@ -649,9 +575,7 @@ fn three_group_reference_cycle_resolves_identically_under_two_processing_orders(
     let summary1 = store1.dedupe_entity_ids(false).unwrap();
 
     // Variant 2: same relational shape (A -> B's loser -> C's loser ->
-    // A's loser), but groups are created in C, A, B physical order, so
-    // `duplicate_groups`' earliest-created_at-derived vector order is
-    // C, A, B instead of A, B, C.
+    // A's loser), but groups are created in C, A, B physical order.
     let store2 = open_store();
     let survivor_c2 = store2
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 100)
@@ -707,29 +631,24 @@ fn three_group_reference_cycle_resolves_identically_under_two_processing_orders(
     assert_eq!(c2.superseded_by, Some(survivor_a2));
 }
 
-// ── Adversarial (round-5 re-verification): hand-derive every summary
-// count for a constructed multi-group scenario and assert the reported
-// numbers match the hand count exactly, not just "no crash" / "no error".
-// Scenario, worked by hand before running:
-//   - group A: survivor_a, loser_a1, loser_a2. loser_a1 points at loser_a2
-//     (a same-group loser->loser reference: inert clean-up, must be
-//     cleared but NOT counted in supersede_edges_repointed). survivor_a's
-//     own field points at loser_c1 (a DIFFERENT group's loser): resolves
-//     to survivor_c, not a self-edge-drop (target != survivor_a), and not
-//     counted in supersede_edges_repointed either (that counter only
-//     covers rewrite_cross_references's *non-survivor* rows, per the
-//     module's own doc — the survivor's own adoption is deliberately a
-//     separate mechanism from the "elsewhere in the table" rewrite).
-//   - group B: survivor_b, loser_b1. Nothing points at anything.
-//   - group C: survivor_c, loser_c1. Nothing points at anything.
-//   - ordinary (no group at all): points at loser_b1 -> resolves to
+// Adversarial (round-5 re-verification): hand-derive every summary count
+// for a multi-group scenario and assert exact match, not just "no crash".
+//   group A: survivor_a, loser_a1, loser_a2. loser_a1 -> loser_a2 is a
+//     same-group reference: inert clean-up, cleared but NOT counted in
+//     supersede_edges_repointed. survivor_a's own field -> loser_c1 (a
+//     DIFFERENT group's loser): resolves to survivor_c, not a
+//     self-edge-drop, and also not counted in supersede_edges_repointed
+//     (that counter covers rewrite_cross_references's non-survivor rows
+//     only; the survivor's own adoption is a separate mechanism).
+//   group B: survivor_b, loser_b1. Nothing points at anything.
+//   group C: survivor_c, loser_c1. Nothing points at anything.
+//   ordinary (no group at all): points at loser_b1 -> resolves to
 //     survivor_b, IS counted (genuinely external, non-same-group).
-// Hand count: total_notes = 8, duplicate_groups = 3, rows_collapsed =
-// 2 (group A) + 1 (group B) + 1 (group C) = 4, tags_merged = 0,
-// linked_files_merged = 0, supersede_edges_repointed = 1 (only
+// Hand count: total_notes=8, duplicate_groups=3, rows_collapsed=4 (2+1+1),
+// tags_merged=0, linked_files_merged=0, supersede_edges_repointed=1 (only
 // `ordinary`'s edge; loser_a1's same-group edge to loser_a2 is excluded),
-// supersede_self_edges_dropped = 0 (survivor_a's own field resolves to a
-// genuine external target, survivor_c, not to itself). ─────────────────
+// supersede_self_edges_dropped=0 (survivor_a's own field resolves to a
+// genuine external target, survivor_c, not to itself).
 #[test]
 fn hand_derived_summary_counts_match_multi_group_scenario_exactly() {
     let store = open_store();
@@ -793,20 +712,16 @@ fn hand_derived_summary_counts_match_multi_group_scenario_exactly() {
     assert_eq!(note_count(&store), 4, "8 - 4 collapsed = 4 remaining rows");
 }
 
-// ── Test-engineer adversarial round: fold-group tie-breaking boundary ───
-//
-// The merge rule says "survivor = earliest created_at", but says nothing
-// about what happens when two rows in a duplicate group share the exact
-// same `created_at` (plausible for anything inserted in the same batch
-// import or the same second via `add_note_with_created_at`, or even two
-// ordinary `add_note` calls landing in the same unixepoch() second).
+// Test-engineer adversarial: fold-group tie-breaking boundary. The merge
+// rule says "survivor = earliest created_at" but not what happens when
+// two rows in a group share the exact same created_at (plausible for a
+// batch import or two calls landing in the same unixepoch() second).
 // `all_notes_for_dedup` orders `ORDER BY created_at ASC` with no
-// secondary key, so a tie's resolution order is whatever SQLite's query
-// plan happens to produce — not guaranteed stable by the SQL standard.
-// Pin the id as an explicit secondary tie-break (lower id = inserted
-// first = survivor) so the choice is a documented invariant instead of
-// an accident of the query planner, and prove it holds across repeated
-// runs on independently-built stores.
+// secondary key, so a tie's resolution order is query-plan-dependent,
+// not guaranteed stable by the SQL standard. Pin id as an explicit
+// secondary tie-break (lower id = inserted first = survivor) so the
+// choice is a documented invariant rather than an accident of the query
+// planner, and prove it holds across repeated runs.
 #[test]
 fn tied_created_at_breaks_deterministically_on_lower_id() {
     for _ in 0..5 {
@@ -854,18 +769,17 @@ fn tied_created_at_breaks_deterministically_on_lower_id() {
     }
 }
 
-// ── Test-engineer adversarial round: dedupe interacting with rows built
-// via `add_note_superseding` (ADR-068 fifth amendment E1), not just
-// `add_note`/`add_note_with_created_at` as every prior dedupe.rs test
+// Test-engineer adversarial: dedupe interacting with rows built via
+// `add_note_superseding` (ADR-068 fifth amendment E1), not just
+// `add_note`/`add_note_with_created_at` as every prior test in this file
 // does. Pre-promotion, two independent `add_note_superseding` calls for
-// byte-identical content (each superseding a *different* OLD row) create
-// two distinct rows sharing one entity_id — a duplicate group whose
+// byte-identical content (each superseding a different OLD row) create
+// two distinct rows sharing one entity_id, a duplicate group whose
 // members both carry an *inbound* edge from an OLD row's own
-// `superseded_by`, not an outbound one. Verifies `dedupe_entity_ids`
-// repoints those inbound edges to the survivor exactly like any other
-// external reference, proving the two features (E1's supersede path and
-// the third amendment's dedupe) compose correctly rather than only ever
-// having been tested in isolation.
+// superseded_by. Verifies `dedupe_entity_ids` repoints those inbound
+// edges to the survivor exactly like any other external reference,
+// proving E1's supersede path and the third amendment's dedupe compose
+// correctly.
 #[test]
 fn duplicate_group_built_via_add_note_superseding_repoints_old_rows_to_survivor() {
     let store = open_store();
@@ -911,7 +825,7 @@ fn duplicate_group_built_via_add_note_superseding_repoints_old_rows_to_survivor(
     );
 
     // Precondition: each OLD row now points at its own distinct
-    // successor — new1 and new2, which are themselves a duplicate group.
+    // successor - new1 and new2, which are themselves a duplicate group.
     assert_eq!(store.get(old1).unwrap().unwrap().superseded_by, Some(new1));
     assert_eq!(store.get(old2).unwrap().unwrap().superseded_by, Some(new2));
 
@@ -924,9 +838,9 @@ fn duplicate_group_built_via_add_note_superseding_repoints_old_rows_to_survivor(
     assert!(store.get(new2).unwrap().is_none());
 
     // old2's superseded_by, which pointed at the now-deleted new2, must
-    // be repointed to the survivor new1 — this is the cross-reference
-    // rewrite exercising an edge that originated from the supersede path
-    // rather than a plain add_note/set_superseded_by call.
+    // be repointed to the survivor new1: the cross-reference rewrite
+    // exercising an edge that originated from the supersede path rather
+    // than a plain add_note/set_superseded_by call.
     assert_eq!(
         store.get(old2).unwrap().unwrap().superseded_by,
         Some(new1),

--- a/crates/spelunk-core/src/storage/memory/dedupe/superseded_by_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/superseded_by_tests.rs
@@ -1,0 +1,957 @@
+//! `superseded_by` reference-resolution edge cases across duplicate-`entity_id`
+//! groups: adoption self-loop/dangling guards, deletion-order safety, and
+//! cross-group reference resolution (see the module doc on `dedupe/mod.rs`
+//! for the five rounds of adversarial hardening this covers).
+
+use super::test_support::{note_count, open_store};
+use super::*;
+
+// ── Adversarial: the survivor's adoption of a group member's
+// `superseded_by` value does not validate that the value isn't itself a
+// member of the same duplicate group. When a loser's own `superseded_by`
+// points directly at the survivor, adoption creates SURVIVOR -> SURVIVOR
+// (a self-loop), unlike the *rewrite* path (AC19), which explicitly
+// guards against exactly this and drops to NULL instead. This is a
+// genuine bug, not a documented scope gap: a self-referencing
+// `superseded_by` is nonsensical regardless of the ADR's text. ─────────
+#[test]
+fn adoption_must_not_selfloop_when_a_loser_points_at_the_survivor() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    // loser was (per this row) "superseded by" the survivor itself.
+    store.set_superseded_by(loser, survivor).unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_ne!(
+        note.superseded_by,
+        Some(survivor),
+        "BUG: the survivor's superseded_by must never be adopted as its \
+         own id, that is a self-loop. The adoption step at dedupe.rs's \
+         `first_non_null` handling has no self-edge guard, unlike the \
+         rewrite loop just below it (AC19)."
+    );
+}
+
+// ── Adversarial: a chained loser->loser `superseded_by` pointer (one
+// loser's `superseded_by` points at *another* loser in the same group,
+// not at the survivor) gets blindly adopted onto the survivor by value,
+// even though that target row is about to be deleted in this very
+// transaction. The rewrite loop (which repoints external dependents)
+// never sees this adoption write, because `rewrites` is computed from a
+// read taken *before* the adoption write happens.
+//
+// The practical symptom is even sharper than "a dangling pointer": this
+// SQLite build enforces `foreign_keys` ON by default (verified directly),
+// and `notes` (`superseded_by INTEGER REFERENCES notes(id)`) has no
+// `ON DELETE` clause, so once the survivor's adoption write leaves it
+// pointing at loser_b, the later `DELETE FROM notes WHERE id = loser_b` in
+// the same transaction is rejected outright with a FOREIGN KEY constraint
+// error: the whole dedupe run fails (and correctly rolls back) for a
+// duplicate shape it should handle cleanly. ─────────────────────────────
+#[test]
+fn adoption_must_not_dangle_when_a_loser_points_at_a_fellow_loser() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_a = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_b = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    // loser_a claims to be "superseded by" loser_b, a fellow member of
+    // the very same duplicate group, not an external note.
+    store.set_superseded_by(loser_a, loser_b).unwrap();
+
+    let result = store.dedupe_entity_ids(false);
+
+    assert!(
+        result.is_ok(),
+        "BUG: a loser's superseded_by pointing at a fellow loser in the \
+         same group (a chained in-group reference) makes the whole \
+         dedupe run fail with a FOREIGN KEY constraint error instead of \
+         collapsing cleanly: {:?}. The adoption step blindly copies that \
+         in-group value onto the survivor before the deletion loop runs, \
+         creating a live FK reference to a row this very transaction \
+         then tries to delete.",
+        result.as_ref().err()
+    );
+    // If a future fix makes this succeed, it must not merely trade the
+    // hard error for a silent dangling pointer.
+    if result.is_ok() {
+        let note = store.get(survivor).unwrap().unwrap();
+        if let Some(target) = note.superseded_by {
+            assert!(
+                store.get(target).unwrap().is_some(),
+                "survivor.superseded_by ({target}) must not point at a \
+                 row that no longer exists"
+            );
+        }
+    }
+}
+
+// ── Adversarial (re-verification pass): the survivor's OWN pre-existing
+// `superseded_by` pointed at a fellow in-group loser (not itself, and not
+// the "loser points at survivor" shape already covered above — this is
+// the third permutation: *survivor* points at a *loser*). The adoption
+// fix correctly filters this in-group value out of `external_values` and
+// falls through to a genuinely-external candidate elsewhere in the group
+// (mirroring the "3+ losers, first candidate intra-group-dangling, later
+// candidate valid" check). But the *rewrite* loop below adoption computes
+// `notes_pointing_at(loser_x.id)` against the ORIGINAL pre-transaction
+// state, which still shows survivor -> loser_x, so it independently
+// re-discovers this same edge, treats it as a self-edge case (`ref_id ==
+// survivor.id`), and clears it back to NULL *after* the adoption write
+// already ran — clobbering the correctly-adopted external value.
+#[test]
+fn adoption_survivor_own_in_group_pointer_does_not_clobber_fallthrough_adoption() {
+    let store = open_store();
+    let external = store
+        .add_note("note", "external target", "b", &[], &[], None, None)
+        .unwrap();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_x = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_y = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    // Survivor's own pre-existing value points at a fellow duplicate
+    // (loser_x), an in-group reference that must not be adopted verbatim.
+    store.set_superseded_by(survivor, loser_x).unwrap();
+    // loser_y carries a genuinely-external candidate: once the in-group
+    // value is filtered out, this should be what the survivor ends up
+    // pointing at (fall-through adoption), not NULL.
+    store.set_superseded_by(loser_y, external).unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(
+        note.superseded_by,
+        Some(external),
+        "BUG: the survivor's own pre-existing in-group pointer (at loser_x) \
+         should be filtered out of adoption and fall through to loser_y's \
+         genuinely-external value, same as any other in-group candidate. \
+         Instead the rewrite loop (computed from notes_pointing_at(loser_x), \
+         which still shows the ORIGINAL survivor->loser_x edge) independently \
+         rediscovers survivor as a 'self-edge' dependent of loser_x and clears \
+         it to NULL *after* the adoption write already set the correct \
+         external value, silently discarding a valid adopted candidate."
+    );
+}
+
+// ── Adversarial (re-verification pass): 3+ losers, first candidate in
+// iteration order is intra-group-dangling (points at a fellow loser), a
+// later candidate is genuinely external. Confirms fall-through works when
+// the in-group pointer is on a *loser*, not the survivor. ───────────────
+#[test]
+fn fallthrough_adoption_skips_intragroup_dangling_candidate_and_adopts_later_external_one() {
+    let store = open_store();
+    let external = store
+        .add_note("note", "external target", "b", &[], &[], None, None)
+        .unwrap();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_a = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_b = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    let loser_c = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
+        .unwrap();
+    // loser_a (earliest loser, first candidate in iteration order) points
+    // at a fellow loser: intra-group-dangling, must be skipped.
+    store.set_superseded_by(loser_a, loser_b).unwrap();
+    // loser_c (later in iteration order) carries the only valid external
+    // candidate.
+    store.set_superseded_by(loser_c, external).unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(
+        note.superseded_by,
+        Some(external),
+        "the intra-group-dangling candidate from loser_a must be skipped \
+         and the later, genuinely-external candidate from loser_c adopted"
+    );
+}
+
+// ── Adversarial (re-verification pass): only intra-group candidates
+// exist anywhere in the group (no genuinely external value at all).
+// Confirms adoption correctly resolves to None rather than erroring or
+// keeping a bad in-group value. ─────────────────────────────────────────
+#[test]
+fn adoption_resolves_to_none_when_every_candidate_is_intragroup() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_a = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_b = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    // loser_a -> loser_b and loser_b -> survivor: every candidate value
+    // in the group resolves to a fellow group member, none external.
+    store.set_superseded_by(loser_a, loser_b).unwrap();
+    store.set_superseded_by(loser_b, survivor).unwrap();
+
+    let result = store.dedupe_entity_ids(false);
+    assert!(
+        result.is_ok(),
+        "an all-intra-group candidate set must not error: {:?}",
+        result.as_ref().err()
+    );
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(
+        note.superseded_by, None,
+        "with zero valid external candidates in the group, the survivor \
+         must adopt None, not error and not retain a dangling/self value"
+    );
+}
+
+// ── Adversarial (round 3): a LATER-created loser's own `superseded_by`
+// points at an EARLIER-created fellow loser (not the survivor). Neither
+// adoption nor the rewrite loop ever touches this value — it's correctly
+// excluded from both, per the "a fellow loser's own field doesn't matter
+// since that row is being deleted" comment above the rewrite loop — so it
+// sits untouched on loser_late's own row until deletion time. But the
+// deletion loop deletes losers in `created_at` ASC order (loser_early,
+// then loser_late), i.e. it tries to delete loser_early — the row
+// loser_late still references — *before* loser_late (the referencing
+// row) is gone. Under live FK enforcement (empirically confirmed active
+// on this connection: `notes.superseded_by` has no `ON DELETE` clause)
+// this must fail with a FOREIGN KEY constraint error on the delete of
+// loser_early, exactly the same user-visible symptom as the two
+// previously-fixed bugs, but via the deletion loop's ordering rather than
+// the adoption/rewrite write paths. ──────────────────────────────────────
+#[test]
+fn later_loser_pointing_at_earlier_fellow_loser_must_not_break_deletion_order() {
+    let store = open_store();
+    let _survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_early = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_late = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    // loser_late (deleted SECOND, per created_at ASC order) points at
+    // loser_early (deleted FIRST) — the referencing row outlives, in
+    // deletion order, the row it references.
+    store.set_superseded_by(loser_late, loser_early).unwrap();
+
+    let result = store.dedupe_entity_ids(false);
+
+    assert!(
+        result.is_ok(),
+        "BUG: a later-created loser pointing at an earlier-created \
+         fellow loser breaks the deletion loop's naive created_at-ASC \
+         order — deleting loser_early while loser_late (not yet \
+         deleted) still references it via superseded_by triggers a \
+         live FOREIGN KEY constraint error and the whole run fails \
+         instead of collapsing cleanly: {:?}",
+        result.as_ref().err()
+    );
+}
+
+// ── Adversarial (round 3): the same deletion-order hazard as above, but
+// with the roles swapped per the story's own round-2-repro-swap
+// instruction: two losers point AT EACH OTHER (a 2-cycle among fellow
+// losers), survivor points at nothing. Neither value is external, so
+// nothing is adopted onto the survivor and nothing is queued in
+// `rewrites` — same as the one-directional case above — but now
+// *whichever* loser the deletion loop tries to delete first is still
+// referenced by the other (not-yet-deleted) loser, so this must fail
+// regardless of `created_at` order, not just in the "later points at
+// earlier" direction. ────────────────────────────────────────────────────
+#[test]
+fn mutually_referencing_fellow_losers_must_not_break_deletion_order() {
+    let store = open_store();
+    let _survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_a = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_b = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    store.set_superseded_by(loser_a, loser_b).unwrap();
+    store.set_superseded_by(loser_b, loser_a).unwrap();
+
+    let result = store.dedupe_entity_ids(false);
+
+    assert!(
+        result.is_ok(),
+        "BUG: two fellow losers pointing at each other (a 2-cycle) \
+         breaks the deletion loop regardless of created_at order — \
+         whichever is deleted first is still referenced by the other, \
+         not-yet-deleted loser, triggering a FOREIGN KEY constraint \
+         error: {:?}",
+        result.as_ref().err()
+    );
+}
+
+// ── Adversarial (round 3): a 4-note group where multiple members carry
+// non-null superseded_by pointing at a mix of intra-group and external
+// targets, including a chain (loser -> loser -> external). Confirms the
+// unified resolution still picks a sensible, deterministic external
+// value, the counts stay accurate, AND — this is the actual failure mode
+// this round found — the deletion loop must not choke on the in-group
+// chain reference along the way. ─────────────────────────────────────────
+#[test]
+fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_deterministically() {
+    let store = open_store();
+    let external_a = store
+        .add_note("note", "external a", "b", &[], &[], None, None)
+        .unwrap();
+    let external_b = store
+        .add_note("note", "external b", "b", &[], &[], None, None)
+        .unwrap();
+    let _survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser1 = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser2 = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    let loser3 = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
+        .unwrap();
+    // loser1 (earliest loser, first candidate in iteration order) chains
+    // to a fellow loser: intra-group, must be skipped for adoption AND
+    // must not break deletion order.
+    store.set_superseded_by(loser1, loser2).unwrap();
+    // loser2 itself carries a genuinely-external value.
+    store.set_superseded_by(loser2, external_a).unwrap();
+    // loser3 carries a different external value (conflict case).
+    store.set_superseded_by(loser3, external_b).unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    // Resolution order is group order (created_at ASC): survivor(None),
+    // loser1(->loser2, in-group, dropped), loser2(->external_a, first
+    // surviving external candidate), loser3(->external_b, conflicting).
+    // external_a must win.
+    let note = store.get(_survivor).unwrap().unwrap();
+    assert_eq!(
+        note.superseded_by,
+        Some(external_a),
+        "the earliest-created external candidate (from loser2) must win, \
+         with loser1's in-group chain to loser2 correctly excluded"
+    );
+    assert_eq!(summary.rows_collapsed, 3);
+
+    // Re-run determinism: rebuild an identical store and confirm the same
+    // resolution and counts on a second, independent run (not just
+    // repeatable within one process — a genuinely fresh grouping pass).
+    let store2 = open_store();
+    let external_a2 = store2
+        .add_note("note", "external a", "b", &[], &[], None, None)
+        .unwrap();
+    let external_b2 = store2
+        .add_note("note", "external b", "b", &[], &[], None, None)
+        .unwrap();
+    let survivor2 = store2
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser1b = store2
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser2b = store2
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    let loser3b = store2
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
+        .unwrap();
+    store2.set_superseded_by(loser1b, loser2b).unwrap();
+    store2.set_superseded_by(loser2b, external_a2).unwrap();
+    store2.set_superseded_by(loser3b, external_b2).unwrap();
+    store2.dedupe_entity_ids(false).unwrap();
+    let note2 = store2.get(survivor2).unwrap().unwrap();
+    assert_eq!(
+        note2.superseded_by,
+        Some(external_a2),
+        "the resolution must be deterministic across independent runs \
+         on an equivalent input shape, not HashMap-iteration-order- \
+         dependent"
+    );
+}
+
+// ── Adversarial (round-4 re-verification): TWO duplicate groups in the
+// SAME `dedupe_entity_ids` call, where a member of the *second* group
+// (processed later) has its own `superseded_by` pointing at a member of
+// the *first* group (processed earlier). This probes whether "the
+// current group" is scoped correctly when the run collapses more than
+// one group.
+//
+// `group: &[Note]` passed into `collapse_group` is a fixed snapshot taken
+// by `all_notes_for_dedup()` once, before the transaction begins and
+// before any group is processed. The external-rewrite loop reads live via
+// `notes_pointing_at`, so it sees every prior group's writes. But the
+// in-group/adoption resolution reads a group member's `superseded_by`
+// straight off that same stale, pre-transaction `Note` snapshot — it has
+// no way to know a *different* group, processed earlier in this same
+// run, already rewrote that value or deleted its target.
+//
+// Group A (survivor_a, loser_a) is processed first (created_at 100/200).
+// Group B (survivor_b, external_x) is processed second (created_at
+// 150/250). `external_x` is itself group B's loser, but its own
+// `superseded_by` points at `loser_a` — a member of group A, unrelated to
+// group B's identity.
+//
+// Processing group A: the external-rewrite loop's live query correctly
+// finds external_x pointing at loser_a and repoints it to survivor_a
+// (external_x is not a member of group A, so this is legitimate), then
+// deletes loser_a.
+//
+// Processing group B: survivor_b's adoption resolution reads external_x's
+// *stale* snapshot value (still `loser_a`, not survivor_a) and treats it
+// as a genuinely-external candidate (loser_a isn't a member of group B's
+// `group_ids`), so it tries to write `survivor_b.superseded_by =
+// loser_a.id` — a row deleted by group A moments earlier in the very
+// same transaction. Under live FK enforcement this fails outright instead
+// of collapsing cleanly, the same user-visible symptom as rounds 1-3, but
+// via cross-group snapshot staleness rather than a single group's own
+// internal bookkeeping.
+#[test]
+fn external_row_that_is_itself_a_duplicate_in_a_different_group_is_resolved_correctly_across_groups()
+ {
+    let store = open_store();
+    let survivor_a = store
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_a = store
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let survivor_b = store
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 150)
+        .unwrap();
+    let external_x = store
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 250)
+        .unwrap();
+    // external_x is a loser in group B, but its own pre-existing
+    // superseded_by points at loser_a, a member of the unrelated group A.
+    store.set_superseded_by(external_x, loser_a).unwrap();
+
+    let result = store.dedupe_entity_ids(false);
+
+    assert!(
+        result.is_ok(),
+        "BUG: group B's adoption resolution read external_x's \
+         superseded_by from a stale pre-transaction snapshot (still \
+         pointing at loser_a) rather than the live DB (where group A's \
+         earlier processing already repointed it to survivor_a and \
+         deleted loser_a), so it tried to write survivor_b.superseded_by \
+         = loser_a onto a row already deleted in this same transaction: \
+         {:?}",
+        result.as_ref().err()
+    );
+    if let Ok(summary) = &result {
+        assert_eq!(summary.rows_collapsed, 2, "both groups' losers collapsed");
+        let sb = store.get(survivor_b).unwrap().unwrap();
+        assert_eq!(
+            sb.superseded_by,
+            Some(survivor_a),
+            "survivor_b must end up pointing at survivor_a (the row \
+             loser_a was merged into), not the deleted loser_a, and not \
+             be left dangling"
+        );
+    }
+}
+
+// ── AC24 (structural): dedupe is never reachable except via this method ─
+// Covered by construction: `MemoryStore::open` only ever calls
+// `backfill_entity_ids`/`promote_entity_id_unique_index` (see
+// `entity_id_migration.rs`), never `dedupe_entity_ids`. See also
+// `entity_id_migration::tests::promote_with_duplicates_leaves_index_non_unique_and_does_not_error`,
+// which proves opening a store with duplicates present does not collapse
+// them.
+
+// ── Adversarial (round-5 re-verification, whole-run restructuring):
+// a CHAINED cross-group reference. Group A's survivor's own field points
+// at a *loser* of group B; group B's survivor's own field independently
+// points at a *loser* of group C. `loser_to_survivor` is a flat, one-hop
+// map (every doomed id maps directly to its own group's survivor, never
+// to another doomed id, since group membership partitions disjointly),
+// so each edge should resolve in exactly one redirect to the concrete
+// target group's survivor — never a raw loser id, and never chasing
+// through what the *target* survivor's own field happens to point at
+// (that would be a different, unrelated edge). This test proves both
+// hops resolve independently and correctly in the same run. ────────────
+#[test]
+fn chained_cross_group_reference_resolves_one_hop_not_to_intermediate_loser() {
+    let store = open_store();
+    let survivor_a = store
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let survivor_b = store
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 150)
+        .unwrap();
+    let loser_b = store
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 250)
+        .unwrap();
+    let survivor_c = store
+        .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 175)
+        .unwrap();
+    let loser_c = store
+        .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 275)
+        .unwrap();
+    // A's survivor points at B's loser; B's survivor independently points
+    // at C's loser. Two separate edges, not a transitive chain.
+    store.set_superseded_by(survivor_a, loser_b).unwrap();
+    store.set_superseded_by(survivor_b, loser_c).unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(
+        summary.rows_collapsed, 2,
+        "one loser each in groups B and C"
+    );
+
+    let a = store.get(survivor_a).unwrap().unwrap();
+    assert_eq!(
+        a.superseded_by,
+        Some(survivor_b),
+        "A's edge to B's loser must resolve to B's survivor id directly, \
+         not the raw (now-deleted) loser_b id"
+    );
+    let b = store.get(survivor_b).unwrap().unwrap();
+    assert_eq!(
+        b.superseded_by,
+        Some(survivor_c),
+        "B's own edge to C's loser must resolve to C's survivor \
+         independently of A's edge into B"
+    );
+    assert!(
+        store.get(loser_b).unwrap().is_none() && store.get(loser_c).unwrap().is_none(),
+        "both losers must actually be gone"
+    );
+}
+
+// ── Adversarial (round-5 re-verification): an ordinary note that is a
+// member of *no* duplicate group at all (not a survivor, not a loser of
+// any group) whose `superseded_by` points at a loser belonging to some
+// *other* group being collapsed in this same run. `rewrite_cross_references`'s
+// "every non-survivor row" framing must genuinely include this row: its
+// id is absent from `note_group_of` entirely (unlike a fellow loser's,
+// which *is* present), so the `same_group` check must not accidentally
+// treat "absent from the map" as "same group" (e.g. via a mismatched
+// default or an `unwrap_or` that coerces both sides to a shared
+// sentinel). Three unrelated duplicate groups are present simultaneously
+// so there's a real chance for the ordinary note's id or the target's id
+// to collide with map bookkeeping if the None-handling were wrong. ─────
+#[test]
+fn ordinary_note_outside_every_group_pointing_at_a_loser_is_rewritten_and_counted() {
+    let store = open_store();
+    // Three unrelated duplicate groups, present purely as bookkeeping
+    // noise / potential id-collision surface for note_group_of.
+    let _survivor_a = store
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let _loser_a = store
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 110)
+        .unwrap();
+    let survivor_b = store
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 120)
+        .unwrap();
+    let loser_b = store
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 130)
+        .unwrap();
+    let _survivor_c = store
+        .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 140)
+        .unwrap();
+    let _loser_c = store
+        .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 150)
+        .unwrap();
+    // An ordinary, wholly unique note: not a member of any group above.
+    let ordinary = store
+        .add_note("note", "ordinary unique note", "body", &[], &[], None, None)
+        .unwrap();
+    store.set_superseded_by(ordinary, loser_b).unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.rows_collapsed, 3, "one loser in each of 3 groups");
+    assert_eq!(
+        summary.supersede_edges_repointed, 1,
+        "the ordinary note's edge into group B's loser must count as a \
+         genuine (non-same-group) repoint"
+    );
+    let note = store.get(ordinary).unwrap().unwrap();
+    assert_eq!(
+        note.superseded_by,
+        Some(survivor_b),
+        "BUG CHECK: an ordinary note with no group membership at all must \
+         still be rewritten by rewrite_cross_references; note_group_of.get \
+         returning None for this row must not be mistaken for group \
+         membership"
+    );
+}
+
+// ── Adversarial (round-5 re-verification): three duplicate groups whose
+// survivors form a reference CYCLE through each other's losers (A -> B's
+// loser, B -> C's loser, C -> A's loser). `loser_to_survivor` is computed
+// once, structurally, before any group is processed, so no group's
+// resolution can depend on another group having been processed first —
+// this test constructs the identical relational shape under two
+// different physical `created_at` orderings (which changes
+// `duplicate_groups`' internal vector order, since that order follows
+// each group's earliest-member `created_at`) and confirms the resulting
+// graph is the same in both cases, proving the whole-run map's
+// construction is genuinely order-independent rather than accidentally
+// relying on processing group A before B before C. ──────────────────────
+#[test]
+fn three_group_reference_cycle_resolves_identically_under_two_processing_orders() {
+    // Variant 1: groups created in A, B, C order (duplicate_groups will
+    // be ordered A, B, C, since that's each group's earliest-created_at
+    // order too).
+    let store1 = open_store();
+    let survivor_a1 = store1
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_a1 = store1
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 110)
+        .unwrap();
+    let survivor_b1 = store1
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_b1 = store1
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 210)
+        .unwrap();
+    let survivor_c1 = store1
+        .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    let loser_c1 = store1
+        .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 310)
+        .unwrap();
+    store1.set_superseded_by(survivor_a1, loser_b1).unwrap();
+    store1.set_superseded_by(survivor_b1, loser_c1).unwrap();
+    store1.set_superseded_by(survivor_c1, loser_a1).unwrap();
+
+    let summary1 = store1.dedupe_entity_ids(false).unwrap();
+
+    // Variant 2: same relational shape (A -> B's loser -> C's loser ->
+    // A's loser), but groups are created in C, A, B physical order, so
+    // `duplicate_groups`' earliest-created_at-derived vector order is
+    // C, A, B instead of A, B, C.
+    let store2 = open_store();
+    let survivor_c2 = store2
+        .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_c2 = store2
+        .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 110)
+        .unwrap();
+    let survivor_a2 = store2
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_a2 = store2
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 210)
+        .unwrap();
+    let survivor_b2 = store2
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    let loser_b2 = store2
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 310)
+        .unwrap();
+    store2.set_superseded_by(survivor_a2, loser_b2).unwrap();
+    store2.set_superseded_by(survivor_b2, loser_c2).unwrap();
+    store2.set_superseded_by(survivor_c2, loser_a2).unwrap();
+
+    let summary2 = store2.dedupe_entity_ids(false).unwrap();
+
+    assert_eq!(
+        summary1.rows_collapsed, summary2.rows_collapsed,
+        "same relational shape must collapse the same number of rows \
+         regardless of which group's earliest member happens to sort \
+         first"
+    );
+    assert_eq!(summary1.rows_collapsed, 3);
+
+    // Same relational outcome under both physical orderings: each
+    // survivor ends up pointing at the *next* group's survivor around
+    // the cycle, in both variants.
+    let a1 = store1.get(survivor_a1).unwrap().unwrap();
+    let b1 = store1.get(survivor_b1).unwrap().unwrap();
+    let c1 = store1.get(survivor_c1).unwrap().unwrap();
+    assert_eq!(a1.superseded_by, Some(survivor_b1));
+    assert_eq!(b1.superseded_by, Some(survivor_c1));
+    assert_eq!(c1.superseded_by, Some(survivor_a1));
+
+    let a2 = store2.get(survivor_a2).unwrap().unwrap();
+    let b2 = store2.get(survivor_b2).unwrap().unwrap();
+    let c2 = store2.get(survivor_c2).unwrap().unwrap();
+    assert_eq!(
+        a2.superseded_by,
+        Some(survivor_b2),
+        "identical relational outcome under the C, A, B physical/vector order"
+    );
+    assert_eq!(b2.superseded_by, Some(survivor_c2));
+    assert_eq!(c2.superseded_by, Some(survivor_a2));
+}
+
+// ── Adversarial (round-5 re-verification): hand-derive every summary
+// count for a constructed multi-group scenario and assert the reported
+// numbers match the hand count exactly, not just "no crash" / "no error".
+// Scenario, worked by hand before running:
+//   - group A: survivor_a, loser_a1, loser_a2. loser_a1 points at loser_a2
+//     (a same-group loser->loser reference: inert clean-up, must be
+//     cleared but NOT counted in supersede_edges_repointed). survivor_a's
+//     own field points at loser_c1 (a DIFFERENT group's loser): resolves
+//     to survivor_c, not a self-edge-drop (target != survivor_a), and not
+//     counted in supersede_edges_repointed either (that counter only
+//     covers rewrite_cross_references's *non-survivor* rows, per the
+//     module's own doc — the survivor's own adoption is deliberately a
+//     separate mechanism from the "elsewhere in the table" rewrite).
+//   - group B: survivor_b, loser_b1. Nothing points at anything.
+//   - group C: survivor_c, loser_c1. Nothing points at anything.
+//   - ordinary (no group at all): points at loser_b1 -> resolves to
+//     survivor_b, IS counted (genuinely external, non-same-group).
+// Hand count: total_notes = 8, duplicate_groups = 3, rows_collapsed =
+// 2 (group A) + 1 (group B) + 1 (group C) = 4, tags_merged = 0,
+// linked_files_merged = 0, supersede_edges_repointed = 1 (only
+// `ordinary`'s edge; loser_a1's same-group edge to loser_a2 is excluded),
+// supersede_self_edges_dropped = 0 (survivor_a's own field resolves to a
+// genuine external target, survivor_c, not to itself). ─────────────────
+#[test]
+fn hand_derived_summary_counts_match_multi_group_scenario_exactly() {
+    let store = open_store();
+    let survivor_a = store
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_a1 = store
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 110)
+        .unwrap();
+    let loser_a2 = store
+        .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 120)
+        .unwrap();
+    let survivor_b = store
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_b1 = store
+        .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 210)
+        .unwrap();
+    let survivor_c = store
+        .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    let loser_c1 = store
+        .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 310)
+        .unwrap();
+    let ordinary = store
+        .add_note("note", "ordinary unique note", "body", &[], &[], None, None)
+        .unwrap();
+
+    store.set_superseded_by(loser_a1, loser_a2).unwrap();
+    store.set_superseded_by(survivor_a, loser_c1).unwrap();
+    store.set_superseded_by(ordinary, loser_b1).unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+
+    assert_eq!(summary.total_notes, 8);
+    assert_eq!(summary.duplicate_groups, 3);
+    assert_eq!(summary.rows_collapsed, 4, "hand count: 2 + 1 + 1");
+    assert_eq!(summary.tags_merged, 0);
+    assert_eq!(summary.linked_files_merged, 0);
+    assert_eq!(
+        summary.supersede_edges_repointed, 1,
+        "hand count: only `ordinary`'s edge; loser_a1's same-group edge \
+         to loser_a2 must not be counted"
+    );
+    assert_eq!(
+        summary.supersede_self_edges_dropped, 0,
+        "hand count: survivor_a's own field resolves to a genuine \
+         cross-group external target (survivor_c), not a self-edge"
+    );
+
+    // Cross-check the actual field values agree with the hand-derived
+    // counts, not just the counts in isolation.
+    let a = store.get(survivor_a).unwrap().unwrap();
+    assert_eq!(a.superseded_by, Some(survivor_c));
+    let b = store.get(survivor_b).unwrap().unwrap();
+    assert_eq!(b.superseded_by, None);
+    let c = store.get(survivor_c).unwrap().unwrap();
+    assert_eq!(c.superseded_by, None);
+    let o = store.get(ordinary).unwrap().unwrap();
+    assert_eq!(o.superseded_by, Some(survivor_b));
+    assert_eq!(note_count(&store), 4, "8 - 4 collapsed = 4 remaining rows");
+}
+
+// ── Test-engineer adversarial round: fold-group tie-breaking boundary ───
+//
+// The merge rule says "survivor = earliest created_at", but says nothing
+// about what happens when two rows in a duplicate group share the exact
+// same `created_at` (plausible for anything inserted in the same batch
+// import or the same second via `add_note_with_created_at`, or even two
+// ordinary `add_note` calls landing in the same unixepoch() second).
+// `all_notes_for_dedup` orders `ORDER BY created_at ASC` with no
+// secondary key, so a tie's resolution order is whatever SQLite's query
+// plan happens to produce — not guaranteed stable by the SQL standard.
+// Pin the id as an explicit secondary tie-break (lower id = inserted
+// first = survivor) so the choice is a documented invariant instead of
+// an accident of the query planner, and prove it holds across repeated
+// runs on independently-built stores.
+#[test]
+fn tied_created_at_breaks_deterministically_on_lower_id() {
+    for _ in 0..5 {
+        let store = open_store();
+        let first = store
+            .add_note_with_created_at(
+                "decision",
+                "tied dup",
+                "body",
+                &[],
+                &[],
+                None,
+                "active",
+                500,
+            )
+            .unwrap();
+        let second = store
+            .add_note_with_created_at(
+                "decision",
+                "tied dup",
+                "body",
+                &[],
+                &[],
+                None,
+                "active",
+                500,
+            )
+            .unwrap();
+        assert!(
+            first < second,
+            "precondition: insertion order gives first the lower id"
+        );
+
+        let summary = store.dedupe_entity_ids(false).unwrap();
+        assert_eq!(summary.rows_collapsed, 1);
+        assert!(
+            store.get(first).unwrap().is_some(),
+            "the lower-id (first-inserted) row must be the deterministic \
+             survivor when created_at ties, on every run"
+        );
+        assert!(
+            store.get(second).unwrap().is_none(),
+            "the higher-id row must be the loser when created_at ties"
+        );
+    }
+}
+
+// ── Test-engineer adversarial round: dedupe interacting with rows built
+// via `add_note_superseding` (ADR-068 fifth amendment E1), not just
+// `add_note`/`add_note_with_created_at` as every prior dedupe.rs test
+// does. Pre-promotion, two independent `add_note_superseding` calls for
+// byte-identical content (each superseding a *different* OLD row) create
+// two distinct rows sharing one entity_id — a duplicate group whose
+// members both carry an *inbound* edge from an OLD row's own
+// `superseded_by`, not an outbound one. Verifies `dedupe_entity_ids`
+// repoints those inbound edges to the survivor exactly like any other
+// external reference, proving the two features (E1's supersede path and
+// the third amendment's dedupe) compose correctly rather than only ever
+// having been tested in isolation.
+#[test]
+fn duplicate_group_built_via_add_note_superseding_repoints_old_rows_to_survivor() {
+    let store = open_store();
+    assert!(
+        !index_is_unique_for_test(&store),
+        "precondition: not yet promoted, so add_note_superseding can \
+         still create two distinct rows for identical content"
+    );
+
+    let old1 = store
+        .add_note("decision", "old one", "old body one", &[], &[], None, None)
+        .unwrap();
+    let old2 = store
+        .add_note("decision", "old two", "old body two", &[], &[], None, None)
+        .unwrap();
+
+    let new1 = store
+        .add_note_superseding(
+            "decision",
+            "dup replacement",
+            "dup body",
+            &[],
+            &[],
+            None,
+            old1,
+        )
+        .unwrap();
+    let new2 = store
+        .add_note_superseding(
+            "decision",
+            "dup replacement",
+            "dup body",
+            &[],
+            &[],
+            None,
+            old2,
+        )
+        .unwrap();
+    assert_ne!(
+        new1, new2,
+        "pre-promotion: identical content still creates a second, \
+         distinct row (the duplicate-group precondition for this test)"
+    );
+
+    // Precondition: each OLD row now points at its own distinct
+    // successor — new1 and new2, which are themselves a duplicate group.
+    assert_eq!(store.get(old1).unwrap().unwrap().superseded_by, Some(new1));
+    assert_eq!(store.get(old2).unwrap().unwrap().superseded_by, Some(new2));
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.duplicate_groups, 1, "new1/new2 form one group");
+    assert_eq!(summary.rows_collapsed, 1);
+
+    // new1 (earlier created_at) survives; new2 is the loser.
+    assert!(store.get(new1).unwrap().is_some());
+    assert!(store.get(new2).unwrap().is_none());
+
+    // old2's superseded_by, which pointed at the now-deleted new2, must
+    // be repointed to the survivor new1 — this is the cross-reference
+    // rewrite exercising an edge that originated from the supersede path
+    // rather than a plain add_note/set_superseded_by call.
+    assert_eq!(
+        store.get(old2).unwrap().unwrap().superseded_by,
+        Some(new1),
+        "old2's supersede edge, created by add_note_superseding, must be \
+         repointed off the deleted duplicate onto the survivor"
+    );
+    assert_eq!(
+        store.get(old1).unwrap().unwrap().superseded_by,
+        Some(new1),
+        "old1's own edge already pointed at the survivor and must be \
+         unaffected"
+    );
+}
+
+/// Test-only helper mirroring `entity_id_migration.rs`'s private
+/// `index_is_unique`, needed here since this module's tests also drive
+/// `promote_entity_id_unique_index` directly.
+fn index_is_unique_for_test(store: &MemoryStore) -> bool {
+    let sql: String = store
+        .conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_notes_entity_id'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    sql.to_uppercase().contains("UNIQUE")
+}

--- a/crates/spelunk-core/src/storage/memory/dedupe/test_support.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/test_support.rs
@@ -1,0 +1,83 @@
+//! Shared test-only helpers for `dedupe`'s `tests` and `superseded_by_tests`
+//! submodules.
+
+use super::MemoryStore;
+use std::sync::OnceLock;
+
+fn register_sqlite_vec() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite_vec::sqlite3_vec_init as *const (),
+            )));
+        }
+    });
+}
+
+/// A store built via the schema-only path: `migrate()` creates the
+/// (non-unique) `idx_notes_entity_id` but skips the automatic Step A/B
+/// pipeline a real `MemoryStore::open` runs. `dedupe_entity_ids` itself
+/// doesn't care whether Step A/B ran: it groups by recomputing
+/// `note_entity_id` in Rust regardless of the stored column or index
+/// state, but these tests need to seed duplicate-content rows directly,
+/// which a real `open()` on a fresh (zero-row, zero-duplicate) store
+/// would already have promoted to a UNIQUE index, rejecting the seed.
+pub(super) fn open_store() -> MemoryStore {
+    register_sqlite_vec();
+    let conn = rusqlite::Connection::open(std::path::Path::new(":memory:"))
+        .expect("open in-memory sqlite");
+    let store = MemoryStore { conn };
+    store.migrate().expect("schema migration");
+    store
+}
+
+pub(super) fn note_count(store: &MemoryStore) -> i64 {
+    store
+        .conn
+        .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap()
+}
+
+pub(super) fn has_embedding(store: &MemoryStore, note_id: i64) -> bool {
+    store.get_embedding(note_id).unwrap().is_some()
+}
+
+/// Snapshot every column of every row in `table`, ordered by `order_by`,
+/// as generic SQLite `Value`s. Used to assert a rolled-back or dry-run
+/// call left the database byte-for-byte unchanged: unlike a row-count or
+/// single-column check, this catches a regression in *any* column
+/// (tags, superseded_by, status, entity_id, uuid, remote_id, ...) without
+/// having to hand-maintain a column list.
+fn full_table_snapshot(
+    store: &MemoryStore,
+    table: &str,
+    order_by: &str,
+) -> Vec<Vec<rusqlite::types::Value>> {
+    let sql = format!("SELECT * FROM {table} ORDER BY {order_by}");
+    let mut stmt = store.conn.prepare(&sql).unwrap();
+    let n = stmt.column_count();
+    stmt.query_map([], |row| {
+        (0..n)
+            .map(|i| row.get::<_, rusqlite::types::Value>(i))
+            .collect()
+    })
+    .unwrap()
+    .collect::<rusqlite::Result<Vec<_>>>()
+    .unwrap()
+}
+
+pub(super) type TableSnapshot = Vec<Vec<rusqlite::types::Value>>;
+
+/// Snapshot of `notes` + `memory_edges` + `note_embeddings`, the three
+/// tables `dedupe_entity_ids` can touch.
+pub(super) fn full_db_snapshot(
+    store: &MemoryStore,
+) -> (TableSnapshot, TableSnapshot, TableSnapshot) {
+    (
+        full_table_snapshot(store, "notes", "id"),
+        full_table_snapshot(store, "memory_edges", "from_id, to_id, kind"),
+        full_table_snapshot(store, "note_embeddings", "note_id"),
+    )
+}

--- a/crates/spelunk-core/src/storage/memory/dedupe/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/tests.rs
@@ -1,0 +1,583 @@
+//! Core `dedupe_entity_ids` behavior: happy path, dry-run, tags/linked_files
+//! merge, archived/superseded_by merge, rollback, and basic edge handling.
+//! See `superseded_by_tests` for the intra- and cross-group `superseded_by`
+//! reference-resolution edge cases.
+
+use super::test_support::*;
+use super::*;
+
+// ── AC22 (zero groups): all-zero counts, no writes, dry-run or not ──────
+#[test]
+fn zero_duplicates_reports_all_zero_and_writes_nothing() {
+    let store = open_store();
+    store
+        .add_note("note", "solo", "body", &[], &[], None, None)
+        .unwrap();
+
+    for dry in [true, false] {
+        let summary = store.dedupe_entity_ids(dry).unwrap();
+        assert_eq!(summary.total_notes, 1);
+        assert_eq!(summary.duplicate_groups, 0);
+        assert_eq!(summary.rows_collapsed, 0);
+        assert_eq!(summary.tags_merged, 0);
+        assert_eq!(summary.linked_files_merged, 0);
+        assert_eq!(summary.supersede_edges_repointed, 0);
+        assert_eq!(summary.supersede_self_edges_dropped, 0);
+    }
+    assert_eq!(note_count(&store), 1, "no row must be touched");
+}
+
+// ── AC9: --dry-run reports counts, makes no writes ──────────────────────
+#[test]
+fn dry_run_reports_counts_and_writes_nothing() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["a"],
+            &["f.rs"],
+            None,
+            "active",
+            100,
+        )
+        .unwrap();
+    let _loser = store
+        .add_note_with_created_at("decision", "dup", "body", &["b"], &[], None, "active", 200)
+        .unwrap();
+
+    let before_count = note_count(&store);
+    let (before_tags, _): (String, String) = store
+        .conn
+        .query_row(
+            "SELECT tags, linked_files FROM notes WHERE id = ?1",
+            rusqlite::params![survivor],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+
+    let summary = store.dedupe_entity_ids(true).unwrap();
+    assert_eq!(summary.total_notes, 2);
+    assert_eq!(summary.duplicate_groups, 1);
+    assert_eq!(summary.rows_collapsed, 1, "one loser in the group");
+    assert_eq!(summary.tags_merged, 1, "loser's 'b' tag would be merged");
+
+    assert_eq!(note_count(&store), before_count, "row count unchanged");
+    let (after_tags, _): (String, String) = store
+        .conn
+        .query_row(
+            "SELECT tags, linked_files FROM notes WHERE id = ?1",
+            rusqlite::params![survivor],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(before_tags, after_tags, "tags unchanged under dry-run");
+}
+
+// ── AC10 + AC11: real run collapses to one row, survivor = earliest ────
+#[test]
+fn real_run_collapses_group_survivor_is_earliest_created() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.rows_collapsed, 1);
+    assert_eq!(
+        note_count(&store),
+        1,
+        "row count must drop by rows_collapsed"
+    );
+    assert!(store.get(survivor).unwrap().is_some(), "survivor remains");
+    assert!(store.get(loser).unwrap().is_none(), "loser is gone");
+}
+
+// ── AC12 + AC13: tags/linked_files union add-wins, no survivor value dropped ─
+#[test]
+fn tags_and_linked_files_union_add_wins() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["keep"],
+            &["keep.rs"],
+            None,
+            "active",
+            100,
+        )
+        .unwrap();
+    store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["keep", "new"],
+            &["new.rs"],
+            None,
+            "active",
+            200,
+        )
+        .unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.tags_merged, 1, "only the genuinely-new tag counts");
+    assert_eq!(summary.linked_files_merged, 1);
+
+    let note = store.get(survivor).unwrap().unwrap();
+    assert!(note.tags.contains(&"keep".to_string()));
+    assert!(note.tags.contains(&"new".to_string()));
+    assert!(note.linked_files.contains(&"keep.rs".to_string()));
+    assert!(note.linked_files.contains(&"new.rs".to_string()));
+}
+
+// ── AC14: any row archived -> survivor becomes archived ─────────────────
+#[test]
+fn any_archived_row_makes_survivor_archived() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "archived", 200)
+        .unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(note.status, "archived");
+}
+
+// ── AC15: no row archived -> survivor status unchanged ──────────────────
+#[test]
+fn no_archived_row_leaves_survivor_status_unchanged() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(note.status, "active");
+}
+
+// ── AC16: survivor lacks superseded_by, another row has one -> adopted ──
+#[test]
+fn survivor_adopts_lone_superseded_by_from_group() {
+    let store = open_store();
+    let elsewhere = store
+        .add_note("note", "elsewhere target", "b", &[], &[], None, None)
+        .unwrap();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    store.set_superseded_by(loser, elsewhere).unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(note.superseded_by, Some(elsewhere));
+}
+
+// ── AC17: conflicting superseded_by values -> earliest wins, warn, no error ─
+#[test]
+fn conflicting_superseded_by_earliest_wins_no_error() {
+    let store = open_store();
+    let target_a = store
+        .add_note("note", "a", "b", &[], &[], None, None)
+        .unwrap();
+    let target_b = store
+        .add_note("note", "b", "b", &[], &[], None, None)
+        .unwrap();
+
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    store.set_superseded_by(survivor, target_a).unwrap();
+    store.set_superseded_by(loser, target_b).unwrap();
+
+    let result = store.dedupe_entity_ids(false);
+    assert!(result.is_ok(), "a conflicting value must never error");
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(
+        note.superseded_by,
+        Some(target_a),
+        "the earliest-created row's (survivor's own) value must win"
+    );
+}
+
+// ── AC18: a row elsewhere pointing at a loser is rewritten to the survivor ─
+#[test]
+fn edge_elsewhere_pointing_at_loser_is_repointed_to_survivor() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let dependent = store
+        .add_note("note", "points at loser", "b", &[], &[], None, None)
+        .unwrap();
+    store.set_superseded_by(dependent, loser).unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.supersede_edges_repointed, 1);
+    let note = store.get(dependent).unwrap().unwrap();
+    assert_eq!(note.superseded_by, Some(survivor));
+}
+
+// ── AC19: a rewrite that would self-point is dropped to NULL instead ────
+#[test]
+fn rewrite_that_would_self_point_is_dropped_to_null() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    // The survivor itself already points at its own duplicate-group loser.
+    store.set_superseded_by(survivor, loser).unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.supersede_self_edges_dropped, 1);
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(
+        note.superseded_by, None,
+        "a self-pointing rewrite must drop to NULL rather than self-loop"
+    );
+}
+
+// ── AC20: a loser's note_embeddings row is deleted; survivor's is untouched ─
+#[test]
+fn loser_embedding_deleted_survivor_embedding_untouched() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    // note_embeddings is FLOAT[896]: 896 * 4-byte floats per row.
+    let vec_a = vec![0u8; 896 * 4];
+    let mut vec_b = vec![0u8; 896 * 4];
+    vec_b[0] = 1;
+    store.insert_embedding(survivor, &vec_a).unwrap();
+    store.insert_embedding(loser, &vec_b).unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+    assert!(has_embedding(&store, survivor), "survivor embedding kept");
+    assert_eq!(
+        store.get_embedding(survivor).unwrap().as_deref(),
+        Some(vec_a.as_slice()),
+        "survivor's embedding bytes must be provably untouched, not merely present"
+    );
+    assert!(
+        store.get_embedding(loser).unwrap().is_none(),
+        "loser's embedding row must be gone (loser row itself is deleted too)"
+    );
+}
+
+// ── AC21: a failure injected partway through rolls back the whole run ───
+#[test]
+fn injected_fault_partway_rolls_back_whole_run() {
+    let store = open_store();
+    // Two independent duplicate groups so a fault after group 0 leaves
+    // group 1 (and group 0's own writes) to prove the ROLLBACK, not just
+    // an early-return before any write happened.
+    store
+        .add_note_with_created_at("decision", "dup one", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    store
+        .add_note_with_created_at("decision", "dup one", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    store
+        .add_note_with_created_at("note", "dup two", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    store
+        .add_note_with_created_at("note", "dup two", "body", &[], &[], None, "active", 400)
+        .unwrap();
+
+    let before = note_count(&store);
+
+    inject_fault_after_group(0);
+    let result = store.dedupe_entity_ids(false);
+    clear_fault();
+
+    assert!(
+        result.is_err(),
+        "the injected fault must surface as an error"
+    );
+    assert_eq!(
+        note_count(&store),
+        before,
+        "memory.db must be unchanged after a rolled-back run (no partial collapse)"
+    );
+}
+
+// ── Adversarial: fault mid-group (after a loser is fully deleted, before
+// the next loser in the *same* group is touched), with a byte-for-byte
+// full-table comparison rather than just a row count. AC21's own test
+// only proves rollback at a *group* boundary; this proves it holds at a
+// finer grain too, and that every column of every table dedupe can touch
+// (notes, memory_edges, note_embeddings) is provably restored, not just
+// the row count. ─────────────────────────────────────────────────────
+#[test]
+fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byte() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["orig"],
+            &[],
+            None,
+            "active",
+            100,
+        )
+        .unwrap();
+    let loser_a = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["from-a"],
+            &[],
+            None,
+            "archived",
+            200,
+        )
+        .unwrap();
+    let loser_b = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["from-b"],
+            &[],
+            None,
+            "active",
+            300,
+        )
+        .unwrap();
+    let external = store
+        .add_note("note", "external dependent", "b", &[], &[], None, None)
+        .unwrap();
+    // external's supersede edge points at loser_a; a fully-correct
+    // rollback must restore both the notes.superseded_by column AND this
+    // memory_edges row exactly as they were.
+    store.supersede(external, loser_a).unwrap();
+    store.insert_embedding(loser_a, &[7u8; 896 * 4]).unwrap();
+
+    let before = full_db_snapshot(&store);
+    assert_eq!(before.0.len(), 4, "precondition: 4 notes seeded");
+
+    // Fault fires right after loser_a (index 0) is fully deleted
+    // (embedding + edges + note row gone) but before loser_b is touched
+    // at all: a genuinely different point than the group-boundary fault
+    // AC21's own test injects.
+    inject_fault_after_loser(0);
+    let result = store.dedupe_entity_ids(false);
+    clear_loser_fault();
+
+    assert!(
+        result.is_err(),
+        "the mid-group injected fault must surface as an error"
+    );
+    let after = full_db_snapshot(&store);
+    assert_eq!(
+        after, before,
+        "notes + memory_edges + note_embeddings must be byte-for-byte \
+         unchanged after a run that fails mid-group (partial loser \
+         deletion must roll back too, not just whole-group commits)"
+    );
+    // Sanity: the row that would have been deleted is genuinely still
+    // present with its original content (not just "some 4 rows exist").
+    assert!(
+        store.get(loser_a).unwrap().is_some(),
+        "loser_a survives rollback"
+    );
+    let restored_survivor = store.get(survivor).unwrap().unwrap();
+    assert_eq!(
+        restored_survivor.tags,
+        vec!["orig".to_string()],
+        "survivor's own tags must not have been touched by the aborted run"
+    );
+    let _ = loser_b; // seeded only to make this a real multi-loser group
+}
+
+// ── Adversarial: --dry-run must leave every column of every touched
+// table untouched, not just row count / one column. ────────────────────
+#[test]
+fn dry_run_leaves_full_db_state_byte_for_byte_unchanged() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["a"],
+            &["f.rs"],
+            None,
+            "active",
+            100,
+        )
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["b"],
+            &[],
+            None,
+            "archived",
+            200,
+        )
+        .unwrap();
+    let external = store
+        .add_note("note", "external", "b", &[], &[], None, None)
+        .unwrap();
+    store.supersede(external, loser).unwrap();
+    store.insert_embedding(survivor, &[1u8; 896 * 4]).unwrap();
+    store.insert_embedding(loser, &[2u8; 896 * 4]).unwrap();
+
+    let before = full_db_snapshot(&store);
+    let summary = store.dedupe_entity_ids(true).unwrap();
+    assert_eq!(
+        summary.duplicate_groups, 1,
+        "precondition: a group exists to report on"
+    );
+
+    let after = full_db_snapshot(&store);
+    assert_eq!(
+        after, before,
+        "dry-run must leave notes + memory_edges + note_embeddings \
+         completely unchanged, in every column, not just row count"
+    );
+}
+
+// ── Adversarial: multiple external rows point at *different* losers
+// within the same duplicate group. Each must be independently repointed
+// to the survivor. ───────────────────────────────────────────────────────
+#[test]
+fn multiple_external_rows_pointing_at_different_losers_all_repoint_to_survivor() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_a = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_b = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    let dep_a = store
+        .add_note("note", "points at loser_a", "b", &[], &[], None, None)
+        .unwrap();
+    let dep_b = store
+        .add_note("note", "points at loser_b", "b", &[], &[], None, None)
+        .unwrap();
+    store.set_superseded_by(dep_a, loser_a).unwrap();
+    store.set_superseded_by(dep_b, loser_b).unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.supersede_edges_repointed, 2);
+    assert_eq!(
+        store.get(dep_a).unwrap().unwrap().superseded_by,
+        Some(survivor),
+        "dep_a's edge to loser_a must repoint to the survivor"
+    );
+    assert_eq!(
+        store.get(dep_b).unwrap().unwrap().superseded_by,
+        Some(survivor),
+        "dep_b's edge to loser_b must repoint to the survivor, independently of dep_a"
+    );
+}
+
+// ── Adversarial: delete_edges_for_note must remove edges in *both*
+// directions for a loser (edges the loser points from, and edges other
+// notes point at the loser), leaving no orphan. ─────────────────────────
+#[test]
+fn loser_deletion_removes_memory_edges_in_both_directions_no_orphan() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let other_a = store
+        .add_note("note", "a", "b", &[], &[], None, None)
+        .unwrap();
+    let other_b = store
+        .add_note("note", "b", "b", &[], &[], None, None)
+        .unwrap();
+    // loser -> other_a (loser is from_id) and other_b -> loser (loser is to_id).
+    store.add_edge(loser, other_a, "relates_to").unwrap();
+    store.add_edge(other_b, loser, "relates_to").unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+
+    let orphans: i64 = store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM memory_edges WHERE from_id = ?1 OR to_id = ?1",
+            rusqlite::params![loser],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        orphans, 0,
+        "no memory_edges row may reference the deleted loser id"
+    );
+    let _ = survivor;
+}
+
+// ── Adversarial: relates_to/contradicts edges to a loser are dropped
+// outright by `delete_edges_for_note`, not repointed to the survivor.
+// This differs from tags/linked_files/superseded_by, which are carefully
+// merged. ADR-068's third amendment only specifies a merge rule for
+// `superseded_by`, not for the `memory_edges` relationship graph, so this
+// pins the current (lossy) behavior as a known, flagged gap rather than a
+// spec violation, catching any silent further regression. ──────────────
+#[test]
+fn relates_to_edge_to_external_note_is_dropped_not_repointed_known_gap() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let external = store
+        .add_note("note", "external relation", "b", &[], &[], None, None)
+        .unwrap();
+    store.add_edge(loser, external, "relates_to").unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+
+    let (survivor_out, _) = store.get_edges(survivor).unwrap();
+    assert!(
+        !survivor_out.iter().any(|e| e.to_id == external),
+        "documents current behavior: the loser's relates_to edge to an \
+         external note is NOT repointed onto the survivor (it is simply \
+         deleted with the loser). If this assertion ever fails, dedupe's \
+         edge handling changed; update this test alongside the ADR."
+    );
+}

--- a/crates/spelunk-core/src/storage/memory/dedupe/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/tests.rs
@@ -329,13 +329,10 @@ fn injected_fault_partway_rolls_back_whole_run() {
     );
 }
 
-// ── Adversarial: fault mid-group (after a loser is fully deleted, before
-// the next loser in the *same* group is touched), with a byte-for-byte
-// full-table comparison rather than just a row count. AC21's own test
-// only proves rollback at a *group* boundary; this proves it holds at a
-// finer grain too, and that every column of every table dedupe can touch
-// (notes, memory_edges, note_embeddings) is provably restored, not just
-// the row count. ─────────────────────────────────────────────────────
+// Adversarial: fault mid-group (after a loser is deleted, before the
+// next loser in the same group is touched), checked byte-for-byte across
+// every table dedupe can touch, not just a row count. AC21's own test
+// only proves rollback at a group boundary; this proves it holds mid-group.
 #[test]
 fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byte() {
     let store = open_store();
@@ -549,13 +546,11 @@ fn loser_deletion_removes_memory_edges_in_both_directions_no_orphan() {
     let _ = survivor;
 }
 
-// ── Adversarial: relates_to/contradicts edges to a loser are dropped
-// outright by `delete_edges_for_note`, not repointed to the survivor.
-// This differs from tags/linked_files/superseded_by, which are carefully
-// merged. ADR-068's third amendment only specifies a merge rule for
-// `superseded_by`, not for the `memory_edges` relationship graph, so this
-// pins the current (lossy) behavior as a known, flagged gap rather than a
-// spec violation, catching any silent further regression. ──────────────
+// Adversarial: relates_to/contradicts edges to a loser are dropped by
+// delete_edges_for_note, not repointed, unlike tags/linked_files/
+// superseded_by. ADR-068's third amendment only specifies a merge rule
+// for superseded_by, not the memory_edges graph, so this pins the
+// current (lossy) behavior as a known gap rather than a spec violation.
 #[test]
 fn relates_to_edge_to_external_note_is_dropped_not_repointed_known_gap() {
     let store = open_store();

--- a/crates/spelunk-core/src/storage/memory/edges.rs
+++ b/crates/spelunk-core/src/storage/memory/edges.rs
@@ -107,6 +107,19 @@ impl MemoryStore {
         }
     }
 
+    /// Delete every `memory_edges` row touching `note_id` (either endpoint).
+    ///
+    /// `memory dedupe` is the first place in this codebase that deletes an
+    /// existing note row, so it cleans up incident edges explicitly here
+    /// rather than relying on `memory_edges`' `ON DELETE CASCADE`.
+    pub fn delete_edges_for_note(&self, note_id: i64) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM memory_edges WHERE from_id = ?1 OR to_id = ?1",
+            rusqlite::params![note_id],
+        )?;
+        Ok(())
+    }
+
     /// Insert a directed edge between two notes.
     /// `kind` must be one of: supersedes, relates_to, contradicts.
     pub fn add_edge(&self, from_id: i64, to_id: i64, kind: &str) -> Result<()> {

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
@@ -1,0 +1,293 @@
+//! Step A (`backfill_entity_ids`) and Step B (`promote_entity_id_unique_index`)
+//! behavior: population, idempotency, resumption after partial population,
+//! index promotion, and the marker short-circuit.
+
+use super::test_support::*;
+
+// ── AC1: a store with rows lacking entity_id gets them populated ────────
+#[test]
+fn backfill_populates_null_entity_ids() {
+    let store = open_store();
+    // Insert directly, bypassing add_note (which already stamps entity_id),
+    // to simulate a pre-023 row that predates the column.
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 't', 'b', NULL)",
+            [],
+        )
+        .unwrap();
+    assert_eq!(null_entity_id_count(&store), 1);
+
+    store.backfill_entity_ids().unwrap();
+
+    assert_eq!(null_entity_id_count(&store), 0);
+    let stamped: String = store
+        .conn
+        .query_row("SELECT entity_id FROM notes WHERE title='t'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        stamped,
+        crate::storage::entity_id::entity_id("note", "t", "b")
+    );
+}
+
+// ── AC2: a fully-populated store is a no-op ─────────────────────────────
+#[test]
+fn backfill_on_fully_populated_store_is_noop() {
+    let store = open_store();
+    store
+        .add_note("note", "t", "b", &[], &[], None, None)
+        .unwrap();
+    assert_eq!(null_entity_id_count(&store), 0);
+    // Must not error and must not disturb the already-correct value.
+    store.backfill_entity_ids().unwrap();
+    assert_eq!(null_entity_id_count(&store), 0);
+}
+
+// ── AC3: rows inserted post-023 already carrying entity_id are untouched ─
+#[test]
+fn backfill_leaves_already_stamped_rows_untouched() {
+    let store = open_store();
+    let id = store
+        .add_note("decision", "already stamped", "body", &[], &[], None, None)
+        .unwrap();
+    let before: String = store
+        .conn
+        .query_row(
+            "SELECT entity_id FROM notes WHERE id = ?1",
+            rusqlite::params![id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    store.backfill_entity_ids().unwrap();
+    let after: String = store
+        .conn
+        .query_row(
+            "SELECT entity_id FROM notes WHERE id = ?1",
+            rusqlite::params![id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(before, after);
+}
+
+// ── AC4: an interrupted population resumes cleanly with no duplication ──
+#[test]
+fn backfill_resumes_after_partial_population() {
+    let store = open_store();
+    store
+        .conn
+        .execute_batch(
+            "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'a', 'a-body', NULL);
+             INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'b', 'b-body', NULL);",
+        )
+        .unwrap();
+    assert_eq!(null_entity_id_count(&store), 2);
+
+    // First pass populates both.
+    store.backfill_entity_ids().unwrap();
+    assert_eq!(null_entity_id_count(&store), 0);
+
+    // Simulate a fresh row landing NULL again (as if a third row arrived
+    // between an interrupted run and the next open) and rerun: only the
+    // new row is touched, no duplication of existing rows.
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'c', 'c-body', NULL)",
+            [],
+        )
+        .unwrap();
+    store.backfill_entity_ids().unwrap();
+    assert_eq!(null_entity_id_count(&store), 0);
+
+    let total: i64 = store
+        .conn
+        .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(total, 3, "no row must be duplicated across the two passes");
+}
+
+// ── AC5: zero duplicate groups promotes the index and records the marker ─
+#[test]
+fn promote_with_zero_duplicates_creates_unique_index_and_marker() {
+    let store = open_store();
+    store
+        .add_note("note", "unique one", "body", &[], &[], None, None)
+        .unwrap();
+    store
+        .add_note("note", "unique two", "body two", &[], &[], None, None)
+        .unwrap();
+
+    assert!(!marker_exists(&store), "marker must not pre-exist");
+    store.promote_entity_id_unique_index().unwrap();
+
+    assert!(marker_exists(&store), "marker must be recorded");
+    assert!(index_is_unique(&store), "index must be promoted to UNIQUE");
+}
+
+// ── AC6: one or more duplicate groups leaves the index non-unique, no error ─
+#[test]
+fn promote_with_duplicates_leaves_index_non_unique_and_does_not_error() {
+    let store = open_store();
+    // Two rows sharing kind/title/body (the entity_id key) but different
+    // created_at, simulating the exact real-data shape from the task brief.
+    store
+        .add_note_with_created_at(
+            "requirement",
+            "Exit codes follow protocol",
+            "body",
+            &[],
+            &[],
+            None,
+            "active",
+            1_700_000_000,
+        )
+        .unwrap();
+    store
+        .add_note_with_created_at(
+            "requirement",
+            "Exit codes follow protocol",
+            "body",
+            &[],
+            &[],
+            None,
+            "active",
+            1_700_000_001,
+        )
+        .unwrap();
+
+    let result = store.promote_entity_id_unique_index();
+    assert!(result.is_ok(), "duplicates must never abort the open");
+    assert!(
+        !marker_exists(&store),
+        "marker must not be recorded while duplicates remain"
+    );
+    assert!(
+        !index_is_unique(&store),
+        "index must stay non-unique while duplicates remain"
+    );
+}
+
+// ── AC7: once promoted, later opens skip the duplicate scan ─────────────
+#[test]
+fn promote_skips_rescan_once_marker_present() {
+    let store = open_store();
+    store
+        .add_note("note", "solo", "body", &[], &[], None, None)
+        .unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(marker_exists(&store));
+
+    // Drop the notes table entirely: if the marker check did not
+    // short-circuit before the duplicate-group scan, the scan's query
+    // against a now-missing table would surface as an error.
+    store.conn.execute_batch("DROP TABLE notes;").unwrap();
+
+    let result = store.promote_entity_id_unique_index();
+    assert!(
+        result.is_ok(),
+        "marker must short-circuit before any duplicate scan runs: {:?}",
+        result.err()
+    );
+}
+
+// ── AC8: duplicates dedupe'd to zero, then reopened: promotes next open ─
+#[test]
+fn promote_after_manual_collapse_to_zero_duplicates_succeeds() {
+    let store = open_store();
+    let survivor_id = store
+        .add_note_with_created_at(
+            "note",
+            "dup title",
+            "dup body",
+            &[],
+            &[],
+            None,
+            "active",
+            1_700_000_000,
+        )
+        .unwrap();
+    let loser_id = store
+        .add_note_with_created_at(
+            "note",
+            "dup title",
+            "dup body",
+            &[],
+            &[],
+            None,
+            "active",
+            1_700_000_050,
+        )
+        .unwrap();
+
+    // First open-equivalent: duplicates present, index stays non-unique.
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(!index_is_unique(&store));
+
+    // Collapse manually (mirrors what `spelunk memory dedupe` would do).
+    store
+        .conn
+        .execute(
+            "DELETE FROM notes WHERE id = ?1",
+            rusqlite::params![loser_id],
+        )
+        .unwrap();
+    assert!(survivor_id > 0);
+
+    // "Reopen": call promote again now duplicates are gone.
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(
+        index_is_unique(&store),
+        "index must promote once duplicates are collapsed to zero"
+    );
+    assert!(marker_exists(&store));
+}
+
+// ── Adversarial (AC5/item 8): the promoted index must genuinely reject a
+// duplicate INSERT at the SQL level, not merely report itself as "UNIQUE"
+// in `sqlite_master`'s stored SQL text (index_is_unique() above proves
+// only the latter). A CREATE UNIQUE INDEX statement can be issued against
+// a table that already violates it in edge cases (e.g. NULLs, or a
+// logic bug in the WHERE-partial-index clause); the only real proof is a
+// rejected write. ────────────────────────────────────────────────────────
+#[test]
+fn promoted_unique_index_genuinely_rejects_a_duplicate_insert() {
+    let store = open_store();
+    store
+        .add_note("note", "only one", "body", &[], &[], None, None)
+        .unwrap();
+
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(index_is_unique(&store), "precondition: index promoted");
+
+    let dup_entity_id = crate::storage::entity_id::entity_id("note", "only one", "body");
+    let insert_result = store.conn.execute(
+        "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'only one', 'body', ?1)",
+        rusqlite::params![dup_entity_id],
+    );
+    assert!(
+        insert_result.is_err(),
+        "a promoted UNIQUE index must reject a subsequent duplicate \
+         entity_id insert, not merely exist with 'UNIQUE' in its SQL text"
+    );
+    let msg = insert_result.unwrap_err().to_string().to_lowercase();
+    assert!(
+        msg.contains("unique"),
+        "expected a UNIQUE constraint violation, got: {msg}"
+    );
+
+    // A non-duplicate insert must still succeed: the index is selective
+    // (WHERE entity_id IS NOT NULL), not a blanket rejection of writes.
+    let other_entity_id = crate::storage::entity_id::entity_id("note", "a different one", "body");
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'a different one', 'body', ?1)",
+            rusqlite::params![other_entity_id],
+        )
+        .expect("a genuinely distinct entity_id must still insert fine");
+}

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
@@ -247,13 +247,10 @@ fn promote_after_manual_collapse_to_zero_duplicates_succeeds() {
     assert!(marker_exists(&store));
 }
 
-// ── Adversarial (AC5/item 8): the promoted index must genuinely reject a
-// duplicate INSERT at the SQL level, not merely report itself as "UNIQUE"
-// in `sqlite_master`'s stored SQL text (index_is_unique() above proves
-// only the latter). A CREATE UNIQUE INDEX statement can be issued against
-// a table that already violates it in edge cases (e.g. NULLs, or a
-// logic bug in the WHERE-partial-index clause); the only real proof is a
-// rejected write. ────────────────────────────────────────────────────────
+// Adversarial (AC5/item 8): the promoted index must genuinely reject a
+// duplicate INSERT at the SQL level, not merely report "UNIQUE" in
+// sqlite_master's stored SQL text (index_is_unique() above only proves
+// that). The only real proof is a rejected write.
 #[test]
 fn promoted_unique_index_genuinely_rejects_a_duplicate_insert() {
     let store = open_store();

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs
@@ -1,0 +1,121 @@
+//! ADR-068 third amendment: backfill `entity_id` onto existing rows and
+//! promote `idx_notes_entity_id` to UNIQUE once it is safe to do so.
+//!
+//! Split into two independently-safe steps, run unconditionally at
+//! `MemoryStore::open` (mirrors the `apply_dim_upgrade_migration` /
+//! `schema_int8_embeddings` marker-table idiom already used for the
+//! 768->896 embedding dim upgrade in `db.rs` and for
+//! `schema_v896_note_embeddings` in this same store):
+//!
+//! - Step A (`backfill_entity_ids`) populates `entity_id` for any row where
+//!   it is still `NULL`. This can never fail on a constraint: migration
+//!   023's index starts non-unique, and Step B (below) only ever promotes it
+//!   once a duplicate scan comes back clean.
+//! - Step B (`promote_entity_id_unique_index`) checks for duplicate
+//!   `entity_id` groups. Zero groups: promote the index to UNIQUE and record
+//!   a marker so later opens skip the scan. One or more groups: leave the
+//!   non-unique index in place and log an actionable message pointing at
+//!   `spelunk memory dedupe`. Neither step ever hard-aborts `open`.
+
+use anyhow::{Context, Result};
+use rusqlite::OptionalExtension;
+
+use super::MemoryStore;
+use crate::storage::entity_id::entity_id;
+
+/// Marker table recorded once the index has been promoted to UNIQUE, so
+/// later opens skip the duplicate-group scan entirely.
+const ENTITY_ID_UNIQUE_MARKER: &str = "schema_entity_id_unique";
+
+impl MemoryStore {
+    /// Step A: populate `entity_id` for every row where it is currently
+    /// `NULL`, computed in Rust (sha256 is unavailable to raw SQL). Idempotent:
+    /// an interrupted run just leaves the remaining `NULL` rows for the next
+    /// open to pick up, and rows that already carry a value are never
+    /// re-selected.
+    pub(super) fn backfill_entity_ids(&self) -> Result<()> {
+        let rows: Vec<(i64, String, String, String)> = {
+            let mut stmt = self
+                .conn
+                .prepare("SELECT id, kind, title, body FROM notes WHERE entity_id IS NULL")
+                .context("preparing entity_id backfill scan")?;
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))
+                .context("scanning notes for entity_id backfill")?
+                .collect::<rusqlite::Result<_>>()
+                .context("reading entity_id backfill rows")?
+        };
+
+        for (id, kind, title, body) in rows {
+            let eid = entity_id(&kind, &title, &body);
+            self.conn
+                .execute(
+                    "UPDATE notes SET entity_id = ?1 WHERE id = ?2",
+                    rusqlite::params![eid, id],
+                )
+                .with_context(|| format!("backfilling entity_id for note #{id}"))?;
+        }
+        Ok(())
+    }
+
+    /// Step B: promote `idx_notes_entity_id` to UNIQUE once zero duplicate
+    /// groups remain. Never hard-aborts: a store with duplicates stays fully
+    /// functional under the non-unique index until the user runs `spelunk
+    /// memory dedupe`.
+    pub(super) fn promote_entity_id_unique_index(&self) -> Result<()> {
+        let already: bool = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+                rusqlite::params![ENTITY_ID_UNIQUE_MARKER],
+                |_| Ok(true),
+            )
+            .optional()
+            .context("checking entity_id unique-index marker")?
+            .is_some();
+        if already {
+            return Ok(());
+        }
+
+        let dup_groups = self.entity_id_duplicate_group_count()?;
+        if dup_groups > 0 {
+            tracing::warn!(
+                "entity_id has {dup_groups} duplicate group(s); run \
+                 `spelunk memory dedupe` to collapse them, then re-run spelunk \
+                 to enforce uniqueness"
+            );
+            return Ok(());
+        }
+
+        self.conn
+            .execute_batch(&format!(
+                "DROP INDEX IF EXISTS idx_notes_entity_id; \
+                 CREATE UNIQUE INDEX idx_notes_entity_id \
+                     ON notes(entity_id) WHERE entity_id IS NOT NULL; \
+                 CREATE TABLE IF NOT EXISTS {ENTITY_ID_UNIQUE_MARKER} \
+                     (sentinel INTEGER PRIMARY KEY);"
+            ))
+            .context("promoting idx_notes_entity_id to UNIQUE")?;
+        Ok(())
+    }
+
+    /// Count of distinct `entity_id` values shared by more than one row.
+    /// Shared by Step B's gate and `spelunk memory dedupe`'s summary.
+    pub fn entity_id_duplicate_group_count(&self) -> Result<i64> {
+        self.conn
+            .query_row(
+                "SELECT COUNT(*) FROM (
+                     SELECT entity_id FROM notes
+                     WHERE entity_id IS NOT NULL
+                     GROUP BY entity_id HAVING COUNT(*) > 1
+                 )",
+                [],
+                |r| r.get(0),
+            )
+            .context("counting duplicate entity_id groups")
+    }
+}
+
+#[cfg(test)]
+mod migration_tests;
+#[cfg(test)]
+mod test_support;

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/test_support.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/test_support.rs
@@ -1,0 +1,69 @@
+//! Shared test-only helpers for `entity_id_migration`'s `migration_tests`
+//! submodule.
+
+use super::ENTITY_ID_UNIQUE_MARKER;
+use crate::storage::memory::MemoryStore;
+use rusqlite::OptionalExtension;
+use std::sync::OnceLock;
+
+fn register_sqlite_vec() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite_vec::sqlite3_vec_init as *const (),
+            )));
+        }
+    });
+}
+
+/// A store built via the schema-only path: `migrate()` creates the
+/// (non-unique) `idx_notes_entity_id` but skips the Step A/B pipeline a
+/// real `MemoryStore::open` runs. Each test then drives Step A/B itself,
+/// so a fresh empty store isn't auto-promoted to UNIQUE before the test
+/// gets a chance to seed the rows it actually wants to exercise.
+pub(super) fn open_store() -> MemoryStore {
+    register_sqlite_vec();
+    let conn = rusqlite::Connection::open(std::path::Path::new(":memory:"))
+        .expect("open in-memory sqlite");
+    let store = MemoryStore { conn };
+    store.migrate().expect("schema migration");
+    store
+}
+
+pub(super) fn marker_exists(store: &MemoryStore) -> bool {
+    store
+        .conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+            rusqlite::params![ENTITY_ID_UNIQUE_MARKER],
+            |_| Ok(true),
+        )
+        .optional()
+        .unwrap()
+        .is_some()
+}
+
+pub(super) fn index_is_unique(store: &MemoryStore) -> bool {
+    let sql: String = store
+        .conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_notes_entity_id'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    sql.to_uppercase().contains("UNIQUE")
+}
+
+pub(super) fn null_entity_id_count(store: &MemoryStore) -> i64 {
+    store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM notes WHERE entity_id IS NULL",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap()
+}

--- a/crates/spelunk-core/src/storage/memory/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/mod.rs
@@ -3,11 +3,14 @@ use rusqlite::{Connection, OptionalExtension};
 use serde::Serialize;
 use std::path::Path;
 
+mod dedupe;
 mod edges;
+mod entity_id_migration;
 mod notes;
 mod search;
 mod sync;
 
+pub use dedupe::DedupeSummary;
 pub use sync::SyncRow;
 
 #[cfg(test)]
@@ -84,6 +87,11 @@ impl MemoryStore {
             .with_context(|| format!("opening memory DB at {}", path.display()))?;
         let store = Self { conn };
         store.migrate()?;
+        // ADR-068 third amendment: Step A (unconditional backfill) then Step B
+        // (conditional UNIQUE-index promotion). Neither ever hard-aborts open;
+        // see `entity_id_migration.rs`.
+        store.backfill_entity_ids()?;
+        store.promote_entity_id_unique_index()?;
         Ok(store)
     }
 

--- a/crates/spelunk-core/src/storage/memory/notes.rs
+++ b/crates/spelunk-core/src/storage/memory/notes.rs
@@ -148,17 +148,24 @@ impl MemoryStore {
         Ok(self.conn.last_insert_rowid())
     }
 
-    /// Return all notes for a project ordered by created_at ASC (used by reconcile
-    /// to compute the memory.db content-hash set).
+    /// Return all notes for a project ordered by created_at ASC, id ASC (used
+    /// by reconcile to compute the memory.db content-hash set, and by
+    /// `dedupe_entity_ids` to pick each duplicate group's survivor).
     ///
     /// Returns all notes regardless of status so that archived entries also
     /// participate in dedup (we must not re-import a note that was already
     /// imported and then archived in memory.db).
+    ///
+    /// The `id ASC` secondary key is a deliberate tie-break: two rows can
+    /// share the same `created_at` (e.g. a batch import), and `id` is
+    /// monotonically increasing with insertion order, so this pins
+    /// "earliest created, and among ties, first inserted" as the actual
+    /// definition of "earliest" every caller relies on.
     pub fn all_notes_for_dedup(&self) -> Result<Vec<Note>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, kind, title, body, tags, linked_files, created_at, status, \
              superseded_by, source_ref, valid_at, invalid_at \
-             FROM notes ORDER BY created_at ASC",
+             FROM notes ORDER BY created_at ASC, id ASC",
         )?;
         let notes = stmt
             .query_map([], super::notes::row_to_note)?
@@ -208,6 +215,51 @@ impl MemoryStore {
         self.conn.execute(
             "UPDATE notes SET superseded_by = ?1 WHERE id = ?2",
             rusqlite::params![successor_id, note_id],
+        )?;
+        Ok(())
+    }
+
+    /// Clear an existing note's `superseded_by` link back to NULL. Used by
+    /// `memory dedupe`'s self-edge guard: a rewrite that would otherwise point
+    /// a row at itself drops the link instead.
+    pub fn clear_superseded_by(&self, note_id: i64) -> Result<()> {
+        self.conn.execute(
+            "UPDATE notes SET superseded_by = NULL WHERE id = ?1",
+            rusqlite::params![note_id],
+        )?;
+        Ok(())
+    }
+
+    /// Ids of every row whose `superseded_by` points at `target_id`.
+    pub fn notes_pointing_at(&self, target_id: i64) -> Result<Vec<i64>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM notes WHERE superseded_by = ?1")?;
+        let ids = stmt
+            .query_map(rusqlite::params![target_id], |r| r.get(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(ids)
+    }
+
+    /// Delete a note row outright. Used only by `memory dedupe` to remove a
+    /// duplicate-group loser after its tags/linked_files/superseded_by have
+    /// been folded into the survivor and any edges pointing at it rewritten.
+    pub fn delete_note(&self, note_id: i64) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM notes WHERE id = ?1",
+            rusqlite::params![note_id],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a note's embedding row, if present. A no-op when absent. Used by
+    /// `memory dedupe` when deleting a duplicate-group loser: two vectors have
+    /// no meaningful union, so the loser's embedding is dropped rather than
+    /// merged (the survivor's own embedding, if any, is untouched).
+    pub fn delete_note_embedding(&self, note_id: i64) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM note_embeddings WHERE note_id = ?1",
+            rusqlite::params![note_id],
         )?;
         Ok(())
     }

--- a/crates/spelunk-core/src/storage/memory/notes.rs
+++ b/crates/spelunk-core/src/storage/memory/notes.rs
@@ -148,19 +148,17 @@ impl MemoryStore {
         Ok(self.conn.last_insert_rowid())
     }
 
-    /// Return all notes for a project ordered by created_at ASC, id ASC (used
-    /// by reconcile to compute the memory.db content-hash set, and by
-    /// `dedupe_entity_ids` to pick each duplicate group's survivor).
+    /// Return all notes ordered by created_at ASC, id ASC (used by reconcile
+    /// for the content-hash set, and by `dedupe_entity_ids` to pick each
+    /// group's survivor).
     ///
-    /// Returns all notes regardless of status so that archived entries also
-    /// participate in dedup (we must not re-import a note that was already
-    /// imported and then archived in memory.db).
+    /// Includes every status, including archived, so dedup doesn't re-import
+    /// a note that was already imported and then archived.
     ///
-    /// The `id ASC` secondary key is a deliberate tie-break: two rows can
-    /// share the same `created_at` (e.g. a batch import), and `id` is
-    /// monotonically increasing with insertion order, so this pins
-    /// "earliest created, and among ties, first inserted" as the actual
-    /// definition of "earliest" every caller relies on.
+    /// `id ASC` is a deliberate tie-break: created_at can collide (e.g. a
+    /// batch import), and id increases with insertion order, so this pins
+    /// "earliest created, ties broken by first inserted" as the definition
+    /// every caller relies on.
     pub fn all_notes_for_dedup(&self) -> Result<Vec<Note>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, kind, title, body, tags, linked_files, created_at, status, \
@@ -241,9 +239,9 @@ impl MemoryStore {
         Ok(ids)
     }
 
-    /// Delete a note row outright. Used only by `memory dedupe` to remove a
-    /// duplicate-group loser after its tags/linked_files/superseded_by have
-    /// been folded into the survivor and any edges pointing at it rewritten.
+    /// Used only by `memory dedupe`, after a duplicate-group loser's
+    /// tags/linked_files/superseded_by have been folded into the survivor
+    /// and any edges pointing at it rewritten.
     pub fn delete_note(&self, note_id: i64) -> Result<()> {
         self.conn.execute(
             "DELETE FROM notes WHERE id = ?1",
@@ -252,10 +250,10 @@ impl MemoryStore {
         Ok(())
     }
 
-    /// Delete a note's embedding row, if present. A no-op when absent. Used by
-    /// `memory dedupe` when deleting a duplicate-group loser: two vectors have
-    /// no meaningful union, so the loser's embedding is dropped rather than
-    /// merged (the survivor's own embedding, if any, is untouched).
+    /// No-op if absent. Used by `memory dedupe` when deleting a
+    /// duplicate-group loser: two vectors have no meaningful union, so the
+    /// embedding is dropped rather than merged; the survivor's own
+    /// embedding is untouched.
     pub fn delete_note_embedding(&self, note_id: i64) -> Result<()> {
         self.conn.execute(
             "DELETE FROM note_embeddings WHERE note_id = ?1",

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -487,17 +487,26 @@ fn union_tags_keeps_fts_in_sync() {
 
 /// The entity_id migration runs against a store that predates the column and
 /// already holds rows that collide under the new key. It must add the column
-/// without aborting, and without deleting or merging any existing row — those
-/// duplicates are legitimate (the previous key folded in `created_at`).
+/// without aborting, and, per ADR-068's third amendment, backfill every
+/// legacy row's `entity_id` (Step A) while leaving the *rows themselves*
+/// alone: collapsing duplicates is `spelunk memory dedupe`'s job, not an
+/// automatic side effect of opening the store, so Step B must also leave the
+/// index non-unique while a duplicate group remains.
 #[test]
-fn entity_id_migration_is_additive_on_a_store_with_duplicates() {
+fn entity_id_migration_backfills_but_does_not_collapse_duplicates() {
     register_sqlite_vec();
     let dir = tempfile::TempDir::new().expect("tempdir");
     let path = dir.path().join("memory.db");
 
-    // Build a store, then take the column away to model a pre-migration DB.
+    // Build a store via the schema-only path (skips the Step A/B pipeline a
+    // real `open()` runs), so seeding two duplicate-content rows below isn't
+    // rejected by an index a fresh, zero-duplicate store would otherwise have
+    // already promoted to UNIQUE. Then take the column away entirely to model
+    // a genuinely pre-023 DB.
     {
-        let store = MemoryStore::open(&path).expect("open");
+        let conn = rusqlite::Connection::open(&path).expect("open raw");
+        let store = MemoryStore { conn };
+        store.migrate().expect("schema migration only");
         for created_at in [1_700_000_001_i64, 1_700_000_002] {
             store
                 .add_note_with_created_at(
@@ -529,14 +538,15 @@ fn entity_id_migration_is_additive_on_a_store_with_duplicates() {
         assert_eq!(has_col, 0, "precondition: the column is gone");
     }
 
-    // Re-opening runs the migration over that data.
+    // Re-opening (the real `MemoryStore::open`) re-adds the column (migration
+    // 023), then runs Step A (backfill) and Step B (duplicate scan).
     let store = MemoryStore::open(&path).expect("migration must not abort on existing data");
 
     let rows: i64 = store
         .conn
         .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(rows, 2, "no existing row may be deleted or merged");
+    assert_eq!(rows, 2, "opening alone must not delete or merge any row");
 
     let has_col: i64 = store
         .conn
@@ -548,7 +558,7 @@ fn entity_id_migration_is_additive_on_a_store_with_duplicates() {
         .unwrap();
     assert_eq!(has_col, 1, "the column is added");
 
-    // Not backfilled: identity for these legacy rows is recomputed on read.
+    // Step A backfills: no legacy row is left NULL.
     let nulls: i64 = store
         .conn
         .query_row(
@@ -557,11 +567,30 @@ fn entity_id_migration_is_additive_on_a_store_with_duplicates() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(nulls, 2, "backfill is a separate decision; rows stay NULL");
+    assert_eq!(
+        nulls, 0,
+        "Step A must backfill entity_id for every legacy row"
+    );
     assert_eq!(
         super::super::entity_id::note_entity_id(&store.list(None, 10, true).unwrap()[0]),
         super::super::entity_id::note_entity_id(&store.list(None, 10, true).unwrap()[1]),
-        "the two legacy rows do collide under the new key — a UNIQUE index would have aborted"
+        "the two legacy rows do collide under the new key"
+    );
+
+    // Step B must not have promoted the index: the two rows above are a
+    // duplicate group, so the store stays on the non-unique index until an
+    // explicit `spelunk memory dedupe` collapses it.
+    let idx_sql: String = store
+        .conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_notes_entity_id'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(
+        !idx_sql.to_uppercase().contains("UNIQUE"),
+        "a duplicate group must keep the index non-unique: {idx_sql}"
     );
 
     // Idempotent: opening again is a no-op, not a duplicate-column error.

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -27,7 +27,7 @@ pub use git_notes::{
     ensure_notes_rewrite_ref, lock_notes, merge_tracking_notes, publish_notes,
 };
 pub use graph::GraphEdge;
-pub use memory::{MemoryEdge, MemoryStore, SyncRow};
+pub use memory::{DedupeSummary, MemoryEdge, MemoryStore, SyncRow};
 pub use note_record::{NoteRecord, now_millis, now_secs};
 pub use remote::{
     BatchItemResult, BatchPushItem, BatchPushResult, CloudSyncClient, RemoteEntry,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -765,6 +765,7 @@ spelunk memory pull                         # one-way: pull new server entries i
 spelunk memory sync                         # two-way: push local + pull remote (see `spelunk sync`)
 spelunk memory watch                        # stream new entries from the server (SSE)
 spelunk memory reconcile [--dry-run] [--all-projects] [--source-db <path>]
+spelunk memory dedupe [--dry-run] [--format text|json]
 ```
 
 All `memory` subcommands accept `--backend sqlite|git-notes` (default `sqlite`)
@@ -796,6 +797,9 @@ import dedup on it: entries with identical text collapse into one even when
 their creation time, tags, or linked files differ, and the survivor carries the
 union of the tags and linked files. The `id` shown by `memory list` is a local
 row number, not this identity. See [Entry identity](memory.md#project-memory).
+Existing duplicate rows already resident in `memory.db` are never collapsed
+automatically; use `spelunk memory dedupe` to do that explicitly (see
+[Collapsing duplicate entries already in memory.db](memory.md#collapsing-duplicate-entries-already-in-memorydb)).
 
 ---
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -688,6 +688,79 @@ project's own `memory.db`. Embeddings are re-generated from the imported text
 via the configured server (best-effort; notes import successfully even when the
 server is unreachable).
 
+## Collapsing duplicate entries already in memory.db
+
+Content identity (see **Entry identity** at the top of this page) is derived
+only from `kind`, `title`, and `body`. A `memory.db` that predates this, or
+that picked up entries from more than one machine, can already contain rows
+that share that identity while differing in `created_at`, `tags`,
+`linked_files`, or `status`, for example the same decision recorded twice by
+a repeated `memory harvest` run. spelunk leaves those rows in place: they are
+harmless, and nothing reads or writes memory any differently because of them.
+
+Because collapsing existing rows means deleting some of them, it never
+happens automatically. If `spelunk` finds duplicate groups while opening a
+project's `memory.db`, it logs an actionable one-line warning instead of
+touching anything:
+
+```
+entity_id has 2 duplicate group(s); run `spelunk memory dedupe` to collapse
+them, then re-run spelunk to enforce uniqueness
+```
+
+`spelunk memory dedupe` is the command that warning points at. It is a
+one-time backfill you run when you want to clean up, not a step in the normal
+workflow: `init`, `memory add`, and every other command keep working with
+duplicates present.
+
+For each group of rows sharing an identity, the surviving row is the one with
+the earliest `created_at`. The other rows are deleted after their `tags` and
+`linked_files` are merged into the survivor (union, nothing dropped), its
+status becomes `archived` if any row in the group was archived, and any
+`supersedes` edge elsewhere in the store that pointed at a deleted row is
+repointed to the survivor. One run collapses every duplicate group in a
+single transaction: an error midway rolls the whole run back, so `memory.db`
+either ends up fully collapsed or is left exactly as it was.
+
+```bash
+# Preview what would be collapsed, without writing anything
+spelunk memory dedupe --dry-run
+
+# Collapse duplicate groups
+spelunk memory dedupe
+
+# Machine-readable summary
+spelunk memory dedupe --format json
+```
+
+Sample output, collapsing one group of two rows (the newer row's `cli`,
+`exit-codes` tags and its linked file merge into the survivor):
+
+```
+$ spelunk memory dedupe --dry-run
+[spelunk] dedupe (dry-run): total_notes=2 duplicate_groups=1 rows_would_collapse=1
+
+$ spelunk memory dedupe
+[spelunk] dedupe: total_notes=2 duplicate_groups=1 rows_collapsed=1 tags_merged=2 linked_files_merged=1 supersede_edges_repointed=0 supersede_self_edges_dropped=0
+
+$ spelunk memory dedupe --format json
+{"total_notes":2,"duplicate_groups":1,"rows_collapsed":1,"tags_merged":2,"linked_files_merged":1,"supersede_edges_repointed":0,"supersede_self_edges_dropped":0}
+```
+
+Once a store has zero duplicate groups, `dedupe` (dry-run or not) reports
+all-zero counts and makes no writes, and the next `spelunk` run promotes
+`memory.db`'s `entity_id` index to enforce uniqueness going forward; after
+that, a duplicate group can no longer occur.
+
+### Security notes
+
+`dedupe` only reads and writes the project's own `memory.db`; it never
+contacts a server or an LLM. The collapse runs as a single transaction, so a
+failure partway through leaves the store exactly as it was rather than
+half-collapsed. Deleting the losing rows is destructive and not reversible by
+spelunk itself (back up `memory.db`, or your git-notes ref, first if you want
+to be able to undo it).
+
 ## Using memory as context
 
 `spelunk memory search` results are best consumed alongside `spelunk search` results — they answer the *why* while the code search answers the *how*. Pass both to your reasoning model for a complete picture.


### PR DESCRIPTION
## Summary

First of three PRs splitting the entity_id backfill / dedupe story (previously one large PR) into independently-reviewable pieces, split along the ADR-068 amendment boundaries. This PR is the third ADR-068 amendment on its own: it does not depend on the other two.

- `MemoryStore::open` now backfills `entity_id` onto any pre-existing row lacking it (Step A), then promotes `idx_notes_entity_id` to UNIQUE once a duplicate scan comes back clean (Step B). Neither step ever hard-aborts the open; a store with duplicate groups just stays on the non-unique index and logs an actionable message.
- New `spelunk memory dedupe [--dry-run] [--format text|json]` subcommand collapses existing duplicate-`entity_id` groups already resident in `memory.db`: earliest-created row survives, `tags`/`linked_files` union add-wins, `archived` sticks, and any `supersedes` edge pointing at a removed row is repointed to the survivor. One run is a single all-or-nothing transaction.
- `dedupe`/`entity_id_migration` are split into small, focused files (a few hundred lines each) rather than one large module, matching the existing `config/`, `storage/memory/`, `storage/remote/` convention in this codebase.

Full design in [ADR-068's third amendment](docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md).

Stacks on top of `main` directly (no dependency on the other two PRs in this split).

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace` — 0 failures across every crate/suite (both default and `--no-default-features`).
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets --features rich-formats -- -D warnings` and `--no-default-features` — both clean.
- `cargo fmt --all -- --check` — clean.
- Manually built the CLI and ran `spelunk memory dedupe --dry-run`, a real run, and `--format json` against a seeded duplicate pair; output matches `docs/memory.md`.