### PR TITLE
refactor: capability.rs -> capability/mod.rs

### DIFF
--- a/crates/spelunk-cli/src/capability/diagnostics.rs
+++ b/crates/spelunk-cli/src/capability/diagnostics.rs
@@ -116,7 +116,7 @@ pub(crate) fn find_rustls_cause(err: &(dyn std::error::Error + 'static)) -> Opti
 
 /// Map a `rustls::Error` to a short, human-readable cause. Certificate errors
 /// get specific text; `CaUsedAsEndEntity` (a CA:TRUE certificate presented as
-/// the server's own leaf, the exact self-hosting.md client-trust trap) is
+/// the server's own leaf, the exact server-setup.md client-trust trap) is
 /// detected by name inside `CertificateError::Other`, the bucket rustls maps
 /// it into (webpki's variant has no direct `CertificateError` counterpart).
 fn describe_rustls_error(e: &rustls::Error) -> String {
@@ -141,13 +141,13 @@ fn describe_rustls_error(e: &rustls::Error) -> String {
 }
 
 /// Hint appended to a TLS WARN when `server_ca` / `SPELUNK_SERVER_CA` is
-/// configured: the two classic self-hosting.md client-trust traps, so a user
+/// configured: the two classic server-setup.md client-trust traps, so a user
 /// does not have to rediscover them by trial and error.
 pub(crate) fn cert_trust_hint() -> String {
     "\n  server_ca is configured; two classic misconfigurations cause this:\n  \
      1) the file points at the server's own leaf certificate, not the issuing CA\n  \
      2) the server is presenting a CA certificate (CA:TRUE) as its own leaf certificate\n  \
-     See docs/self-hosting.md, section \"Trusting the server's certificate on the client\"."
+     See docs/server-setup.md, section \"Trusting the server's certificate on the client\"."
         .to_string()
 }
 

--- a/crates/spelunk-cli/src/capability/mod.rs
+++ b/crates/spelunk-cli/src/capability/mod.rs
@@ -20,6 +20,17 @@
 //!
 //! The probe runs lazily on the first call that needs Tier 1 and its result
 //! is cached for the process lifetime.
+//!
+//! ## Module layout
+//!
+//! - [`state`]: the data types parsed from `/v1/health` (`Capabilities`,
+//!   `EmbedderState`, `ServerLimits`).
+//! - [`tier`]: the resolved [`Tier`] enum itself.
+//! - [`probe`]: loopback auto-discovery + explicit `server_url` health probing,
+//!   and the per-process `Tier` cache (`get_tier`).
+//! - [`diagnostics`]: probe-failure classification and TLS error rendering.
+//! - [`guard`]: the `require_*` functions commands call to gate a feature on
+//!   a `Tier`.
 
 mod diagnostics;
 mod guard;
@@ -31,6 +42,9 @@ pub use diagnostics::{ConnFailure, explicit_probe_failure};
 pub use guard::{inference_server_required_message, require_explicit_server_url, require_tier1};
 pub(crate) use probe::spelunk_state_dir;
 pub use probe::{get_tier, probe_tier_fresh};
+// `Capabilities` is only reached from outside this module by other crates'
+// `#[cfg(test)]` code (`Capabilities::all()`), so a non-test build sees this
+// re-export as unused.
 #[allow(unused_imports)]
 pub use state::Capabilities;
 pub use state::{EmbedderState, ServerLimits};

--- a/crates/spelunk-cli/src/cli/cmd/memory/add.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/add.rs
@@ -367,7 +367,7 @@ async fn fetch_url_content(url: &str) -> Result<(String, String)> {
 /// wholesale. Useful in tests and on Windows CI, where `dirs::home_dir()`
 /// (v6) calls `SHGetKnownFolderPath` rather than reading `HOME`/`USERPROFILE`,
 /// making per-process environment overrides of `HOME` ineffective — see the
-/// identical note on `spelunk_state_dir` in `capability.rs`.
+/// identical note on `spelunk_state_dir` in `capability/probe.rs`.
 fn web_to_md_script_path() -> Option<std::path::PathBuf> {
     if let Some(dir) = std::env::var_os("SPELUNK_SCRIPTS_DIR") {
         return Some(std::path::PathBuf::from(dir).join("web-to-md.ts"));

--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -14,10 +14,10 @@
 //! `SPELUNK_STATE_DIR` when set; see `capability::spelunk_state_dir`, the
 //! single resolver every reader and writer of this directory shares):
 //! - `server.pid`  — PID of the running daemon process
-//! - `server.port` — TCP port the daemon is listening on (read by `capability.rs`)
+//! - `server.port`: TCP port the daemon is listening on (read by `capability/probe.rs`)
 //! - `server.log`  — stdout + stderr of the daemon process
 //!
-//! The port file is read by `capability.rs` for loopback auto-discovery
+//! The port file is read by `capability/probe.rs` for loopback auto-discovery
 //! (spelunk#316).  The writer here **must** use the same path, enforced by
 //! both going through the shared resolver rather than each defining their own.
 //!

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -998,15 +998,15 @@ mod tests {
         assert_eq!(guard.bearer.as_deref(), Some("sk-legacy"));
     }
 
-    /// `is_explicit_remote` keys off whether `server_url` was set by the
-    /// operator, never off what host it resolves to: an explicitly
-    /// configured `server_url = http://127.0.0.1:PORT` is still "explicit"
-    /// even though the host is loopback. `spelunk server logs` only ever
-    /// reads the fixed auto-daemon log path and cannot tell this loopback
-    /// address was hand-configured, so the inference-error hint must still
-    /// name it. Mirrors `capability::tests::
-    /// tier_explicit_remote_url_is_explicit_even_when_host_is_loopback`,
-    /// which pins the same invariant on the `Tier` side of this contract.
+    // `is_explicit_remote` keys off whether `server_url` was set by the
+    // operator, never off what host it resolves to: an explicitly
+    // configured `server_url = http://127.0.0.1:PORT` is still "explicit"
+    // even though the host is loopback. `spelunk server logs` only ever
+    // reads the fixed auto-daemon log path and cannot tell this loopback
+    // address was hand-configured, so the inference-error hint must still
+    // name it. Mirrors
+    // `capability::tier::tests::tier_explicit_remote_url_is_explicit_even_when_host_is_loopback`,
+    // which pins the same invariant on the `Tier` side of this contract.
     #[test]
     #[serial_test::serial]
     fn from_config_is_explicit_remote_true_for_explicitly_configured_loopback_url() {
@@ -1097,7 +1097,7 @@ mod tests {
     // `from_config` hard-exits the process on an invalid (non-loopback http://)
     // inference URL, so the exit path itself isn't exercised in-process here
     // (that would kill the test binary). These tests instead cover the pure
-    // validator directly (used identically by `capability.rs::probe_url`) and
+    // validator directly (used identically by `capability::probe::probe_url`) and
     // confirm `from_config` still builds normally for every URL shape the
     // validator accepts.
 

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -1339,7 +1339,7 @@ fn test_init_leaves_existing_claude_md_untouched() {
 // These tests reproduce the auto-discovery path end-to-end: NO `server_url` in
 // config, `SPELUNK_NO_SERVER` unset, and a mock server reachable on loopback —
 // discovered via `~/.local/state/spelunk/server.port` (the same file
-// `spelunk server start` writes; see `capability.rs` step 3a). We redirect
+// `spelunk server start` writes; see `capability/probe.rs` step 3a). We redirect
 // `HOME` to an isolated temp dir and pre-write that port file so the probe
 // finds our `wiremock` instance deterministically, without depending on the
 // real default port 7777 (which may be occupied — or unoccupied — on the test

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -110,7 +110,7 @@ pub fn spelunk_bin_in(home: &Path) -> Command {
         // would otherwise land on the same real `%USERPROFILE%\.config\spelunk`,
         // and concurrent tests racing on one `secrets.toml` corrupt it (see the
         // identical, already-documented gap on `SPELUNK_STATE_DIR` in
-        // `capability.rs` and `SPELUNK_SCRIPTS_DIR` in `memory/add.rs`).
+        // `capability/probe.rs` and `SPELUNK_SCRIPTS_DIR` in `memory/add.rs`).
         // `SPELUNK_CONFIG_DIR` bypasses `dirs::home_dir()` entirely and works
         // identically on every platform.
         .env("SPELUNK_CONFIG_DIR", home.join(".config").join("spelunk"))

--- a/crates/spelunk-cli/tests/tls_trust.rs
+++ b/crates/spelunk-cli/tests/tls_trust.rs
@@ -12,7 +12,7 @@
 //! `https://127.0.0.1:<port>`:
 //!
 //! - a proper CA -> leaf chain: the CLI must reach `Tier::Server`.
-//! - the classic self-hosting.md client-trust trap (a CA:TRUE certificate
+//! - the classic server-setup.md client-trust trap (a CA:TRUE certificate
 //!   served as the listener's own leaf): the CLI must stay offline AND name
 //!   the certificate cause, not just report "unreachable".
 
@@ -274,10 +274,10 @@ fn tls_server_with_proper_ca_chain_reaches_server_tier() {
     );
 }
 
-/// The classic self-hosting.md client-trust trap: the server presents a
-/// CA:TRUE certificate as its own leaf. The CLI must stay offline, but must
-/// distinguish "reachable, TLS trust failed" from a plain "[unreachable]",
-/// and must name the certificate cause in both the WARN and the status line.
+// The classic server-setup.md client-trust trap: the server presents a
+// CA:TRUE certificate as its own leaf. The CLI must stay offline, but must
+// distinguish "reachable, TLS trust failed" from a plain "[unreachable]",
+// and must name the certificate cause in both the WARN and the status line.
 #[test]
 fn tls_server_with_ca_cert_as_leaf_names_the_cause_not_just_unreachable() {
     let ca = new_ca();
@@ -340,7 +340,7 @@ fn tls_server_with_ca_cert_as_leaf_names_the_cause_not_just_unreachable() {
          flattened top-level message: {combined}"
     );
     assert!(
-        combined.contains("self-hosting.md"),
+        combined.contains("server-setup.md"),
         "with server_ca configured, the WARN must point at the client-trust \
          doc section: {combined}"
     );
@@ -440,7 +440,7 @@ fn tls_server_with_untrusted_cert_and_no_server_ca_configured_names_cause_withou
         "a reachable server with an untrusted cert is not '[unreachable]'; stdout:\n{stdout}"
     );
     assert!(
-        !combined.contains("server_ca is configured") && !combined.contains("self-hosting.md"),
+        !combined.contains("server_ca is configured") && !combined.contains("server-setup.md"),
         "the server_ca-specific hint must not appear when server_ca isn't set: {combined}"
     );
 }

--- a/crates/spelunk-core/src/config/paths.rs
+++ b/crates/spelunk-core/src/config/paths.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 /// calls `SHGetKnownFolderPath` (a Registry lookup) rather than reading
 /// `HOME`/`USERPROFILE`, making a per-process environment override of `HOME`
 /// ineffective (the identical portability gap documented on
-/// `spelunk_state_dir` in the CLI's `capability.rs` and on
+/// `spelunk_state_dir` in the CLI's `capability/probe.rs` and on
 /// `web_to_md_script_path` in `memory/add.rs`). Tests that need an isolated
 /// config/secret-store location (this crate's own `config::mod::tests`, and
 /// the CLI integration tests via `spelunk_bin_in`) set this instead of relying


### PR DESCRIPTION
## Summary
- Sixth and final PR of the capability.rs module split. Stacked on #716.
- What remained of `capability.rs` after the previous five extractions was already just the module doc plus `mod` declarations and re-exports, so this is a mechanical rename to `capability/mod.rs` (matching the `config/mod.rs`, `storage/memory/mod.rs` convention), plus documenting the completed module layout in the top-of-file doc comment.
- Also lands the small set of content fixes that were deliberately deferred until the split finished, so no intermediate commit in this stack ever referenced a file that didn't exist yet:
  - `cert_trust_hint()`'s TLS-trust hint message (and its doc comment) now say `docs/server-setup.md` instead of `docs/self-hosting.md`, matching the doc the sibling docs-consolidation PR (#669) introduces. `tests/tls_trust.rs`'s two assertions checking for that string are updated in this same commit so nothing is transiently broken.
  - Stale `capability.rs`/bare-`capability::` cross-references elsewhere in the crate now point at the specific submodule: `server_client.rs` (`capability::tier::tests::...`, `capability::probe::probe_url`), `cli/cmd/server.rs` and `cli/cmd/memory/add.rs` (`capability/probe.rs`), spelunk-core's `config/paths.rs` (`capability/probe.rs`), and two test-file comments (`e2e_cli.rs`, `plumbing_helpers.rs`).

## Test plan
- `SPELUNK_SECRET_STORE=file cargo build --workspace`
- `SPELUNK_SECRET_STORE=file cargo test --workspace` and `--no-default-features`: all green (407 spelunk-cli / 436 spelunk-core tests, same counts as before the split)
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` clean, both feature configs
- `cargo fmt --all -- --check` clean