### PR TITLE
ci: fix Scoop release job pushing directly to protected main (GH013)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,6 +478,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      pull-requests: write
     steps:
       # Commit lands on main, not the tag ref.
       - uses: actions/checkout@v7
@@ -508,17 +509,41 @@ jobs:
 
           cat bucket/spelunk.json
 
-      - name: Commit and push bucket/spelunk.json
+      # This repo doubles as the Scoop bucket (unlike the separate,
+      # unprotected homebrew-spelunk tap repo above), so main's ruleset
+      # applies: a direct `git push origin main` is rejected with GH013
+      # (pull_request rule violation). That ruleset's
+      # required_approving_review_count is 0 and it has no required status
+      # checks, so opening a PR and merging it immediately in this same job
+      # satisfies the rule with no human in the loop and no extra token:
+      # just the default GITHUB_TOKEN with pull-requests: write added above.
+      - name: Open and merge a PR updating bucket/spelunk.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
           if git diff --quiet -- bucket/spelunk.json; then
-            echo "No changes to bucket/spelunk.json — skipping push."
+            echo "No changes to bucket/spelunk.json — skipping PR."
             exit 0
           fi
 
+          BRANCH="ci/scoop-manifest-${{ github.ref_name }}"
+
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add bucket/spelunk.json
           git commit -m "scoop: spelunk ${{ github.ref_name }}"
-          git push origin main
+          # -f: a retried run of this workflow (same tag) reuses the branch name.
+          git push -f origin "$BRANCH"
+
+          if ! gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr create \
+              --title "scoop: spelunk ${{ github.ref_name }}" \
+              --body "Automated Scoop bucket update for ${{ github.ref_name }}." \
+              --base main \
+              --head "$BRANCH"
+          fi
+
+          gh pr merge "$BRANCH" --merge --delete-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -476,6 +476,13 @@ jobs:
     if: ${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Serializes retries/manual re-runs for the same tag: two overlapping runs
+    # would both push to the same ci/scoop-manifest-<tag> branch and race on
+    # `gh pr create` (the loser errors "pull request already exists" and
+    # fails the job even though the PR the winner opened is fine).
+    concurrency:
+      group: scoop-manifest-${{ github.ref_name }}
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Root cause

`update-scoop-manifest` in `.github/workflows/release.yml` regenerates `bucket/spelunk.json` and used to `git push origin main` directly. This repo (`spelunk-cloud/spelunk`) doubles as the Scoop bucket itself (see `scoop bucket add spelunk https://github.com/spelunk-cloud/spelunk` in the docs), and `main` carries a repository ruleset requiring a pull request — so the direct push was rejected with GH013 on every release.

The sibling `update-homebrew-formula` job never hits this because it pushes to a separate, unprotected repo (`spelunk-cloud/homebrew-spelunk`).

Verified live against the ruleset (`gh api repos/spelunk-cloud/spelunk/rulesets/14457975`):
- `conditions.ref_name.include: ["~DEFAULT_BRANCH"]` — only `main` is protected; a working branch is unrestricted.
- `pull_request` rule has `required_approving_review_count: 0`, no `required_status_checks`, `allowed_merge_methods: ["merge", "squash"]`.
- `bypass_actors: []`, `current_user_can_bypass: "never"` — a PR is the only compliant path.

Since zero reviews/checks are required, opening and merging a PR in the same job satisfies the ruleset with no human in the loop and no new secret.

## Fix

- Added `pull-requests: write` to the job's `permissions` (alongside existing `contents: write`).
- Added a job-level `concurrency` group (`scoop-manifest-<tag>`, `cancel-in-progress: false`) so overlapping runs for the same tag (manual re-run / retry racing an in-flight run) don't both fight over the same working branch/PR.
- Replaced `git push origin main` with: commit on `ci/scoop-manifest-<tag>` → `git push -f origin "$BRANCH"` (idempotent on retry) → `gh pr create` (skipped if a PR for that branch already exists) → `gh pr merge "$BRANCH" --merge --delete-branch`.

## Test plan

This is pure CI YAML changing a release-only job path; it cannot be exercised end-to-end locally (no way to simulate a real tag push through the real protected branch and org PR-merge permissions from a dev machine). What *was* verified:

- `actionlint .github/workflows/release.yml` — zero new findings vs `origin/main` (both show the same single pre-existing `SC2129` shellcheck style note on line 413, in the untouched homebrew job).
- The ruleset fields cited above were re-fetched live via `gh api` during review, not taken on faith from an earlier snapshot.
- Retry/partial-failure states were walked through by inspection (branch-pushed-no-PR, PR-opened-not-merged, merged-but-job-reported-failure) — `push -f`, the `gh pr view` idempotency check, and a no-diff no-op on retry all resolve cleanly.
- Confirmed via `gh api repos/spelunk-cloud/spelunk/actions/permissions/workflow` that Actions is permitted to create PRs on this repo (`can_approve_pull_request_reviews: true`), and that the job's own `permissions:` block overrides the repo's `read`-only default.

**This has not run for real.** The PR-open-and-merge sequence itself will get its first real exercise on the next stable tag push. Recommend watching that release's `update-scoop-manifest` job run once this merges, in case something environment-specific (auth scope, branch protection interaction not visible via the ruleset API) surfaces only under a live run.