### PR TITLE
Fix preceding_comment() missing docstring for first member of enclosing block

### DIFF
--- a/crates/spelunk-core/src/indexer/parser/ts_walker.rs
+++ b/crates/spelunk-core/src/indexer/parser/ts_walker.rs
@@ -597,21 +597,37 @@ fn sql_object_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
 /// below. Python wraps decorator+def in one `decorated_definition` node, so
 /// the walk must start from that parent instead of `node`. TS/Java attach
 /// decorators as a child, so neither case applies there.
+///
+/// Some grammars (Python `class_definition`/`function_definition`, Ruby
+/// `class`/`module`) attach a leading comment as a child of the enclosing
+/// `block`'s own parent, immediately before the `body` field, rather than as
+/// the first child inside the block. That bites only the first documented
+/// member of a body: when `start` has no sibling of its own (nothing else in
+/// its block precedes it), check one level up for that comment-as-child case.
 pub(super) fn preceding_comment(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
     let start = match node.parent() {
         Some(parent) if parent.kind() == "decorated_definition" => parent,
         _ => *node,
     };
-    let mut prev = start.prev_sibling()?;
-    while prev.kind() == "\n"
-        || prev.kind() == "newline"
-        || prev.kind() == "attribute_item"
-        || prev.is_extra()
-            && prev.kind() != "comment"
-            && prev.kind() != "line_comment"
-            && prev.kind() != "block_comment"
-            && prev.kind() != "doc_comment"
-    {
+    match start.prev_sibling() {
+        Some(prev) => scan_backward_for_comment(prev, src),
+        None => scan_backward_for_comment(start.parent()?.prev_sibling()?, src),
+    }
+}
+
+fn scan_backward_for_comment(mut prev: tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
+    loop {
+        let skip = prev.kind() == "\n"
+            || prev.kind() == "newline"
+            || prev.kind() == "attribute_item"
+            || prev.is_extra()
+                && prev.kind() != "comment"
+                && prev.kind() != "line_comment"
+                && prev.kind() != "block_comment"
+                && prev.kind() != "doc_comment";
+        if !skip {
+            break;
+        }
         prev = prev.prev_sibling()?;
     }
     if matches!(

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -419,3 +419,37 @@ fn no_docstring_for_first_member_of_class_body_when_none_precedes_it() {
         .unwrap();
     assert_eq!(f.docstring, None);
 }
+
+#[test]
+fn docstring_scopes_to_immediate_enclosing_block_across_three_levels() {
+    // Guards the "bounded to one level" invariant: Inner's own doc must not
+    // leak down to m, and m must still find its own doc one level up rather
+    // than falling through to Outer's.
+    let src = "class Outer:\n    # outer doc\n    class Inner:\n        # inner doc\n        def m():\n            pass\n";
+    let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
+    let inner = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("Inner"))
+        .unwrap();
+    let m = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("m"))
+        .unwrap();
+    assert_eq!(inner.docstring.as_deref(), Some("# outer doc"));
+    assert_eq!(m.docstring.as_deref(), Some("# inner doc"));
+}
+
+#[test]
+fn docstring_captured_for_first_member_of_ruby_class_body() {
+    // Same grammar quirk as Python's class_definition/function_definition:
+    // tree-sitter-ruby attaches the leading comment as a child of `class`
+    // itself rather than inside `body_statement`. preceding_comment() is
+    // shared across languages, so the fix applies here too.
+    let src = "class Outer\n  # inner\n  def attributed\n  end\nend\n";
+    let chunks = SourceParser::parse(src, "f.rb", "ruby").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("# inner"));
+}

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -353,3 +353,69 @@ fn no_docstring_when_python_decorator_has_none_above_it() {
         .unwrap();
     assert_eq!(f.docstring, None);
 }
+
+// ── docstring on the first documented member of a block (spelunk-oss^257) ──
+//
+// tree-sitter-python attaches a comment that leads the first statement of a
+// class/function body as a child of the *enclosing* class_definition /
+// function_definition node (a sibling of `body`), not as the first child
+// inside the `block` itself. Only the first member is affected; once there's
+// an earlier statement in the block, the comment is already a normal sibling
+// within it.
+
+#[test]
+fn docstring_captured_for_first_member_of_class_body() {
+    let src = "class Outer:\n    # inner\n    def attributed():\n        pass\n";
+    let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("# inner"));
+}
+
+#[test]
+fn docstring_captured_for_first_decorated_member_of_class_body() {
+    let src = "class Outer:\n    # inner\n    @staticmethod\n    def attributed():\n        pass\n";
+    let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("# inner"));
+}
+
+#[test]
+fn docstring_captured_for_first_statement_of_function_body() {
+    let src = "def outer():\n    # inner\n    def attributed():\n        pass\n";
+    let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("# inner"));
+}
+
+#[test]
+fn docstring_captured_for_first_decorated_statement_of_function_body() {
+    let src = "def outer():\n    # inner\n    @staticmethod\n    def attributed():\n        pass\n";
+    let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("# inner"));
+}
+
+#[test]
+fn no_docstring_for_first_member_of_class_body_when_none_precedes_it() {
+    // First member, no comment at all — must not pick up an unrelated node
+    // one level up (e.g. the class name or `:` token).
+    let src = "class Outer:\n    def attributed():\n        pass\n";
+    let chunks = SourceParser::parse(src, "f.py", "python").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring, None);
+}

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -354,7 +354,7 @@ fn no_docstring_when_python_decorator_has_none_above_it() {
     assert_eq!(f.docstring, None);
 }
 
-// ── docstring on the first documented member of a block (spelunk-oss^257) ──
+// ── docstring on the first documented member of a block ──
 //
 // tree-sitter-python attaches a comment that leads the first statement of a
 // class/function body as a child of the *enclosing* class_definition /


### PR DESCRIPTION
## Summary
- `preceding_comment()` in `crates/spelunk-core/src/indexer/parser/ts_walker.rs` failed to capture the docstring for a nested function/class when its preceding comment was the first statement inside the enclosing block (tree-sitter-python/ruby attach that comment as a child of the *enclosing* node, one level above where `prev_sibling()` was looking).
- Fix adds a single bounded `.parent()?.prev_sibling()?` hop when there's no in-block sibling, structurally incapable of climbing more than one level (verified via a 3-level adversarial nesting test).
- Fixes the same gap in Ruby as a side effect (shared code path), verified empirically; JS/Rust were unaffected (comment already lives inside the block there).
- Added 6 tests: first member of class body (plain + decorated), first statement of function body (plain + decorated), 3-level nesting scope-bound regression, Ruby first-member regression, plus a negative case confirming no false-positive pickup of the class name/`:` token one level up.

## Test plan
- [x] `SPELUNK_SECRET_STORE=file cargo test -p spelunk-core` — full suite green, 0 failures (454 in main suite, 27 in `unit_chunker` incl. all 6 new/hardened tests)
- [x] Confirmed new tests are honest: file-swapped `ts_walker.rs` back to pre-fix `origin/main`, all 6 new/changed tests failed as expected (`None` vs `Some(...)`), restored fixed file, `git diff HEAD` byte-identical
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo audit` — no new advisories (diff touches no `Cargo.toml`/`Cargo.lock`)
- [x] Diff scope confirmed via `git diff origin/main --stat`: only `ts_walker.rs` and `unit_chunker.rs` touched