### PR TITLE
fix(memory): add_note reuses the existing row on an entity_id collision

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
@@ -543,7 +543,7 @@ fn import_batch(
                 "active"
             };
 
-            let id = store.add_note_with_created_at(
+            let (id, _created) = store.add_note_with_created_at(
                 &note.kind,
                 &note.title,
                 &note.body,

--- a/crates/spelunk-cli/tests/cross_project_memory.rs
+++ b/crates/spelunk-cli/tests/cross_project_memory.rs
@@ -1335,7 +1335,7 @@ fn memory_store_list_excludes_archived_by_default() {
     store
         .add_note("decision", "Active note", "body", &[], &[], None, None)
         .expect("add active note");
-    let archived_id = store
+    let (archived_id, _) = store
         .add_note("decision", "Archived note", "body", &[], &[], None, None)
         .expect("add to-be-archived note");
     store.archive(archived_id).expect("archive note");

--- a/crates/spelunk-core/src/storage/backend.rs
+++ b/crates/spelunk-core/src/storage/backend.rs
@@ -132,7 +132,7 @@ impl MemoryBackend for LocalMemoryBackend {
                 supersedes_id,
             )?
         } else {
-            store.add_note(
+            let (id, _created) = store.add_note(
                 &input.kind,
                 &input.title,
                 &input.body,
@@ -140,7 +140,8 @@ impl MemoryBackend for LocalMemoryBackend {
                 &files,
                 input.source_ref.as_deref(),
                 input.valid_at,
-            )?
+            )?;
+            id
         };
         if let Some(blob) = &input.embedding {
             store.insert_embedding(id, blob)?;

--- a/crates/spelunk-core/src/storage/memory/dedupe/superseded_by_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/superseded_by_tests.rs
@@ -13,10 +13,10 @@ use super::*;
 #[test]
 fn adoption_must_not_selfloop_when_a_loser_points_at_the_survivor() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
     // loser was (per this row) "superseded by" the survivor itself.
@@ -44,13 +44,13 @@ fn adoption_must_not_selfloop_when_a_loser_points_at_the_survivor() {
 #[test]
 fn adoption_must_not_dangle_when_a_loser_points_at_a_fellow_loser() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
     // loser_a points at fellow loser loser_b: in-group, not external.
@@ -95,16 +95,16 @@ fn adoption_must_not_dangle_when_a_loser_points_at_a_fellow_loser() {
 #[test]
 fn adoption_survivor_own_in_group_pointer_does_not_clobber_fallthrough_adoption() {
     let store = open_store();
-    let external = store
+    let (external, _) = store
         .add_note("note", "external target", "b", &[], &[], None, None)
         .unwrap();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_x = store
+    let (loser_x, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_y = store
+    let (loser_y, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
     // Survivor's own value points at fellow duplicate loser_x: in-group,
@@ -138,19 +138,19 @@ fn adoption_survivor_own_in_group_pointer_does_not_clobber_fallthrough_adoption(
 #[test]
 fn fallthrough_adoption_skips_intragroup_dangling_candidate_and_adopts_later_external_one() {
     let store = open_store();
-    let external = store
+    let (external, _) = store
         .add_note("note", "external target", "b", &[], &[], None, None)
         .unwrap();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser_c = store
+    let (loser_c, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
         .unwrap();
     // loser_a (first candidate in iteration order) points at a fellow
@@ -177,13 +177,13 @@ fn fallthrough_adoption_skips_intragroup_dangling_candidate_and_adopts_later_ext
 #[test]
 fn adoption_resolves_to_none_when_every_candidate_is_intragroup() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
     // loser_a -> loser_b -> survivor: every candidate resolves to a
@@ -215,13 +215,13 @@ fn adoption_resolves_to_none_when_every_candidate_is_intragroup() {
 #[test]
 fn later_loser_pointing_at_earlier_fellow_loser_must_not_break_deletion_order() {
     let store = open_store();
-    let _survivor = store
+    let (_survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_early = store
+    let (loser_early, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_late = store
+    let (loser_late, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
     // loser_late (deleted second, per created_at ASC) points at
@@ -252,13 +252,13 @@ fn later_loser_pointing_at_earlier_fellow_loser_must_not_break_deletion_order() 
 #[test]
 fn mutually_referencing_fellow_losers_must_not_break_deletion_order() {
     let store = open_store();
-    let _survivor = store
+    let (_survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
     store.set_superseded_by(loser_a, loser_b).unwrap();
@@ -285,22 +285,22 @@ fn mutually_referencing_fellow_losers_must_not_break_deletion_order() {
 #[test]
 fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_deterministically() {
     let store = open_store();
-    let external_a = store
+    let (external_a, _) = store
         .add_note("note", "external a", "b", &[], &[], None, None)
         .unwrap();
-    let external_b = store
+    let (external_b, _) = store
         .add_note("note", "external b", "b", &[], &[], None, None)
         .unwrap();
-    let _survivor = store
+    let (_survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser1 = store
+    let (loser1, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser2 = store
+    let (loser2, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser3 = store
+    let (loser3, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
         .unwrap();
     // loser1 chains to fellow loser2: in-group, skipped for adoption,
@@ -327,22 +327,22 @@ fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_determin
     // Re-run on an independent store to confirm determinism, not just
     // repeatability within one process.
     let store2 = open_store();
-    let external_a2 = store2
+    let (external_a2, _) = store2
         .add_note("note", "external a", "b", &[], &[], None, None)
         .unwrap();
-    let external_b2 = store2
+    let (external_b2, _) = store2
         .add_note("note", "external b", "b", &[], &[], None, None)
         .unwrap();
-    let survivor2 = store2
+    let (survivor2, _) = store2
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser1b = store2
+    let (loser1b, _) = store2
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser2b = store2
+    let (loser2b, _) = store2
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser3b = store2
+    let (loser3b, _) = store2
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 400)
         .unwrap();
     store2.set_superseded_by(loser1b, loser2b).unwrap();
@@ -373,16 +373,16 @@ fn four_note_group_with_mixed_intragroup_and_external_pointers_resolves_determin
 fn external_row_that_is_itself_a_duplicate_in_a_different_group_is_resolved_correctly_across_groups()
  {
     let store = open_store();
-    let survivor_a = store
+    let (survivor_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let survivor_b = store
+    let (survivor_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 150)
         .unwrap();
-    let external_x = store
+    let (external_x, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 250)
         .unwrap();
     // external_x is a loser in group B, but its own pre-existing
@@ -434,19 +434,19 @@ fn external_row_that_is_itself_a_duplicate_in_a_different_group_is_resolved_corr
 #[test]
 fn chained_cross_group_reference_resolves_one_hop_not_to_intermediate_loser() {
     let store = open_store();
-    let survivor_a = store
+    let (survivor_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let survivor_b = store
+    let (survivor_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 150)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 250)
         .unwrap();
-    let survivor_c = store
+    let (survivor_c, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 175)
         .unwrap();
-    let loser_c = store
+    let (loser_c, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 275)
         .unwrap();
     // A's survivor points at B's loser; B's survivor independently
@@ -495,26 +495,26 @@ fn chained_cross_group_reference_resolves_one_hop_not_to_intermediate_loser() {
 fn ordinary_note_outside_every_group_pointing_at_a_loser_is_rewritten_and_counted() {
     let store = open_store();
     // Bookkeeping noise: unrelated groups to stress note_group_of lookups.
-    let _survivor_a = store
+    let (_survivor_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let _loser_a = store
+    let (_loser_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 110)
         .unwrap();
-    let survivor_b = store
+    let (survivor_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 120)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 130)
         .unwrap();
-    let _survivor_c = store
+    let (_survivor_c, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 140)
         .unwrap();
-    let _loser_c = store
+    let (_loser_c, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 150)
         .unwrap();
     // An ordinary, wholly unique note: not a member of any group above.
-    let ordinary = store
+    let (ordinary, _) = store
         .add_note("note", "ordinary unique note", "body", &[], &[], None, None)
         .unwrap();
     store.set_superseded_by(ordinary, loser_b).unwrap();
@@ -550,22 +550,22 @@ fn ordinary_note_outside_every_group_pointing_at_a_loser_is_rewritten_and_counte
 fn three_group_reference_cycle_resolves_identically_under_two_processing_orders() {
     // Variant 1: groups created in A, B, C order.
     let store1 = open_store();
-    let survivor_a1 = store1
+    let (survivor_a1, _) = store1
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a1 = store1
+    let (loser_a1, _) = store1
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 110)
         .unwrap();
-    let survivor_b1 = store1
+    let (survivor_b1, _) = store1
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b1 = store1
+    let (loser_b1, _) = store1
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 210)
         .unwrap();
-    let survivor_c1 = store1
+    let (survivor_c1, _) = store1
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser_c1 = store1
+    let (loser_c1, _) = store1
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 310)
         .unwrap();
     store1.set_superseded_by(survivor_a1, loser_b1).unwrap();
@@ -577,22 +577,22 @@ fn three_group_reference_cycle_resolves_identically_under_two_processing_orders(
     // Variant 2: same relational shape (A -> B's loser -> C's loser ->
     // A's loser), but groups are created in C, A, B physical order.
     let store2 = open_store();
-    let survivor_c2 = store2
+    let (survivor_c2, _) = store2
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_c2 = store2
+    let (loser_c2, _) = store2
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 110)
         .unwrap();
-    let survivor_a2 = store2
+    let (survivor_a2, _) = store2
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_a2 = store2
+    let (loser_a2, _) = store2
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 210)
         .unwrap();
-    let survivor_b2 = store2
+    let (survivor_b2, _) = store2
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser_b2 = store2
+    let (loser_b2, _) = store2
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 310)
         .unwrap();
     store2.set_superseded_by(survivor_a2, loser_b2).unwrap();
@@ -652,28 +652,28 @@ fn three_group_reference_cycle_resolves_identically_under_two_processing_orders(
 #[test]
 fn hand_derived_summary_counts_match_multi_group_scenario_exactly() {
     let store = open_store();
-    let survivor_a = store
+    let (survivor_a, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a1 = store
+    let (loser_a1, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 110)
         .unwrap();
-    let loser_a2 = store
+    let (loser_a2, _) = store
         .add_note_with_created_at("decision", "dup-a", "body", &[], &[], None, "active", 120)
         .unwrap();
-    let survivor_b = store
+    let (survivor_b, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b1 = store
+    let (loser_b1, _) = store
         .add_note_with_created_at("decision", "dup-b", "body", &[], &[], None, "active", 210)
         .unwrap();
-    let survivor_c = store
+    let (survivor_c, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let loser_c1 = store
+    let (loser_c1, _) = store
         .add_note_with_created_at("decision", "dup-c", "body", &[], &[], None, "active", 310)
         .unwrap();
-    let ordinary = store
+    let (ordinary, _) = store
         .add_note("note", "ordinary unique note", "body", &[], &[], None, None)
         .unwrap();
 
@@ -726,7 +726,7 @@ fn hand_derived_summary_counts_match_multi_group_scenario_exactly() {
 fn tied_created_at_breaks_deterministically_on_lower_id() {
     for _ in 0..5 {
         let store = open_store();
-        let first = store
+        let (first, _) = store
             .add_note_with_created_at(
                 "decision",
                 "tied dup",
@@ -738,7 +738,7 @@ fn tied_created_at_breaks_deterministically_on_lower_id() {
                 500,
             )
             .unwrap();
-        let second = store
+        let (second, _) = store
             .add_note_with_created_at(
                 "decision",
                 "tied dup",
@@ -789,10 +789,10 @@ fn duplicate_group_built_via_add_note_superseding_repoints_old_rows_to_survivor(
          still create two distinct rows for identical content"
     );
 
-    let old1 = store
+    let (old1, _) = store
         .add_note("decision", "old one", "old body one", &[], &[], None, None)
         .unwrap();
-    let old2 = store
+    let (old2, _) = store
         .add_note("decision", "old two", "old body two", &[], &[], None, None)
         .unwrap();
 

--- a/crates/spelunk-core/src/storage/memory/dedupe/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/tests.rs
@@ -31,7 +31,7 @@ fn zero_duplicates_reports_all_zero_and_writes_nothing() {
 #[test]
 fn dry_run_reports_counts_and_writes_nothing() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -43,7 +43,7 @@ fn dry_run_reports_counts_and_writes_nothing() {
             100,
         )
         .unwrap();
-    let _loser = store
+    let (_loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &["b"], &[], None, "active", 200)
         .unwrap();
 
@@ -79,10 +79,10 @@ fn dry_run_reports_counts_and_writes_nothing() {
 #[test]
 fn real_run_collapses_group_survivor_is_earliest_created() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
 
@@ -101,7 +101,7 @@ fn real_run_collapses_group_survivor_is_earliest_created() {
 #[test]
 fn tags_and_linked_files_union_add_wins() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -141,7 +141,7 @@ fn tags_and_linked_files_union_add_wins() {
 #[test]
 fn any_archived_row_makes_survivor_archived() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
     store
@@ -157,7 +157,7 @@ fn any_archived_row_makes_survivor_archived() {
 #[test]
 fn no_archived_row_leaves_survivor_status_unchanged() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
     store
@@ -173,13 +173,13 @@ fn no_archived_row_leaves_survivor_status_unchanged() {
 #[test]
 fn survivor_adopts_lone_superseded_by_from_group() {
     let store = open_store();
-    let elsewhere = store
+    let (elsewhere, _) = store
         .add_note("note", "elsewhere target", "b", &[], &[], None, None)
         .unwrap();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
     store.set_superseded_by(loser, elsewhere).unwrap();
@@ -193,17 +193,17 @@ fn survivor_adopts_lone_superseded_by_from_group() {
 #[test]
 fn conflicting_superseded_by_earliest_wins_no_error() {
     let store = open_store();
-    let target_a = store
+    let (target_a, _) = store
         .add_note("note", "a", "b", &[], &[], None, None)
         .unwrap();
-    let target_b = store
+    let (target_b, _) = store
         .add_note("note", "b", "b", &[], &[], None, None)
         .unwrap();
 
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
     store.set_superseded_by(survivor, target_a).unwrap();
@@ -223,13 +223,13 @@ fn conflicting_superseded_by_earliest_wins_no_error() {
 #[test]
 fn edge_elsewhere_pointing_at_loser_is_repointed_to_survivor() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let dependent = store
+    let (dependent, _) = store
         .add_note("note", "points at loser", "b", &[], &[], None, None)
         .unwrap();
     store.set_superseded_by(dependent, loser).unwrap();
@@ -244,10 +244,10 @@ fn edge_elsewhere_pointing_at_loser_is_repointed_to_survivor() {
 #[test]
 fn rewrite_that_would_self_point_is_dropped_to_null() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
     // The survivor itself already points at its own duplicate-group loser.
@@ -266,10 +266,10 @@ fn rewrite_that_would_self_point_is_dropped_to_null() {
 #[test]
 fn loser_embedding_deleted_survivor_embedding_untouched() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
     // note_embeddings is FLOAT[896]: 896 * 4-byte floats per row.
@@ -336,7 +336,7 @@ fn injected_fault_partway_rolls_back_whole_run() {
 #[test]
 fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byte() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -348,7 +348,7 @@ fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byt
             100,
         )
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -360,7 +360,7 @@ fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byt
             200,
         )
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -372,7 +372,7 @@ fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byt
             300,
         )
         .unwrap();
-    let external = store
+    let (external, _) = store
         .add_note("note", "external dependent", "b", &[], &[], None, None)
         .unwrap();
     // external's supersede edge points at loser_a; a fully-correct
@@ -423,7 +423,7 @@ fn injected_fault_mid_group_after_partial_loser_deletion_rolls_back_byte_for_byt
 #[test]
 fn dry_run_leaves_full_db_state_byte_for_byte_unchanged() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -435,7 +435,7 @@ fn dry_run_leaves_full_db_state_byte_for_byte_unchanged() {
             100,
         )
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at(
             "decision",
             "dup",
@@ -447,7 +447,7 @@ fn dry_run_leaves_full_db_state_byte_for_byte_unchanged() {
             200,
         )
         .unwrap();
-    let external = store
+    let (external, _) = store
         .add_note("note", "external", "b", &[], &[], None, None)
         .unwrap();
     store.supersede(external, loser).unwrap();
@@ -475,19 +475,19 @@ fn dry_run_leaves_full_db_state_byte_for_byte_unchanged() {
 #[test]
 fn multiple_external_rows_pointing_at_different_losers_all_repoint_to_survivor() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser_a = store
+    let (loser_a, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let loser_b = store
+    let (loser_b, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 300)
         .unwrap();
-    let dep_a = store
+    let (dep_a, _) = store
         .add_note("note", "points at loser_a", "b", &[], &[], None, None)
         .unwrap();
-    let dep_b = store
+    let (dep_b, _) = store
         .add_note("note", "points at loser_b", "b", &[], &[], None, None)
         .unwrap();
     store.set_superseded_by(dep_a, loser_a).unwrap();
@@ -513,16 +513,16 @@ fn multiple_external_rows_pointing_at_different_losers_all_repoint_to_survivor()
 #[test]
 fn loser_deletion_removes_memory_edges_in_both_directions_no_orphan() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let other_a = store
+    let (other_a, _) = store
         .add_note("note", "a", "b", &[], &[], None, None)
         .unwrap();
-    let other_b = store
+    let (other_b, _) = store
         .add_note("note", "b", "b", &[], &[], None, None)
         .unwrap();
     // loser -> other_a (loser is from_id) and other_b -> loser (loser is to_id).
@@ -554,13 +554,13 @@ fn loser_deletion_removes_memory_edges_in_both_directions_no_orphan() {
 #[test]
 fn relates_to_edge_to_external_note_is_dropped_not_repointed_known_gap() {
     let store = open_store();
-    let survivor = store
+    let (survivor, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 100)
         .unwrap();
-    let loser = store
+    let (loser, _) = store
         .add_note_with_created_at("decision", "dup", "body", &[], &[], None, "active", 200)
         .unwrap();
-    let external = store
+    let (external, _) = store
         .add_note("note", "external relation", "b", &[], &[], None, None)
         .unwrap();
     store.add_edge(loser, external, "relates_to").unwrap();

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs
@@ -1,0 +1,242 @@
+// ADR-068 fourth amendment coverage: `add_note`'s insert-then-recover
+// behavior once `idx_notes_entity_id` is promoted to UNIQUE.
+
+use super::test_support::*;
+
+// Once Step B promotes idx_notes_entity_id to UNIQUE, a plain add_note for
+// byte-identical kind/title/body must recover instead of surfacing the raw
+// SQLite UNIQUE-constraint error to the caller.
+#[test]
+fn add_note_after_promotion_does_not_hard_crash_on_duplicate_content() {
+    let store = open_store();
+    let (first_id, first_created) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    assert!(
+        first_created,
+        "criterion 25: a genuinely new row inserts fine"
+    );
+
+    // Zero duplicate groups at this point: promotes immediately, exactly
+    // as a real `MemoryStore::open` would on this store's very next open.
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(index_is_unique(&store), "precondition: index is now UNIQUE");
+
+    // The exact scenario the ADR's third amendment says "yields one
+    // entry": a second, ordinary `add_note` call for byte-identical
+    // kind/title/body content.
+    let result = store.add_note(
+        "decision",
+        "dup entry",
+        "same content",
+        &[],
+        &[],
+        None,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "a colliding add_note must recover, not surface the raw UNIQUE \
+         constraint error: {:?}",
+        result.as_ref().err()
+    );
+
+    // Criterion 26/30: the reused row's id is returned with created=false.
+    let (second_id, second_created) = result.unwrap();
+    assert_eq!(
+        second_id, first_id,
+        "criterion 26: a collision must return the EXISTING row's id"
+    );
+    assert!(
+        !second_created,
+        "criterion 30: the bool must be false for a reused row"
+    );
+
+    // Only one row exists: no phantom second insert survived underneath
+    // the recovery path.
+    assert_eq!(
+        store.count().unwrap(),
+        1,
+        "the collision must not leave behind a second row"
+    );
+}
+
+// Criterion 26: tags/linked_files on the call that collides must merge
+// (add-wins) into the existing row rather than being dropped.
+#[test]
+fn add_note_after_promotion_merges_tags_and_linked_files_into_existing_row() {
+    let store = open_store();
+    let (id, _) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &["alpha"],
+            &["a.rs"],
+            None,
+            None,
+        )
+        .unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+
+    let (reused_id, created) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &["beta"],
+            &["b.rs"],
+            None,
+            None,
+        )
+        .unwrap();
+    assert_eq!(reused_id, id);
+    assert!(!created);
+
+    let note = store.get(id).unwrap().expect("row still exists");
+    assert_eq!(
+        note.tags,
+        vec!["alpha".to_string(), "beta".to_string()],
+        "tags must union, add-wins, existing tag never dropped"
+    );
+    assert_eq!(
+        note.linked_files,
+        vec!["a.rs".to_string(), "b.rs".to_string()],
+        "linked_files must union the same way"
+    );
+}
+
+// Criterion 27: the collision path must not touch status or superseded_by
+// on the existing row, mirrors reconcile.rs's own existing-row handling,
+// not dedupe.rs's fuller merge (a different scenario: collapsing two rows
+// that already diverged, not a single fresh insert colliding with one).
+#[test]
+fn add_note_after_promotion_does_not_touch_status_or_superseded_by() {
+    let store = open_store();
+    let (other_id, _) = store
+        .add_note("note", "unrelated", "b", &[], &[], None, None)
+        .unwrap();
+    let (id, _) = store
+        .add_note_with_created_at(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            "archived",
+            100,
+        )
+        .unwrap();
+    store.set_superseded_by(id, other_id).unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+
+    let (reused_id, created) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    assert_eq!(reused_id, id);
+    assert!(!created);
+
+    let note = store.get(id).unwrap().expect("row still exists");
+    assert_eq!(
+        note.status, "archived",
+        "criterion 27: status must be left untouched by the collision path"
+    );
+    assert_eq!(
+        note.superseded_by,
+        Some(other_id),
+        "criterion 27: superseded_by must be left untouched by the collision path"
+    );
+}
+
+// Criterion 29: before promotion (the common case while duplicate groups
+// still exist), identical content must keep inserting distinct rows:
+// the very mechanism dedupe.rs's own fixtures rely on to build
+// duplicate-group scenarios in the first place.
+#[test]
+fn add_note_before_promotion_still_inserts_distinct_rows_for_identical_content() {
+    let store = open_store();
+    assert!(!index_is_unique(&store), "precondition: not yet promoted");
+
+    let (first_id, first_created) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    let (second_id, second_created) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+
+    assert!(first_created);
+    assert!(
+        second_created,
+        "pre-promotion, a second identical insert must still be a fresh row"
+    );
+    assert_ne!(first_id, second_id);
+    assert_eq!(store.count().unwrap(), 2);
+}
+
+// ── Criterion 28: any error other than the specific notes.entity_id
+// UNIQUE violation must propagate unchanged, not be swallowed by the
+// collision-recovery match arm. Exercised via a synthetic trigger that
+// raises a distinct error for a specific title, so the failure is
+// unambiguously NOT a UNIQUE-on-entity_id violation.
+#[test]
+fn add_note_other_error_propagates_unchanged_not_swallowed_as_collision() {
+    let store = open_store();
+    store
+        .conn
+        .execute_batch(
+            "CREATE TRIGGER reject_specific_title
+             BEFORE INSERT ON notes
+             WHEN NEW.title = 'trigger-reject'
+             BEGIN SELECT RAISE(ABORT, 'synthetic non-unique failure'); END;",
+        )
+        .unwrap();
+
+    let result = store.add_note("note", "trigger-reject", "body", &[], &[], None, None);
+    assert!(
+        result.is_err(),
+        "criterion 28: a non-UNIQUE error must propagate, not be swallowed"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("synthetic non-unique failure"),
+        "expected the synthetic trigger error to propagate verbatim, got: {msg}"
+    );
+    let total_rows: i64 = store
+        .conn
+        .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(total_rows, 0, "a failed insert must leave no row behind");
+}

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
@@ -51,7 +51,7 @@ fn backfill_on_fully_populated_store_is_noop() {
 #[test]
 fn backfill_leaves_already_stamped_rows_untouched() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("decision", "already stamped", "body", &[], &[], None, None)
         .unwrap();
     let before: String = store
@@ -199,7 +199,7 @@ fn promote_skips_rescan_once_marker_present() {
 #[test]
 fn promote_after_manual_collapse_to_zero_duplicates_succeeds() {
     let store = open_store();
-    let survivor_id = store
+    let (survivor_id, _) = store
         .add_note_with_created_at(
             "note",
             "dup title",
@@ -211,7 +211,7 @@ fn promote_after_manual_collapse_to_zero_duplicates_succeeds() {
             1_700_000_000,
         )
         .unwrap();
-    let loser_id = store
+    let (loser_id, _) = store
         .add_note_with_created_at(
             "note",
             "dup title",

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs
@@ -106,6 +106,8 @@ impl MemoryStore {
 }
 
 #[cfg(test)]
+mod collision_recovery_tests;
+#[cfg(test)]
 mod migration_tests;
 #[cfg(test)]
 mod test_support;

--- a/crates/spelunk-core/src/storage/memory/notes.rs
+++ b/crates/spelunk-core/src/storage/memory/notes.rs
@@ -81,8 +81,12 @@ pub(super) fn split_csv(s: Option<&str>) -> Vec<String> {
 // ── MemoryStore note methods ─────────────────────────────────────────────────
 
 impl MemoryStore {
-    /// Insert a note and return its id. Does not store an embedding —
-    /// call `insert_embedding` afterwards if the embedder is available.
+    /// Insert a note and return `(id, created)`. `created` is `true` when a
+    /// genuinely new row was inserted, `false` when the insert collided with
+    /// an existing row's `entity_id` (only possible once `idx_notes_entity_id`
+    /// has been promoted to UNIQUE, see `entity_id_migration.rs`) and that
+    /// existing row was reused instead. Does not store an embedding on a fresh
+    /// insert; call `insert_embedding` afterwards if the embedder is available.
     #[allow(clippy::too_many_arguments)]
     pub fn add_note(
         &self,
@@ -93,8 +97,9 @@ impl MemoryStore {
         linked_files: &[&str],
         source_ref: Option<&str>,
         valid_at: Option<i64>,
-    ) -> Result<i64> {
-        self.conn.execute(
+    ) -> Result<(i64, bool)> {
+        let entity_id = crate::storage::entity_id::entity_id(kind, title, body);
+        let result = self.conn.execute(
             "INSERT INTO notes \
              (kind, title, body, tags, linked_files, source_ref, valid_at, entity_id)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
@@ -106,10 +111,10 @@ impl MemoryStore {
                 linked_files.join(","),
                 source_ref,
                 valid_at,
-                crate::storage::entity_id::entity_id(kind, title, body),
+                entity_id,
             ],
-        )?;
-        Ok(self.conn.last_insert_rowid())
+        );
+        self.recover_from_entity_id_collision(result, &entity_id, tags, linked_files)
     }
 
     /// Insert a note with an explicit `created_at` timestamp (unix epoch seconds).
@@ -117,6 +122,8 @@ impl MemoryStore {
     /// Used by `memory reconcile` to preserve the original creation timestamp
     /// from the source store. All other callers should use `add_note`, which
     /// defers to the SQLite `DEFAULT (unixepoch())`.
+    ///
+    /// Returns `(id, created)`, see `add_note` for what `created` means.
     #[allow(clippy::too_many_arguments)]
     pub fn add_note_with_created_at(
         &self,
@@ -128,8 +135,9 @@ impl MemoryStore {
         source_ref: Option<&str>,
         status: &str,
         created_at: i64,
-    ) -> Result<i64> {
-        self.conn.execute(
+    ) -> Result<(i64, bool)> {
+        let entity_id = crate::storage::entity_id::entity_id(kind, title, body);
+        let result = self.conn.execute(
             "INSERT INTO notes \
              (kind, title, body, tags, linked_files, source_ref, status, created_at, entity_id)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
@@ -142,10 +150,47 @@ impl MemoryStore {
                 source_ref,
                 status,
                 created_at,
-                crate::storage::entity_id::entity_id(kind, title, body),
+                entity_id,
             ],
-        )?;
-        Ok(self.conn.last_insert_rowid())
+        );
+        self.recover_from_entity_id_collision(result, &entity_id, tags, linked_files)
+    }
+
+    /// Shared insert-then-recover tail for `add_note`/`add_note_with_created_at`.
+    /// A UNIQUE-constraint failure here can only be `idx_notes_entity_id`:
+    /// neither function populates `uuid` or `remote_id`, and both of those
+    /// indexes are partial (`WHERE ... IS NOT NULL`), so NULL never collides.
+    /// Recovers by merging `tags`/`linked_files` into the existing row
+    /// (add-wins, via `union_tags_and_files`) and returning its id with
+    /// `created = false`. Leaves `status`/`superseded_by` untouched, unlike
+    /// `dedupe.rs`'s fuller merge (that collapses two rows already diverged
+    /// in the store; this is one fresh insert colliding with one existing row).
+    /// Any other error propagates unchanged.
+    pub(super) fn recover_from_entity_id_collision(
+        &self,
+        insert_result: rusqlite::Result<usize>,
+        entity_id: &str,
+        tags: &[&str],
+        linked_files: &[&str],
+    ) -> Result<(i64, bool)> {
+        match insert_result {
+            Ok(_) => Ok((self.conn.last_insert_rowid(), true)),
+            Err(rusqlite::Error::SqliteFailure(err, _))
+                if err.code == rusqlite::ErrorCode::ConstraintViolation
+                    && err.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE =>
+            {
+                let existing_id: i64 = self.conn.query_row(
+                    "SELECT id FROM notes WHERE entity_id = ?1",
+                    rusqlite::params![entity_id],
+                    |r| r.get(0),
+                )?;
+                let owned_tags: Vec<String> = tags.iter().map(|s| s.to_string()).collect();
+                let owned_files: Vec<String> = linked_files.iter().map(|s| s.to_string()).collect();
+                self.union_tags_and_files(existing_id, &owned_tags, &owned_files)?;
+                Ok((existing_id, false))
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Return all notes ordered by created_at ASC, id ASC (used by reconcile

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -39,10 +39,10 @@ fn count_edges(store: &MemoryStore, from_id: i64, to_id: i64, kind: &str) -> i64
 fn supersede_happy_path() {
     let store = open_store();
 
-    let old_id = store
+    let (old_id, _) = store
         .add_note("decision", "Old decision", "old body", &[], &[], None, None)
         .unwrap();
-    let new_id = store
+    let (new_id, _) = store
         .add_note("decision", "New decision", "new body", &[], &[], None, None)
         .unwrap();
 
@@ -66,10 +66,10 @@ fn supersede_happy_path() {
 fn supersede_idempotent() {
     let store = open_store();
 
-    let old_id = store
+    let (old_id, _) = store
         .add_note("note", "Alpha", "body", &[], &[], None, None)
         .unwrap();
-    let new_id = store
+    let (new_id, _) = store
         .add_note("note", "Beta", "body", &[], &[], None, None)
         .unwrap();
 
@@ -97,7 +97,7 @@ fn supersede_idempotent() {
 fn add_note_superseding_happy_path_archives_old_and_links_new() {
     let store = open_store();
 
-    let old_id = store
+    let (old_id, _) = store
         .add_note("decision", "Old decision", "old body", &[], &[], None, None)
         .unwrap();
 
@@ -132,7 +132,7 @@ fn add_note_superseding_happy_path_archives_old_and_links_new() {
 fn add_note_superseding_rejects_already_archived_old_and_writes_nothing() {
     let store = open_store();
 
-    let old_id = store
+    let (old_id, _) = store
         .add_note("decision", "Old decision", "old body", &[], &[], None, None)
         .unwrap();
     let successor_a = store
@@ -192,10 +192,10 @@ fn add_note_superseding_rejects_nonexistent_old() {
 #[test]
 fn add_edge_valid_kinds_accepted() {
     let store = open_store();
-    let a = store
+    let (a, _) = store
         .add_note("note", "A", "", &[], &[], None, None)
         .unwrap();
-    let b = store
+    let (b, _) = store
         .add_note("note", "B", "", &[], &[], None, None)
         .unwrap();
 
@@ -209,10 +209,10 @@ fn add_edge_valid_kinds_accepted() {
 #[test]
 fn add_edge_invalid_kind_returns_err() {
     let store = open_store();
-    let a = store
+    let (a, _) = store
         .add_note("note", "A", "", &[], &[], None, None)
         .unwrap();
-    let b = store
+    let (b, _) = store
         .add_note("note", "B", "", &[], &[], None, None)
         .unwrap();
 
@@ -228,10 +228,10 @@ fn add_edge_invalid_kind_returns_err() {
 #[test]
 fn add_edge_duplicate_silently_ignored() {
     let store = open_store();
-    let a = store
+    let (a, _) = store
         .add_note("note", "A", "", &[], &[], None, None)
         .unwrap();
-    let b = store
+    let (b, _) = store
         .add_note("note", "B", "", &[], &[], None, None)
         .unwrap();
 
@@ -250,7 +250,7 @@ fn add_edge_duplicate_silently_ignored() {
 #[test]
 fn ensure_uuid_backfills_and_is_idempotent() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("decision", "D", "body", &[], &[], None, None)
         .unwrap();
 
@@ -362,13 +362,13 @@ fn max_remote_id_is_the_pull_cursor() {
 
     // Record a few cloud ids. UUIDv7 strings sort lexically == time order, so
     // MAX() returns the newest one regardless of insertion order.
-    let a = store
+    let (a, _) = store
         .add_note("note", "A", "b", &[], &[], None, None)
         .unwrap();
-    let b = store
+    let (b, _) = store
         .add_note("note", "B", "b", &[], &[], None, None)
         .unwrap();
-    let c = store
+    let (c, _) = store
         .add_note("note", "C", "b", &[], &[], None, None)
         .unwrap();
     store
@@ -391,7 +391,7 @@ fn max_remote_id_is_the_pull_cursor() {
 #[test]
 fn set_remote_id_records_and_dedupes() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "N", "b", &[], &[], None, None)
         .unwrap();
     store.ensure_uuid(id).unwrap();
@@ -406,7 +406,7 @@ fn set_remote_id_records_and_dedupes() {
 #[test]
 fn add_note_persists_entity_id() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("decision", "HTTP layer", "use axum", &[], &[], None, None)
         .unwrap();
 
@@ -428,7 +428,7 @@ fn add_note_persists_entity_id() {
 #[test]
 fn union_tags_and_files_is_add_wins() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "N", "b", &["alpha"], &["a.rs"], None, None)
         .unwrap();
 
@@ -467,7 +467,7 @@ fn union_tags_and_files_is_add_wins() {
 #[test]
 fn union_tags_keeps_fts_in_sync() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "Findable", "body", &["alpha"], &[], None, None)
         .unwrap();
     store
@@ -603,7 +603,7 @@ fn entity_id_migration_backfills_but_does_not_collapse_duplicates() {
 #[test]
 fn insert_embedding_replaces_a_repeated_note_id() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "N", "b", &[], &[], None, None)
         .unwrap();
 
@@ -651,7 +651,7 @@ fn insert_embedding_replaces_a_repeated_note_id() {
 #[test]
 fn insert_embedding_of_nonexistent_note_id_is_a_harmless_delete_no_op() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "N", "b", &[], &[], None, None)
         .unwrap();
 
@@ -686,7 +686,7 @@ fn insert_embedding_of_nonexistent_note_id_is_a_harmless_delete_no_op() {
 #[test]
 fn insert_embedding_joins_callers_transaction_and_rolls_back_with_it() {
     let store = open_store();
-    let id = store
+    let (id, _) = store
         .add_note("note", "N", "b", &[], &[], None, None)
         .unwrap();
 


### PR DESCRIPTION
## Summary

Fourth of a 7-PR stack replacing #696/#697/#698. Stacked on the dedupe hardening PR. ADR-068's fourth amendment: once `idx_notes_entity_id` is promoted to UNIQUE, `spelunk memory add` for byte-identical content previously hard-crashed with a raw `UNIQUE constraint failed: notes.entity_id` error. This PR fixes the storage layer.

## What's in this PR

- `crates/spelunk-core/src/storage/memory/notes.rs` — `add_note`/`add_note_with_created_at` attempt the insert as before; on a UNIQUE-constraint failure specifically on `notes.entity_id`, they look up the existing row, merge `tags`/`linked_files` into it (add-wins), and return its id instead of propagating the error. Any other error still propagates unchanged. `status`/`superseded_by` are left untouched on this path (mirrors `reconcile.rs`'s own existing-row handling, not `dedupe.rs`'s fuller merge).
- `crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs` (new) — coverage for the collision-recovery path, tags/linked_files merge, status/superseded_by left alone, pre-promotion behavior unchanged, and non-UNIQUE errors still propagating.
- Mechanical fallout: both functions' return type changes from `Result<i64>` to `Result<(i64, bool)>` (the bool says whether a fresh row was created), which is a compile-enforced ripple to every direct call site of these two functions — `backend.rs`'s `LocalMemoryBackend::add`, `reconcile.rs`'s `import_batch`, and the existing test fixtures in `dedupe/tests.rs`, `dedupe/superseded_by_tests.rs`, `entity_id_migration/migration_tests.rs`, `memory/tests.rs`, and `cross_project_memory.rs` that call `add_note`/`add_note_with_created_at` directly.

**Deviation from the original split plan:** the direct-call-site ripple above was originally planned for the next PR in the stack, but a function's return-type change breaks every direct caller in the same compilation unit — deferring those fixes would leave this PR unable to build. This PR includes only the *direct* callers of `add_note`/`add_note_with_created_at`. The next PR in the stack still owns the `MemoryBackend` *trait*-level ripple (`Result<i64>` → `Result<(i64, bool)>` on the trait itself, its `GitNotesBackend`/`RemoteMemoryBackend` implementors, and CLI callers that go through `backend.add()` rather than calling `add_note` directly), since none of those needed to change for this PR to compile.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace` — all green (default and `--no-default-features`)
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` — clean (default and `--no-default-features`)
- `cargo fmt --all -- --check` — clean
- Diff swept for em-dashes and internal ticket references: none found