### PR TITLE
test: move server_url/project_id test fixtures to project-level config

### DIFF
--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -5,6 +5,7 @@ use tempfile::tempdir;
 mod plumbing_helpers;
 use plumbing_helpers::{
     FIXTURE_PROJECT_ID, IndexEmbedResponder, spelunk_bin, spelunk_bin_in, write_config_with_server,
+    write_project_server_config,
 };
 
 #[test]
@@ -191,19 +192,19 @@ async fn test_index_and_status() {
                 "db_path = {:?}\n",
                 "embedding_model = \"test-model\"\n",
                 "llm_model = \"test-chat-model\"\n",
-                "server_url = {:?}\n",
-                "project_id = {:?}\n",
             ),
             db_path,
-            mock_server.uri(),
-            project_id,
         ),
     )
     .unwrap();
+    // `server_url`/`project_id` only take effect from project-level
+    // `.spelunk/config.toml` (or env), never from the `--config` global file.
+    write_project_server_config(&project_dir, &mock_server.uri(), project_id);
 
     // 1. Index the project
     let mut cmd = spelunk_bin();
-    cmd.arg("--config")
+    cmd.current_dir(&project_dir)
+        .arg("--config")
         .arg(&config_path)
         .arg("index")
         .arg(&project_dir)
@@ -299,18 +300,19 @@ async fn test_index_encodes_project_id_with_slashes_as_single_segment() {
                     "db_path = {:?}\n",
                     "embedding_model = \"test-model\"\n",
                     "llm_model = \"test-chat-model\"\n",
-                    "server_url = {:?}\n",
-                    "project_id = {:?}\n",
                 ),
                 db_path,
-                mock_server.uri(),
-                project_id,
             ),
         )
         .unwrap();
 
+        // `server_url` only loads from project-level `.spelunk/config.toml` (or
+        // env), never the personal global config: see `Config::load_with_store`.
+        write_project_server_config(&project_dir, &mock_server.uri(), project_id);
+
         // Index the project — must reach the embedding phase without a 404.
         spelunk_bin()
+            .current_dir(&project_dir)
             .arg("--config")
             .arg(&config_path)
             .arg("index")
@@ -453,10 +455,12 @@ async fn test_status_shows_server_tier() {
         &db_path,
         &mock_server.uri(),
         &mock_server.uri(),
+        &project_dir,
     );
 
     let mut cmd = spelunk_bin();
-    cmd.arg("--config")
+    cmd.current_dir(&project_dir)
+        .arg("--config")
         .arg(&config_path)
         .arg("index")
         .arg(&project_dir)
@@ -514,10 +518,12 @@ async fn test_status_json_includes_tier_fields() {
         &db_path,
         &mock_server.uri(),
         &mock_server.uri(),
+        &project_dir,
     );
 
     let mut cmd = spelunk_bin();
-    cmd.arg("--config")
+    cmd.current_dir(&project_dir)
+        .arg("--config")
         .arg(&config_path)
         .arg("index")
         .arg(&project_dir)
@@ -806,10 +812,12 @@ async fn test_check_reports_server_reachable() {
         &db_path,
         &mock_server.uri(),
         &mock_server.uri(),
+        &project_dir,
     );
 
     let mut cmd = spelunk_bin();
-    cmd.arg("--config")
+    cmd.current_dir(&project_dir)
+        .arg("--config")
         .arg(&config_path)
         .arg("index")
         .arg(&project_dir)
@@ -841,14 +849,16 @@ async fn test_check_reports_server_unreachable() {
     fs::write(
         &config_path,
         format!(
-            "db_path = {:?}\napi_base_url = {:?}\nembedding_model = \"test\"\nllm_model = \"test\"\nserver_url = {:?}\nproject_id = {:?}\n",
-            db_path, bad_url, bad_url, FIXTURE_PROJECT_ID
+            "db_path = {:?}\napi_base_url = {:?}\nembedding_model = \"test\"\nllm_model = \"test\"\n",
+            db_path, bad_url
         ),
     )
     .unwrap();
+    write_project_server_config(&project_dir, bad_url, FIXTURE_PROJECT_ID);
 
     let mut cmd = spelunk_bin();
-    cmd.arg("--config")
+    cmd.current_dir(&project_dir)
+        .arg("--config")
         .arg(&config_path)
         .arg("index")
         .arg(&project_dir)
@@ -2086,8 +2096,13 @@ async fn test_search_explicit_semantic_zero_coverage_is_actionable_error() {
     // runs at Tier 1 and reaches the coverage gate instead of the Tier-0
     // text fallback.
     let db_ignored = home.path().join("unused.db");
-    let server_config =
-        write_config_with_server(home.path(), &db_ignored, &mock.uri(), &mock.uri());
+    let server_config = write_config_with_server(
+        home.path(),
+        &db_ignored,
+        &mock.uri(),
+        &mock.uri(),
+        &project_dir,
+    );
 
     let assert = spelunk_bin_in(home.path())
         .current_dir(&project_dir)
@@ -2132,10 +2147,17 @@ async fn test_search_auto_partial_coverage_emits_warmup_notice_on_stderr() {
     )
     .unwrap();
     let db_ignored = home.path().join("unused.db");
-    let config_path = write_config_with_server(home.path(), &db_ignored, &mock.uri(), &mock.uri());
+    let config_path = write_config_with_server(
+        home.path(),
+        &db_ignored,
+        &mock.uri(),
+        &mock.uri(),
+        &project_dir,
+    );
 
     // Pass 1: embed everything via the mock server (full coverage).
     spelunk_bin_in(home.path())
+        .current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
         .arg("index")
@@ -2152,6 +2174,7 @@ async fn test_search_auto_partial_coverage_emits_warmup_notice_on_stderr() {
     .unwrap();
     spelunk_bin_in(home.path())
         .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)
         .arg("index")

--- a/crates/spelunk-cli/tests/embed.rs
+++ b/crates/spelunk-cli/tests/embed.rs
@@ -12,22 +12,15 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-/// Build a config.toml that points `server_url` at the given mock server URI.
+// Build a config.toml with `embedding_model`, and separately point
+// `server_url`/`project_id` at `<dir>/.spelunk/config.toml`: `Config::load`
+// only honors those two fields from a project-level config (or env), never
+// the global `--config` file. The caller's `Command` must set
+// `.current_dir(dir.path())`.
 fn write_server_config(dir: &TempDir, server_uri: &str) -> std::path::PathBuf {
     let config = dir.path().join("config.toml");
-    std::fs::write(
-        &config,
-        format!(
-            concat!(
-                "server_url = \"{server_uri}\"\n",
-                "project_id = \"{project_id}\"\n",
-                "embedding_model = \"test-model\"\n",
-            ),
-            server_uri = server_uri,
-            project_id = FIXTURE_PROJECT_ID,
-        ),
-    )
-    .unwrap();
+    std::fs::write(&config, "embedding_model = \"test-model\"\n").unwrap();
+    plumbing_helpers::write_project_server_config(dir.path(), server_uri, FIXTURE_PROJECT_ID);
     config
 }
 
@@ -51,6 +44,7 @@ async fn embed_exits_0_with_empty_piped_stdin() {
 
     // Pipe empty stdin — command should succeed (no lines to embed).
     spelunk_bin()
+        .current_dir(tmp.path())
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -88,6 +82,7 @@ async fn embed_document_mode_produces_jsonl_vector() {
     let config = write_server_config(&tmp, &mock.uri());
 
     let output = spelunk_bin()
+        .current_dir(tmp.path())
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -140,6 +135,7 @@ async fn embed_query_mode_produces_jsonl_vector() {
     let config = write_server_config(&tmp, &mock.uri());
 
     let output = spelunk_bin()
+        .current_dir(tmp.path())
         .arg("--config")
         .arg(&config)
         .arg("plumbing")
@@ -180,6 +176,7 @@ async fn embed_multiple_lines_produce_multiple_vectors() {
     let config = write_server_config(&tmp, &mock.uri());
 
     let output = spelunk_bin()
+        .current_dir(tmp.path())
         .arg("--config")
         .arg(&config)
         .arg("plumbing")

--- a/crates/spelunk-cli/tests/harvest_ref_injection.rs
+++ b/crates/spelunk-cli/tests/harvest_ref_injection.rs
@@ -14,14 +14,22 @@ use predicates::prelude::*;
 use std::fs;
 use tempfile::tempdir;
 
-fn write_harvest_config(dir: &std::path::Path, extra: &str) -> std::path::PathBuf {
+// `server_url`/`project_id` only satisfy harvest's upfront "server
+// configured" gate: the injection guard under test fires before any request
+// reaches that address, so it deliberately never needs to be reachable.
+// `Config::load` only honors those two fields from project-level
+// `.spelunk/config.toml` (or env), never the global `--config` file, so they
+// land in `dir`'s project config instead of `dir/config.toml`. Every caller
+// sets `.current_dir(dir)`.
+fn write_harvest_config(dir: &std::path::Path) -> std::path::PathBuf {
     let db_path = dir.join("memory.db");
     let config_path = dir.join("config.toml");
     let content = format!(
-        "db_path = {:?}\napi_base_url = \"http://127.0.0.1:1234\"\n{extra}",
+        "db_path = {:?}\napi_base_url = \"http://127.0.0.1:1234\"\n",
         db_path
     );
     fs::write(&config_path, content).expect("write config.toml");
+    plumbing_helpers::write_project_server_config(dir, "http://127.0.0.1:7777", "test/proj");
     config_path
 }
 
@@ -45,10 +53,7 @@ fn harvest_rejects_option_like_branch_and_does_not_touch_victim_file() {
     let victim_path = victim_dir.path().join("victim.txt");
     assert!(!victim_path.exists());
 
-    let config_path = write_harvest_config(
-        temp.path(),
-        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
-    );
+    let config_path = write_harvest_config(temp.path());
 
     let malicious_branch_arg = format!("--branch=--output={}", victim_path.display());
 
@@ -80,10 +85,7 @@ fn harvest_rejects_option_like_git_range() {
     let victim_dir = tempdir().unwrap();
     let victim_path = victim_dir.path().join("victim2.txt");
 
-    let config_path = write_harvest_config(
-        temp.path(),
-        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
-    );
+    let config_path = write_harvest_config(temp.path());
 
     let malicious_range_arg = format!("--git-range=--output={}", victim_path.display());
 
@@ -112,10 +114,7 @@ fn harvest_rejects_short_option_like_branch() {
     let temp = tempdir().unwrap();
     init_repo(temp.path());
 
-    let config_path = write_harvest_config(
-        temp.path(),
-        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
-    );
+    let config_path = write_harvest_config(temp.path());
 
     let mut cmd = spelunk_bin();
     cmd.current_dir(temp.path())
@@ -139,10 +138,7 @@ fn harvest_rejects_bare_double_dash_branch() {
     let temp = tempdir().unwrap();
     init_repo(temp.path());
 
-    let config_path = write_harvest_config(
-        temp.path(),
-        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
-    );
+    let config_path = write_harvest_config(temp.path());
 
     let mut cmd = spelunk_bin();
     cmd.current_dir(temp.path())
@@ -172,10 +168,7 @@ fn harvest_rejects_option_like_branch_with_shell_metacharacters() {
     let victim_dir = tempdir().unwrap();
     let victim_path = victim_dir.path().join("victim3.txt");
 
-    let config_path = write_harvest_config(
-        temp.path(),
-        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
-    );
+    let config_path = write_harvest_config(temp.path());
 
     let malicious_branch_arg = format!(
         "--branch=--output={};touch /tmp/oss61-pwned",

--- a/crates/spelunk-cli/tests/harvest_upfront_check.rs
+++ b/crates/spelunk-cli/tests/harvest_upfront_check.rs
@@ -74,10 +74,14 @@ fn harvest_fails_with_actionable_error_when_no_server_and_no_model() {
 #[test]
 fn harvest_check_passes_when_server_url_is_set() {
     let temp = tempdir().unwrap();
-    // server_url is set; project_id is required alongside it.
-    let config_path = write_harvest_config(
+    // `Config::load` only honors `server_url`/`project_id` from project-level
+    // `.spelunk/config.toml` (or env), never the global `--config` file, so
+    // they're written separately from `write_harvest_config`'s `extra`.
+    let config_path = write_harvest_config(temp.path(), "");
+    plumbing_helpers::write_project_server_config(
         temp.path(),
-        "server_url = \"http://127.0.0.1:7777\"\nproject_id = \"test/proj\"\n",
+        "http://127.0.0.1:7777",
+        "test/proj",
     );
 
     // The command will fail (no live server, no git repo) but NOT with the

--- a/crates/spelunk-cli/tests/index_summary_completion.rs
+++ b/crates/spelunk-cli/tests/index_summary_completion.rs
@@ -44,6 +44,9 @@ fn index_command(home: &Path, config: &Path, db: &Path, project: &Path) -> Comma
     cmd.env("SPELUNK_SECRET_STORE", "file")
         .env("HOME", home)
         .env_remove("XDG_CONFIG_HOME")
+        // Project-level config discovery walks up from CWD; every caller here
+        // writes `server_url` to `<project>/.spelunk/config.toml`.
+        .current_dir(project)
         .arg("--config")
         .arg(config)
         .arg("index")
@@ -131,8 +134,13 @@ fn summary_pass_completes_before_index_returns() {
     });
 
     let mock_url = mock_server.uri();
-    let config_path =
-        plumbing_helpers::write_config_with_server(project.path(), &db_path, &mock_url, &mock_url);
+    let config_path = plumbing_helpers::write_config_with_server(
+        project.path(),
+        &db_path,
+        &mock_url,
+        &mock_url,
+        project.path(),
+    );
 
     let mut child = index_command(project.path(), &config_path, &db_path, project.path())
         .stdout(Stdio::null())
@@ -224,8 +232,13 @@ fn summary_failure_is_reported_but_index_still_succeeds() {
     });
 
     let mock_url = mock_server.uri();
-    let config_path =
-        plumbing_helpers::write_config_with_server(project.path(), &db_path, &mock_url, &mock_url);
+    let config_path = plumbing_helpers::write_config_with_server(
+        project.path(),
+        &db_path,
+        &mock_url,
+        &mock_url,
+        project.path(),
+    );
 
     let output = index_command(project.path(), &config_path, &db_path, project.path())
         .output()
@@ -291,8 +304,13 @@ fn background_phases_mode_completes_summaries() {
     });
 
     let mock_url = mock_server.uri();
-    let config_path =
-        plumbing_helpers::write_config_with_server(project.path(), &db_path, &mock_url, &mock_url);
+    let config_path = plumbing_helpers::write_config_with_server(
+        project.path(),
+        &db_path,
+        &mock_url,
+        &mock_url,
+        project.path(),
+    );
 
     // Populate chunks first: background-phases mode skips parse/embed.
     let seed = index_command(project.path(), &config_path, &db_path, project.path())

--- a/crates/spelunk-cli/tests/integration_compose.rs
+++ b/crates/spelunk-cli/tests/integration_compose.rs
@@ -68,7 +68,11 @@ fn plumbing_knn_returns_valid_chunk_ids() {
 
     // Step 1: embed a query string via `spelunk plumbing embed --query`
     // The mock server returns [0.1f32; 768] for every request.
+    // `index_fixture_project` writes `server_url` to `<_tmp>/.spelunk/config.toml`
+    // (project-level, since `Config::load` never honors it from `--config`);
+    // `.current_dir` must match for this second, separate invocation to see it.
     let embed_output = spelunk_bin()
+        .current_dir(_tmp.path())
         .arg("--config")
         .arg(&config_path)
         .arg("plumbing")

--- a/crates/spelunk-cli/tests/memory_push_sync_total_failure.rs
+++ b/crates/spelunk-cli/tests/memory_push_sync_total_failure.rs
@@ -70,10 +70,13 @@ async fn mount_since_empty(server: &MockServer) {
         .await;
 }
 
-/// Write a config with an explicit `server_url`/`project_id` pointing at the
-/// mock server, and no `server_key`/`[auth]`, so `ensure_fresh_server_key`
-/// takes its no-op path (`auth_api.rs`) and push/sync never needs a real
-/// WorkOS login against a keyless plaintext loopback server.
+// Write a config with no `server_key`/`[auth]`, so `ensure_fresh_server_key`
+// takes its no-op path (`auth_api.rs`) and push/sync never needs a real
+// WorkOS login against a keyless plaintext loopback server. `server_url`/
+// `project_id` point at the mock server via `<dir>/.spelunk/config.toml`
+// instead of this global file: `Config::load` only honors those two fields
+// from a project-level config (or env). Every caller already sets
+// `.current_dir(dir)`.
 fn write_config(dir: &Path, server_url: &str) -> std::path::PathBuf {
     let db_path = dir.join(".spelunk").join("index.db");
     let config_path = dir.join("config.toml");
@@ -82,12 +85,11 @@ fn write_config(dir: &Path, server_url: &str) -> std::path::PathBuf {
         format!(
             "db_path = {db_path:?}\n\
              embedding_model = \"test-model\"\n\
-             llm_model = \"test-chat\"\n\
-             server_url = {server_url:?}\n\
-             project_id = {PROJECT_SLUG:?}\n"
+             llm_model = \"test-chat\"\n"
         ),
     )
     .expect("write config.toml");
+    plumbing_helpers::write_project_server_config(dir, server_url, PROJECT_SLUG);
     config_path
 }
 

--- a/crates/spelunk-cli/tests/memory_read_mode_notice.rs
+++ b/crates/spelunk-cli/tests/memory_read_mode_notice.rs
@@ -103,7 +103,14 @@ fn local_first_read_serves_data_without_sync_nag() {
         tmp.path(),
         "config-local-first.toml",
         &tmp.path().join("spelunk.db"),
-        "server_url = \"https://team.invalid:7777\"\nproject_id = \"team/proj\"\n",
+        "",
+    );
+    // `server_url`/`project_id` only take effect from project-level
+    // `.spelunk/config.toml` (`memory_list` sets `.current_dir(tmp.path())`).
+    plumbing_helpers::write_project_server_config(
+        tmp.path(),
+        "https://team.invalid:7777",
+        "team/proj",
     );
 
     let out = memory_list(&tmp, &mem_path, &cfg);
@@ -129,14 +136,19 @@ fn cloud_first_read_unreachable_server_errors_without_local_data() {
     let (tmp, mem_path, _id) = seeded_project();
     // Loopback http passes the transport guard; nothing listens on port 1, so
     // the read must fail. A raw-UUID project_id skips slug resolution, proving
-    // the failure is the memory read itself.
+    // the failure is the memory read itself. `mode` isn't a `ProjectConfig`
+    // field, so it stays in the global file; `server_url`/`project_id` only
+    // take effect from project-level `.spelunk/config.toml`.
     let cfg = write_cfg(
         tmp.path(),
         "config-cloud-first.toml",
         &tmp.path().join("spelunk.db"),
-        "server_url = \"http://127.0.0.1:1\"\n\
-         project_id = \"11111111-1111-1111-1111-111111111111\"\n\
-         mode = \"cloud_first\"\n",
+        "mode = \"cloud_first\"\n",
+    );
+    plumbing_helpers::write_project_server_config(
+        tmp.path(),
+        "http://127.0.0.1:1",
+        "11111111-1111-1111-1111-111111111111",
     );
 
     let out = memory_list(&tmp, &mem_path, &cfg);
@@ -196,8 +208,12 @@ fn status_shows_neutral_mode_and_truthful_hints_with_unreachable_server_url() {
         tmp.path(),
         "config-team.toml",
         &tmp.path().join("index.db"),
-        "server_url = \"https://127.0.0.1:1\"\nproject_id = \"team/proj\"\n",
+        "",
     );
+    // `server_url`/`project_id` only take effect from project-level
+    // `.spelunk/config.toml`; the `status` command below runs with
+    // `.current_dir(&project)`, so it must land there, not under `tmp.path()`.
+    plumbing_helpers::write_project_server_config(&project, "https://127.0.0.1:1", "team/proj");
 
     let out = spelunk_bin()
         .current_dir(&project)

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -158,28 +158,44 @@ pub fn write_config(dir: &Path, db_path: &Path, api_base: &str) -> PathBuf {
     config_path
 }
 
-/// Like `write_config` but also configures `server_url` + `project_id` for
-/// Tier 1 operation (server-based embedding during `spelunk index`).
+// Like `write_config` but also configures `server_url` + `project_id` for
+// Tier 1 operation (server-based embedding during `spelunk index`).
+//
+// `Config::load` only honors `server_url`/`project_id` from a project-level
+// `.spelunk/config.toml` (discovered by walking up from CWD) or
+// `SPELUNK_SERVER_URL`/`SPELUNK_PROJECT_ID` env, never from the `--config`
+// file, which is the global personal config. So this writes those two fields
+// to `<project_dir>/.spelunk/config.toml` instead of the returned global
+// file. The caller's `Command` must set `.current_dir(project_dir)` (or
+// wherever `project_dir` resolves to) or the discovery walk will never find
+// it.
 pub fn write_config_with_server(
     dir: &Path,
     db_path: &Path,
     api_base: &str,
     server_url: &str,
+    project_dir: &Path,
 ) -> PathBuf {
-    let cfg = format!(
-        concat!(
-            "db_path = {:?}\n",
-            "api_base_url = {:?}\n",
-            "embedding_model = \"test-model\"\n",
-            "llm_model = \"test-chat\"\n",
-            "server_url = {:?}\n",
-            "project_id = {:?}\n",
-        ),
-        db_path, api_base, server_url, FIXTURE_PROJECT_ID,
-    );
-    let config_path = dir.join("config.toml");
-    std::fs::write(&config_path, cfg).expect("write config");
+    let config_path = write_config(dir, db_path, api_base);
+    write_project_server_config(project_dir, server_url, FIXTURE_PROJECT_ID);
     config_path
+}
+
+// Write `<project_dir>/.spelunk/config.toml` with `server_url` + `project_id`,
+// the only config file `Config::load` honors those fields from (besides env).
+// The caller's `Command` must set `.current_dir(project_dir)`.
+//
+// An empty `project_id` is omitted entirely (rather than written as `""`) so
+// a loopback-only test that doesn't need one (see `Config::validate_with_project`)
+// leaves `project_id` genuinely unset, not set to an empty string.
+pub fn write_project_server_config(project_dir: &Path, server_url: &str, project_id: &str) {
+    let spelunk_dir = project_dir.join(".spelunk");
+    std::fs::create_dir_all(&spelunk_dir).expect("create .spelunk dir");
+    let mut cfg = format!("server_url = {server_url:?}\n");
+    if !project_id.is_empty() {
+        cfg.push_str(&format!("project_id = {project_id:?}\n"));
+    }
+    std::fs::write(spelunk_dir.join("config.toml"), cfg).expect("write project config");
 }
 
 /// Dynamic responder for `POST /v1/projects/{id}/index/embed`.
@@ -323,11 +339,16 @@ pub fn index_project_dir(project_dir: &Path) -> (TempDir, PathBuf, PathBuf) {
     });
 
     let mock_url = _mock_server.uri();
-    let config_path = write_config_with_server(tmp.path(), &db_path, &mock_url, &mock_url);
+    let config_path =
+        write_config_with_server(tmp.path(), &db_path, &mock_url, &mock_url, tmp.path());
 
     // Pass `--db` explicitly so the index is written to our temp DB path,
     // not to `<project_dir>/.spelunk/index.db` (the default project-local location).
+    // `.current_dir(tmp.path())`: the project-level config discovery walks up
+    // from CWD, not from the `project_dir` positional arg (which may be an
+    // unrelated source tree, e.g. the shared fixture).
     spelunk_bin_in(tmp.path())
+        .current_dir(tmp.path())
         .arg("--config")
         .arg(&config_path)
         .arg("index")

--- a/crates/spelunk-cli/tests/secret_scanner.rs
+++ b/crates/spelunk-cli/tests/secret_scanner.rs
@@ -191,12 +191,18 @@ fn summary_secret_is_not_persisted() {
     });
 
     let mock_url = mock_server.uri();
-    let config_path =
-        plumbing_helpers::write_config_with_server(tmp.path(), &db_path, &mock_url, &mock_url);
+    let config_path = plumbing_helpers::write_config_with_server(
+        tmp.path(),
+        &db_path,
+        &mock_url,
+        &mock_url,
+        tmp.path(),
+    );
 
     // Run the real `spelunk index` (no `--no-summaries`), same as production:
     // parse → embed → summary generation, all through `generate_summaries`.
     plumbing_helpers::spelunk_bin_in(tmp.path())
+        .current_dir(tmp.path())
         .arg("--config")
         .arg(&config_path)
         .arg("index")

--- a/crates/spelunk-cli/tests/server_key_resolution_e2e.rs
+++ b/crates/spelunk-cli/tests/server_key_resolution_e2e.rs
@@ -39,15 +39,15 @@ async fn mount_health_and_since(server: &MockServer) {
         .await;
 }
 
-fn write_server_config(dir: &Path, name: &str, server_url: &str) -> std::path::PathBuf {
+// `server_url`/`project_id` are set via `SPELUNK_SERVER_URL`/`SPELUNK_PROJECT_ID`
+// env on each command below, not this file: `Config::load` only honors those
+// two fields from a project-level `.spelunk/config.toml` (discovered by
+// walking up from CWD) or env, never from the `--config` file this test
+// swaps per origin. Env is the natural fit here since this file's whole
+// point is bearer-per-origin resolution, not config-file precedence.
+fn write_server_config(dir: &Path, name: &str) -> std::path::PathBuf {
     let config_path = dir.join(format!("{name}.toml"));
-    std::fs::write(
-        &config_path,
-        format!(
-            "server_url = {server_url:?}\nproject_id = {PROJECT_ID:?}\nembedding_model = \"test-model\"\n"
-        ),
-    )
-    .unwrap();
+    std::fs::write(&config_path, "embedding_model = \"test-model\"\n").unwrap();
     config_path
 }
 
@@ -82,13 +82,15 @@ async fn two_servers_two_keys_each_gets_only_its_own_bearer_over_the_wire() {
     set_key(home.path(), &server_a.uri(), "sk-project-a-secret");
     set_key(home.path(), &server_b.uri(), "sk-project-b-secret");
 
-    let config_a = write_server_config(cfg_dir.path(), "a", &server_a.uri());
-    let config_b = write_server_config(cfg_dir.path(), "b", &server_b.uri());
+    let config_a = write_server_config(cfg_dir.path(), "a");
+    let config_b = write_server_config(cfg_dir.path(), "b");
 
     let mem_db = cfg_dir.path().join("memory.db");
 
     spelunk_bin_in(home.path())
         .env_remove("SPELUNK_SERVER_KEY")
+        .env("SPELUNK_SERVER_URL", server_a.uri())
+        .env("SPELUNK_PROJECT_ID", PROJECT_ID)
         .arg("--config")
         .arg(&config_a)
         .arg("memory")
@@ -101,6 +103,8 @@ async fn two_servers_two_keys_each_gets_only_its_own_bearer_over_the_wire() {
 
     spelunk_bin_in(home.path())
         .env_remove("SPELUNK_SERVER_KEY")
+        .env("SPELUNK_SERVER_URL", server_b.uri())
+        .env("SPELUNK_PROJECT_ID", PROJECT_ID)
         .arg("--config")
         .arg(&config_b)
         .arg("memory")
@@ -173,11 +177,13 @@ async fn legacy_flat_key_migrates_transparently_on_first_real_request() {
     )
     .unwrap();
 
-    let config_path = write_server_config(cfg_dir.path(), "legacy", &server.uri());
+    let config_path = write_server_config(cfg_dir.path(), "legacy");
     let mem_db = cfg_dir.path().join("memory.db");
 
     spelunk_bin_in(home.path())
         .env_remove("SPELUNK_SERVER_KEY")
+        .env("SPELUNK_SERVER_URL", server.uri())
+        .env("SPELUNK_PROJECT_ID", PROJECT_ID)
         .arg("--config")
         .arg(&config_path)
         .arg("memory")

--- a/crates/spelunk-cli/tests/tls_trust.rs
+++ b/crates/spelunk-cli/tests/tls_trust.rs
@@ -191,25 +191,42 @@ fn setup_project() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
     (temp, project_dir, config_path)
 }
 
-/// Overwrite `config_path` to point at `server_url` (our TLS test listener),
-/// trusting `ca_pem_path` via `server_ca`.
-fn write_tls_config(config_path: &Path, db_path: &Path, port: u16, ca_pem_path: &Path) {
+// Overwrite `config_path` (the global `--config` file) with `db_path` and
+// `server_ca`, and separately point `server_url` (our TLS test listener) at
+// `<project_dir>/.spelunk/config.toml`: `Config::load` only honors
+// `server_url` from a project-level config (or env), never the global file.
+// The loopback address means `project_id` is not required (see
+// `Config::validate_with_project`).
+fn write_tls_config(
+    config_path: &Path,
+    db_path: &Path,
+    port: u16,
+    ca_pem_path: &Path,
+    project_dir: &Path,
+) {
     let cfg = format!(
-        "db_path = {:?}\nserver_url = \"https://127.0.0.1:{port}\"\nserver_ca = {:?}\n",
+        "db_path = {:?}\nserver_ca = {:?}\n",
         db_path.display().to_string(),
         ca_pem_path.display().to_string(),
     );
     fs::write(config_path, cfg).expect("write tls config");
+    plumbing_helpers::write_project_server_config(
+        project_dir,
+        &format!("https://127.0.0.1:{port}"),
+        "",
+    );
 }
 
 /// Same as `write_tls_config`, but deliberately omits `server_ca`: the CLI
 /// trusts only the default root store, so our in-test CA is untrusted.
-fn write_tls_config_no_ca(config_path: &Path, db_path: &Path, port: u16) {
-    let cfg = format!(
-        "db_path = {:?}\nserver_url = \"https://127.0.0.1:{port}\"\n",
-        db_path.display().to_string(),
-    );
+fn write_tls_config_no_ca(config_path: &Path, db_path: &Path, port: u16, project_dir: &Path) {
+    let cfg = format!("db_path = {:?}\n", db_path.display().to_string());
     fs::write(config_path, cfg).expect("write tls config with no server_ca");
+    plumbing_helpers::write_project_server_config(
+        project_dir,
+        &format!("https://127.0.0.1:{port}"),
+        "",
+    );
 }
 
 // ── tests ────────────────────────────────────────────────────────────────────
@@ -230,6 +247,7 @@ fn tls_server_with_proper_ca_chain_reaches_server_tier() {
         &temp.path().join("index.db"),
         port,
         &ca_pem_path,
+        &project_dir,
     );
 
     let output = spelunk_bin()
@@ -274,6 +292,7 @@ fn tls_server_with_ca_cert_as_leaf_names_the_cause_not_just_unreachable() {
         &temp.path().join("index.db"),
         port,
         &ca_pem_path,
+        &project_dir,
     );
 
     let output = spelunk_bin()
@@ -346,6 +365,7 @@ fn tls_server_with_expired_leaf_names_expired_cause() {
         &temp.path().join("index.db"),
         port,
         &ca_pem_path,
+        &project_dir,
     );
 
     let output = spelunk_bin()
@@ -386,7 +406,12 @@ fn tls_server_with_untrusted_cert_and_no_server_ca_configured_names_cause_withou
     let port = spawn_tls_server(leaf_pem, leaf_key_pem);
 
     let (temp, project_dir, config_path) = setup_project();
-    write_tls_config_no_ca(&config_path, &temp.path().join("index.db"), port);
+    write_tls_config_no_ca(
+        &config_path,
+        &temp.path().join("index.db"),
+        port,
+        &project_dir,
+    );
 
     let output = spelunk_bin()
         .current_dir(&project_dir)


### PR DESCRIPTION
## Summary
- 12 CLI integration test files wrote `server_url`/`project_id` into the global `--config` file used by the process. Moves those two fields to `<project_dir>/.spelunk/config.toml` via a new `write_project_server_config` helper in `plumbing_helpers.rs`, matching how a real project configures a team server.
- No behavior change: this is purely a fixture relocation, independent of whether production enforces the project-level restriction (that lands as a follow-on PR, stacked on this one).

## Test plan
- `SPELUNK_SECRET_STORE=file cargo build --workspace`
- `SPELUNK_SECRET_STORE=file cargo test --workspace` and `--no-default-features`: all green (407/435/72/108-suite counts unchanged from main, 0 failures)
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` clean, both feature configs
- `cargo fmt --all -- --check` clean