### PR TITLE
feat(memory): add spelunk memory dedupe subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`spelunk memory dedupe` collapses duplicate-`entity_id` groups already
+  resident in a project's `memory.db`.** A store can already hold rows that
+  share the same content identity (`kind`/`title`/`body`) while differing in
+  `created_at`, `tags`, `linked_files`, or `status`, for example a decision
+  recorded twice by a repeated `memory harvest` run, or one merged in from
+  another machine. Opening the store now backfills each row's `entity_id` but
+  never deletes an existing row on its own, so this new command is the
+  explicit, dry-runnable way to clean duplicates up: `--dry-run` reports
+  duplicate groups and does nothing, otherwise the earliest-created row in
+  each group survives, the others' `tags` and `linked_files` merge onto it,
+  and any `supersedes` edge pointing at a removed row is repointed to the
+  survivor. It is a one-time backfill you run when you want to, not a step
+  `init` or `memory add` perform for you. See [ADR-068's third
+  amendment](docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md).
+
 ### Changed
 
 - **Chunk re-windowing is now token-aware, and windowed chunks keep their identity.**

--- a/crates/spelunk-cli/src/cli/cmd/memory/dedupe.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/dedupe.rs
@@ -1,0 +1,60 @@
+//! `spelunk memory dedupe`: collapse duplicate-`entity_id` groups already
+//! resident in the local `memory.db`.
+//!
+//! Existing duplicate rows under the ADR-068 canonical `entity_id` (rows with
+//! byte-identical `{kind, title, body}` but differing `created_at`, `tags`,
+//! `linked_files`, or `status`) are never collapsed automatically: opening
+//! the store only backfills `entity_id` and, once zero duplicate groups
+//! remain, promotes `idx_notes_entity_id` to UNIQUE (see
+//! `spelunk_core::storage::memory::entity_id_migration`). This command is the
+//! first place in the codebase that deletes existing local memory rows, so
+//! it is explicit and dry-run-able rather than riding along on that
+//! migration. See ADR-068's third amendment for the merge rule.
+
+use anyhow::{Context, Result};
+
+use super::MemoryDedupeArgs;
+use crate::storage::{DedupeSummary, MemoryStore};
+
+pub(super) async fn memory_dedupe(
+    args: MemoryDedupeArgs,
+    mem_path: &std::path::Path,
+) -> Result<()> {
+    let json = crate::utils::effective_format(&args.format) == "json";
+
+    let store = MemoryStore::open(mem_path)
+        .with_context(|| format!("opening memory.db at {}", mem_path.display()))?;
+
+    let summary = store
+        .dedupe_entity_ids(args.dry_run)
+        .context("collapsing duplicate entity_id groups")?;
+
+    emit_summary(&summary, json, args.dry_run);
+    Ok(())
+}
+
+fn emit_summary(summary: &DedupeSummary, json: bool, dry_run: bool) {
+    if json {
+        println!("{}", serde_json::to_string(summary).unwrap_or_default());
+        return;
+    }
+    if dry_run {
+        eprintln!(
+            "[spelunk] dedupe (dry-run): total_notes={} duplicate_groups={} rows_would_collapse={}",
+            summary.total_notes, summary.duplicate_groups, summary.rows_collapsed
+        );
+        return;
+    }
+    eprintln!(
+        "[spelunk] dedupe: total_notes={} duplicate_groups={} rows_collapsed={} \
+         tags_merged={} linked_files_merged={} supersede_edges_repointed={} \
+         supersede_self_edges_dropped={}",
+        summary.total_notes,
+        summary.duplicate_groups,
+        summary.rows_collapsed,
+        summary.tags_merged,
+        summary.linked_files_merged,
+        summary.supersede_edges_repointed,
+        summary.supersede_self_edges_dropped,
+    );
+}

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -50,6 +50,8 @@ pub enum MemoryCommand {
     Failures(MemoryFailuresArgs),
     /// Import unique notes from server.db into the local memory.db (recovery / migration tool)
     Reconcile(MemoryReconcileArgs),
+    /// Collapse duplicate-entity_id groups already resident in local memory.db (recovery tool)
+    Dedupe(MemoryDedupeArgs),
 }
 
 #[derive(Args, Debug)]
@@ -350,11 +352,23 @@ pub struct MemoryReconcileArgs {
     pub format: String,
 }
 
+#[derive(Args, Debug)]
+pub struct MemoryDedupeArgs {
+    /// Detect and report duplicate entity_id groups without collapsing anything
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Output format: text or json (NDJSON summary object)
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
 use super::status::format_age;
 
 mod add;
 mod archive;
 pub(crate) mod cross_project;
+mod dedupe;
 mod failures;
 mod graph_cmd;
 mod harvest;
@@ -397,6 +411,7 @@ pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> 
         MemoryCommand::Watch(a) => watch::memory_watch(a, &cfg).await,
         MemoryCommand::Failures(a) => failures::memory_failures(a, &mem_path, &cfg, be).await,
         MemoryCommand::Reconcile(a) => reconcile::memory_reconcile(a, &mem_path, &cfg).await,
+        MemoryCommand::Dedupe(a) => dedupe::memory_dedupe(a, &mem_path).await,
     }
 }
 

--- a/crates/spelunk-cli/tests/memory_dedupe.rs
+++ b/crates/spelunk-cli/tests/memory_dedupe.rs
@@ -1,0 +1,240 @@
+// Integration tests for `spelunk memory dedupe`.
+//
+// Covers the CLI-facing acceptance criteria (see ADR-068's third amendment):
+// - `--dry-run` reports counts and makes no writes (AC9).
+// - Without `--dry-run`, duplicate groups collapse and row count drops by
+//   exactly `rows_collapsed` (AC10).
+// - Zero duplicate groups: all-zero counts, no writes, either mode (AC22).
+// - `--format json` emits one JSON summary object (AC23).
+//
+// Storage-layer mechanics (survivor selection, tag/file union, archived
+// sticks, supersede adoption/rewrite/self-edge-guard, embedding cleanup,
+// transactional rollback) are covered directly against `MemoryStore` in
+// `spelunk_core::storage::memory::dedupe`; these tests exercise the command
+// surface end to end instead of re-proving that mechanics.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
+use assert_cmd::Command;
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use tempfile::TempDir;
+
+fn ensure_sqlite_vec() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite_vec::sqlite3_vec_init as *const (),
+            )));
+        }
+    });
+}
+
+// Write a minimal spelunk config and make `dir` a real project, mirroring
+// `memory_reconcile.rs`'s `write_config`. Returns `(config_path, mem_path)`.
+fn write_config(dir: &Path) -> (PathBuf, PathBuf) {
+    let spelunk_dir = dir.join(".spelunk");
+    std::fs::create_dir_all(&spelunk_dir).expect("create .spelunk");
+    let index_db = spelunk_dir.join("index.db");
+    let config_path = dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "db_path = {:?}\nllm_model = \"test-model\"\n",
+            index_db.display().to_string()
+        ),
+    )
+    .expect("write config");
+    let mem_path = index_db.with_file_name("memory.db");
+    (config_path, mem_path)
+}
+
+// Seed `mem_path` with two rows sharing `{kind, title, body}` (a duplicate
+// entity_id group) via a schema-only connection, bypassing the CLI's own
+// `MemoryStore::open` pipeline so the seed isn't rejected: a fresh,
+// zero-duplicate store would otherwise already have promoted the index to
+// UNIQUE by the time we try to insert the second row.
+fn seed_duplicate_group(mem_path: &Path) {
+    ensure_sqlite_vec();
+    std::fs::create_dir_all(mem_path.parent().unwrap()).expect("create .spelunk dir");
+    let conn = Connection::open(mem_path).expect("open memory.db");
+    conn.execute_batch(include_str!("../../spelunk-core/migrations/004_memory.sql"))
+        .expect("base memory schema");
+    conn.execute_batch(
+        "ALTER TABLE notes ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
+         ALTER TABLE notes ADD COLUMN superseded_by INTEGER REFERENCES notes(id);
+         ALTER TABLE notes ADD COLUMN source_ref TEXT;
+         ALTER TABLE notes ADD COLUMN valid_at INTEGER;
+         ALTER TABLE notes ADD COLUMN invalid_at INTEGER;
+         ALTER TABLE notes ADD COLUMN uuid TEXT;
+         ALTER TABLE notes ADD COLUMN remote_id TEXT;
+         ALTER TABLE notes ADD COLUMN entity_id TEXT;
+         CREATE INDEX IF NOT EXISTS idx_notes_entity_id ON notes(entity_id) WHERE entity_id IS NOT NULL;",
+    )
+    .expect("lifecycle/uuid/entity_id columns");
+
+    for created_at in [1_700_000_001_i64, 1_700_000_002_i64] {
+        conn.execute(
+            "INSERT INTO notes (kind, title, body, created_at) VALUES ('decision', 'dup', 'body', ?1)",
+            rusqlite::params![created_at],
+        )
+        .expect("seed duplicate row");
+    }
+}
+
+fn count_memory_notes(mem_path: &Path) -> i64 {
+    ensure_sqlite_vec();
+    let conn = Connection::open(mem_path).expect("open memory.db");
+    conn.query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap_or(0)
+}
+
+fn dedupe_cmd(config_path: &Path) -> Command {
+    let tmp_dir = config_path
+        .parent()
+        .expect("config_path must have a parent");
+    let mut cmd = spelunk_bin();
+    cmd.current_dir(tmp_dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(config_path)
+        .arg("memory")
+        .arg("dedupe");
+    cmd
+}
+
+// ── AC9: --dry-run reports counts, makes no writes ───────────────────────────
+
+#[test]
+fn dry_run_reports_counts_and_writes_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let (config_path, mem_path) = write_config(tmp.path());
+    seed_duplicate_group(&mem_path);
+    let before = count_memory_notes(&mem_path);
+    assert_eq!(before, 2, "precondition: two duplicate rows seeded");
+
+    let output = dedupe_cmd(&config_path)
+        .arg("--dry-run")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8(output).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(text.trim()).expect("stdout should be valid JSON");
+    assert_eq!(value["duplicate_groups"].as_i64(), Some(1));
+    assert_eq!(value["rows_collapsed"].as_i64(), Some(1));
+
+    assert_eq!(
+        count_memory_notes(&mem_path),
+        before,
+        "dry-run must write nothing"
+    );
+}
+
+// ── AC10: without --dry-run, duplicates collapse and row count drops exactly ─
+
+#[test]
+fn real_run_collapses_and_row_count_drops_by_rows_collapsed() {
+    let tmp = TempDir::new().unwrap();
+    let (config_path, mem_path) = write_config(tmp.path());
+    seed_duplicate_group(&mem_path);
+    let before = count_memory_notes(&mem_path);
+
+    let output = dedupe_cmd(&config_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8(output).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(text.trim()).expect("stdout should be valid JSON");
+    let rows_collapsed = value["rows_collapsed"].as_i64().expect("rows_collapsed");
+    assert_eq!(rows_collapsed, 1);
+
+    assert_eq!(count_memory_notes(&mem_path), before - rows_collapsed);
+}
+
+// ── AC22: zero duplicate groups -> all-zero counts, no writes ───────────────
+
+#[test]
+fn zero_duplicates_reports_all_zero_and_writes_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let (config_path, mem_path) = write_config(tmp.path());
+
+    // A single `memory add` seeds one unique row and, on its own `open()`,
+    // the empty-store Step B promotes the index: no duplicates ever exist.
+    spelunk_bin()
+        .current_dir(tmp.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("add")
+        .arg("--title")
+        .arg("solo")
+        .arg("--body")
+        .arg("only entry")
+        .assert()
+        .success();
+
+    let before = count_memory_notes(&mem_path);
+    assert_eq!(before, 1);
+
+    let output = dedupe_cmd(&config_path)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    let value: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+    assert_eq!(value["duplicate_groups"].as_i64(), Some(0));
+    assert_eq!(value["rows_collapsed"].as_i64(), Some(0));
+    assert_eq!(value["tags_merged"].as_i64(), Some(0));
+    assert_eq!(value["linked_files_merged"].as_i64(), Some(0));
+    assert_eq!(value["supersede_edges_repointed"].as_i64(), Some(0));
+    assert_eq!(value["supersede_self_edges_dropped"].as_i64(), Some(0));
+
+    assert_eq!(
+        count_memory_notes(&mem_path),
+        before,
+        "no writes on zero groups"
+    );
+}
+
+// ── AC23: default/text format emits a human-readable line, not JSON ─────────
+
+#[test]
+fn default_format_emits_human_readable_line() {
+    let tmp = TempDir::new().unwrap();
+    let (config_path, mem_path) = write_config(tmp.path());
+    seed_duplicate_group(&mem_path);
+
+    let assert = dedupe_cmd(&config_path).arg("--dry-run").assert().success();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "text-format summary goes to stderr, not stdout: {stdout}"
+    );
+    assert!(
+        stderr.contains("dedupe") && stderr.contains("duplicate_groups=1"),
+        "expected a human-readable dedupe summary line, got: {stderr}"
+    );
+}

--- a/crates/spelunk-core/src/storage/memory/dedupe/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/mod.rs
@@ -1,0 +1,381 @@
+// Collapse duplicate-`entity_id` groups already resident in `memory.db`.
+// Backs `spelunk memory dedupe`. See ADR-068's third amendment for the merge
+// rule: survivor = earliest `created_at`; `tags`/`linked_files` union
+// add-wins; archived sticks.
+//
+// Invariant: no live row may reference a loser once it's deleted, whether
+// the reference is in-group or cross-group. `loser_to_survivor` (every id
+// being deleted this run, mapped to its group's survivor) is computed once
+// up front from the pre-transaction snapshot, so it stays valid regardless
+// of processing order. All `superseded_by` rewrites happen before any
+// delete: each group's own survivor resolves first, then every other row,
+// then losers are deleted in any order.
+//
+// One transaction for the whole run: any error rolls back, `memory.db`
+// stays unchanged. Never called automatically (`open`, `init`, `add`, ...):
+// collapsing is destructive, so it only runs via explicit `memory dedupe`.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+
+use super::{MemoryStore, Note};
+use crate::storage::entity_id::note_entity_id;
+
+// Summary of one `dedupe_entity_ids` run (or dry-run estimate).
+#[derive(Debug, Default, Serialize, PartialEq, Eq)]
+pub struct DedupeSummary {
+    pub total_notes: usize,
+    pub duplicate_groups: usize,
+    // Losers collapsed (rows removed).
+    pub rows_collapsed: usize,
+    pub tags_merged: usize,
+    pub linked_files_merged: usize,
+    pub supersede_edges_repointed: usize,
+    pub supersede_self_edges_dropped: usize,
+}
+
+#[cfg(test)]
+thread_local! {
+    // Fires after the (0-indexed) n-th group has been fully applied, before
+    // COMMIT. Proves the whole-run rollback guarantee under a real
+    // multi-group transaction, not just the empty/no-op case.
+    static FAULT_AFTER_GROUP: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+fn inject_fault_after_group(n: usize) {
+    FAULT_AFTER_GROUP.with(|f| f.set(Some(n)));
+}
+
+#[cfg(test)]
+fn clear_fault() {
+    FAULT_AFTER_GROUP.with(|f| f.set(None));
+}
+
+#[cfg(test)]
+fn fault_due(i: usize) -> bool {
+    FAULT_AFTER_GROUP.with(|f| f.get() == Some(i))
+}
+
+#[cfg(not(test))]
+fn fault_due(_i: usize) -> bool {
+    false
+}
+
+#[cfg(test)]
+thread_local! {
+    // Finer-grained than FAULT_AFTER_GROUP: fires after the (0-indexed) n-th
+    // loser within the current group is fully deleted, before the next
+    // loser in the same group is touched. Proves rollback holds mid-group.
+    static FAULT_AFTER_LOSER: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+fn inject_fault_after_loser(n: usize) {
+    FAULT_AFTER_LOSER.with(|f| f.set(Some(n)));
+}
+
+#[cfg(test)]
+fn clear_loser_fault() {
+    FAULT_AFTER_LOSER.with(|f| f.set(None));
+}
+
+#[cfg(test)]
+fn loser_fault_due(i: usize) -> bool {
+    FAULT_AFTER_LOSER.with(|f| f.get() == Some(i))
+}
+
+#[cfg(not(test))]
+fn loser_fault_due(_i: usize) -> bool {
+    false
+}
+
+impl MemoryStore {
+    // Collapse every duplicate `entity_id` group in one all-or-nothing
+    // transaction. `dry_run` computes the same summary via read-only queries
+    // and writes nothing.
+    pub fn dedupe_entity_ids(&self, dry_run: bool) -> Result<DedupeSummary> {
+        let all = self
+            .all_notes_for_dedup()
+            .context("reading notes for dedupe")?;
+        let total_notes = all.len();
+
+        // Index into `all` rather than moving the `Note`: `all` (including
+        // non-duplicate notes) is needed again below for the cross-reference
+        // rewrite pass. `all_notes_for_dedup` orders by created_at ASC, so
+        // each group's first element is already the survivor.
+        let mut group_indices: Vec<Vec<usize>> = Vec::new();
+        let mut index: HashMap<String, usize> = HashMap::new();
+        for (i, n) in all.iter().enumerate() {
+            let eid = note_entity_id(n);
+            match index.get(&eid) {
+                Some(&gi) => group_indices[gi].push(i),
+                None => {
+                    index.insert(eid, group_indices.len());
+                    group_indices.push(vec![i]);
+                }
+            }
+        }
+        let duplicate_group_indices: Vec<Vec<usize>> =
+            group_indices.into_iter().filter(|g| g.len() > 1).collect();
+
+        let mut summary = DedupeSummary {
+            total_notes,
+            duplicate_groups: duplicate_group_indices.len(),
+            ..Default::default()
+        };
+
+        if duplicate_group_indices.is_empty() {
+            return Ok(summary);
+        }
+
+        let duplicate_groups: Vec<Vec<&Note>> = duplicate_group_indices
+            .iter()
+            .map(|idxs| idxs.iter().map(|&i| &all[i]).collect())
+            .collect();
+
+        // Whole-run facts, computed once up front (see module doc).
+        // loser_to_survivor: every id deleted this run -> its group's
+        // survivor. Purely structural (derived from group membership), so
+        // it's identical regardless of processing order.
+        // note_group_of: id -> group index, used only to classify a rewrite
+        // as "external" for reporting, not for correctness.
+        let mut loser_to_survivor: HashMap<i64, i64> = HashMap::new();
+        let mut note_group_of: HashMap<i64, usize> = HashMap::new();
+        let mut survivor_ids: HashSet<i64> = HashSet::new();
+        for (gi, group) in duplicate_groups.iter().enumerate() {
+            let survivor_id = group[0].id;
+            survivor_ids.insert(survivor_id);
+            for n in group {
+                note_group_of.insert(n.id, gi);
+            }
+            for loser in &group[1..] {
+                loser_to_survivor.insert(loser.id, survivor_id);
+            }
+        }
+
+        if dry_run {
+            for group in &duplicate_groups {
+                self.collapse_group_survivor(group, &loser_to_survivor, &mut summary, false)?;
+            }
+            self.rewrite_cross_references(
+                &all,
+                &survivor_ids,
+                &loser_to_survivor,
+                &note_group_of,
+                &mut summary,
+                false,
+            )?;
+            return Ok(summary);
+        }
+
+        self.execute_batch("BEGIN IMMEDIATE")
+            .context("beginning dedupe transaction")?;
+        let result: Result<()> = (|| {
+            // Phase 1: per group, merge tags/linked_files/status and resolve
+            // the survivor's final superseded_by, from the pre-transaction
+            // snapshot only (never a live read) so group order doesn't matter.
+            for (i, group) in duplicate_groups.iter().enumerate() {
+                self.collapse_group_survivor(group, &loser_to_survivor, &mut summary, true)?;
+                if fault_due(i) {
+                    anyhow::bail!("injected test fault after group {i}");
+                }
+            }
+            // Phase 2: rewrite every other row (ordinary note or loser of any
+            // group) whose field still points at a doomed id, before any
+            // loser is deleted, so phase 3 can delete in any order safely.
+            self.rewrite_cross_references(
+                &all,
+                &survivor_ids,
+                &loser_to_survivor,
+                &note_group_of,
+                &mut summary,
+                true,
+            )?;
+            // Phase 3: delete every loser, any order - phase 2 already
+            // cleared every live reference to these ids.
+            for group in &duplicate_groups {
+                for (li, loser) in group[1..].iter().enumerate() {
+                    self.delete_note_embedding(loser.id)?;
+                    self.delete_edges_for_note(loser.id)?;
+                    self.delete_note(loser.id)?;
+                    if loser_fault_due(li) {
+                        anyhow::bail!(
+                            "injected test fault after deleting loser index {li} within group"
+                        );
+                    }
+                }
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => {
+                self.execute_batch("COMMIT")
+                    .context("committing dedupe transaction")?;
+                Ok(summary)
+            }
+            Err(e) => {
+                let _ = self.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
+    // Plan (and, when `apply`, execute) one duplicate group's
+    // tags/linked_files/status merge and its survivor's final
+    // `superseded_by`. `group` is created_at-ASC ordered; `group[0]` is the
+    // survivor.
+    //
+    // Dry-run and real-run share this path so their counts always agree;
+    // only the trailing writes are skipped when `!apply`.
+    //
+    // Does not touch any other row or delete anything (see
+    // `rewrite_cross_references` and phase 3 in `dedupe_entity_ids`) - kept
+    // separate so no group's processing can interact with another's.
+    fn collapse_group_survivor(
+        &self,
+        group: &[&Note],
+        loser_to_survivor: &HashMap<i64, i64>,
+        summary: &mut DedupeSummary,
+        apply: bool,
+    ) -> Result<()> {
+        let survivor = group[0];
+        let losers = &group[1..];
+        let survivor_id = survivor.id;
+
+        // tags / linked_files: union, add-wins
+        let mut new_tags: Vec<String> = Vec::new();
+        let mut new_files: Vec<String> = Vec::new();
+        for loser in losers {
+            for t in &loser.tags {
+                if !survivor.tags.contains(t) && !new_tags.contains(t) {
+                    new_tags.push(t.clone());
+                }
+            }
+            for f in &loser.linked_files {
+                if !survivor.linked_files.contains(f) && !new_files.contains(f) {
+                    new_files.push(f.clone());
+                }
+            }
+        }
+        summary.tags_merged += new_tags.len();
+        summary.linked_files_merged += new_files.len();
+
+        // status: archived sticks
+        let any_archived = group.iter().any(|n| n.status == "archived");
+
+        // superseded_by: resolve against every id doomed this run, not just
+        // this group. A candidate redirects through loser_to_survivor to its
+        // group's survivor (no-op if not doomed). If that target is *this*
+        // group's own survivor, it's self-referential and dropped; otherwise
+        // it's a genuine external value (possibly another group's survivor).
+        let resolve = |v: i64| -> Option<i64> {
+            let target = loser_to_survivor.get(&v).copied().unwrap_or(v);
+            if target == survivor_id {
+                None
+            } else {
+                Some(target)
+            }
+        };
+
+        let external_values: Vec<i64> = group
+            .iter()
+            .filter_map(|n| n.superseded_by.and_then(resolve))
+            .collect();
+        let resolved_survivor_target = external_values.first().copied();
+        if let Some(val) = resolved_survivor_target {
+            let conflicting = external_values.iter().any(|v| *v != val);
+            if conflicting {
+                tracing::warn!(
+                    "memory dedupe: duplicate-entity_id group for survivor #{} carries \
+                     conflicting superseded_by values; the earliest-created row's value \
+                     ({val}) wins",
+                    survivor.id
+                );
+            }
+        }
+        // supersede_self_edges_dropped counts only the survivor's own value
+        // resolving to nothing; losers' references are handled (and not
+        // counted) by rewrite_cross_references, since those rows are deleted.
+        let survivor_self_edge_dropped = matches!(survivor.superseded_by.map(resolve), Some(None));
+        if survivor_self_edge_dropped {
+            summary.supersede_self_edges_dropped += 1;
+        }
+
+        summary.rows_collapsed += losers.len();
+
+        if !apply {
+            return Ok(());
+        }
+
+        // apply phase (real run only)
+        if !new_tags.is_empty() || !new_files.is_empty() {
+            self.union_tags_and_files(survivor.id, &new_tags, &new_files)?;
+        }
+        if any_archived {
+            self.archive(survivor.id)?;
+        }
+        match resolved_survivor_target {
+            Some(val) if survivor.superseded_by != Some(val) => {
+                self.set_superseded_by(survivor.id, val)?;
+            }
+            None if survivor.superseded_by.is_some() => {
+                // Resolved to nothing (self-referential) with no external
+                // fallback in the group: clear rather than leave stale.
+                self.clear_superseded_by(survivor.id)?;
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    // Rewrite every row that is not itself a survivor (an ordinary note or
+    // a loser of any group) whose `superseded_by` still points at an id
+    // being deleted this run. Targets resolve through `loser_to_survivor`,
+    // so a rewrite can only land on a surviving id, never another doomed one.
+    //
+    // Runs once, globally, before any loser is deleted (see module doc for
+    // why this ordering is the actual invariant).
+    fn rewrite_cross_references(
+        &self,
+        all_notes: &[Note],
+        survivor_ids: &HashSet<i64>,
+        loser_to_survivor: &HashMap<i64, i64>,
+        note_group_of: &HashMap<i64, usize>,
+        summary: &mut DedupeSummary,
+        apply: bool,
+    ) -> Result<()> {
+        for note in all_notes {
+            if survivor_ids.contains(&note.id) {
+                continue; // the survivor's own field is resolved separately
+            }
+            let Some(v) = note.superseded_by else {
+                continue;
+            };
+            let Some(&target) = loser_to_survivor.get(&v) else {
+                continue; // not a doomed id: nothing to do
+            };
+            // In-group rewrites are inert clean-up (target is deleted
+            // regardless), so only cross-group rewrites count as a "repoint".
+            let same_group = matches!(
+                (note_group_of.get(&note.id), note_group_of.get(&v)),
+                (Some(a), Some(b)) if a == b
+            );
+            if !same_group {
+                summary.supersede_edges_repointed += 1;
+            }
+            if apply {
+                self.set_superseded_by(note.id, target)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test_support;
+#[cfg(test)]
+mod tests;

--- a/crates/spelunk-core/src/storage/memory/dedupe/test_support.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/test_support.rs
@@ -1,0 +1,83 @@
+// Shared test-only helpers for `dedupe`'s `tests` and `superseded_by_tests`
+// submodules.
+
+use super::MemoryStore;
+use std::sync::OnceLock;
+
+fn register_sqlite_vec() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite_vec::sqlite3_vec_init as *const (),
+            )));
+        }
+    });
+}
+
+// A store built via the schema-only path: `migrate()` creates the
+// (non-unique) `idx_notes_entity_id` but skips the automatic Step A/B
+// pipeline a real `MemoryStore::open` runs. `dedupe_entity_ids` itself
+// doesn't care whether Step A/B ran: it groups by recomputing
+// `note_entity_id` in Rust regardless of the stored column or index
+// state, but these tests need to seed duplicate-content rows directly,
+// which a real `open()` on a fresh (zero-row, zero-duplicate) store
+// would already have promoted to a UNIQUE index, rejecting the seed.
+pub(super) fn open_store() -> MemoryStore {
+    register_sqlite_vec();
+    let conn = rusqlite::Connection::open(std::path::Path::new(":memory:"))
+        .expect("open in-memory sqlite");
+    let store = MemoryStore { conn };
+    store.migrate().expect("schema migration");
+    store
+}
+
+pub(super) fn note_count(store: &MemoryStore) -> i64 {
+    store
+        .conn
+        .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap()
+}
+
+pub(super) fn has_embedding(store: &MemoryStore, note_id: i64) -> bool {
+    store.get_embedding(note_id).unwrap().is_some()
+}
+
+// Snapshot every column of every row in `table`, ordered by `order_by`,
+// as generic SQLite `Value`s. Used to assert a rolled-back or dry-run
+// call left the database byte-for-byte unchanged: unlike a row-count or
+// single-column check, this catches a regression in *any* column
+// (tags, superseded_by, status, entity_id, uuid, remote_id, ...) without
+// having to hand-maintain a column list.
+fn full_table_snapshot(
+    store: &MemoryStore,
+    table: &str,
+    order_by: &str,
+) -> Vec<Vec<rusqlite::types::Value>> {
+    let sql = format!("SELECT * FROM {table} ORDER BY {order_by}");
+    let mut stmt = store.conn.prepare(&sql).unwrap();
+    let n = stmt.column_count();
+    stmt.query_map([], |row| {
+        (0..n)
+            .map(|i| row.get::<_, rusqlite::types::Value>(i))
+            .collect()
+    })
+    .unwrap()
+    .collect::<rusqlite::Result<Vec<_>>>()
+    .unwrap()
+}
+
+pub(super) type TableSnapshot = Vec<Vec<rusqlite::types::Value>>;
+
+// Snapshot of `notes` + `memory_edges` + `note_embeddings`, the three
+// tables `dedupe_entity_ids` can touch.
+pub(super) fn full_db_snapshot(
+    store: &MemoryStore,
+) -> (TableSnapshot, TableSnapshot, TableSnapshot) {
+    (
+        full_table_snapshot(store, "notes", "id"),
+        full_table_snapshot(store, "memory_edges", "from_id, to_id, kind"),
+        full_table_snapshot(store, "note_embeddings", "note_id"),
+    )
+}

--- a/crates/spelunk-core/src/storage/memory/dedupe/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/tests.rs
@@ -1,0 +1,578 @@
+// Core `dedupe_entity_ids` behavior: happy path, dry-run, tags/linked_files
+// merge, archived/superseded_by merge, rollback, and basic edge handling.
+// See `superseded_by_tests` for the intra- and cross-group `superseded_by`
+// reference-resolution edge cases.
+
+use super::test_support::*;
+use super::*;
+
+// ── AC22 (zero groups): all-zero counts, no writes, dry-run or not ──────
+#[test]
+fn zero_duplicates_reports_all_zero_and_writes_nothing() {
+    let store = open_store();
+    store
+        .add_note("note", "solo", "body", &[], &[], None, None)
+        .unwrap();
+
+    for dry in [true, false] {
+        let summary = store.dedupe_entity_ids(dry).unwrap();
+        assert_eq!(summary.total_notes, 1);
+        assert_eq!(summary.duplicate_groups, 0);
+        assert_eq!(summary.rows_collapsed, 0);
+        assert_eq!(summary.tags_merged, 0);
+        assert_eq!(summary.linked_files_merged, 0);
+        assert_eq!(summary.supersede_edges_repointed, 0);
+        assert_eq!(summary.supersede_self_edges_dropped, 0);
+    }
+    assert_eq!(note_count(&store), 1, "no row must be touched");
+}
+
+// ── AC9: --dry-run reports counts, makes no writes ──────────────────────
+#[test]
+fn dry_run_reports_counts_and_writes_nothing() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["a"],
+            &["f.rs"],
+            None,
+            "active",
+            100,
+        )
+        .unwrap();
+    let _loser = store
+        .add_note_with_created_at("decision", "dup", "body", &["b"], &[], None, "active", 200)
+        .unwrap();
+
+    let before_count = note_count(&store);
+    let (before_tags, _): (String, String) = store
+        .conn
+        .query_row(
+            "SELECT tags, linked_files FROM notes WHERE id = ?1",
+            rusqlite::params![survivor],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+
+    let summary = store.dedupe_entity_ids(true).unwrap();
+    assert_eq!(summary.total_notes, 2);
+    assert_eq!(summary.duplicate_groups, 1);
+    assert_eq!(summary.rows_collapsed, 1, "one loser in the group");
+    assert_eq!(summary.tags_merged, 1, "loser's 'b' tag would be merged");
+
+    assert_eq!(note_count(&store), before_count, "row count unchanged");
+    let (after_tags, _): (String, String) = store
+        .conn
+        .query_row(
+            "SELECT tags, linked_files FROM notes WHERE id = ?1",
+            rusqlite::params![survivor],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(before_tags, after_tags, "tags unchanged under dry-run");
+}
+
+// ── AC10 + AC11: real run collapses to one row, survivor = earliest ────
+#[test]
+fn real_run_collapses_group_survivor_is_earliest_created() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.rows_collapsed, 1);
+    assert_eq!(
+        note_count(&store),
+        1,
+        "row count must drop by rows_collapsed"
+    );
+    assert!(store.get(survivor).unwrap().is_some(), "survivor remains");
+    assert!(store.get(loser).unwrap().is_none(), "loser is gone");
+}
+
+// ── AC12 + AC13: tags/linked_files union add-wins, no survivor value dropped ─
+#[test]
+fn tags_and_linked_files_union_add_wins() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["keep"],
+            &["keep.rs"],
+            None,
+            "active",
+            100,
+        )
+        .unwrap();
+    store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["keep", "new"],
+            &["new.rs"],
+            None,
+            "active",
+            200,
+        )
+        .unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.tags_merged, 1, "only the genuinely-new tag counts");
+    assert_eq!(summary.linked_files_merged, 1);
+
+    let note = store.get(survivor).unwrap().unwrap();
+    assert!(note.tags.contains(&"keep".to_string()));
+    assert!(note.tags.contains(&"new".to_string()));
+    assert!(note.linked_files.contains(&"keep.rs".to_string()));
+    assert!(note.linked_files.contains(&"new.rs".to_string()));
+}
+
+// ── AC14: any row archived -> survivor becomes archived ─────────────────
+#[test]
+fn any_archived_row_makes_survivor_archived() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "archived", 200)
+        .unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(note.status, "archived");
+}
+
+// ── AC15: no row archived -> survivor status unchanged ──────────────────
+#[test]
+fn no_archived_row_leaves_survivor_status_unchanged() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(note.status, "active");
+}
+
+// ── AC16: survivor lacks superseded_by, another row has one -> adopted ──
+#[test]
+fn survivor_adopts_lone_superseded_by_from_group() {
+    let store = open_store();
+    let elsewhere = store
+        .add_note("note", "elsewhere target", "b", &[], &[], None, None)
+        .unwrap();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    store.set_superseded_by(loser, elsewhere).unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(note.superseded_by, Some(elsewhere));
+}
+
+// ── AC17: conflicting superseded_by values -> earliest wins, warn, no error ─
+#[test]
+fn conflicting_superseded_by_earliest_wins_no_error() {
+    let store = open_store();
+    let target_a = store
+        .add_note("note", "a", "b", &[], &[], None, None)
+        .unwrap();
+    let target_b = store
+        .add_note("note", "b", "b", &[], &[], None, None)
+        .unwrap();
+
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    store.set_superseded_by(survivor, target_a).unwrap();
+    store.set_superseded_by(loser, target_b).unwrap();
+
+    let result = store.dedupe_entity_ids(false);
+    assert!(result.is_ok(), "a conflicting value must never error");
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(
+        note.superseded_by,
+        Some(target_a),
+        "the earliest-created row's (survivor's own) value must win"
+    );
+}
+
+// ── AC18: a row elsewhere pointing at a loser is rewritten to the survivor ─
+#[test]
+fn edge_elsewhere_pointing_at_loser_is_repointed_to_survivor() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let dependent = store
+        .add_note("note", "points at loser", "b", &[], &[], None, None)
+        .unwrap();
+    store.set_superseded_by(dependent, loser).unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.supersede_edges_repointed, 1);
+    let note = store.get(dependent).unwrap().unwrap();
+    assert_eq!(note.superseded_by, Some(survivor));
+}
+
+// ── AC19: a rewrite that would self-point is dropped to NULL instead ────
+#[test]
+fn rewrite_that_would_self_point_is_dropped_to_null() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    // The survivor itself already points at its own duplicate-group loser.
+    store.set_superseded_by(survivor, loser).unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.supersede_self_edges_dropped, 1);
+    let note = store.get(survivor).unwrap().unwrap();
+    assert_eq!(
+        note.superseded_by, None,
+        "a self-pointing rewrite must drop to NULL rather than self-loop"
+    );
+}
+
+// ── AC20: a loser's note_embeddings row is deleted; survivor's is untouched ─
+#[test]
+fn loser_embedding_deleted_survivor_embedding_untouched() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    // note_embeddings is FLOAT[896]: 896 * 4-byte floats per row.
+    let vec_a = vec![0u8; 896 * 4];
+    let mut vec_b = vec![0u8; 896 * 4];
+    vec_b[0] = 1;
+    store.insert_embedding(survivor, &vec_a).unwrap();
+    store.insert_embedding(loser, &vec_b).unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+    assert!(has_embedding(&store, survivor), "survivor embedding kept");
+    assert_eq!(
+        store.get_embedding(survivor).unwrap().as_deref(),
+        Some(vec_a.as_slice()),
+        "survivor's embedding bytes must be provably untouched, not merely present"
+    );
+    assert!(
+        store.get_embedding(loser).unwrap().is_none(),
+        "loser's embedding row must be gone (loser row itself is deleted too)"
+    );
+}
+
+// ── AC21: a failure injected partway through rolls back the whole run ───
+#[test]
+fn injected_fault_partway_rolls_back_whole_run() {
+    let store = open_store();
+    // Two independent duplicate groups so a fault after group 0 leaves
+    // group 1 (and group 0's own writes) to prove the ROLLBACK, not just
+    // an early-return before any write happened.
+    store
+        .add_note_with_created_at("decision", "dup one", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    store
+        .add_note_with_created_at("decision", "dup one", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    store
+        .add_note_with_created_at("note", "dup two", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    store
+        .add_note_with_created_at("note", "dup two", "body", &[], &[], None, "active", 400)
+        .unwrap();
+
+    let before = note_count(&store);
+
+    inject_fault_after_group(0);
+    let result = store.dedupe_entity_ids(false);
+    clear_fault();
+
+    assert!(
+        result.is_err(),
+        "the injected fault must surface as an error"
+    );
+    assert_eq!(
+        note_count(&store),
+        before,
+        "memory.db must be unchanged after a rolled-back run (no partial collapse)"
+    );
+}
+
+// Adversarial: fault mid-group (after a loser is deleted, before the
+// next loser in the same group is touched), checked byte-for-byte across
+// every table dedupe can touch, not just a row count. AC21's own test
+// only proves rollback at a group boundary; this proves it holds mid-group.
+#[test]
+fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byte() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["orig"],
+            &[],
+            None,
+            "active",
+            100,
+        )
+        .unwrap();
+    let loser_a = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["from-a"],
+            &[],
+            None,
+            "archived",
+            200,
+        )
+        .unwrap();
+    let loser_b = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["from-b"],
+            &[],
+            None,
+            "active",
+            300,
+        )
+        .unwrap();
+    let external = store
+        .add_note("note", "external dependent", "b", &[], &[], None, None)
+        .unwrap();
+    // external's supersede edge points at loser_a; a fully-correct
+    // rollback must restore both the notes.superseded_by column AND this
+    // memory_edges row exactly as they were.
+    store.supersede(external, loser_a).unwrap();
+    store.insert_embedding(loser_a, &[7u8; 896 * 4]).unwrap();
+
+    let before = full_db_snapshot(&store);
+    assert_eq!(before.0.len(), 4, "precondition: 4 notes seeded");
+
+    // Fault fires right after loser_a (index 0) is fully deleted
+    // (embedding + edges + note row gone) but before loser_b is touched
+    // at all: a genuinely different point than the group-boundary fault
+    // AC21's own test injects.
+    inject_fault_after_loser(0);
+    let result = store.dedupe_entity_ids(false);
+    clear_loser_fault();
+
+    assert!(
+        result.is_err(),
+        "the mid-group injected fault must surface as an error"
+    );
+    let after = full_db_snapshot(&store);
+    assert_eq!(
+        after, before,
+        "notes + memory_edges + note_embeddings must be byte-for-byte \
+         unchanged after a run that fails mid-group (partial loser \
+         deletion must roll back too, not just whole-group commits)"
+    );
+    // Sanity: the row that would have been deleted is genuinely still
+    // present with its original content (not just "some 4 rows exist").
+    assert!(
+        store.get(loser_a).unwrap().is_some(),
+        "loser_a survives rollback"
+    );
+    let restored_survivor = store.get(survivor).unwrap().unwrap();
+    assert_eq!(
+        restored_survivor.tags,
+        vec!["orig".to_string()],
+        "survivor's own tags must not have been touched by the aborted run"
+    );
+    let _ = loser_b; // seeded only to make this a real multi-loser group
+}
+
+// ── Adversarial: --dry-run must leave every column of every touched
+// table untouched, not just row count / one column. ────────────────────
+#[test]
+fn dry_run_leaves_full_db_state_byte_for_byte_unchanged() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["a"],
+            &["f.rs"],
+            None,
+            "active",
+            100,
+        )
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at(
+            "decision",
+            "dup",
+            "body",
+            &["b"],
+            &[],
+            None,
+            "archived",
+            200,
+        )
+        .unwrap();
+    let external = store
+        .add_note("note", "external", "b", &[], &[], None, None)
+        .unwrap();
+    store.supersede(external, loser).unwrap();
+    store.insert_embedding(survivor, &[1u8; 896 * 4]).unwrap();
+    store.insert_embedding(loser, &[2u8; 896 * 4]).unwrap();
+
+    let before = full_db_snapshot(&store);
+    let summary = store.dedupe_entity_ids(true).unwrap();
+    assert_eq!(
+        summary.duplicate_groups, 1,
+        "precondition: a group exists to report on"
+    );
+
+    let after = full_db_snapshot(&store);
+    assert_eq!(
+        after, before,
+        "dry-run must leave notes + memory_edges + note_embeddings \
+         completely unchanged, in every column, not just row count"
+    );
+}
+
+// ── Adversarial: multiple external rows point at *different* losers
+// within the same duplicate group. Each must be independently repointed
+// to the survivor. ───────────────────────────────────────────────────────
+#[test]
+fn multiple_external_rows_pointing_at_different_losers_all_repoint_to_survivor() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser_a = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let loser_b = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
+        .unwrap();
+    let dep_a = store
+        .add_note("note", "points at loser_a", "b", &[], &[], None, None)
+        .unwrap();
+    let dep_b = store
+        .add_note("note", "points at loser_b", "b", &[], &[], None, None)
+        .unwrap();
+    store.set_superseded_by(dep_a, loser_a).unwrap();
+    store.set_superseded_by(dep_b, loser_b).unwrap();
+
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(summary.supersede_edges_repointed, 2);
+    assert_eq!(
+        store.get(dep_a).unwrap().unwrap().superseded_by,
+        Some(survivor),
+        "dep_a's edge to loser_a must repoint to the survivor"
+    );
+    assert_eq!(
+        store.get(dep_b).unwrap().unwrap().superseded_by,
+        Some(survivor),
+        "dep_b's edge to loser_b must repoint to the survivor, independently of dep_a"
+    );
+}
+
+// ── Adversarial: delete_edges_for_note must remove edges in *both*
+// directions for a loser (edges the loser points from, and edges other
+// notes point at the loser), leaving no orphan. ─────────────────────────
+#[test]
+fn loser_deletion_removes_memory_edges_in_both_directions_no_orphan() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let other_a = store
+        .add_note("note", "a", "b", &[], &[], None, None)
+        .unwrap();
+    let other_b = store
+        .add_note("note", "b", "b", &[], &[], None, None)
+        .unwrap();
+    // loser -> other_a (loser is from_id) and other_b -> loser (loser is to_id).
+    store.add_edge(loser, other_a, "relates_to").unwrap();
+    store.add_edge(other_b, loser, "relates_to").unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+
+    let orphans: i64 = store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM memory_edges WHERE from_id = ?1 OR to_id = ?1",
+            rusqlite::params![loser],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        orphans, 0,
+        "no memory_edges row may reference the deleted loser id"
+    );
+    let _ = survivor;
+}
+
+// Adversarial: relates_to/contradicts edges to a loser are dropped by
+// delete_edges_for_note, not repointed, unlike tags/linked_files/
+// superseded_by. ADR-068's third amendment only specifies a merge rule
+// for superseded_by, not the memory_edges graph, so this pins the
+// current (lossy) behavior as a known gap rather than a spec violation.
+#[test]
+fn relates_to_edge_to_external_note_is_dropped_not_repointed_known_gap() {
+    let store = open_store();
+    let survivor = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
+        .unwrap();
+    let loser = store
+        .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
+        .unwrap();
+    let external = store
+        .add_note("note", "external relation", "b", &[], &[], None, None)
+        .unwrap();
+    store.add_edge(loser, external, "relates_to").unwrap();
+
+    store.dedupe_entity_ids(false).unwrap();
+
+    let (survivor_out, _) = store.get_edges(survivor).unwrap();
+    assert!(
+        !survivor_out.iter().any(|e| e.to_id == external),
+        "documents current behavior: the loser's relates_to edge to an \
+         external note is NOT repointed onto the survivor (it is simply \
+         deleted with the loser). If this assertion ever fails, dedupe's \
+         edge handling changed; update this test alongside the ADR."
+    );
+}

--- a/crates/spelunk-core/src/storage/memory/edges.rs
+++ b/crates/spelunk-core/src/storage/memory/edges.rs
@@ -107,6 +107,19 @@ impl MemoryStore {
         }
     }
 
+    /// Delete every `memory_edges` row touching `note_id` (either endpoint).
+    ///
+    /// `memory dedupe` is the first place in this codebase that deletes an
+    /// existing note row, so it cleans up incident edges explicitly here
+    /// rather than relying on `memory_edges`' `ON DELETE CASCADE`.
+    pub fn delete_edges_for_note(&self, note_id: i64) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM memory_edges WHERE from_id = ?1 OR to_id = ?1",
+            rusqlite::params![note_id],
+        )?;
+        Ok(())
+    }
+
     /// Insert a directed edge between two notes.
     /// `kind` must be one of: supersedes, relates_to, contradicts.
     pub fn add_edge(&self, from_id: i64, to_id: i64, kind: &str) -> Result<()> {

--- a/crates/spelunk-core/src/storage/memory/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/mod.rs
@@ -3,12 +3,14 @@ use rusqlite::{Connection, OptionalExtension};
 use serde::Serialize;
 use std::path::Path;
 
+mod dedupe;
 mod edges;
 mod entity_id_migration;
 mod notes;
 mod search;
 mod sync;
 
+pub use dedupe::DedupeSummary;
 pub use sync::SyncRow;
 
 #[cfg(test)]

--- a/crates/spelunk-core/src/storage/memory/notes.rs
+++ b/crates/spelunk-core/src/storage/memory/notes.rs
@@ -148,17 +148,22 @@ impl MemoryStore {
         Ok(self.conn.last_insert_rowid())
     }
 
-    /// Return all notes for a project ordered by created_at ASC (used by reconcile
-    /// to compute the memory.db content-hash set).
+    /// Return all notes ordered by created_at ASC, id ASC (used by reconcile
+    /// for the content-hash set, and by `dedupe_entity_ids` to pick each
+    /// group's survivor).
     ///
-    /// Returns all notes regardless of status so that archived entries also
-    /// participate in dedup (we must not re-import a note that was already
-    /// imported and then archived in memory.db).
+    /// Includes every status, including archived, so dedup doesn't re-import
+    /// a note that was already imported and then archived.
+    ///
+    /// `id ASC` is a deliberate tie-break: created_at can collide (e.g. a
+    /// batch import), and id increases with insertion order, so this pins
+    /// "earliest created, ties broken by first inserted" as the definition
+    /// every caller relies on.
     pub fn all_notes_for_dedup(&self) -> Result<Vec<Note>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, kind, title, body, tags, linked_files, created_at, status, \
              superseded_by, source_ref, valid_at, invalid_at \
-             FROM notes ORDER BY created_at ASC",
+             FROM notes ORDER BY created_at ASC, id ASC",
         )?;
         let notes = stmt
             .query_map([], super::notes::row_to_note)?
@@ -208,6 +213,51 @@ impl MemoryStore {
         self.conn.execute(
             "UPDATE notes SET superseded_by = ?1 WHERE id = ?2",
             rusqlite::params![successor_id, note_id],
+        )?;
+        Ok(())
+    }
+
+    /// Clear an existing note's `superseded_by` link back to NULL. Used by
+    /// `memory dedupe`'s self-edge guard: a rewrite that would otherwise point
+    /// a row at itself drops the link instead.
+    pub fn clear_superseded_by(&self, note_id: i64) -> Result<()> {
+        self.conn.execute(
+            "UPDATE notes SET superseded_by = NULL WHERE id = ?1",
+            rusqlite::params![note_id],
+        )?;
+        Ok(())
+    }
+
+    /// Ids of every row whose `superseded_by` points at `target_id`.
+    pub fn notes_pointing_at(&self, target_id: i64) -> Result<Vec<i64>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM notes WHERE superseded_by = ?1")?;
+        let ids = stmt
+            .query_map(rusqlite::params![target_id], |r| r.get(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(ids)
+    }
+
+    /// Used only by `memory dedupe`, after a duplicate-group loser's
+    /// tags/linked_files/superseded_by have been folded into the survivor
+    /// and any edges pointing at it rewritten.
+    pub fn delete_note(&self, note_id: i64) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM notes WHERE id = ?1",
+            rusqlite::params![note_id],
+        )?;
+        Ok(())
+    }
+
+    /// No-op if absent. Used by `memory dedupe` when deleting a
+    /// duplicate-group loser: two vectors have no meaningful union, so the
+    /// embedding is dropped rather than merged; the survivor's own
+    /// embedding is untouched.
+    pub fn delete_note_embedding(&self, note_id: i64) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM note_embeddings WHERE note_id = ?1",
+            rusqlite::params![note_id],
         )?;
         Ok(())
     }

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -27,7 +27,7 @@ pub use git_notes::{
     ensure_notes_rewrite_ref, lock_notes, merge_tracking_notes, publish_notes,
 };
 pub use graph::GraphEdge;
-pub use memory::{MemoryEdge, MemoryStore, SyncRow};
+pub use memory::{DedupeSummary, MemoryEdge, MemoryStore, SyncRow};
 pub use note_record::{NoteRecord, now_millis, now_secs};
 pub use remote::{
     BatchItemResult, BatchPushItem, BatchPushResult, CloudSyncClient, RemoteEntry,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -765,6 +765,7 @@ spelunk memory pull                         # one-way: pull new server entries i
 spelunk memory sync                         # two-way: push local + pull remote (see `spelunk sync`)
 spelunk memory watch                        # stream new entries from the server (SSE)
 spelunk memory reconcile [--dry-run] [--all-projects] [--source-db <path>]
+spelunk memory dedupe [--dry-run] [--format text|json]
 ```
 
 All `memory` subcommands accept `--backend sqlite|git-notes` (default `sqlite`)
@@ -796,6 +797,9 @@ import dedup on it: entries with identical text collapse into one even when
 their creation time, tags, or linked files differ, and the survivor carries the
 union of the tags and linked files. The `id` shown by `memory list` is a local
 row number, not this identity. See [Entry identity](memory.md#project-memory).
+Existing duplicate rows already resident in `memory.db` are never collapsed
+automatically; use `spelunk memory dedupe` to do that explicitly (see
+[Collapsing duplicate entries already in memory.db](memory.md#collapsing-duplicate-entries-already-in-memorydb)).
 
 ---
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -688,6 +688,79 @@ project's own `memory.db`. Embeddings are re-generated from the imported text
 via the configured server (best-effort; notes import successfully even when the
 server is unreachable).
 
+## Collapsing duplicate entries already in memory.db
+
+Content identity (see **Entry identity** at the top of this page) is derived
+only from `kind`, `title`, and `body`. A `memory.db` that predates this, or
+that picked up entries from more than one machine, can already contain rows
+that share that identity while differing in `created_at`, `tags`,
+`linked_files`, or `status`, for example the same decision recorded twice by
+a repeated `memory harvest` run. spelunk leaves those rows in place: they are
+harmless, and nothing reads or writes memory any differently because of them.
+
+Because collapsing existing rows means deleting some of them, it never
+happens automatically. If `spelunk` finds duplicate groups while opening a
+project's `memory.db`, it logs an actionable one-line warning instead of
+touching anything:
+
+```
+entity_id has 2 duplicate group(s); run `spelunk memory dedupe` to collapse
+them, then re-run spelunk to enforce uniqueness
+```
+
+`spelunk memory dedupe` is the command that warning points at. It is a
+one-time backfill you run when you want to clean up, not a step in the normal
+workflow: `init`, `memory add`, and every other command keep working with
+duplicates present.
+
+For each group of rows sharing an identity, the surviving row is the one with
+the earliest `created_at`. The other rows are deleted after their `tags` and
+`linked_files` are merged into the survivor (union, nothing dropped), its
+status becomes `archived` if any row in the group was archived, and any
+`supersedes` edge elsewhere in the store that pointed at a deleted row is
+repointed to the survivor. One run collapses every duplicate group in a
+single transaction: an error midway rolls the whole run back, so `memory.db`
+either ends up fully collapsed or is left exactly as it was.
+
+```bash
+# Preview what would be collapsed, without writing anything
+spelunk memory dedupe --dry-run
+
+# Collapse duplicate groups
+spelunk memory dedupe
+
+# Machine-readable summary
+spelunk memory dedupe --format json
+```
+
+Sample output, collapsing one group of two rows (the newer row's `cli`,
+`exit-codes` tags and its linked file merge into the survivor):
+
+```
+$ spelunk memory dedupe --dry-run
+[spelunk] dedupe (dry-run): total_notes=2 duplicate_groups=1 rows_would_collapse=1
+
+$ spelunk memory dedupe
+[spelunk] dedupe: total_notes=2 duplicate_groups=1 rows_collapsed=1 tags_merged=2 linked_files_merged=1 supersede_edges_repointed=0 supersede_self_edges_dropped=0
+
+$ spelunk memory dedupe --format json
+{"total_notes":2,"duplicate_groups":1,"rows_collapsed":1,"tags_merged":2,"linked_files_merged":1,"supersede_edges_repointed":0,"supersede_self_edges_dropped":0}
+```
+
+Once a store has zero duplicate groups, `dedupe` (dry-run or not) reports
+all-zero counts and makes no writes, and the next `spelunk` run promotes
+`memory.db`'s `entity_id` index to enforce uniqueness going forward; after
+that, a duplicate group can no longer occur.
+
+### Security notes
+
+`dedupe` only reads and writes the project's own `memory.db`; it never
+contacts a server or an LLM. The collapse runs as a single transaction, so a
+failure partway through leaves the store exactly as it was rather than
+half-collapsed. Deleting the losing rows is destructive and not reversible by
+spelunk itself (back up `memory.db`, or your git-notes ref, first if you want
+to be able to undo it).
+
 ## Using memory as context
 
 `spelunk memory search` results are best consumed alongside `spelunk search` results — they answer the *why* while the code search answers the *how*. Pass both to your reasoning model for a complete picture.


### PR DESCRIPTION
## Summary

Second of a 7-PR stack replacing #696/#697/#698. Stacked on the entity_id backfill/promote PR (Step A/B) — needs the UNIQUE-index machinery to exist. Adds `spelunk memory dedupe`, ADR-068's third amendment: collapses duplicate-`entity_id` groups already resident in `memory.db`.

## What's in this PR

- `crates/spelunk-core/src/storage/memory/dedupe/{mod.rs,test_support.rs,tests.rs}` — `MemoryStore::dedupe_entity_ids`: survivor = earliest `created_at`; `tags`/`linked_files` union add-wins; archived sticks; supersede edges pointing at a removed row repoint to the survivor; whole run is one transaction. (The adversarial `superseded_by` edge-case coverage from five rounds of hardening is a separate PR next in the stack, kept out of this one to stay reviewable.)
- `crates/spelunk-cli/src/cli/cmd/memory/dedupe.rs` + `mod.rs` wiring — the `spelunk memory dedupe [--dry-run] [--format text|json]` subcommand.
- `crates/spelunk-cli/tests/memory_dedupe.rs` — CLI-facing integration tests.
- `crates/spelunk-core/src/storage/memory/{notes.rs,edges.rs}` — small dedupe-support helpers (`clear_superseded_by`, `notes_pointing_at`, `delete_note`, `delete_note_embedding`, `delete_edges_for_note`) and an `id ASC` tie-break on `all_notes_for_dedup`.
- `docs/memory.md`, `docs/commands.md`, `CHANGELOG.md` — user-facing docs for the new command.

Test files use plain `//` comments only, no `///`/`//!` doc-comment syntax.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace` — all green (default and `--no-default-features`)
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` — clean (default and `--no-default-features`)
- `cargo fmt --all -- --check` — clean
- Diff swept for em-dashes and internal ticket references: none found