### PR TITLE
docs: remove stale external-embedding-model framing

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -340,13 +340,9 @@ spelunk-server --embedding-url http://127.0.0.1:1234
 There is no embedding-model flag: `spelunk` always computes 896-dim
 F2LLM-v2-330M vectors, and your endpoint must serve that model. (A legacy
 `SPELUNK_EMBEDDING_MODEL` / `--embedding-model` is ignored, with a startup
-warning, rather than honoured.) `--embedding-dim` still exists so an endpoint
-whose vectors differ in dimension can be matched, but changing it means you are
-running a different model at your own risk — the server records the dimension on
-the first write and rejects later writes that disagree (see
-[Embedding dimension](server-setup.md#embedding-dimension)). Re-embedding an existing
-index through a new endpoint needs a full re-index (`spelunk index --force`),
-since unchanged files are otherwise skipped.
+warning, rather than honoured.) Re-embedding an existing index through a new
+endpoint needs a full re-index (`spelunk index --force`), since unchanged files
+are otherwise skipped.
 
 Tune the per-request embedding batch ceiling at index time with
 `spelunk index --batch-size <n>` if a slow or memory-constrained endpoint

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -533,34 +533,6 @@ says so explicitly so no one has to infer it from behaviour.
   v1.0; see ADR-056's "Revisit if" clause). The managed cloud product
   provides organization-scoped isolation if you need that instead.
 
-## Embedding dimension
-
-All clients writing to the same project must use the same embedding model. The
-embedding model is fixed product-wide to codefuse-ai/F2LLM-v2-330M (896-dim) and
-cannot be selected; a mismatched model silently corrupts semantic search. The
-server records the embedding dimension on the first write and rejects subsequent
-writes with a different dimension.
-
-Default: 896 dimensions (codefuse-ai/F2LLM-v2-330M, the bundled native embedder).
-
-`--embedding-dim` sets the dimension the server enforces. Change it only to match
-an external endpoint whose vectors differ in size; doing so means you are
-running a different model at your own risk (the one-model-per-vector-space
-invariant no longer holds), not a supported way to swap embedding models. See
-[Third-party models](third-party-models.md) for configuring an external
-embedding endpoint.
-
-```bash
-docker compose run spelunk-server --embedding-dim 1024
-```
-
-Or via compose environment:
-
-```yaml
-environment:
-  SPELUNK_EMBEDDING_DIM: "1024"
-```
-
 ## Production deployment
 
 **Bare-metal / systemd is the recommended way to run a team-reachable

--- a/docs/third-party-models.md
+++ b/docs/third-party-models.md
@@ -104,12 +104,6 @@ spelunk-server --embedding-url http://127.0.0.1:1234
 When set, the server calls out to that OpenAI-compatible embeddings endpoint
 instead of running the bundled native embedder.
 
-`--embedding-dim` overrides the dimension the server enforces (default 896) for
-the rare case where your endpoint's vectors are a different size; changing it
-means you are running a different model at your own risk, and the server
-rejects later writes with a mismatched dimension (see
-[Server setup → Embedding dimension](server-setup.md#embedding-dimension)).
-
 `SPELUNK_EMBEDDER_GGUF_REPO` is unrelated to the above: it points the *bundled
 native* embedder at an alternate source for the same F2LLM-v2-330M GGUF and
 tokenizer artifacts, not a different model. See


### PR DESCRIPTION
## What

The embedding model is fixed product-wide (codefuse-ai/F2LLM-v2-330M @ 896-dim) and cannot be selected. `--embedding-model` / `SPELUNK_EMBEDDING_MODEL` is deprecated, hidden, and ignored in code (`crates/spelunk-server/src/main.rs`: "Never selects a model"). The docs, however, still framed `--embedding-dim` as a way to run a **different** model at an external endpoint "at your own risk." That model-swap capability no longer exists, so the copy described behavior the code does not support. This removes only that framing.

## Removed

- **`docs/server-setup.md`**: the entire `## Embedding dimension` section. Since the model is fixed and cannot be selected, there is nothing for a reader to configure here; the dimension-mismatch rejection is an automatic internal guard, not a user knob.
- **`docs/third-party-models.md`**: the `--embedding-dim` "different model at your own risk" paragraph, including its now-broken cross-link to `server-setup.md#embedding-dimension`.
- **`docs/getting-started.md`**: the same `--embedding-dim` model-swap sentence and its dangling `#embedding-dimension` anchor link (this also removed one em-dash).

## Deliberately left intact

- **`--embedding-url` / `SPELUNK_EMBEDDING_URL`** docs (the `## Configuring an external embedding endpoint` subsection in `third-party-models.md` and the equivalent in `getting-started.md`). This relocates *where* embeddings are computed using the *same* fixed F2LLM model, and remains supported in code.
- **`--llm-url` / `--llm-model`** docs. External OpenAI-compatible LLM is a core feature and was not touched.
- The `SPELUNK_EMBEDDER_GGUF_REPO` note (points the bundled native embedder at an alternate source for the *same* model artifacts).

## Verification

- Grepped the whole `docs/` tree: no `#embedding-dimension` anchor links remain, and no "different model / at your own risk" model-swap framing remains.
- The `embedding_dim` references in `docs/openapi.json` and `docs/architecture/server-api.md` are the legitimate `/v1/health` API response field and were left untouched.

## Test plan

- `grep -rn "#embedding-dimension" docs/` returns no anchor links.
- `grep -rni "at your own risk\|running a different model\|different dimension" docs/` returns no matches.
- Render `docs/server-setup.md`, `docs/third-party-models.md`, and `docs/getting-started.md` and confirm no dangling internal links and that the `--embedding-url` / `--llm-url` sections read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)