### PR TITLE
fix(docker): give the embedder a writable, persistent model cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,45 @@ jobs:
           test -n "$(docker run --rm spelunk-server:ci --version)"
           docker run --rm spelunk-server:ci --print-openapi | head -c1 | grep -q .
 
+      # Regression check for the container-user-has-no-home bug: start the
+      # image against a real named volume (as a deployment would) and poll
+      # `/v1/health` from a sidecar sharing its network namespace (the
+      # pattern documented at the top of the Dockerfile, since the server
+      # only binds loopback). This only needs the embedder's model-cache
+      # `mkdir` to succeed, not the full ~339 MB download: `create_dir_all`
+      # runs before any network I/O in `load_from_hub()`, so a cache-dir
+      # failure surfaces as an `unavailable` state within a couple of
+      # seconds, well before "loading" would ever complete.
+      - name: Check embedder initializes against the persistent volume
+        run: |
+          docker run -d --name spelunk-server-ci -v spelunk-data-ci:/data spelunk-server:ci
+          trap 'docker logs spelunk-server-ci || true; docker rm -f spelunk-server-ci >/dev/null 2>&1; docker volume rm spelunk-data-ci >/dev/null 2>&1' EXIT
+
+          health=""
+          for _ in $(seq 1 30); do
+            health="$(docker run --rm --network container:spelunk-server-ci curlimages/curl -s http://127.0.0.1:7777/v1/health || true)"
+            [ -n "$health" ] && break
+            sleep 1
+          done
+
+          if [ -z "$health" ]; then
+            echo "ERROR: /v1/health never answered"
+            exit 1
+          fi
+          echo "$health"
+
+          state="$(echo "$health" | jq -r '.embedder.state')"
+          detail_lower="$(echo "$health" | jq -r '.embedder.detail // empty' | tr '[:upper:]' '[:lower:]')"
+
+          if [ "$state" = "unavailable" ]; then
+            case "$detail_lower" in
+              *mkdir*|*"permission denied"*)
+                echo "ERROR: embedder failed to initialize (model-cache dir/permissions failure): $detail_lower"
+                exit 1
+                ;;
+            esac
+          fi
+
   openapi-snapshot:
     name: OpenAPI snapshot check
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,11 +86,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -r -s /bin/false spelunk
+# `-m -d /data` gives the service user a real home at the same path the
+# volume is mounted, so any `$HOME`-relative path a dependency resolves stays
+# writable; `useradd -m` also creates /data pre-owned by spelunk, so no
+# separate chown is needed. WORKDIR after useradd picks up that existing dir.
+RUN useradd -r -m -d /data -s /bin/false spelunk
 WORKDIR /data
-RUN chown spelunk:spelunk /data
 
 COPY --from=builder /build/target/release/spelunk-server /usr/local/bin/spelunk-server
+
+# Primary fix: point the embedder's model cache at the persistent /data
+# volume instead of the default $HOME/.local/share resolution. Without this,
+# a fresh container re-downloads the ~339 MB model into the container layer
+# on every `docker rm`/recreate even once $HOME itself is writable (see
+# useradd above).
+ENV XDG_DATA_HOME=/data
 
 USER spelunk
 

--- a/crates/spelunk-server/src/embed_hub.rs
+++ b/crates/spelunk-server/src/embed_hub.rs
@@ -217,6 +217,37 @@ mod tests {
         }
     }
 
+    /// `model_cache_dir()` honours `XDG_DATA_HOME` when set (the Docker image
+    /// points this at the persistent `/data` volume so the ~339 MB model
+    /// survives `docker rm`/recreate, instead of landing in the container
+    /// layer or a home directory that doesn't exist for the `-r` service
+    /// user). Linux-only: `dirs::data_local_dir()` follows the XDG spec on
+    /// Linux/BSD, but macOS ignores `XDG_DATA_HOME` entirely in favor of
+    /// `~/Library/Application Support` (the Docker image is Linux, so that's
+    /// the platform this fix targets). Uses `serial` because it mutates a
+    /// process-global env var.
+    #[test]
+    #[cfg(target_os = "linux")]
+    #[serial_test::serial(xdg_data_home_env)]
+    fn model_cache_dir_honours_xdg_data_home() {
+        // SAFETY: guarded by #[serial] so no other test reads/writes this var
+        // concurrently; we restore it before returning.
+        let prev = std::env::var("XDG_DATA_HOME").ok();
+
+        let tmp = std::env::temp_dir().join("spelunk-model-cache-dir-test");
+        unsafe { std::env::set_var("XDG_DATA_HOME", &tmp) };
+
+        assert_eq!(
+            model_cache_dir().expect("resolve cache dir"),
+            tmp.join("spelunk").join("models")
+        );
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("XDG_DATA_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_DATA_HOME") },
+        }
+    }
+
     /// End-to-end semantic-discrimination check over the real model. Ignored by
     /// default: it downloads the ~339 MB pre-quantized GGUF and runs inference.
     /// Run with `cargo test -p spelunk-server -- --ignored embeddings_discriminate`.

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -377,7 +377,7 @@ async fn run(budget: ThreadBudget) -> Result<()> {
                     );
                 }
                 Ok(Err(e)) => {
-                    let msg = format!("{e}");
+                    let msg = embedder_load_failure_message(&e);
                     tracing::warn!(
                         "native embedding model failed to load: {msg}; \
                          embedder unavailable (set --embedding-url to override)"
@@ -385,7 +385,9 @@ async fn run(budget: ThreadBudget) -> Result<()> {
                     slot.set_unavailable(msg);
                 }
                 Err(join_err) => {
-                    let msg = format!("embedder load task panicked: {join_err}");
+                    let msg = embedder_load_failure_message(format_args!(
+                        "embedder load task panicked: {join_err}"
+                    ));
                     tracing::warn!("{msg}");
                     slot.set_unavailable(msg);
                 }
@@ -414,6 +416,16 @@ async fn run(budget: ThreadBudget) -> Result<()> {
     }
 
     Ok(())
+}
+
+// ── Native embedder load failure ──────────────────────────────────────────────
+
+/// Prefix a native-embedder load failure so `/v1/health`'s `embedder.detail`
+/// reads unambiguously as terminal: the underlying `anyhow::Context` message
+/// (e.g. "creating model cache dir ...") otherwise reads like in-progress
+/// bootstrap text rather than a failure.
+fn embedder_load_failure_message(context: impl std::fmt::Display) -> String {
+    format!("failed: {context}")
 }
 
 // ── Embed CPU thread budget ───────────────────────────────────────────────────
@@ -930,6 +942,22 @@ mod arg_tests {
         ] {
             assert!(!super::host_is_loopback(h), "{h} should NOT be loopback");
         }
+    }
+
+    /// A native-embedder load failure's `/v1/health` detail must read as a
+    /// terminal failure, not in-progress bootstrap text (the underlying
+    /// `anyhow::Context` message, e.g. "creating model cache dir ...", reads
+    /// like progress on its own).
+    #[test]
+    fn embedder_load_failure_message_is_prefixed() {
+        assert_eq!(
+            super::embedder_load_failure_message(
+                "creating model cache dir /home/spelunk/.local/share/spelunk/models: \
+                 Permission denied (os error 13)"
+            ),
+            "failed: creating model cache dir /home/spelunk/.local/share/spelunk/models: \
+             Permission denied (os error 13)"
+        );
     }
 
     // ── ADR-066 §4: TLS-aware bind-safety table ─────────────────────────────

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -340,6 +340,13 @@ the loopback scaffold will **not** be reachable, because `-p` forwards host
 traffic to the container's routable interface, not into its private loopback, so
 nothing published reaches a loopback-only bind.
 
+**What's on the `/data` volume.** Both the SQLite database (`/data/spelunk.db`)
+and the native embedder's downloaded model cache (`/data/spelunk/models/`, a
+one-time ~339 MB pull) live on the same named volume. Size it accordingly, and
+when backing it up, only the database needs your normal database backup
+process (per [Production deployment](#production-deployment) below); the model
+cache is a re-downloadable artifact, not project data.
+
 ## 5. Point a remote agent at it
 
 On the remote host (or in its container), the configuration is identical to


### PR DESCRIPTION
## Summary

The Docker image's `useradd -r` service user has no home directory, so the native embedder's default cache path (`$HOME/.local/share/spelunk/models`) fails its first `mkdir`, and the embedder is permanently unavailable in every containerized deployment (no `index.embed`/`search.semantic`, `embedding_dim: 0`). Even with a writable home, the model would land in the container layer and re-download on every `docker rm`/recreate rather than living on the persistent volume.

- **Dockerfile**: `ENV XDG_DATA_HOME=/data` points the cache at the already-persistent, already-mounted volume. `useradd -r -s /bin/false spelunk` becomes `useradd -r -m -d /data -s /bin/false spelunk` as a defense-in-depth fallback for any other `$HOME`-relative path a future dependency might resolve; the now-redundant explicit `chown` is dropped since `useradd -m` already creates `/data` owned by `spelunk`.
- **`main.rs`**: the `/v1/health` `embedder.detail` string for a load failure is now prefixed `"failed: "` (via a small, unit-tested helper) so it reads unambiguously as terminal instead of looking like in-progress bootstrap text (e.g. "creating model cache dir ...").
- **CI** (`docker-build` job): a new step starts the built image against a real named volume and polls `/v1/health` via a sidecar sharing its network namespace, failing the job if `embedder.detail` shows an mkdir/permission failure while `state == "unavailable"`.
- **Docs**: notes what lives on the `/data` volume (DB + model cache) and that only the DB needs backing up.

## Test plan

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `SPELUNK_SECRET_STORE=file cargo test --workspace` all clean (0 failures across the full workspace).
- Built the fixed image locally (`docker build`) and ran it against a fresh named volume, exactly as a real deployment would:
  - `docker run -d -v <vol>:/data -p 7777:7777 <image>`, then polled `/v1/health` via `docker run --network container:<name> curlimages/curl ...` (the loopback-only bind pattern documented in the Dockerfile).
  - Observed `embedder.state` go from `"loading"` to `"ready"` with `embedding_dim: 896` and `capabilities` including `index.embed`/`search.semantic` — no mkdir/permission-denied failure at any point.
  - `docker exec ... ls /data/spelunk/models` confirmed the ~339 MB GGUF and tokenizer/config landed on the persistent volume, owned by the `spelunk` user, not the container layer.
  - Cleaned up the test container/volume/image afterward.