### PR TITLE
feat(memory): backfill entity_id and promote uniqueness index

### DIFF
--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
@@ -1,0 +1,290 @@
+// Step A (backfill_entity_ids) and Step B (promote_entity_id_unique_index):
+// population, idempotency, resumption after partial population, index
+// promotion, and the marker short-circuit.
+
+use super::test_support::*;
+
+// ── AC1: a store with rows lacking entity_id gets them populated ────────
+#[test]
+fn backfill_populates_null_entity_ids() {
+    let store = open_store();
+    // Insert directly, bypassing add_note (which already stamps entity_id),
+    // to simulate a pre-023 row that predates the column.
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 't', 'b', NULL)",
+            [],
+        )
+        .unwrap();
+    assert_eq!(null_entity_id_count(&store), 1);
+
+    store.backfill_entity_ids().unwrap();
+
+    assert_eq!(null_entity_id_count(&store), 0);
+    let stamped: String = store
+        .conn
+        .query_row("SELECT entity_id FROM notes WHERE title='t'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        stamped,
+        crate::storage::entity_id::entity_id("note", "t", "b")
+    );
+}
+
+// ── AC2: a fully-populated store is a no-op ─────────────────────────────
+#[test]
+fn backfill_on_fully_populated_store_is_noop() {
+    let store = open_store();
+    store
+        .add_note("note", "t", "b", &[], &[], None, None)
+        .unwrap();
+    assert_eq!(null_entity_id_count(&store), 0);
+    // Must not error and must not disturb the already-correct value.
+    store.backfill_entity_ids().unwrap();
+    assert_eq!(null_entity_id_count(&store), 0);
+}
+
+// ── AC3: rows inserted post-023 already carrying entity_id are untouched ─
+#[test]
+fn backfill_leaves_already_stamped_rows_untouched() {
+    let store = open_store();
+    let id = store
+        .add_note("decision", "already stamped", "body", &[], &[], None, None)
+        .unwrap();
+    let before: String = store
+        .conn
+        .query_row(
+            "SELECT entity_id FROM notes WHERE id = ?1",
+            rusqlite::params![id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    store.backfill_entity_ids().unwrap();
+    let after: String = store
+        .conn
+        .query_row(
+            "SELECT entity_id FROM notes WHERE id = ?1",
+            rusqlite::params![id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(before, after);
+}
+
+// ── AC4: an interrupted population resumes cleanly with no duplication ──
+#[test]
+fn backfill_resumes_after_partial_population() {
+    let store = open_store();
+    store
+        .conn
+        .execute_batch(
+            "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'a', 'a-body', NULL);
+             INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'b', 'b-body', NULL);",
+        )
+        .unwrap();
+    assert_eq!(null_entity_id_count(&store), 2);
+
+    // First pass populates both.
+    store.backfill_entity_ids().unwrap();
+    assert_eq!(null_entity_id_count(&store), 0);
+
+    // Simulate a fresh row landing NULL again (as if a third row arrived
+    // between an interrupted run and the next open) and rerun: only the
+    // new row is touched, no duplication of existing rows.
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'c', 'c-body', NULL)",
+            [],
+        )
+        .unwrap();
+    store.backfill_entity_ids().unwrap();
+    assert_eq!(null_entity_id_count(&store), 0);
+
+    let total: i64 = store
+        .conn
+        .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(total, 3, "no row must be duplicated across the two passes");
+}
+
+// ── AC5: zero duplicate groups promotes the index and records the marker ─
+#[test]
+fn promote_with_zero_duplicates_creates_unique_index_and_marker() {
+    let store = open_store();
+    store
+        .add_note("note", "unique one", "body", &[], &[], None, None)
+        .unwrap();
+    store
+        .add_note("note", "unique two", "body two", &[], &[], None, None)
+        .unwrap();
+
+    assert!(!marker_exists(&store), "marker must not pre-exist");
+    store.promote_entity_id_unique_index().unwrap();
+
+    assert!(marker_exists(&store), "marker must be recorded");
+    assert!(index_is_unique(&store), "index must be promoted to UNIQUE");
+}
+
+// ── AC6: one or more duplicate groups leaves the index non-unique, no error ─
+#[test]
+fn promote_with_duplicates_leaves_index_non_unique_and_does_not_error() {
+    let store = open_store();
+    // Two rows sharing kind/title/body (the entity_id key) but different
+    // created_at, simulating the exact real-data shape from the task brief.
+    store
+        .add_note_with_created_at(
+            "requirement",
+            "Exit codes follow protocol",
+            "body",
+            &[],
+            &[],
+            None,
+            "active",
+            1_700_000_000,
+        )
+        .unwrap();
+    store
+        .add_note_with_created_at(
+            "requirement",
+            "Exit codes follow protocol",
+            "body",
+            &[],
+            &[],
+            None,
+            "active",
+            1_700_000_001,
+        )
+        .unwrap();
+
+    let result = store.promote_entity_id_unique_index();
+    assert!(result.is_ok(), "duplicates must never abort the open");
+    assert!(
+        !marker_exists(&store),
+        "marker must not be recorded while duplicates remain"
+    );
+    assert!(
+        !index_is_unique(&store),
+        "index must stay non-unique while duplicates remain"
+    );
+}
+
+// ── AC7: once promoted, later opens skip the duplicate scan ─────────────
+#[test]
+fn promote_skips_rescan_once_marker_present() {
+    let store = open_store();
+    store
+        .add_note("note", "solo", "body", &[], &[], None, None)
+        .unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(marker_exists(&store));
+
+    // Drop the notes table entirely: if the marker check did not
+    // short-circuit before the duplicate-group scan, the scan's query
+    // against a now-missing table would surface as an error.
+    store.conn.execute_batch("DROP TABLE notes;").unwrap();
+
+    let result = store.promote_entity_id_unique_index();
+    assert!(
+        result.is_ok(),
+        "marker must short-circuit before any duplicate scan runs: {:?}",
+        result.err()
+    );
+}
+
+// ── AC8: duplicates dedupe'd to zero, then reopened: promotes next open ─
+#[test]
+fn promote_after_manual_collapse_to_zero_duplicates_succeeds() {
+    let store = open_store();
+    let survivor_id = store
+        .add_note_with_created_at(
+            "note",
+            "dup title",
+            "dup body",
+            &[],
+            &[],
+            None,
+            "active",
+            1_700_000_000,
+        )
+        .unwrap();
+    let loser_id = store
+        .add_note_with_created_at(
+            "note",
+            "dup title",
+            "dup body",
+            &[],
+            &[],
+            None,
+            "active",
+            1_700_000_050,
+        )
+        .unwrap();
+
+    // First open-equivalent: duplicates present, index stays non-unique.
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(!index_is_unique(&store));
+
+    // Collapse manually (mirrors what `spelunk memory dedupe` would do).
+    store
+        .conn
+        .execute(
+            "DELETE FROM notes WHERE id = ?1",
+            rusqlite::params![loser_id],
+        )
+        .unwrap();
+    assert!(survivor_id > 0);
+
+    // "Reopen": call promote again now duplicates are gone.
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(
+        index_is_unique(&store),
+        "index must promote once duplicates are collapsed to zero"
+    );
+    assert!(marker_exists(&store));
+}
+
+// Adversarial (AC5/item 8): the promoted index must genuinely reject a
+// duplicate INSERT at the SQL level, not merely report "UNIQUE" in
+// sqlite_master's stored SQL text (index_is_unique() above only proves
+// that). The only real proof is a rejected write.
+#[test]
+fn promoted_unique_index_genuinely_rejects_a_duplicate_insert() {
+    let store = open_store();
+    store
+        .add_note("note", "only one", "body", &[], &[], None, None)
+        .unwrap();
+
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(index_is_unique(&store), "precondition: index promoted");
+
+    let dup_entity_id = crate::storage::entity_id::entity_id("note", "only one", "body");
+    let insert_result = store.conn.execute(
+        "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'only one', 'body', ?1)",
+        rusqlite::params![dup_entity_id],
+    );
+    assert!(
+        insert_result.is_err(),
+        "a promoted UNIQUE index must reject a subsequent duplicate \
+         entity_id insert, not merely exist with 'UNIQUE' in its SQL text"
+    );
+    let msg = insert_result.unwrap_err().to_string().to_lowercase();
+    assert!(
+        msg.contains("unique"),
+        "expected a UNIQUE constraint violation, got: {msg}"
+    );
+
+    // A non-duplicate insert must still succeed: the index is selective
+    // (WHERE entity_id IS NOT NULL), not a blanket rejection of writes.
+    let other_entity_id = crate::storage::entity_id::entity_id("note", "a different one", "body");
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'a different one', 'body', ?1)",
+            rusqlite::params![other_entity_id],
+        )
+        .expect("a genuinely distinct entity_id must still insert fine");
+}

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs
@@ -1,0 +1,111 @@
+//! ADR-068 third amendment: backfill `entity_id` onto existing rows and
+//! promote `idx_notes_entity_id` to UNIQUE once it is safe to do so.
+//!
+//! Two independently-safe steps, run unconditionally at `MemoryStore::open`
+//! (same marker-table idiom as `apply_dim_upgrade_migration` in `db.rs`).
+//! Step A backfills `entity_id`; it can never hit a constraint because the
+//! index stays non-unique until Step B promotes it, and Step B only
+//! promotes once a duplicate scan comes back clean. A duplicate group
+//! leaves the index non-unique and logs a message pointing at `spelunk
+//! memory dedupe`. Neither step ever hard-aborts `open`.
+
+use anyhow::{Context, Result};
+use rusqlite::OptionalExtension;
+
+use super::MemoryStore;
+use crate::storage::entity_id::entity_id;
+
+/// Marker table recorded once the index has been promoted to UNIQUE, so
+/// later opens skip the duplicate-group scan entirely.
+const ENTITY_ID_UNIQUE_MARKER: &str = "schema_entity_id_unique";
+
+impl MemoryStore {
+    /// Populates `entity_id` for every row still `NULL`. Computed in Rust:
+    /// sha256 is unavailable to raw SQL. Idempotent: an interrupted run
+    /// leaves the rest `NULL` for the next open to pick up.
+    pub(super) fn backfill_entity_ids(&self) -> Result<()> {
+        let rows: Vec<(i64, String, String, String)> = {
+            let mut stmt = self
+                .conn
+                .prepare("SELECT id, kind, title, body FROM notes WHERE entity_id IS NULL")
+                .context("preparing entity_id backfill scan")?;
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))
+                .context("scanning notes for entity_id backfill")?
+                .collect::<rusqlite::Result<_>>()
+                .context("reading entity_id backfill rows")?
+        };
+
+        for (id, kind, title, body) in rows {
+            let eid = entity_id(&kind, &title, &body);
+            self.conn
+                .execute(
+                    "UPDATE notes SET entity_id = ?1 WHERE id = ?2",
+                    rusqlite::params![eid, id],
+                )
+                .with_context(|| format!("backfilling entity_id for note #{id}"))?;
+        }
+        Ok(())
+    }
+
+    /// Step B: promote `idx_notes_entity_id` to UNIQUE once zero duplicate
+    /// groups remain. Never hard-aborts: a store with duplicates stays fully
+    /// functional under the non-unique index until the user runs `spelunk
+    /// memory dedupe`.
+    pub(super) fn promote_entity_id_unique_index(&self) -> Result<()> {
+        let already: bool = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+                rusqlite::params![ENTITY_ID_UNIQUE_MARKER],
+                |_| Ok(true),
+            )
+            .optional()
+            .context("checking entity_id unique-index marker")?
+            .is_some();
+        if already {
+            return Ok(());
+        }
+
+        let dup_groups = self.entity_id_duplicate_group_count()?;
+        if dup_groups > 0 {
+            tracing::warn!(
+                "entity_id has {dup_groups} duplicate group(s); run \
+                 `spelunk memory dedupe` to collapse them, then re-run spelunk \
+                 to enforce uniqueness"
+            );
+            return Ok(());
+        }
+
+        self.conn
+            .execute_batch(&format!(
+                "DROP INDEX IF EXISTS idx_notes_entity_id; \
+                 CREATE UNIQUE INDEX idx_notes_entity_id \
+                     ON notes(entity_id) WHERE entity_id IS NOT NULL; \
+                 CREATE TABLE IF NOT EXISTS {ENTITY_ID_UNIQUE_MARKER} \
+                     (sentinel INTEGER PRIMARY KEY);"
+            ))
+            .context("promoting idx_notes_entity_id to UNIQUE")?;
+        Ok(())
+    }
+
+    /// Count of distinct `entity_id` values shared by more than one row.
+    /// Shared by Step B's gate and `spelunk memory dedupe`'s summary.
+    pub fn entity_id_duplicate_group_count(&self) -> Result<i64> {
+        self.conn
+            .query_row(
+                "SELECT COUNT(*) FROM (
+                     SELECT entity_id FROM notes
+                     WHERE entity_id IS NOT NULL
+                     GROUP BY entity_id HAVING COUNT(*) > 1
+                 )",
+                [],
+                |r| r.get(0),
+            )
+            .context("counting duplicate entity_id groups")
+    }
+}
+
+#[cfg(test)]
+mod migration_tests;
+#[cfg(test)]
+mod test_support;

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/test_support.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/test_support.rs
@@ -1,0 +1,65 @@
+// Shared test-only helpers for `entity_id_migration`'s `migration_tests` submodule.
+
+use super::ENTITY_ID_UNIQUE_MARKER;
+use crate::storage::memory::MemoryStore;
+use rusqlite::OptionalExtension;
+use std::sync::OnceLock;
+
+fn register_sqlite_vec() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite_vec::sqlite3_vec_init as *const (),
+            )));
+        }
+    });
+}
+
+// Schema-only path: skips the Step A/B pipeline a real `MemoryStore::open`
+// runs, so tests can seed rows before driving Step A/B themselves.
+pub(super) fn open_store() -> MemoryStore {
+    register_sqlite_vec();
+    let conn = rusqlite::Connection::open(std::path::Path::new(":memory:"))
+        .expect("open in-memory sqlite");
+    let store = MemoryStore { conn };
+    store.migrate().expect("schema migration");
+    store
+}
+
+pub(super) fn marker_exists(store: &MemoryStore) -> bool {
+    store
+        .conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+            rusqlite::params![ENTITY_ID_UNIQUE_MARKER],
+            |_| Ok(true),
+        )
+        .optional()
+        .unwrap()
+        .is_some()
+}
+
+pub(super) fn index_is_unique(store: &MemoryStore) -> bool {
+    let sql: String = store
+        .conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_notes_entity_id'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    sql.to_uppercase().contains("UNIQUE")
+}
+
+pub(super) fn null_entity_id_count(store: &MemoryStore) -> i64 {
+    store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM notes WHERE entity_id IS NULL",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap()
+}

--- a/crates/spelunk-core/src/storage/memory/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/mod.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use std::path::Path;
 
 mod edges;
+mod entity_id_migration;
 mod notes;
 mod search;
 mod sync;
@@ -84,6 +85,11 @@ impl MemoryStore {
             .with_context(|| format!("opening memory DB at {}", path.display()))?;
         let store = Self { conn };
         store.migrate()?;
+        // ADR-068 third amendment: Step A (unconditional backfill) then Step B
+        // (conditional UNIQUE-index promotion). Neither ever hard-aborts open;
+        // see `entity_id_migration.rs`.
+        store.backfill_entity_ids()?;
+        store.promote_entity_id_unique_index()?;
         Ok(store)
     }
 
@@ -152,11 +158,8 @@ impl MemoryStore {
         // watermark to persist. The unique `idx_notes_remote_id` above is what
         // makes that cursor lookup and the `remote_id` dedupe cheap.
 
-        // Migration 023 (ADR-068): content-addressed `entity_id`.
-        // Not backfilled: every identity is recomputed in Rust from
-        // kind/title/body, so a NULL column costs nothing (sha256 is
-        // unavailable in SQLite regardless). The column is written but not yet
-        // read back — it is never the system of record.
+        // Migration 023 (ADR-068): content-addressed `entity_id`. Backfilled
+        // for existing rows by Step A below, right after `migrate()` returns.
         match self
             .conn
             .execute_batch("ALTER TABLE notes ADD COLUMN entity_id TEXT")
@@ -165,9 +168,9 @@ impl MemoryStore {
             Err(e) if e.to_string().contains("duplicate column name") => {}
             Err(e) => return Err(e).context("running memory entity_id migration"),
         }
-        // Non-unique: existing stores legitimately hold rows with identical
-        // kind/title/body (the previous dedup key folded in created_at), so a
-        // UNIQUE index would abort on real data.
+        // Non-unique: existing stores can hold rows with identical
+        // kind/title/body. Step B promotes this to UNIQUE once a duplicate
+        // scan comes back clean.
         self.conn
             .execute_batch(
                 "CREATE INDEX IF NOT EXISTS idx_notes_entity_id \

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -485,19 +485,26 @@ fn union_tags_keeps_fts_in_sync() {
     assert_eq!(hits, 1, "the unioned tag must be searchable");
 }
 
-/// The entity_id migration runs against a store that predates the column and
-/// already holds rows that collide under the new key. It must add the column
-/// without aborting, and without deleting or merging any existing row — those
-/// duplicates are legitimate (the previous key folded in `created_at`).
+// Runs against a store that predates the entity_id column and already holds
+// rows colliding under the new key. Must add the column without aborting,
+// backfill every legacy row (Step A), and leave the rows themselves alone:
+// collapsing is `spelunk memory dedupe`'s job, so Step B must also leave the
+// index non-unique while a duplicate group remains.
 #[test]
-fn entity_id_migration_is_additive_on_a_store_with_duplicates() {
+fn entity_id_migration_backfills_but_does_not_collapse_duplicates() {
     register_sqlite_vec();
     let dir = tempfile::TempDir::new().expect("tempdir");
     let path = dir.path().join("memory.db");
 
-    // Build a store, then take the column away to model a pre-migration DB.
+    // Build a store via the schema-only path (skips the Step A/B pipeline a
+    // real `open()` runs), so seeding two duplicate-content rows below isn't
+    // rejected by an index a fresh, zero-duplicate store would otherwise have
+    // already promoted to UNIQUE. Then take the column away entirely to model
+    // a genuinely pre-023 DB.
     {
-        let store = MemoryStore::open(&path).expect("open");
+        let conn = rusqlite::Connection::open(&path).expect("open raw");
+        let store = MemoryStore { conn };
+        store.migrate().expect("schema migration only");
         for created_at in [1_700_000_001_i64, 1_700_000_002] {
             store
                 .add_note_with_created_at(
@@ -529,14 +536,15 @@ fn entity_id_migration_is_additive_on_a_store_with_duplicates() {
         assert_eq!(has_col, 0, "precondition: the column is gone");
     }
 
-    // Re-opening runs the migration over that data.
+    // Re-opening (the real `MemoryStore::open`) re-adds the column (migration
+    // 023), then runs Step A (backfill) and Step B (duplicate scan).
     let store = MemoryStore::open(&path).expect("migration must not abort on existing data");
 
     let rows: i64 = store
         .conn
         .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(rows, 2, "no existing row may be deleted or merged");
+    assert_eq!(rows, 2, "opening alone must not delete or merge any row");
 
     let has_col: i64 = store
         .conn
@@ -548,7 +556,7 @@ fn entity_id_migration_is_additive_on_a_store_with_duplicates() {
         .unwrap();
     assert_eq!(has_col, 1, "the column is added");
 
-    // Not backfilled: identity for these legacy rows is recomputed on read.
+    // Step A backfills: no legacy row is left NULL.
     let nulls: i64 = store
         .conn
         .query_row(
@@ -557,11 +565,30 @@ fn entity_id_migration_is_additive_on_a_store_with_duplicates() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(nulls, 2, "backfill is a separate decision; rows stay NULL");
+    assert_eq!(
+        nulls, 0,
+        "Step A must backfill entity_id for every legacy row"
+    );
     assert_eq!(
         super::super::entity_id::note_entity_id(&store.list(None, 10, true).unwrap()[0]),
         super::super::entity_id::note_entity_id(&store.list(None, 10, true).unwrap()[1]),
-        "the two legacy rows do collide under the new key — a UNIQUE index would have aborted"
+        "the two legacy rows do collide under the new key"
+    );
+
+    // Step B must not have promoted the index: the two rows above are a
+    // duplicate group, so the store stays on the non-unique index until an
+    // explicit `spelunk memory dedupe` collapses it.
+    let idx_sql: String = store
+        .conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_notes_entity_id'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(
+        !idx_sql.to_uppercase().contains("UNIQUE"),
+        "a duplicate group must keep the index non-unique: {idx_sql}"
     );
 
     // Idempotent: opening again is a no-op, not a duplicate-column error.


### PR DESCRIPTION
## Summary

First of a 7-PR stack replacing #696/#697/#698 (which Johan flagged as still too big, needing at least 3 PRs each split along amendment boundaries). This PR is ADR-068's third amendment, Step A/B only: `MemoryStore::open` now backfills `entity_id` onto any pre-existing row lacking it (Step A), then promotes `idx_notes_entity_id` to UNIQUE once a duplicate scan comes back clean (Step B). Neither step ever hard-aborts `open`.

The `spelunk memory dedupe` subcommand that collapses existing duplicate groups is a separate PR next in the stack (needs this one merged first).

## What's in this PR

- `crates/spelunk-core/src/storage/memory/entity_id_migration/{mod.rs,migration_tests.rs,test_support.rs}` — Step A (`backfill_entity_ids`) and Step B (`promote_entity_id_unique_index`), mirroring the `apply_dim_upgrade_migration` marker-table idiom already used for the embedding dim upgrade in `db.rs`.
- `crates/spelunk-core/src/storage/memory/mod.rs` — wires both steps into `MemoryStore::open`.
- `crates/spelunk-core/src/storage/memory/tests.rs` — updates the pre-existing entity_id migration test for the new backfill+promote behavior.

Test files use plain `//` comments only, no `///`/`//!` doc-comment syntax (rustdoc is never generated for tests).

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace` — all green (default and `--no-default-features`)
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` — clean (default and `--no-default-features`)
- `cargo fmt --all -- --check` — clean
- Diff swept for em-dashes and internal ticket references: none found