### PR TITLE
docs(getting-started): lead with search over graph, add spelunk.cloud tier row

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -207,11 +207,12 @@ project here` error instead of using a machine-global store. From inside your
 project you can:
 
 ```bash
-# Trace callers and callees for any symbol
-spelunk graph validate_token
-
-# Full-text search
+# Find the code behind a concept: search takes any phrase, no symbol name needed
 spelunk search "error handling" --mode text
+
+# Trace how a symbol connects. graph resolves an exact identifier (a real symbol
+# name, e.g. one you just saw in the search results above), not a concept phrase
+spelunk graph validate_token
 
 # Store a decision for your team
 spelunk memory add --kind decision \
@@ -263,24 +264,28 @@ spelunk hooks uninstall
 
 ## Capability tiers: where inference and memory live
 
-spelunk works at three tiers. You do not pick one by hand; spelunk uses the best
-one available and degrades cleanly when a server is not reachable. The
-load-bearing distinction is that a **local server does inference only and never
-stores memory**. Your memory always lives in the project's local `memory.db`
-until you *explicitly* configure a team server.
+spelunk works at three tiers; the team-memory tier can be a server you host
+yourself or the managed spelunk.cloud, shown as separate rows below. You do not
+pick one by hand; spelunk uses the best one available and degrades cleanly when a
+server is not reachable. The load-bearing distinction is that a **local server
+does inference only and never stores memory**. Your memory always lives in the
+project's local `memory.db` until you *explicitly* configure a team server or use
+the managed spelunk.cloud.
 
 | Tier | What runs it | What it adds | Where memory lives |
 |---|---|---|---|
 | **Built-in** (zero infra) | just the `spelunk` binary | git-notes memory, full-text and ast-grep search, code graph | local `memory.db` |
 | **Local semantic server** | a loopback `spelunk-server`, auto-started on demand | semantic / hybrid `search`, `explore`, LLM summaries | still local `memory.db`: the server is **inference only, never a memory store** |
-| **Team memory server** | a shared `spelunk-server` you deploy, set via an explicit `server_url` | shared memory across the team | the shared server, the **only** way memory leaves your machine |
+| **Team memory server** | a shared `spelunk-server` you deploy, set via an explicit `server_url` | shared memory across the team | the shared server you run: memory leaves your machine, your code stays local |
+| **spelunk.cloud** (hosted) | a managed service: nothing to deploy or maintain | the same shared-team memory as a self-hosted server, without running one | the hosted service: memory leaves your machine, your code stays local |
 
 Built-in works with nothing installed but the binary (the always-available
 commands in section 3). The local semantic server is auto-discovered on loopback
 (`127.0.0.1`) and started for you the first time a command needs it; it embeds
 queries and runs LLM calls, but a project's memory stays in `memory.db`
 regardless of whether it is running. Memory moves off the local machine only when
-you set an explicit team `server_url` (see
+you point at a team server, self-hosted via an explicit `server_url` or the
+managed spelunk.cloud (see
 [Team setup](#team-setup-shared-memory-with-spelunk-server)); each developer's
 code still stays local.
 


### PR DESCRIPTION
## What this is

A targeted back-port of the two genuinely source-doc-worthy editorial
improvements that were made during a docs walk-the-store but only ever landed in
the marketing mirror, never in these source-of-truth `docs/*.md`. This is **not**
a wholesale sync: the marketing docs mostly mirror (and were later re-mirrored
from) these files, so most of that content is behind `docs/` now, not ahead. Each
change below was diffed against today's `docs/` and verified against the shipped
CLI/server source before porting.

## Ported (both in `docs/getting-started.md`)

- **Lead the command tour with `search`, not a bare `graph` placeholder.** The
  "start using it inside your project" block opened with `spelunk graph
  validate_token`, an exact identifier a first-time reader has no way to know
  yet. It now leads with `spelunk search` (takes any phrase, no symbol name) and
  states that `graph` resolves an **exact** symbol (for example one from the
  search results), not a concept phrase. Verified against `spelunk graph`'s
  behavior (`commands.md` + the CLI graph handler: it looks up a literal symbol
  / matches call-site `symbol(...)`, no fuzzy/phrase matching).
- **Add a `spelunk.cloud` row to the capability-tiers table.** The table
  documented Built-in / Local semantic server / Team memory server but omitted
  the hosted option, so the data-flow table under-described where memory can
  live. Added a `spelunk.cloud` (hosted) row framed conservatively as the managed
  equivalent of a self-hosted team server (shared team memory, code stays local),
  matching the tone of the existing rows. This is data-flow transparency, not a
  sales pitch. `spelunk.cloud` is already referenced elsewhere in these public
  docs (`README.md`, `commands.md` login/org, `remote-agents.md`). Softened the
  now-inaccurate "the **only** way memory leaves your machine" wording on the
  team-server row and the intro/summary prose so the table stays internally
  consistent with a fourth row.

## Checked and deliberately left (oss was already correct or ahead)

- **`--mode text` "always works" overclaim** : the marketing troubleshooting copy
  claimed text search "always works even when semantic search is unavailable,"
  which is false on a fresh repo (`--mode text` needs a built FTS index). These
  `docs/` carry **no such claim** (`grep` for "always works" / that sentence in
  `docs/` is empty), so there was nothing to correct. Left untouched.
- **Deprecated `memory_server_url` / `memory_server_key` aliases** : nothing to
  remove: these `docs/` already contain **zero** mentions of the aliases, and the
  alias-handling **code has already landed as removed** (the config layer now
  ignores them; the parse layer keeps regression tests named
  `deprecated_memory_server_keys_are_ignored` and
  `env_spelunk_memory_server_url_is_ignored`, the latter commented "Breaking
  change: the deprecated SPELUNK_MEMORY_SERVER_URL env fallback was removed"). No
  struct field reads them. So both the code-state precondition and the doc-state
  are already where we want them.
- **Server lifecycle / native-TLS / fail-closed items** : these were the marketing
  mirror catching up **to** these docs, not the other way round. Left untouched.

## Decision to surface: no oss `config-reference`

The marketing site has a consolidated `config-reference.mdx` (every
`config.toml` field in one page). There is **no equivalent single doc** here;
config is spread across getting-started / server-setup / commands. I did **not**
create one on my own initiative. Options for a maintainer/architect to choose:

1. **Author `docs/config-reference.md`** as a new source-of-truth page and have
   the marketing doc mirror it (consistent with how the other user docs work).
2. **Keep it marketing-only**, deriving from the `config.toml` struct comments.

If option 1: the current marketing `config-reference.mdx` is **stale vs the
actual `Config` struct** and should not be mirrored as-is. Cheap cross-check
against `crates/spelunk-core/src/config/mod.rs` `struct Config`:

- **Missing fields:** `server_ca` (custom-CA trust), `mode` (`SyncMode`:
  `offline` / `local_first` / `cloud_first`), `inference_url`, `auth`, and the
  `index` (`IndexConfig`) block are all documented nowhere in the marketing page.
- **`embedding_model` is documented as a selectable field with a default**, but
  the embedding model is fixed product-wide (F2LLM-v2-330M) and the legacy
  selector is ignored with a startup warning. Documenting it as settable is
  misleading.
- The page's claim that only `server_url` / `server_key` / `project_id` are read
  from a project-level `.spelunk/config.toml` is worth re-verifying against the
  project-level merge now that `mode` / `server_ca` exist.

## Notes

- Docs only; nothing under `crates/` touched. No doc build to run (plain
  Markdown). The repo pre-commit hook (`cargo fmt`/`clippy`) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
