### PR TITLE
Chunk-size bench/quality-eval harnesses + docstring-loss fix for attribute/decorator-preceded items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,26 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   (or by a lost cross-machine race) is also hardened: `superseded_by_entity_id`
   now resolves to the record with the greatest `created_at`, not the smallest
   `entity_id` string. (ADR-068 E4/E5)
+- **Indexing no longer drops the docstring from a documented Rust item
+  followed by an attribute, or a documented Python function/class wrapped in
+  a decorator.** `preceding_comment`'s walk back over sibling nodes stopped
+  at the first non-whitespace node it found, so a Rust `#[derive(...)]` /
+  `#[async_trait]` attribute (a real sibling sitting between the item and
+  its doc comment) or a Python `@decorator` (which tree-sitter-python wraps
+  together with the definition in one `decorated_definition` node) made the
+  walk land on the attribute or wrapper instead of the comment, so no
+  docstring was captured at all, silently. This affects retrieval quality,
+  since a chunk's docstring is part of what gets embedded and searched
+  (`Chunk::embedding_text()`); attributed/decorated items are common in
+  async Rust services and in most idiomatic Python. The walk now skips
+  `attribute_item` siblings (Rust) and starts from the enclosing
+  `decorated_definition` when present (Python), so the docstring is
+  captured as before. TypeScript decorators, Java annotations, and every
+  other currently supported language with similar syntax (PHP, Kotlin,
+  Swift, C#, C++, C) attach it as a child of the item in their grammars and
+  were confirmed unaffected. No schema or embedding-format change; run
+  `spelunk index --force` to recover docstrings on already-indexed
+  attributed/decorated items.
 
 ## [0.9.4] — 2026-07-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,6 +5307,7 @@ dependencies = [
  "sqlite-vec",
  "tempfile",
  "thiserror 2.0.18",
+ "tokenizers 0.23.1",
  "tokio",
  "toml",
  "tracing",
@@ -5336,6 +5337,7 @@ dependencies = [
  "tokenizers 0.23.1",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -76,3 +76,7 @@ tempfile = { workspace = true }
 wiremock = { workspace = true }
 pretty_assertions = { workspace = true }
 serial_test = { workspace = true }
+# Only for the chunk_quality_eval example: an independent tokenizer-exact
+# token count for the Recall@token-budget metric (avoids reintroducing the
+# chars/4 `estimate_tokens` bias the embed_bench harness exists to fix).
+tokenizers = { workspace = true }

--- a/crates/spelunk-core/examples/chunk_quality_eval.rs
+++ b/crates/spelunk-core/examples/chunk_quality_eval.rs
@@ -1,0 +1,686 @@
+// Chunk-size retrieval-quality eval: measures MRR@10 / Recall@10 / nDCG@10 +
+// Recall@fixed-token-budget at a swept set of chunk-token caps, so the
+// MAX_CHUNK_TOKENS default can be picked on quality evidence, not perf alone.
+//
+// Lives here (not in `spelunk-embed`, where `embed_bench` lives) because it
+// needs the real chunker (`spelunk_core::indexer`), and `spelunk-core`
+// depends on `spelunk-embed` – the reverse dependency isn't available, so a
+// tool needing both can only live on the `spelunk-core` side of that edge.
+//
+// No `spelunk` CLI and no `spelunk-server`/HTTP in the path: this calls
+// `SourceParser` and `NativeEmbedder` directly, the same way `embed_bench`
+// calls the embedder directly.
+//
+// Methodology (see the task this harness was built for):
+//   - Relevance is keyed on file + line-range overlap, not chunk id, because
+//     the retrieval unit itself changes with the cap (a chunk that's whole at
+//     2048 may be split into several pieces at 512).
+//   - Two arms: "leaky" embeds chunks as shipped (the docstring named in a
+//     query is present inside `embedding_text()`, so retrieval is
+//     near-exact-match); "held_out" strips the docstring from every indexed
+//     chunk first, a genuine "can NL find this code" test.
+//   - Recall@token-budget (not just @10) because the decision this data feeds
+//     is about context-window cost per unit of relevant code, which `@10`
+//     alone structurally flatters large chunks on.
+//
+// Usage:
+//   cargo run --release -p spelunk-core --example chunk_quality_eval -- \
+//       --gguf <path> --tokenizer <path> --config <path> \
+//       --corpus /path/to/repo \
+//       [--caps 2048,1024,512,384] [--budget-tokens 8192] \
+//       [--min-docstring-chars 20] [--max-queries 300] [--limit-files 0] \
+//       [--out results.json]
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use ignore::WalkBuilder;
+use spelunk_core::embeddings::EmbeddingBackend;
+use spelunk_core::indexer::filter::{Decision, IndexFilter, generated_marker};
+use spelunk_core::indexer::parser::detect_language;
+use spelunk_core::indexer::{Chunk, SourceParser, set_chunk_token_cap};
+use spelunk_embed::NativeEmbedder;
+use tokenizers::Tokenizer;
+
+/// Code-search query instruction prefix – matches the format `spelunk-server`
+/// uses for real code-search queries (see CLAUDE.md "Embedding input format").
+const QUERY_INSTRUCTION: &str =
+    "Instruct: Given a code search query, retrieve the relevant code snippets\nQuery: ";
+
+const DEFAULT_CAPS: &[usize] = &[2048, 1024, 512, 384];
+const DEFAULT_TOP_K: usize = 10;
+/// A modest, realistic context-assembly budget (tokens) for Recall@budget –
+/// not tied to any particular cap's `@10`, since the whole point of this
+/// metric is to compare caps on a cap-independent axis.
+const DEFAULT_BUDGET_TOKENS: usize = 8192;
+/// Docstrings shorter than this are usually a one-word `// TODO` or a bare
+/// derive comment, not a usable natural-language query.
+const DEFAULT_MIN_DOCSTRING_CHARS: usize = 20;
+/// External batch size for embedding calls: bounds one call's memory and
+/// gives incremental progress output on a multi-minute corpus embed.
+const EMBED_PROGRESS_BATCH: usize = 32;
+
+struct Args {
+    gguf: PathBuf,
+    tokenizer: PathBuf,
+    config: PathBuf,
+    corpus: PathBuf,
+    caps: Vec<usize>,
+    budget_tokens: usize,
+    min_docstring_chars: usize,
+    max_queries: Option<usize>,
+    limit_files: Option<usize>,
+    out: Option<PathBuf>,
+}
+
+fn print_usage() {
+    eprintln!(
+        "chunk_quality_eval – chunk-size retrieval-quality eval\n\n\
+         Required:\n\
+         \x20 --gguf <path>       Q8_0 GGUF weights\n\
+         \x20 --tokenizer <path>  tokenizer.json\n\
+         \x20 --config <path>     Qwen3 config.json\n\
+         \x20 --corpus <dir>      repo root to index and query against\n\
+         Optional:\n\
+         \x20 --caps a,b,c            chunk-token caps to sweep (default: {DEFAULT_CAPS:?})\n\
+         \x20 --budget-tokens N       Recall@budget token budget (default: {DEFAULT_BUDGET_TOKENS})\n\
+         \x20 --min-docstring-chars N minimum docstring length to source a query from (default: {DEFAULT_MIN_DOCSTRING_CHARS})\n\
+         \x20 --max-queries N         cap the query set (deterministic stride sample)\n\
+         \x20 --limit-files N         cap the corpus file list (deterministic even stride over the sorted list)\n\
+         \x20 --out <path>            write results as JSON\n"
+    );
+}
+
+fn parse_args() -> Result<Args> {
+    let mut gguf = None;
+    let mut tokenizer = None;
+    let mut config = None;
+    let mut corpus = None;
+    let mut caps = None;
+    let mut budget_tokens = DEFAULT_BUDGET_TOKENS;
+    let mut min_docstring_chars = DEFAULT_MIN_DOCSTRING_CHARS;
+    let mut max_queries = None;
+    let mut limit_files = None;
+    let mut out = None;
+
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        let mut next_path = |flag: &str| -> Result<PathBuf> {
+            it.next()
+                .map(PathBuf::from)
+                .with_context(|| format!("{flag} requires a value"))
+        };
+        match arg.as_str() {
+            "--gguf" => gguf = Some(next_path("--gguf")?),
+            "--tokenizer" => tokenizer = Some(next_path("--tokenizer")?),
+            "--config" => config = Some(next_path("--config")?),
+            "--corpus" => corpus = Some(next_path("--corpus")?),
+            "--out" => out = Some(next_path("--out")?),
+            "--caps" => {
+                let raw = it.next().context("--caps requires a value")?;
+                caps = Some(
+                    raw.split(',')
+                        .map(|s| {
+                            s.trim()
+                                .parse::<usize>()
+                                .context("--caps must be a comma-separated integer list")
+                        })
+                        .collect::<Result<Vec<_>>>()?,
+                );
+            }
+            "--budget-tokens" => {
+                budget_tokens = it
+                    .next()
+                    .context("--budget-tokens requires a value")?
+                    .parse()
+                    .context("--budget-tokens must be a positive integer")?;
+            }
+            "--min-docstring-chars" => {
+                min_docstring_chars = it
+                    .next()
+                    .context("--min-docstring-chars requires a value")?
+                    .parse()
+                    .context("--min-docstring-chars must be a positive integer")?;
+            }
+            "--max-queries" => {
+                max_queries = Some(
+                    it.next()
+                        .context("--max-queries requires a value")?
+                        .parse()
+                        .context("--max-queries must be a positive integer")?,
+                );
+            }
+            "--limit-files" => {
+                let n: usize = it
+                    .next()
+                    .context("--limit-files requires a value")?
+                    .parse()
+                    .context("--limit-files must be an integer")?;
+                if n > 0 {
+                    limit_files = Some(n);
+                }
+            }
+            "-h" | "--help" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => bail!("unrecognised argument: {other}"),
+        }
+    }
+
+    let mut caps = caps.unwrap_or_else(|| DEFAULT_CAPS.to_vec());
+    caps.sort_unstable_by(|a, b| b.cmp(a)); // descending – largest (gold) cap first
+    caps.dedup();
+    anyhow::ensure!(!caps.is_empty(), "--caps must name at least one cap");
+
+    Ok(Args {
+        gguf: gguf.context("--gguf is required")?,
+        tokenizer: tokenizer.context("--tokenizer is required")?,
+        config: config.context("--config is required")?,
+        corpus: corpus.context("--corpus is required")?,
+        caps,
+        budget_tokens,
+        min_docstring_chars,
+        max_queries,
+        limit_files,
+        out,
+    })
+}
+
+/// One corpus file: absolute path (for reading), corpus-relative path (the
+/// stable identity used for both chunk `file_path` and query ground truth),
+/// and detected language.
+struct CorpusFile {
+    abs: PathBuf,
+    rel: String,
+    language: &'static str,
+}
+
+/// Walk `root` for code files, applying the same two exclude layers the real
+/// indexer applies (`IndexFilter` defaults + self-declared generated-file
+/// markers) so the eval corpus matches what `spelunk index` would actually
+/// embed. This is a simplified mirror of `spelunk-cli`'s `collect_files` (not
+/// reusable directly – it lives in a crate `spelunk-core` doesn't depend on)
+/// and skips its sensitive-file `OverrideBuilder` layer, since this harness
+/// only ever points at repos the operator already trusts locally.
+fn collect_corpus_files(root: &Path, limit_files: Option<usize>) -> Result<Vec<CorpusFile>> {
+    anyhow::ensure!(
+        root.is_dir(),
+        "--corpus {} is not a directory",
+        root.display()
+    );
+    let filter = IndexFilter::build(&[], true, true).context("building index filter")?;
+
+    let mut walk = WalkBuilder::new(root);
+    walk.standard_filters(true);
+    let root_owned = root.to_path_buf();
+    let dir_filter = filter.clone();
+    walk.filter_entry(move |entry| {
+        let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+        if !is_dir {
+            return true;
+        }
+        match entry.path().strip_prefix(&root_owned) {
+            Ok(rel) if !rel.as_os_str().is_empty() => !dir_filter.prune_dir(rel),
+            _ => true,
+        }
+    });
+
+    let mut files = Vec::new();
+    for entry in walk.build().filter_map(|e| e.ok()) {
+        if !entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+            continue;
+        }
+        let abs = entry.path().to_path_buf();
+        let Some(language) = detect_language(&abs) else {
+            continue; // text/doc formats out of scope for a code-search eval
+        };
+        let rel_path = abs.strip_prefix(root).unwrap_or(&abs);
+        match filter.decide(rel_path, false) {
+            Decision::Exclude(_) => continue,
+            Decision::ForceInclude(_) => {}
+            Decision::Keep => {
+                if generated_marker(&abs).is_some() {
+                    continue;
+                }
+            }
+        }
+        files.push(CorpusFile {
+            abs: abs.clone(),
+            rel: rel_path.to_string_lossy().replace('\\', "/"),
+            language,
+        });
+    }
+
+    // Deterministic order (walk order isn't stable across filesystems).
+    files.sort_by(|a, b| a.rel.cmp(&b.rel));
+    if let Some(limit) = limit_files
+        && files.len() > limit
+    {
+        // An even stride across the sorted list, not a prefix: a real repo's
+        // first paths alphabetically are often one lightly-commented
+        // directory (e.g. `migrations/` sorts before `src/`), so a prefix
+        // truncate silently samples only that directory instead of the whole
+        // corpus.
+        let step = (files.len() as f64 / limit as f64).ceil() as usize;
+        files = files.into_iter().step_by(step.max(1)).take(limit).collect();
+    }
+    Ok(files)
+}
+
+/// Parse every corpus file at the process-global `chunk_token_cap()` in
+/// effect (caller sets it via `set_chunk_token_cap` first). Files that fail
+/// to read or parse are skipped with a warning, not fatal – a benchmark
+/// corpus is expected to contain the odd oddball file.
+fn chunk_corpus(files: &[CorpusFile]) -> Vec<Chunk> {
+    let mut chunks = Vec::new();
+    for f in files {
+        let source = match std::fs::read_to_string(&f.abs) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("skipping {} (read error: {e})", f.rel);
+                continue;
+            }
+        };
+        match SourceParser::parse(&source, &f.rel, f.language) {
+            Ok(cs) => chunks.extend(cs),
+            Err(e) => eprintln!("skipping {} (parse error: {e})", f.rel),
+        }
+    }
+    chunks
+}
+
+/// A query sourced from one gold-pass chunk's docstring, with the ground-truth
+/// line range it was drawn from (see module doc: relevance at every cap is
+/// judged against this range by overlap, not by chunk id).
+struct Query {
+    text: String,
+    file_path: String,
+    start_line: usize,
+    end_line: usize,
+}
+
+fn build_gold_queries(
+    gold_chunks: &[Chunk],
+    min_docstring_chars: usize,
+    max_queries: Option<usize>,
+) -> Vec<Query> {
+    let mut queries: Vec<Query> = gold_chunks
+        .iter()
+        .filter_map(|c| {
+            let doc = c.docstring.as_deref()?.trim();
+            if doc.chars().count() < min_docstring_chars {
+                return None;
+            }
+            Some(Query {
+                text: doc.to_string(),
+                file_path: c.file_path.clone(),
+                start_line: c.start_line,
+                end_line: c.end_line,
+            })
+        })
+        .collect();
+
+    if let Some(max) = max_queries
+        && queries.len() > max
+    {
+        // Deterministic stride sample rather than a shuffle – reproducible
+        // without needing an RNG dependency, and spreads the sample evenly
+        // across the corpus (queries are in file-walk order) instead of
+        // biasing toward whichever files sort first.
+        let step = (queries.len() as f64 / max as f64).ceil() as usize;
+        queries = queries.into_iter().step_by(step.max(1)).take(max).collect();
+    }
+    queries
+}
+
+fn ranges_overlap(a_start: usize, a_end: usize, b_start: usize, b_end: usize) -> bool {
+    a_start <= b_end && b_start <= a_end
+}
+
+/// Indices into `chunks` whose (file, line-range) overlaps `q`'s gold range –
+/// the cap-dependent relevant set for this query (see module doc: this is
+/// what makes Recall/nDCG comparable across caps despite the retrieval unit
+/// itself changing size).
+fn relevant_indices(chunks: &[Chunk], q: &Query) -> HashSet<usize> {
+    chunks
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| {
+            c.file_path == q.file_path
+                && ranges_overlap(c.start_line, c.end_line, q.start_line, q.end_line)
+        })
+        .map(|(i, _)| i)
+        .collect()
+}
+
+fn mrr_at_k(ranked: &[usize], relevant: &HashSet<usize>, k: usize) -> f64 {
+    for (i, idx) in ranked.iter().take(k).enumerate() {
+        if relevant.contains(idx) {
+            return 1.0 / (i as f64 + 1.0);
+        }
+    }
+    0.0
+}
+
+fn recall_at_k(
+    ranked: &[usize],
+    relevant: &HashSet<usize>,
+    k: usize,
+    total_relevant: usize,
+) -> f64 {
+    let hits = ranked
+        .iter()
+        .take(k)
+        .filter(|idx| relevant.contains(idx))
+        .count();
+    hits as f64 / total_relevant as f64
+}
+
+/// Binary-relevance nDCG@k: `1/log2(rank+1)` per hit, normalised by the ideal
+/// ordering (all `min(total_relevant, k)` relevant items ranked first).
+fn ndcg_at_k(ranked: &[usize], relevant: &HashSet<usize>, k: usize, total_relevant: usize) -> f64 {
+    let dcg: f64 = ranked
+        .iter()
+        .take(k)
+        .enumerate()
+        .filter(|(_, idx)| relevant.contains(idx))
+        .map(|(i, _)| 1.0 / ((i as f64) + 2.0).log2()) // rank i is 0-based -> position i+1 -> log2(position+1)
+        .sum();
+    let ideal_hits = total_relevant.min(k);
+    let idcg: f64 = (0..ideal_hits)
+        .map(|i| 1.0 / ((i as f64) + 2.0).log2())
+        .sum();
+    if idcg == 0.0 { 0.0 } else { dcg / idcg }
+}
+
+/// Recall among chunks retrievable within `budget` tokens: walk `ranked` in
+/// order, greedily accumulating each chunk's real embedding-text token cost,
+/// and stop at the first chunk that would overflow the budget (a rank-order
+/// context assembly, not a knapsack pack – swapping in a smaller lower-ranked
+/// chunk to keep filling would break rank fidelity).
+fn recall_at_budget(
+    ranked: &[usize],
+    relevant: &HashSet<usize>,
+    token_counts: &[usize],
+    budget: usize,
+    total_relevant: usize,
+) -> f64 {
+    let mut used = 0usize;
+    let mut hits = 0usize;
+    for &idx in ranked {
+        let cost = token_counts[idx];
+        if used + cost > budget {
+            break;
+        }
+        used += cost;
+        if relevant.contains(&idx) {
+            hits += 1;
+        }
+    }
+    hits as f64 / total_relevant as f64
+}
+
+fn dot(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+/// Full ranking of every corpus chunk by descending cosine similarity to
+/// `query_vec`. Vectors are L2-normalised (`NativeEmbedder`'s contract), so a
+/// plain dot product is cosine similarity – brute force is fine at the
+/// corpus sizes this harness targets (thousands of chunks, not millions).
+fn rank_by_similarity(query_vec: &[f32], chunk_vecs: &[Vec<f32>]) -> Vec<usize> {
+    let mut scored: Vec<(usize, f32)> = chunk_vecs
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i, dot(query_vec, v)))
+        .collect();
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).expect("no NaNs in embedding output"));
+    scored.into_iter().map(|(i, _)| i).collect()
+}
+
+/// Embed `texts` in `EMBED_PROGRESS_BATCH`-sized external batches (each one
+/// call to the backend, which does its own internal sub-batching) so a
+/// multi-minute corpus embed prints incremental progress instead of going
+/// silent, and a crash mid-run loses at most one external batch of work.
+async fn embed_all(
+    embedder: &NativeEmbedder,
+    texts: &[String],
+    label: &str,
+) -> Result<Vec<Vec<f32>>> {
+    let mut out = Vec::with_capacity(texts.len());
+    for batch in texts.chunks(EMBED_PROGRESS_BATCH) {
+        let refs: Vec<&str> = batch.iter().map(String::as_str).collect();
+        let vecs = embedder
+            .embed(&refs)
+            .await
+            .context("embed_all: embedder.embed failed")?;
+        out.extend(vecs);
+        eprintln!("  {label}: embedded {}/{}", out.len(), texts.len());
+    }
+    Ok(out)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Arm {
+    Leaky,
+    HeldOut,
+}
+
+impl Arm {
+    fn label(self) -> &'static str {
+        match self {
+            Arm::Leaky => "leaky",
+            Arm::HeldOut => "held_out",
+        }
+    }
+
+    /// The text actually indexed for one chunk under this arm. `Leaky` is
+    /// `embedding_text()` as-shipped (docstring included, so a query drawn
+    /// from that same docstring is near-exact-match). `HeldOut` strips the
+    /// docstring first – the genuine "can NL find this code" test.
+    fn embedding_text(self, c: &Chunk) -> String {
+        match self {
+            Arm::Leaky => c.embedding_text(),
+            Arm::HeldOut => {
+                let mut stripped = c.clone();
+                stripped.docstring = None;
+                stripped.embedding_text()
+            }
+        }
+    }
+}
+
+struct ResultRow {
+    cap: usize,
+    arm: &'static str,
+    n_chunks: usize,
+    n_queries: usize,
+    mrr_at_10: f64,
+    recall_at_10: f64,
+    ndcg_at_10: f64,
+    recall_at_budget: f64,
+}
+
+fn main() -> Result<()> {
+    let args = parse_args()?;
+
+    let embedder = NativeEmbedder::load_from_path(&args.gguf, &args.tokenizer, &args.config)
+        .context("loading NativeEmbedder")?;
+    let tokenizer = Tokenizer::from_file(&args.tokenizer)
+        .map_err(|e| anyhow::anyhow!("loading measurement tokenizer copy: {e}"))?;
+    let rt = tokio::runtime::Runtime::new().context("building tokio runtime")?;
+
+    let files = collect_corpus_files(&args.corpus, args.limit_files)?;
+    anyhow::ensure!(
+        !files.is_empty(),
+        "no code files found under {}",
+        args.corpus.display()
+    );
+    println!(
+        "corpus: {} files under {}",
+        files.len(),
+        args.corpus.display()
+    );
+
+    // Gold pass: ground-truth query set drawn from the largest (least
+    // fragmented) cap in the sweep – the current shipped default when 2048 is
+    // included, or the closest stand-in otherwise.
+    let gold_cap = args.caps[0]; // sorted descending in parse_args
+    set_chunk_token_cap(gold_cap);
+    let gold_chunks = chunk_corpus(&files);
+    let queries = build_gold_queries(&gold_chunks, args.min_docstring_chars, args.max_queries);
+    anyhow::ensure!(
+        !queries.is_empty(),
+        "no eligible queries (docstring >= {} chars) at cap={gold_cap} – lower --min-docstring-chars or point at a larger corpus",
+        args.min_docstring_chars
+    );
+    println!(
+        "gold queries: {} (docstring >= {} chars, sourced at cap={gold_cap})",
+        queries.len(),
+        args.min_docstring_chars
+    );
+
+    // Query embeddings don't depend on cap or arm (same input text, same
+    // model), so compute them once up front.
+    let query_texts: Vec<String> = queries
+        .iter()
+        .map(|q| format!("{QUERY_INSTRUCTION}{}", q.text))
+        .collect();
+    let query_vecs = rt.block_on(embed_all(&embedder, &query_texts, "queries"))?;
+
+    let mut results = Vec::new();
+    for &cap in &args.caps {
+        set_chunk_token_cap(cap);
+        let chunks = chunk_corpus(&files);
+        println!("\ncap={cap}: {} chunks", chunks.len());
+
+        // Relevance is structural (file + line overlap), not embedding-based,
+        // so it's computed once per cap and reused across both arms.
+        let relevant_sets: Vec<HashSet<usize>> = queries
+            .iter()
+            .map(|q| relevant_indices(&chunks, q))
+            .collect();
+        let zero_relevant = relevant_sets.iter().filter(|s| s.is_empty()).count();
+        if zero_relevant > 0 {
+            eprintln!(
+                "  warning: {zero_relevant}/{} queries have no overlapping chunk at cap={cap} (excluded from this cap's aggregate)",
+                queries.len()
+            );
+        }
+
+        for arm in [Arm::Leaky, Arm::HeldOut] {
+            let texts: Vec<String> = chunks.iter().map(|c| arm.embedding_text(c)).collect();
+            let chunk_vecs = rt.block_on(embed_all(
+                &embedder,
+                &texts,
+                &format!("cap={cap} arm={}", arm.label()),
+            ))?;
+            let token_counts: Vec<usize> = texts
+                .iter()
+                .map(|t| {
+                    tokenizer
+                        .encode(t.as_str(), true)
+                        .map(|e| e.get_ids().len())
+                        .unwrap_or(0)
+                })
+                .collect();
+
+            let (mut mrr_sum, mut recall_sum, mut ndcg_sum, mut budget_sum, mut n) =
+                (0.0, 0.0, 0.0, 0.0, 0usize);
+            for (qi, _q) in queries.iter().enumerate() {
+                let relevant = &relevant_sets[qi];
+                if relevant.is_empty() {
+                    continue;
+                }
+                let ranked = rank_by_similarity(&query_vecs[qi], &chunk_vecs);
+                let total_relevant = relevant.len();
+                mrr_sum += mrr_at_k(&ranked, relevant, DEFAULT_TOP_K);
+                recall_sum += recall_at_k(&ranked, relevant, DEFAULT_TOP_K, total_relevant);
+                ndcg_sum += ndcg_at_k(&ranked, relevant, DEFAULT_TOP_K, total_relevant);
+                budget_sum += recall_at_budget(
+                    &ranked,
+                    relevant,
+                    &token_counts,
+                    args.budget_tokens,
+                    total_relevant,
+                );
+                n += 1;
+            }
+
+            results.push(ResultRow {
+                cap,
+                arm: arm.label(),
+                n_chunks: chunks.len(),
+                n_queries: n,
+                mrr_at_10: mrr_sum / n as f64,
+                recall_at_10: recall_sum / n as f64,
+                ndcg_at_10: ndcg_sum / n as f64,
+                recall_at_budget: budget_sum / n as f64,
+            });
+        }
+    }
+
+    print_table(&results);
+    println!(
+        "\ncorpus-size caveat: top-{DEFAULT_TOP_K} is less discriminative on a small corpus – this run had \
+         {} gold queries against corpora ranging {}-{} chunks across caps.",
+        queries.len(),
+        results.iter().map(|r| r.n_chunks).min().unwrap_or(0),
+        results.iter().map(|r| r.n_chunks).max().unwrap_or(0),
+    );
+
+    if let Some(path) = &args.out {
+        write_json(path, &args, &results)?;
+        println!("wrote {}", path.display());
+    }
+
+    Ok(())
+}
+
+fn print_table(rows: &[ResultRow]) {
+    println!(
+        "\n{:>6} {:>9} {:>9} {:>9} {:>10} {:>10} {:>14}",
+        "cap", "arm", "n_chunks", "n_queries", "mrr@10", "recall@10", "ndcg@10"
+    );
+    for r in rows {
+        println!(
+            "{:>6} {:>9} {:>9} {:>9} {:>10.4} {:>10.4} {:>14.4}  recall@budget={:.4}",
+            r.cap,
+            r.arm,
+            r.n_chunks,
+            r.n_queries,
+            r.mrr_at_10,
+            r.recall_at_10,
+            r.ndcg_at_10,
+            r.recall_at_budget
+        );
+    }
+}
+
+fn write_json(path: &Path, args: &Args, rows: &[ResultRow]) -> Result<()> {
+    let mut out = String::from("{\n");
+    out.push_str(&format!(
+        "  \"corpus\": {:?},\n",
+        args.corpus.display().to_string()
+    ));
+    out.push_str(&format!("  \"budget_tokens\": {},\n", args.budget_tokens));
+    out.push_str("  \"results\": [\n");
+    for (i, r) in rows.iter().enumerate() {
+        out.push_str(&format!(
+            "    {{\"cap\": {}, \"arm\": {:?}, \"n_chunks\": {}, \"n_queries\": {}, \"mrr_at_10\": {:.6}, \"recall_at_10\": {:.6}, \"ndcg_at_10\": {:.6}, \"recall_at_budget\": {:.6}}}{}\n",
+            r.cap,
+            r.arm,
+            r.n_chunks,
+            r.n_queries,
+            r.mrr_at_10,
+            r.recall_at_10,
+            r.ndcg_at_10,
+            r.recall_at_budget,
+            if i + 1 < rows.len() { "," } else { "" }
+        ));
+    }
+    out.push_str("  ]\n}\n");
+    std::fs::write(path, out).with_context(|| format!("writing {}", path.display()))
+}

--- a/crates/spelunk-core/examples/chunk_quality_eval.rs
+++ b/crates/spelunk-core/examples/chunk_quality_eval.rs
@@ -1,27 +1,18 @@
-// Chunk-size retrieval-quality eval: measures MRR@10 / Recall@10 / nDCG@10 +
-// Recall@fixed-token-budget at a swept set of chunk-token caps, so the
-// MAX_CHUNK_TOKENS default can be picked on quality evidence, not perf alone.
+// Chunk-size retrieval-quality eval: MRR@10 / Recall@10 / nDCG@10 +
+// Recall@fixed-token-budget across swept chunk-token caps, to pick
+// MAX_CHUNK_TOKENS on quality evidence, not perf alone.
 //
-// Lives here (not in `spelunk-embed`, where `embed_bench` lives) because it
-// needs the real chunker (`spelunk_core::indexer`), and `spelunk-core`
-// depends on `spelunk-embed` – the reverse dependency isn't available, so a
-// tool needing both can only live on the `spelunk-core` side of that edge.
+// Lives in spelunk-core, not spelunk-embed (where embed_bench lives): needs
+// the real chunker, and spelunk-core depends on spelunk-embed, not the
+// reverse. No spelunk CLI or spelunk-server/HTTP in the path; calls
+// SourceParser and NativeEmbedder directly.
 //
-// No `spelunk` CLI and no `spelunk-server`/HTTP in the path: this calls
-// `SourceParser` and `NativeEmbedder` directly, the same way `embed_bench`
-// calls the embedder directly.
-//
-// Methodology (see the task this harness was built for):
-//   - Relevance is keyed on file + line-range overlap, not chunk id, because
-//     the retrieval unit itself changes with the cap (a chunk that's whole at
-//     2048 may be split into several pieces at 512).
-//   - Two arms: "leaky" embeds chunks as shipped (the docstring named in a
-//     query is present inside `embedding_text()`, so retrieval is
-//     near-exact-match); "held_out" strips the docstring from every indexed
-//     chunk first, a genuine "can NL find this code" test.
-//   - Recall@token-budget (not just @10) because the decision this data feeds
-//     is about context-window cost per unit of relevant code, which `@10`
-//     alone structurally flatters large chunks on.
+// Relevance is keyed on file + line-range overlap, not chunk id, since the
+// retrieval unit changes with the cap. Two arms: "leaky" embeds chunks as
+// shipped (docstring included, so retrieval is near-exact-match); "held_out"
+// strips the docstring first, a genuine NL-to-code test. Recall@token-budget
+// is reported alongside @10 because @10 alone structurally flatters large
+// chunks.
 //
 // Usage:
 //   cargo run --release -p spelunk-core --example chunk_quality_eval -- \
@@ -43,16 +34,15 @@ use spelunk_core::indexer::{Chunk, SourceParser, set_chunk_token_cap};
 use spelunk_embed::NativeEmbedder;
 use tokenizers::Tokenizer;
 
-/// Code-search query instruction prefix – matches the format `spelunk-server`
-/// uses for real code-search queries (see CLAUDE.md "Embedding input format").
+/// Matches the query format `spelunk-server` uses for code search (see
+/// CLAUDE.md "Embedding input format").
 const QUERY_INSTRUCTION: &str =
     "Instruct: Given a code search query, retrieve the relevant code snippets\nQuery: ";
 
 const DEFAULT_CAPS: &[usize] = &[2048, 1024, 512, 384];
 const DEFAULT_TOP_K: usize = 10;
-/// A modest, realistic context-assembly budget (tokens) for Recall@budget –
-/// not tied to any particular cap's `@10`, since the whole point of this
-/// metric is to compare caps on a cap-independent axis.
+/// Recall@budget token budget: cap-independent by design, not tied to any
+/// cap's `@10`.
 const DEFAULT_BUDGET_TOKENS: usize = 8192;
 /// Docstrings shorter than this are usually a one-word `// TODO` or a bare
 /// derive comment, not a usable natural-language query.
@@ -170,7 +160,7 @@ fn parse_args() -> Result<Args> {
     }
 
     let mut caps = caps.unwrap_or_else(|| DEFAULT_CAPS.to_vec());
-    caps.sort_unstable_by(|a, b| b.cmp(a)); // descending – largest (gold) cap first
+    caps.sort_unstable_by(|a, b| b.cmp(a)); // descending: largest (gold) cap first
     caps.dedup();
     anyhow::ensure!(!caps.is_empty(), "--caps must name at least one cap");
 
@@ -197,13 +187,11 @@ struct CorpusFile {
     language: &'static str,
 }
 
-/// Walk `root` for code files, applying the same two exclude layers the real
-/// indexer applies (`IndexFilter` defaults + self-declared generated-file
-/// markers) so the eval corpus matches what `spelunk index` would actually
-/// embed. This is a simplified mirror of `spelunk-cli`'s `collect_files` (not
-/// reusable directly – it lives in a crate `spelunk-core` doesn't depend on)
-/// and skips its sensitive-file `OverrideBuilder` layer, since this harness
-/// only ever points at repos the operator already trusts locally.
+/// Applies the same excludes real indexing does (`IndexFilter` defaults +
+/// generated-file markers), mirroring `spelunk-cli`'s `collect_files` (not
+/// reusable directly: it lives in a crate `spelunk-core` doesn't depend on).
+/// Skips the sensitive-file `OverrideBuilder` layer since this only ever
+/// points at repos the operator already trusts locally.
 fn collect_corpus_files(root: &Path, limit_files: Option<usize>) -> Result<Vec<CorpusFile>> {
     anyhow::ensure!(
         root.is_dir(),
@@ -258,21 +246,17 @@ fn collect_corpus_files(root: &Path, limit_files: Option<usize>) -> Result<Vec<C
     if let Some(limit) = limit_files
         && files.len() > limit
     {
-        // An even stride across the sorted list, not a prefix: a real repo's
-        // first paths alphabetically are often one lightly-commented
-        // directory (e.g. `migrations/` sorts before `src/`), so a prefix
-        // truncate silently samples only that directory instead of the whole
-        // corpus.
+        // Even stride, not a prefix: a repo's alphabetically-first paths are
+        // often one lightly-commented directory (e.g. `migrations/` before
+        // `src/`), so a prefix would silently sample only that directory.
         let step = (files.len() as f64 / limit as f64).ceil() as usize;
         files = files.into_iter().step_by(step.max(1)).take(limit).collect();
     }
     Ok(files)
 }
 
-/// Parse every corpus file at the process-global `chunk_token_cap()` in
-/// effect (caller sets it via `set_chunk_token_cap` first). Files that fail
-/// to read or parse are skipped with a warning, not fatal – a benchmark
-/// corpus is expected to contain the odd oddball file.
+/// Parses at the process-global cap (caller sets it via `set_chunk_token_cap`
+/// first). Read/parse failures are skipped with a warning, not fatal.
 fn chunk_corpus(files: &[CorpusFile]) -> Vec<Chunk> {
     let mut chunks = Vec::new();
     for f in files {
@@ -325,10 +309,8 @@ fn build_gold_queries(
     if let Some(max) = max_queries
         && queries.len() > max
     {
-        // Deterministic stride sample rather than a shuffle – reproducible
-        // without needing an RNG dependency, and spreads the sample evenly
-        // across the corpus (queries are in file-walk order) instead of
-        // biasing toward whichever files sort first.
+        // Deterministic stride, not a shuffle: no RNG dep, and spreads evenly
+        // across file-walk order instead of biasing toward early files.
         let step = (queries.len() as f64 / max as f64).ceil() as usize;
         queries = queries.into_iter().step_by(step.max(1)).take(max).collect();
     }
@@ -339,10 +321,8 @@ fn ranges_overlap(a_start: usize, a_end: usize, b_start: usize, b_end: usize) ->
     a_start <= b_end && b_start <= a_end
 }
 
-/// Indices into `chunks` whose (file, line-range) overlaps `q`'s gold range –
-/// the cap-dependent relevant set for this query (see module doc: this is
-/// what makes Recall/nDCG comparable across caps despite the retrieval unit
-/// itself changing size).
+/// The cap-dependent relevant set for `q`: what keeps Recall/nDCG comparable
+/// across caps despite the retrieval unit itself changing size.
 fn relevant_indices(chunks: &[Chunk], q: &Query) -> HashSet<usize> {
     chunks
         .iter()
@@ -395,11 +375,9 @@ fn ndcg_at_k(ranked: &[usize], relevant: &HashSet<usize>, k: usize, total_releva
     if idcg == 0.0 { 0.0 } else { dcg / idcg }
 }
 
-/// Recall among chunks retrievable within `budget` tokens: walk `ranked` in
-/// order, greedily accumulating each chunk's real embedding-text token cost,
-/// and stop at the first chunk that would overflow the budget (a rank-order
-/// context assembly, not a knapsack pack – swapping in a smaller lower-ranked
-/// chunk to keep filling would break rank fidelity).
+/// Recall within a `budget`-token context: greedy rank-order accumulation
+/// (not knapsack packing, which would break rank fidelity), stopping at the
+/// first chunk that would overflow the budget.
 fn recall_at_budget(
     ranked: &[usize],
     relevant: &HashSet<usize>,
@@ -426,10 +404,8 @@ fn dot(a: &[f32], b: &[f32]) -> f32 {
     a.iter().zip(b).map(|(x, y)| x * y).sum()
 }
 
-/// Full ranking of every corpus chunk by descending cosine similarity to
-/// `query_vec`. Vectors are L2-normalised (`NativeEmbedder`'s contract), so a
-/// plain dot product is cosine similarity – brute force is fine at the
-/// corpus sizes this harness targets (thousands of chunks, not millions).
+/// Vectors are L2-normalised (`NativeEmbedder`'s contract), so dot product is
+/// cosine similarity. Brute force: fine at thousands of chunks, not millions.
 fn rank_by_similarity(query_vec: &[f32], chunk_vecs: &[Vec<f32>]) -> Vec<usize> {
     let mut scored: Vec<(usize, f32)> = chunk_vecs
         .iter()
@@ -440,10 +416,9 @@ fn rank_by_similarity(query_vec: &[f32], chunk_vecs: &[Vec<f32>]) -> Vec<usize> 
     scored.into_iter().map(|(i, _)| i).collect()
 }
 
-/// Embed `texts` in `EMBED_PROGRESS_BATCH`-sized external batches (each one
-/// call to the backend, which does its own internal sub-batching) so a
-/// multi-minute corpus embed prints incremental progress instead of going
-/// silent, and a crash mid-run loses at most one external batch of work.
+/// Batches embed calls (`EMBED_PROGRESS_BATCH` texts each) so a multi-minute
+/// corpus embed prints progress instead of going silent, and a crash mid-run
+/// loses at most one batch.
 async fn embed_all(
     embedder: &NativeEmbedder,
     texts: &[String],
@@ -476,10 +451,9 @@ impl Arm {
         }
     }
 
-    /// The text actually indexed for one chunk under this arm. `Leaky` is
-    /// `embedding_text()` as-shipped (docstring included, so a query drawn
-    /// from that same docstring is near-exact-match). `HeldOut` strips the
-    /// docstring first – the genuine "can NL find this code" test.
+    /// The text indexed for one chunk under this arm. `Leaky`:
+    /// `embedding_text()` as-shipped (docstring included, near-exact-match).
+    /// `HeldOut`: docstring stripped first, the genuine NL-to-code test.
     fn embedding_text(self, c: &Chunk) -> String {
         match self {
             Arm::Leaky => c.embedding_text(),
@@ -524,9 +498,8 @@ fn main() -> Result<()> {
         args.corpus.display()
     );
 
-    // Gold pass: ground-truth query set drawn from the largest (least
-    // fragmented) cap in the sweep – the current shipped default when 2048 is
-    // included, or the closest stand-in otherwise.
+    // Gold pass: ground truth drawn from the largest (least fragmented) cap
+    // in the sweep, the shipped default when 2048 is included.
     let gold_cap = args.caps[0]; // sorted descending in parse_args
     set_chunk_token_cap(gold_cap);
     let gold_chunks = chunk_corpus(&files);

--- a/crates/spelunk-core/src/indexer/chunker.rs
+++ b/crates/spelunk-core/src/indexer/chunker.rs
@@ -79,22 +79,15 @@ impl Chunk {
 /// Distinct from the embedder's hard `token_cap` OOM guard.
 pub const MAX_CHUNK_TOKENS: usize = 2048;
 
-/// Process-global chunk token cap, seeded from `MAX_CHUNK_TOKENS`. All cap
-/// comparisons (`chunk_token_cap()`) read this instead of the constant
-/// directly, so a benchmark harness can sweep the cap without a rebuild per
-/// value (see `set_chunk_token_cap`). Product code never calls the setter, so
-/// shipped indexing behaviour is unchanged.
+/// Process-global cap, seeded from `MAX_CHUNK_TOKENS`. Only benchmark/eval
+/// harnesses call the setter; production code always runs on the default.
 static CHUNK_TOKEN_CAP: AtomicUsize = AtomicUsize::new(MAX_CHUNK_TOKENS);
 
-/// Current chunk token cap in effect (defaults to `MAX_CHUNK_TOKENS`).
 pub fn chunk_token_cap() -> usize {
     CHUNK_TOKEN_CAP.load(Ordering::Relaxed)
 }
 
-/// Override the process-wide chunk token cap. For benchmark/eval harnesses
-/// only – e.g. sweeping `MAX_CHUNK_TOKENS`-equivalent caps across a re-chunk
-/// without a rebuild per value. Never call this from a production indexing
-/// path, which must run on the shipped `MAX_CHUNK_TOKENS`.
+/// Test/benchmark use only; never call from a production indexing path.
 pub fn set_chunk_token_cap(tokens: usize) {
     CHUNK_TOKEN_CAP.store(tokens, Ordering::Relaxed);
 }
@@ -202,11 +195,8 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
-    // `chunk_token_cap()` reads a process-global `AtomicUsize`; tests that call
-    // `set_chunk_token_cap` must run `#[serial]` (never in parallel with each
-    // other) and always restore the shipped default before returning, so a
-    // test failure mid-mutation can't leak a wrong cap into an unrelated test
-    // running later in the same binary.
+    // Mutates a process-global; must run #[serial] and restore the default,
+    // or a failure mid-mutation leaks a wrong cap into a later test.
     fn with_cap<R>(tokens: usize, f: impl FnOnce() -> R) -> R {
         set_chunk_token_cap(tokens);
         let result = f();
@@ -236,9 +226,8 @@ mod tests {
     #[test]
     #[serial]
     fn sliding_window_respects_the_injected_cap() {
-        // 200 lines of 20 chars each = ~4000 chars = ~1000 estimated tokens
-        // (chars/4). Under the shipped 2048 cap this is one window; capped
-        // down to 100 tokens (400 chars) it must split into several.
+        // ~1000 estimated tokens (chars/4): one window at the 2048 default,
+        // several once capped to 100.
         let source = (0..200)
             .map(|i| format!("let line_{i:03} = 1;"))
             .collect::<Vec<_>>()
@@ -257,8 +246,7 @@ mod tests {
                 capped_chunks.len() > 1,
                 "a 100-token cap must split the same source into multiple windows"
             );
-            // Every window must individually respect the injected budget (chars/4
-            // estimate, so budget_chars = 100 * 4 = 400).
+            // budget_chars = 100 tokens * 4 (chars/4 estimate) = 400.
             for c in &capped_chunks {
                 assert!(
                     c.content.chars().count() <= 400,

--- a/crates/spelunk-core/src/indexer/chunker.rs
+++ b/crates/spelunk-core/src/indexer/chunker.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use serde::{Deserialize, Serialize};
 
 /// The semantic kind of an extracted code chunk.
@@ -77,6 +79,26 @@ impl Chunk {
 /// Distinct from the embedder's hard `token_cap` OOM guard.
 pub const MAX_CHUNK_TOKENS: usize = 2048;
 
+/// Process-global chunk token cap, seeded from `MAX_CHUNK_TOKENS`. All cap
+/// comparisons (`chunk_token_cap()`) read this instead of the constant
+/// directly, so a benchmark harness can sweep the cap without a rebuild per
+/// value (see `set_chunk_token_cap`). Product code never calls the setter, so
+/// shipped indexing behaviour is unchanged.
+static CHUNK_TOKEN_CAP: AtomicUsize = AtomicUsize::new(MAX_CHUNK_TOKENS);
+
+/// Current chunk token cap in effect (defaults to `MAX_CHUNK_TOKENS`).
+pub fn chunk_token_cap() -> usize {
+    CHUNK_TOKEN_CAP.load(Ordering::Relaxed)
+}
+
+/// Override the process-wide chunk token cap. For benchmark/eval harnesses
+/// only – e.g. sweeping `MAX_CHUNK_TOKENS`-equivalent caps across a re-chunk
+/// without a rebuild per value. Never call this from a production indexing
+/// path, which must run on the shipped `MAX_CHUNK_TOKENS`.
+pub fn set_chunk_token_cap(tokens: usize) {
+    CHUNK_TOKEN_CAP.store(tokens, Ordering::Relaxed);
+}
+
 /// Split `source` into token-aware sliding-window chunks (fallback for
 /// languages without a tree-sitter grammar, for files that failed parsing, and
 /// for re-windowing oversized semantic nodes).
@@ -117,8 +139,8 @@ pub fn sliding_window(
     // `estimate_tokens` is `chars/4`, so the budget in characters mirrors the
     // token budget without introducing a second constant. Overlap targets
     // ~12.5% of the budget (the historical 15/120-line ratio), in tokens.
-    const BUDGET_CHARS: usize = MAX_CHUNK_TOKENS * 4;
-    const OVERLAP_CHARS: usize = BUDGET_CHARS / 8;
+    let budget_chars: usize = chunk_token_cap() * 4;
+    let overlap_chars: usize = budget_chars / 8;
 
     let line_chars: Vec<usize> = lines.iter().map(|l| l.chars().count()).collect();
 
@@ -133,7 +155,7 @@ pub fn sliding_window(
         let mut acc = 0usize; // characters accumulated in the current window
         while end < lines.len() {
             let add = line_chars[end] + usize::from(end > start); // +1 for the '\n' join
-            if end > start && acc + add > BUDGET_CHARS {
+            if end > start && acc + add > budget_chars {
                 break;
             }
             acc += add;
@@ -157,13 +179,13 @@ pub fn sliding_window(
             break;
         }
 
-        // Start the next window ~OVERLAP_CHARS earlier, on a line boundary, but
+        // Start the next window ~overlap_chars earlier, on a line boundary, but
         // always strictly after the current start so the loop makes progress.
         let mut next_start = end;
         let mut overlap = 0usize;
         while next_start > start + 1 {
             let candidate = line_chars[next_start - 1] + 1; // +1 for the join '\n'
-            if overlap + candidate > OVERLAP_CHARS {
+            if overlap + candidate > overlap_chars {
                 break;
             }
             overlap += candidate;
@@ -173,4 +195,77 @@ pub fn sliding_window(
     }
 
     chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    // `chunk_token_cap()` reads a process-global `AtomicUsize`; tests that call
+    // `set_chunk_token_cap` must run `#[serial]` (never in parallel with each
+    // other) and always restore the shipped default before returning, so a
+    // test failure mid-mutation can't leak a wrong cap into an unrelated test
+    // running later in the same binary.
+    fn with_cap<R>(tokens: usize, f: impl FnOnce() -> R) -> R {
+        set_chunk_token_cap(tokens);
+        let result = f();
+        set_chunk_token_cap(MAX_CHUNK_TOKENS);
+        result
+    }
+
+    #[test]
+    #[serial]
+    fn chunk_token_cap_defaults_to_max_chunk_tokens() {
+        assert_eq!(chunk_token_cap(), MAX_CHUNK_TOKENS);
+    }
+
+    #[test]
+    #[serial]
+    fn set_chunk_token_cap_overrides_the_getter() {
+        with_cap(512, || {
+            assert_eq!(chunk_token_cap(), 512);
+        });
+        assert_eq!(
+            chunk_token_cap(),
+            MAX_CHUNK_TOKENS,
+            "must restore the default"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn sliding_window_respects_the_injected_cap() {
+        // 200 lines of 20 chars each = ~4000 chars = ~1000 estimated tokens
+        // (chars/4). Under the shipped 2048 cap this is one window; capped
+        // down to 100 tokens (400 chars) it must split into several.
+        let source = (0..200)
+            .map(|i| format!("let line_{i:03} = 1;"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let default_chunks = sliding_window(&source, "f.rs", "rust", None, None, None);
+        assert_eq!(
+            default_chunks.len(),
+            1,
+            "default 2048-token cap must fit this source in one window"
+        );
+
+        with_cap(100, || {
+            let capped_chunks = sliding_window(&source, "f.rs", "rust", None, None, None);
+            assert!(
+                capped_chunks.len() > 1,
+                "a 100-token cap must split the same source into multiple windows"
+            );
+            // Every window must individually respect the injected budget (chars/4
+            // estimate, so budget_chars = 100 * 4 = 400).
+            for c in &capped_chunks {
+                assert!(
+                    c.content.chars().count() <= 400,
+                    "window content ({} chars) exceeds the 400-char budget for cap=100",
+                    c.content.chars().count()
+                );
+            }
+        });
+    }
 }

--- a/crates/spelunk-core/src/indexer/mod.rs
+++ b/crates/spelunk-core/src/indexer/mod.rs
@@ -11,6 +11,6 @@ pub mod secrets;
 pub mod summariser;
 
 #[allow(unused_imports)]
-pub use chunker::{Chunk, ChunkKind, sliding_window};
+pub use chunker::{Chunk, ChunkKind, chunk_token_cap, set_chunk_token_cap, sliding_window};
 #[allow(unused_imports)]
 pub use parser::SourceParser;

--- a/crates/spelunk-core/src/indexer/parser/text.rs
+++ b/crates/spelunk-core/src/indexer/parser/text.rs
@@ -1,4 +1,4 @@
-use super::super::chunker::{Chunk, ChunkKind, MAX_CHUNK_TOKENS, sliding_window};
+use super::super::chunker::{Chunk, ChunkKind, chunk_token_cap, sliding_window};
 use crate::search::tokens::estimate_tokens;
 
 /// Parse a `.ipynb` notebook into per-cell chunks.
@@ -112,7 +112,7 @@ pub(super) fn parse_markdown(source: &str, file_path: &str) -> Vec<Chunk> {
         if content.trim().is_empty() {
             return;
         }
-        if estimate_tokens(&content) > MAX_CHUNK_TOKENS {
+        if estimate_tokens(&content) > chunk_token_cap() {
             // Section start is 0-based line index `start`; sub-chunk lines are
             // 1-based within the section, so `start` is the correct offset.
             // Thread the section heading through as each sub-chunk's name so an

--- a/crates/spelunk-core/src/indexer/parser/ts_walker.rs
+++ b/crates/spelunk-core/src/indexer/parser/ts_walker.rs
@@ -593,31 +593,10 @@ fn sql_object_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
 /// Return the text of the comment node that immediately precedes `node`
 /// (skipping whitespace), if any.
 ///
-/// Two grammars need special handling here, and they need *different*
-/// handling because they attach decorator-like syntax differently:
-///
-/// - **Rust**: `#[derive(...)]` / `#[async_trait]` etc. are a real,
-///   non-extra `attribute_item` *sibling* of the item, sitting directly
-///   between it and any doc comment above (stacked attributes are just
-///   more siblings in the chain). Skipping past `attribute_item` in the
-///   while-loop below, walking `node`'s own sibling chain, is enough.
-/// - **Python**: `@staticmethod` / `@property` etc. are *not* siblings of
-///   the function/class at all. Tree-sitter-python wraps the decorator(s)
-///   and the definition together in one `decorated_definition` node (a
-///   single wrapper even when several decorators are stacked), so the
-///   function/class node's own `prev_sibling` chain only ever contains
-///   other decorators and bottoms out at `None`; it never reaches the
-///   doc comment, which precedes the *wrapper*, not the definition. So
-///   for Python the walk has to start from `decorated_definition` (the
-///   node's parent, when present) instead of from the node itself.
-///
-/// TS decorators and Java annotations, by contrast, attach as a *child* of
-/// the item they modify, so the item's own `prev_sibling` already lands on
-/// the doc comment directly and neither needs special-casing here.
-///
-/// Without this, any decorated Python function/class (or attributed Rust
-/// item) silently comes back with `docstring: None` even though a comment
-/// is right there in the source.
+/// Rust attributes (`#[derive(...)]`) are real siblings, skipped in the loop
+/// below. Python wraps decorator+def in one `decorated_definition` node, so
+/// the walk must start from that parent instead of `node`. TS/Java attach
+/// decorators as a child, so neither case applies there.
 pub(super) fn preceding_comment(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
     let start = match node.parent() {
         Some(parent) if parent.kind() == "decorated_definition" => parent,

--- a/crates/spelunk-core/src/indexer/parser/ts_walker.rs
+++ b/crates/spelunk-core/src/indexer/parser/ts_walker.rs
@@ -592,18 +592,38 @@ fn sql_object_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
 
 /// Return the text of the comment node that immediately precedes `node`
 /// (skipping whitespace), if any.
+///
+/// Two grammars need special handling here, and they need *different*
+/// handling because they attach decorator-like syntax differently:
+///
+/// - **Rust**: `#[derive(...)]` / `#[async_trait]` etc. are a real,
+///   non-extra `attribute_item` *sibling* of the item, sitting directly
+///   between it and any doc comment above (stacked attributes are just
+///   more siblings in the chain). Skipping past `attribute_item` in the
+///   while-loop below, walking `node`'s own sibling chain, is enough.
+/// - **Python**: `@staticmethod` / `@property` etc. are *not* siblings of
+///   the function/class at all. Tree-sitter-python wraps the decorator(s)
+///   and the definition together in one `decorated_definition` node (a
+///   single wrapper even when several decorators are stacked), so the
+///   function/class node's own `prev_sibling` chain only ever contains
+///   other decorators and bottoms out at `None`; it never reaches the
+///   doc comment, which precedes the *wrapper*, not the definition. So
+///   for Python the walk has to start from `decorated_definition` (the
+///   node's parent, when present) instead of from the node itself.
+///
+/// TS decorators and Java annotations, by contrast, attach as a *child* of
+/// the item they modify, so the item's own `prev_sibling` already lands on
+/// the doc comment directly and neither needs special-casing here.
+///
+/// Without this, any decorated Python function/class (or attributed Rust
+/// item) silently comes back with `docstring: None` even though a comment
+/// is right there in the source.
 pub(super) fn preceding_comment(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
-    let mut prev = node.prev_sibling()?;
-    // Skip over whitespace/newline tokens and Rust attributes
-    // (`#[derive(...)]`, `#[async_trait]`, etc.). Unlike a TS decorator or a
-    // Java annotation – attached by their grammars as a *child* of the
-    // item they modify, so the item's own prev_sibling still lands on the
-    // doc comment directly – a Rust `attribute_item` is a real, non-extra
-    // *sibling* of the item, sitting between it and any doc comment above.
-    // Looping past it here (the while condition, not a one-off skip) also
-    // covers the common stacked case (`#[derive(..)]` then `#[serde(..)]`).
-    // Without this, any attributed item's docstring silently comes back
-    // `None` even though a `///` comment is right there in the source.
+    let start = match node.parent() {
+        Some(parent) if parent.kind() == "decorated_definition" => parent,
+        _ => *node,
+    };
+    let mut prev = start.prev_sibling()?;
     while prev.kind() == "\n"
         || prev.kind() == "newline"
         || prev.kind() == "attribute_item"

--- a/crates/spelunk-core/src/indexer/parser/ts_walker.rs
+++ b/crates/spelunk-core/src/indexer/parser/ts_walker.rs
@@ -1,4 +1,4 @@
-use super::super::chunker::{Chunk, ChunkKind, MAX_CHUNK_TOKENS, sliding_window};
+use super::super::chunker::{Chunk, ChunkKind, chunk_token_cap, sliding_window};
 use crate::error::IndexError;
 use crate::search::tokens::estimate_tokens;
 use anyhow::Result;
@@ -282,7 +282,7 @@ fn walk_node_inner(
                 | ChunkKind::Interface
         );
 
-        if estimate_tokens(&content) > MAX_CHUNK_TOKENS {
+        if estimate_tokens(&content) > chunk_token_cap() {
             if is_container {
                 // Suppress the container's own chunk; its children already carry
                 // fine-grained chunks framed by parent_scope. Re-window only if the
@@ -594,9 +594,19 @@ fn sql_object_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
 /// (skipping whitespace), if any.
 pub(super) fn preceding_comment(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
     let mut prev = node.prev_sibling()?;
-    // skip over whitespace / newline tokens
+    // Skip over whitespace/newline tokens and Rust attributes
+    // (`#[derive(...)]`, `#[async_trait]`, etc.). Unlike a TS decorator or a
+    // Java annotation – attached by their grammars as a *child* of the
+    // item they modify, so the item's own prev_sibling still lands on the
+    // doc comment directly – a Rust `attribute_item` is a real, non-extra
+    // *sibling* of the item, sitting between it and any doc comment above.
+    // Looping past it here (the while condition, not a one-off skip) also
+    // covers the common stacked case (`#[derive(..)]` then `#[serde(..)]`).
+    // Without this, any attributed item's docstring silently comes back
+    // `None` even though a `///` comment is right there in the source.
     while prev.kind() == "\n"
         || prev.kind() == "newline"
+        || prev.kind() == "attribute_item"
         || prev.is_extra()
             && prev.kind() != "comment"
             && prev.kind() != "line_comment"

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -127,6 +127,58 @@ fn sliding_window_threads_identity_onto_every_subchunk() {
     }
 }
 
+// ── tree-sitter docstring extraction (preceding_comment) ────────────────────
+
+#[test]
+fn docstring_captured_for_plain_function() {
+    let src = "/// does a thing\nfn plain() {}\n";
+    let chunks = SourceParser::parse(src, "f.rs", "rust").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("plain"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("/// does a thing\n"));
+}
+
+#[test]
+fn docstring_captured_across_a_single_attribute() {
+    // A Rust `attribute_item` is a real sibling between an item and any doc
+    // comment above it (unlike a TS decorator or Java annotation, which their
+    // grammars attach as a child of the item instead) – `preceding_comment`
+    // must skip over it, not stop there and report no docstring.
+    let src = "/// does a thing\n#[allow(dead_code)]\nfn attributed() {}\n";
+    let chunks = SourceParser::parse(src, "f.rs", "rust").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("/// does a thing\n"));
+}
+
+#[test]
+fn docstring_captured_across_stacked_attributes() {
+    let src = "/// does a thing\n#[derive(Debug)]\n#[allow(dead_code)]\nstruct Stacked;\n";
+    let chunks = SourceParser::parse(src, "f.rs", "rust").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("Stacked"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("/// does a thing\n"));
+}
+
+#[test]
+fn no_docstring_when_attribute_has_none_above_it() {
+    // No false positive: an attributed item with nothing but other code above
+    // it must still come back with no docstring.
+    let src = "fn other() {}\n#[allow(dead_code)]\nfn attributed() {}\n";
+    let chunks = SourceParser::parse(src, "f.rs", "rust").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring, None);
+}
+
 // ── Chunk::embedding_text ────────────────────────────────────────────────────
 
 fn make_chunk(name: Option<&str>, docstring: Option<&str>, content: &str) -> Chunk {

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -324,3 +324,49 @@ fn oversized_container_suppresses_own_chunk_keeps_children() {
     let names: Vec<&str> = fns.iter().filter_map(|c| c.name.as_deref()).collect();
     assert!(names.contains(&"f0") && names.contains(&"f4"));
 }
+
+#[test]
+fn docstring_captured_across_a_python_decorator() {
+    // Tree-sitter-python wraps a decorated def in a `decorated_definition`
+    // node holding the decorator(s) *and* the definition together, so the
+    // function node's own prev_sibling chain only contains other decorators
+    // and never reaches the doc comment above the wrapper. Same silent-drop
+    // shape as Rust's attribute_item case, different grammar structure.
+    let src = "# does a thing\n@staticmethod\ndef attributed():\n    pass\n";
+    let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    // Unlike Rust's `line_comment` token, tree-sitter-python's `comment`
+    // token span stops before the newline, so there is no trailing `\n`
+    // here (verified against the grammar directly, not pasted from a run).
+    assert_eq!(f.docstring.as_deref(), Some("# does a thing"));
+}
+
+#[test]
+fn docstring_captured_across_stacked_python_decorators() {
+    // Multiple stacked decorators still live under a single
+    // `decorated_definition` wrapper (not one wrapper per decorator), so
+    // this must resolve the same way as the single-decorator case above.
+    let src = "# does a thing\n@foo\n@bar\ndef attributed():\n    pass\n";
+    let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("# does a thing"));
+}
+
+#[test]
+fn no_docstring_when_python_decorator_has_none_above_it() {
+    // No false positive: a decorated function with nothing but other code
+    // above it must still come back with no docstring.
+    let src = "def other():\n    pass\n@staticmethod\ndef attributed():\n    pass\n";
+    let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring, None);
+}

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -142,10 +142,6 @@ fn docstring_captured_for_plain_function() {
 
 #[test]
 fn docstring_captured_across_a_single_attribute() {
-    // A Rust `attribute_item` is a real sibling between an item and any doc
-    // comment above it (unlike a TS decorator or Java annotation, which their
-    // grammars attach as a child of the item instead) – `preceding_comment`
-    // must skip over it, not stop there and report no docstring.
     let src = "/// does a thing\n#[allow(dead_code)]\nfn attributed() {}\n";
     let chunks = SourceParser::parse(src, "f.rs", "rust").unwrap();
     let f = chunks
@@ -168,8 +164,6 @@ fn docstring_captured_across_stacked_attributes() {
 
 #[test]
 fn no_docstring_when_attribute_has_none_above_it() {
-    // No false positive: an attributed item with nothing but other code above
-    // it must still come back with no docstring.
     let src = "fn other() {}\n#[allow(dead_code)]\nfn attributed() {}\n";
     let chunks = SourceParser::parse(src, "f.rs", "rust").unwrap();
     let f = chunks
@@ -327,28 +321,19 @@ fn oversized_container_suppresses_own_chunk_keeps_children() {
 
 #[test]
 fn docstring_captured_across_a_python_decorator() {
-    // Tree-sitter-python wraps a decorated def in a `decorated_definition`
-    // node holding the decorator(s) *and* the definition together, so the
-    // function node's own prev_sibling chain only contains other decorators
-    // and never reaches the doc comment above the wrapper. Same silent-drop
-    // shape as Rust's attribute_item case, different grammar structure.
     let src = "# does a thing\n@staticmethod\ndef attributed():\n    pass\n";
     let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
     let f = chunks
         .iter()
         .find(|c| c.name.as_deref() == Some("attributed"))
         .unwrap();
-    // Unlike Rust's `line_comment` token, tree-sitter-python's `comment`
-    // token span stops before the newline, so there is no trailing `\n`
-    // here (verified against the grammar directly, not pasted from a run).
+    // Unlike Rust's `line_comment`, Python's `comment` token excludes the trailing newline.
     assert_eq!(f.docstring.as_deref(), Some("# does a thing"));
 }
 
 #[test]
 fn docstring_captured_across_stacked_python_decorators() {
-    // Multiple stacked decorators still live under a single
-    // `decorated_definition` wrapper (not one wrapper per decorator), so
-    // this must resolve the same way as the single-decorator case above.
+    // Stacked decorators share one `decorated_definition` wrapper, not one each.
     let src = "# does a thing\n@foo\n@bar\ndef attributed():\n    pass\n";
     let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
     let f = chunks
@@ -360,8 +345,6 @@ fn docstring_captured_across_stacked_python_decorators() {
 
 #[test]
 fn no_docstring_when_python_decorator_has_none_above_it() {
-    // No false positive: a decorated function with nothing but other code
-    // above it must still come back with no docstring.
     let src = "def other():\n    pass\n@staticmethod\ndef attributed():\n    pass\n";
     let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
     let f = chunks

--- a/crates/spelunk-embed/Cargo.toml
+++ b/crates/spelunk-embed/Cargo.toml
@@ -42,3 +42,6 @@ libc = "0.2"
 tempfile = { workspace = true }
 pretty_assertions = { workspace = true }
 serial_test = { workspace = true }
+# Only for the embed_bench example (surfaces the loader's device-selection log
+# line without requiring the caller to export RUST_LOG themselves).
+tracing-subscriber = { workspace = true }

--- a/crates/spelunk-embed/examples/embed_bench.rs
+++ b/crates/spelunk-embed/examples/embed_bench.rs
@@ -1,0 +1,426 @@
+// Sequence-length perf sweep for the native embedder, with no `spelunk` CLI
+// and no `spelunk-server`/HTTP in the path – calls `NativeEmbedder` directly.
+//
+// Device is selected at compile time by the crate's existing `metal` feature
+// (see `select_device` in `embedder_native.rs`): build without the feature for
+// a CPU run, with `--features metal` for a Metal/GPU run. Run both and diff
+// the two tables to compare the cost curve across devices.
+//
+// x-axis is tokenizer-exact: every reported `n` is what the real
+// `tokenizer.json` actually produced for the text handed to `embed()` (not
+// the `chars/4` estimate `spelunk-core` uses at index time, which carries
+// ~±25% per-chunk error and produced non-monotonic artifacts in an earlier
+// HTTP-based profiling pass).
+//
+// Usage:
+//   cargo run --release -p spelunk-embed --example embed_bench -- \
+//       --gguf <path> --tokenizer <path> --config <path> \
+//       [--sizes 128,256,512,1024] [--batches 1,8] [--repeat 5] [--csv out.csv]
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use anyhow::{Context, Result, bail};
+use spelunk_embed::{EmbeddingBackend, NativeEmbedder};
+use tokenizers::Tokenizer;
+
+/// Sequence lengths (tokens) to sweep by default. Covers the spike's plateau
+/// region (256-512) plus enough range either side to see the curve bend.
+const DEFAULT_SIZES: &[usize] = &[
+    32, 64, 128, 192, 256, 320, 384, 448, 512, 640, 768, 896, 1024, 1280, 1536, 1792, 2048, 3072,
+    4096,
+];
+
+/// Batch sizes to sweep by default: 1 (sequential) vs 8 (the CPU batching
+/// path's sub-batch size, `EMBED_BATCH_SIZE` in `embedder_native.rs`).
+const DEFAULT_BATCHES: &[usize] = &[1, 8];
+
+/// Repeats per (size, batch) point; the reported latency is the median.
+const DEFAULT_REPEAT: usize = 5;
+
+/// This crate's own source, concatenated as the synthetic corpus: real,
+/// representative Rust code without needing a network fetch or an external
+/// checkout. Cycled (see `corpus_token_ids`) if a run's largest size needs
+/// more tokens than one copy provides.
+const CORPUS_SOURCES: &[&str] = &[
+    include_str!("../src/lib.rs"),
+    include_str!("../src/embedder_native.rs"),
+    include_str!("../src/backend.rs"),
+    include_str!("../src/error.rs"),
+];
+
+struct Args {
+    gguf: PathBuf,
+    tokenizer: PathBuf,
+    config: PathBuf,
+    sizes: Vec<usize>,
+    batches: Vec<usize>,
+    repeat: usize,
+    csv: Option<PathBuf>,
+}
+
+fn print_usage() {
+    eprintln!(
+        "embed_bench – sequence-length perf sweep for the native embedder\n\n\
+         Required:\n\
+         \x20 --gguf <path>       Q8_0 GGUF weights\n\
+         \x20 --tokenizer <path>  tokenizer.json\n\
+         \x20 --config <path>     Qwen3 config.json\n\
+         Optional:\n\
+         \x20 --sizes a,b,c       token-count sweep points (default: {:?})\n\
+         \x20 --batches a,b       batch sizes to sweep (default: {:?})\n\
+         \x20 --repeat N          repeats per point, median reported (default: {})\n\
+         \x20 --csv <path>        also write results as CSV\n",
+        DEFAULT_SIZES, DEFAULT_BATCHES, DEFAULT_REPEAT
+    );
+}
+
+fn parse_args() -> Result<Args> {
+    let mut gguf = None;
+    let mut tokenizer = None;
+    let mut config = None;
+    let mut sizes = None;
+    let mut batches = None;
+    let mut repeat = DEFAULT_REPEAT;
+    let mut csv = None;
+
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        let mut next_path = |flag: &str| -> Result<PathBuf> {
+            it.next()
+                .map(PathBuf::from)
+                .with_context(|| format!("{flag} requires a value"))
+        };
+        match arg.as_str() {
+            "--gguf" => gguf = Some(next_path("--gguf")?),
+            "--tokenizer" => tokenizer = Some(next_path("--tokenizer")?),
+            "--config" => config = Some(next_path("--config")?),
+            "--csv" => csv = Some(next_path("--csv")?),
+            "--sizes" => {
+                let raw = it.next().context("--sizes requires a value")?;
+                sizes = Some(parse_usize_list(&raw)?);
+            }
+            "--batches" => {
+                let raw = it.next().context("--batches requires a value")?;
+                batches = Some(parse_usize_list(&raw)?);
+            }
+            "--repeat" => {
+                let raw = it.next().context("--repeat requires a value")?;
+                repeat = raw.parse().context("--repeat must be a positive integer")?;
+            }
+            "-h" | "--help" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => bail!("unrecognised argument: {other}"),
+        }
+    }
+
+    Ok(Args {
+        gguf: gguf.context("--gguf is required")?,
+        tokenizer: tokenizer.context("--tokenizer is required")?,
+        config: config.context("--config is required")?,
+        sizes: sizes.unwrap_or_else(|| DEFAULT_SIZES.to_vec()),
+        batches: batches.unwrap_or_else(|| DEFAULT_BATCHES.to_vec()),
+        repeat: repeat.max(1),
+        csv,
+    })
+}
+
+fn parse_usize_list(raw: &str) -> Result<Vec<usize>> {
+    raw.split(',')
+        .map(|s| {
+            s.trim()
+                .parse::<usize>()
+                .context("expected a comma-separated integer list")
+        })
+        .collect()
+}
+
+/// One sweep measurement: a (target size, batch) point.
+struct Row {
+    /// The nominal sweep point requested (label only – `actual_n` is what was
+    /// really embedded).
+    target: usize,
+    batch: usize,
+    /// Mean tokenizer-exact token count actually embedded per item in the
+    /// batch (see module doc – this is the real x-axis).
+    actual_n: f64,
+    median_ms: f64,
+    tokens_per_sec: f64,
+}
+
+fn main() -> Result<()> {
+    // Surface the embedder's own "loading ... on Metal/GPU (...)" / fallback
+    // warning log without requiring the caller to export RUST_LOG themselves.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = parse_args()?;
+
+    println!(
+        "device: compiled with `metal` feature = {} (see the loader log line above for whether \
+         it actually got a GPU device or fell back to CPU)",
+        cfg!(feature = "metal")
+    );
+
+    let embedder = NativeEmbedder::load_from_path(&args.gguf, &args.tokenizer, &args.config)
+        .context("loading NativeEmbedder")?;
+    let tokenizer = Tokenizer::from_file(&args.tokenizer)
+        .map_err(|e| anyhow::anyhow!("loading measurement tokenizer copy: {e}"))?;
+
+    let max_needed =
+        *args.sizes.iter().max().unwrap_or(&0) * (*args.batches.iter().max().unwrap_or(&1));
+    // Clamped to >= 128 so the fixed warmup point below (n=128) always has
+    // enough corpus to slice from, even for a sweep of only smaller sizes.
+    let corpus_ids = corpus_token_ids(&tokenizer, max_needed.max(128))?;
+
+    let rt = tokio::runtime::Runtime::new().context("building tokio runtime")?;
+
+    // Warm up the allocator / BLAS thread pool / first-call page faults before
+    // timing anything – otherwise whichever point runs first absorbs all of
+    // that one-time cost and its latency isn't comparable to the rest of the
+    // curve (this is what made n=128 look slower than n=256 in an untimed
+    // dry run).
+    eprintln!("warming up...");
+    rt.block_on(sweep_point(&embedder, &tokenizer, &corpus_ids, 128, 1, 1))?;
+
+    let mut rows = Vec::new();
+
+    for &target in &args.sizes {
+        for &batch in &args.batches {
+            eprintln!(
+                "sweeping n≈{target} batch={batch} ({} repeats)...",
+                args.repeat
+            );
+            let row = rt.block_on(sweep_point(
+                &embedder,
+                &tokenizer,
+                &corpus_ids,
+                target,
+                batch,
+                args.repeat,
+            ))?;
+            rows.push(row);
+        }
+    }
+
+    print_table(&rows);
+    print_fit(&rows, 1);
+
+    if let Some(path) = &args.csv {
+        write_csv(path, &rows)?;
+        println!("\nwrote {}", path.display());
+    }
+
+    Ok(())
+}
+
+/// Tokenize the concatenated crate source (cycled until it has at least
+/// `min_tokens` ids) with `add_special_tokens=false` – the raw pool that
+/// per-point windows are sliced from.
+fn corpus_token_ids(tokenizer: &Tokenizer, min_tokens: usize) -> Result<Vec<u32>> {
+    let one_copy = CORPUS_SOURCES.concat();
+    anyhow::ensure!(!one_copy.is_empty(), "embed_bench corpus sources are empty");
+
+    let mut ids = Vec::new();
+    while ids.len() < min_tokens.max(1) {
+        let encoding = tokenizer
+            .encode(one_copy.as_str(), false)
+            .map_err(|e| anyhow::anyhow!("tokenizing embed_bench corpus: {e}"))?;
+        ids.extend_from_slice(encoding.get_ids());
+    }
+    Ok(ids)
+}
+
+/// Build `batch` distinct texts targeting `target` tokens each, by slicing
+/// `batch` different (circularly-wrapped) windows out of `corpus_ids` and
+/// decoding them back to text. The **actual** token count embedded is
+/// measured after decode by re-encoding with `add_special_tokens=true` – the
+/// same call `NativeEmbedder` makes internally – since decode/encode is not
+/// perfectly bijective (this is the whole point of a tokenizer-exact x-axis
+/// instead of assuming the slice length is what gets embedded).
+fn build_batch_texts(
+    tokenizer: &Tokenizer,
+    corpus_ids: &[u32],
+    target: usize,
+    batch: usize,
+) -> Result<(Vec<String>, Vec<usize>)> {
+    anyhow::ensure!(!corpus_ids.is_empty(), "empty corpus token pool");
+    let len = corpus_ids.len();
+    // Spread the `batch` windows across the pool so they're not all the same
+    // text (avoids flattering any per-text cache the backend doesn't have,
+    // and better represents a real mixed sub-batch).
+    let spacing = (len / batch.max(1)).max(1);
+
+    let mut texts = Vec::with_capacity(batch);
+    let mut actual_ns = Vec::with_capacity(batch);
+    for i in 0..batch {
+        let start = (i * spacing) % len;
+        let take = target.min(len);
+        let slice: Vec<u32> = (0..take).map(|k| corpus_ids[(start + k) % len]).collect();
+        let text = tokenizer
+            .decode(&slice, true)
+            .map_err(|e| anyhow::anyhow!("decoding corpus slice: {e}"))?;
+        let actual_n = tokenizer
+            .encode(text.as_str(), true)
+            .map_err(|e| anyhow::anyhow!("measuring actual token count: {e}"))?
+            .get_ids()
+            .len();
+        texts.push(text);
+        actual_ns.push(actual_n);
+    }
+    Ok((texts, actual_ns))
+}
+
+async fn sweep_point(
+    embedder: &NativeEmbedder,
+    tokenizer: &Tokenizer,
+    corpus_ids: &[u32],
+    target: usize,
+    batch: usize,
+    repeat: usize,
+) -> Result<Row> {
+    let (texts, actual_ns) = build_batch_texts(tokenizer, corpus_ids, target, batch)?;
+    let text_refs: Vec<&str> = texts.iter().map(String::as_str).collect();
+    let total_actual_n: usize = actual_ns.iter().sum();
+    let mean_actual_n = total_actual_n as f64 / batch as f64;
+
+    let mut samples_ms = Vec::with_capacity(repeat);
+    for _ in 0..repeat {
+        let start = Instant::now();
+        let out = embedder
+            .embed(&text_refs)
+            .await
+            .with_context(|| format!("embed at n≈{target} batch={batch}"))?;
+        let elapsed = start.elapsed();
+        anyhow::ensure!(
+            out.len() == batch,
+            "embedder returned {} vectors for a batch of {batch}",
+            out.len()
+        );
+        samples_ms.push(elapsed.as_secs_f64() * 1000.0);
+    }
+
+    let median_ms = median(&mut samples_ms);
+    let tokens_per_sec = if median_ms > 0.0 {
+        (total_actual_n as f64) / (median_ms / 1000.0)
+    } else {
+        f64::INFINITY
+    };
+
+    Ok(Row {
+        target,
+        batch,
+        actual_n: mean_actual_n,
+        median_ms,
+        tokens_per_sec,
+    })
+}
+
+fn median(samples: &mut [f64]) -> f64 {
+    samples.sort_by(|a, b| a.partial_cmp(b).expect("no NaNs in timing samples"));
+    let mid = samples.len() / 2;
+    if samples.len().is_multiple_of(2) {
+        (samples[mid - 1] + samples[mid]) / 2.0
+    } else {
+        samples[mid]
+    }
+}
+
+fn print_table(rows: &[Row]) {
+    println!(
+        "\n{:>10} {:>7} {:>12} {:>12} {:>14}",
+        "target_n", "batch", "actual_n", "median_ms", "tok/s"
+    );
+    for r in rows {
+        println!(
+            "{:>10} {:>7} {:>12.1} {:>12.3} {:>14.1}",
+            r.target, r.batch, r.actual_n, r.median_ms, r.tokens_per_sec
+        );
+    }
+}
+
+/// Least-squares fit of `ms = a + b*n + c*n^2` over the rows at `batch`,
+/// via the 3x3 normal-equations solved by Cramer's rule (no linear-algebra
+/// dependency needed for 3 unknowns). Reproduces the spike's curve-fit but
+/// against tokenizer-exact `n` instead of the `chars/4` estimate.
+fn print_fit(rows: &[Row], batch: usize) {
+    let pts: Vec<(f64, f64)> = rows
+        .iter()
+        .filter(|r| r.batch == batch)
+        .map(|r| (r.actual_n, r.median_ms))
+        .collect();
+    if pts.len() < 3 {
+        println!("\n(need >= 3 batch={batch} points to fit a quadratic; skipping)");
+        return;
+    }
+
+    // Normal equations for y = a + b*x + c*x^2: minimise sum((y - fit)^2).
+    let n = pts.len() as f64;
+    let (mut sx, mut sx2, mut sx3, mut sx4) = (0.0, 0.0, 0.0, 0.0);
+    let (mut sy, mut sxy, mut sx2y) = (0.0, 0.0, 0.0);
+    for &(x, y) in &pts {
+        let x2 = x * x;
+        sx += x;
+        sx2 += x2;
+        sx3 += x2 * x;
+        sx4 += x2 * x2;
+        sy += y;
+        sxy += x * y;
+        sx2y += x2 * y;
+    }
+
+    // | n   sx  sx2 | |a|   | sy   |
+    // | sx  sx2 sx3 | |b| = | sxy  |
+    // | sx2 sx3 sx4 | |c|   | sx2y |
+    let m = [[n, sx, sx2], [sx, sx2, sx3], [sx2, sx3, sx4]];
+    let v = [sy, sxy, sx2y];
+    match solve_3x3(m, v) {
+        Some([a, b, c]) => {
+            println!(
+                "\nfitted (batch={batch}, n={} points): ms = {a:.4} + {b:.6}*n + {c:.8}*n^2",
+                pts.len()
+            );
+        }
+        None => println!("\n(batch={batch} points are degenerate; quadratic fit skipped)"),
+    }
+}
+
+/// Solve `m * x = v` for a 3x3 system via Cramer's rule. `None` if `m` is
+/// (near-)singular (all sweep points collinear/degenerate in x).
+fn solve_3x3(m: [[f64; 3]; 3], v: [f64; 3]) -> Option<[f64; 3]> {
+    let det3 = |r: [[f64; 3]; 3]| -> f64 {
+        r[0][0] * (r[1][1] * r[2][2] - r[1][2] * r[2][1])
+            - r[0][1] * (r[1][0] * r[2][2] - r[1][2] * r[2][0])
+            + r[0][2] * (r[1][0] * r[2][1] - r[1][1] * r[2][0])
+    };
+    let d = det3(m);
+    if d.abs() < 1e-9 {
+        return None;
+    }
+    let mut result = [0.0; 3];
+    for col in 0..3 {
+        let mut mc = m;
+        for row in 0..3 {
+            mc[row][col] = v[row];
+        }
+        result[col] = det3(mc) / d;
+    }
+    Some(result)
+}
+
+fn write_csv(path: &Path, rows: &[Row]) -> Result<()> {
+    let mut out = String::from("target_n,batch,actual_n,median_ms,tokens_per_sec\n");
+    for r in rows {
+        out.push_str(&format!(
+            "{},{},{:.2},{:.4},{:.2}\n",
+            r.target, r.batch, r.actual_n, r.median_ms, r.tokens_per_sec
+        ));
+    }
+    std::fs::write(path, out).with_context(|| format!("writing {}", path.display()))
+}

--- a/crates/spelunk-embed/examples/embed_bench.rs
+++ b/crates/spelunk-embed/examples/embed_bench.rs
@@ -1,16 +1,13 @@
-// Sequence-length perf sweep for the native embedder, with no `spelunk` CLI
-// and no `spelunk-server`/HTTP in the path – calls `NativeEmbedder` directly.
+// Sequence-length perf sweep for the native embedder: no `spelunk` CLI or
+// `spelunk-server`/HTTP in the path, calls `NativeEmbedder` directly.
 //
-// Device is selected at compile time by the crate's existing `metal` feature
-// (see `select_device` in `embedder_native.rs`): build without the feature for
-// a CPU run, with `--features metal` for a Metal/GPU run. Run both and diff
-// the two tables to compare the cost curve across devices.
+// Device is chosen at compile time via the crate's `metal` feature (see
+// `select_device` in `embedder_native.rs`): build without it for CPU, with
+// `--features metal` for GPU. Run both and diff the tables to compare devices.
 //
-// x-axis is tokenizer-exact: every reported `n` is what the real
-// `tokenizer.json` actually produced for the text handed to `embed()` (not
-// the `chars/4` estimate `spelunk-core` uses at index time, which carries
-// ~±25% per-chunk error and produced non-monotonic artifacts in an earlier
-// HTTP-based profiling pass).
+// x-axis is tokenizer-exact (real `tokenizer.json` output), not the `chars/4`
+// estimate `spelunk-core` uses at index time, which carries ~±25% per-chunk
+// error and produced non-monotonic artifacts in an earlier profiling pass.
 //
 // Usage:
 //   cargo run --release -p spelunk-embed --example embed_bench -- \
@@ -38,10 +35,9 @@ const DEFAULT_BATCHES: &[usize] = &[1, 8];
 /// Repeats per (size, batch) point; the reported latency is the median.
 const DEFAULT_REPEAT: usize = 5;
 
-/// This crate's own source, concatenated as the synthetic corpus: real,
-/// representative Rust code without needing a network fetch or an external
-/// checkout. Cycled (see `corpus_token_ids`) if a run's largest size needs
-/// more tokens than one copy provides.
+/// This crate's own source as the synthetic corpus (no network fetch
+/// needed); cycled in `corpus_token_ids` if a run needs more tokens than one
+/// copy provides.
 const CORPUS_SOURCES: &[&str] = &[
     include_str!("../src/lib.rs"),
     include_str!("../src/embedder_native.rs"),
@@ -139,12 +135,11 @@ fn parse_usize_list(raw: &str) -> Result<Vec<usize>> {
 
 /// One sweep measurement: a (target size, batch) point.
 struct Row {
-    /// The nominal sweep point requested (label only – `actual_n` is what was
-    /// really embedded).
+    /// Requested sweep point (label only; `actual_n` is what was embedded).
     target: usize,
     batch: usize,
-    /// Mean tokenizer-exact token count actually embedded per item in the
-    /// batch (see module doc – this is the real x-axis).
+    /// Mean tokenizer-exact tokens actually embedded per batch item: the
+    /// real x-axis.
     actual_n: f64,
     median_ms: f64,
     tokens_per_sec: f64,
@@ -181,11 +176,9 @@ fn main() -> Result<()> {
 
     let rt = tokio::runtime::Runtime::new().context("building tokio runtime")?;
 
-    // Warm up the allocator / BLAS thread pool / first-call page faults before
-    // timing anything – otherwise whichever point runs first absorbs all of
-    // that one-time cost and its latency isn't comparable to the rest of the
-    // curve (this is what made n=128 look slower than n=256 in an untimed
-    // dry run).
+    // Warm up the allocator/BLAS pool/page faults before timing, or whichever
+    // point runs first absorbs that one-time cost (this made n=128 look
+    // slower than n=256 in an untimed dry run).
     eprintln!("warming up...");
     rt.block_on(sweep_point(&embedder, &tokenizer, &corpus_ids, 128, 1, 1))?;
 
@@ -220,9 +213,8 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Tokenize the concatenated crate source (cycled until it has at least
-/// `min_tokens` ids) with `add_special_tokens=false` – the raw pool that
-/// per-point windows are sliced from.
+/// Tokenizes the concatenated corpus (cycled to >= `min_tokens` ids,
+/// `add_special_tokens=false`): the raw pool windows are sliced from.
 fn corpus_token_ids(tokenizer: &Tokenizer, min_tokens: usize) -> Result<Vec<u32>> {
     let one_copy = CORPUS_SOURCES.concat();
     anyhow::ensure!(!one_copy.is_empty(), "embed_bench corpus sources are empty");
@@ -237,13 +229,11 @@ fn corpus_token_ids(tokenizer: &Tokenizer, min_tokens: usize) -> Result<Vec<u32>
     Ok(ids)
 }
 
-/// Build `batch` distinct texts targeting `target` tokens each, by slicing
-/// `batch` different (circularly-wrapped) windows out of `corpus_ids` and
-/// decoding them back to text. The **actual** token count embedded is
-/// measured after decode by re-encoding with `add_special_tokens=true` – the
-/// same call `NativeEmbedder` makes internally – since decode/encode is not
-/// perfectly bijective (this is the whole point of a tokenizer-exact x-axis
-/// instead of assuming the slice length is what gets embedded).
+/// Slices `batch` circularly-wrapped windows from `corpus_ids`, decodes to
+/// text, then re-measures the actual token count via the same
+/// `add_special_tokens=true` encode `NativeEmbedder` uses internally:
+/// decode/encode isn't perfectly bijective, so slice length isn't what
+/// actually gets embedded.
 fn build_batch_texts(
     tokenizer: &Tokenizer,
     corpus_ids: &[u32],
@@ -252,9 +242,8 @@ fn build_batch_texts(
 ) -> Result<(Vec<String>, Vec<usize>)> {
     anyhow::ensure!(!corpus_ids.is_empty(), "empty corpus token pool");
     let len = corpus_ids.len();
-    // Spread the `batch` windows across the pool so they're not all the same
-    // text (avoids flattering any per-text cache the backend doesn't have,
-    // and better represents a real mixed sub-batch).
+    // Spread windows across the pool so they're not all the same text: avoids
+    // flattering any per-text cache, and represents a real mixed sub-batch.
     let spacing = (len / batch.max(1)).max(1);
 
     let mut texts = Vec::with_capacity(batch);
@@ -345,10 +334,8 @@ fn print_table(rows: &[Row]) {
     }
 }
 
-/// Least-squares fit of `ms = a + b*n + c*n^2` over the rows at `batch`,
-/// via the 3x3 normal-equations solved by Cramer's rule (no linear-algebra
-/// dependency needed for 3 unknowns). Reproduces the spike's curve-fit but
-/// against tokenizer-exact `n` instead of the `chars/4` estimate.
+/// Least-squares fit of `ms = a + b*n + c*n^2`, via 3x3 normal equations
+/// solved by Cramer's rule (no linalg dependency needed for 3 unknowns).
 fn print_fit(rows: &[Row], batch: usize) {
     let pts: Vec<(f64, f64)> = rows
         .iter()


### PR DESCRIPTION
## Summary

Two dev-only cargo examples to gather the retrieval-quality data needed to
size the chunk-token cap default on evidence, plus one real production
bugfix found while building them.

- **`embed_bench`** (`spelunk-embed/examples/`): a perf harness that calls
  the native embedder directly (no CLI, no server). Sweeps sequence length,
  reports tokenizer-exact token counts (not the `chars/4` estimate used
  elsewhere), median ms, tok/s, and a fitted cost curve. Device A/B via the
  existing `metal` cargo feature; batch A/B (1 vs 8).
- **`chunk_quality_eval`** (`spelunk-core/examples/`): a retrieval-quality
  eval at swept chunk-token caps (2048/1024/512/384), reporting MRR@10,
  Recall@10, nDCG@10, and Recall@fixed-token-budget. Relevance is judged by
  file + line-range overlap (not chunk id) so the comparison stays valid as
  the cap changes what a "chunk" is. Runs both a leaky arm (docstring left
  in the indexed text, as shipped) and a held-out arm (docstring stripped)
  to separate real retrieval signal from the docstring-in-index leak. To
  let one process sweep the cap without a rebuild per value, the
  previously-compile-time `MAX_CHUNK_TOKENS` constant is now backed by a
  process-global `chunk_token_cap()` / `set_chunk_token_cap()` pair;
  production indexing code only ever reads the default and never calls the
  setter, so shipped behavior is unchanged.
- **Bugfix, found while building the eval**: indexing was silently dropping
  the docstring for a documented Rust item followed by an attribute
  (`#[derive(...)]`, `#[async_trait]`, etc.) or a documented Python
  function/class wrapped in a decorator (`@staticmethod` etc.). Both are
  common in modern async Rust and idiomatic Python, so this was a real,
  live retrieval-quality bug (docstrings are part of what gets embedded and
  searched). Fixed in `ts_walker.rs`'s `preceding_comment`, with 7 new
  regression tests. No schema or embedding-format change; `spelunk index
  --force` will recover docstrings on already-indexed affected items.

This does **not** change the shipped `MAX_CHUNK_TOKENS` default — that stays
a separate decision. A real run against a cloud-api subset (197 queries,
caps 2048/1024/512) found 512 costs nothing in quality versus today's 2048
default and wins on perf and on Recall@budget, but the corpus is small
enough that a fuller run is recommended before anyone actually changes the
default.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (default features)
- [x] `cargo clippy --workspace --all-targets --features metal -- -D warnings` clean
- [x] `cargo test --workspace` green (all suites, 0 failed), including the
      new chunker cap-injection tests and all 7 docstring-extraction
      regression tests (Rust attribute-macro + Python decorator, positive
      and negative cases)
- [x] Ran `embed_bench` and `chunk_quality_eval` for real against local
      models/corpora, not just compiled
- [x] `cargo audit`: no new advisories; both new deps
      (`tokenizers`, `tracing-subscriber`) are dev-dependencies already
      resolved elsewhere in the workspace at the same versions
