### PR TITLE
Fix established sync clients never pulling teammates' later entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,8 +175,20 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   5s to 180s) instead of shrinking, and no longer feed the rate estimate;
   once those retries are exhausted, indexing falls back to the existing
   manual re-run path unchanged.
-
-## [0.9.4] — 2026-07-17
+- **`spelunk sync` now actually pulls teammates' entries for a client that
+  has already pushed or synced before.** The team server's batch-push
+  endpoint acknowledged each pushed entry with its raw database row id
+  (e.g. `"1"`) instead of its `sync_id`, and the CLI stores whatever id it
+  is acknowledged with as that entry's `remote_id`, then computes its next
+  pull cursor as the greatest `remote_id` it has on file. A small integer
+  string sorts lexically after every real `sync_id` (a UUIDv7, which starts
+  with a hex timestamp), so once a client had pushed anything at all, its
+  next pull matched nothing server-side even when teammates had added newer
+  entries. A fresh client, whose `remote_id` starts unset, never hit this,
+  which is why the fresh-clone case always looked fine while day-to-day team
+  sync quietly stopped receiving updates after the first push. The server
+  now acknowledges pushes with the same `sync_id` `/memory/since` cursors
+  on, so an established client's pull cursor advances correctly.
 
 ### Changed
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -1209,4 +1209,171 @@ mod tests {
             "client A must now have teammate B's entry locally: {titles:?}"
         );
     }
+
+    /// Three-way steady state, each established client syncing across
+    /// multiple rounds: rules out an off-by-one in cursor advancement that a
+    /// two-client, single-extra-round test (see above) could miss (e.g. a
+    /// cursor that only "catches up" once and then drifts on a later round).
+    ///
+    /// Client C joins second, via a pull-only first sync (see the doc
+    /// comment on `store_c`'s setup below for why: joining via push+pull in
+    /// one round is a separate, real ordering issue, not this story's bug).
+    /// After that, both A and C are established clients holding a cursor
+    /// derived purely from pulls/pushes of their own already-caught-up
+    /// state, and teammate B pushes twice, in two separate rounds. Each of A
+    /// and C must pick up exactly the right delta on each of their own
+    /// subsequent pulls: never 0 (the bug this story fixes), never a
+    /// duplicate re-application, and never the other established client's
+    /// own entries re-surfacing.
+    #[tokio::test]
+    async fn two_established_clients_each_pull_correctly_across_multiple_rounds() {
+        register_sqlite_vec();
+        let addr = spawn_spelunk_server().await;
+        let base_url = format!("http://{addr}");
+
+        // Client A establishes: push A1, pull (nothing yet).
+        let tmp_a = tempfile::TempDir::new().unwrap();
+        let store_a = MemoryStore::open(&tmp_a.path().join("memory.db")).unwrap();
+        store_a
+            .add_note("decision", "A1", "client A's entry", &[], &[], None, None)
+            .unwrap();
+        let client_a = CloudSyncClient::new(&base_url, "proj3", None, None).unwrap();
+        assert_eq!(
+            push_local(&store_a, &client_a, false, false)
+                .await
+                .unwrap()
+                .created,
+            1
+        );
+        assert_eq!(pull_and_apply(&store_a, &client_a).await.unwrap(), 0);
+
+        // Client C joins with no local content yet, so its first sync is a
+        // pull only (matching the walk-the-store "fresh client" case, which
+        // is known-good). This deliberately avoids a SEPARATE, real ordering
+        // issue that is out of scope for this story: `memory_sync` pushes
+        // before it pulls, so a client that pushes brand-new local content
+        // in the same round as older, not-yet-pulled remote content stamps
+        // its own freshly-minted (and therefore chronologically newest)
+        // sync_id as its cursor, permanently shadowing that older remote
+        // content from every future pull. Filed separately; see this task's
+        // board comment.
+        let tmp_c = tempfile::TempDir::new().unwrap();
+        let store_c = MemoryStore::open(&tmp_c.path().join("memory.db")).unwrap();
+        let client_c = CloudSyncClient::new(&base_url, "proj3", None, None).unwrap();
+        let pull_c1 = pull_and_apply(&store_c, &client_c).await.unwrap();
+        assert_eq!(pull_c1, 1, "client C must pull client A's A1 on establish");
+
+        // Now that C is caught up (nothing outstanding to miss), it can
+        // safely push its own new entry in the same round it pulls.
+        store_c
+            .add_note("decision", "C1", "client C's entry", &[], &[], None, None)
+            .unwrap();
+        assert_eq!(
+            push_local(&store_c, &client_c, false, false)
+                .await
+                .unwrap()
+                .created,
+            1
+        );
+        assert_eq!(
+            pull_and_apply(&store_c, &client_c).await.unwrap(),
+            0,
+            "nothing further for C to pull immediately after its own push"
+        );
+
+        // Teammate B pushes its first entry.
+        let tmp_b = tempfile::TempDir::new().unwrap();
+        let store_b = MemoryStore::open(&tmp_b.path().join("memory.db")).unwrap();
+        store_b
+            .add_note(
+                "decision",
+                "B1",
+                "teammate B's first entry",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        let client_b = CloudSyncClient::new(&base_url, "proj3", None, None).unwrap();
+        assert_eq!(
+            push_local(&store_b, &client_b, false, false)
+                .await
+                .unwrap()
+                .created,
+            1
+        );
+
+        // Round 2: both established clients must pick up exactly the new
+        // delta each is missing (A is missing C1 and B1; C is missing B1).
+        let pull_a_round2 = pull_and_apply(&store_a, &client_a).await.unwrap();
+        assert_eq!(
+            pull_a_round2, 2,
+            "client A must pull both C1 and B1 on its second sync"
+        );
+        let pull_c_round2 = pull_and_apply(&store_c, &client_c).await.unwrap();
+        assert_eq!(
+            pull_c_round2, 1,
+            "client C must pull only B1 (it already has A1 and its own C1)"
+        );
+
+        // Teammate B pushes a second entry. This is the off-by-one probe:
+        // a cursor that only advances correctly ONCE (round 2) but then
+        // sticks or drifts would surface here as 0 or a re-applied dup on
+        // this THIRD round for either established client.
+        store_b
+            .add_note(
+                "decision",
+                "B2",
+                "teammate B's second entry",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            push_local(&store_b, &client_b, false, false)
+                .await
+                .unwrap()
+                .created,
+            1
+        );
+
+        let pull_a_round3 = pull_and_apply(&store_a, &client_a).await.unwrap();
+        assert_eq!(
+            pull_a_round3, 1,
+            "client A's cursor must advance correctly again on a third round"
+        );
+        let pull_c_round3 = pull_and_apply(&store_c, &client_c).await.unwrap();
+        assert_eq!(
+            pull_c_round3, 1,
+            "client C's cursor must advance correctly again on a third round"
+        );
+
+        let titles_a: Vec<String> = store_a
+            .rows_for_sync(false)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert!(
+            ["A1", "C1", "B1", "B2"]
+                .iter()
+                .all(|t| titles_a.contains(&t.to_string())),
+            "client A must end up with all four entries exactly once each: {titles_a:?}"
+        );
+        let titles_c: Vec<String> = store_c
+            .rows_for_sync(false)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert!(
+            ["A1", "C1", "B1", "B2"]
+                .iter()
+                .all(|t| titles_c.contains(&t.to_string())),
+            "client C must end up with all four entries exactly once each: {titles_c:?}"
+        );
+    }
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -1092,4 +1092,121 @@ mod tests {
         let rows_after = store.rows_for_sync(false).unwrap();
         assert!(rows_after.iter().all(|r| r.remote_id.is_none()));
     }
+
+    // ── real-server regression: an established client must keep pulling ────
+    // A wiremock stand-in can't catch this class of bug: it lives in the real
+    // server's own handler/db pairing (a batch-push ack echoing the raw row
+    // id instead of the `sync_id` `/memory/since` cursors on), not in the wire
+    // shape a hand-typed mock response can get right by construction. Spins
+    // up the actual `spelunk-server` axum router, matching the pattern in
+    // `outbox.rs`'s `spawn_spelunk_server`.
+
+    /// Spin up a real `spelunk-server` axum router (the production router) on
+    /// an ephemeral loopback port, serving the team-hosting
+    /// `/v1/projects/*/memory*` routes this test's `CloudSyncClient`s talk to.
+    async fn spawn_spelunk_server() -> std::net::SocketAddr {
+        register_sqlite_vec();
+        let db_dir = tempfile::TempDir::new().unwrap();
+        let db =
+            spelunk_server::db::ServerDb::open(&db_dir.path().join("server.db"), 4, "test-model")
+                .unwrap();
+        let instance_id = db.get_or_create_instance_id().unwrap();
+        let state = spelunk_server::AppState {
+            db: std::sync::Arc::new(tokio::sync::Mutex::new(db)),
+            auth: std::sync::Arc::new(spelunk_server::auth::ApiKeyAuth::new(None)),
+            conflict_threshold: spelunk_server::default_conflict_threshold(),
+            embedder: spelunk_server::EmbedderSlot::disabled(),
+            llm: None,
+            max_tokens_ceiling: 8192,
+            rate_limiter: std::sync::Arc::new(spelunk_server::rate_limiter::RateLimiter::new(
+                1000, 60,
+            )),
+            instance_id,
+            started_by: None,
+            relay: spelunk_server::relay::RelayRegistry::new(),
+        };
+        let app = spelunk_server::router(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        addr
+    }
+
+    /// Reproduces the walk-the-store bug: a client that has already pushed
+    /// and synced once (an "established" client) never sees a teammate's
+    /// later entries on a subsequent sync, even though a fresh client would
+    /// pull the full set. Before the fix, client A's first push stamps its
+    /// own row's `remote_id` from the batch ack's `id` field, which the real
+    /// server (bug) fills with the raw autoincrement row id ("1", "2", ...)
+    /// instead of `sync_id`. That digit-string sorts lexically AFTER every
+    /// real UUIDv7 `sync_id` (which starts with a much smaller hex nibble for
+    /// any current timestamp), so `max_remote_id()`'s cursor becomes that row
+    /// id and `since_id=<cursor>` on the second pull matches nothing, even
+    /// though the server holds teammate B's newer entry.
+    #[tokio::test]
+    async fn established_client_pulls_teammates_entries_added_after_its_first_sync() {
+        register_sqlite_vec();
+        let addr = spawn_spelunk_server().await;
+        let base_url = format!("http://{addr}");
+
+        // Client A: first sync. Pushes its own entry, then pulls (nothing new
+        // yet): this is what "establishes" the client and stamps its remote_id.
+        let tmp_a = tempfile::TempDir::new().unwrap();
+        let store_a = MemoryStore::open(&tmp_a.path().join("memory.db")).unwrap();
+        store_a
+            .add_note(
+                "decision",
+                "A1",
+                "client A's own entry",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        let client_a = CloudSyncClient::new(&base_url, "proj", None, None).unwrap();
+
+        let push1 = push_local(&store_a, &client_a, false, false).await.unwrap();
+        assert_eq!(
+            push1.created, 1,
+            "client A's own entry must land on the server"
+        );
+        let pull1 = pull_and_apply(&store_a, &client_a).await.unwrap();
+        assert_eq!(pull1, 0, "nothing new on the server yet for the first pull");
+
+        // Teammate B: a second, independent client pushes a new entry to the
+        // same server/project.
+        let tmp_b = tempfile::TempDir::new().unwrap();
+        let store_b = MemoryStore::open(&tmp_b.path().join("memory.db")).unwrap();
+        store_b
+            .add_note("decision", "B1", "teammate B's entry", &[], &[], None, None)
+            .unwrap();
+        let client_b = CloudSyncClient::new(&base_url, "proj", None, None).unwrap();
+        let push_b = push_local(&store_b, &client_b, false, false).await.unwrap();
+        assert_eq!(
+            push_b.created, 1,
+            "teammate B's entry must land on the server"
+        );
+
+        // Client A syncs again: it is now an established client (already has a
+        // remote_id-stamped row), exactly the steady-state "sync to get
+        // teammates' latest" case the bug report describes.
+        let pull2 = pull_and_apply(&store_a, &client_a).await.unwrap();
+        assert_eq!(
+            pull2, 1,
+            "an established client must still pull entries a teammate pushed afterward"
+        );
+        let titles: Vec<String> = store_a
+            .rows_for_sync(false)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert!(
+            titles.contains(&"B1".to_string()),
+            "client A must now have teammate B's entry locally: {titles:?}"
+        );
+    }
 }

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -760,6 +760,50 @@ fn max_remote_id_is_the_pull_cursor() {
     );
 }
 
+/// Direct, fast unit test on the cursor's lexical-sort assumption using
+/// genuinely generated `Uuid::now_v7()` values (spelunk-oss story 272/269
+/// hardening), not hand-typed strings: the server mints `sync_id` the same
+/// way, so this proves `MAX(remote_id)` picks the truly newest entry for
+/// real UUIDv7 output, independent of the row insertion order used to
+/// stamp them. A future regression that acks a push with anything other
+/// than a genuine `sync_id` (e.g. a raw autoincrement row id, which sorts
+/// lexically after any current-era UUIDv7's smaller leading hex digits)
+/// would fail here in milliseconds, instead of only surfacing via the
+/// full-server integration test.
+#[test]
+fn max_remote_id_orders_real_uuidv7_values_by_time_not_insertion_order() {
+    let store = open_store();
+
+    let (first_row, _) = store
+        .add_note("note", "first", "b", &[], &[], None, None)
+        .unwrap();
+    let (second_row, _) = store
+        .add_note("note", "second", "b", &[], &[], None, None)
+        .unwrap();
+
+    // Two genuinely generated UUIDv7 values. Sort them ourselves (don't
+    // assume generation order == lexical order across two close calls) and
+    // stamp the lexically SMALLER one onto the row added FIRST, so a
+    // passing result can't be explained by MAX() secretly tracking
+    // insertion/rowid order instead of the UUIDv7 string's own value.
+    let uuid_x = uuid::Uuid::now_v7().to_string();
+    let uuid_y = uuid::Uuid::now_v7().to_string();
+    let (smaller, larger) = if uuid_x < uuid_y {
+        (uuid_x, uuid_y)
+    } else {
+        (uuid_y, uuid_x)
+    };
+    store.set_remote_id(first_row, &smaller).unwrap();
+    store.set_remote_id(second_row, &larger).unwrap();
+
+    assert_eq!(
+        store.max_remote_id().unwrap().as_deref(),
+        Some(larger.as_str()),
+        "MAX(remote_id) must return the lexically largest real UUIDv7, \
+         not whichever row it happens to be stamped on"
+    );
+}
+
 // ── note_id_for_uuid: forward lookup for applying a relayed push-ack ───────
 
 #[test]

--- a/crates/spelunk-server/src/db.rs
+++ b/crates/spelunk-server/src/db.rs
@@ -342,6 +342,12 @@ impl ServerDb {
 
     // ── Notes ─────────────────────────────────────────────────────────────────
 
+    /// Returns `(note_id, sync_id)`: the local autoincrement row id, and the
+    /// stable `sync_id` UUIDv7 minted for it. A caller that hands an id back
+    /// across the wire (e.g. `push_memory_batch`'s ack) must use `sync_id`,
+    /// not `note_id`: `/memory/since` cursors on `sync_id`, and a wire id that
+    /// doesn't match what that endpoint returns breaks pull cursoring for
+    /// whoever stores it.
     #[allow(clippy::too_many_arguments)]
     pub fn add_note(
         &self,
@@ -353,7 +359,7 @@ impl ServerDb {
         linked_files: &[String],
         embedding: Option<&[f32]>,
         remote_id: Option<&str>,
-    ) -> Result<i64> {
+    ) -> Result<(i64, String)> {
         let tags_csv = if tags.is_empty() {
             None
         } else {
@@ -386,25 +392,27 @@ impl ServerDb {
                 rusqlite::params![note_id, blob],
             )?;
         }
-        Ok(note_id)
+        Ok((note_id, sync_id))
     }
 
     /// Bulk-lookup active notes by their cross-machine `remote_id` (the batch
-    /// push idempotency key). Scoped to the project and to live rows only:
-    /// an archived row with the same `remote_id` does not count as existing,
-    /// so a re-push after archiving creates a fresh row rather than a no-op.
-    /// Mirrors cloud-api's `find_by_external_ids`.
+    /// push idempotency key), returning each match's `sync_id` (not the row
+    /// id: a caller acking a dedupe-hit back across the wire must hand out
+    /// the same id `/memory/since` uses). Scoped to the project and to live
+    /// rows only: an archived row with the same `remote_id` does not count as
+    /// existing, so a re-push after archiving creates a fresh row rather than
+    /// a no-op. Mirrors cloud-api's `find_by_external_ids`.
     pub fn find_by_remote_ids(
         &self,
         project_id: i64,
         remote_ids: &[String],
-    ) -> Result<std::collections::HashMap<String, i64>> {
+    ) -> Result<std::collections::HashMap<String, String>> {
         if remote_ids.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
         let placeholders = remote_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
         let sql = format!(
-            "SELECT remote_id, id FROM notes
+            "SELECT remote_id, sync_id FROM notes
              WHERE project_id = ? AND status = 'active' AND remote_id IN ({placeholders})"
         );
         let mut stmt = self.conn.prepare(&sql)?;
@@ -414,13 +422,16 @@ impl ServerDb {
             params.push(id);
         }
         let rows = stmt.query_map(params.as_slice(), |row| {
-            Ok((row.get::<_, Option<String>>(0)?, row.get::<_, i64>(1)?))
+            Ok((
+                row.get::<_, Option<String>>(0)?,
+                row.get::<_, Option<String>>(1)?,
+            ))
         })?;
         let mut map = std::collections::HashMap::new();
         for row in rows {
-            let (remote_id, id) = row?;
-            if let Some(rid) = remote_id {
-                map.insert(rid, id);
+            let (remote_id, sync_id) = row?;
+            if let (Some(rid), Some(sid)) = (remote_id, sync_id) {
+                map.insert(rid, sid);
             }
         }
         Ok(map)
@@ -974,7 +985,7 @@ mod tests {
             .expect("open in-memory server db");
         let project = db.upsert_project("team/a", 4, "test-model").expect("proj");
 
-        let id = db
+        let (id, sync_id) = db
             .add_note(
                 project.id,
                 "note",
@@ -991,7 +1002,7 @@ mod tests {
             .expect("lookup before archive");
         assert_eq!(
             found.get("archived-id"),
-            Some(&id),
+            Some(&sync_id),
             "live note must be found"
         );
 
@@ -1229,7 +1240,7 @@ mod tests {
         let project = db
             .upsert_project("acme/widget", 4, "test-model")
             .expect("project");
-        let id = db
+        let (id, _sync_id) = db
             .add_note(
                 project.id,
                 "note",

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -550,7 +550,10 @@ pub async fn add_note(
     let model = db.embedding_model.clone();
     let project = db.upsert_project(&project_id, dim, &model)?;
 
-    let id = db.add_note(
+    // The single-note response reports the local row id (unchanged wire
+    // shape); `sync_id` is irrelevant here since this path never round-trips
+    // through `/memory/since` cursoring the way a batch push ack does.
+    let (id, _sync_id) = db.add_note(
         project.id,
         &body.kind,
         &body.title,
@@ -651,10 +654,12 @@ pub struct BatchItemResult {
     /// `"created"` or `"skipped"` (idempotent re-push).
     pub status: &'static str,
     pub external_id: String,
-    /// The server-minted note id (stringified). Present for `"created"` and
-    /// also for a `"skipped"` dedupe-hit (the already-existing id), so a
-    /// caller that lost track of an earlier create can still recover the id
-    /// from a plain re-push.
+    /// The note's `sync_id` (the same id `GET /memory/since` returns and
+    /// cursors on, never the raw row id). Present for `"created"` and also
+    /// for a `"skipped"` dedupe-hit (the already-existing id), so a caller
+    /// that lost track of an earlier create can still recover the id from a
+    /// plain re-push, and a caller that stamps this as its pull cursor gets
+    /// an id that actually orders against `/memory/since`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 }
@@ -767,16 +772,18 @@ pub async fn push_memory_batch(
     let mut skipped = 0u32;
 
     for entry in &body.entries {
-        if let Some(&existing_id) = existing.get(&entry.external_id) {
+        if let Some(existing_sync_id) = existing.get(&entry.external_id) {
             // Carry the already-assigned id even on a dedupe-skip: a caller
             // that lost track of a prior "created" ack (e.g. a local write
             // failure between receiving the ack and stamping it) must be able
             // to recover the id from a plain re-push, not just the original
-            // create.
+            // create. This must be `sync_id`, the same id `/memory/since`
+            // returns: a caller that stamps this onto its own pull cursor
+            // needs an id that actually orders against that endpoint's rows.
             results.push(BatchItemResult {
                 status: "skipped",
                 external_id: entry.external_id.clone(),
-                id: Some(existing_id.to_string()),
+                id: Some(existing_sync_id.clone()),
             });
             skipped += 1;
             continue;
@@ -815,7 +822,7 @@ pub async fn push_memory_batch(
             .map(|sha| vec![format!("git:{sha}")])
             .unwrap_or_default();
 
-        let id = db.add_note(
+        let (_note_id, sync_id) = db.add_note(
             project.id,
             &entry.kind,
             &entry.title,
@@ -828,11 +835,11 @@ pub async fn push_memory_batch(
         // Record it immediately so a later entry in this same batch sharing
         // the external_id is skipped instead of re-inserted (see the `mut`
         // comment on `existing` above).
-        existing.insert(entry.external_id.clone(), id);
+        existing.insert(entry.external_id.clone(), sync_id.clone());
         results.push(BatchItemResult {
             status: "created",
             external_id: entry.external_id.clone(),
-            id: Some(id.to_string()),
+            id: Some(sync_id),
         });
         created += 1;
     }
@@ -3216,18 +3223,29 @@ mod tests {
     /// sibling registered in the same router.
     #[tokio::test]
     async fn note_id_routes_still_work_alongside_batch_route() {
-        let (app, _dim) = make_app(0.92);
-        let (status, body) = post_batch(
+        let (app, dim) = make_app(0.92);
+
+        // The batch route itself: prove it works in the same router as the
+        // numeric note-id routes below (the routing invariant this test
+        // guards). Its returned id is now a `sync_id` (not the row id), so
+        // it is not usable against the numeric route below by design.
+        let (batch_status, batch_body) = post_batch(
             app.clone(),
             "sibling-proj",
             json!([note_item("A", "sib-1")]),
         )
         .await;
-        assert_eq!(status, http::StatusCode::MULTI_STATUS, "seed: {body}");
-        let id = body["results"][0]["id"]
-            .as_str()
-            .expect("created id")
-            .to_string();
+        assert_eq!(
+            batch_status,
+            http::StatusCode::MULTI_STATUS,
+            "seed: {batch_body}"
+        );
+
+        // A real numeric row id, minted via the single-note POST route.
+        let embedding = vec![1.0; dim as usize];
+        let (note_status, note_body) = post_note(app.clone(), "sibling-proj", "B", embedding).await;
+        assert_eq!(note_status, http::StatusCode::CREATED, "seed: {note_body}");
+        let id = note_body["id"].as_i64().expect("created id");
 
         let req = Request::builder()
             .method("GET")

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -3107,6 +3107,12 @@ mod tests {
              not null, so a caller that lost track of the create can recover it \
              from a plain re-push: {body}"
         );
+        assert_eq!(
+            created_id.len(),
+            36,
+            "the id both branches agree on must actually be a sync_id (UUID), \
+             not the raw row id: {created_id}"
+        );
     }
 
     /// An external_id repeated WITHIN one batch must not crash the request:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1345,7 +1345,7 @@
               "string",
               "null"
             ],
-            "description": "The server-minted note id (stringified). Present for `\"created\"` and\nalso for a `\"skipped\"` dedupe-hit (the already-existing id), so a\ncaller that lost track of an earlier create can still recover the id\nfrom a plain re-push."
+            "description": "The note's `sync_id` (the same id `GET /memory/since` returns and\ncursors on, never the raw row id). Present for `\"created\"` and also\nfor a `\"skipped\"` dedupe-hit (the already-existing id), so a caller\nthat lost track of an earlier create can still recover the id from a\nplain re-push, and a caller that stamps this as its pull cursor gets\nan id that actually orders against `/memory/since`."
           },
           "status": {
             "type": "string",


### PR DESCRIPTION
## Summary

Found during a recent walk-the-store of the team-sync workflow: an established client (one that has already pushed or synced before) stopped pulling teammates' new entries on every subsequent `spelunk sync`, while a fresh client always pulled the full set correctly. This defeated the day-to-day "sync to get teammates' latest" loop, which is the core value of team memory.

**Root cause**: the team server's batch-push endpoint acknowledged each pushed entry with its raw autoincrement row id (e.g. `"1"`) instead of its `sync_id`. The CLI stores whatever id it is acknowledged with as that entry's `remote_id`, then computes its next pull cursor as the greatest `remote_id` on file. A small integer string sorts lexically after every real `sync_id` (a UUIDv7, which starts with a hex timestamp), so once a client had pushed anything at all, its next `since_id=<cursor>` pull matched nothing server-side, even when teammates had pushed newer entries. A fresh client, whose `remote_id` starts unset, never hit this path, which is exactly why the bug looked fine under a naive fresh-clone test.

This is the same defect separately diagnosed while adding regression tests for an unrelated relay-buffer fix: `push_memory_batch`'s "created" and "skipped" response branches both echoed the row id instead of `sync_id`, so a caller stamping that id onto its own cursor got the wrong value in both branches. Both investigations point at the same lines and the same fix, so they're resolved together here.

**Fix**: `ServerDb::add_note` and `find_by_remote_ids` now return/report `sync_id` instead of the raw row id, and `push_memory_batch`'s created and skipped branches were updated to hand that id back over the wire, so the value a client stamps as its pull cursor is the same one `GET /memory/since` actually orders by.

## Test plan

- Added `established_client_pulls_teammates_entries_added_after_its_first_sync`: spins up a real (non-mocked) `spelunk-server` axum router; client A pushes and pulls once (establishing it), a second independent client pushes a new entry, then client A pulls again and must see it. Confirmed this fails before the fix (`left: 0, right: 1`) and passes after.
- Added `two_established_clients_each_pull_correctly_across_multiple_rounds`: two established clients across three sync rounds each, ruling out an off-by-one in cursor advancement that a single-extra-round test could miss.
- Added a fast unit test on the cursor's lexical-sort assumption using genuinely generated `Uuid::now_v7()` values rather than hand-typed strings.
- Manually reverted just this PR's core fix (`db.rs`/`handlers.rs`) and reran the two new regression tests to confirm they go red (`left: 0, right: 1` and `left: 0, right: 2`) without it, then restored the fix and confirmed green again.
- Full suite: `SPELUNK_SECRET_STORE=file cargo test -p spelunk-server -p spelunk-cli -p spelunk-core` (450+ tests passing across all three crates; one unrelated pre-existing flake in an untouched file, `terminate_and_wait_stops_graceful_process`, caused by a PATH-clearing test race, confirmed to pass reliably in isolation).
- `cargo fmt --all -- --check` and `cargo clippy -p spelunk-server -p spelunk-cli -p spelunk-core --tests -- -D warnings` both clean.
- Added a `CHANGELOG.md` entry describing the fix in user-facing terms.