### PR TITLE
fix(memory): archived entries now travel via the git-notes carrier

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/archive.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/archive.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 
 use super::MemoryArchiveArgs;
-use crate::{config::Config, storage::open_memory_backend};
+use crate::{
+    config::Config,
+    storage::{append_state_update, now_secs, open_memory_backend},
+};
 
 pub(super) async fn memory_archive(
     args: MemoryArchiveArgs,
@@ -12,6 +15,48 @@ pub(super) async fn memory_archive(
     let backend = open_memory_backend(cfg, mem_path, backend_override).await?;
     if backend.archive(args.id).await? {
         println!("Archived memory entry #{}.", args.id);
+
+        // ── Git-notes write-through carrier ──────────────────────────────────
+        // Best-effort and non-fatal, matching `memory add`/`memory supersede`'s
+        // contract: the primary store above already holds the authoritative
+        // archive, so a failed carry means only that it stays local for now,
+        // never that the command fails. `GitNotesBackend::archive` stays
+        // unsupported as a write-through target (explicit `--backend
+        // git-notes` never reaches here: it is the primary store then, and
+        // already returned `Ok` above).
+        let write_through = cfg.store_in_git_notes && backend_override != Some("git-notes");
+        if write_through {
+            match backend.get(args.id).await {
+                // `append_state_update` derives the entity_id from `note`
+                // itself (ADR-068 A6) rather than from the rowid `args.id`.
+                Ok(Some(note)) => {
+                    let invalid_at = note.invalid_at.or_else(|| Some(now_secs()));
+                    if let Err(e) =
+                        append_state_update(None, &note, "archived", invalid_at, None).await
+                    {
+                        eprintln!(
+                            "Warning: #{} archived locally, but the git-notes carry failed, \
+                             so it will not travel with the repo: {e:#}",
+                            args.id
+                        );
+                    }
+                }
+                Ok(None) => {
+                    eprintln!(
+                        "Warning: could not re-read #{} after archiving it, so it was not \
+                         carried to git notes.",
+                        args.id
+                    );
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Warning: could not re-read #{} after archiving it, so it was not \
+                         carried to git notes: {e:#}",
+                        args.id
+                    );
+                }
+            }
+        }
     } else {
         anyhow::bail!("No active memory entry with id {}.", args.id);
     }

--- a/crates/spelunk-cli/tests/archive_git_notes_carrier.rs
+++ b/crates/spelunk-cli/tests/archive_git_notes_carrier.rs
@@ -279,6 +279,38 @@ fn two_clone_archive_travels_and_folds_to_archived_once_despite_divergent_note()
         archived_stdout.contains("[archived]"),
         "X's single folded copy must be marked archived, got:\n{archived_stdout}"
     );
+
+    // Assert on the raw git ref too, not just the CLI's folded view: the
+    // fold could hide either a rewrite (one line, wrongly convincing) or an
+    // over-eager append (three-plus lines). The archive state-update is a new
+    // line alongside X's original, never a replacement of it, so exactly two
+    // raw lines must carry X's entity_id: the untouched original (still
+    // "active") and the appended state-update ("archived").
+    let raw_lines = spelunk_note_lines(&b);
+    let x_entity_id = record_field(&seeded[0], "entity_id");
+    let x_lines: Vec<&String> = raw_lines
+        .iter()
+        .filter(|l| record_field(l, "entity_id") == x_entity_id)
+        .collect();
+    assert_eq!(
+        x_lines.len(),
+        2,
+        "X must carry exactly two raw lines after the merge (original + \
+         appended state-update); a rewrite collapses to one, an unbounded \
+         re-append would exceed two, got:\n{raw_lines:?}"
+    );
+    assert!(
+        x_lines
+            .iter()
+            .any(|l| record_field(l, "status") == "active"),
+        "the original active line must survive byte-for-byte on the raw ref, got:\n{raw_lines:?}"
+    );
+    assert!(
+        x_lines
+            .iter()
+            .any(|l| record_field(l, "status") == "archived"),
+        "the appended state-update line must be present on the raw ref, got:\n{raw_lines:?}"
+    );
 }
 
 /// Two clones each archive the same entity independently, neither aware of
@@ -349,5 +381,95 @@ fn concurrent_archives_from_two_clones_fold_to_one_archived_entry() {
     assert!(
         archived_stdout.contains("[archived]"),
         "the folded entry must be marked archived, got:\n{archived_stdout}"
+    );
+}
+
+// The carrier write is best-effort (matching `memory add`/`memory
+// supersede`'s contract): if `refs/notes` cannot be written, `memory
+// archive` must still report success and the SQLite primary must still hold
+// the archive. Only the carry is allowed to fail quietly.
+#[cfg(unix)]
+#[test]
+fn carrier_write_failure_does_not_fail_the_sqlite_archive() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    let dir = tmp.path().join("repo");
+    std::fs::create_dir_all(&dir).unwrap();
+    init_repo_with_commit(&dir);
+    std::fs::create_dir_all(dir.join(".spelunk")).unwrap();
+
+    bin(home.path(), &dir)
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "note",
+            "--title",
+            "carrier-fail-probe",
+            "--body",
+            "b",
+        ])
+        .assert()
+        .success();
+    let id = local_id_for_title(home.path(), &dir, "carrier-fail-probe");
+
+    let refs_notes = dir.join(".git/refs/notes");
+    let original = std::fs::metadata(&refs_notes).unwrap().permissions();
+    let mut read_only = original.clone();
+    read_only.set_mode(0o555);
+    std::fs::set_permissions(&refs_notes, read_only).unwrap();
+
+    // Probe with raw git, never the code under test: root (or a mount that
+    // ignores the mode) can still write there, and there would be no failure
+    // to assert against.
+    let enforced = !git_out(
+        &dir,
+        &["notes", "--ref=spelunk", "add", "-f", "-m", "x", "HEAD"],
+    )
+    .status
+    .success();
+    if !enforced {
+        std::fs::set_permissions(&refs_notes, original).unwrap();
+        return;
+    }
+
+    let out = bin(home.path(), &dir)
+        .args(["memory", "archive", &id.to_string()])
+        .output()
+        .expect("spawn spelunk memory archive");
+
+    // Restore before asserting: a panic below would otherwise leave a
+    // read-only directory behind that `TempDir` cannot clean up.
+    std::fs::set_permissions(&refs_notes, original).unwrap();
+
+    assert!(
+        out.status.success(),
+        "a failed git-notes carry must not fail the command, got:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("git-notes carry failed"),
+        "the failure must surface as a warning, got:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let archived = bin(home.path(), &dir)
+        .args([
+            "memory",
+            "list",
+            "--archived",
+            "--format",
+            "jsonl",
+            "--limit",
+            "10",
+        ])
+        .output()
+        .expect("spawn spelunk memory list --archived");
+    assert!(
+        String::from_utf8_lossy(&archived.stdout).contains("carrier-fail-probe"),
+        "the SQLite primary must hold the archive even though the carrier failed, got:\n{}",
+        String::from_utf8_lossy(&archived.stdout)
     );
 }

--- a/crates/spelunk-cli/tests/archive_git_notes_carrier.rs
+++ b/crates/spelunk-cli/tests/archive_git_notes_carrier.rs
@@ -1,0 +1,353 @@
+// Coverage for `memory archive`'s git-notes write-through carrier.
+//
+// A single-repo test cannot tell an append from an in-place rewrite: both
+// leave that one repo's `git notes show` looking archived. Only a clone that
+// genuinely had to MERGE (not fast-forward) the incoming notes distinguishes
+// them, so every test here runs across two real clones of a shared origin.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+const TRACKING_REF: &str = "refs/notes/origin/spelunk";
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = git_out(dir, args);
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_out(dir: &Path, args: &[&str]) -> std::process::Output {
+    std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@example.com")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@example.com")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("spawn git")
+}
+
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    String::from_utf8_lossy(&git_out(dir, args).stdout).into_owned()
+}
+
+// Fetch `refs/notes/spelunk` from `origin` into this repo's tracking ref.
+// Explicit rather than relying on `spelunk init`'s configured refspec, so
+// each test controls exactly when a fetch happens.
+fn fetch_notes(dir: &Path) {
+    git(
+        dir,
+        &[
+            "fetch",
+            "-q",
+            "origin",
+            &format!("refs/notes/spelunk:{TRACKING_REF}"),
+        ],
+    );
+}
+
+fn init_repo_with_commit(dir: &Path) {
+    git(dir, &["init", "-q", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@example.com"]);
+    git(dir, &["config", "user.name", "Test"]);
+    std::fs::write(dir.join("f.txt"), "x\n").unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-q", "-m", "init"]);
+}
+
+// A `spelunk` command with an isolated HOME and no server contact.
+fn bin(home: &Path, cwd: &Path) -> Command {
+    let mut cmd = spelunk_bin_in(home);
+    cmd.current_dir(cwd)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL");
+    cmd
+}
+
+// Write an empty spelunk config (init needs `--config` but no values here).
+fn empty_config(dir: &Path) -> PathBuf {
+    let cfg = dir.join("config.toml");
+    std::fs::write(&cfg, "").unwrap();
+    cfg
+}
+
+// Run `spelunk init --no-index` in `dir`, using `dir` itself as HOME (so the
+// import writes `dir/.spelunk/memory.db`). Offline, non-TTY.
+fn run_init(dir: &Path) -> String {
+    let cfg = empty_config(dir);
+    let out = spelunk_bin_in(dir)
+        .current_dir(dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&cfg)
+        .args(["init", "--no-index"])
+        .output()
+        .expect("spawn spelunk init");
+    assert!(
+        out.status.success(),
+        "spelunk init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+// The spelunk records currently in HEAD's `refs/notes/spelunk` note.
+fn spelunk_note_lines(dir: &Path) -> Vec<String> {
+    let blob = git_stdout(dir, &["notes", "--ref=spelunk", "show", "HEAD"]);
+    blob.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn record_field(line: &str, key: &str) -> String {
+    let v: serde_json::Value = serde_json::from_str(line).expect("record parses as JSON");
+    v.get(key)
+        .unwrap_or_else(|| panic!("record has no {key:?}: {line}"))
+        .to_string()
+        .trim_matches('"')
+        .to_string()
+}
+
+// The `id` spelunk assigned locally (in `dir`'s own `memory.db`) to the entry
+// titled `title`. Distinct from the `id` on a git-notes record: two clones
+// mint their own rowids for the same entity independently.
+fn local_id_for_title(home: &Path, dir: &Path, title: &str) -> i64 {
+    let out = bin(home, dir)
+        .args(["memory", "list", "--format", "jsonl", "--limit", "100"])
+        .output()
+        .expect("spawn spelunk memory list");
+    assert!(
+        out.status.success(),
+        "memory list failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    stdout
+        .lines()
+        .find_map(|line| {
+            let v: serde_json::Value = serde_json::from_str(line).ok()?;
+            (v.get("title")?.as_str()? == title)
+                .then(|| v.get("id")?.as_i64())
+                .flatten()
+        })
+        .unwrap_or_else(|| panic!("no local entry titled {title:?} in:\n{stdout}"))
+}
+
+// A bare origin plus two clones ("a" and "b") that both hold the same
+// single-commit history. Both get a `.spelunk/` dir so a plain `memory add`
+// resolves to the SQLite-primary-plus-carrier path (not the pre-init
+// fallback). Returns (origin, a, b).
+fn setup_origin_with_two_clones(tmp: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let origin = tmp.join("origin.git");
+    git(
+        tmp,
+        &[
+            "init",
+            "--bare",
+            "-q",
+            "-b",
+            "main",
+            origin.to_str().unwrap(),
+        ],
+    );
+
+    let a = tmp.join("a");
+    std::fs::create_dir_all(&a).unwrap();
+    init_repo_with_commit(&a);
+    git(&a, &["remote", "add", "origin", origin.to_str().unwrap()]);
+    git(&a, &["push", "-q", "-u", "origin", "main"]);
+    std::fs::create_dir_all(a.join(".spelunk")).unwrap();
+
+    let b = tmp.join("b");
+    git(
+        tmp,
+        &["clone", "-q", origin.to_str().unwrap(), b.to_str().unwrap()],
+    );
+    git(&b, &["config", "user.email", "b@example.com"]);
+    git(&b, &["config", "user.name", "B"]);
+    std::fs::create_dir_all(b.join(".spelunk")).unwrap();
+
+    (origin, a, b)
+}
+
+/// Clone A archives entry X and pushes; clone B fetches and merges. B holds a
+/// divergent local note of its own (added after adopting X but before A's
+/// archive lands), so the merge genuinely unions two histories rather than
+/// fast-forwarding. Without that divergence, B's working ref would just be an
+/// ancestor of the incoming tracking ref, and a broken in-place rewrite of X's
+/// status would look correct too — this is the trap the two-clone shape
+/// exists to close.
+#[test]
+fn two_clone_archive_travels_and_folds_to_archived_once_despite_divergent_note() {
+    let tmp = TempDir::new().unwrap();
+    let home_a = TempDir::new().unwrap();
+    let home_b = TempDir::new().unwrap();
+    let (_origin, a, b) = setup_origin_with_two_clones(tmp.path());
+
+    bin(home_a.path(), &a)
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "decision",
+            "--title",
+            "clone-a-archives-me",
+            "--body",
+            "b1",
+        ])
+        .assert()
+        .success();
+    let seeded = spelunk_note_lines(&a);
+    assert_eq!(seeded.len(), 1, "setup: A's own add");
+    let x_id = record_field(&seeded[0], "id");
+    git(&a, &["push", "-q", "origin", "refs/notes/spelunk"]);
+
+    // B adopts X onto its own working ref before diverging: without a prior
+    // local commit of its own, this merge is a plain fast-forward/create.
+    fetch_notes(&b);
+    bin(home_b.path(), &b)
+        .args(["memory", "--backend", "git-notes", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("clone-a-archives-me"));
+
+    // B's own, unrelated entry: the divergent local note.
+    bin(home_b.path(), &b)
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "note",
+            "--title",
+            "clone-b-local-only",
+            "--body",
+            "b2",
+        ])
+        .assert()
+        .success();
+
+    bin(home_a.path(), &a)
+        .args(["memory", "archive", &x_id])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Archived memory entry"));
+    git(&a, &["push", "-q", "origin", "refs/notes/spelunk"]);
+
+    fetch_notes(&b);
+
+    let default_list = bin(home_b.path(), &b)
+        .args(["memory", "--backend", "git-notes", "list"])
+        .output()
+        .expect("spawn spelunk memory list");
+    assert!(default_list.status.success());
+    let default_stdout = String::from_utf8_lossy(&default_list.stdout);
+    assert!(
+        !default_stdout.contains("clone-a-archives-me"),
+        "archived X must not appear in a default list, got:\n{default_stdout}"
+    );
+    assert!(
+        default_stdout.contains("clone-b-local-only"),
+        "the union must not drop B's own divergent entry, got:\n{default_stdout}"
+    );
+
+    // Exactly once: the archived state-update must have FOLDED onto X's
+    // original active copy, not merely sit next to it as a second entry.
+    let archived_list = bin(home_b.path(), &b)
+        .args(["memory", "--backend", "git-notes", "list", "--archived"])
+        .output()
+        .expect("spawn spelunk memory list --archived");
+    let archived_stdout = String::from_utf8_lossy(&archived_list.stdout);
+    assert_eq!(
+        archived_stdout.matches("clone-a-archives-me").count(),
+        1,
+        "X must fold to exactly one entry, got:\n{archived_stdout}"
+    );
+    assert!(
+        archived_stdout.contains("[archived]"),
+        "X's single folded copy must be marked archived, got:\n{archived_stdout}"
+    );
+}
+
+/// Two clones each archive the same entity independently, neither aware of
+/// the other, before either fetches the other's update. The read-side fold
+/// (ADR-068 A6) must converge the two archived-state-update copies to one
+/// entry rather than surfacing a duplicate or a conflict.
+#[test]
+fn concurrent_archives_from_two_clones_fold_to_one_archived_entry() {
+    let tmp = TempDir::new().unwrap();
+    let home_a = TempDir::new().unwrap();
+    let (_origin, a, b) = setup_origin_with_two_clones(tmp.path());
+
+    bin(home_a.path(), &a)
+        .args([
+            "memory",
+            "add",
+            "--kind",
+            "decision",
+            "--title",
+            "double-archived-entry",
+            "--body",
+            "b1",
+        ])
+        .assert()
+        .success();
+    let seeded = spelunk_note_lines(&a);
+    assert_eq!(seeded.len(), 1, "setup: A's own add");
+    let a_id = record_field(&seeded[0], "id");
+    git(&a, &["push", "-q", "origin", "refs/notes/spelunk"]);
+
+    // B needs its own local (SQLite) copy of X to archive it through the
+    // normal command, so it imports via a real `spelunk init` rather than the
+    // manual `.spelunk` mkdir the other clones in this file use.
+    fetch_notes(&b);
+    let init_stdout = run_init(&b);
+    assert!(
+        init_stdout.contains("imported 1 entries from git notes"),
+        "setup: B must import X via init, got:\n{init_stdout}"
+    );
+    let b_id = local_id_for_title(&b, &b, "double-archived-entry");
+
+    // B archives its own copy — unaware A hasn't pushed an archive yet.
+    bin(&b, &b)
+        .args(["memory", "archive", &b_id.to_string()])
+        .assert()
+        .success();
+
+    // A independently archives its own copy and pushes — unaware B already did.
+    bin(home_a.path(), &a)
+        .args(["memory", "archive", &a_id])
+        .assert()
+        .success();
+    git(&a, &["push", "-q", "origin", "refs/notes/spelunk"]);
+
+    fetch_notes(&b);
+
+    let archived_list = bin(&b, &b)
+        .args(["memory", "--backend", "git-notes", "list", "--archived"])
+        .output()
+        .expect("spawn spelunk memory list --archived");
+    assert!(archived_list.status.success());
+    let archived_stdout = String::from_utf8_lossy(&archived_list.stdout);
+    assert_eq!(
+        archived_stdout.matches("double-archived-entry").count(),
+        1,
+        "two independent archives of the same entity must fold to one entry, got:\n{archived_stdout}"
+    );
+    assert!(
+        archived_stdout.contains("[archived]"),
+        "the folded entry must be marked archived, got:\n{archived_stdout}"
+    );
+}

--- a/crates/spelunk-core/src/storage/git_notes/backend_impl.rs
+++ b/crates/spelunk-core/src/storage/git_notes/backend_impl.rs
@@ -89,13 +89,38 @@ impl MemoryBackend for GitNotesBackend {
         Ok(self.noted_commits().await?.len() as i64)
     }
 
+    /// Resolves `id` to its underlying record with the same strict,
+    /// per-commit read `add`/`append_record` use, so that a failed read fails
+    /// the archive rather than looking like a missing entry (a writer's own
+    /// resolve step is not the lenient batch read `get`/`folded_records` use
+    /// for listing, where one unreadable historical note must not block an
+    /// unrelated read). Then appends a `status: "archived"` state-update for
+    /// that record's entity via the shared carrier helper, targeting it by
+    /// `entity_id` rather than the rowid (ADR-068 A6). Never rewrites the
+    /// entity's existing line(s) in place: the ref is an append-only,
+    /// entity-keyed event log (see [`append_state_update`]'s doc), and a
+    /// rewrite mutates an already-written line's bytes, breaking that
+    /// invariant even on a single machine with no other clone involved.
     async fn archive(&self, id: i64) -> Result<bool> {
-        for noted in self.noted_commits().await? {
-            if self.archive_record(&noted.commit, id).await? {
-                return Ok(true);
+        let mut found = None;
+        for (commit, _) in self.noted_commits().await? {
+            let blob = self.read_note_blob(&commit).await?;
+            if let Some(record) = blob
+                .lines()
+                .find_map(|line| super::parse_spelunk_line(line).filter(|r| r.id == id))
+            {
+                found = Some(record);
+                break;
             }
         }
-        Ok(false)
+        let Some(record) = found else {
+            return Ok(false);
+        };
+
+        let base = record_to_note(record);
+        let invalid_at = base.invalid_at.or_else(|| Some(now_secs()));
+        super::append_state_update(self.git_root(), &base, "archived", invalid_at, None).await?;
+        Ok(true)
     }
 
     // ── Unsupported ──────────────────────────────────────────────────────────

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -342,10 +342,11 @@ pub async fn append_to_git_notes(
 /// that way; a guard that did would silently swallow every state update this
 /// function writes.
 ///
-/// Shared by `memory supersede` and `memory add --supersedes` (the two
-/// carriers of a supersede edge); shaped so `memory archive`'s carrier
-/// write-through, tracked as separate follow-up work, can call it too with
-/// `superseded_by_entity_id: None`.
+/// Shared by three callers, all passing `superseded_by_entity_id: None`
+/// except the supersede pair: `memory archive`'s carrier write-through
+/// (`archive.rs`), `GitNotesBackend::archive` (git-notes as the primary
+/// store, not the carrier), and `memory supersede` / `memory add
+/// --supersedes` (the two carriers of a supersede edge, which do pass it).
 pub async fn append_state_update(
     git_root: Option<&std::path::Path>,
     base: &Note,
@@ -513,10 +514,13 @@ const GIT_NOTES_MAX_LIST: usize = 500;
 /// Multiple entries accumulate within a commit's note and across commits.
 ///
 /// # Concurrency
-/// `add`/`archive` do read-modify-write and rewrite the note with
-/// `git notes add -f`. Each is serialized by [`lock_notes`], which is keyed on
-/// the git **common** dir so that worktrees sharing one notes ref contend on
-/// one lock (#185).
+/// `add` and `archive` both do read-modify-write and rewrite the note with
+/// `git notes add -f`, appending a new JSON line rather than mutating an
+/// existing one (`archive` appends a `status: "archived"` state-update via
+/// [`append_state_update`], resolving its target by `entity_id` first, per
+/// ADR-068 A6). Each is serialized by [`lock_notes`], which is keyed on the
+/// git **common** dir so that worktrees sharing one notes ref contend on one
+/// lock (#185).
 ///
 /// # Unsupported methods
 /// Semantic search (`search`, `search_hybrid`, `search_timeline`, `search_text`),
@@ -551,6 +555,14 @@ impl GitNotesBackend {
             cmd.current_dir(root);
         }
         cmd
+    }
+
+    /// Exposes the configured root to the free-function carrier helpers
+    /// (`append_state_update` et al.), which take `Option<&Path>` rather than
+    /// `&GitNotesBackend`: they are shared with the SQLite-primary write-through
+    /// path, which has no `GitNotesBackend` to borrow from.
+    fn git_root(&self) -> Option<&std::path::Path> {
+        self.git_root.as_deref()
     }
 
     async fn run(&self, args: &[&str]) -> Result<String> {
@@ -609,13 +621,13 @@ impl GitNotesBackend {
         Ok(self.run(&["rev-parse", "HEAD"]).await?.trim().to_string())
     }
 
-    /// Commits carrying a spelunk note, in reverse-chronological (newest first)
-    /// order.
+    /// `(commit_sha, note_blob_sha)` for every commit reachable from HEAD that
+    /// carries a spelunk note, in reverse-chronological (newest first) order.
     ///
     /// Only commits reachable from HEAD are listed: memory travels with the
     /// code that carries it, so a teammate's note on a fetched-but-unmerged
     /// commit stays invisible until that commit is merged.
-    async fn noted_commits(&self) -> Result<Vec<NotedCommit>> {
+    async fn noted_commits(&self) -> Result<Vec<(String, String)>> {
         // `git notes --ref=spelunk list` → "<note-blob-sha> <commit-sha>"
         let list_out = self
             .git()
@@ -648,18 +660,29 @@ impl GitNotesBackend {
             return Ok(vec![]);
         }
 
-        let commits = String::from_utf8_lossy(&log_out.stdout)
+        let pairs = String::from_utf8_lossy(&log_out.stdout)
             .lines()
             .filter_map(|line| {
                 let commit = line.trim();
-                noted.get(commit).map(|blob| NotedCommit {
-                    commit: commit.to_owned(),
-                    note_blob: (*blob).to_owned(),
-                })
+                noted
+                    .get(commit)
+                    .map(|blob| (commit.to_owned(), (*blob).to_owned()))
             })
             .collect();
 
-        Ok(commits)
+        Ok(pairs)
+    }
+
+    /// Note blob shas only, for the lenient batch read `folded_records` uses:
+    /// listing/lookup reads must not break because one historical note is
+    /// unreadable (see [`read_note_blobs`](Self::read_note_blobs)).
+    async fn noted_blobs(&self) -> Result<Vec<String>> {
+        Ok(self
+            .noted_commits()
+            .await?
+            .into_iter()
+            .map(|(_, blob)| blob)
+            .collect())
     }
 
     /// Read every listed note blob in one `git cat-file --batch`, in the order
@@ -710,9 +733,9 @@ impl GitNotesBackend {
 
     /// Read the raw note blob for `commit_sha` (empty string if no note).
     ///
-    /// A failed read is an `Err`, never an empty blob: `append_record` and
-    /// `archive_record` write back what this returns, so conflating the two
-    /// turns one transient git failure into a wiped note (#185).
+    /// A failed read is an `Err`, never an empty blob: `append_record` writes
+    /// back what this returns, so conflating the two turns one transient git
+    /// failure into a wiped note (#185).
     async fn read_note_blob(&self, commit_sha: &str) -> Result<String> {
         Ok(
             read_note_body_with_retry(self.git_root.as_deref(), commit_sha)
@@ -741,34 +764,6 @@ impl GitNotesBackend {
         self.add_note_stdin(object, &combined).await
     }
 
-    /// Set `status = "archived"` on the single spelunk record whose `id` matches
-    /// `id` within `object`'s note. Every other line (sibling records and
-    /// foreign content) is re-emitted unchanged in its original position; only
-    /// the matched record's line is re-serialized. Returns whether a match was
-    /// rewritten.
-    async fn archive_record(&self, object: &str, id: i64) -> Result<bool> {
-        let _lock = writer_lock(self.git_root.as_deref()).await?;
-
-        let blob = self.read_note_blob(object).await?;
-        let mut out_lines: Vec<String> = Vec::new();
-        let mut changed = false;
-        for line in blob.lines() {
-            match parse_spelunk_line(line) {
-                Some(mut record) if !changed && record.id == id => {
-                    record.status = "archived".to_string();
-                    out_lines.push(serde_json::to_string(&record)?);
-                    changed = true;
-                }
-                // Foreign lines and untargeted records: re-emit verbatim.
-                _ => out_lines.push(line.to_string()),
-            }
-        }
-        if changed {
-            self.add_note_stdin(object, &out_lines.join("\n")).await?;
-        }
-        Ok(changed)
-    }
-
     /// Every entry on the ref, folded to one record per entity, no filtering
     /// or limit truncation — the shared basis for `collect()`'s filtered
     /// listing and `get()`'s single-entity lookup, so both see the same
@@ -780,12 +775,7 @@ impl GitNotesBackend {
     /// The only site that sees every commit's records, so the only site that
     /// can fold an entity's copies together.
     async fn folded_records(&self) -> Result<Vec<NoteRecord>> {
-        let blob_shas: Vec<String> = self
-            .noted_commits()
-            .await?
-            .into_iter()
-            .map(|c| c.note_blob)
-            .collect();
+        let blob_shas = self.noted_blobs().await?;
 
         let mut records = Vec::new();
         for blob in self.read_note_blobs(&blob_shas).await? {
@@ -835,12 +825,6 @@ impl GitNotesBackend {
 
         Ok(folded.into_iter().map(record_to_note).collect())
     }
-}
-
-/// A commit carrying a spelunk note, and the note's blob sha.
-struct NotedCommit {
-    commit: String,
-    note_blob: String,
 }
 
 /// Permissively parse the spelunk records from one note blob.

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -754,6 +754,97 @@ async fn git_notes_archive_does_not_clobber_siblings_or_prose() {
     assert_eq!(rec2.status, "archived", "only record 2 is archived");
 }
 
+/// `archive` must append a new state-update record for the entity rather than
+/// rewrite the matched line in place, mirroring
+/// `append_state_update_appends_never_rewrites` but for `GitNotesBackend`'s
+/// own primary-store `archive` (`--backend git-notes`, not the SQLite-primary
+/// carrier that free function serves). Checked directly on the raw ref,
+/// single-repo: a two-clone merge cannot distinguish the two here, because
+/// `cat_sort_uniq` reconstructs a rewrite's discarded original line from any
+/// clone that never touched it, making a rewrite and an append converge to
+/// the same union either way. Only the raw line count on the writing repo
+/// itself, before any merge, tells them apart.
+#[tokio::test]
+#[serial]
+async fn git_notes_backend_archive_appends_never_rewrites() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+
+    let id = backend
+        .add(note_input("decision", "archive me"))
+        .await
+        .expect("add");
+    let original = read_raw_note(root);
+    let original_line = original
+        .lines()
+        .next()
+        .expect("one seeded line")
+        .to_string();
+    let original_record: NoteRecord = serde_json::from_str(&original_line).expect("parse original");
+
+    let archived = backend.archive(id).await.expect("archive");
+    assert!(archived);
+
+    let after = read_raw_note(root);
+    let lines: Vec<&str> = after.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "archiving must append a state-update record, not rewrite the \
+         original line in place: {after}"
+    );
+    assert_eq!(
+        lines[0], original_line,
+        "the original active line must survive byte-for-byte"
+    );
+
+    let update: NoteRecord = serde_json::from_str(lines[1]).expect("parse appended record");
+    assert_eq!(update.status, "archived");
+    assert_ne!(
+        update.id, id,
+        "the appended state-update mints its own id, never reusing the \
+         original rowid"
+    );
+    assert_eq!(
+        update.entity_id, original_record.entity_id,
+        "the appended record must target the entity by entity_id (ADR-068 A6), \
+         not the rowid the old in-place rewrite matched on"
+    );
+
+    // The fold still converges to one entry, correctly archived.
+    let all = backend.list(None, 10, true, None).await.expect("list all");
+    assert_eq!(all.len(), 1, "the two raw lines fold to one entity");
+    assert_eq!(all[0].status, "archived");
+}
+
+/// Archiving the same entity twice (sequentially, one machine) must converge
+/// to one folded, archived entry, not a duplicate or a conflict, even though
+/// each call appends its own state-update record with its own minted id.
+#[tokio::test]
+#[serial]
+async fn git_notes_backend_archive_twice_is_idempotent() {
+    let dir = make_temp_git_repo();
+    let root = dir.path();
+    let backend = GitNotesBackend::with_root(root.to_path_buf());
+
+    let id = backend
+        .add(note_input("decision", "archive me twice"))
+        .await
+        .expect("add");
+
+    assert!(backend.archive(id).await.expect("first archive"));
+    assert!(backend.archive(id).await.expect("second archive"));
+
+    let all = backend.list(None, 10, true, None).await.expect("list all");
+    assert_eq!(
+        all.len(),
+        1,
+        "two archives of the same entity must still fold to one entry"
+    );
+    assert_eq!(all[0].status, "archived");
+}
+
 // ── concurrent append safety (#185 / ADR-069 D8) ─────────────────────────────
 
 /// The D8 invariant for N concurrent writers: every writer's entry **lands or

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -771,7 +771,7 @@ async fn git_notes_backend_archive_appends_never_rewrites() {
     let root = dir.path();
     let backend = GitNotesBackend::with_root(root.to_path_buf());
 
-    let id = backend
+    let (id, _created) = backend
         .add(note_input("decision", "archive me"))
         .await
         .expect("add");
@@ -828,7 +828,7 @@ async fn git_notes_backend_archive_twice_is_idempotent() {
     let root = dir.path();
     let backend = GitNotesBackend::with_root(root.to_path_buf());
 
-    let id = backend
+    let (id, _created) = backend
         .add(note_input("decision", "archive me twice"))
         .await
         .expect("add");

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -51,6 +51,17 @@ surviving entry carries the earliest recording time, and the union of the copies
 any copy reads as archived everywhere, so archiving it on one machine does not
 un-archive when a still-active copy arrives from another.
 
+**Archiving travels too.** `memory archive <id>` appends a state-update record
+for the entry to the carrier, carrying archived status and invalidation time,
+rather than editing the entry's line in place. This holds on both storage
+paths: the default SQLite-primary path (a write-through carry, best-effort and
+non-fatal like `memory add`) and explicit `--backend git-notes` (git notes is
+the primary store, and `archive` itself appends the record there). Because the
+write is always an append, a clone that already holds an independent copy of
+the pre-archive entry still converges to one archived entry once the notes ref
+is fetched and merged, instead of leaving a stale active copy sitting
+alongside it.
+
 **Superseding travels too.** `--supersedes <old-id>` (on `memory add`) and
 `memory supersede` both append a state-update record for the *old* entry to the
 carrier — archived status, invalidation time, and an edge naming the new


### PR DESCRIPTION
## What was broken

`memory archive` only ever mutated the local SQLite store. Once git-notes sync is in play, an archived entry kept showing as active on every other clone: the note ref (`refs/notes/spelunk`) had no writer for archival at all. A teammate archives a stale decision; everyone else's `memory list` keeps surfacing it as live.

A second, related bug surfaced during review: `GitNotesBackend::archive` (used when git-notes is the *primary* store via `--backend git-notes`, not just the write-through carrier) matched the target record by its local SQLite rowid and rewrote that line in place. The note ref is meant to be an append-only, entity-keyed event log — an in-place rewrite breaks that invariant. Verified live: a second clone holding its own divergent copy of the pre-archive line ends up with both the stale "active" line and the rewritten "archived" line side by side after a real merge, instead of converging to one archived entry.

## The fix

- `memory archive` (`crates/spelunk-cli/src/cli/cmd/memory/archive.rs`) now write-throughs to the git-notes carrier after a successful SQLite archive, appending a `status: "archived"` state-update record for the entry via the same shared helper `memory add`/`memory supersede` already use. This is best-effort and non-fatal, matching the existing carrier contract: a failed carry warns but never fails the command.
- `GitNotesBackend::archive` (`crates/spelunk-core/src/storage/git_notes/backend_impl.rs`) no longer rewrites the matched line in place. It resolves the target record, then appends a state-update for that record's content-addressed entity id, so the git-notes-primary path has the same append-only convergence property as every other writer on the ref.
- Both paths locate their target by entity id rather than by the machine-local rowid, so the update travels correctly even though rowids aren't stable across clones.

## Tests

- Two-clone end-to-end test: clone A archives an entry and pushes; clone B (holding its own independent, divergent note so the merge genuinely unions two histories instead of fast-forwarding) fetches and merges — the entry is archived exactly once and absent from a default `memory list`, with a raw git-ref assertion confirming the original line survives untouched alongside the new archived line.
- Idempotence tests: archiving the same entry twice, and two clones independently archiving the same entry before either sees the other's update, both converge to one archived entry.
- A direct unit test on `GitNotesBackend::archive` asserting the raw note carries two lines (untouched original + new state-update), not one rewritten line — the two-clone test above can't discriminate this bug on its own, since a real git merge reconstructs a rewritten-away line from any clone that never touched it.
- A regression test pinning the best-effort/non-fatal contract: an unwritable `refs/notes` must not fail `memory archive`, and the SQLite side must still hold the archive.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-core -p spelunk-cli` — full suite green (74/74 in `integration_git_notes.rs`, all `spelunk-cli` binaries including the 3 new tests in `archive_git_notes_carrier.rs`).
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `SPELUNK_SECRET_STORE=file cargo fmt --check` — clean.
- `SPELUNK_SECRET_STORE=file cargo audit` — no new advisories (2 pre-existing unmaintained-crate warnings in the `gix`/`jiff` dependency tree, unrelated to this change).