### PR TITLE
fix(cli): tolerate bounded fork-fd race in start_lock_is_exclusive_while_held

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -1418,13 +1418,36 @@ mod tests {
 
     // ── start lock (single-instance guard) ───────────────────────────────────
 
+    /// Polls `acquire_start_lock` until it succeeds or `timeout` elapses,
+    /// returning the last `Result`. `cargo test` compiles every `#[cfg(test)]`
+    /// module in the crate into one binary, so a `fork()` in an unrelated,
+    /// untagged test elsewhere in that binary can transiently duplicate this
+    /// process's fd table (including an already-released lock fd) and delay
+    /// when `flock`'s refcount actually reaches zero. That window is bounded
+    /// (milliseconds), so a short bounded retry reflects the lock's real
+    /// contract without requiring crate-wide serialization.
+    #[cfg(unix)]
+    fn retry_acquire_start_lock(state_dir: &Path, timeout: Duration) -> Result<StartLock> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            match acquire_start_lock(state_dir) {
+                Ok(lock) => return Ok(lock),
+                Err(e) if std::time::Instant::now() >= deadline => return Err(e),
+                Err(_) => std::thread::sleep(Duration::from_millis(10)),
+            }
+        }
+    }
+
     /// A second `acquire_start_lock` on the same state dir must fail while the
     /// first guard is still held (serialises concurrent `server start`).
     ///
     /// `#[serial(server_start_lock)]`: this test asserts on `flock` release
     /// timing, which a concurrent `fork()+exec()` in another test can delay (a
     /// forked child transiently inherits the lock fd until it execs). Grouped
-    /// with the process-spawning tests below so they never overlap.
+    /// with the process-spawning tests below so they never overlap each
+    /// other, though untagged subprocess-spawning tests elsewhere in the
+    /// crate's single test binary can still race this one; see
+    /// `retry_acquire_start_lock`.
     #[cfg(unix)]
     #[test]
     #[serial(server_start_lock)]
@@ -1436,8 +1459,26 @@ mod tests {
             "second lock must fail while the first is held"
         );
         drop(first);
-        // Released — a fresh acquire now succeeds.
-        assert!(acquire_start_lock(tmp.path()).is_ok(), "lock frees on drop");
+        // Released, but tolerate the bounded fork-fd race documented above
+        // instead of asserting success on the very first attempt.
+        assert!(
+            retry_acquire_start_lock(tmp.path(), Duration::from_millis(500)).is_ok(),
+            "lock frees on drop"
+        );
+    }
+
+    /// `retry_acquire_start_lock` must still report failure when the lock
+    /// genuinely never frees, not silently pass once the timeout elapses.
+    #[cfg(unix)]
+    #[test]
+    #[serial(server_start_lock)]
+    fn retry_acquire_start_lock_fails_when_lock_never_frees() {
+        let tmp = TempDir::new().unwrap();
+        let _held = acquire_start_lock(tmp.path()).expect("first lock acquires");
+        assert!(
+            retry_acquire_start_lock(tmp.path(), Duration::from_millis(50)).is_err(),
+            "must fail when the lock genuinely never frees within the timeout"
+        );
     }
 
     // ── state file / dir permissions (unix-gated) ───────────────────────────


### PR DESCRIPTION
## Summary

`start_lock_is_exclusive_while_held` (in `crates/spelunk-cli/src/cli/cmd/server.rs`) flaked under `--test-threads=10`: its final assertion re-acquired the start lock immediately after `drop(first)` and expected instant success. Because `cargo test` compiles every `#[cfg(test)]` module in the crate into one binary, an unrelated subprocess-spawning test elsewhere (`hooks.rs`, `memory/reconcile.rs`, `memory/harvest.rs`, etc.) can `fork()` concurrently and transiently duplicate this test's already-released lock fd via the fd-table copy, keeping the `flock`'s open-file-description refcount above zero for a brief window even after `drop(first)`.

- Widening `#[serial(server_start_lock)]` to cover every git-spawning test in the crate was considered and rejected — it would kill meaningful test parallelism without addressing the actual fork race (those tests would still fork, just serialized against this one test instead of racing it).
- Instead, the final assertion now polls via a new test-only `retry_acquire_start_lock(state_dir, timeout)` helper (10ms interval, 500ms total bound) instead of asserting success on the very first attempt. This matches the lock's real "frees eventually" contract.
- Added `retry_acquire_start_lock_fails_when_lock_never_frees`, which holds the lock for the whole timeout window and asserts the retry helper still returns `Err` — proving the loop can't silently pass just because time ran out.

**Test-only change — no production behavior is affected.** `acquire_start_lock`'s real-world caller (`spelunk server start`) has no concurrent lock-holding thread in that scenario; this only changes how the test tolerates a known, bounded test-isolation race.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli --bin spelunk` → 450 passed, 0 failed.
- `cargo fmt --check` → clean.
- `cargo clippy -p spelunk-cli --tests -- -D warnings` → clean.
- Repro (engineer, before/after, same commands both times): looped a subprocess-heavy filtered subset (`start_lock`, `hooks_dir_is_tracked`, `resolve_hooks_dir`, `reconcile`, `harvest`; 39 tests) 100x at `--test-threads=10`. Before fix: 4/100 failures, all `panicked at .../server.rs: lock frees on drop`. After fix: 0/100 failures.
- Independent confirmation (test-engineer): 25/25 passes of the same filtered subset.
- Independent re-verification (this review): ran the same filtered subset 10/10 times at `--test-threads=10` — 0 failures across all runs (400 individual test executions, 0 flakes). Ran the two lock-specific tests alone 10/10 times as a baseline sanity check — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)