### PR TITLE
Track pre-commit hook in .githooks, document core.hooksPath setup

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+# Linked worktrees (code/worktrees/*) share this repo's common git dir, so a
+# bare `cargo fmt`/`cargo clippy` here would default to a target/ dir inside
+# whichever worktree is committing. On a disk that runs close to full, that is
+# a multi-GB stray per commit. Default CARGO_TARGET_DIR to the main checkout's
+# already-warm target/ so every worktree's commit reuses it instead.
+# `git rev-parse --path-format=absolute --git-common-dir` resolves to the main
+# checkout's .git dir from any worktree (main or linked), so this works no
+# matter which one is committing.
+GIT_COMMON_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${GIT_COMMON_DIR%/.git}/target}"
+
+echo "→ cargo fmt --check"
+cargo fmt -- --check || {
+    echo ""
+    echo "  Formatting errors found. Run: cargo fmt"
+    exit 1
+}
+
+echo "→ cargo clippy"
+cargo clippy --all-targets -- -D warnings || {
+    echo ""
+    echo "  Clippy errors found. Fix the warnings above before committing."
+    exit 1
+}

--- a/docs/building.md
+++ b/docs/building.md
@@ -17,6 +17,19 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 Rust 1.80 or later is required (spelunk uses the 2024 edition).
 
+### Git hooks
+
+The repo ships a pre-commit hook (`cargo fmt --check` + `cargo clippy`) under
+`.githooks/`. Git does not run hooks from a tracked directory on its own, so
+point it there once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This also applies to any `git worktree add` checkout of this repo, since
+worktrees share the parent repo's hooks path.
+
 ### No external inference server required
 
 From v0.9.0, `spelunk-server` bundles a native embedder


### PR DESCRIPTION
## Summary

Linked worktrees under `code/worktrees/` share the main checkout's git common dir, so `.git/hooks/pre-commit` (untracked, local-only) already runs for every worktree's commits. Without a `CARGO_TARGET_DIR` default, a bare `cargo fmt`/`cargo clippy` in that hook defaults to a `target/` inside whichever worktree is committing — on a disk that runs close to full, that's a multi-GB stray per commit, and it silently defeats any external `CARGO_TARGET_DIR` mitigation the moment the shell that set it isn't the same one that runs `git commit`.

This PR ships the fix as a **tracked** hook so it's durable across machines/clones, not just a one-off edit to someone's local `.git/hooks`:

- `.githooks/pre-commit` (new, executable): the same `cargo fmt --check` + `cargo clippy --all-targets` checks as before, now defaulting `CARGO_TARGET_DIR` to the main checkout's own `target/` (resolved via `git rev-parse --path-format=absolute --git-common-dir`, so it works correctly from the main checkout or any linked worktree) while still respecting an already-set value.
- `docs/building.md`: documents the one-time `git config core.hooksPath .githooks` step, including that it covers `git worktree add` checkouts since worktrees share the parent repo's hooks path.

`cargo clippy --all-targets` on every commit is left as-is (out of scope here, though it remains the most expensive part of the hook).

## Test plan

- Cloned the branch fresh into an isolated scratch dir, confirmed `core.hooksPath` was genuinely unset, then ran `git config core.hooksPath .githooks`.
- Added a linked worktree off that fresh clone and ran a real `git commit` with `CARGO_TARGET_DIR` unset in the shell.
- Confirmed the hook fired (`cargo fmt --check`, `cargo clippy --all-targets`), the cold build compiled the full workspace and landed `target/` at the clone root (grew to 1.0G), and `target/` never appeared inside the linked worktree (`ls target` → "No such file or directory" throughout).
- Confirmed `git status --porcelain` was clean in the worktree after the commit.
- Confirmed the branch merges cleanly against current `main` with no conflicts (`git merge-tree`), and that no commits since this branch was cut touch `.githooks/` or `docs/building.md`.