### PR TITLE
fix(memory): thread add_note's created flag through MemoryBackend

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -136,8 +136,8 @@ pub(super) async fn memory_add(
     // server, or (with `--backend git-notes`) git notes itself. Pre-init there
     // is no primary; the write-through carrier below is the sole writer, so mint
     // an id the same way the backends do (`now_millis`).
-    let id = if pre_init_notes {
-        now_millis()
+    let (id, _created) = if pre_init_notes {
+        (now_millis(), true)
     } else {
         let backend = match backend_for_add.take() {
             Some(backend) => backend,

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -398,7 +398,7 @@ async fn memory_harvest_git(
                 })
                 .await
             {
-                Ok(id) => id,
+                Ok((id, _created)) => id,
                 Err(e) => {
                     eprintln!(
                         "  warning: failed to store entry '{title}' ({full_sha}), skipping: {e:#}"
@@ -761,7 +761,7 @@ async fn memory_harvest_failures(
                 })
                 .await
             {
-                Ok(id) => id,
+                Ok((id, _created)) => id,
                 Err(e) => {
                     eprintln!(
                         "  warning: failed to store entry '{title}' ({full_sha}), skipping: {e:#}"

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
@@ -425,7 +425,7 @@ pub(super) async fn harvest_claude_code(
                 })
                 .await
             {
-                Ok(id) => id,
+                Ok((id, _created)) => id,
                 Err(e) => {
                     eprintln!(
                         "  warning: failed to store entry '{title}' (session {session_id}), skipping: {e:#}"

--- a/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
@@ -1014,7 +1014,7 @@ mod init_import_tests {
         let git_root = repo.path();
 
         let backend = GitNotesBackend::with_root(git_root.to_path_buf());
-        let id = backend
+        let (id, _created) = backend
             .add(NoteInput {
                 kind: "note".to_string(),
                 title: "retired decision".to_string(),

--- a/crates/spelunk-core/src/storage/backend.rs
+++ b/crates/spelunk-core/src/storage/backend.rs
@@ -26,7 +26,13 @@ pub struct NoteInput {
 /// Abstraction over local SQLite and remote HTTP memory stores.
 #[async_trait]
 pub trait MemoryBackend: Send {
-    async fn add(&self, input: NoteInput) -> Result<i64>;
+    /// Returns `(id, created)`. `created` is `true` for a genuinely new entry,
+    /// `false` when the write collided with an existing entry's `entity_id`
+    /// and that entry was reused instead (only possible on a local SQLite
+    /// backend whose `idx_notes_entity_id` has been promoted to UNIQUE, see
+    /// `MemoryStore::add_note`). Backends that cannot detect this (git notes,
+    /// remote) always return `true`.
+    async fn add(&self, input: NoteInput) -> Result<(i64, bool)>;
     /// Semantic search over ALL notes (incl. archived), ordered by valid_at/created_at ASC.
     ///
     /// `query`: the raw query text. Local backends search by `query_blob` (a
@@ -40,7 +46,7 @@ pub trait MemoryBackend: Send {
     ) -> Result<Vec<Note>>;
     /// Semantic (vector KNN) search.
     ///
-    /// `query`: the raw query text — see `search_timeline` for why both
+    /// `query`: the raw query text, see `search_timeline` for why both
     /// `query_blob` and `query` are passed to every backend.
     /// `as_of`: if set, only entries valid at that Unix timestamp are returned.
     async fn search(
@@ -117,12 +123,15 @@ impl LocalMemoryBackend {
 
 #[async_trait]
 impl MemoryBackend for LocalMemoryBackend {
-    async fn add(&self, input: NoteInput) -> Result<i64> {
+    async fn add(&self, input: NoteInput) -> Result<(i64, bool)> {
         let store = self.store.lock().await;
         let tags: Vec<&str> = input.tags.iter().map(String::as_str).collect();
         let files: Vec<&str> = input.linked_files.iter().map(String::as_str).collect();
-        let id = if let Some(supersedes_id) = input.supersedes {
-            store.add_note_superseding(
+        let (id, created) = if let Some(supersedes_id) = input.supersedes {
+            // add_note_superseding doesn't populate entity_id at insert time
+            // today, so it cannot hit the UNIQUE-collision path add_note
+            // recovers from below; every call here is a fresh insert.
+            let id = store.add_note_superseding(
                 &input.kind,
                 &input.title,
                 &input.body,
@@ -130,9 +139,10 @@ impl MemoryBackend for LocalMemoryBackend {
                 &files,
                 input.valid_at,
                 supersedes_id,
-            )?
+            )?;
+            (id, true)
         } else {
-            let (id, _created) = store.add_note(
+            store.add_note(
                 &input.kind,
                 &input.title,
                 &input.body,
@@ -140,13 +150,12 @@ impl MemoryBackend for LocalMemoryBackend {
                 &files,
                 input.source_ref.as_deref(),
                 input.valid_at,
-            )?;
-            id
+            )?
         };
         if let Some(blob) = &input.embedding {
             store.insert_embedding(id, blob)?;
         }
-        Ok(id)
+        Ok((id, created))
     }
 
     async fn search_timeline(

--- a/crates/spelunk-core/src/storage/git_notes/backend_impl.rs
+++ b/crates/spelunk-core/src/storage/git_notes/backend_impl.rs
@@ -9,7 +9,7 @@ use super::GitNotesBackend;
 
 #[async_trait]
 impl MemoryBackend for GitNotesBackend {
-    async fn add(&self, input: NoteInput) -> Result<i64> {
+    async fn add(&self, input: NoteInput) -> Result<(i64, bool)> {
         let id = now_millis();
         let entity_id =
             crate::storage::entity_id::entity_id(&input.kind, &input.title, &input.body);
@@ -35,7 +35,9 @@ impl MemoryBackend for GitNotesBackend {
         let head = self.head_sha().await?;
         self.append_record(&head, &record).await?;
 
-        Ok(id)
+        // Git notes are append-only: this backend never detects or collapses
+        // a collision, so every add is reported as a fresh insert.
+        Ok((id, true))
     }
 
     async fn list(

--- a/crates/spelunk-core/src/storage/remote/mod.rs
+++ b/crates/spelunk-core/src/storage/remote/mod.rs
@@ -266,7 +266,7 @@ impl RemoteMemoryBackend {
 
 #[async_trait]
 impl MemoryBackend for RemoteMemoryBackend {
-    async fn add(&self, input: NoteInput) -> Result<i64> {
+    async fn add(&self, input: NoteInput) -> Result<(i64, bool)> {
         let embedding = input.embedding.as_deref().map(blob_to_vec);
         let body = AddNoteRequest {
             kind: input.kind,
@@ -302,7 +302,9 @@ impl MemoryBackend for RemoteMemoryBackend {
                     );
                 }
             }
-            return Ok(resp.id);
+            // server.db doesn't enforce this amendment's promoted index, so
+            // there is nothing for this backend to detect as a reuse.
+            return Ok((resp.id, true));
         }
 
         let resp = http_resp
@@ -316,7 +318,7 @@ impl MemoryBackend for RemoteMemoryBackend {
         if let Some(remote_id) = &resp.remote_id {
             tracing::debug!(remote_id, "server assigned remote_id for new memory entry");
         }
-        Ok(resp.id)
+        Ok((resp.id, true))
     }
 
     /// Remote backend: timeline search falls back to regular semantic search.

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -100,7 +100,7 @@ async fn git_notes_add_and_list_round_trip() {
     let dir = make_temp_git_repo();
     let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
 
-    let id = backend
+    let (id, _) = backend
         .add(note_input("decision", "use sqlcipher"))
         .await
         .expect("add");
@@ -240,7 +240,7 @@ async fn git_notes_archive_hides_entry() {
     let dir = make_temp_git_repo();
     let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
 
-    let id = backend
+    let (id, _) = backend
         .add(note_input("decision", "archive me"))
         .await
         .expect("add");
@@ -541,7 +541,7 @@ async fn git_notes_backend_add_with_option_like_body_round_trips() {
     let mut input = note_input("decision", "--amend");
     input.body = "-f --force --output=/tmp/should-not-exist-oss61".to_string();
 
-    let id = backend.add(input).await.expect("add");
+    let (id, _) = backend.add(input).await.expect("add");
 
     let notes = backend
         .list(Some("decision"), 10, false, None)
@@ -1239,7 +1239,7 @@ async fn git_notes_backend_add_and_archive_fail_when_the_lock_is_contended() {
     let root = dir.path();
     let backend = GitNotesBackend::with_root(root.to_path_buf());
 
-    let id = backend
+    let (id, _) = backend
         .add(note_input("decision", "the sibling entry at stake"))
         .await
         .expect("seed");
@@ -1377,7 +1377,7 @@ async fn git_notes_backend_add_and_archive_fail_when_the_note_cannot_be_read() {
     let root = dir.path();
     let backend = GitNotesBackend::with_root(root.to_path_buf());
 
-    let id = backend
+    let (id, _) = backend
         .add(note_input("decision", "the sibling entry at stake"))
         .await
         .expect("seed");
@@ -1772,12 +1772,11 @@ async fn git_notes_backend_concurrent_archives_land_or_fail_visibly() {
     // collision here would archive the wrong record.
     let mut ids = Vec::new();
     for n in 1..=ENTRIES {
-        ids.push(
-            backend
-                .add(note_input("decision", &format!("archive target {n}")))
-                .await
-                .expect("add"),
-        );
+        let (id, _) = backend
+            .add(note_input("decision", &format!("archive target {n}")))
+            .await
+            .expect("add");
+        ids.push(id);
     }
     let distinct: std::collections::HashSet<i64> = ids.iter().copied().collect();
     assert_eq!(distinct.len(), ENTRIES, "setup: the ids must be distinct");
@@ -1856,7 +1855,7 @@ async fn git_notes_backend_uncontended_add_and_archive_never_reach_the_wait_budg
     let backend = GitNotesBackend::with_root(dir.path().to_path_buf());
 
     let started = std::time::Instant::now();
-    let id = backend
+    let (id, _) = backend
         .add(note_input("decision", "no nested acquisition"))
         .await
         .expect("add");


### PR DESCRIPTION
## Summary

Fifth of a 7-PR stack replacing #696/#697/#698. Stacked on the `add_note` collision-recovery PR. Threads the `created` flag from `add_note`'s new `(id, bool)` return type up through the `MemoryBackend` trait, so its callers can eventually branch on whether the write was a fresh insert or a reused row.

## What's in this PR

- `crates/spelunk-core/src/storage/backend.rs` — `MemoryBackend::add` changes from `Result<i64>` to `Result<(i64, bool)>`. `LocalMemoryBackend::add` propagates `add_note`'s tuple directly (the `add_note_superseding` arm always reports `true`: it doesn't populate `entity_id` at insert time today, so it can't hit the collision path).
- `crates/spelunk-core/src/storage/git_notes/backend_impl.rs`, `crates/spelunk-core/src/storage/remote/mod.rs` — `GitNotesBackend`/`RemoteMemoryBackend` implement the new signature, always returning `true` (neither enforces the promoted UNIQUE index today).
- Mechanical fallout across every `backend.add()` call site that binds the result: `harvest.rs`, `harvest_claude.rs`, `reconcile.rs`'s `GitNotesBackend` test fixture, `add.rs`'s primary-store call (destructure only, no behavior change yet), and `integration_git_notes.rs`'s test fixtures.

No user-visible behavior change in this PR — the `created` flag isn't consumed anywhere yet. The CLI's `Already recorded as ...` message that reads it is next in the stack.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace` — all green (default and `--no-default-features`)
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` — clean (default and `--no-default-features`)
- `cargo fmt --all -- --check` — clean
- Diff swept for em-dashes and internal ticket references: none found