### PR TITLE
Fix misdirecting spelunk index diagnostic for an unreachable server_url

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -859,6 +859,12 @@ mod tests {
         assert!(joined.contains("unreachable"), "got: {joined}");
         assert!(joined.contains("server_url"), "got: {joined}");
         assert!(
+            joined.contains("configured"),
+            "must say the target came from a *configured* server_url, not just name \
+             `server_url` in passing (this is the specific wording the defect asked for, \
+             distinguishing it from the auto-discovered daemon): got: {joined}"
+        );
+        assert!(
             joined.contains("overrides") || joined.contains("override"),
             "must explain that an explicit server_url overrides the auto-discovered \
              local daemon, so a healthy daemon elsewhere is not the fix: got: {joined}"

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -492,10 +492,18 @@ async fn run_embed_phases(
 /// notice must then name that server instead of pointing at `spelunk server
 /// logs`, which only reads the local auto-daemon's log and would show clean
 /// logs for a failure that lives on the remote server.
+///
+/// `is_windows` gates the Windows Defender Firewall hint in the offline
+/// case: that hint is a real cause only on Windows, and printing it on every
+/// platform actively misdirects a macOS/Linux user away from the real
+/// problem (an unreachable configured `server_url`). Callers pass
+/// `cfg!(windows)`; injected here so the platform-specific behaviour is
+/// testable without `#[cfg(windows)]` test gating.
 fn embed_skipped_lines(
     embedder_state: Option<capability::EmbedderState>,
     server_url: Option<&str>,
     remote_url: Option<&str>,
+    is_windows: bool,
 ) -> Vec<String> {
     use capability::EmbedderState;
     match embedder_state {
@@ -528,18 +536,32 @@ fn embed_skipped_lines(
             "Note: this server has no embedder — chunks indexed for text/ast-grep search only."
                 .to_string(),
         ],
-        // Offline: no server reachable.
+        // Offline: no server reachable. Reaching this arm with `server_url`
+        // set means the probe took the explicit-URL path (see
+        // `capability::probe::probe`): an auto-discovered loopback miss never
+        // carries a `server_url`, so the message can unconditionally say
+        // "configured server_url" rather than guessing.
         None => {
             if let Some(url) = server_url {
-                vec![
-                    format!(
-                        "Warning: spelunk-server at {url} is unreachable — skipping embedding phase."
-                    ),
-                    "On Windows, allow the loopback listener through Defender Firewall (accept the prompt on `spelunk server start`)."
+                let mut lines = vec![format!(
+                    "Warning: server_url is explicitly configured to {url}, which is \
+                     unreachable, so the embedding phase is skipped. This overrides the \
+                     auto-discovered local server, so a healthy `spelunk server start` \
+                     daemon elsewhere will not be used while server_url is set."
+                )];
+                if is_windows {
+                    lines.push(
+                        "On Windows, allow the loopback listener through Defender Firewall \
+                         (accept the prompt on `spelunk server start`)."
+                            .to_string(),
+                    );
+                }
+                lines.push(
+                    "Chunks are indexed for text/ast-grep search. Re-run `spelunk index` once \
+                     the server is reachable to add embeddings."
                         .to_string(),
-                    "Chunks are indexed for text/ast-grep search. Re-run `spelunk index` once the server is reachable to add embeddings."
-                        .to_string(),
-                ]
+                );
+                lines
             } else {
                 vec![
                     "Note: start a local server (`spelunk server start`) to enable semantic search."
@@ -556,6 +578,7 @@ fn eprint_embed_skipped_notice(tier: &capability::Tier, cfg: &Config) {
         tier.embedder_state(),
         cfg.server_url.as_deref(),
         tier.explicit_remote_url(),
+        cfg!(windows),
     ) {
         eprintln!("{line}");
     }
@@ -776,7 +799,8 @@ mod tests {
 
     #[test]
     fn embed_skipped_loading_advises_retry() {
-        let lines = embed_skipped_lines(Some(capability::EmbedderState::Loading), None, None);
+        let lines =
+            embed_skipped_lines(Some(capability::EmbedderState::Loading), None, None, false);
         assert!(!lines.is_empty(), "notice must not be silent");
         let joined = lines.join("\n");
         assert!(joined.contains("warming up"));
@@ -787,7 +811,12 @@ mod tests {
     fn embed_skipped_unavailable_loopback_points_at_logs() {
         // Loopback auto-discovery: the failing embedder IS the local daemon,
         // so `spelunk server logs` is the right place to look.
-        let lines = embed_skipped_lines(Some(capability::EmbedderState::Unavailable), None, None);
+        let lines = embed_skipped_lines(
+            Some(capability::EmbedderState::Unavailable),
+            None,
+            None,
+            false,
+        );
         let joined = lines.join("\n");
         assert!(joined.contains("failed to load"));
         assert!(joined.contains("spelunk server logs"));
@@ -802,6 +831,7 @@ mod tests {
             Some(capability::EmbedderState::Unavailable),
             None,
             Some("https://team.example:7777"),
+            false,
         );
         let joined = lines.join("\n");
         assert!(joined.contains("failed to load"));
@@ -816,20 +846,48 @@ mod tests {
     }
 
     #[test]
-    fn embed_skipped_unreachable_server_mentions_firewall() {
+    fn embed_skipped_unreachable_server_names_configured_server_url() {
         // Offline (no reachable server) with a configured server_url: the notice
-        // names the URL and the Windows firewall cause, replacing the old silent
-        // 0-chunk embed.
-        let lines = embed_skipped_lines(None, Some("http://127.0.0.1:7777"), None);
+        // must name the actual URL attempted AND say explicitly that it came
+        // from a configured `server_url` (not the auto-discovered loopback
+        // daemon). Without this, a user with a healthy loopback daemon running
+        // has no path from the message to the real cause: the daemon was
+        // never being used because server_url overrides it.
+        let lines = embed_skipped_lines(None, Some("http://127.0.0.1:7777"), None, false);
         let joined = lines.join("\n");
-        assert!(joined.contains("http://127.0.0.1:7777"));
-        assert!(joined.contains("unreachable"));
-        assert!(joined.contains("Firewall"));
+        assert!(joined.contains("http://127.0.0.1:7777"), "got: {joined}");
+        assert!(joined.contains("unreachable"), "got: {joined}");
+        assert!(joined.contains("server_url"), "got: {joined}");
+        assert!(
+            joined.contains("overrides") || joined.contains("override"),
+            "must explain that an explicit server_url overrides the auto-discovered \
+             local daemon, so a healthy daemon elsewhere is not the fix: got: {joined}"
+        );
+    }
+
+    #[test]
+    fn embed_skipped_unreachable_server_shows_firewall_hint_only_on_windows() {
+        // The Windows Defender Firewall hint is a real cause ONLY on Windows;
+        // printing it unconditionally (the field bug, hit on macOS) actively
+        // misdirects a user on any other platform.
+        let windows_lines = embed_skipped_lines(None, Some("http://127.0.0.1:7777"), None, true);
+        assert!(
+            windows_lines.join("\n").contains("Firewall"),
+            "the Windows hint must still show when the host platform is Windows"
+        );
+
+        let non_windows_lines =
+            embed_skipped_lines(None, Some("http://127.0.0.1:7777"), None, false);
+        assert!(
+            !non_windows_lines.join("\n").contains("Firewall"),
+            "the Windows-only hint must not print on a non-Windows host: got: {:?}",
+            non_windows_lines
+        );
     }
 
     #[test]
     fn embed_skipped_no_server_suggests_starting_one() {
-        let lines = embed_skipped_lines(None, None, None);
+        let lines = embed_skipped_lines(None, None, None, false);
         let joined = lines.join("\n");
         assert!(joined.contains("spelunk server start"));
     }
@@ -1087,10 +1145,13 @@ mod tests {
         ] {
             for url in [Some("http://x:1"), None] {
                 for remote_url in [None, Some("https://team.example:7777")] {
-                    assert!(
-                        !embed_skipped_lines(state, url, remote_url).is_empty(),
-                        "state {state:?} url {url:?} remote_url {remote_url:?} produced no notice"
-                    );
+                    for is_windows in [false, true] {
+                        assert!(
+                            !embed_skipped_lines(state, url, remote_url, is_windows).is_empty(),
+                            "state {state:?} url {url:?} remote_url {remote_url:?} \
+                             is_windows {is_windows} produced no notice"
+                        );
+                    }
                 }
             }
         }

--- a/crates/spelunk-core/src/config/mod.rs
+++ b/crates/spelunk-core/src/config/mod.rs
@@ -23,7 +23,10 @@ pub use persist::{
     remove_server_key_with, save_auth_tokens, save_auth_tokens_to, save_server_key,
     save_server_key_with, write_project_slug,
 };
-pub use predicates::{is_loopback_url, looks_like_uuid, no_server_env_set, validate_transport_url};
+pub use predicates::{
+    is_loopback_url, is_loopback_url_missing_port, looks_like_uuid, no_server_env_set,
+    validate_transport_url,
+};
 pub use project_id::derive_project_id;
 pub use sync_mode::SyncMode;
 pub use tls::apply_server_ca;
@@ -488,6 +491,28 @@ pub fn default_secret_store() -> Result<Box<dyn SecretStore>> {
     secret_store::default_store(&spelunk_config_dir())
 }
 
+/// Build the warning line for a loopback `server_url` with no port, or
+/// `None` when no warning applies. Pure so it's unit-testable without
+/// capturing stderr; `Config::validate_with_project` prints the result.
+///
+/// A loopback `server_url` missing a port can never be the auto-discovered
+/// local daemon (which always binds a specific port, default 7777): it is a
+/// near-certain leftover misconfiguration, most often a stale `server_url`
+/// after a team-server value was pared down to a bare host. This is a
+/// warning, not a validation error: unlike a non-loopback plaintext
+/// `http://` URL, it isn't a security problem, just a likely mistake.
+fn portless_loopback_server_url_warning(url: &str) -> Option<String> {
+    if !is_loopback_url_missing_port(url) {
+        return None;
+    }
+    Some(format!(
+        "Warning: server_url ({url}) is a loopback host with no port; this can never be \
+         the auto-discovered local server (default port 7777). If this is a leftover \
+         value, remove server_url from config; otherwise add the port your server \
+         actually listens on."
+    ))
+}
+
 impl Config {
     /// Validate cross-field constraints. Call after `load()`.
     ///
@@ -519,6 +544,11 @@ impl Config {
                  Add `project_id = \"my-project\"` to .spelunk/config.toml \
                  or set SPELUNK_PROJECT_ID."
             );
+        }
+        if let Some(url) = &self.server_url
+            && let Some(warning) = portless_loopback_server_url_warning(url)
+        {
+            eprintln!("{warning}");
         }
         Ok(())
     }
@@ -861,6 +891,57 @@ memory_server_key = "old-token"
             ..Default::default()
         };
         assert!(cfg.validate().is_err());
+    }
+
+    // ── portless_loopback_server_url_warning ─────────────────────────────────
+
+    #[test]
+    fn portless_loopback_server_url_warning_fires_for_bare_localhost() {
+        // The exact field-observed misconfig: `server_url = "http://localhost"`
+        // with no port, silently accepted and used instead of the healthy
+        // auto-discovered daemon on 7777.
+        let warning = portless_loopback_server_url_warning("http://localhost")
+            .expect("a portless loopback server_url must produce a warning");
+        assert!(warning.contains("http://localhost"), "got: {warning}");
+        assert!(warning.contains("no port"), "got: {warning}");
+    }
+
+    #[test]
+    fn portless_loopback_server_url_warning_is_none_when_port_present() {
+        assert_eq!(
+            portless_loopback_server_url_warning("http://localhost:7777"),
+            None
+        );
+        assert_eq!(
+            portless_loopback_server_url_warning("http://127.0.0.1:7777"),
+            None
+        );
+    }
+
+    #[test]
+    fn portless_loopback_server_url_warning_is_none_for_non_loopback_host() {
+        // A non-loopback https:// URL with no explicit port is normal
+        // (default port 443), not a misconfiguration signal.
+        assert_eq!(
+            portless_loopback_server_url_warning("https://team.example.com"),
+            None
+        );
+    }
+
+    #[test]
+    fn validate_still_passes_for_a_portless_loopback_server_url() {
+        // The warning is advisory, not a hard error: a portless loopback
+        // server_url is still a *valid* transport (is_loopback_url_missing_port
+        // is orthogonal to validate_transport_url's scheme/security check).
+        let cfg = Config {
+            server_url: Some("http://localhost".to_string()),
+            project_id: None,
+            ..Default::default()
+        };
+        assert!(
+            cfg.validate().is_ok(),
+            "a portless loopback server_url must warn, not fail validate()"
+        );
     }
 
     // ── validate_with_project() — --project satisfies the requirement ──────────

--- a/crates/spelunk-core/src/config/predicates.rs
+++ b/crates/spelunk-core/src/config/predicates.rs
@@ -48,6 +48,30 @@ pub fn is_loopback_url(url: &str) -> bool {
     matches!(host, "localhost" | "127.0.0.1" | "::1") || host.starts_with("127.")
 }
 
+/// Return `true` when `url` targets a loopback host (see [`is_loopback_url`])
+/// but names no explicit port.
+///
+/// A loopback `server_url` with no port can never be the auto-discovered
+/// local daemon (which always binds a specific port, default `7777`): it is a
+/// near-certain leftover misconfiguration (e.g. a stale `server_url` after a
+/// team-server value was cleared down to a bare host). Callers use this to
+/// warn, not reject: unlike [`validate_transport_url`], a portless loopback
+/// URL is not a security problem, so it's a warning rather than a hard error.
+pub fn is_loopback_url_missing_port(url: &str) -> bool {
+    if !is_loopback_url(url) {
+        return false;
+    }
+    let host_part = url
+        .trim_start_matches("http://")
+        .trim_start_matches("https://");
+    let host = host_part.split('/').next().unwrap_or(host_part);
+    match host.strip_prefix('[') {
+        // IPv6: `[::1]` (no port) vs `[::1]:7777` (port present after `]:`).
+        Some(_) => !host.contains("]:"),
+        None => !host.contains(':'),
+    }
+}
+
 /// Validate that `url` is an acceptable transport for sending a bearer token /
 /// talking to a spelunk-server: either `https://` (any host), or `http://` to a
 /// loopback host (`127.0.0.1`, `::1`, `localhost`).
@@ -125,6 +149,36 @@ mod tests {
     fn is_loopback_url_rejects_address_with_127_in_path() {
         // Should NOT match just because "127" appears somewhere
         assert!(!is_loopback_url("http://example.com/proxy/127.0.0.1"));
+    }
+
+    // ── is_loopback_url_missing_port ─────────────────────────────────────────
+
+    #[test]
+    fn is_loopback_url_missing_port_flags_bare_localhost() {
+        // The exact field-observed misconfig: a stale `server_url =
+        // "http://localhost"` with no port, which can never be the
+        // auto-discovered daemon (default port 7777).
+        assert!(is_loopback_url_missing_port("http://localhost"));
+        assert!(is_loopback_url_missing_port("https://localhost"));
+        assert!(is_loopback_url_missing_port("http://localhost/"));
+        assert!(is_loopback_url_missing_port("http://127.0.0.1"));
+        assert!(is_loopback_url_missing_port("http://[::1]"));
+        assert!(is_loopback_url_missing_port("http://[::1]/"));
+    }
+
+    #[test]
+    fn is_loopback_url_missing_port_accepts_when_port_present() {
+        assert!(!is_loopback_url_missing_port("http://localhost:7777"));
+        assert!(!is_loopback_url_missing_port("http://127.0.0.1:7777"));
+        assert!(!is_loopback_url_missing_port("http://[::1]:7777"));
+    }
+
+    #[test]
+    fn is_loopback_url_missing_port_ignores_non_loopback_hosts() {
+        // A non-loopback host without a port is a normal https:// URL
+        // (default port 443), not a misconfiguration signal.
+        assert!(!is_loopback_url_missing_port("https://example.com"));
+        assert!(!is_loopback_url_missing_port("http://team-server:7777"));
     }
 
     // ── validate_transport_url (loopback-only plaintext http) ──────────────────


### PR DESCRIPTION
## Summary

`spelunk index` skips the embedding phase whenever it cannot reach its inference server, but the diagnostic it printed was misdirecting:

- It always suggested a Windows Defender Firewall exception, even when running on macOS or Linux.
- It never stated that the target came from an explicitly configured `server_url` (as opposed to the auto-discovered local daemon), and gave no path from the message back to the real cause when a healthy local daemon was running elsewhere.
- A loopback `server_url` with no port (for example a stale `http://localhost` left in config) was silently accepted, even though it can never be the auto-discovered daemon, which always binds a specific port.

## Changes

- `crates/spelunk-cli/src/cli/cmd/index/mod.rs`: the embed-skipped notice now names the actual `server_url` it tried, states explicitly that it is a configured override of the auto-discovered local server, and only shows the Windows Defender Firewall hint when actually running on Windows (`cfg!(windows)`).
- `crates/spelunk-core/src/config/predicates.rs`: adds `is_loopback_url_missing_port` to detect a loopback host with no port.
- `crates/spelunk-core/src/config/mod.rs`: wires a soft warning (not a hard validation error) into `Config::validate_with_project` for a portless loopback `server_url`, naming the URL and suggesting either removing it or adding the correct port.

Deliberately left out of scope:
- The exit code for `spelunk index` when embeddings are skipped stays 0; this is existing best-effort degrade behavior (falls back to text/ast-grep search) and changing it is a bigger behavioral change than this diagnostic fix.
- `spelunk search`'s equivalent unreachable-server message (`semantic_unavailable_message` in `crates/spelunk-cli/src/cli/cmd/search.rs`) has the same unconditional Windows hint, and additionally never prints the attempted URL at all. It's a real bug in the same family, but a different command entry point, so it has been filed separately rather than folded into this fix.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo fmt --all -- --check` - clean.
- `SPELUNK_SECRET_STORE=file cargo clippy -p spelunk-core -p spelunk-cli --all-targets -- -D warnings` - clean.
- `SPELUNK_SECRET_STORE=file cargo nextest run -p spelunk-core -p spelunk-cli` - 1428 passed, 4 skipped, 0 failed.
- Added/verified unit tests directly exercise: the Windows-only firewall hint (both branches), the "configured server_url" wording, the portless-loopback warning firing only for loopback hosts with no port (and not for non-loopback hosts or loopback hosts with a port), and that `Config::validate()` still returns `Ok` for a portless loopback `server_url` (advisory warning, not a hard error).
