### PR TITLE
fix(indexer): capture docstring across Ruby private/protected def one-liners

### DIFF
--- a/crates/spelunk-core/src/indexer/parser/ts_walker.rs
+++ b/crates/spelunk-core/src/indexer/parser/ts_walker.rs
@@ -596,7 +596,14 @@ fn sql_object_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
 /// Rust attributes (`#[derive(...)]`) are real siblings, skipped in the loop
 /// below. Python wraps decorator+def in one `decorated_definition` node, so
 /// the walk must start from that parent instead of `node`. TS/Java attach
-/// decorators as a child, so neither case applies there.
+/// decorators as a child, so neither case applies there. Ruby's
+/// `private def foo; end` visibility idiom (and lookalikes like `memoize def
+/// foo; end`) parses the def as a `method` node nested two levels inside a
+/// `call` (`private(def foo; end)`), so the walk must start from that `call`
+/// ancestor instead of the `method` node. Gated on the `method` being the
+/// argument_list's only child so an unrelated comment above a multi-arg call
+/// that merely happens to carry a `def` as one of several arguments (e.g.
+/// `some_call(other_arg, def foo; end)`) doesn't get misattached to `foo`.
 ///
 /// Some grammars (Python `class_definition`/`function_definition`, Ruby
 /// `class`/`module`) attach a leading comment as a child of the enclosing
@@ -607,6 +614,10 @@ fn sql_object_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
 pub(super) fn preceding_comment(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
     let start = match node.parent() {
         Some(parent) if parent.kind() == "decorated_definition" => parent,
+        Some(parent) if parent.kind() == "argument_list" => match parent.parent() {
+            Some(call) if call.kind() == "call" => call,
+            _ => *node,
+        },
         _ => *node,
     };
     match start.prev_sibling() {

--- a/crates/spelunk-core/src/indexer/parser/ts_walker.rs
+++ b/crates/spelunk-core/src/indexer/parser/ts_walker.rs
@@ -614,10 +614,12 @@ fn sql_object_name(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
 pub(super) fn preceding_comment(node: &tree_sitter::Node<'_>, src: &[u8]) -> Option<String> {
     let start = match node.parent() {
         Some(parent) if parent.kind() == "decorated_definition" => parent,
-        Some(parent) if parent.kind() == "argument_list" => match parent.parent() {
-            Some(call) if call.kind() == "call" => call,
-            _ => *node,
-        },
+        Some(parent) if parent.kind() == "argument_list" && parent.named_child_count() == 1 => {
+            match parent.parent() {
+                Some(call) if call.kind() == "call" => call,
+                _ => *node,
+            }
+        }
         _ => *node,
     };
     match start.prev_sibling() {

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -453,3 +453,36 @@ fn docstring_captured_for_first_member_of_ruby_class_body() {
         .unwrap();
     assert_eq!(f.docstring.as_deref(), Some("# inner"));
 }
+
+#[test]
+fn docstring_captured_across_a_ruby_private_def_one_liner() {
+    let src = "# does a thing\nprivate def attributed\nend\n";
+    let chunks = SourceParser::parse(src, "f.rb", "ruby").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("# does a thing"));
+}
+
+#[test]
+fn docstring_captured_across_a_ruby_protected_def_one_liner() {
+    let src = "# does a thing\nprotected def attributed\nend\n";
+    let chunks = SourceParser::parse(src, "f.rb", "ruby").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("# does a thing"));
+}
+
+#[test]
+fn docstring_captured_across_a_plain_ruby_def_no_visibility_wrapper() {
+    let src = "# does a thing\ndef attributed\nend\n";
+    let chunks = SourceParser::parse(src, "f.rb", "ruby").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("# does a thing"));
+}

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -486,3 +486,35 @@ fn docstring_captured_across_a_plain_ruby_def_no_visibility_wrapper() {
         .unwrap();
     assert_eq!(f.docstring.as_deref(), Some("# does a thing"));
 }
+
+#[test]
+fn docstring_captured_across_a_ruby_def_wrapped_by_any_sole_arg_call() {
+    // Generalizes beyond the `private`/`protected`/`public` keywords: any
+    // single-argument call wrapping a `def` (e.g. the `memoize` idiom from
+    // the memoist gem) should get the same treatment, since it parses to
+    // the identical `call(argument_list(method))` shape.
+    let src = "# memoized on first call\nmemoize def attributed\nend\n";
+    let chunks = SourceParser::parse(src, "f.rb", "ruby").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring.as_deref(), Some("# memoized on first call"));
+}
+
+#[test]
+fn no_docstring_misattached_when_def_is_one_of_several_call_arguments() {
+    // Over-reach guard: a `def` merely happens to be one of several
+    // arguments to an unrelated call (rare, but syntactically legal Ruby
+    // since `def` is an expression). The preceding comment describes the
+    // *call* as a whole, not specifically the nested `def`, so it must not
+    // be attached to the method's docstring the way the sole-argument
+    // `private def foo; end` idiom is.
+    let src = "# describes the call, not attributed specifically\nsome_call(other_arg, def attributed\nend)\n";
+    let chunks = SourceParser::parse(src, "f.rb", "ruby").unwrap();
+    let f = chunks
+        .iter()
+        .find(|c| c.name.as_deref() == Some("attributed"))
+        .unwrap();
+    assert_eq!(f.docstring, None);
+}


### PR DESCRIPTION
## Summary
- `preceding_comment()` in `ts_walker.rs` now walks back from the `call` ancestor when a `def` is the sole argument of a wrapping call — covers Ruby's `private def foo; end` / `protected def foo; end` one-liner visibility idiom (and generalizes to lookalikes like the memoist `memoize def foo; end`).
- Guarded with a `named_child_count() == 1` arity check so a `def` that merely happens to be one of several arguments to an unrelated call does not get the call's preceding comment misattached as its own docstring.
- Adds 5 regression tests to `unit_chunker.rs`: `private def`, `protected def`, plain `def` (no-regression negative), the sole-arg generalization (`memoize def`), and the arity-guard negative case (`def` as one of several call arguments).

## Test plan
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-core` — 454+ tests, all binaries green, 0 failed.
- Ran the new arity-guard test in isolation: `cargo test -p spelunk-core --test unit_chunker no_docstring_misattached` — passes, confirming `some_call(other_arg, def foo; end)` does NOT misattach a docstring to `foo`.
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` (full workspace) — clean.