### PR TITLE
fix(memory): add_note_superseding gets entity_id and Step A hardens

### DIFF
--- a/crates/spelunk-core/src/storage/backend.rs
+++ b/crates/spelunk-core/src/storage/backend.rs
@@ -128,10 +128,7 @@ impl MemoryBackend for LocalMemoryBackend {
         let tags: Vec<&str> = input.tags.iter().map(String::as_str).collect();
         let files: Vec<&str> = input.linked_files.iter().map(String::as_str).collect();
         let (id, created) = if let Some(supersedes_id) = input.supersedes {
-            // add_note_superseding doesn't populate entity_id at insert time
-            // today, so it cannot hit the UNIQUE-collision path add_note
-            // recovers from below; every call here is a fresh insert.
-            let id = store.add_note_superseding(
+            store.add_note_superseding(
                 &input.kind,
                 &input.title,
                 &input.body,
@@ -139,8 +136,7 @@ impl MemoryBackend for LocalMemoryBackend {
                 &files,
                 input.valid_at,
                 supersedes_id,
-            )?;
-            (id, true)
+            )?
         } else {
             store.add_note(
                 &input.kind,

--- a/crates/spelunk-core/src/storage/memory/dedupe/superseded_by_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/superseded_by_tests.rs
@@ -796,7 +796,7 @@ fn duplicate_group_built_via_add_note_superseding_repoints_old_rows_to_survivor(
         .add_note("decision", "old two", "old body two", &[], &[], None, None)
         .unwrap();
 
-    let new1 = store
+    let (new1, created1) = store
         .add_note_superseding(
             "decision",
             "dup replacement",
@@ -807,7 +807,8 @@ fn duplicate_group_built_via_add_note_superseding_repoints_old_rows_to_survivor(
             old1,
         )
         .unwrap();
-    let new2 = store
+    assert!(created1, "pre-promotion: fresh row");
+    let (new2, created2) = store
         .add_note_superseding(
             "decision",
             "dup replacement",
@@ -818,11 +819,12 @@ fn duplicate_group_built_via_add_note_superseding_repoints_old_rows_to_survivor(
             old2,
         )
         .unwrap();
-    assert_ne!(
-        new1, new2,
+    assert!(
+        created2,
         "pre-promotion: identical content still creates a second, \
          distinct row (the duplicate-group precondition for this test)"
     );
+    assert_ne!(new1, new2);
 
     // Precondition: each OLD row now points at its own distinct
     // successor - new1 and new2, which are themselves a duplicate group.
@@ -852,6 +854,95 @@ fn duplicate_group_built_via_add_note_superseding_repoints_old_rows_to_survivor(
         Some(new1),
         "old1's own edge already pointed at the survivor and must be \
          unaffected"
+    );
+}
+
+// Step A's collision-skip leaves a colliding row's entity_id column NULL
+// rather than erroring. dedupe_entity_ids recomputes entity_id fresh from
+// {kind,title,body} on every call rather than reading the stored column, so
+// a row Step A was forced to skip is still discoverable and collapsible by
+// spelunk memory dedupe. Proves that end to end, with the skipped row
+// simultaneously the target of an unrelated row's superseded_by.
+#[test]
+fn step_a_skipped_row_that_is_a_supersede_target_is_still_collapsed_by_dedupe() {
+    let store = open_store();
+    let (existing_id, _) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(
+        index_is_unique_for_test(&store),
+        "precondition: index promoted"
+    );
+
+    // A stray NULL-entity_id row colliding with `existing_id` (simulating
+    // a pre-E1 add_note_superseding row, or any other latent NULL-id
+    // insert path): bypasses add_note's own recovery entirely.
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body) VALUES ('decision', 'dup entry', 'same content')",
+            [],
+        )
+        .unwrap();
+    let stray_id = store.conn.last_insert_rowid();
+
+    // A third, unrelated row whose superseded_by points AT the stray
+    // row: the stray is simultaneously a supersede target.
+    let (pointer_id, _) = store
+        .add_note("note", "points at stray", "b", &[], &[], None, None)
+        .unwrap();
+    store.set_superseded_by(pointer_id, stray_id).unwrap();
+
+    // Step A must skip the stray row without error.
+    store
+        .backfill_entity_ids()
+        .expect("Step A must not hard-fail on the collision");
+    let stray_eid: Option<String> = store
+        .conn
+        .query_row(
+            "SELECT entity_id FROM notes WHERE id = ?1",
+            rusqlite::params![stray_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        stray_eid, None,
+        "precondition: Step A left the colliding row's entity_id NULL"
+    );
+
+    // `spelunk memory dedupe` must still find and collapse it, even
+    // though the stored `entity_id` column never got populated: it
+    // recomputes entity_id from {kind,title,body}, not from the column.
+    let summary = store.dedupe_entity_ids(false).unwrap();
+    assert_eq!(
+        summary.duplicate_groups, 1,
+        "dedupe must discover the group despite the stray row's NULL \
+         stored entity_id column"
+    );
+    assert_eq!(summary.rows_collapsed, 1);
+    assert!(
+        store.get(existing_id).unwrap().is_some(),
+        "existing_id (earlier-created) survives"
+    );
+    assert!(
+        store.get(stray_id).unwrap().is_none(),
+        "the stray row is collapsed away"
+    );
+    assert_eq!(
+        store.get(pointer_id).unwrap().unwrap().superseded_by,
+        Some(existing_id),
+        "pointer_id's edge to the now-deleted stray row must be \
+         repointed to the survivor, proving the promised \
+         Step-A-skip-then-dedupe recovery path actually closes the loop"
     );
 }
 

--- a/crates/spelunk-core/src/storage/memory/edges.rs
+++ b/crates/spelunk-core/src/storage/memory/edges.rs
@@ -12,8 +12,25 @@ pub(super) fn row_to_edge(row: &rusqlite::Row<'_>) -> rusqlite::Result<MemoryEdg
 }
 
 impl MemoryStore {
-    /// Insert a note in a transaction that also sets `invalid_at` on the superseded entry.
-    /// Returns the new note's id.
+    /// Insert a note in a transaction that also sets `invalid_at` on the
+    /// superseded entry.
+    ///
+    /// Returns `(id, created)`, see `MemoryStore::add_note` for what
+    /// `created` means. ADR-068's fifth amendment (E1): this INSERT
+    /// populates `entity_id` just like `add_note`/`add_note_with_created_at`,
+    /// so it is subject to the same UNIQUE constraint once
+    /// `idx_notes_entity_id` is promoted, and reuses the same
+    /// `recover_from_entity_id_collision`. On a collision, the *existing*
+    /// row's id is what the archive-`OLD` step below targets, not a fresh one.
+    ///
+    /// A collision can resolve to `supersedes_id` itself (a caller
+    /// superseding `old_id` with content byte-identical to `old_id`'s own
+    /// `{kind,title,body}`). Then there is nothing to archive and no edge to
+    /// add, since the "new" entry already is that row, so both steps are
+    /// skipped and the row is returned unchanged (`created = false`,
+    /// tags/linked_files already merged by the recovery above): a self-loop
+    /// of exactly the shape `dedupe.rs`'s own self-edge guard exists to
+    /// prevent, reached via this path instead.
     #[allow(clippy::too_many_arguments)]
     pub fn add_note_superseding(
         &self,
@@ -24,12 +41,13 @@ impl MemoryStore {
         linked_files: &[&str],
         valid_at: Option<i64>,
         supersedes_id: i64,
-    ) -> Result<i64> {
+    ) -> Result<(i64, bool)> {
         self.conn.execute_batch("BEGIN")?;
-        let result = (|| -> Result<i64> {
-            self.conn.execute(
-                "INSERT INTO notes (kind, title, body, tags, linked_files, valid_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        let result = (|| -> Result<(i64, bool)> {
+            let entity_id = crate::storage::entity_id::entity_id(kind, title, body);
+            let insert_result = self.conn.execute(
+                "INSERT INTO notes (kind, title, body, tags, linked_files, valid_at, entity_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 rusqlite::params![
                     kind,
                     title,
@@ -37,35 +55,46 @@ impl MemoryStore {
                     tags.join(","),
                     linked_files.join(","),
                     valid_at,
+                    entity_id,
                 ],
+            );
+            let (id, created) = self.recover_from_entity_id_collision(
+                insert_result,
+                &entity_id,
+                tags,
+                linked_files,
             )?;
-            let new_id = self.conn.last_insert_rowid();
+            if id == supersedes_id {
+                // Self-collision guard: nothing to archive and no edge to add
+                // when the collision resolved to the supersede target itself.
+                return Ok((id, created));
+            }
             let changed = self.conn.execute(
                 "UPDATE notes
                  SET    status = 'archived',
                         superseded_by = ?2,
                         invalid_at = CASE WHEN invalid_at IS NULL THEN unixepoch() ELSE invalid_at END
                  WHERE  id = ?1 AND status = 'active'",
-                rusqlite::params![supersedes_id, new_id],
+                rusqlite::params![supersedes_id, id],
             )?;
             if changed == 0 {
                 // OLD is absent or already archived (e.g. a prior --supersedes
                 // call already claimed it). Mirrors supersede()'s existing
                 // reject-on-stale-OLD contract (ADR-068 E4): bail so the outer
-                // match rolls the whole transaction back — the just-inserted
+                // match rolls the whole transaction back, so the just-inserted
                 // new note is never committed and no carrier write happens.
                 anyhow::bail!("No active memory entry with id {supersedes_id} (old).");
             }
             self.conn.execute(
                 "INSERT OR IGNORE INTO memory_edges (from_id, to_id, kind) VALUES (?1, ?2, 'supersedes')",
-                rusqlite::params![new_id, supersedes_id],
+                rusqlite::params![id, supersedes_id],
             )?;
-            Ok(new_id)
+            Ok((id, created))
         })();
         match result {
-            Ok(id) => {
+            Ok(v) => {
                 self.conn.execute_batch("COMMIT")?;
-                Ok(id)
+                Ok(v)
             }
             Err(e) => {
                 self.conn.execute_batch("ROLLBACK").ok();

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs
@@ -1,5 +1,7 @@
-// ADR-068 fourth amendment coverage: `add_note`'s insert-then-recover
-// behavior once `idx_notes_entity_id` is promoted to UNIQUE.
+// ADR-068 fourth and fifth amendment coverage: add_note/
+// add_note_superseding insert-then-recover behavior once
+// idx_notes_entity_id is promoted to UNIQUE, and Step A's own
+// per-row collision skip.
 
 use super::test_support::*;
 
@@ -239,4 +241,411 @@ fn add_note_other_error_propagates_unchanged_not_swallowed_as_collision() {
         .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
         .unwrap();
     assert_eq!(total_rows, 0, "a failed insert must leave no row behind");
+}
+
+// ── ADR-068 fifth amendment E1: add_note_superseding gains entity_id ────
+
+// Criterion 1/2: a supersede-created row gets a non-NULL entity_id equal
+// to entity_id(kind, title, body), the INSERT succeeds normally when
+// there's no collision, and the archive-OLD UPDATE runs against the
+// freshly-inserted row.
+#[test]
+fn add_note_superseding_sets_entity_id_and_archives_old_on_fresh_insert() {
+    let store = open_store();
+    let (old_id, _) = store
+        .add_note("decision", "old", "old body", &[], &[], None, None)
+        .unwrap();
+
+    let (new_id, created) = store
+        .add_note_superseding("decision", "new", "new body", &[], &[], None, old_id)
+        .unwrap();
+    assert!(created, "criterion 2: a fresh row inserts normally");
+
+    let expected_eid = crate::storage::entity_id::entity_id("decision", "new", "new body");
+    let stored_eid: Option<String> = store
+        .conn
+        .query_row(
+            "SELECT entity_id FROM notes WHERE id = ?1",
+            rusqlite::params![new_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        stored_eid,
+        Some(expected_eid),
+        "criterion 1: entity_id must be entity_id(kind, title, body)"
+    );
+
+    let old = store.get(old_id).unwrap().expect("old row still exists");
+    assert_eq!(old.status, "archived");
+    assert_eq!(
+        old.superseded_by,
+        Some(new_id),
+        "archive-OLD must target the freshly-inserted row"
+    );
+}
+
+// Criterion 3: a collision with an existing row's entity_id (post-
+// promotion) must not error; tags/linked_files merge into the existing
+// row via union_tags_and_files, and archive-OLD targets the EXISTING row.
+#[test]
+fn add_note_superseding_recovers_from_collision_and_archives_old_on_existing_row() {
+    let store = open_store();
+    let (existing_id, _) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &["alpha"],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(index_is_unique(&store), "precondition: index promoted");
+
+    let (old_id, _) = store
+        .add_note("decision", "to retire", "b", &[], &[], None, None)
+        .unwrap();
+
+    let (returned_id, created) = store
+        .add_note_superseding(
+            "decision",
+            "dup entry",
+            "same content",
+            &["beta"],
+            &[],
+            None,
+            old_id,
+        )
+        .unwrap();
+    assert!(
+        !created,
+        "criterion 3: a colliding insert must report created=false"
+    );
+    assert_eq!(
+        returned_id, existing_id,
+        "criterion 3: the EXISTING row's id must be returned, not a new one"
+    );
+    let total_rows: i64 = store
+        .conn
+        .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        total_rows, 2,
+        "no new row must have been created by the collision, still just \
+         `existing` and (now-archived) `old`"
+    );
+
+    let existing = store.get(existing_id).unwrap().unwrap();
+    assert_eq!(
+        existing.tags,
+        vec!["alpha".to_string(), "beta".to_string()],
+        "tags must union via union_tags_and_files, add-wins"
+    );
+
+    let old = store.get(old_id).unwrap().expect("old row still exists");
+    assert_eq!(old.status, "archived");
+    assert_eq!(
+        old.superseded_by,
+        Some(existing_id),
+        "criterion 3: archive-OLD must target the EXISTING row, not a new one"
+    );
+}
+
+// Criterion 4: pre-promotion, add_note_superseding must keep creating
+// distinct rows for identical content, mirrors add_note's own criterion
+// 29 for this function.
+#[test]
+fn add_note_superseding_before_promotion_still_inserts_distinct_rows() {
+    let store = open_store();
+    assert!(!index_is_unique(&store), "precondition: not yet promoted");
+
+    let (old_id, _) = store
+        .add_note("decision", "old", "old body", &[], &[], None, None)
+        .unwrap();
+    let (first_id, first_created) = store
+        .add_note_superseding("decision", "dup", "body", &[], &[], None, old_id)
+        .unwrap();
+
+    let (old_id2, _) = store
+        .add_note("decision", "old2", "old body2", &[], &[], None, None)
+        .unwrap();
+    let (second_id, second_created) = store
+        .add_note_superseding("decision", "dup", "body", &[], &[], None, old_id2)
+        .unwrap();
+
+    assert!(first_created);
+    assert!(
+        second_created,
+        "pre-promotion, identical content must still create distinct rows"
+    );
+    assert_ne!(first_id, second_id);
+}
+
+// Criterion 5: an error other than the specific notes.entity_id UNIQUE
+// violation must propagate unchanged, exercised here via a
+// `supersedes_id` that doesn't reference any row at all, which the
+// `memory_edges` foreign key rejects. This is a different SQLite error
+// entirely (FOREIGN KEY, not UNIQUE on notes.entity_id), so it must not
+// be swallowed by the collision-recovery path: it must propagate as an
+// error, and the whole transaction must roll back (no orphaned note left
+// behind).
+#[test]
+fn add_note_superseding_other_errors_propagate_and_roll_back() {
+    let store = open_store();
+    let result = store.add_note_superseding("decision", "new", "body", &[], &[], None, 999_999);
+    assert!(
+        result.is_err(),
+        "criterion 5: a non-collision error must propagate, not be swallowed"
+    );
+    assert_eq!(
+        store.count().unwrap(),
+        0,
+        "the failed transaction must roll back; no orphaned note left behind"
+    );
+}
+
+// ── ADR-068 fifth amendment E2: Step A hardens against a collision ──────
+
+// Criterion 7: a NULL-entity_id row whose computed value collides with an
+// existing row's entity_id (only reachable once the index is already
+// UNIQUE from a prior open) is skipped (left NULL), and open succeeds.
+#[test]
+fn backfill_skips_a_row_whose_computed_entity_id_collides_and_open_succeeds() {
+    let store = open_store();
+    let (existing_id, _) = store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(index_is_unique(&store), "precondition: index promoted");
+
+    // Simulate a row left behind by some NULL-entity_id insert path
+    // (e.g. a pre-E1 add_note_superseding row): insert directly with
+    // entity_id NULL, bypassing add_note's own recovery entirely.
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body) VALUES ('decision', 'dup entry', 'same content')",
+            [],
+        )
+        .unwrap();
+    let stray_id = store.conn.last_insert_rowid();
+
+    // Step A must not error even though this row's computed entity_id
+    // collides with `existing_id`'s.
+    store
+        .backfill_entity_ids()
+        .expect("criterion 7: Step A must not hard-fail on a collision");
+
+    let stray_eid: Option<String> = store
+        .conn
+        .query_row(
+            "SELECT entity_id FROM notes WHERE id = ?1",
+            rusqlite::params![stray_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        stray_eid, None,
+        "criterion 7: the colliding row must be left NULL, not silently dropped"
+    );
+
+    let existing_eid: Option<String> = store
+        .conn
+        .query_row(
+            "SELECT entity_id FROM notes WHERE id = ?1",
+            rusqlite::params![existing_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(
+        existing_eid.is_some(),
+        "the pre-existing row's own entity_id must be untouched"
+    );
+}
+
+// Criterion 8: a NULL-entity_id row with no collision backfills exactly
+// as today (already covered by `backfill_populates_null_entity_ids`
+// above; this test pins the *mixed* case: one colliding row alongside one
+// clean row in the same Step A pass).
+#[test]
+fn backfill_still_populates_non_colliding_rows_alongside_a_colliding_one() {
+    let store = open_store();
+    store
+        .add_note(
+            "decision",
+            "dup entry",
+            "same content",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body) VALUES ('decision', 'dup entry', 'same content')",
+            [],
+        )
+        .unwrap();
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body) VALUES ('note', 'clean row', 'clean body')",
+            [],
+        )
+        .unwrap();
+    let clean_id = store.conn.last_insert_rowid();
+
+    store.backfill_entity_ids().unwrap();
+
+    let clean_eid: Option<String> = store
+        .conn
+        .query_row(
+            "SELECT entity_id FROM notes WHERE id = ?1",
+            rusqlite::params![clean_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        clean_eid,
+        Some(crate::storage::entity_id::entity_id(
+            "note",
+            "clean row",
+            "clean body"
+        )),
+        "criterion 8: a non-colliding NULL row must still backfill normally"
+    );
+}
+
+// Test-engineer adversarial: self-supersede collision. Criterion 3's
+// collision-recovery path was only ever exercised with the colliding
+// "existing" row being a THIRD row, distinct from both OLD and the new
+// content. Nothing stops a caller from superseding `old_id` with content
+// byte-identical to `old_id`'s OWN `{kind,title,body}` (e.g. `spelunk
+// memory add --supersedes <id>` with the same title/body as the entry it
+// names). Post-promotion, the INSERT then collides with `old_id` itself:
+// `recover_from_entity_id_collision` finds `old_id`, so `existing_id ==
+// supersedes_id`. The archive-OLD UPDATE then runs with `?1 = ?2 =
+// old_id`: a row would archive itself and point `superseded_by` at its
+// own id, a self-loop of exactly the shape `dedupe.rs`'s own self-edge
+// guard exists to prevent, but reached via the supersede path.
+#[test]
+fn add_note_superseding_self_collision_does_not_create_self_referential_archived_row() {
+    let store = open_store();
+    let (old_id, _) = store
+        .add_note(
+            "decision",
+            "same content",
+            "same body",
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+    store.promote_entity_id_unique_index().unwrap();
+    assert!(index_is_unique(&store), "precondition: index promoted");
+
+    // Supersede `old_id` with content identical to `old_id`'s own
+    // kind/title/body: the INSERT collides with `old_id` itself.
+    let result = store.add_note_superseding(
+        "decision",
+        "same content",
+        "same body",
+        &[],
+        &[],
+        None,
+        old_id,
+    );
+    assert!(
+        result.is_ok(),
+        "a self-collision must not error: {:?}",
+        result.err()
+    );
+    let (returned_id, created) = result.unwrap();
+    assert_eq!(
+        returned_id, old_id,
+        "the collision resolves to old_id itself, there is only one row \
+         with this content"
+    );
+    assert!(!created, "a collision is never a fresh insert");
+
+    let row = store.get(old_id).unwrap().expect("row still exists");
+    assert_ne!(
+        row.superseded_by,
+        Some(old_id),
+        "BUG: a self-supersede collision must not leave a row pointing \
+         superseded_by at its own id, this is a self-loop of the exact \
+         shape dedupe.rs's own self-edge guard exists to prevent, just \
+         reached via the supersede path instead of the collapse path"
+    );
+    let total_rows: i64 = store
+        .conn
+        .query_row("SELECT COUNT(*) FROM notes", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        total_rows, 1,
+        "no phantom second row must be created by the self-collision"
+    );
+}
+
+// ── Step A: any error other than a UNIQUE violation from the per-row
+// backfill UPDATE must propagate unchanged. Exercised via a synthetic
+// trigger on UPDATE, distinct from the UNIQUE-collision path already
+// covered above.
+#[test]
+fn backfill_other_error_from_update_propagates_unchanged() {
+    let store = open_store();
+    store
+        .conn
+        .execute(
+            "INSERT INTO notes (kind, title, body, entity_id) VALUES ('note', 'stray', 'body', NULL)",
+            [],
+        )
+        .unwrap();
+    let stray_id = store.conn.last_insert_rowid();
+    store
+        .conn
+        .execute_batch(&format!(
+            "CREATE TRIGGER reject_specific_update
+             BEFORE UPDATE ON notes
+             WHEN NEW.id = {stray_id}
+             BEGIN SELECT RAISE(ABORT, 'synthetic step a failure'); END;"
+        ))
+        .unwrap();
+
+    let result = store.backfill_entity_ids();
+    assert!(
+        result.is_err(),
+        "criterion 9: a non-UNIQUE error from the backfill UPDATE must propagate"
+    );
+    let err = result.unwrap_err();
+    // `.to_string()` on an anyhow::Error only shows the outermost
+    // `.with_context(...)` layer ("backfilling entity_id for note #1");
+    // the synthetic trigger message is a wrapped source, so it must be
+    // checked via the full chain, not the top-level Display.
+    let full_chain: String = err
+        .chain()
+        .map(|c| c.to_string())
+        .collect::<Vec<_>>()
+        .join(" | ");
+    assert!(
+        full_chain.contains("synthetic step a failure"),
+        "expected the synthetic trigger error to propagate somewhere in \
+         the error chain, got: {full_chain}"
+    );
 }

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/migration_tests.rs
@@ -1,6 +1,7 @@
 // Step A (backfill_entity_ids) and Step B (promote_entity_id_unique_index):
 // population, idempotency, resumption after partial population, index
-// promotion, and the marker short-circuit.
+// promotion, and the marker short-circuit. See collision_recovery_tests for
+// what happens once the index is promoted and a write collides with it.
 
 use super::test_support::*;
 

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs
@@ -3,11 +3,16 @@
 //!
 //! Two independently-safe steps, run unconditionally at `MemoryStore::open`
 //! (same marker-table idiom as `apply_dim_upgrade_migration` in `db.rs`).
-//! Step A backfills `entity_id`; it can never hit a constraint because the
-//! index stays non-unique until Step B promotes it, and Step B only
-//! promotes once a duplicate scan comes back clean. A duplicate group
-//! leaves the index non-unique and logs a message pointing at `spelunk
-//! memory dedupe`. Neither step ever hard-aborts `open`.
+//! Step A backfills `entity_id`; before the index is ever promoted this
+//! can't hit a constraint. Step A/B run on every open though, not just the
+//! first, so on a later open (index already UNIQUE) a row that still has
+//! `entity_id IS NULL` (from an insert path with its own identity gap, e.g.
+//! `add_note_superseding` pre-fix, or `apply_remote_note`) can collide with
+//! an existing row. Step A's per-row UPDATE catches that and skips the row
+//! rather than hard-failing `open` (ADR-068 fifth amendment E2). Step B only
+//! promotes once a duplicate scan comes back clean; a duplicate group leaves
+//! the index non-unique and logs a message pointing at `spelunk memory
+//! dedupe`. Neither step ever hard-aborts `open`.
 
 use anyhow::{Context, Result};
 use rusqlite::OptionalExtension;
@@ -23,6 +28,12 @@ impl MemoryStore {
     /// Populates `entity_id` for every row still `NULL`. Computed in Rust:
     /// sha256 is unavailable to raw SQL. Idempotent: an interrupted run
     /// leaves the rest `NULL` for the next open to pick up.
+    ///
+    /// ADR-068 fifth amendment (E2): once a prior open has promoted
+    /// `idx_notes_entity_id` to UNIQUE, this per-row UPDATE can collide with
+    /// an existing row (see the module doc for how). On that collision,
+    /// skip the row and log a warning naming it, rather than propagating
+    /// the error and hard-failing `open`. Any other error still propagates.
     pub(super) fn backfill_entity_ids(&self) -> Result<()> {
         let rows: Vec<(i64, String, String, String)> = {
             let mut stmt = self
@@ -37,12 +48,27 @@ impl MemoryStore {
 
         for (id, kind, title, body) in rows {
             let eid = entity_id(&kind, &title, &body);
-            self.conn
-                .execute(
-                    "UPDATE notes SET entity_id = ?1 WHERE id = ?2",
-                    rusqlite::params![eid, id],
-                )
-                .with_context(|| format!("backfilling entity_id for note #{id}"))?;
+            let result = self.conn.execute(
+                "UPDATE notes SET entity_id = ?1 WHERE id = ?2",
+                rusqlite::params![eid, id],
+            );
+            match result {
+                Ok(_) => {}
+                Err(rusqlite::Error::SqliteFailure(err, _))
+                    if err.code == rusqlite::ErrorCode::ConstraintViolation
+                        && err.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE =>
+                {
+                    tracing::warn!(
+                        "note #{id} could not be backfilled with an entity_id: it collides \
+                         with an existing row's entity_id under the already-promoted UNIQUE \
+                         index; run `spelunk memory dedupe` to collapse them, then re-run \
+                         spelunk"
+                    );
+                }
+                Err(e) => {
+                    return Err(e).with_context(|| format!("backfilling entity_id for note #{id}"));
+                }
+            }
         }
         Ok(())
     }

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -101,7 +101,7 @@ fn add_note_superseding_happy_path_archives_old_and_links_new() {
         .add_note("decision", "Old decision", "old body", &[], &[], None, None)
         .unwrap();
 
-    let new_id = store
+    let (new_id, created) = store
         .add_note_superseding(
             "decision",
             "New decision",
@@ -112,6 +112,10 @@ fn add_note_superseding_happy_path_archives_old_and_links_new() {
             old_id,
         )
         .unwrap();
+    assert!(
+        created,
+        "a fresh supersede insert must report created = true"
+    );
 
     let old_note = store.get(old_id).unwrap().expect("old note must exist");
     assert_eq!(old_note.status, "archived");
@@ -135,7 +139,7 @@ fn add_note_superseding_rejects_already_archived_old_and_writes_nothing() {
     let (old_id, _) = store
         .add_note("decision", "Old decision", "old body", &[], &[], None, None)
         .unwrap();
-    let successor_a = store
+    let (successor_a, _) = store
         .add_note_superseding("decision", "Successor A", "body a", &[], &[], None, old_id)
         .unwrap();
 

--- a/docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md
+++ b/docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md
@@ -952,19 +952,104 @@ import.
   principle once its own identity gap (not setting `entity_id` on insert) is
   closed; that gap is not closed by this amendment.
 
-## Amendment (2026-07-19): Double-supersede carrier consistency
+## Amendment (2026-07-19): `add_note_superseding` identity gap, Step A hardening, and double-supersede carrier consistency
 
 **Date:** 2026-07-19
-**Deciders:** founder (Johan) — pending review via this PR; architect
+**Deciders:** founder (Johan); architect
 
-A gap in the supersede path, found on the identity-model surface these
-amendments already cover: `memory add --supersedes` can silently fork the
-git-notes carrier when `OLD` is already archived.
+Three related gaps in the supersede path, all found on the identity-model
+surface these amendments already cover: the `add_note_superseding` identity
+gap and the Step A hardening it exposes (E1-E2), a flagged-not-fixed second
+insert path (E3), and a double-supersede carrier-consistency bug (E4-E5).
 
-A second, unrelated identity-model gap (an `add_note_superseding` insertion
-path and a Step A backfill hardening) is being corrected separately, in a
-concurrent change against this same file; this amendment covers only the
-double-supersede fix below.
+**Provenance check (2026-07-19).** At the time of this amendment, the third
+amendment's Step A/B (`entity_id_migration.rs`) and `spelunk memory dedupe`
+exist only on an in-progress branch, not yet on `main`. The fourth
+amendment's C1 (`add_note`/`add_note_with_created_at` insert-then-recover) is
+speced but has no Rust implementation anywhere yet; it is landing on that
+same branch. E1-E3 below are therefore corrections to land **in the same
+implementation pass** as that work, not patches against already-shipped code.
+
+### E1 – `add_note_superseding` gains `entity_id` and the same insert-then-recover as `add_note`
+
+The fourth amendment's C1 explicitly scoped `add_note_superseding` out:
+"its INSERT statement does not populate `entity_id` at all, so it cannot
+violate this index today... tracked as a separate follow-up." This is that
+follow-up.
+
+`add_note_superseding` (`crates/spelunk-core/src/storage/memory/edges.rs`)
+computes `entity_id` at insert time exactly like `add_note` /
+`add_note_with_created_at`:
+
+```rust
+crate::storage::entity_id::entity_id(kind, title, body)
+```
+
+added to its `INSERT INTO notes` column list. This closes the root cause: no
+future `--supersedes`-created row is ever `entity_id = NULL`.
+
+Once this INSERT populates `entity_id`, it is subject to the same UNIQUE
+constraint C1 gave `add_note`, so it needs the same insert-then-recover
+handling, not a bare `INSERT` that can now fail: attempt the insert; on a
+UNIQUE-constraint failure on `notes.entity_id` specifically, look up the
+existing row by `entity_id` and merge `tags`/`linked_files` into it via the
+existing `union_tags_and_files`, exactly as C1 specifies, **and use that
+existing row's id as the successor** for the archive-`OLD` step that follows
+(the transaction's second statement, `UPDATE notes SET status='archived',
+superseded_by=?2, ... WHERE id=?1 AND status='active'`, must run against
+whichever id is authoritative: the freshly inserted row, or the reused
+existing one). Return type changes to expose both the id and whether a fresh
+row was created, mirroring the fourth amendment's C2 (so the CLI can
+distinguish "created" from "reused" here too). `add_note_superseding`'s own
+archive-`OLD` UPDATE must also report whether it actually changed a row: a
+signal the separate follow-up work on re-superseding an already-archived
+entry will also need.
+
+### E2 – Step A backfill hardens against a collision it can now hit
+
+The third amendment's B3 states Step A "cannot fail on a constraint, because
+migration 023's index stays non-unique for this step." That is true only for
+a store's *first* pass through Step A, before Step B has ever promoted the
+index. It is not true in general: Step A and Step B both run, unconditionally,
+on **every** `MemoryStore::open`, not just the first. Once a store has
+already been promoted to UNIQUE by an earlier open, any row that reaches Step
+A still `entity_id IS NULL` (a row inserted by *some* path that predates E1's
+fix, or by any future path that has the same gap) hits Step A's bare
+`UPDATE notes SET entity_id = ?1 WHERE id = ?2` on a now-UNIQUE index. If the
+computed value collides with an existing row's `entity_id`, that `UPDATE`
+raises a UNIQUE-constraint error with no handler, which propagates out of
+`backfill_entity_ids` via `?` and hard-fails `MemoryStore::open` itself,
+bricking every `spelunk` command against that store.
+
+Step A's per-row `UPDATE` catches a UNIQUE-constraint violation on
+`notes.entity_id` specifically and, on that error only, skips the row
+(leaving it `NULL` for a future `dedupe`-then-retry) and logs one actionable
+warning naming the affected row id and pointing at `spelunk memory dedupe`,
+reusing Step B's existing message shape. Any other error from the `UPDATE`
+still propagates unchanged. Step A must never hard-abort `open`, matching the
+third amendment's own stated invariant for Step B; this closes the one case
+where Step A did not yet live up to it.
+
+### E3 – A second latent NULL-`entity_id` insert path found: `apply_remote_note`, flagged, not fixed here
+
+Grepping every `INSERT INTO notes` in `spelunk-core`/`spelunk-cli` found a
+second path that never populates `entity_id`:
+`MemoryStore::apply_remote_note` (`crates/spelunk-core/src/storage/memory/sync.rs`),
+the cloud-pull idempotency path for an explicit team `server_url`. Unlike
+`add_note_superseding`, this one is not a same-shape fix: its own doc comment
+states an **Add-Wins/keep-both** posture ("pulled entries are added, never
+overwriting local ones"), which predates `entity_id` and may not compose
+cleanly with C1's merge-on-collision behavior, a pulled row and a locally
+authored row can legitimately share content but arrive by different paths,
+and which posture is correct there is its own question, not a mechanical
+copy of E1. **Not decided or fixed by this amendment.** Filed as its own
+follow-up task, scoped to: (a) whether `apply_remote_note` should set
+`entity_id` at insert time, and (b) whether a collision there should merge
+(C1-style), keep-both (status quo, requiring the index to stay non-unique for
+this path, which conflicts with E2's premise), or something else. Until that
+is decided, E2's Step A hardening is what keeps this path from being able to
+hard-fail `open` in the meantime, this is additional justification for
+shipping E2 regardless of E1.
 
 ### E4 — Re-superseding an already-archived entry: reject, don't silently fork the carrier
 
@@ -1054,6 +1139,8 @@ were produced by the bug E4 closes, a pre-fix client, or a lost-race write.
 
 ### E6 — Non-goals, consequences, security
 
+- **Non-goal:** deciding `apply_remote_note`'s `entity_id`/collision posture
+  (E3); a separate task, not this amendment.
 - **Non-goal:** a chained-supersede-by-recency feature for `add --supersedes`
   (E4) — rejected in favor of matching `memory supersede`'s existing
   reject-on-stale-`OLD` behavior; YAGNI absent a stated need for chaining.
@@ -1061,10 +1148,15 @@ were produced by the bug E4 closes, a pre-fix client, or a lost-race write.
   specific repo's `refs/notes/spelunk` — E5 fixes how they fold at read time;
   it does not rewrite git-notes history (which this ADR's append-only model
   never does).
+- **Consequence:** `MemoryStore::open` cannot be hard-failed by Step A
+  regardless of which insert path left a row `entity_id = NULL`, closing that
+  hard-fail risk, though E3's path remains an open question for its own
+  collision semantics.
 - **Consequence:** `add --supersedes` against a stale `OLD` now fails
   loudly instead of silently creating an orphaned entry and a conflicting
   carrier record — a deliberate, user-visible behavior change, consistent
   with `memory supersede`'s existing contract.
-- **Security:** no new trust boundary. E4's pre-flight read is a local
-  SQLite/git-notes read already performed by the existing code, just
-  reordered; no new data leaves the machine.
+- **Security:** no new trust boundary. E1/E2 only change how already-local
+  SQLite operations recover from a constraint violation, and E4's pre-flight
+  read is a local SQLite/git-notes read already performed by the existing
+  code, just reordered; no new data leaves the machine.


### PR DESCRIPTION
## Summary

Seventh and last of a 7-PR stack replacing #696/#697/#698. Stacked on the "Already recorded as..." PR. ADR-068's fifth amendment (E1-E3 only; E4-E5 already merged via #681): closes the last identity gap in the supersede path and hardens Step A against a collision it can now hit.

## What's in this PR

- `crates/spelunk-core/src/storage/memory/edges.rs` — `add_note_superseding`'s INSERT now populates `entity_id`, exactly like `add_note`/`add_note_with_created_at`, and reuses the same `recover_from_entity_id_collision` on a UNIQUE-constraint failure. A collision that resolves to the supersede target itself (self-collision) is a no-op — nothing to archive, no edge to add — rather than producing a self-referential archived row. Return type changes from `Result<i64>` to `Result<(i64, bool)>`, matching `add_note`.
- `crates/spelunk-core/src/storage/backend.rs` — `LocalMemoryBackend::add`'s `supersedes` arm now propagates `add_note_superseding`'s own tuple directly instead of synthesizing `(id, true)`.
- `crates/spelunk-core/src/storage/memory/entity_id_migration/mod.rs` — Step A's per-row backfill `UPDATE` can itself hit the UNIQUE constraint once a prior open has already promoted the index (a row with its own identity gap reaching Step A after promotion, e.g. a pre-fix `add_note_superseding` row). It now skips that row and logs a warning naming it, instead of hard-failing `MemoryStore::open`. Any other error still propagates.
- `crates/spelunk-core/src/storage/memory/entity_id_migration/collision_recovery_tests.rs`, `dedupe/superseded_by_tests.rs` — coverage for `add_note_superseding`'s collision recovery (including the self-collision no-op), Step A's collision-skip leaving a row's `entity_id` NULL without erroring, and that `spelunk memory dedupe` still discovers and collapses a Step-A-skipped row on a later run (it recomputes `entity_id` from content, not the stored column).
- `docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md` — records the fifth amendment (E1-E3; E4-E5 were already merged via #681).

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace` — all green (default and `--no-default-features`)
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` — clean (default and `--no-default-features`)
- `cargo fmt --all -- --check` — clean
- Diff swept for em-dashes and internal ticket references: none found