### PR TITLE
docs: reframe spelunk sync as escape hatch (P2 background reconciler shipped)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -491,17 +491,21 @@ for you on first use and caches the result locally, so no manual UUID lookup is
 needed. See [Server setup](server-setup.md#client-configuration) for details.
 
 After setup, all `spelunk memory` commands transparently use the server. Seed it
-with your existing local memory, then keep the two in step as you and your
-teammates record decisions:
+with your existing local memory, then keep recording decisions as usual:
 
 ```bash
-spelunk memory push    # one-way: send your local entries up to the server
-spelunk sync           # two-way: push local entries and pull teammates' entries down
+spelunk memory push    # one-way: seed the server with your existing local entries
+spelunk sync           # force a synchronous two-way reconcile (usually not needed; see below)
 ```
 
-`spelunk sync` is the day-to-day command for a shared server: it pushes what you
-recorded and pulls what everyone else did, so the team reads and writes one
-shared memory. Code never travels; only memory does.
+In the default `local_first` mode you rarely run `spelunk sync` by hand. Your
+writes commit to the local `memory.db` immediately and never block on the
+network; from an interactive terminal a background reconciler then drains what
+you recorded up to the server and pulls teammates' entries down, so the shared
+memory converges on its own. `spelunk sync` is the explicit escape hatch for
+when you want that reconcile to happen synchronously now rather than in the
+background, such as a CI job that needs entries pushed before it exits. Code
+never travels; only memory does.
 
 For full setup and deployment guide: **[Server setup](server-setup.md)**: Docker, configuration, API reference.
 

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -444,8 +444,9 @@ in `project_id` is used as-is. (See [ADR-005](adr/005-cli-slug-uuid-resolution.m
 
 By default a configured `server_url` runs in `local_first` mode: reads and
 writes stay in each developer's local `memory.db` and the server is a
-converging replica (`spelunk status` shows the active mode; use `spelunk sync`
-to reconcile with the server). Add `mode = "cloud_first"` to the same config to
+converging replica kept in step by a background reconciler (`spelunk status`
+shows the active mode; run `spelunk sync` only when you want to force a
+synchronous reconcile). Add `mode = "cloud_first"` to the same config to
 make the server authoritative for reads and writes; an unreachable server is
 then a hard error rather than a silent local read. See [Team server and sync
 modes](memory.md#team-server-and-sync-modes).


### PR DESCRIPTION
## What
The ADR-037 P2 background reconciler now ships: in `local_first` mode local writes commit to `memory.db` immediately and never block on the network, and a background reconciler (hosted by the local `spelunk-server` for its network legs only) drains the outbox to the team server and holds an SSE-driven live pull, so teammates' entries converge without anyone running `spelunk sync` by hand. The getting-started docs still called `spelunk sync` the "day-to-day command", which is now wrong.

## Changes
- **`docs/getting-started.md`** (~L493-504): reframe the `spelunk sync` block and drop the "day-to-day command" sentence. `spelunk sync` is now presented as the explicit synchronous-reconcile escape hatch (CI, or when you want to block until synced), with the background reconciler doing the routine convergence.
- **`docs/server-setup.md`** (~L446-449): soften the `local_first` parenthetical to note the background reconciler; `spelunk sync` = force a synchronous reconcile.

## Not conflated
The new **background reconciler** (auto-sync relay) is kept distinct from the existing **`spelunk memory reconcile`** command (cross-store import of a running server's `server.db` into the local store, `docs/memory.md` L672+). Neither is renamed or cross-linked to the other.

## Notes
- `docs/memory.md` already carries the full reconciler framing (from the sync-docs commit), so it needs no change here.
- Wording verified against ADR-037 D1/D5/D6: best-effort background convergence on the next interactive command, not "real-time" / "live collaboration". No em-dashes; British English.

## Test plan
Docs-only change. Rendered the changed Markdown and confirmed the sync block, `memory push` seed line, and reconciler prose read correctly and internally consistent with `docs/memory.md` and `docs/server-setup.md`. `cargo fmt --check` + `cargo clippy` ran clean on the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)