### PR TITLE
fix: remove em-dashes introduced by #723 and #725

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -599,7 +599,7 @@ async fn run_embed_phase_with_backoff(
                     connect_failures += 1;
                     tracing::warn!(
                         "index/embed: could not connect to {server_url} (attempt \
-                         {connect_failures}/{}) — retrying the same batch of \
+                         {connect_failures}/{}), retrying the same batch of \
                          {this_batch_size} chunk(s) in {backoff:?}: {e:#}",
                         connect_failure_backoffs.len(),
                     );
@@ -662,7 +662,7 @@ async fn run_embed_phase_with_backoff(
 /// An `embed_one_batch` failure, distinguishing "the request budget was too
 /// small for this batch" (408, or a client-side timeout expiring first) and
 /// "the server wasn't reachable at all" (a TCP connect-phase failure) from
-/// every other failure — the first is worth shrinking and retrying, the
+/// every other failure: the first is worth shrinking and retrying, the
 /// second worth retrying at the same size, see `run_embed_phase`.
 enum EmbedBatchError {
     /// Server returned 408, or the client-side `timeout` elapsed after a
@@ -679,7 +679,7 @@ enum EmbedBatchError {
 /// Send one embed batch and return the raw little-endian f32 response bytes: one
 /// `EMBEDDING_DIM`-float vector per chunk, in request order. Applies a
 /// per-request `timeout` (see `batch_timeout`) and validates the response length.
-/// Distinguishes a 408/timeout, a connect failure, and other failures — see
+/// Distinguishes a 408/timeout, a connect failure, and other failures; see
 /// [`EmbedBatchError`].
 async fn embed_one_batch(
     client: &reqwest::Client,
@@ -1373,7 +1373,7 @@ mod tests {
     async fn embed_one_batch_classifies_a_refused_connection_as_connect_failure() {
         // Reserve a port, then release it without ever listening again: a
         // connection attempt fails at the OS connect phase (refused), exactly
-        // like the field failure's "server not accepting connections" — the
+        // like the field failure's "server not accepting connections", the
         // one difference being this fails instantly instead of after a long
         // client-side timeout, which is what makes it fast to test.
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -1409,7 +1409,7 @@ mod tests {
     async fn embed_one_batch_still_classifies_a_slow_connected_server_as_budget_exceeded() {
         // Regression guard: a server that IS reachable but responds slower
         // than the per-request timeout must still classify as
-        // `BudgetExceeded` — the new `is_connect()` check must not swallow a
+        // `BudgetExceeded`: the new `is_connect()` check must not swallow a
         // real request/response timeout.
         let mock = MockServer::start().await;
         Mock::given(method("POST"))
@@ -1942,7 +1942,7 @@ mod tests {
     // backoff schedule instead of the production `CONNECT_FAILURE_BACKOFFS`
     // (which sums to several minutes): real (unpaused) time, kept fast by
     // shrinking the schedule rather than by faking the clock. `tokio::time`
-    // paused-time auto-advance was tried here first and discarded — it races
+    // paused-time auto-advance was tried here first and discarded: it races
     // against the real OS-level TCP connect-refusal this test relies on, and
     // in that race the client's own request `.timeout()` can fire first,
     // misclassifying the failure as `BudgetExceeded` instead of exercising
@@ -1960,7 +1960,7 @@ mod tests {
         // Reserve an address, release it, then start a real mock server on
         // the SAME address partway through the retry backoff schedule: the
         // first couple of attempts hit connect-refused, then the batch
-        // succeeds once the server starts listening — at the SAME batch size
+        // succeeds once the server starts listening, at the SAME batch size
         // throughout (the retry loop never shrinks on a `ConnectFailure`).
         //
         // The spawned task's delay (150ms) is chosen to land strictly

--- a/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs
@@ -1179,8 +1179,8 @@ mod init_import_tests {
     ///
     /// Concurrency is bounded by a semaphore rather than firing all `RUNS`
     /// unbounded: each run shells out to several real `git` subprocesses, and
-    /// letting 20 of those launch at once — stacked on top of the rest of the
-    /// workspace's own parallel test suite doing the same — was observed to
+    /// letting 20 of those launch at once, stacked on top of the rest of the
+    /// workspace's own parallel test suite doing the same, was observed to
     /// spuriously fail `Command::spawn` with ENOENT under `cargo test
     /// --workspace` (not in isolation), i.e. this test flaked from OS-level
     /// process-spawn contention, the exact class of noise it exists to filter


### PR DESCRIPTION
Two just-merged PRs shipped em-dashes into `main`, violating the repo's no-em-dash rule (CLAUDE.md). One is user-facing: the embed-phase connect-retry progress string printed during `spelunk index`.

## Scope
Diffed PR #723 and #725 against their pre-merge bases (`gh pr diff 723/725 --repo spelunk-cloud/spelunk`, grepped added `+` lines for em-dash) to find exactly which files/lines these two PRs introduced em-dashes in, rather than trusting the task's blind file list:

- #723 added 7 em-dash lines, all in `crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs` (touched `CHANGELOG.md`, `crates/spelunk-embed/src/embedder_native.rs`, `docs/commands.md` too, but added zero em-dashes there).
- #725 added 2 em-dash lines, both in `crates/spelunk-cli/src/cli/cmd/memory/reconcile.rs` (touched `crates/spelunk-cli/tests/e2e_cli.rs`, `crates/spelunk-core/src/storage/git_notes/lock.rs` too, added zero em-dashes there).

Fixed all 9: the user-facing retry string plus 6 comments in `embed_phase.rs`, and 2 lines of one doc-comment in `reconcile.rs`. Each replaced with a colon or comma based on what read best; no lazy en-dash swaps. Left the other 5 named files untouched — their em-dash hits are pre-existing, unrelated to these two PRs, and out of scope per this fix's own "no repo-wide sweep" intent (text-only regression fix, not a general em-dash cleanup).

## Test plan (all commands run with `SPELUNK_SECRET_STORE=file` set explicitly)

Diff verification:
- `gh pr diff 723 --repo spelunk-cloud/spelunk` / `gh pr diff 725 --repo spelunk-cloud/spelunk`, grepped `^+.*—` → confirmed the exact 9 lines above, no others.
- `git show origin/main:<file> | grep -c '—'` vs `git show HEAD:<file> | grep -c '—'`: `embed_phase.rs` 32→25 (-7), `reconcile.rs` 19→17 (-2). Matches.
- Confirmed pre-existing (unrelated) em-dashes remain in the 5 out-of-scope files: `embedder_native.rs` 11, `docs/commands.md` 7, `CHANGELOG.md` 91, `e2e_cli.rs` 31, `lock.rs` 0.

Gates:
- `SPELUNK_SECRET_STORE=file cargo fmt --all -- --check` → clean.
- `SPELUNK_SECRET_STORE=file cargo clippy --all-targets --features rich-formats -- -D warnings` → clean.
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli` → full run, every test binary 0 failed (433/433 in the main lib target). The previously-flagged pre-existing flake (`init_import_skip_scenario_is_race_free_under_concurrent_tasks`, documented flake under parallel-load contention) did not reproduce on this run.
- `git fetch origin main && git log HEAD..origin/main` → empty, branch not stale.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>