### PR TITLE
Suppress ANSI color on non-tty stdout and honor NO_COLOR

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/check.rs
+++ b/crates/spelunk-cli/src/cli/cmd/check.rs
@@ -1,3 +1,4 @@
+use super::color::cprintln;
 use anyhow::Result;
 use clap::Args;
 use std::path::PathBuf;
@@ -151,7 +152,7 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                     } else {
                         features.join(", ")
                     };
-                    println!("Server:  {url}  \x1b[32m✓\x1b[0m  ({feature_str} available)");
+                    cprintln!("Server:  {url}  \x1b[32m✓\x1b[0m  ({feature_str} available)");
                 }
                 capability::Tier::Offline => {
                     let url = cfg.server_url.as_deref().unwrap_or("?");
@@ -161,7 +162,7 @@ pub async fn check(args: CheckArgs, cfg: Config) -> Result<()> {
                         }
                         _ => "unreachable, offline mode".to_string(),
                     };
-                    println!("Server:  {url}  \x1b[31m✗\x1b[0m  {label}");
+                    cprintln!("Server:  {url}  \x1b[31m✗\x1b[0m  {label}");
                 }
             }
         }

--- a/crates/spelunk-cli/src/cli/cmd/color.rs
+++ b/crates/spelunk-cli/src/cli/cmd/color.rs
@@ -1,0 +1,115 @@
+//! Centralised policy for whether stdout output includes ANSI SGR color
+//! escapes.
+//!
+//! Every command that hand-writes `\x1b[...m` color codes should print
+//! through [`cprintln`] instead of `println!`, so the on/off decision lives
+//! in exactly one place ([`color_enabled`]) instead of being re-derived (or
+//! forgotten) per command.
+
+use std::io::IsTerminal as _;
+use std::sync::OnceLock;
+
+/// `--color` flag value.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ColorChoice {
+    /// Color on when stdout is a terminal and `NO_COLOR` is unset (default).
+    #[default]
+    Auto,
+    /// Always emit color, regardless of tty state or `NO_COLOR`.
+    Always,
+    /// Never emit color.
+    Never,
+}
+
+static CHOICE: OnceLock<ColorChoice> = OnceLock::new();
+
+/// Record the effective `--color` choice for this process. Called once from
+/// `main`, before any command prints output.
+pub(crate) fn set_color_choice(choice: ColorChoice) {
+    let _ = CHOICE.set(choice);
+}
+
+/// Pure decision function, so the policy is unit-testable without a real tty
+/// or mutating process env: given the `--color` flag, the raw `NO_COLOR`
+/// value (if set), and whether stdout is a terminal, should output be
+/// colored?
+///
+/// `Always`/`Never` are unconditional overrides. Otherwise (`Auto`),
+/// `NO_COLOR` (<https://no-color.org>; present and non-empty) forces color
+/// off regardless of tty state; failing that, color follows the tty.
+pub(crate) fn resolve_color(
+    choice: ColorChoice,
+    no_color_env: Option<&str>,
+    stdout_is_terminal: bool,
+) -> bool {
+    match choice {
+        ColorChoice::Always => true,
+        ColorChoice::Never => false,
+        ColorChoice::Auto => {
+            let no_color = no_color_env.is_some_and(|v| !v.is_empty());
+            !no_color && stdout_is_terminal
+        }
+    }
+}
+
+/// Whether ANSI color should be emitted on stdout right now.
+pub(crate) fn color_enabled() -> bool {
+    resolve_color(
+        CHOICE.get().copied().unwrap_or_default(),
+        std::env::var("NO_COLOR").ok().as_deref(),
+        std::io::stdout().is_terminal(),
+    )
+}
+
+/// `println!`, but strips ANSI SGR escapes from the formatted line when
+/// [`color_enabled`] is false.
+macro_rules! cprintln {
+    () => { println!() };
+    ($($arg:tt)*) => {{
+        let line = format!($($arg)*);
+        if $crate::cli::cmd::color::color_enabled() {
+            println!("{line}");
+        } else {
+            println!("{}", spelunk_core::utils::strip_ansi(&line));
+        }
+    }};
+}
+pub(crate) use cprintln;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_is_off_when_stdout_is_not_a_terminal() {
+        assert!(!resolve_color(ColorChoice::Auto, None, false));
+    }
+
+    #[test]
+    fn auto_is_on_when_stdout_is_a_terminal_and_no_color_unset() {
+        assert!(resolve_color(ColorChoice::Auto, None, true));
+    }
+
+    #[test]
+    fn no_color_wins_even_on_a_terminal() {
+        assert!(!resolve_color(ColorChoice::Auto, Some("1"), true));
+    }
+
+    #[test]
+    fn empty_no_color_does_not_disable_color() {
+        // no-color.org: the convention only fires when the var is "present
+        // and not an empty string" — an exported-but-empty NO_COLOR must not
+        // flip color off.
+        assert!(resolve_color(ColorChoice::Auto, Some(""), true));
+    }
+
+    #[test]
+    fn explicit_always_overrides_no_color_and_non_tty() {
+        assert!(resolve_color(ColorChoice::Always, Some("1"), false));
+    }
+
+    #[test]
+    fn explicit_never_overrides_a_terminal() {
+        assert!(!resolve_color(ColorChoice::Never, None, true));
+    }
+}

--- a/crates/spelunk-cli/src/cli/cmd/context.rs
+++ b/crates/spelunk-cli/src/cli/cmd/context.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::Args;
 use std::path::PathBuf;
 
+use super::color::cprintln;
 use super::memory::cross_project::collect_dep_cross_cutting;
 use super::memory::print_note_summary;
 use crate::storage::memory::Note;
@@ -339,12 +340,12 @@ fn print_section_header(kind: &str) {
         "requirement" => "Requirements",
         other => other,
     };
-    println!("\x1b[1;34m── {label} \x1b[0m");
+    cprintln!("\x1b[1;34m── {label} \x1b[0m");
     println!();
 }
 
 fn print_conventions_section(records: &[crate::conventions::ConventionRecord]) {
-    println!("\x1b[1;34m── Conventions \x1b[0m");
+    cprintln!("\x1b[1;34m── Conventions \x1b[0m");
     println!();
 
     // Group by language for readability.
@@ -354,7 +355,7 @@ fn print_conventions_section(records: &[crate::conventions::ConventionRecord]) {
         by_lang.entry(r.language.as_str()).or_default().push(r);
     }
     for (lang, recs) in &by_lang {
-        println!("\x1b[1m{lang}\x1b[0m");
+        cprintln!("\x1b[1m{lang}\x1b[0m");
         for r in recs {
             println!(
                 "  [{:.0}%] {} — {}",

--- a/crates/spelunk-cli/src/cli/cmd/graph.rs
+++ b/crates/spelunk-cli/src/cli/cmd/graph.rs
@@ -28,6 +28,7 @@ pub struct GraphArgs {
     pub live: bool,
 }
 
+use super::color::cprintln;
 use super::helpers::open_project_db;
 use super::search::{index_is_stale, maybe_warn_stale};
 use crate::config::Config;
@@ -172,12 +173,15 @@ fn graph_live(symbol: &str, format: &str, kind_filter: &Option<String>, root: &P
             }
         }
         _ => {
-            println!("\x1b[1mIncoming to '{symbol}' (live scan — no ranking):\x1b[0m");
+            cprintln!("\x1b[1mIncoming to '{symbol}' (live scan — no ranking):\x1b[0m");
             for e in &edges {
                 let loc = e.source_name.as_deref().unwrap_or(&e.source_file);
-                println!(
+                cprintln!(
                     "  \x1b[36m{}\x1b[0m  {}  \x1b[2m({}:{})\x1b[0m",
-                    e.kind, e.source_file, loc, e.line
+                    e.kind,
+                    e.source_file,
+                    loc,
+                    e.line
                 );
             }
         }
@@ -202,34 +206,44 @@ fn print_edges(edges: &[GraphEdge], query: &str) {
         .collect();
 
     if !outgoing.is_empty() {
-        println!("\x1b[1mOutgoing from '{query}':\x1b[0m");
+        cprintln!("\x1b[1mOutgoing from '{query}':\x1b[0m");
         for e in &outgoing {
             let loc = e.source_name.as_deref().unwrap_or(&e.source_file);
-            println!(
+            cprintln!(
                 "  \x1b[33m{}\x1b[0m  {}  \x1b[2m({}:{})\x1b[0m",
-                e.kind, e.target_name, loc, e.line
+                e.kind,
+                e.target_name,
+                loc,
+                e.line
             );
         }
         println!();
     }
     if !incoming.is_empty() {
-        println!("\x1b[1mIncoming to '{query}':\x1b[0m");
+        cprintln!("\x1b[1mIncoming to '{query}':\x1b[0m");
         for e in &incoming {
             let loc = e.source_name.as_deref().unwrap_or(&e.source_file);
-            println!(
+            cprintln!(
                 "  \x1b[36m{}\x1b[0m  {}  \x1b[2m({}:{})\x1b[0m",
-                e.kind, e.source_file, loc, e.line
+                e.kind,
+                e.source_file,
+                loc,
+                e.line
             );
         }
         println!();
     }
     if !other.is_empty() {
-        println!("\x1b[1mRelated edges:\x1b[0m");
+        cprintln!("\x1b[1mRelated edges:\x1b[0m");
         for e in &other {
             let loc = e.source_name.as_deref().unwrap_or(&e.source_file);
-            println!(
+            cprintln!(
                 "  {} -- \x1b[33m{}\x1b[0m --> {}  \x1b[2m({}:{})\x1b[0m",
-                loc, e.kind, e.target_name, e.source_file, e.line
+                loc,
+                e.kind,
+                e.target_name,
+                e.source_file,
+                e.line
             );
         }
     }

--- a/crates/spelunk-cli/src/cli/cmd/init.rs
+++ b/crates/spelunk-cli/src/cli/cmd/init.rs
@@ -1,3 +1,4 @@
+use super::color::cprintln;
 use anyhow::{Context, Result};
 use clap::Args;
 
@@ -245,7 +246,7 @@ pub async fn init(args: InitArgs, cfg: Config) -> Result<()> {
         println!("  Memory:  {line}");
     }
     if let Some(line) = server_line {
-        println!("  Server:  {line}");
+        cprintln!("  Server:  {line}");
     }
     for line in &notes_lines {
         println!("  {line}");

--- a/crates/spelunk-cli/src/cli/cmd/memory/graph_cmd.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/graph_cmd.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+use super::super::color::cprintln;
 use super::{MemoryGraphArgs, backend_err};
 use crate::{config::Config, storage::open_memory_backend};
 
@@ -55,7 +56,7 @@ pub(super) async fn memory_graph(
         return Ok(());
     }
 
-    println!("\x1b[1m#{} [{}] {}\x1b[0m", root.id, root.kind, root.title);
+    cprintln!("\x1b[1m#{} [{}] {}\x1b[0m", root.id, root.kind, root.title);
 
     if outgoing.is_empty() && incoming.is_empty() {
         println!("  (no relationships)");
@@ -74,7 +75,7 @@ pub(super) async fn memory_graph(
             "contradicts" => "\x1b[31m─[contradicts]→\x1b[0m",
             k => &format!("─[{k}]→"),
         };
-        println!("  {arrow}  #{} {target_title}", e.to_id);
+        cprintln!("  {arrow}  #{} {target_title}", e.to_id);
     }
     for e in &incoming {
         let src_title = backend
@@ -88,7 +89,7 @@ pub(super) async fn memory_graph(
             "contradicts" => "\x1b[31m←[contradicted by]\x1b[0m",
             k => &format!("←[{k}]"),
         };
-        println!("  {arrow}  #{} {src_title}", e.from_id);
+        cprintln!("  {arrow}  #{} {src_title}", e.from_id);
     }
     Ok(())
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 
+use super::super::color::cprintln;
 use super::{MemoryHarvestArgs, backend_err};
 use crate::{
     capability,
@@ -408,7 +409,7 @@ async fn memory_harvest_git(
             };
 
             let short_sha = &full_sha[..full_sha.len().min(8)];
-            println!("  + [{kind}] #{note_id}: {title}  \x1b[2m({short_sha})\x1b[0m");
+            cprintln!("  + [{kind}] #{note_id}: {title}  \x1b[2m({short_sha})\x1b[0m");
             stored += 1;
         }
     }
@@ -771,7 +772,7 @@ async fn memory_harvest_failures(
             };
 
             let short_sha = &full_sha[..full_sha.len().min(8)];
-            println!("  + [antipattern] #{note_id}: {title}  \x1b[2m({short_sha})\x1b[0m");
+            cprintln!("  + [antipattern] #{note_id}: {title}  \x1b[2m({short_sha})\x1b[0m");
             stored += 1;
         }
     }

--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
@@ -9,6 +9,7 @@ use std::io::BufRead as _;
 
 use anyhow::{Context, Result};
 
+use super::super::color::cprintln;
 use super::{MemoryHarvestArgs, backend_err};
 use crate::{
     config::Config,
@@ -435,7 +436,7 @@ pub(super) async fn harvest_claude_code(
             };
 
             let short_id = &session_id[..session_id.len().min(8)];
-            println!("  + [{kind}] #{note_id}: {title}  \x1b[2m({short_id}…)\x1b[0m");
+            cprintln!("  + [{kind}] #{note_id}: {title}  \x1b[2m({short_id}…)\x1b[0m");
             stored += 1;
         }
     }

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -1,3 +1,4 @@
+use super::color::cprintln;
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
@@ -517,7 +518,7 @@ pub(super) fn print_note_summary(n: &crate::storage::memory::Note) {
         .as_deref()
         .map(|p| format!("  \x1b[36m[from: {p}]\x1b[0m"))
         .unwrap_or_default();
-    println!(
+    cprintln!(
         "\x1b[1m#{id}\x1b[0m  \x1b[33m[{kind}]\x1b[0m  {title}{archived}{dist_fmt}{source}",
         id = n.id,
         kind = n.kind,
@@ -530,9 +531,9 @@ pub(super) fn print_note_summary(n: &crate::storage::memory::Note) {
         },
         source = source_badge,
     );
-    println!("     \x1b[2m{}\x1b[0m", format_age(n.created_at));
+    cprintln!("     \x1b[2m{}\x1b[0m", format_age(n.created_at));
     if let Some(valid_at) = n.valid_at {
-        println!("     \x1b[2mvalid_at: {}\x1b[0m", format_age(valid_at));
+        cprintln!("     \x1b[2mvalid_at: {}\x1b[0m", format_age(valid_at));
     }
     if !n.tags.is_empty() {
         println!("     tags: {}", n.tags.join(", "));
@@ -541,18 +542,18 @@ pub(super) fn print_note_summary(n: &crate::storage::memory::Note) {
         println!("     files: {}", n.linked_files.join(", "));
     }
     if let Some(sup) = n.superseded_by {
-        println!("     \x1b[2msuperseded by #{sup}\x1b[0m");
+        cprintln!("     \x1b[2msuperseded by #{sup}\x1b[0m");
     }
     if !matches!(n.kind.as_str(), "question" | "answer") {
         let preview: Vec<&str> = n.body.lines().take(2).collect();
         for line in &preview {
-            println!("     \x1b[2m{line}\x1b[0m");
+            cprintln!("     \x1b[2m{line}\x1b[0m");
         }
         if n.body.lines().count() > 2 {
-            println!("     \x1b[2m…\x1b[0m");
+            cprintln!("     \x1b[2m…\x1b[0m");
         }
     } else {
-        println!(
+        cprintln!(
             "     \x1b[2m(use `spelunk memory show {}` to read body)\x1b[0m",
             n.id
         );

--- a/crates/spelunk-cli/src/cli/cmd/memory/show.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/show.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+use super::super::color::{color_enabled, cprintln};
 use super::super::status::format_age;
 use super::MemoryShowArgs;
 use crate::{config::Config, storage::open_memory_backend};
@@ -18,8 +19,8 @@ pub(super) async fn memory_show(
         Some(n) => match crate::utils::effective_format(&args.format) {
             "json" => println!("{}", serde_json::to_string_pretty(&n)?),
             _ => {
-                println!("\x1b[1m#{} [{}] {}\x1b[0m", n.id, n.kind, n.title);
-                println!("\x1b[2m{}\x1b[0m", format_age(n.created_at));
+                cprintln!("\x1b[1m#{} [{}] {}\x1b[0m", n.id, n.kind, n.title);
+                cprintln!("\x1b[2m{}\x1b[0m", format_age(n.created_at));
                 let effective_valid_at = n.valid_at.unwrap_or(n.created_at);
                 if n.valid_at.is_some() || effective_valid_at != n.created_at {
                     println!("valid_at:   {}", format_age(effective_valid_at));
@@ -37,7 +38,10 @@ pub(super) async fn memory_show(
                 }
                 if let Some(ref sha) = n.source_ref {
                     let short = &sha[..sha.len().min(8)];
-                    if std::io::IsTerminal::is_terminal(&std::io::stdout()) {
+                    // Two genuinely different strings (not just colored vs.
+                    // plain), so this branches on the centralized color
+                    // decision directly instead of going through `cprintln!`.
+                    if color_enabled() {
                         println!(
                             "source:  \x1b[36mgit show {sha}\x1b[0m  \x1b[2m(SHA: {short})\x1b[0m"
                         );
@@ -51,7 +55,7 @@ pub(super) async fn memory_show(
                 let (outgoing, incoming) = backend.get_edges(n.id).await?;
                 if !outgoing.is_empty() || !incoming.is_empty() {
                     println!();
-                    println!("\x1b[2m── relationships ──\x1b[0m");
+                    cprintln!("\x1b[2m── relationships ──\x1b[0m");
                     for e in &outgoing {
                         let label = match e.kind.as_str() {
                             "supersedes" => "\x1b[33m→ supersedes\x1b[0m",
@@ -64,7 +68,7 @@ pub(super) async fn memory_show(
                             .await?
                             .map(|n| n.title)
                             .unwrap_or_else(|| "(deleted)".to_string());
-                        println!("  {label}  #{} {target_title}", e.to_id);
+                        cprintln!("  {label}  #{} {target_title}", e.to_id);
                     }
                     for e in &incoming {
                         let label = match e.kind.as_str() {
@@ -78,7 +82,7 @@ pub(super) async fn memory_show(
                             .await?
                             .map(|n| n.title)
                             .unwrap_or_else(|| "(deleted)".to_string());
-                        println!("  {label}  #{} {src_title}", e.from_id);
+                        cprintln!("  {label}  #{} {src_title}", e.from_id);
                     }
                 }
             }

--- a/crates/spelunk-cli/src/cli/cmd/memory/since.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/since.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+use super::super::color::cprintln;
 use super::MemorySinceArgs;
 use crate::{capability, config::Config};
 
@@ -124,19 +125,19 @@ fn print_notes(notes: &[NoteResponse], format: &str) {
                 } else {
                     ""
                 };
-                println!(
+                cprintln!(
                     "\x1b[1m#{id}\x1b[0m  \x1b[33m[{kind}]\x1b[0m  {title}{archived}{dist}",
                     id = n.id,
                     kind = n.kind,
                     title = n.title,
                     archived = archived_badge,
                 );
-                println!(
+                cprintln!(
                     "     \x1b[2m{}\x1b[0m",
                     super::super::status::format_age(n.created_at)
                 );
                 if let Some(sup) = n.superseded_by {
-                    println!("     \x1b[2msuperseded by #{sup}\x1b[0m");
+                    cprintln!("     \x1b[2msuperseded by #{sup}\x1b[0m");
                 }
                 if !n.tags.is_empty() {
                     println!("     tags: {}", n.tags.join(", "));
@@ -146,10 +147,10 @@ fn print_notes(notes: &[NoteResponse], format: &str) {
                 }
                 let preview: Vec<&str> = n.body.lines().take(2).collect();
                 for line in &preview {
-                    println!("     \x1b[2m{line}\x1b[0m");
+                    cprintln!("     \x1b[2m{line}\x1b[0m");
                 }
                 if n.body.lines().count() > 2 {
-                    println!("     \x1b[2m…\x1b[0m");
+                    cprintln!("     \x1b[2m…\x1b[0m");
                 }
                 println!();
             }

--- a/crates/spelunk-cli/src/cli/cmd/memory/timeline.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/timeline.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+use super::super::color::cprintln;
 use super::super::helpers::{embed_query, require_server_client};
 use super::super::status::format_age;
 use super::{MemoryTimelineArgs, backend_err};
@@ -45,12 +46,12 @@ pub(super) async fn memory_timeline(
     match crate::utils::effective_format(&args.format) {
         "json" => println!("{}", serde_json::to_string_pretty(&notes)?),
         _ => {
-            println!("\x1b[1mTimeline: {}\x1b[0m\n", args.query);
+            cprintln!("\x1b[1mTimeline: {}\x1b[0m\n", args.query);
             let (active, superseded): (Vec<_>, Vec<_>) =
                 notes.iter().partition(|n| n.status == "active");
 
             if !active.is_empty() {
-                println!("\x1b[32mActive\x1b[0m");
+                cprintln!("\x1b[32mActive\x1b[0m");
                 for n in &active {
                     print_timeline_entry(n);
                 }
@@ -59,7 +60,7 @@ pub(super) async fn memory_timeline(
                 if !active.is_empty() {
                     println!();
                 }
-                println!("\x1b[2mSuperseded / Archived\x1b[0m");
+                cprintln!("\x1b[2mSuperseded / Archived\x1b[0m");
                 for n in &superseded {
                     print_timeline_entry(n);
                 }
@@ -86,7 +87,7 @@ fn print_timeline_entry(n: &crate::storage::memory::Note) {
         .invalid_at
         .map(|t| format!(" \x1b[2m– {}\x1b[0m", format_age(t)))
         .unwrap_or_default();
-    println!(
+    cprintln!(
         " {marker} \x1b[36m{}\x1b[0m  \x1b[1m[{}] #{} {}\x1b[0m{sup}{short_ref}{inv}",
         format_age(ts),
         n.kind,
@@ -95,5 +96,5 @@ fn print_timeline_entry(n: &crate::storage::memory::Note) {
     );
     let excerpt: String = n.body.chars().take(80).collect();
     let ellipsis = if n.body.len() > 80 { "…" } else { "" };
-    println!("     \x1b[2m{excerpt}{ellipsis}\x1b[0m");
+    cprintln!("     \x1b[2m{excerpt}{ellipsis}\x1b[0m");
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/watch.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/watch.rs
@@ -13,6 +13,7 @@
 use anyhow::{Context, Result};
 use futures_util::StreamExt;
 
+use super::super::color::cprintln;
 use super::MemoryWatchArgs;
 use crate::{capability, config::Config};
 
@@ -256,9 +257,9 @@ fn print_cloud_event(data: &str) -> bool {
             let kind = e.kind.as_deref().unwrap_or("?");
             let title = e.title.as_deref().unwrap_or("(untitled)");
             let seq = e.seq.unwrap_or(0);
-            println!("\x1b[1mseq-{seq:07}\x1b[0m  \x1b[33m[{kind}]\x1b[0m  {title}",);
+            cprintln!("\x1b[1mseq-{seq:07}\x1b[0m  \x1b[33m[{kind}]\x1b[0m  {title}",);
             if let Some(ts) = &e.created_at {
-                println!("     \x1b[2m{ts}\x1b[0m");
+                cprintln!("     \x1b[2m{ts}\x1b[0m");
             }
             println!();
             true
@@ -266,12 +267,12 @@ fn print_cloud_event(data: &str) -> bool {
         "memory.archived" => {
             let id = e.entry_id.as_deref().unwrap_or("?");
             let seq = e.seq.unwrap_or(0);
-            println!("\x1b[2mseq-{seq:07}  archived {id}\x1b[0m");
+            cprintln!("\x1b[2mseq-{seq:07}  archived {id}\x1b[0m");
             println!();
             true
         }
         "memory.conflict_detected" | "memory.conflict_resolved" => {
-            println!("\x1b[2m{data}\x1b[0m");
+            cprintln!("\x1b[2m{data}\x1b[0m");
             true
         }
         "auth_error" => {
@@ -294,13 +295,13 @@ fn print_legacy_note(data: &str) {
         tags: Vec<String>,
     }
     if let Ok(n) = serde_json::from_str::<Slim>(data) {
-        println!(
+        cprintln!(
             "\x1b[1m#{id}\x1b[0m  \x1b[33m[{kind}]\x1b[0m  {title}",
             id = n.id,
             kind = n.kind,
             title = n.title,
         );
-        println!(
+        cprintln!(
             "     \x1b[2m{}\x1b[0m",
             super::super::status::format_age(n.created_at)
         );

--- a/crates/spelunk-cli/src/cli/cmd/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod auth_api;
 pub mod check;
+pub(crate) mod color;
 pub mod context;
 mod embed_worker;
 pub mod explore;
@@ -26,6 +27,7 @@ mod ui;
 
 pub use auth::auth;
 pub use check::check;
+pub(crate) use color::{ColorChoice, set_color_choice};
 pub use context::context;
 pub use explore::explore;
 pub use graph::graph;

--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -45,6 +45,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use super::color::cprintln;
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 
@@ -903,7 +904,7 @@ async fn cmd_status() -> Result<()> {
 
     match (pid, port) {
         (Some(pid), Some(port)) if pid_is_alive(pid) => {
-            println!("spelunk-server  \x1b[32mrunning\x1b[0m");
+            cprintln!("spelunk-server  \x1b[32mrunning\x1b[0m");
             println!("  PID:   {pid}");
             println!("  Port:  {port}");
             println!("  Log:   {}", log_path(&state_dir).display());
@@ -920,20 +921,20 @@ async fn cmd_status() -> Result<()> {
                     }
                 }
                 None => {
-                    println!("  URL:   http://127.0.0.1:{port}  \x1b[31m(unreachable)\x1b[0m");
+                    cprintln!("  URL:   http://127.0.0.1:{port}  \x1b[31m(unreachable)\x1b[0m");
                 }
             }
         }
         (Some(pid), _) if pid_is_alive(pid) => {
-            println!("spelunk-server  \x1b[33mrunning\x1b[0m (port unknown)");
+            cprintln!("spelunk-server  \x1b[33mrunning\x1b[0m (port unknown)");
             println!("  PID: {pid}");
         }
         (Some(pid), _) => {
-            println!("spelunk-server  \x1b[31mstopped\x1b[0m (stale pid={pid})");
+            cprintln!("spelunk-server  \x1b[31mstopped\x1b[0m (stale pid={pid})");
             println!("  Run `spelunk server start` to start.");
         }
         (None, _) => {
-            println!("spelunk-server  \x1b[31mnot started\x1b[0m");
+            cprintln!("spelunk-server  \x1b[31mnot started\x1b[0m");
             println!("  Run `spelunk server start` to start.");
         }
     }

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -1,3 +1,4 @@
+use super::color::cprintln;
 use anyhow::{Context, Result};
 use clap::Args;
 
@@ -269,9 +270,9 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
         } else {
             // Detailed view per project
             for p in &projects {
-                println!("\x1b[1m{}\x1b[0m", p.root_path.display());
+                cprintln!("\x1b[1m{}\x1b[0m", p.root_path.display());
                 if !p.root_path.exists() {
-                    println!("  \x1b[31m[root path missing from disk]\x1b[0m");
+                    cprintln!("  \x1b[31m[root path missing from disk]\x1b[0m");
                 }
                 println!("  DB: {}", p.db_path.display());
                 println!("  Registered: {}", format_age(p.registered_at));
@@ -285,7 +286,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
                             println!("  Last indexed: {}", format_age(ts));
                         }
                     }
-                    Err(_) => println!("  \x1b[2m(no index yet)\x1b[0m"),
+                    Err(_) => cprintln!("  \x1b[2m(no index yet)\x1b[0m"),
                 }
                 let deps = reg.get_deps(p.id)?;
                 if !deps.is_empty() {
@@ -335,7 +336,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
     print_tier_section(tier, &cfg, &mem_label, &mem_path_text).await;
 
     if let Some(p) = &resolved.project {
-        println!("Project: \x1b[1m{}\x1b[0m", p.root_path.display());
+        cprintln!("Project: \x1b[1m{}\x1b[0m", p.root_path.display());
     }
     println!("Index:      {}", db_path.display());
     println!("Files:      {}", s.file_count);
@@ -367,7 +368,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
             tokens.as_ref().map(|t| t.pending_tokens).unwrap_or(0),
             eta,
         ) {
-            println!("{line}");
+            cprintln!("{line}");
         }
     }
     if let Some(ts) = s.last_indexed {
@@ -389,7 +390,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
     // Drift signals: files that haven't changed while the project has evolved
     let drift = db.drift_candidates(30, 5).unwrap_or_default();
     if !drift.is_empty() {
-        println!("\n\x1b[33mDrift signals\x1b[0m  (unchanged while project evolved):");
+        cprintln!("\n\x1b[33mDrift signals\x1b[0m  (unchanged while project evolved):");
         println!("  {:<6}  {:<8}  File", "Days", "Callers");
         println!("  {}", "─".repeat(60));
         for d in &drift {
@@ -400,7 +401,7 @@ pub async fn status(args: StatusArgs, cfg: Config) -> Result<()> {
             };
             println!("  {:<6}  {:<8}  {}", d.days_behind, callers, d.path);
         }
-        println!(
+        cprintln!(
             "  \x1b[2mRun `spelunk search \"<topic>\"` to check if these are still relevant.\x1b[0m"
         );
     }
@@ -446,7 +447,7 @@ async fn print_tier_section(
             } else {
                 "  [set server_url to enable semantic search]".to_string()
             };
-            println!("Capability tier:  \x1b[33mOffline\x1b[0m");
+            cprintln!("Capability tier:  \x1b[33mOffline\x1b[0m");
             if let Some(line) = sync_mode_line(cfg, mem_path).await {
                 println!("{line}");
             }
@@ -469,7 +470,7 @@ async fn print_tier_section(
             } else {
                 url.clone()
             };
-            println!("Capability tier:  \x1b[32mServer\x1b[0m  \x1b[2m({url_label})\x1b[0m");
+            cprintln!("Capability tier:  \x1b[32mServer\x1b[0m  \x1b[2m({url_label})\x1b[0m");
             if let Some(line) = sync_mode_line(cfg, mem_path).await {
                 println!("{line}");
             }
@@ -486,7 +487,7 @@ async fn print_tier_section(
             // failing embedder lives on an explicit remote server_url.
             let remote_url = (!*auto_discovered).then_some(url.as_str());
             if let Some(line) = embedder_status_line(embedder_state, remote_url) {
-                println!("{line}");
+                cprintln!("{line}");
             }
             println!("  memory          {mem_label}");
             let explore_label = if caps.explore {

--- a/crates/spelunk-cli/src/cli/cmd/ui.rs
+++ b/crates/spelunk-cli/src/cli/cmd/ui.rs
@@ -1,3 +1,4 @@
+use super::color::cprintln;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::io::IsTerminal as _;
 
@@ -36,7 +37,9 @@ pub(crate) fn print_results_text(results: &[crate::search::SearchResult]) {
 
     for r in results {
         if r.from_graph && !printed_graph_header {
-            println!("\x1b[2m── Graph neighbours ─────────────────────────────────────────\x1b[0m");
+            cprintln!(
+                "\x1b[2m── Graph neighbours ─────────────────────────────────────────\x1b[0m"
+            );
             println!();
             display_idx = 0;
             printed_graph_header = true;
@@ -58,7 +61,7 @@ pub(crate) fn print_results_text(results: &[crate::search::SearchResult]) {
             String::new()
         };
 
-        println!(
+        cprintln!(
             "{:2}. {}\x1b[1m{}\x1b[0m  \x1b[2m{}:{}-{}\x1b[0m  \x1b[33m[{}: {}]\x1b[0m{}",
             display_idx,
             project_prefix,
@@ -78,7 +81,7 @@ pub(crate) fn print_results_text(results: &[crate::search::SearchResult]) {
         }
 
         if !r.governing_specs.is_empty() {
-            println!("    \x1b[2mSpec: {}\x1b[0m", r.governing_specs.join(", "));
+            cprintln!("    \x1b[2mSpec: {}\x1b[0m", r.governing_specs.join(", "));
         }
 
         let lines: Vec<&str> = r.content.lines().collect();
@@ -87,7 +90,7 @@ pub(crate) fn print_results_text(results: &[crate::search::SearchResult]) {
             println!("    {line}");
         }
         if lines.len() > preview_lines {
-            println!(
+            cprintln!(
                 "    \x1b[2m… ({} more lines)\x1b[0m",
                 lines.len() - preview_lines
             );
@@ -99,7 +102,7 @@ pub(crate) fn print_results_text(results: &[crate::search::SearchResult]) {
 pub(crate) fn print_chunks_text(chunks: &[crate::search::SearchResult]) {
     for (i, c) in chunks.iter().enumerate() {
         let name = c.name.as_deref().unwrap_or("<anonymous>");
-        println!(
+        cprintln!(
             "{:2}. \x1b[2m{}:{}-{}\x1b[0m  \x1b[33m[{}: {}]\x1b[0m",
             i + 1,
             c.language,
@@ -114,7 +117,7 @@ pub(crate) fn print_chunks_text(chunks: &[crate::search::SearchResult]) {
             println!("    {line}");
         }
         if lines.len() > preview {
-            println!("    \x1b[2m… ({} more lines)\x1b[0m", lines.len() - preview);
+            cprintln!("    \x1b[2m… ({} more lines)\x1b[0m", lines.len() - preview);
         }
         println!();
     }

--- a/crates/spelunk-cli/src/cli/mod.rs
+++ b/crates/spelunk-cli/src/cli/mod.rs
@@ -40,6 +40,11 @@ pub struct Cli {
     #[arg(short, long, global = true)]
     pub config: Option<std::path::PathBuf>,
 
+    /// Color output: auto (default, on when stdout is a terminal and
+    /// NO_COLOR is unset), always, or never
+    #[arg(long, global = true, value_enum, default_value_t = cmd::ColorChoice::Auto)]
+    pub color: cmd::ColorChoice,
+
     #[command(subcommand)]
     pub command: Command,
 }

--- a/crates/spelunk-cli/src/main.rs
+++ b/crates/spelunk-cli/src/main.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<()> {
         .mut_subcommand("explore", |c| c.hide(!llm_configured))
         .get_matches();
     let cli = Cli::from_arg_matches(&matches)?;
+    cli::cmd::set_color_choice(cli.color);
 
     // Config loads before dispatch, so `--best-effort` has to be honoured here
     // or a publish never reaches the arm that keeps a hook's push alive (D3).

--- a/crates/spelunk-cli/tests/color_output.rs
+++ b/crates/spelunk-cli/tests/color_output.rs
@@ -169,3 +169,146 @@ fn color_never_flag_suppresses_color() {
         .clone();
     assert_no_ansi(&out);
 }
+
+// ── spot-checks on other converted call sites ───────────────────────────────
+//
+// `memory list` above exercises `memory/mod.rs::print_note_summary` through
+// the shared `cprintln!` macro. The macro itself is one code path, but each
+// command still has to actually call through it instead of a leftover raw
+// `println!` with a hand-written `\x1b[...m` escape. These spot-check two of
+// the other converted sites named in the bug report (`graph`, `context`) so a
+// regression that reverts one call site back to `println!` fails here even
+// if `memory list` still passes.
+
+/// `spelunk graph <symbol> --live` needs no index or config: it runs an
+/// in-process ast-grep scan over the given directory (see
+/// `crates/spelunk-cli/src/cli/cmd/graph.rs::graph_live`). Its header line
+/// (`\x1b[1m...\x1b[0m`) and the `calls`/location fields go through
+/// `cprintln!` independently of `memory list`'s call site.
+fn graph_live_project() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join("a.rs"),
+        "fn helper_fn() {}\nfn caller() { helper_fn(); }\n",
+    )
+    .unwrap();
+    tmp
+}
+
+#[test]
+fn graph_live_default_has_no_ansi_on_non_tty_stdout() {
+    let tmp = graph_live_project();
+    let out = spelunk_bin()
+        .current_dir(tmp.path())
+        .arg("graph")
+        .arg("helper_fn")
+        .arg("--live")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_no_ansi(&out);
+}
+
+#[test]
+fn graph_live_color_always_has_ansi() {
+    let tmp = graph_live_project();
+    let out = spelunk_bin()
+        .current_dir(tmp.path())
+        .arg("--color")
+        .arg("always")
+        .arg("graph")
+        .arg("helper_fn")
+        .arg("--live")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_has_ansi(&out);
+}
+
+/// `spelunk context`'s section header (`print_section_header` in
+/// `crates/spelunk-cli/src/cli/cmd/context.rs`) emits a multi-parameter SGR
+/// code (`\x1b[1;34m`), the exact form the original bug report called out as
+/// a risk for a naive strip regex. `--no-conventions --local-only` keeps this
+/// to the plain memory-list path (no index DB, no cross-project lookup, no
+/// embedding call needed).
+fn context_project_with_decision() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("spelunk.db");
+    let mem_path = db_path.with_file_name("memory.db");
+    let config_path = write_config(tmp.path(), &db_path, "http://127.0.0.1:1");
+
+    spelunk_bin()
+        .current_dir(tmp.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_path)
+        .arg("add")
+        .arg("--kind")
+        .arg("decision")
+        .arg("--title")
+        .arg("color output test decision")
+        .arg("--body")
+        .arg("why we made this call")
+        .assert()
+        .success();
+
+    (tmp, mem_path, config_path)
+}
+
+fn context_cmd(mem_path: &std::path::Path, config_path: &std::path::Path) -> Command {
+    let mut cmd = spelunk_bin();
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("context")
+        .arg("--db")
+        .arg(mem_path)
+        .arg("--no-conventions")
+        .arg("--local-only");
+    cmd
+}
+
+#[test]
+fn context_section_header_has_no_ansi_on_non_tty_stdout() {
+    let (_tmp, mem_path, config_path) = context_project_with_decision();
+    let out = context_cmd(&mem_path, &config_path)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_no_ansi(&out);
+}
+
+#[test]
+fn context_section_header_no_color_env_suppresses_color() {
+    let (_tmp, mem_path, config_path) = context_project_with_decision();
+    let out = context_cmd(&mem_path, &config_path)
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_no_ansi(&out);
+}
+
+#[test]
+fn context_section_header_color_always_has_ansi() {
+    let (_tmp, mem_path, config_path) = context_project_with_decision();
+    let mut cmd = context_cmd(&mem_path, &config_path);
+    let out = cmd
+        .arg("--color")
+        .arg("always")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_has_ansi(&out);
+}

--- a/crates/spelunk-cli/tests/color_output.rs
+++ b/crates/spelunk-cli/tests/color_output.rs
@@ -1,0 +1,171 @@
+//! Regression coverage for the "ANSI color leaks onto piped/non-tty stdout,
+//! and NO_COLOR is ignored" bug.
+//!
+//! `spelunk memory list` (default text format) is the lightweight target here
+//! (no index or server needed, see `memory_list_format.rs`), but the fix
+//! lives in a shared helper so this doubles as coverage for every text-mode
+//! command that prints `\x1b[...m` escapes.
+
+mod plumbing_helpers;
+use plumbing_helpers::{spelunk_bin, write_config};
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+/// Create a temp project with a single memory note and return
+/// `(TempDir, mem_path, config_path)`. The `TempDir` must be kept alive for
+/// the duration of the test.
+fn project_with_memory_note() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("spelunk.db");
+    let mem_path = db_path.with_file_name("memory.db");
+
+    let config_path = write_config(tmp.path(), &db_path, "http://127.0.0.1:1");
+
+    spelunk_bin()
+        .current_dir(tmp.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_path)
+        .arg("add")
+        .arg("--kind")
+        .arg("note")
+        .arg("--title")
+        .arg("color output test note")
+        .arg("--body")
+        .arg("body content here")
+        .assert()
+        .success();
+
+    (tmp, mem_path, config_path)
+}
+
+fn memory_list_cmd(mem_path: &std::path::Path, config_path: &std::path::Path) -> Command {
+    let mut cmd = spelunk_bin();
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(mem_path)
+        .arg("list");
+    cmd
+}
+
+/// `assert_cmd::Command` always captures stdout through a pipe, so the child
+/// process's stdout is never a tty. That's exactly the "piped" case in the
+/// bug report: the raw `\x1b` (0x1b) control byte must never appear in
+/// output that isn't going to a terminal.
+fn assert_no_ansi(stdout: &[u8]) {
+    assert!(
+        !stdout.contains(&0x1b),
+        "expected no ANSI escape bytes in non-tty stdout, got: {:?}",
+        String::from_utf8_lossy(stdout)
+    );
+}
+
+fn assert_has_ansi(stdout: &[u8]) {
+    assert!(
+        stdout.contains(&0x1b),
+        "expected ANSI escape bytes (forced via --color=always), got: {:?}",
+        String::from_utf8_lossy(stdout)
+    );
+}
+
+// ── (a) non-tty stdout defaults to no color ─────────────────────────────────
+
+#[test]
+fn memory_list_default_has_no_ansi_on_non_tty_stdout() {
+    let (_tmp, mem_path, config_path) = project_with_memory_note();
+    let out = memory_list_cmd(&mem_path, &config_path)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_no_ansi(&out);
+}
+
+// ── (b) NO_COLOR forces color off regardless of tty state ──────────────────
+
+#[test]
+fn no_color_env_suppresses_color() {
+    let (_tmp, mem_path, config_path) = project_with_memory_note();
+    let out = memory_list_cmd(&mem_path, &config_path)
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_no_ansi(&out);
+}
+
+// ── (c) --color=always overrides both the non-tty default and NO_COLOR ─────
+
+#[test]
+fn color_always_flag_overrides_non_tty_default() {
+    let (_tmp, mem_path, config_path) = project_with_memory_note();
+    let mut cmd = spelunk_bin();
+    let out = cmd
+        .arg("--color")
+        .arg("always")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_path)
+        .arg("list")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_has_ansi(&out);
+}
+
+#[test]
+fn color_always_flag_overrides_no_color_env() {
+    let (_tmp, mem_path, config_path) = project_with_memory_note();
+    let mut cmd = spelunk_bin();
+    let out = cmd
+        .arg("--color")
+        .arg("always")
+        .env("NO_COLOR", "1")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_path)
+        .arg("list")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_has_ansi(&out);
+}
+
+// ── --color=never is an explicit, unconditional off-switch ─────────────────
+
+#[test]
+fn color_never_flag_suppresses_color() {
+    let (_tmp, mem_path, config_path) = project_with_memory_note();
+    let mut cmd = spelunk_bin();
+    let out = cmd
+        .arg("--color")
+        .arg("never")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("memory")
+        .arg("--db")
+        .arg(&mem_path)
+        .arg("list")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_no_ansi(&out);
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,8 +1,10 @@
 # Commands Reference
 
 Every command accepts `-c, --config <path>` to override the default config file
-(`~/.config/spelunk/config.toml`). The flags and defaults below match the
-installed binary; run `spelunk <command> --help` to confirm against your version.
+(`~/.config/spelunk/config.toml`), and `--color <auto|always|never>` to control
+colored output (default `auto`: on when stdout is a terminal and `NO_COLOR` is
+unset). The flags and defaults below match the installed binary; run
+`spelunk <command> --help` to confirm against your version.
 
 A local `spelunk-server` is autostarted on demand and provides embeddings
 (native, via the candle-served F2LLM-v2-330M model) and, when a chat model is
@@ -904,6 +906,7 @@ and publish on your next push.
 | Variable | Effect |
 |----------|--------|
 | `AGENT=true` | Force JSON output for commands that support it |
+| `NO_COLOR` | Any non-empty value disables colored output, overriding the `auto` default (`--color=always` still overrides `NO_COLOR`) |
 | `SPELUNK_NO_SERVER=1` | Never autostart or use a server (fully offline / no-server mode) |
 | `SPELUNK_SERVER_URL` | Point the CLI at a specific server URL |
 | `SPELUNK_CLOUD_URL` | Override the spelunk.cloud API URL used by `login` / `org` (default `https://api.spelunk.cloud`) |


### PR DESCRIPTION
## Summary

`spelunk` always emitted raw ANSI SGR color escapes on stdout, even when stdout was not a terminal (piped, redirected to a file, captured by an agent harness), and ignored the `NO_COLOR` convention (no-color.org). This garbled output for any human piping a command or any agent reading stdout.

- New `crates/spelunk-cli/src/cli/cmd/color.rs`: `ColorChoice::{Auto,Always,Never}`, a pure `resolve_color` decision function, and a `cprintln!` macro that strips ANSI when color is disabled.
- New global `--color <auto|always|never>` flag (default `auto`: color on only when stdout is a real terminal and `NO_COLOR` is unset).
- `NO_COLOR` (any non-empty value) now disables color under `auto`; an explicit `--color=always` still overrides it.
- Every command that hand-writes `\x1b[...m` escapes now prints through `cprintln!` instead of raw `println!`: `search`, `status`, `graph`, `check`, `server status`, `init`, `context`, and all `memory` subcommands.
- Added e2e coverage (`tests/color_output.rs`) across multiple call sites, including the multi-parameter `\x1b[1;34m` form used by `context`'s section headers.
- `docs/commands.md` documents the new flag and env var.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo fmt --all -- --check` — clean.
- `SPELUNK_SECRET_STORE=file cargo clippy -p spelunk-cli --all-targets -- -D warnings` — clean.
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli` — 455 unit tests + all integration suites green, 0 failed.
- Built the binary and manually ran `status`, `search`, `graph --live`, and `context` piped to `cat -v`:
  - Default (piped, non-tty): no raw ANSI bytes.
  - `NO_COLOR=1` (piped): no raw ANSI bytes.
  - `--color=always` (piped): raw `\x1b[...m` sequences present, including the `\x1b[1;34m` multi-param form in `context`.
- Verified real-tty behavior with `script` (pty): default output on a real terminal still shows color (no regression), and `NO_COLOR=1` on a real terminal still suppresses it.