### PR TITLE
fix: extract require_explicit_server_url guard shared by memory push and sync

### DIFF
--- a/crates/spelunk-cli/src/capability.rs
+++ b/crates/spelunk-cli/src/capability.rs
@@ -908,6 +908,33 @@ pub fn require_tier1(feature: &str, tier: &Tier, server_url: Option<&str>) -> an
     }
 }
 
+/// Guard for a feature that moves memory to or from an explicitly-configured
+/// server (`memory push`, `sync`, `memory pull`): a self-hosted team server or
+/// Spelunk Cloud both work identically here. Distinct from features that
+/// merely need *an* inference-capable server (covered by [`require_tier1`]).
+///
+/// `require_tier1` alone is not sufficient for these commands: an
+/// auto-discovered loopback inference server makes the tier `Server` while
+/// `cfg.server_url` stays `None`, and that loopback server is never a memory
+/// store (ADR-004). Callers check `require_tier1` first, which already bails
+/// on `Tier::Offline`; this guard then confirms the server was configured
+/// explicitly rather than merely auto-discovered.
+///
+/// Deliberately **explicit-config-only**: it reads `cfg.server_url` and
+/// nothing else, never probing reachability or consulting the health-probe
+/// `Capabilities` itself. By the time this runs, every current caller has
+/// already established reachability via `require_tier1`, so this only ever
+/// needs to answer one question: was the server set explicitly? Returns the
+/// configured `server_url` on success.
+pub fn require_explicit_server_url(feature: &str, cfg: &Config) -> anyhow::Result<String> {
+    cfg.server_url.clone().ok_or_else(|| {
+        anyhow::anyhow!(
+            "'spelunk {feature}' requires a server. Set `server_url` in your spelunk config \
+             (e.g. ~/.config/spelunk/config.toml or .spelunk/config.toml)."
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1287,6 +1314,65 @@ mod tests {
         let err = require_tier1("memory push", &tier, None).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("'spelunk memory push'"));
+    }
+
+    // require_explicit_server_url: `memory push`, `sync`, and `memory pull` all move
+    // memory to/from an explicitly-configured team server; an auto-discovered
+    // loopback inference server must never satisfy them (ADR-004: it is never
+    // a memory store). `require_tier1` alone is not enough for these commands,
+    // since a loopback server makes the tier `Server` while `cfg.server_url`
+    // stays `None`. This guard checks explicit configuration only and must
+    // never probe reachability, so it stays usable before any network call is
+    // made.
+
+    #[test]
+    fn require_explicit_server_url_errs_when_unset() {
+        let cfg = Config {
+            server_url: None,
+            ..Default::default()
+        };
+        let err = require_explicit_server_url("sync", &cfg).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("server_url"));
+    }
+
+    #[test]
+    fn require_explicit_server_url_ok_regardless_of_reachability() {
+        // A garbage, unreachable URL: the guard must still succeed, because it
+        // checks configuration presence only, never reachability. Reachability
+        // is `require_tier1`'s job at the actual call site.
+        let cfg = Config {
+            server_url: Some("https://unreachable.invalid:1".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            require_explicit_server_url("sync", &cfg).unwrap(),
+            "https://unreachable.invalid:1"
+        );
+    }
+
+    /// The load-bearing regression test: `memory push` and `sync` must refuse
+    /// with the exact same message shape (only the feature name differs), so
+    /// they can never again drift into the two different messages this guard
+    /// was extracted to prevent.
+    #[test]
+    fn require_explicit_server_url_message_is_identical_in_shape_across_features() {
+        let cfg = Config {
+            server_url: None,
+            ..Default::default()
+        };
+        let push_msg = require_explicit_server_url("memory push", &cfg)
+            .unwrap_err()
+            .to_string();
+        let sync_msg = require_explicit_server_url("sync", &cfg)
+            .unwrap_err()
+            .to_string();
+        assert_eq!(
+            push_msg.replace("memory push", "sync"),
+            sync_msg,
+            "push and sync messages must differ only in the feature name: \
+             push={push_msg:?} sync={sync_msg:?}"
+        );
     }
 
     // ── read_server_port_file ────────────────────────────────────────────────

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -40,10 +40,7 @@ pub async fn memory_push(
     let tier = capability::get_tier(cfg).await;
     capability::require_tier1("memory push", tier, cfg.server_url.as_deref())?;
 
-    let base_url = cfg
-        .server_url
-        .clone()
-        .ok_or_else(|| anyhow::anyhow!("memory push requires `server_url` to be configured."))?;
+    let base_url = capability::require_explicit_server_url("memory push", cfg)?;
     let project_id = cfg.project_id.clone().ok_or_else(|| {
         anyhow::anyhow!(
             "`project_id` is not configured. Set it in `.spelunk/config.toml` \

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -59,27 +59,24 @@ fn resolve_sync_project(cli_project: Option<&str>, cfg: &Config) -> Result<Strin
 
 /// Resolve the cloud sync target (base URL, server-side project id, key).
 ///
-/// Sync always speaks to an explicit `server_url` — it is the cloud-convergence
-/// path, not the inference loopback. Errors with actionable guidance when the
-/// server is missing, or when no project slug is available (see
-/// [`resolve_sync_project`]).
+/// Sync always speaks to an explicit `server_url`, not the inference loopback.
+/// Errors with actionable guidance when the server is missing (via
+/// [`capability::require_explicit_server_url`], the same guard `memory push` uses),
+/// or when no project slug is available (see [`resolve_sync_project`]).
 ///
-/// `cli_project` is the optional `--project <slug>` override; when `None` the
-/// configured `project_id` is used.
+/// `feature` names the calling command (`"sync"` or `"memory pull"`) for the
+/// error message. `cli_project` is the optional `--project <slug>` override;
+/// when `None` the configured `project_id` is used.
 ///
 /// The bearer key is resolved through [`auth_api::ensure_fresh_server_key`] so a
 /// WorkOS access token that has expired since `spelunk login` is refreshed (and
 /// the rotated tokens persisted) before the cloud-api call, rather than 401-ing.
 async fn sync_target(
+    feature: &str,
     cfg: &Config,
     cli_project: Option<&str>,
 ) -> Result<(String, String, Option<String>)> {
-    let base_url = cfg.server_url.clone().ok_or_else(|| {
-        anyhow::anyhow!(
-            "sync requires a server. Set `server_url` in your spelunk config \
-             (e.g. ~/.config/spelunk/config.toml or .spelunk/config.toml)."
-        )
-    })?;
+    let base_url = capability::require_explicit_server_url(feature, cfg)?;
     let project_id = resolve_sync_project(cli_project, cfg)?;
     let key = auth_api::ensure_fresh_server_key(cfg, &base_url).await?;
     Ok((base_url, project_id, key))
@@ -93,7 +90,7 @@ pub async fn memory_pull(
 ) -> Result<()> {
     let tier = capability::get_tier(cfg).await;
     capability::require_tier1("memory pull", tier, cfg.server_url.as_deref())?;
-    let (base_url, project_id, key) = sync_target(cfg, None).await?;
+    let (base_url, project_id, key) = sync_target("memory pull", cfg, None).await?;
 
     let local = MemoryStore::open(mem_path)
         .with_context(|| format!("opening local memory at {}", mem_path.display()))?;
@@ -117,7 +114,7 @@ pub async fn memory_sync(
 ) -> Result<()> {
     let tier = capability::get_tier(cfg).await;
     capability::require_tier1("sync", tier, cfg.server_url.as_deref())?;
-    let (base_url, project_id, key) = sync_target(cfg, args.project.as_deref()).await?;
+    let (base_url, project_id, key) = sync_target("sync", cfg, args.project.as_deref()).await?;
 
     let src_path = args.source.as_deref().unwrap_or(mem_path);
     let local = MemoryStore::open(src_path)


### PR DESCRIPTION
## Summary
- `memory push` and `sync` each built their own "server_url is not configured" error message inline; the two had drifted into different wording.
- Extracts a single `capability::require_explicit_server_url(feature, cfg)` guard used by both call sites, so the message is byte-identical in shape (only the feature name differs).
- The guard is deliberately explicit-config-only: it never probes reachability itself, since `require_tier1` already establishes that at the call site; it exists to distinguish an auto-discovered loopback inference server (never a memory store, ADR-004) from an explicitly-configured server.

Split out of #669 at Johan's request: that PR was titled/scoped as docs-only but carried this logic change, so it's landing here on its own for proper review.

## Test plan
- `SPELUNK_SECRET_STORE=file cargo build --workspace` (default and `--no-default-features`) — clean.
- `SPELUNK_SECRET_STORE=file cargo test --workspace` (default and `--no-default-features`) — all green, including the new `require_explicit_server_url_*` unit tests and the load-bearing `require_explicit_server_url_message_is_identical_in_shape_across_features` regression test.
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` (both feature configs) — clean.
- `cargo fmt --all -- --check` — clean.