### PR TITLE
fix(memory): add_note reuses the existing row on an entity_id collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   `init` or `memory add` perform for you. See [ADR-068's third
   amendment](docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md).
 
+### Fixed
+
+- **`spelunk memory add` no longer crashes on a byte-identical duplicate once
+  a project's `entity_id` index has been promoted to UNIQUE.** Previously a
+  second `memory add` with the same `kind`/`title`/`body` as an existing
+  entry hit `Error: UNIQUE constraint failed: notes.entity_id`. It now reuses
+  the existing entry instead, merging the new call's `tags` and
+  `linked_files` into it, and prints `Already recorded as [kind] #id: title`
+  in place of `Stored [kind] #id: title`. See [ADR-068's fourth
+  amendment](docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md).
+
 ### Changed
 
 - **Chunk re-windowing is now token-aware, and windowed chunks keep their identity.**

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -135,7 +135,9 @@ pub(super) async fn memory_add(
     // Primary store (ADR-004): the local SQLite `memory.db`, an explicit team
     // server, or (with `--backend git-notes`) git notes itself. Pre-init there
     // is no primary; the write-through carrier below is the sole writer, so mint
-    // an id the same way the backends do (`now_millis`).
+    // an id the same way the backends do (`now_millis`). Reuses the backend
+    // opened above for the E4 pre-flight read (`backend_for_add`) instead of
+    // opening it twice.
     let (id, created) = if pre_init_notes {
         (now_millis(), true)
     } else {

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -136,8 +136,8 @@ pub(super) async fn memory_add(
     // server, or (with `--backend git-notes`) git notes itself. Pre-init there
     // is no primary; the write-through carrier below is the sole writer, so mint
     // an id the same way the backends do (`now_millis`).
-    let id = if pre_init_notes {
-        now_millis()
+    let (id, created) = if pre_init_notes {
+        (now_millis(), true)
     } else {
         let backend = match backend_for_add.take() {
             Some(backend) => backend,
@@ -258,7 +258,14 @@ pub(super) async fn memory_add(
         }
     }
 
-    println!("Stored [{kind}] #{id}: {title}", kind = args.kind);
+    if created {
+        println!("Stored [{kind}] #{id}: {title}", kind = args.kind);
+    } else {
+        println!(
+            "Already recorded as [{kind}] #{id}: {title}",
+            kind = args.kind
+        );
+    }
     if let Some(line) = notes_rewrite_note {
         println!("{line}");
     }

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -398,7 +398,7 @@ async fn memory_harvest_git(
                 })
                 .await
             {
-                Ok(id) => id,
+                Ok((id, _created)) => id,
                 Err(e) => {
                     eprintln!(
                         "  warning: failed to store entry '{title}' ({full_sha}), skipping: {e:#}"
@@ -761,7 +761,7 @@ async fn memory_harvest_failures(
                 })
                 .await
             {
-                Ok(id) => id,
+                Ok((id, _created)) => id,
                 Err(e) => {
                     eprintln!(
                         "  warning: failed to store entry '{title}' ({full_sha}), skipping: {e:#}"

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
@@ -425,7 +425,7 @@ pub(super) async fn harvest_claude_code(
                 })
                 .await
             {
-                Ok(id) => id,
+                Ok((id, _created)) => id,
                 Err(e) => {
                     eprintln!(
                         "  warning: failed to store entry '{title}' (session {session_id}), skipping: {e:#}"

--- a/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
@@ -543,7 +543,7 @@ fn import_batch(
                 "active"
             };
 
-            let id = store.add_note_with_created_at(
+            let (id, _created) = store.add_note_with_created_at(
                 &note.kind,
                 &note.title,
                 &note.body,
@@ -1014,7 +1014,7 @@ mod init_import_tests {
         let git_root = repo.path();
 
         let backend = GitNotesBackend::with_root(git_root.to_path_buf());
-        let id = backend
+        let (id, _created) = backend
             .add(NoteInput {
                 kind: "note".to_string(),
                 title: "retired decision".to_string(),

--- a/crates/spelunk-cli/tests/cross_project_memory.rs
+++ b/crates/spelunk-cli/tests/cross_project_memory.rs
@@ -1335,7 +1335,7 @@ fn memory_store_list_excludes_archived_by_default() {
     store
         .add_note("decision", "Active note", "body", &[], &[], None, None)
         .expect("add active note");
-    let archived_id = store
+    let (archived_id, _) = store
         .add_note("decision", "Archived note", "body", &[], &[], None, None)
         .expect("add to-be-archived note");
     store.archive(archived_id).expect("archive note");

--- a/crates/spelunk-cli/tests/memory_add_dedupe.rs
+++ b/crates/spelunk-cli/tests/memory_add_dedupe.rs
@@ -4,7 +4,7 @@
 //!
 //! Every existing test proving this behavior (`entity_id_migration.rs`'s
 //! `add_note_after_promotion_*` tests) drives `MemoryStore::add_note`
-//! directly — the storage layer, one level below the actual regression QA
+//! directly, the storage layer, one level below the actual regression QA
 //! reproduced: "`spelunk memory add` for a second time with identical
 //! kind/title/body prints 'Error: UNIQUE constraint failed: notes.entity_id'
 //! and exits 1", run against the *built CLI binary*. Nothing in the existing
@@ -117,7 +117,7 @@ fn second_identical_add_reuses_the_row_and_prints_already_recorded() {
 
     // Second add: byte-identical kind/title/body. Pre-fix this hard-crashed
     // with a raw "UNIQUE constraint failed: notes.entity_id" SQLite error and
-    // a non-zero exit — reproduced live against the built binary during the
+    // a non-zero exit, reproduced live against the built binary during the
     // original QA review this story fixes.
     memory_add_cmd(tmp.path(), &cfg, &mem_db)
         .arg("--title")
@@ -177,7 +177,7 @@ fn second_identical_add_merges_tags_into_the_existing_row() {
     );
 }
 
-// ── Criterion 34: the git-notes write-through carrier is unconditional —
+// ── Criterion 34: the git-notes write-through carrier is unconditional:
 // it appends on a reused row exactly as on a fresh one, using the SAME id ───
 
 #[test]
@@ -208,13 +208,13 @@ fn second_identical_add_still_writes_through_to_git_notes_with_the_same_id() {
     assert_eq!(
         ids.len(),
         2,
-        "criterion 34: the carrier must write on BOTH calls, reuse or not — \
+        "criterion 34: the carrier must write on BOTH calls, reuse or not, \
          got records: {ids:?}"
     );
     assert_eq!(
         ids[0], ids[1],
-        "criterion 34: both records must carry the SAME id — the reused \
-         row's, not a fresh one — so a later reader can't see two different \
+        "criterion 34: both records must carry the SAME id, the reused \
+         row's, not a fresh one, so a later reader can't see two different \
          ids for what SQLite considers a single entry"
     );
 

--- a/crates/spelunk-cli/tests/memory_add_dedupe.rs
+++ b/crates/spelunk-cli/tests/memory_add_dedupe.rs
@@ -1,0 +1,223 @@
+//! End-to-end regression tests for `spelunk memory add`'s insert-then-recover
+//! behavior once `idx_notes_entity_id` has been promoted to UNIQUE (ADR-068's
+//! fourth amendment, criteria 25-30, 33, 34).
+//!
+//! Every existing test proving this behavior (`entity_id_migration.rs`'s
+//! `add_note_after_promotion_*` tests) drives `MemoryStore::add_note`
+//! directly — the storage layer, one level below the actual regression QA
+//! reproduced: "`spelunk memory add` for a second time with identical
+//! kind/title/body prints 'Error: UNIQUE constraint failed: notes.entity_id'
+//! and exits 1", run against the *built CLI binary*. Nothing in the existing
+//! suite drives the real `spelunk` binary through this path end to end, so
+//! this file closes that gap: it proves the CLI's own output branch
+//! (criterion 33: "Stored" vs "Already recorded as") and the git-notes
+//! write-through carrier's behavior on a reuse (criterion 34) against the
+//! actual process, not just the library call it wraps.
+
+mod plumbing_helpers;
+use plumbing_helpers::{init_git_repo, spelunk_bin};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn write_config(dir: &Path, mem_db: &Path) -> PathBuf {
+    let cfg = dir.join("config.toml");
+    std::fs::write(
+        &cfg,
+        format!(
+            "db_path = {:?}\nllm_model = \"test-model\"\nstore_in_git_notes = true\n",
+            mem_db.display().to_string()
+        ),
+    )
+    .expect("write config.toml");
+    cfg
+}
+
+fn memory_add_cmd(dir: &Path, cfg: &Path, mem_db: &Path) -> Command {
+    let mut cmd = spelunk_bin();
+    cmd.current_dir(dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(cfg)
+        .arg("memory")
+        .arg("--db")
+        .arg(mem_db)
+        .arg("add")
+        .arg("--kind")
+        .arg("decision");
+    cmd
+}
+
+fn row_count(mem_db: &Path) -> i64 {
+    let conn = Connection::open(mem_db).expect("open memory.db");
+    conn.query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap_or(0)
+}
+
+fn note_tags(mem_db: &Path, id: i64) -> String {
+    let conn = Connection::open(mem_db).expect("open memory.db");
+    conn.query_row(
+        "SELECT COALESCE(tags, '') FROM notes WHERE id = ?1",
+        rusqlite::params![id],
+        |r| r.get(0),
+    )
+    .unwrap_or_default()
+}
+
+/// Parse every `{"id": ..., ...}` JSONL record out of `git notes --ref=spelunk
+/// show HEAD`, returning each record's `id` field in file order.
+fn git_note_record_ids(dir: &Path) -> Vec<i64> {
+    let out = std::process::Command::new("git")
+        .args(["notes", "--ref=spelunk", "show", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .expect("git notes show HEAD");
+    assert!(
+        out.status.success(),
+        "git notes show HEAD failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = String::from_utf8_lossy(&out.stdout);
+    text.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            let v: serde_json::Value = serde_json::from_str(l)
+                .unwrap_or_else(|e| panic!("git note line is not valid JSON: {l:?}: {e}"));
+            v["id"].as_i64().expect("record has an id field")
+        })
+        .collect()
+}
+
+// ── Criteria 25/29/30/33: a fresh insert prints "Stored", a colliding second
+// insert prints "Already recorded as", and the row count stays at 1 ─────────
+
+#[test]
+fn second_identical_add_reuses_the_row_and_prints_already_recorded() {
+    let tmp = TempDir::new().unwrap();
+    let mem_db = tmp.path().join("memory.db");
+    let cfg = write_config(tmp.path(), &mem_db);
+
+    // First add: a fresh store with zero rows promotes idx_notes_entity_id to
+    // UNIQUE on this very `open()` (zero duplicate groups trivially), so the
+    // *second* call below hits the promoted index.
+    memory_add_cmd(tmp.path(), &cfg, &mem_db)
+        .arg("--title")
+        .arg("dup entry")
+        .arg("--body")
+        .arg("same content")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [decision]"));
+
+    assert_eq!(row_count(&mem_db), 1, "first add creates one row");
+
+    // Second add: byte-identical kind/title/body. Pre-fix this hard-crashed
+    // with a raw "UNIQUE constraint failed: notes.entity_id" SQLite error and
+    // a non-zero exit — reproduced live against the built binary during the
+    // original QA review this story fixes.
+    memory_add_cmd(tmp.path(), &cfg, &mem_db)
+        .arg("--title")
+        .arg("dup entry")
+        .arg("--body")
+        .arg("same content")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Already recorded as [decision]"))
+        .stdout(predicate::str::contains("Stored [decision]").not());
+
+    assert_eq!(
+        row_count(&mem_db),
+        1,
+        "criterion 26/30: a collision must reuse the existing row, not create a second one"
+    );
+}
+
+// ── Criterion 26: tags supplied on the colliding call merge into the
+// existing row (add-wins) rather than being silently dropped ────────────────
+
+#[test]
+fn second_identical_add_merges_tags_into_the_existing_row() {
+    let tmp = TempDir::new().unwrap();
+    let mem_db = tmp.path().join("memory.db");
+    let cfg = write_config(tmp.path(), &mem_db);
+
+    memory_add_cmd(tmp.path(), &cfg, &mem_db)
+        .arg("--title")
+        .arg("dup entry")
+        .arg("--body")
+        .arg("same content")
+        .arg("--tags")
+        .arg("alpha")
+        .assert()
+        .success();
+
+    memory_add_cmd(tmp.path(), &cfg, &mem_db)
+        .arg("--title")
+        .arg("dup entry")
+        .arg("--body")
+        .arg("same content")
+        .arg("--tags")
+        .arg("beta")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Already recorded as"));
+
+    let conn = Connection::open(&mem_db).unwrap();
+    let id: i64 = conn
+        .query_row("SELECT id FROM notes LIMIT 1", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        note_tags(&mem_db, id),
+        "alpha,beta",
+        "criterion 26: tags must union add-wins, neither dropped"
+    );
+}
+
+// ── Criterion 34: the git-notes write-through carrier is unconditional —
+// it appends on a reused row exactly as on a fresh one, using the SAME id ───
+
+#[test]
+fn second_identical_add_still_writes_through_to_git_notes_with_the_same_id() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    let mem_db = tmp.path().join("memory.db");
+    let cfg = write_config(tmp.path(), &mem_db);
+
+    memory_add_cmd(tmp.path(), &cfg, &mem_db)
+        .arg("--title")
+        .arg("dup entry")
+        .arg("--body")
+        .arg("same content")
+        .assert()
+        .success();
+
+    memory_add_cmd(tmp.path(), &cfg, &mem_db)
+        .arg("--title")
+        .arg("dup entry")
+        .arg("--body")
+        .arg("same content")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Already recorded as"));
+
+    let ids = git_note_record_ids(tmp.path());
+    assert_eq!(
+        ids.len(),
+        2,
+        "criterion 34: the carrier must write on BOTH calls, reuse or not — \
+         got records: {ids:?}"
+    );
+    assert_eq!(
+        ids[0], ids[1],
+        "criterion 34: both records must carry the SAME id — the reused \
+         row's, not a fresh one — so a later reader can't see two different \
+         ids for what SQLite considers a single entry"
+    );
+
+    // SQLite itself agrees there is exactly one row.
+    assert_eq!(row_count(&mem_db), 1);
+}

--- a/crates/spelunk-core/src/storage/backend.rs
+++ b/crates/spelunk-core/src/storage/backend.rs
@@ -26,7 +26,13 @@ pub struct NoteInput {
 /// Abstraction over local SQLite and remote HTTP memory stores.
 #[async_trait]
 pub trait MemoryBackend: Send {
-    async fn add(&self, input: NoteInput) -> Result<i64>;
+    /// Returns `(id, created)`. `created` is `true` for a genuinely new entry,
+    /// `false` when the write collided with an existing entry's `entity_id`
+    /// and that entry was reused instead (only possible on a local SQLite
+    /// backend whose `idx_notes_entity_id` has been promoted to UNIQUE — see
+    /// `MemoryStore::add_note`). Backends that cannot detect this (git notes,
+    /// remote) always return `true`.
+    async fn add(&self, input: NoteInput) -> Result<(i64, bool)>;
     /// Semantic search over ALL notes (incl. archived), ordered by valid_at/created_at ASC.
     ///
     /// `query`: the raw query text. Local backends search by `query_blob` (a
@@ -117,12 +123,16 @@ impl LocalMemoryBackend {
 
 #[async_trait]
 impl MemoryBackend for LocalMemoryBackend {
-    async fn add(&self, input: NoteInput) -> Result<i64> {
+    async fn add(&self, input: NoteInput) -> Result<(i64, bool)> {
         let store = self.store.lock().await;
         let tags: Vec<&str> = input.tags.iter().map(String::as_str).collect();
         let files: Vec<&str> = input.linked_files.iter().map(String::as_str).collect();
-        let id = if let Some(supersedes_id) = input.supersedes {
-            store.add_note_superseding(
+        let (id, created) = if let Some(supersedes_id) = input.supersedes {
+            // `add_note_superseding` doesn't populate `entity_id` at insert
+            // time today, so it cannot hit the UNIQUE-collision path
+            // `add_note` recovers from below; every call here is a fresh
+            // insert.
+            let id = store.add_note_superseding(
                 &input.kind,
                 &input.title,
                 &input.body,
@@ -130,7 +140,8 @@ impl MemoryBackend for LocalMemoryBackend {
                 &files,
                 input.valid_at,
                 supersedes_id,
-            )?
+            )?;
+            (id, true)
         } else {
             store.add_note(
                 &input.kind,
@@ -145,7 +156,7 @@ impl MemoryBackend for LocalMemoryBackend {
         if let Some(blob) = &input.embedding {
             store.insert_embedding(id, blob)?;
         }
-        Ok(id)
+        Ok((id, created))
     }
 
     async fn search_timeline(

--- a/crates/spelunk-core/src/storage/backend.rs
+++ b/crates/spelunk-core/src/storage/backend.rs
@@ -29,7 +29,7 @@ pub trait MemoryBackend: Send {
     /// Returns `(id, created)`. `created` is `true` for a genuinely new entry,
     /// `false` when the write collided with an existing entry's `entity_id`
     /// and that entry was reused instead (only possible on a local SQLite
-    /// backend whose `idx_notes_entity_id` has been promoted to UNIQUE — see
+    /// backend whose `idx_notes_entity_id` has been promoted to UNIQUE, see
     /// `MemoryStore::add_note`). Backends that cannot detect this (git notes,
     /// remote) always return `true`.
     async fn add(&self, input: NoteInput) -> Result<(i64, bool)>;
@@ -46,7 +46,7 @@ pub trait MemoryBackend: Send {
     ) -> Result<Vec<Note>>;
     /// Semantic (vector KNN) search.
     ///
-    /// `query`: the raw query text — see `search_timeline` for why both
+    /// `query`: the raw query text, see `search_timeline` for why both
     /// `query_blob` and `query` are passed to every backend.
     /// `as_of`: if set, only entries valid at that Unix timestamp are returned.
     async fn search(

--- a/crates/spelunk-core/src/storage/git_notes/backend_impl.rs
+++ b/crates/spelunk-core/src/storage/git_notes/backend_impl.rs
@@ -9,7 +9,7 @@ use super::GitNotesBackend;
 
 #[async_trait]
 impl MemoryBackend for GitNotesBackend {
-    async fn add(&self, input: NoteInput) -> Result<i64> {
+    async fn add(&self, input: NoteInput) -> Result<(i64, bool)> {
         let id = now_millis();
         let entity_id =
             crate::storage::entity_id::entity_id(&input.kind, &input.title, &input.body);
@@ -35,7 +35,9 @@ impl MemoryBackend for GitNotesBackend {
         let head = self.head_sha().await?;
         self.append_record(&head, &record).await?;
 
-        Ok(id)
+        // Git notes are append-only: this backend never detects or collapses
+        // a collision, so every add is reported as a fresh insert.
+        Ok((id, true))
     }
 
     async fn list(

--- a/crates/spelunk-core/src/storage/memory/dedupe/superseded_by_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/superseded_by_tests.rs
@@ -17,10 +17,10 @@ use super::*;
 #[test]
 fn adoption_must_not_selfloop_when_a_loser_points_at_the_survivor() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
     // loser was (per this row) "superseded by" the survivor itself.
@@ -58,13 +58,13 @@ fn adoption_must_not_selfloop_when_a_loser_points_at_the_survivor() {
 #[test]
 fn adoption_must_not_dangle_when_a_loser_points_at_a_fellow_loser() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
     // loser_a claims to be "superseded by" loser_b, a fellow member of
@@ -114,16 +114,16 @@ fn adoption_must_not_dangle_when_a_loser_points_at_a_fellow_loser() {
 #[test]
 fn adoption_survivor_own_in_group_pointer_does_not_clobber_fallthrough_adoption() {
     let store = open_store();
-    let external = store
+    let (external, _) = store
         .add_note("note", "external target", "b", &[], &[], None, None)
         .unwrap();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_x = store
+    let (loser_x, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_y = store
+    let (loser_y, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
     // Survivor's own pre-existing value points at a fellow duplicate
@@ -158,19 +158,19 @@ fn adoption_survivor_own_in_group_pointer_does_not_clobber_fallthrough_adoption(
 #[test]
 fn fallthrough_adoption_skips_intragroup_dangling_candidate_and_adopts_later_external_one() {
     let store = open_store();
-    let external = store
+    let (external, _) = store
         .add_note("note", "external target", "b", &[], &[], None, None)
         .unwrap();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser_c = store
+    let (loser_c, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
         .unwrap();
     // loser_a (earliest loser, first candidate in iteration order) points
@@ -198,13 +198,13 @@ fn fallthrough_adoption_skips_intragroup_dangling_candidate_and_adopts_later_ext
 #[test]
 fn adoption_resolves_to_none_when_every_candidate_is_intragroup() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
     // loser_a -> loser_b and loser_b -> survivor: every candidate value
@@ -244,13 +244,13 @@ fn adoption_resolves_to_none_when_every_candidate_is_intragroup() {
 #[test]
 fn later_loser_pointing_at_earlier_fellow_loser_must_not_break_deletion_order() {
     let store = open_store();
-    let _survivor = store
+    let (_survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_early = store
+    let (loser_early, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_late = store
+    let (loser_late, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
     // loser_late (deleted SECOND, per created_at ASC order) points at
@@ -285,13 +285,13 @@ fn later_loser_pointing_at_earlier_fellow_loser_must_not_break_deletion_order() 
 #[test]
 fn mutually_referencing_fellow_losers_must_not_break_deletion_order() {
     let store = open_store();
-    let _survivor = store
+    let (_survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
     store.set_superseded_by(loser_a, loser_b).unwrap();
@@ -320,22 +320,22 @@ fn mutually_referencing_fellow_losers_must_not_break_deletion_order() {
 #[test]
 fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_deterministically() {
     let store = open_store();
-    let external_a = store
+    let (external_a, _) = store
         .add_note("note", "external a", "b", &[], &[], None, None)
         .unwrap();
-    let external_b = store
+    let (external_b, _) = store
         .add_note("note", "external b", "b", &[], &[], None, None)
         .unwrap();
-    let _survivor = store
+    let (_survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser1 = store
+    let (loser1, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser2 = store
+    let (loser2, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser3 = store
+    let (loser3, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
         .unwrap();
     // loser1 (earliest loser, first candidate in iteration order) chains
@@ -365,22 +365,22 @@ fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_determin
     // resolution and counts on a second, independent run (not just
     // repeatable within one process — a genuinely fresh grouping pass).
     let store2 = open_store();
-    let external_a2 = store2
+    let (external_a2, _) = store2
         .add_note("note", "external a", "b", &[], &[], None, None)
         .unwrap();
-    let external_b2 = store2
+    let (external_b2, _) = store2
         .add_note("note", "external b", "b", &[], &[], None, None)
         .unwrap();
-    let survivor2 = store2
+    let (survivor2, _) = store2
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser1b = store2
+    let (loser1b, _) = store2
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser2b = store2
+    let (loser2b, _) = store2
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser3b = store2
+    let (loser3b, _) = store2
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
         .unwrap();
     store2.set_superseded_by(loser1b, loser2b).unwrap();
@@ -437,16 +437,16 @@ fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_determin
 fn external_row_that_is_itself_a_duplicate_in_a_different_group_is_resolved_correctly_across_groups()
  {
     let store = open_store();
-    let survivor_a = store
+    let (survivor_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let survivor_b = store
+    let (survivor_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 150)
         .unwrap();
-    let external_x = store
+    let (external_x, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 250)
         .unwrap();
     // external_x is a loser in group B, but its own pre-existing
@@ -501,19 +501,19 @@ fn external_row_that_is_itself_a_duplicate_in_a_different_group_is_resolved_corr
 #[test]
 fn chained_cross_group_reference_resolves_one_hop_not_to_intermediate_loser() {
     let store = open_store();
-    let survivor_a = store
+    let (survivor_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let survivor_b = store
+    let (survivor_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 150)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 250)
         .unwrap();
-    let survivor_c = store
+    let (survivor_c, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 175)
         .unwrap();
-    let loser_c = store
+    let (loser_c, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 275)
         .unwrap();
     // A's survivor points at B's loser; B's survivor independently points
@@ -564,26 +564,26 @@ fn ordinary_note_outside_every_group_pointing_at_a_loser_is_rewritten_and_counte
     let store = open_store();
     // Three unrelated duplicate groups, present purely as bookkeeping
     // noise / potential id-collision surface for note_group_of.
-    let _survivor_a = store
+    let (_survivor_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let _loser_a = store
+    let (_loser_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 110)
         .unwrap();
-    let survivor_b = store
+    let (survivor_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 120)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 130)
         .unwrap();
-    let _survivor_c = store
+    let (_survivor_c, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 140)
         .unwrap();
-    let _loser_c = store
+    let (_loser_c, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 150)
         .unwrap();
     // An ordinary, wholly unique note: not a member of any group above.
-    let ordinary = store
+    let (ordinary, _) = store
         .add_note("note", "ordinary unique note", "body", &[], &[], None, None)
         .unwrap();
     store.set_superseded_by(ordinary, loser_b).unwrap();
@@ -624,22 +624,22 @@ fn three_group_reference_cycle_resolves_identically_under_two_processing_orders(
     // be ordered A, B, C, since that's each group's earliest-created_at
     // order too).
     let store1 = open_store();
-    let survivor_a1 = store1
+    let (survivor_a1, _) = store1
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a1 = store1
+    let (loser_a1, _) = store1
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 110)
         .unwrap();
-    let survivor_b1 = store1
+    let (survivor_b1, _) = store1
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b1 = store1
+    let (loser_b1, _) = store1
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 210)
         .unwrap();
-    let survivor_c1 = store1
+    let (survivor_c1, _) = store1
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser_c1 = store1
+    let (loser_c1, _) = store1
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 310)
         .unwrap();
     store1.set_superseded_by(survivor_a1, loser_b1).unwrap();
@@ -653,22 +653,22 @@ fn three_group_reference_cycle_resolves_identically_under_two_processing_orders(
     // `duplicate_groups`' earliest-created_at-derived vector order is
     // C, A, B instead of A, B, C.
     let store2 = open_store();
-    let survivor_c2 = store2
+    let (survivor_c2, _) = store2
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_c2 = store2
+    let (loser_c2, _) = store2
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 110)
         .unwrap();
-    let survivor_a2 = store2
+    let (survivor_a2, _) = store2
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_a2 = store2
+    let (loser_a2, _) = store2
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 210)
         .unwrap();
-    let survivor_b2 = store2
+    let (survivor_b2, _) = store2
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser_b2 = store2
+    let (loser_b2, _) = store2
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 310)
         .unwrap();
     store2.set_superseded_by(survivor_a2, loser_b2).unwrap();
@@ -733,28 +733,28 @@ fn three_group_reference_cycle_resolves_identically_under_two_processing_orders(
 #[test]
 fn hand_derived_summary_counts_match_multi_group_scenario_exactly() {
     let store = open_store();
-    let survivor_a = store
+    let (survivor_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a1 = store
+    let (loser_a1, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 110)
         .unwrap();
-    let loser_a2 = store
+    let (loser_a2, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 120)
         .unwrap();
-    let survivor_b = store
+    let (survivor_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b1 = store
+    let (loser_b1, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 210)
         .unwrap();
-    let survivor_c = store
+    let (survivor_c, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser_c1 = store
+    let (loser_c1, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 310)
         .unwrap();
-    let ordinary = store
+    let (ordinary, _) = store
         .add_note("note", "ordinary unique note", "body", &[], &[], None, None)
         .unwrap();
 
@@ -811,7 +811,7 @@ fn hand_derived_summary_counts_match_multi_group_scenario_exactly() {
 fn tied_created_at_breaks_deterministically_on_lower_id() {
     for _ in 0..5 {
         let store = open_store();
-        let first = store
+        let (first, _) = store
             .add_note_with_created_at(
                 "decision",
                 "tied dup",
@@ -823,7 +823,7 @@ fn tied_created_at_breaks_deterministically_on_lower_id() {
                 500,
             )
             .unwrap();
-        let second = store
+        let (second, _) = store
             .add_note_with_created_at(
                 "decision",
                 "tied dup",
@@ -875,10 +875,10 @@ fn duplicate_group_built_via_add_note_superseding_repoints_old_rows_to_survivor(
          still create two distinct rows for identical content"
     );
 
-    let old1 = store
+    let (old1, _) = store
         .add_note("decision", "old one", "old body one", &[], &[], None, None)
         .unwrap();
-    let old2 = store
+    let (old2, _) = store
         .add_note("decision", "old two", "old body two", &[], &[], None, None)
         .unwrap();
 

--- a/crates/spelunk-core/src/storage/memory/dedupe/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/tests.rs
@@ -31,7 +31,7 @@ fn zero_duplicates_reports_all_zero_and_writes_nothing() {
 #[test]
 fn dry_run_reports_counts_and_writes_nothing() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -43,7 +43,7 @@ fn dry_run_reports_counts_and_writes_nothing() {
             100,
         )
         .unwrap();
-    let _loser = store
+    let (_loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &["b"], &[], None, "active", 200)
         .unwrap();
 
@@ -79,10 +79,10 @@ fn dry_run_reports_counts_and_writes_nothing() {
 #[test]
 fn real_run_collapses_group_survivor_is_earliest_created() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
 
@@ -101,7 +101,7 @@ fn real_run_collapses_group_survivor_is_earliest_created() {
 #[test]
 fn tags_and_linked_files_union_add_wins() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -141,7 +141,7 @@ fn tags_and_linked_files_union_add_wins() {
 #[test]
 fn any_archived_row_makes_survivor_archived() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
     store
@@ -157,7 +157,7 @@ fn any_archived_row_makes_survivor_archived() {
 #[test]
 fn no_archived_row_leaves_survivor_status_unchanged() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
     store
@@ -173,13 +173,13 @@ fn no_archived_row_leaves_survivor_status_unchanged() {
 #[test]
 fn survivor_adopts_lone_superseded_by_from_group() {
     let store = open_store();
-    let elsewhere = store
+    let (elsewhere, _) = store
         .add_note("note", "elsewhere target", "b", &[], &[], None, None)
         .unwrap();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
     store.set_superseded_by(loser, elsewhere).unwrap();
@@ -193,17 +193,17 @@ fn survivor_adopts_lone_superseded_by_from_group() {
 #[test]
 fn conflicting_superseded_by_earliest_wins_no_error() {
     let store = open_store();
-    let target_a = store
+    let (target_a, _) = store
         .add_note("note", "a", "b", &[], &[], None, None)
         .unwrap();
-    let target_b = store
+    let (target_b, _) = store
         .add_note("note", "b", "b", &[], &[], None, None)
         .unwrap();
 
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
     store.set_superseded_by(survivor, target_a).unwrap();
@@ -223,13 +223,13 @@ fn conflicting_superseded_by_earliest_wins_no_error() {
 #[test]
 fn edge_elsewhere_pointing_at_loser_is_repointed_to_survivor() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let dependent = store
+    let (dependent, _) = store
         .add_note("note", "points at loser", "b", &[], &[], None, None)
         .unwrap();
     store.set_superseded_by(dependent, loser).unwrap();
@@ -244,10 +244,10 @@ fn edge_elsewhere_pointing_at_loser_is_repointed_to_survivor() {
 #[test]
 fn rewrite_that_would_self_point_is_dropped_to_null() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
     // The survivor itself already points at its own duplicate-group loser.
@@ -266,10 +266,10 @@ fn rewrite_that_would_self_point_is_dropped_to_null() {
 #[test]
 fn loser_embedding_deleted_survivor_embedding_untouched() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
     // note_embeddings is FLOAT[896]: 896 * 4-byte floats per row.
@@ -339,7 +339,7 @@ fn injected_fault_partway_rolls_back_whole_run() {
 #[test]
 fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byte() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -351,7 +351,7 @@ fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byt
             100,
         )
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -363,7 +363,7 @@ fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byt
             200,
         )
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -375,7 +375,7 @@ fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byt
             300,
         )
         .unwrap();
-    let external = store
+    let (external, _) = store
         .add_note("note", "external dependent", "b", &[], &[], None, None)
         .unwrap();
     // external's supersede edge points at loser_a; a fully-correct
@@ -426,7 +426,7 @@ fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byt
 #[test]
 fn dry_run_leaves_full_db_state_byte_for_byte_unchanged() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -438,7 +438,7 @@ fn dry_run_leaves_full_db_state_byte_for_byte_unchanged() {
             100,
         )
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -450,7 +450,7 @@ fn dry_run_leaves_full_db_state_byte_for_byte_unchanged() {
             200,
         )
         .unwrap();
-    let external = store
+    let (external, _) = store
         .add_note("note", "external", "b", &[], &[], None, None)
         .unwrap();
     store.supersede(external, loser).unwrap();
@@ -478,19 +478,19 @@ fn dry_run_leaves_full_db_state_byte_for_byte_unchanged() {
 #[test]
 fn multiple_external_rows_pointing_at_different_losers_all_repoint_to_survivor() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let dep_a = store
+    let (dep_a, _) = store
         .add_note("note", "points at loser_a", "b", &[], &[], None, None)
         .unwrap();
-    let dep_b = store
+    let (dep_b, _) = store
         .add_note("note", "points at loser_b", "b", &[], &[], None, None)
         .unwrap();
     store.set_superseded_by(dep_a, loser_a).unwrap();
@@ -516,16 +516,16 @@ fn multiple_external_rows_pointing_at_different_losers_all_repoint_to_survivor()
 #[test]
 fn loser_deletion_removes_memory_edges_in_both_directions_no_orphan() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let other_a = store
+    let (other_a, _) = store
         .add_note("note", "a", "b", &[], &[], None, None)
         .unwrap();
-    let other_b = store
+    let (other_b, _) = store
         .add_note("note", "b", "b", &[], &[], None, None)
         .unwrap();
     // loser -> other_a (loser is from_id) and other_b -> loser (loser is to_id).
@@ -559,13 +559,13 @@ fn loser_deletion_removes_memory_edges_in_both_directions_no_orphan() {
 #[test]
 fn relates_to_edge_to_external_note_is_dropped_not_repointed_known_gap() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let external = store
+    let (external, _) = store
         .add_note("note", "external relation", "b", &[], &[], None, None)
         .unwrap();
     store.add_edge(loser, external, "relates_to").unwrap();

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs
@@ -90,7 +90,7 @@ fn add_note_after_promotion_does_not_hard_crash_on_duplicate_content() {
         "criterion 30: the bool must be false for a reused row"
     );
 
-    // Only one row exists — no phantom second insert survived underneath
+    // Only one row exists: no phantom second insert survived underneath
     // the recovery path.
     assert_eq!(
         store.count().unwrap(),
@@ -145,7 +145,7 @@ fn add_note_after_promotion_merges_tags_and_linked_files_into_existing_row() {
 }
 
 // Criterion 27: the collision path must not touch status or superseded_by
-// on the existing row — mirrors reconcile.rs's own existing-row handling,
+// on the existing row, mirrors reconcile.rs's own existing-row handling,
 // not dedupe.rs's fuller merge (a different scenario: collapsing two rows
 // that already diverged, not a single fresh insert colliding with one).
 #[test]

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs
@@ -1,0 +1,280 @@
+//! ADR-068 fourth amendment coverage: `add_note`'s insert-then-recover
+//! behavior once `idx_notes_entity_id` is promoted to UNIQUE.
+
+use super::test_support::*;
+
+// ── Adversarial (QA final review): the public `add_note` API, not the
+// raw SQL layer, hitting the promoted index with duplicate content.
+//
+// The previous test intentionally documents that a raw duplicate INSERT
+// *should* be rejected at the SQL level once the index is promoted —
+// that's the index doing its job. This test is about a level up: does
+// anything in the codebase catch that rejection before it reaches a
+// real caller? Nothing does. `MemoryStore::add_note` (used directly by
+// `spelunk memory add`, the most common write path in the CLI, per
+// CLAUDE.md's own agent-workflow guidance to run it "as you make
+// decisions") performs a bare `INSERT` with no pre-check and no error
+// handling for a UNIQUE-constraint rejection.
+//
+// Once Step B has promoted `idx_notes_entity_id` to UNIQUE — which, per
+// AC5, happens on the very next `MemoryStore::open` of *any* store with
+// zero duplicate groups, the overwhelmingly common steady state for a
+// real project — the very next `spelunk memory add` (or a harvest/reconcile
+// retry) that happens to submit byte-identical `kind`/`title`/`body`
+// content to something already stored no longer succeeds. It hard-fails
+// with a raw, low-level SQLite error surfaced straight to the user
+// ("Error: UNIQUE constraint failed: notes.entity_id"), reproduced
+// directly against a real built binary during this review.
+//
+// This directly contradicts this story's own ADR-068 third-amendment
+// decision text: "Excluding `created_at` from identity is settled... The
+// consequence, recording byte-identical `kind`/`title`/`body` twice now
+// yields one entry, is accepted." "Yields one entry" describes a graceful,
+// idempotent-ish outcome, not an unhandled crash. None of this story's
+// 24 acceptance criteria or five rounds of adversarial testing exercised
+// this interaction: every round was scoped to `dedupe.rs`'s own collapse
+// logic (the DELETE path), never to the ordinary INSERT path colliding
+// with the index `entity_id_migration.rs` newly promotes.
+#[test]
+fn add_note_after_promotion_does_not_hard_crash_on_duplicate_content() {
+    let store = open_store();
+    let (first_id, first_created) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    assert!(
+        first_created,
+        "criterion 25: a genuinely new row inserts fine"
+    );
+
+    // Zero duplicate groups at this point: promotes immediately, exactly
+    // as a real `MemoryStore::open` would on this store's very next open.
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(index_is_unique(&store), "precondition: index is now UNIQUE");
+
+    // The exact scenario the ADR's third amendment says "yields one
+    // entry": a second, ordinary `add_note` call for byte-identical
+    // kind/title/body content.
+    let result = store.add_note(
+        "decision",
+        "dup entry",
+        "same content",
+        &[],
+        &[],
+        None,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "BUG: after Step B promotes idx_notes_entity_id to UNIQUE (the \
+         very next open of any store with zero duplicate groups, the \
+         common case), a plain `memory add` of byte-identical \
+         kind/title/body content hard-fails with a raw UNIQUE constraint \
+         SQL error instead of the 'yields one entry' outcome ADR-068's \
+         third amendment says is the accepted consequence of excluding \
+         created_at from identity. Reproduced live against the built \
+         CLI binary: `spelunk memory add` for a second time with \
+         identical kind/title/body prints \
+         'Error: UNIQUE constraint failed: notes.entity_id' and exits 1. \
+         Underlying error: {:?}",
+        result.as_ref().err()
+    );
+
+    // Criterion 26/30: the reused row's id is returned with created=false.
+    let (second_id, second_created) = result.unwrap();
+    assert_eq!(
+        second_id, first_id,
+        "criterion 26: a collision must return the EXISTING row's id"
+    );
+    assert!(
+        !second_created,
+        "criterion 30: the bool must be false for a reused row"
+    );
+
+    // Only one row exists — no phantom second insert survived underneath
+    // the recovery path.
+    assert_eq!(
+        store.count().unwrap(),
+        1,
+        "the collision must not leave behind a second row"
+    );
+}
+
+// Criterion 26: tags/linked_files on the call that collides must merge
+// (add-wins) into the existing row rather than being dropped.
+#[test]
+fn add_note_after_promotion_merges_tags_and_linked_files_into_existing_row() {
+    let store = open_store();
+    let (id, _) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &["alpha"],
+            &["a.rs"],
+            None,
+            None,
+        )
+        .unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+
+    let (reused_id, created) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &["beta"],
+            &["b.rs"],
+            None,
+            None,
+        )
+        .unwrap();
+    assert_eq!(reused_id, id);
+    assert!(!created);
+
+    let note = store.get(id).unwrap().expect("row still exists");
+    assert_eq!(
+        note.tags,
+        vec!["alpha".to_string(), "beta".to_string()],
+        "tags must union, add-wins, existing tag never dropped"
+    );
+    assert_eq!(
+        note.linked_files,
+        vec!["a.rs".to_string(), "b.rs".to_string()],
+        "linked_files must union the same way"
+    );
+}
+
+// Criterion 27: the collision path must not touch status or superseded_by
+// on the existing row — mirrors reconcile.rs's own existing-row handling,
+// not dedupe.rs's fuller merge (a different scenario: collapsing two rows
+// that already diverged, not a single fresh insert colliding with one).
+#[test]
+fn add_note_after_promotion_does_not_touch_status_or_superseded_by() {
+    let store = open_store();
+    let (other_id, _) = store
+        .add_note("note", "unrelated", "b", &[], &[], None, None)
+        .unwrap();
+    let (id, _) = store
+        .add_note_with_created_at(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            "archived",
+            100,
+        )
+        .unwrap();
+    store.set_superseded_by(id, other_id).unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+
+    let (reused_id, created) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    assert_eq!(reused_id, id);
+    assert!(!created);
+
+    let note = store.get(id).unwrap().expect("row still exists");
+    assert_eq!(
+        note.status, "archived",
+        "criterion 27: status must be left untouched by the collision path"
+    );
+    assert_eq!(
+        note.superseded_by,
+        Some(other_id),
+        "criterion 27: superseded_by must be left untouched by the collision path"
+    );
+}
+
+// Criterion 29: before promotion (the common case while duplicate groups
+// still exist), identical content must keep inserting distinct rows —
+// this is the very mechanism dedupe.rs's own fixtures rely on to build
+// duplicate-group scenarios in the first place.
+#[test]
+fn add_note_before_promotion_still_inserts_distinct_rows_for_identical_content() {
+    let store = open_store();
+    assert!(!index_is_unique(&store), "precondition: not yet promoted");
+
+    let (first_id, first_created) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    let (second_id, second_created) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+
+    assert!(first_created);
+    assert!(
+        second_created,
+        "pre-promotion, a second identical insert must still be a fresh row"
+    );
+    assert_ne!(first_id, second_id);
+    assert_eq!(store.count().unwrap(), 2);
+}
+
+// ── Criterion 28: any error other than the specific notes.entity_id
+// UNIQUE violation must propagate unchanged, not be swallowed by the
+// collision-recovery match arm. Exercised via a synthetic trigger that
+// raises a distinct error for a specific title, so the failure is
+// unambiguously NOT a UNIQUE-on-entity_id violation.
+#[test]
+fn add_note_other_error_propagates_unchanged_not_swallowed_as_collision() {
+    let store = open_store();
+    store
+        .conn
+        .execute_batch(
+            "CREATE TRIGGER reject_specific_title
+             BEFORE INSERT ON notes
+             WHEN NEW.title = 'trigger-reject'
+             BEGIN SELECT RAISE(ABORT, 'synthetic non-unique failure'); END;",
+        )
+        .unwrap();
+
+    let result = store.add_note("note", "trigger-reject", "body", &[], &[], None, None);
+    assert!(
+        result.is_err(),
+        "criterion 28: a non-UNIQUE error must propagate, not be swallowed"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("synthetic non-unique failure"),
+        "expected the synthetic trigger error to propagate verbatim, got: {msg}"
+    );
+    let total_rows: i64 = store
+        .conn
+        .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(total_rows, 0, "a failed insert must leave no row behind");
+}

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs
@@ -3,38 +3,30 @@
 
 use super::test_support::*;
 
-// ── Adversarial (QA final review): the public `add_note` API, not the
-// raw SQL layer, hitting the promoted index with duplicate content.
+// Adversarial (QA final review): the public `add_note` API, not the raw
+// SQL layer, hitting the promoted index with duplicate content.
 //
-// The previous test intentionally documents that a raw duplicate INSERT
-// *should* be rejected at the SQL level once the index is promoted —
-// that's the index doing its job. This test is about a level up: does
-// anything in the codebase catch that rejection before it reaches a
-// real caller? Nothing does. `MemoryStore::add_note` (used directly by
-// `spelunk memory add`, the most common write path in the CLI, per
-// CLAUDE.md's own agent-workflow guidance to run it "as you make
-// decisions") performs a bare `INSERT` with no pre-check and no error
-// handling for a UNIQUE-constraint rejection.
+// A raw duplicate INSERT should be rejected at the SQL level once the
+// index is promoted (the previous test proves that; that's the index
+// doing its job). But nothing in the codebase catches that rejection
+// before it reaches a real caller: `MemoryStore::add_note` (used
+// directly by `spelunk memory add`, the most common write path) performs
+// a bare INSERT with no pre-check and no error handling for it.
 //
-// Once Step B has promoted `idx_notes_entity_id` to UNIQUE — which, per
-// AC5, happens on the very next `MemoryStore::open` of *any* store with
-// zero duplicate groups, the overwhelmingly common steady state for a
-// real project — the very next `spelunk memory add` (or a harvest/reconcile
-// retry) that happens to submit byte-identical `kind`/`title`/`body`
-// content to something already stored no longer succeeds. It hard-fails
-// with a raw, low-level SQLite error surfaced straight to the user
+// Once Step B promotes `idx_notes_entity_id` to UNIQUE (per AC5, on the
+// very next open of any store with zero duplicate groups, the
+// overwhelmingly common steady state), the next `spelunk memory add` (or
+// a harvest/reconcile retry) submitting byte-identical kind/title/body
+// content hard-fails with a raw SQLite error surfaced to the user
 // ("Error: UNIQUE constraint failed: notes.entity_id"), reproduced
-// directly against a real built binary during this review.
+// directly against a real built binary.
 //
-// This directly contradicts this story's own ADR-068 third-amendment
-// decision text: "Excluding `created_at` from identity is settled... The
-// consequence, recording byte-identical `kind`/`title`/`body` twice now
-// yields one entry, is accepted." "Yields one entry" describes a graceful,
-// idempotent-ish outcome, not an unhandled crash. None of this story's
-// 24 acceptance criteria or five rounds of adversarial testing exercised
-// this interaction: every round was scoped to `dedupe.rs`'s own collapse
-// logic (the DELETE path), never to the ordinary INSERT path colliding
-// with the index `entity_id_migration.rs` newly promotes.
+// This contradicts the third amendment's own decision text: recording
+// byte-identical kind/title/body twice "yields one entry" and "is
+// accepted". None of the 24 acceptance criteria or five rounds of
+// adversarial testing exercised this: every round was scoped to
+// `dedupe.rs`'s own collapse (DELETE) path, never the ordinary INSERT
+// colliding with the index `entity_id_migration.rs` newly promotes.
 #[test]
 fn add_note_after_promotion_does_not_hard_crash_on_duplicate_content() {
     let store = open_store();
@@ -204,8 +196,8 @@ fn add_note_after_promotion_does_not_touch_status_or_superseded_by() {
 }
 
 // Criterion 29: before promotion (the common case while duplicate groups
-// still exist), identical content must keep inserting distinct rows —
-// this is the very mechanism dedupe.rs's own fixtures rely on to build
+// still exist), identical content must keep inserting distinct rows:
+// the very mechanism dedupe.rs's own fixtures rely on to build
 // duplicate-group scenarios in the first place.
 #[test]
 fn add_note_before_promotion_still_inserts_distinct_rows_for_identical_content() {

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
@@ -51,7 +51,7 @@ fn backfill_on_fully_populated_store_is_noop() {
 #[test]
 fn backfill_leaves_already_stamped_rows_untouched() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("decision", "already stamped", "body", &[], &[], None, None)
         .unwrap();
     let before: String = store
@@ -199,7 +199,7 @@ fn promote_skips_rescan_once_marker_present() {
 #[test]
 fn promote_after_manual_collapse_to_zero_duplicates_succeeds() {
     let store = open_store();
-    let survivor_id = store
+    let (survivor_id, _) = store
         .add_note_with_created_at(
             "note",
             "dup title",
@@ -211,7 +211,7 @@ fn promote_after_manual_collapse_to_zero_duplicates_succeeds() {
             1_700_000_000,
         )
         .unwrap();
-    let loser_id = store
+    let (loser_id, _) = store
         .add_note_with_created_at(
             "note",
             "dup title",

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs
@@ -116,6 +116,8 @@ impl MemoryStore {
 }
 
 #[cfg(test)]
+mod collision_recovery_tests;
+#[cfg(test)]
 mod migration_tests;
 #[cfg(test)]
 mod test_support;

--- a/crates/spelunk-core/src/storage/memory/notes.rs
+++ b/crates/spelunk-core/src/storage/memory/notes.rs
@@ -81,8 +81,12 @@ pub(super) fn split_csv(s: Option<&str>) -> Vec<String> {
 // ── MemoryStore note methods ─────────────────────────────────────────────────
 
 impl MemoryStore {
-    /// Insert a note and return its id. Does not store an embedding —
-    /// call `insert_embedding` afterwards if the embedder is available.
+    /// Insert a note and return `(id, created)`. `created` is `true` when a
+    /// genuinely new row was inserted, `false` when the insert collided with
+    /// an existing row's `entity_id` (only possible once `idx_notes_entity_id`
+    /// has been promoted to UNIQUE — see `entity_id_migration.rs`) and that
+    /// existing row was reused instead. Does not store an embedding on a fresh
+    /// insert — call `insert_embedding` afterwards if the embedder is available.
     #[allow(clippy::too_many_arguments)]
     pub fn add_note(
         &self,
@@ -93,8 +97,9 @@ impl MemoryStore {
         linked_files: &[&str],
         source_ref: Option<&str>,
         valid_at: Option<i64>,
-    ) -> Result<i64> {
-        self.conn.execute(
+    ) -> Result<(i64, bool)> {
+        let entity_id = crate::storage::entity_id::entity_id(kind, title, body);
+        let result = self.conn.execute(
             "INSERT INTO notes \
              (kind, title, body, tags, linked_files, source_ref, valid_at, entity_id)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
@@ -106,10 +111,10 @@ impl MemoryStore {
                 linked_files.join(","),
                 source_ref,
                 valid_at,
-                crate::storage::entity_id::entity_id(kind, title, body),
+                entity_id,
             ],
-        )?;
-        Ok(self.conn.last_insert_rowid())
+        );
+        self.recover_from_entity_id_collision(result, &entity_id, tags, linked_files)
     }
 
     /// Insert a note with an explicit `created_at` timestamp (unix epoch seconds).
@@ -117,6 +122,8 @@ impl MemoryStore {
     /// Used by `memory reconcile` to preserve the original creation timestamp
     /// from the source store. All other callers should use `add_note`, which
     /// defers to the SQLite `DEFAULT (unixepoch())`.
+    ///
+    /// Returns `(id, created)` — see `add_note` for what `created` means.
     #[allow(clippy::too_many_arguments)]
     pub fn add_note_with_created_at(
         &self,
@@ -128,8 +135,9 @@ impl MemoryStore {
         source_ref: Option<&str>,
         status: &str,
         created_at: i64,
-    ) -> Result<i64> {
-        self.conn.execute(
+    ) -> Result<(i64, bool)> {
+        let entity_id = crate::storage::entity_id::entity_id(kind, title, body);
+        let result = self.conn.execute(
             "INSERT INTO notes \
              (kind, title, body, tags, linked_files, source_ref, status, created_at, entity_id)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
@@ -142,10 +150,52 @@ impl MemoryStore {
                 source_ref,
                 status,
                 created_at,
-                crate::storage::entity_id::entity_id(kind, title, body),
+                entity_id,
             ],
-        )?;
-        Ok(self.conn.last_insert_rowid())
+        );
+        self.recover_from_entity_id_collision(result, &entity_id, tags, linked_files)
+    }
+
+    /// Shared insert-then-recover tail for `add_note`/`add_note_with_created_at`.
+    ///
+    /// On a UNIQUE-constraint failure, this can only be `idx_notes_entity_id`:
+    /// neither function's INSERT populates `uuid` or `remote_id` (both left
+    /// `NULL`, and both columns' own UNIQUE indexes are partial `WHERE ... IS
+    /// NOT NULL`, so a `NULL` never collides). Recover by looking up the
+    /// existing row, merging `tags` and `linked_files` into it (add-wins, via
+    /// the existing `union_tags_and_files`), and returning its id with
+    /// `created = false`. Does **not** touch `status` or `superseded_by` on
+    /// this path — mirrors `reconcile.rs`'s own handling of an existing-row
+    /// collision, not `dedupe.rs`'s fuller merge (which collapses two rows
+    /// that already diverged in the store, a different scenario from a single
+    /// fresh insert colliding with one existing row).
+    ///
+    /// Any other error (a different constraint, I/O, etc.) propagates unchanged.
+    pub(super) fn recover_from_entity_id_collision(
+        &self,
+        insert_result: rusqlite::Result<usize>,
+        entity_id: &str,
+        tags: &[&str],
+        linked_files: &[&str],
+    ) -> Result<(i64, bool)> {
+        match insert_result {
+            Ok(_) => Ok((self.conn.last_insert_rowid(), true)),
+            Err(rusqlite::Error::SqliteFailure(err, _))
+                if err.code == rusqlite::ErrorCode::ConstraintViolation
+                    && err.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE =>
+            {
+                let existing_id: i64 = self.conn.query_row(
+                    "SELECT id FROM notes WHERE entity_id = ?1",
+                    rusqlite::params![entity_id],
+                    |r| r.get(0),
+                )?;
+                let owned_tags: Vec<String> = tags.iter().map(|s| s.to_string()).collect();
+                let owned_files: Vec<String> = linked_files.iter().map(|s| s.to_string()).collect();
+                self.union_tags_and_files(existing_id, &owned_tags, &owned_files)?;
+                Ok((existing_id, false))
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Return all notes for a project ordered by created_at ASC, id ASC (used

--- a/crates/spelunk-core/src/storage/memory/notes.rs
+++ b/crates/spelunk-core/src/storage/memory/notes.rs
@@ -84,9 +84,9 @@ impl MemoryStore {
     /// Insert a note and return `(id, created)`. `created` is `true` when a
     /// genuinely new row was inserted, `false` when the insert collided with
     /// an existing row's `entity_id` (only possible once `idx_notes_entity_id`
-    /// has been promoted to UNIQUE — see `entity_id_migration.rs`) and that
+    /// has been promoted to UNIQUE, see `entity_id_migration.rs`) and that
     /// existing row was reused instead. Does not store an embedding on a fresh
-    /// insert — call `insert_embedding` afterwards if the embedder is available.
+    /// insert; call `insert_embedding` afterwards if the embedder is available.
     #[allow(clippy::too_many_arguments)]
     pub fn add_note(
         &self,
@@ -123,7 +123,7 @@ impl MemoryStore {
     /// from the source store. All other callers should use `add_note`, which
     /// defers to the SQLite `DEFAULT (unixepoch())`.
     ///
-    /// Returns `(id, created)` — see `add_note` for what `created` means.
+    /// Returns `(id, created)`, see `add_note` for what `created` means.
     #[allow(clippy::too_many_arguments)]
     pub fn add_note_with_created_at(
         &self,
@@ -165,7 +165,7 @@ impl MemoryStore {
     /// existing row, merging `tags` and `linked_files` into it (add-wins, via
     /// the existing `union_tags_and_files`), and returning its id with
     /// `created = false`. Does **not** touch `status` or `superseded_by` on
-    /// this path — mirrors `reconcile.rs`'s own handling of an existing-row
+    /// this path, mirrors `reconcile.rs`'s own handling of an existing-row
     /// collision, not `dedupe.rs`'s fuller merge (which collapses two rows
     /// that already diverged in the store, a different scenario from a single
     /// fresh insert colliding with one existing row).

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -39,10 +39,10 @@ fn count_edges(store: &MemoryStore, from_id: i64, to_id: i64, kind: &str) -> i64
 fn supersede_happy_path() {
     let store = open_store();
 
-    let old_id = store
+    let (old_id, _) = store
         .add_note("decision", "Old decision", "old body", &[], &[], None, None)
         .unwrap();
-    let new_id = store
+    let (new_id, _) = store
         .add_note("decision", "New decision", "new body", &[], &[], None, None)
         .unwrap();
 
@@ -66,10 +66,10 @@ fn supersede_happy_path() {
 fn supersede_idempotent() {
     let store = open_store();
 
-    let old_id = store
+    let (old_id, _) = store
         .add_note("note", "Alpha", "body", &[], &[], None, None)
         .unwrap();
-    let new_id = store
+    let (new_id, _) = store
         .add_note("note", "Beta", "body", &[], &[], None, None)
         .unwrap();
 
@@ -97,7 +97,7 @@ fn supersede_idempotent() {
 fn add_note_superseding_happy_path_archives_old_and_links_new() {
     let store = open_store();
 
-    let old_id = store
+    let (old_id, _) = store
         .add_note("decision", "Old decision", "old body", &[], &[], None, None)
         .unwrap();
 
@@ -132,7 +132,7 @@ fn add_note_superseding_happy_path_archives_old_and_links_new() {
 fn add_note_superseding_rejects_already_archived_old_and_writes_nothing() {
     let store = open_store();
 
-    let old_id = store
+    let (old_id, _) = store
         .add_note("decision", "Old decision", "old body", &[], &[], None, None)
         .unwrap();
     let successor_a = store
@@ -192,10 +192,10 @@ fn add_note_superseding_rejects_nonexistent_old() {
 #[test]
 fn add_edge_valid_kinds_accepted() {
     let store = open_store();
-    let a = store
+    let (a, _) = store
         .add_note("note", "A", "", &[], &[], None, None)
         .unwrap();
-    let b = store
+    let (b, _) = store
         .add_note("note", "B", "", &[], &[], None, None)
         .unwrap();
 
@@ -209,10 +209,10 @@ fn add_edge_valid_kinds_accepted() {
 #[test]
 fn add_edge_invalid_kind_returns_err() {
     let store = open_store();
-    let a = store
+    let (a, _) = store
         .add_note("note", "A", "", &[], &[], None, None)
         .unwrap();
-    let b = store
+    let (b, _) = store
         .add_note("note", "B", "", &[], &[], None, None)
         .unwrap();
 
@@ -228,10 +228,10 @@ fn add_edge_invalid_kind_returns_err() {
 #[test]
 fn add_edge_duplicate_silently_ignored() {
     let store = open_store();
-    let a = store
+    let (a, _) = store
         .add_note("note", "A", "", &[], &[], None, None)
         .unwrap();
-    let b = store
+    let (b, _) = store
         .add_note("note", "B", "", &[], &[], None, None)
         .unwrap();
 
@@ -250,7 +250,7 @@ fn add_edge_duplicate_silently_ignored() {
 #[test]
 fn ensure_uuid_backfills_and_is_idempotent() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("decision", "D", "body", &[], &[], None, None)
         .unwrap();
 
@@ -362,13 +362,13 @@ fn max_remote_id_is_the_pull_cursor() {
 
     // Record a few cloud ids. UUIDv7 strings sort lexically == time order, so
     // MAX() returns the newest one regardless of insertion order.
-    let a = store
+    let (a, _) = store
         .add_note("note", "A", "b", &[], &[], None, None)
         .unwrap();
-    let b = store
+    let (b, _) = store
         .add_note("note", "B", "b", &[], &[], None, None)
         .unwrap();
-    let c = store
+    let (c, _) = store
         .add_note("note", "C", "b", &[], &[], None, None)
         .unwrap();
     store
@@ -391,7 +391,7 @@ fn max_remote_id_is_the_pull_cursor() {
 #[test]
 fn set_remote_id_records_and_dedupes() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "N", "b", &[], &[], None, None)
         .unwrap();
     store.ensure_uuid(id).unwrap();
@@ -406,7 +406,7 @@ fn set_remote_id_records_and_dedupes() {
 #[test]
 fn add_note_persists_entity_id() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("decision", "HTTP layer", "use axum", &[], &[], None, None)
         .unwrap();
 
@@ -428,7 +428,7 @@ fn add_note_persists_entity_id() {
 #[test]
 fn union_tags_and_files_is_add_wins() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "N", "b", &["alpha"], &["a.rs"], None, None)
         .unwrap();
 
@@ -467,7 +467,7 @@ fn union_tags_and_files_is_add_wins() {
 #[test]
 fn union_tags_keeps_fts_in_sync() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "Findable", "body", &["alpha"], &[], None, None)
         .unwrap();
     store
@@ -605,7 +605,7 @@ fn entity_id_migration_backfills_but_does_not_collapse_duplicates() {
 #[test]
 fn insert_embedding_replaces_a_repeated_note_id() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "N", "b", &[], &[], None, None)
         .unwrap();
 
@@ -653,7 +653,7 @@ fn insert_embedding_replaces_a_repeated_note_id() {
 #[test]
 fn insert_embedding_of_nonexistent_note_id_is_a_harmless_delete_no_op() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "N", "b", &[], &[], None, None)
         .unwrap();
 
@@ -688,7 +688,7 @@ fn insert_embedding_of_nonexistent_note_id_is_a_harmless_delete_no_op() {
 #[test]
 fn insert_embedding_joins_callers_transaction_and_rolls_back_with_it() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "N", "b", &[], &[], None, None)
         .unwrap();
 

--- a/crates/spelunk-core/src/storage/remote/mod.rs
+++ b/crates/spelunk-core/src/storage/remote/mod.rs
@@ -303,7 +303,7 @@ impl MemoryBackend for RemoteMemoryBackend {
                 }
             }
             // `server.db` doesn't enforce this amendment's promoted index, so
-            // there is nothing for this backend to detect as a reuse — report
+            // there is nothing for this backend to detect as a reuse: report
             // the conflict-handling outcome as a fresh insert.
             return Ok((resp.id, true));
         }

--- a/crates/spelunk-core/src/storage/remote/mod.rs
+++ b/crates/spelunk-core/src/storage/remote/mod.rs
@@ -266,7 +266,7 @@ impl RemoteMemoryBackend {
 
 #[async_trait]
 impl MemoryBackend for RemoteMemoryBackend {
-    async fn add(&self, input: NoteInput) -> Result<i64> {
+    async fn add(&self, input: NoteInput) -> Result<(i64, bool)> {
         let embedding = input.embedding.as_deref().map(blob_to_vec);
         let body = AddNoteRequest {
             kind: input.kind,
@@ -302,7 +302,10 @@ impl MemoryBackend for RemoteMemoryBackend {
                     );
                 }
             }
-            return Ok(resp.id);
+            // `server.db` doesn't enforce this amendment's promoted index, so
+            // there is nothing for this backend to detect as a reuse — report
+            // the conflict-handling outcome as a fresh insert.
+            return Ok((resp.id, true));
         }
 
         let resp = http_resp
@@ -316,7 +319,7 @@ impl MemoryBackend for RemoteMemoryBackend {
         if let Some(remote_id) = &resp.remote_id {
             tracing::debug!(remote_id, "server assigned remote_id for new memory entry");
         }
-        Ok(resp.id)
+        Ok((resp.id, true))
     }
 
     /// Remote backend: timeline search falls back to regular semantic search.

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -100,7 +100,7 @@ async fn git_notes_add_and_list_round_trip() {
     let dir = make_temp_git_repo();
     let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
 
-    let id = backend
+    let (id, _) = backend
         .add(note_input("decision", "use sqlcipher"))
         .await
         .expect("add");
@@ -240,7 +240,7 @@ async fn git_notes_archive_hides_entry() {
     let dir = make_temp_git_repo();
     let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
 
-    let id = backend
+    let (id, _) = backend
         .add(note_input("decision", "archive me"))
         .await
         .expect("add");
@@ -541,7 +541,7 @@ async fn git_notes_backend_add_with_option_like_body_round_trips() {
     let mut input = note_input("decision", "--amend");
     input.body = "-f --force --output=/tmp/should-not-exist-oss61".to_string();
 
-    let id = backend.add(input).await.expect("add");
+    let (id, _) = backend.add(input).await.expect("add");
 
     let notes = backend
         .list(Some("decision"), 10, false, None)
@@ -1239,7 +1239,7 @@ async fn git_notes_backend_add_and_archive_fail_when_the_lock_is_contended() {
     let root = dir.path();
     let backend = GitNotesBackend::with_root(root.to_path_buf());
 
-    let id = backend
+    let (id, _) = backend
         .add(note_input("decision", "the sibling entry at stake"))
         .await
         .expect("seed");
@@ -1377,7 +1377,7 @@ async fn git_notes_backend_add_and_archive_fail_when_the_note_cannot_be_read() {
     let root = dir.path();
     let backend = GitNotesBackend::with_root(root.to_path_buf());
 
-    let id = backend
+    let (id, _) = backend
         .add(note_input("decision", "the sibling entry at stake"))
         .await
         .expect("seed");
@@ -1772,12 +1772,11 @@ async fn git_notes_backend_concurrent_archives_land_or_fail_visibly() {
     // collision here would archive the wrong record.
     let mut ids = Vec::new();
     for n in 1..=ENTRIES {
-        ids.push(
-            backend
-                .add(note_input("decision", &format!("archive target {n}")))
-                .await
-                .expect("add"),
-        );
+        let (id, _) = backend
+            .add(note_input("decision", &format!("archive target {n}")))
+            .await
+            .expect("add");
+        ids.push(id);
     }
     let distinct: std::collections::HashSet<i64> = ids.iter().copied().collect();
     assert_eq!(distinct.len(), ENTRIES, "setup: the ids must be distinct");
@@ -1856,7 +1855,7 @@ async fn git_notes_backend_uncontended_add_and_archive_never_reach_the_wait_budg
     let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
 
     let started = std::time::Instant::now();
-    let id = backend
+    let (id, _) = backend
         .add(note_input("decision", "no nested acquisition"))
         .await
         .expect("add");

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -800,6 +800,10 @@ row number, not this identity. See [Entry identity](memory.md#project-memory).
 Existing duplicate rows already resident in `memory.db` are never collapsed
 automatically; use `spelunk memory dedupe` to do that explicitly (see
 [Collapsing duplicate entries already in memory.db](memory.md#collapsing-duplicate-entries-already-in-memorydb)).
+Once a store's duplicates are cleared and its `entity_id` index is promoted to
+UNIQUE, a plain `memory add` for byte-identical content no longer errors: it
+reuses the existing entry and prints `Already recorded as ...` instead of
+`Stored ...`.
 
 ---
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -752,6 +752,18 @@ all-zero counts and makes no writes, and the next `spelunk` run promotes
 `memory.db`'s `entity_id` index to enforce uniqueness going forward; after
 that, a duplicate group can no longer occur.
 
+Once that index is promoted, a plain `memory add` for byte-identical
+`kind`/`title`/`body` content no longer inserts a second row: it reuses the
+existing entry (merging the new call's `tags` and `linked_files` into it,
+add-wins) and reports it instead of erroring:
+
+```
+$ spelunk memory add --kind decision --title "dup entry" --body "same content"
+Stored [decision] #3: dup entry
+$ spelunk memory add --kind decision --title "dup entry" --body "same content"
+Already recorded as [decision] #3: dup entry
+```
+
 ### Security notes
 
 `dedupe` only reads and writes the project's own `memory.db`; it never


### PR DESCRIPTION
## Summary

Second of three PRs splitting the entity_id backfill / dedupe story into independently-reviewable pieces, split along the ADR-068 amendment boundaries. Stacked on #696 (the third amendment: entity_id backfill + `spelunk memory dedupe`) — this PR's diff is the fourth amendment, the collision-recovery fix that depends on #696's UNIQUE-index work existing.

- Once `idx_notes_entity_id` promotes to UNIQUE, a plain `memory add` for byte-identical `kind`/`title`/`body` content used to hard-crash with `Error: UNIQUE constraint failed: notes.entity_id`. `MemoryStore::add_note`/`add_note_with_created_at` now attempt the insert as before and, only on that specific UNIQUE violation, recover: look up the existing row, merge the call's `tags`/`linked_files` into it (add-wins), and return its id instead of propagating the error. Any other error still propagates unchanged.
- Return type changes from `Result<i64>` to `Result<(i64, bool)>` across both functions, `MemoryBackend::add`, and every call site. `spelunk memory add` prints `Already recorded as [kind] #id: title` in place of `Stored [kind] #id: title` on a reuse.
- Pre-promotion behavior (while duplicate groups still exist) is unchanged: identical content still inserts distinct rows, which is what `dedupe`'s own test fixtures rely on.

Full design in [ADR-068's fourth amendment](docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md).

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace` — 0 failures across every crate/suite (both default and `--no-default-features`).
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets --features rich-formats -- -D warnings` and `--no-default-features` — both clean.
- `cargo fmt --all -- --check` — clean.
- New `crates/spelunk-cli/tests/memory_add_dedupe.rs` drives the actual `spelunk` binary through the reuse path end to end: "Already recorded as" output, tag merge, and the git-notes write-through carrier appending the same id on both calls.