### PR TITLE
spelunk-server: bounded embed admission control (429 + Retry-After)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -57,8 +57,8 @@ const CONNECT_FAILURE_BACKOFFS: [Duration; 5] = [
     Duration::from_secs(180),
 ];
 
-/// Fallback wait before retrying a `429` (server embed admission queue full,
-/// spelunk-oss#262) when the response carries no usable `Retry-After`. The
+/// Fallback wait before retrying a `429` (server embed admission queue full)
+/// when the response carries no usable `Retry-After`. The
 /// server always sends one in practice; this only guards a legacy/misbehaving
 /// server.
 const DEFAULT_SATURATION_RETRY: Duration = Duration::from_secs(5);
@@ -624,7 +624,7 @@ async fn run_embed_phase_with_backoff(
                 }
                 Err(EmbedBatchError::Saturated(retry_after)) => {
                     // The server is up and reachable but shed this request:
-                    // its bounded embed admission queue is full (spelunk-oss#262).
+                    // its bounded embed admission queue is full.
                     // No batch size fixes that either — retry the same size
                     // after the server's own `Retry-After`, composing with the
                     // connect-failure retry above rather than reusing its
@@ -717,8 +717,8 @@ enum EmbedBatchError {
     /// `reqwest::Error::is_connect`): the server is unreachable, which says
     /// nothing about whether this batch's size is appropriate.
     ConnectFailure(anyhow::Error),
-    /// Server returned 429: its bounded embed admission queue is full
-    /// (spelunk-oss#262), an explicit "shed and back off" signal from a
+    /// Server returned 429: its bounded embed admission queue is full,
+    /// an explicit "shed and back off" signal from a
     /// server that IS up and reachable — unlike `BudgetExceeded`, says
     /// nothing about this batch's size, and unlike `ConnectFailure`, the
     /// server itself names the wait via `Retry-After`.
@@ -1567,9 +1567,9 @@ mod tests {
     }
 
     // ── embed_one_batch: 429 (embed admission queue saturated) ──────────────
-    // (spelunk-oss#262: the server's admission gate sheds a request with 429
-    // + Retry-After instead of letting it queue behind the mutex-serialized
-    // embedder past its own timeout.)
+    // The server's admission gate sheds a request with 429 + Retry-After
+    // instead of letting it queue behind the mutex-serialized embedder past
+    // its own timeout.
 
     #[tokio::test]
     async fn embed_one_batch_classifies_429_as_saturated_with_parsed_retry_after() {
@@ -1794,7 +1794,6 @@ mod tests {
     }
 
     // ── run_embed_phase: honoring the server's 429 admission shedding ───────
-    // (spelunk-oss#262)
 
     #[tokio::test]
     async fn saturated_429_retries_same_batch_after_retry_after_then_succeeds() {

--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -57,6 +57,19 @@ const CONNECT_FAILURE_BACKOFFS: [Duration; 5] = [
     Duration::from_secs(180),
 ];
 
+/// Fallback wait before retrying a `429` (server embed admission queue full,
+/// spelunk-oss#262) when the response carries no usable `Retry-After`. The
+/// server always sends one in practice; this only guards a legacy/misbehaving
+/// server.
+const DEFAULT_SATURATION_RETRY: Duration = Duration::from_secs(5);
+
+/// Safety valve on how many times a batch retries a `429` before giving up
+/// like any other unrecoverable failure. Unlike a connect failure (binary
+/// up/down), the server explicitly tells us when to retry via `Retry-After`,
+/// so this is not expected to trigger in practice — it only bounds the
+/// pathological case of a queue that never drains.
+const MAX_SATURATION_RETRIES: usize = 30;
+
 /// Effective ceiling the calibrated batch size may grow to: `--batch-size`
 /// (0 → `DEFAULT_BATCH_CEILING`) clamped to `MAX_BATCH` and, when advertised,
 /// the server's own `max_batch_chunks` (413 above it). Only an upper bound —
@@ -488,9 +501,12 @@ async fn run_embed_phase_with_backoff(
         // patience (calibration batch 1, no rate estimate yet) or shrink and
         // retry, rather than aborting at 0 embedded. A connect failure is
         // also recoverable, but via a bounded backoff retry at the same size
-        // (see the `ConnectFailure` arm below). Any other failure aborts.
+        // (see the `ConnectFailure` arm below). A 429 (see `Saturated`) is
+        // recoverable the same way, but the wait comes from the server's own
+        // `Retry-After` instead of a fixed schedule. Any other failure aborts.
         let mut escalated_calibration_once = false;
         let mut connect_failures = 0usize;
+        let mut saturation_retries = 0usize;
         let bytes = 'retry: loop {
             let batch_tokens: u64 = chunk_ids_and_texts[cursor..cursor + this_batch_size]
                 .iter()
@@ -606,6 +622,35 @@ async fn run_embed_phase_with_backoff(
                     tokio::time::sleep(backoff).await;
                     continue 'retry;
                 }
+                Err(EmbedBatchError::Saturated(retry_after)) => {
+                    // The server is up and reachable but shed this request:
+                    // its bounded embed admission queue is full (spelunk-oss#262).
+                    // No batch size fixes that either — retry the same size
+                    // after the server's own `Retry-After`, composing with the
+                    // connect-failure retry above rather than reusing its
+                    // fixed schedule (the server already told us how long).
+                    if saturation_retries >= MAX_SATURATION_RETRIES {
+                        report_embed_failure(
+                            &bar,
+                            embedded,
+                            total,
+                            &server_url,
+                            anyhow::anyhow!(
+                                "server embed admission queue stayed saturated after \
+                                 {MAX_SATURATION_RETRIES} retries"
+                            ),
+                        );
+                        return Ok(embedded);
+                    }
+                    saturation_retries += 1;
+                    tracing::info!(
+                        "index/embed: server embedder busy (429), retrying the same batch \
+                         of {this_batch_size} chunk(s) in {retry_after:?} (attempt \
+                         {saturation_retries}/{MAX_SATURATION_RETRIES})",
+                    );
+                    tokio::time::sleep(retry_after).await;
+                    continue 'retry;
+                }
                 Err(EmbedBatchError::Other(e)) => {
                     // Any other failure: prior batches stay committed and a
                     // re-run backfills the rest. Report and stop rather than
@@ -672,8 +717,26 @@ enum EmbedBatchError {
     /// `reqwest::Error::is_connect`): the server is unreachable, which says
     /// nothing about whether this batch's size is appropriate.
     ConnectFailure(anyhow::Error),
+    /// Server returned 429: its bounded embed admission queue is full
+    /// (spelunk-oss#262), an explicit "shed and back off" signal from a
+    /// server that IS up and reachable — unlike `BudgetExceeded`, says
+    /// nothing about this batch's size, and unlike `ConnectFailure`, the
+    /// server itself names the wait via `Retry-After`.
+    Saturated(Duration),
     /// Any other failure (network error, non-408 status, malformed body).
     Other(anyhow::Error),
+}
+
+/// Parse a `Retry-After` header value as whole seconds, falling back to
+/// [`DEFAULT_SATURATION_RETRY`] when absent or not a plain integer (the
+/// server only ever sends delta-seconds, never an HTTP-date).
+fn parse_retry_after(resp: &reqwest::Response) -> Duration {
+    resp.headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_SATURATION_RETRY)
 }
 
 /// Send one embed batch and return the raw little-endian f32 response bytes: one
@@ -726,6 +789,10 @@ async fn embed_one_batch(
             "server returned 408 Request Timeout for index/embed \
              (batch of {batch_len} chunk(s) exceeded the server's request budget)"
         )));
+    }
+
+    if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return Err(EmbedBatchError::Saturated(parse_retry_after(&resp)));
     }
 
     let resp = match resp.error_for_status() {
@@ -1398,6 +1465,9 @@ mod tests {
             Err(EmbedBatchError::BudgetExceeded(e)) => panic!(
                 "a refused connection must classify as ConnectFailure, not BudgetExceeded: {e:#}"
             ),
+            Err(EmbedBatchError::Saturated(_)) => {
+                panic!("a refused connection must classify as ConnectFailure, not Saturated")
+            }
             Err(EmbedBatchError::Other(e)) => {
                 panic!("a refused connection must classify as ConnectFailure, not Other: {e:#}")
             }
@@ -1437,6 +1507,9 @@ mod tests {
                 "a slow-but-connected server must classify as BudgetExceeded, not \
                  ConnectFailure: {e:#}"
             ),
+            Err(EmbedBatchError::Saturated(_)) => {
+                panic!("a slow-but-connected server must classify as BudgetExceeded, not Saturated")
+            }
             Err(EmbedBatchError::Other(e)) => panic!(
                 "a slow-but-connected server must classify as BudgetExceeded, not Other: {e:#}"
             ),
@@ -1483,10 +1556,103 @@ mod tests {
                  BudgetExceeded, even when the underlying error also satisfies \
                  is_timeout(): {e:#}"
             ),
+            Err(EmbedBatchError::Saturated(_)) => {
+                panic!("a connect-phase timeout must classify as ConnectFailure, not Saturated")
+            }
             Err(EmbedBatchError::Other(e)) => {
                 panic!("a connect-phase timeout must classify as ConnectFailure, not Other: {e:#}")
             }
             Ok(_) => panic!("192.0.2.1 must never actually accept a connection"),
+        }
+    }
+
+    // ── embed_one_batch: 429 (embed admission queue saturated) ──────────────
+    // (spelunk-oss#262: the server's admission gate sheds a request with 429
+    // + Retry-After instead of letting it queue behind the mutex-serialized
+    // embedder past its own timeout.)
+
+    #[tokio::test]
+    async fn embed_one_batch_classifies_429_as_saturated_with_parsed_retry_after() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "7"))
+            .mount(&mock)
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/projects/x/index/embed", mock.uri());
+
+        let result = embed_one_batch(
+            &client,
+            &url,
+            None,
+            EmbedRequest { chunks: vec![] },
+            0,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        match result {
+            Err(EmbedBatchError::Saturated(retry_after)) => {
+                assert_eq!(
+                    retry_after,
+                    Duration::from_secs(7),
+                    "must parse the server's Retry-After value verbatim"
+                );
+            }
+            Err(EmbedBatchError::BudgetExceeded(e)) => {
+                panic!("a 429 must classify as Saturated, not BudgetExceeded: {e:#}")
+            }
+            Err(EmbedBatchError::ConnectFailure(e)) => {
+                panic!("a 429 must classify as Saturated, not ConnectFailure: {e:#}")
+            }
+            Err(EmbedBatchError::Other(e)) => {
+                panic!("a 429 must classify as Saturated, not Other: {e:#}")
+            }
+            Ok(_) => panic!("a 429 response must not classify as success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn embed_one_batch_defaults_retry_after_when_429_header_is_missing() {
+        // A legacy/misbehaving server that sends 429 with no Retry-After must
+        // not crash the classification — fall back to DEFAULT_SATURATION_RETRY
+        // rather than panicking on a missing/unparseable header.
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&mock)
+            .await;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/projects/x/index/embed", mock.uri());
+
+        let result = embed_one_batch(
+            &client,
+            &url,
+            None,
+            EmbedRequest { chunks: vec![] },
+            0,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        match result {
+            Err(EmbedBatchError::Saturated(retry_after)) => {
+                assert_eq!(retry_after, DEFAULT_SATURATION_RETRY);
+            }
+            Err(EmbedBatchError::BudgetExceeded(e)) => {
+                panic!("a 429 must classify as Saturated, not BudgetExceeded: {e:#}")
+            }
+            Err(EmbedBatchError::ConnectFailure(e)) => {
+                panic!("a 429 must classify as Saturated, not ConnectFailure: {e:#}")
+            }
+            Err(EmbedBatchError::Other(e)) => {
+                panic!("a 429 must classify as Saturated, not Other: {e:#}")
+            }
+            Ok(_) => panic!("a 429 response must not classify as success"),
         }
     }
 
@@ -1625,6 +1791,99 @@ mod tests {
 
         assert_eq!(embedded, 50);
         assert_eq!(db.stats().unwrap().embedding_count, 50);
+    }
+
+    // ── run_embed_phase: honoring the server's 429 admission shedding ───────
+    // (spelunk-oss#262)
+
+    #[tokio::test]
+    async fn saturated_429_retries_same_batch_after_retry_after_then_succeeds() {
+        // The server's admission queue may be transiently full; the client
+        // must honor `Retry-After` and retry the SAME batch (no shrink,
+        // unlike a 408 — queue depth says nothing about this batch's size)
+        // rather than treating it as an unrecoverable failure.
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+            .up_to_n_times(2)
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+            .respond_with(OkEmbedResponder)
+            .mount(&mock)
+            .await;
+
+        let (db, ids) = seed_chunks(10);
+        let chunk_ids_and_texts: Vec<(i64, String, usize)> = ids
+            .iter()
+            .map(|id| (*id, format!("text {id}"), 3))
+            .collect();
+
+        let cfg = Config::default();
+        let tier = server_tier(mock.uri());
+        let mp = MultiProgress::new();
+
+        let embedded = run_embed_phase(
+            chunk_ids_and_texts,
+            &db,
+            &cfg,
+            &tier,
+            std::path::Path::new("/tmp/proj"),
+            4,
+            &mp,
+        )
+        .await
+        .expect("a transient 429 must not abort the run");
+
+        assert_eq!(
+            embedded, 10,
+            "every chunk must still get embedded once the admission queue's 429s clear"
+        );
+        assert_eq!(db.stats().unwrap().embedding_count, 10);
+    }
+
+    #[tokio::test]
+    async fn saturated_429_gives_up_gracefully_after_max_retries_exhausted() {
+        // Safety valve: if the server's admission queue never drains (or a
+        // misbehaving server always sheds), the run must still terminate
+        // rather than retry forever, and must report progress-so-far (here,
+        // 0) instead of propagating an `Err` that would discard it.
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+            .mount(&mock)
+            .await;
+
+        let (db, ids) = seed_chunks(3);
+        let chunk_ids_and_texts: Vec<(i64, String, usize)> = ids
+            .iter()
+            .map(|id| (*id, format!("text {id}"), 3))
+            .collect();
+
+        let cfg = Config::default();
+        let tier = server_tier(mock.uri());
+        let mp = MultiProgress::new();
+
+        let embedded = run_embed_phase(
+            chunk_ids_and_texts,
+            &db,
+            &cfg,
+            &tier,
+            std::path::Path::new("/tmp/proj"),
+            4,
+            &mp,
+        )
+        .await
+        .expect("an always-saturated server must not return Err; it stops gracefully");
+
+        assert_eq!(
+            embedded, 0,
+            "a permanently-saturated queue must give up after MAX_SATURATION_RETRIES, not hang \
+             forever"
+        );
     }
 
     #[tokio::test]

--- a/crates/spelunk-cli/src/cli/cmd/memory/outbox.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/outbox.rs
@@ -374,6 +374,10 @@ mod tests {
             auth: std::sync::Arc::new(spelunk_server::auth::ApiKeyAuth::new(None)),
             conflict_threshold: spelunk_server::default_conflict_threshold(),
             embedder: spelunk_server::EmbedderSlot::disabled(),
+            embed_admission: spelunk_server::EmbedAdmission::new(
+                spelunk_server::EMBED_QUEUE_CAPACITY,
+                spelunk_server::EMBED_BUSY_RETRY_AFTER_SECS,
+            ),
             llm: None,
             max_tokens_ceiling: 8192,
             rate_limiter: std::sync::Arc::new(spelunk_server::rate_limiter::RateLimiter::new(

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -988,7 +988,7 @@ mod tests {
         }
     }
 
-    /// **Gap check (spelunk-oss#262):** `/v1/health`'s embedder state stays
+    /// **Gap check:** `/v1/health`'s embedder state stays
     /// `ready` while the embed admission queue sheds a `/search` call with
     /// 429 (health is a separate, unaffected endpoint) - so `search_query`'s
     /// failure surfaces here with `embedder_state = Some(Ready)`. There is no

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -987,4 +987,32 @@ mod tests {
             }
         }
     }
+
+    /// **Gap check (spelunk-oss#262):** `/v1/health`'s embedder state stays
+    /// `ready` while the embed admission queue sheds a `/search` call with
+    /// 429 (health is a separate, unaffected endpoint) - so `search_query`'s
+    /// failure surfaces here with `embedder_state = Some(Ready)`. There is no
+    /// dedicated "busy" case; it falls into the generic `Some(_)` arm. The
+    /// 2026-07-22 live-repro comment on this task asked for the client to
+    /// distinguish "server busy (embedding)" from "unavailable" so it can say
+    /// "busy, retrying" - that request is NOT implemented: a saturated-but-
+    /// healthy server still gets labeled "unavailable," not "busy." This is a
+    /// real, verified gap (not a regression from this change, and not fixed
+    /// by it), left as a follow-up rather than guessed at here since the
+    /// exact wording and whether to plumb the 429/EmbedderBusy reason through
+    /// `search_query` is a product/UX call, not a mechanical hardening fix.
+    #[test]
+    fn notice_ready_embedder_still_says_unavailable_not_busy() {
+        let msg = semantic_unavailable_message(Some(EmbedderState::Ready), true, None);
+        assert!(
+            msg.contains("unavailable"),
+            "documents current behavior: a Ready-but-saturated embedder gets the generic \
+             'unavailable' notice, not a busy/retry-specific one: {msg}"
+        );
+        assert!(
+            !msg.to_lowercase().contains("busy") && !msg.to_lowercase().contains("retry"),
+            "if this ever starts mentioning busy/retry, a Busy-aware notice has been added - \
+             update this test to lock in the new behavior instead: {msg}"
+        );
+    }
 }

--- a/crates/spelunk-cli/src/cli/cmd/status.rs
+++ b/crates/spelunk-cli/src/cli/cmd/status.rs
@@ -968,6 +968,10 @@ mod tests {
             auth: std::sync::Arc::new(spelunk_server::auth::ApiKeyAuth::new(None)),
             conflict_threshold: spelunk_server::default_conflict_threshold(),
             embedder: spelunk_server::EmbedderSlot::disabled(),
+            embed_admission: spelunk_server::EmbedAdmission::new(
+                spelunk_server::EMBED_QUEUE_CAPACITY,
+                spelunk_server::EMBED_BUSY_RETRY_AFTER_SECS,
+            ),
             llm: None,
             max_tokens_ceiling: 8192,
             rate_limiter: std::sync::Arc::new(spelunk_server::rate_limiter::RateLimiter::new(
@@ -1075,6 +1079,10 @@ mod tests {
             auth: std::sync::Arc::new(spelunk_server::auth::ApiKeyAuth::new(None)),
             conflict_threshold: spelunk_server::default_conflict_threshold(),
             embedder: spelunk_server::EmbedderSlot::disabled(),
+            embed_admission: spelunk_server::EmbedAdmission::new(
+                spelunk_server::EMBED_QUEUE_CAPACITY,
+                spelunk_server::EMBED_BUSY_RETRY_AFTER_SECS,
+            ),
             llm: None,
             max_tokens_ceiling: 8192,
             rate_limiter: std::sync::Arc::new(spelunk_server::rate_limiter::RateLimiter::new(

--- a/crates/spelunk-cli/tests/adr037_p2_auto_start_scope.rs
+++ b/crates/spelunk-cli/tests/adr037_p2_auto_start_scope.rs
@@ -287,6 +287,10 @@ async fn explicit_git_notes_backend_pre_init_never_creates_a_phantom_memory_db()
         auth: Arc::new(spelunk_server::auth::ApiKeyAuth::new(None)),
         conflict_threshold: spelunk_server::default_conflict_threshold(),
         embedder: spelunk_server::EmbedderSlot::disabled(),
+        embed_admission: spelunk_server::EmbedAdmission::new(
+            spelunk_server::EMBED_QUEUE_CAPACITY,
+            spelunk_server::EMBED_BUSY_RETRY_AFTER_SECS,
+        ),
         llm: None,
         max_tokens_ceiling: 8192,
         rate_limiter: Arc::new(spelunk_server::rate_limiter::RateLimiter::new(1000, 60)),

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -947,9 +947,9 @@ pub async fn search_notes(
         "This server has no embedder configured. Semantic memory search is unavailable.",
     )?;
 
-    // Admission control (spelunk-oss#262): same shared mutex-serialized
-    // embedder as `/index/embed` and `project_search`; shed with 429 once the
-    // bounded queue is full instead of queuing silently.
+    // Admission control: same shared mutex-serialized embedder as
+    // `/index/embed` and `project_search`; shed with 429 once the bounded
+    // queue is full instead of queuing silently.
     let _admission = state.embed_admission.try_acquire()?;
 
     // F2LLM QA query prefix — matches the instruction format used for memory documents.
@@ -1414,8 +1414,8 @@ pub async fn index_embed(
         return Ok(octet_stream(Vec::new()));
     }
 
-    // Admission control (spelunk-oss#262): the embedder is mutex-serialized
-    // and processes one request at a time, so a saturated index run must not
+    // Admission control: the embedder is mutex-serialized and processes
+    // one request at a time, so a saturated index run must not
     // let this request join an unbounded wait behind it. Shed with `429`
     // immediately if the bounded queue is already full, rather than parking
     // as another blocking-pool thread on the mutex. Held for the whole embed
@@ -1572,8 +1572,8 @@ pub async fn project_search(
          Configure SPELUNK_EMBEDDING_URL on the server, or use mode=text.",
     )?;
 
-    // Admission control (spelunk-oss#262): a query embed sharing the mutex-
-    // serialized embedder with a running `/index/embed` batch must not queue
+    // Admission control: a query embed sharing the mutex-serialized
+    // embedder with a running `/index/embed` batch must not queue
     // silently behind it until the client's own timeout fires (the observed
     // symptom: `search` reporting "no results" against a live-but-busy
     // server). Shed with 429 instead once the bounded queue is full.
@@ -3510,9 +3510,9 @@ mod tests {
     }
 
     /// Same as [`spawn_test_server_with_embed`], but with the embed admission
-    /// gate injected too — exists so tests can prove the `429` shedding
-    /// behaviour (spelunk-oss#262) with a small, deterministic queue capacity
-    /// instead of the production default.
+    /// gate injected too: exists so tests can prove the `429` shedding
+    /// behaviour with a small, deterministic queue capacity instead of the
+    /// production default.
     async fn spawn_test_server_with_embed_and_admission(
         embedder: super::super::EmbedderSlot,
         request_timeout: std::time::Duration,
@@ -4603,7 +4603,6 @@ mod tests {
     }
 
     // ── Embed admission control (429 on queue saturation) ────────────────────
-    // (spelunk-oss#262)
     //
     // The embedder itself is mutex-serialized (one call at a time) by design
     // (GPU memory / CPU thread-budget reasons in `spelunk-embed`); these tests
@@ -4738,7 +4737,7 @@ mod tests {
         }
     }
 
-    // ── add_note under a saturated embedder (spelunk-oss#262 scope check) ───
+    // ── add_note under a saturated embedder (scope check) ────────────────────
     //
     // `add_note`/`push_memory_batch` are deliberately NOT gated by
     // `EmbedAdmission` (see the task's scope note: they "already catch any
@@ -4746,8 +4745,8 @@ mod tests {
     // in-band `Err` from `embed()`, but a saturated embedder doesn't error
     // quickly, it just makes the caller wait behind the `Mutex`. This proves
     // what actually happens when the embedder is busy longer than the
-    // general request timeout, under the exact load pattern spelunk-oss#262
-    // targets for `index_embed`/`search`/`search_notes`.
+    // general request timeout, under the exact load pattern the embed
+    // admission control targets for `index_embed`/`search`/`search_notes`.
     #[tokio::test]
     async fn add_note_under_saturated_embedder_is_cancelled_not_degraded() {
         let started = Arc::new(tokio::sync::Notify::new());

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -932,6 +932,7 @@ pub async fn get_note(
         (status = 400, description = "No embedder configured", body = ErrorBody),
         (status = 401, description = "Unauthorized", body = ErrorBody),
         (status = 404, description = "Project not found", body = ErrorBody),
+        (status = 429, description = "Embed admission queue full; retry after the given delay", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "memory"
@@ -945,6 +946,11 @@ pub async fn search_notes(
         &state,
         "This server has no embedder configured. Semantic memory search is unavailable.",
     )?;
+
+    // Admission control (spelunk-oss#262): same shared mutex-serialized
+    // embedder as `/index/embed` and `project_search`; shed with 429 once the
+    // bounded queue is full instead of queuing silently.
+    let _admission = state.embed_admission.try_acquire()?;
 
     // F2LLM QA query prefix — matches the instruction format used for memory documents.
     let query_text = format!(
@@ -1359,6 +1365,7 @@ impl Drop for EmbedAbandonGuard {
 ///
 /// Returns 400 if no embedder is configured.
 /// Returns 413 if the batch exceeds 256 chunks.
+/// Returns 429 (with `Retry-After`) if the embed admission queue is full.
 #[utoipa::path(
     post,
     path = "/v1/projects/{project_id}/index/embed",
@@ -1370,6 +1377,7 @@ impl Drop for EmbedAbandonGuard {
         (status = 200, description = "Embedding vectors as raw little-endian f32 bytes, row-major [n_chunks x dim] in request order (not stored server-side)", content_type = "application/octet-stream"),
         (status = 400, description = "No embedder configured", body = ErrorBody),
         (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 429, description = "Embed admission queue full; retry after the given delay", body = ErrorBody),
         (status = 413, description = "Batch exceeds 256 chunks", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
@@ -1405,6 +1413,14 @@ pub async fn index_embed(
     if body.chunks.is_empty() {
         return Ok(octet_stream(Vec::new()));
     }
+
+    // Admission control (spelunk-oss#262): the embedder is mutex-serialized
+    // and processes one request at a time, so a saturated index run must not
+    // let this request join an unbounded wait behind it. Shed with `429`
+    // immediately if the bounded queue is already full, rather than parking
+    // as another blocking-pool thread on the mutex. Held for the whole embed
+    // call so the permit only frees up once this request's turn is done.
+    let _admission = state.embed_admission.try_acquire()?;
 
     // Collect texts, preserving order for reassembly.
     let texts: Vec<&str> = body.chunks.iter().map(|c| c.content.as_str()).collect();
@@ -1521,6 +1537,7 @@ pub struct CodeSearchResponse {
         (status = 200, description = "Query vector (CLI runs KNN locally)", body = CodeSearchResponse),
         (status = 400, description = "No embedder configured or invalid mode", body = ErrorBody),
         (status = 401, description = "Unauthorized", body = ErrorBody),
+        (status = 429, description = "Embed admission queue full; retry after the given delay", body = ErrorBody),
     ),
     security(("bearer_auth" = [])),
     tag = "search"
@@ -1554,6 +1571,13 @@ pub async fn project_search(
         "semantic/hybrid search requires an embedder. \
          Configure SPELUNK_EMBEDDING_URL on the server, or use mode=text.",
     )?;
+
+    // Admission control (spelunk-oss#262): a query embed sharing the mutex-
+    // serialized embedder with a running `/index/embed` batch must not queue
+    // silently behind it until the client's own timeout fires (the observed
+    // symptom: `search` reporting "no results" against a live-but-busy
+    // server). Shed with 429 instead once the bounded queue is full.
+    let _admission = state.embed_admission.try_acquire()?;
 
     // F2LLM-v2-330M query prefix: instruction + query. Documents are embedded
     // without a prefix; queries must use this format for correct retrieval.
@@ -1935,6 +1959,10 @@ mod tests {
             auth: Arc::new(ApiKeyAuth::new(None)),
             conflict_threshold,
             embedder: super::super::EmbedderSlot::disabled(),
+            embed_admission: super::super::EmbedAdmission::new(
+                super::super::EMBED_QUEUE_CAPACITY,
+                super::super::EMBED_BUSY_RETRY_AFTER_SECS,
+            ),
             llm: None,
             max_tokens_ceiling: 8192,
             rate_limiter: Arc::new(super::super::rate_limiter::RateLimiter::new(1000, 60)),
@@ -2105,6 +2133,10 @@ mod tests {
             auth: Arc::new(ApiKeyAuth::new(None)),
             conflict_threshold: 0.92,
             embedder,
+            embed_admission: super::super::EmbedAdmission::new(
+                super::super::EMBED_QUEUE_CAPACITY,
+                super::super::EMBED_BUSY_RETRY_AFTER_SECS,
+            ),
             llm: None,
             max_tokens_ceiling: 8192,
             rate_limiter: Arc::new(super::super::rate_limiter::RateLimiter::new(1000, 60)),
@@ -2659,6 +2691,10 @@ mod tests {
             auth: Arc::new(ApiKeyAuth::new(None)),
             conflict_threshold: 0.92,
             embedder: super::super::EmbedderSlot::disabled(),
+            embed_admission: super::super::EmbedAdmission::new(
+                super::super::EMBED_QUEUE_CAPACITY,
+                super::super::EMBED_BUSY_RETRY_AFTER_SECS,
+            ),
             llm: Some(Arc::new(NoopLlm)),
             max_tokens_ceiling: 8192,
             rate_limiter: Arc::new(super::super::rate_limiter::RateLimiter::new(
@@ -2824,6 +2860,10 @@ mod tests {
             auth: Arc::new(ApiKeyAuth::new(key.map(str::to_string))),
             conflict_threshold: 0.92,
             embedder: super::super::EmbedderSlot::disabled(),
+            embed_admission: super::super::EmbedAdmission::new(
+                super::super::EMBED_QUEUE_CAPACITY,
+                super::super::EMBED_BUSY_RETRY_AFTER_SECS,
+            ),
             llm: None,
             max_tokens_ceiling: 8192,
             rate_limiter: Arc::new(super::super::rate_limiter::RateLimiter::new(1000, 60)),
@@ -3417,6 +3457,10 @@ mod tests {
             auth: Arc::new(ApiKeyAuth::new(None)),
             conflict_threshold: 0.92,
             embedder: super::super::EmbedderSlot::disabled(),
+            embed_admission: super::super::EmbedAdmission::new(
+                super::super::EMBED_QUEUE_CAPACITY,
+                super::super::EMBED_BUSY_RETRY_AFTER_SECS,
+            ),
             llm,
             max_tokens_ceiling: 8192,
             rate_limiter: Arc::new(super::super::rate_limiter::RateLimiter::new(1000, 60)),
@@ -3453,6 +3497,28 @@ mod tests {
         request_timeout: std::time::Duration,
         embed_request_timeout: std::time::Duration,
     ) -> (String, Arc<tokio::sync::Mutex<ServerDb>>) {
+        spawn_test_server_with_embed_and_admission(
+            embedder,
+            request_timeout,
+            embed_request_timeout,
+            super::super::EmbedAdmission::new(
+                super::super::EMBED_QUEUE_CAPACITY,
+                super::super::EMBED_BUSY_RETRY_AFTER_SECS,
+            ),
+        )
+        .await
+    }
+
+    /// Same as [`spawn_test_server_with_embed`], but with the embed admission
+    /// gate injected too — exists so tests can prove the `429` shedding
+    /// behaviour (spelunk-oss#262) with a small, deterministic queue capacity
+    /// instead of the production default.
+    async fn spawn_test_server_with_embed_and_admission(
+        embedder: super::super::EmbedderSlot,
+        request_timeout: std::time::Duration,
+        embed_request_timeout: std::time::Duration,
+        embed_admission: super::super::EmbedAdmission,
+    ) -> (String, Arc<tokio::sync::Mutex<ServerDb>>) {
         register_sqlite_vec();
         let db = ServerDb::open(std::path::Path::new(":memory:"), 4, "test-model")
             .expect("failed to open in-memory server db");
@@ -3465,6 +3531,7 @@ mod tests {
             auth: Arc::new(ApiKeyAuth::new(None)),
             conflict_threshold: 0.92,
             embedder,
+            embed_admission,
             llm: None,
             max_tokens_ceiling: 8192,
             rate_limiter: Arc::new(super::super::rate_limiter::RateLimiter::new(1000, 60)),
@@ -4533,5 +4600,141 @@ mod tests {
             N_REQUESTS,
             "all requests should eventually be admitted once slots free up"
         );
+    }
+
+    // ── Embed admission control (429 on queue saturation) ────────────────────
+    // (spelunk-oss#262)
+    //
+    // The embedder itself is mutex-serialized (one call at a time) by design
+    // (GPU memory / CPU thread-budget reasons in `spelunk-embed`); these tests
+    // cover the layer in FRONT of it — `EmbedAdmission` — which bounds how
+    // many callers may hold a slot waiting their turn before the server sheds
+    // load with 429 instead of letting a request queue silently past its own
+    // timeout.
+
+    /// An embedder that signals `started` the instant it is invoked, then
+    /// blocks until `release` fires — lets a test hold the only admission
+    /// slot open for as long as it needs to prove the *next* request is shed
+    /// immediately rather than queued.
+    struct GatedEmbedder {
+        dim: usize,
+        started: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl spelunk_core::embeddings::EmbeddingBackend for GatedEmbedder {
+        async fn embed(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+            self.started.notify_one();
+            self.release.notified().await;
+            Ok(vec![vec![0.0_f32; self.dim]; texts.len()])
+        }
+
+        fn dimension(&self) -> usize {
+            self.dim
+        }
+    }
+
+    /// **T1:** with the admission queue's only slot held by an in-flight
+    /// request, a second `/index/embed` call must be shed immediately with
+    /// `429` + the configured `Retry-After` — not queue behind the first and
+    /// wait. Once the first request is released, it must still complete
+    /// normally: admission control sheds excess load, it does not break the
+    /// request that WAS within budget.
+    #[tokio::test]
+    async fn index_embed_returns_429_with_retry_after_once_admission_queue_is_saturated() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let embedder = super::super::EmbedderSlot::ready(Arc::new(GatedEmbedder {
+            dim: 4,
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+        }));
+        let (base, _db) = spawn_test_server_with_embed_and_admission(
+            embedder,
+            std::time::Duration::from_secs(60),
+            std::time::Duration::from_secs(60),
+            super::super::EmbedAdmission::new(1, 3),
+        )
+        .await;
+
+        let first_base = base.clone();
+        let first = tokio::spawn(async move {
+            reqwest::Client::new()
+                .post(format!("{first_base}/v1/projects/timeout-test/index/embed"))
+                .json(&json!({"chunks": [{"chunk_id": "1", "content": "fn f() {}"}]}))
+                .send()
+                .await
+        });
+
+        // Wait for the first request to actually be holding the (only) slot
+        // before firing the second, so this proves saturation shedding, not
+        // an accidental race.
+        started.notified().await;
+
+        let second = reqwest::Client::new()
+            .post(format!("{base}/v1/projects/timeout-test/index/embed"))
+            .json(&json!({"chunks": [{"chunk_id": "2", "content": "fn g() {}"}]}))
+            .send()
+            .await
+            .expect("a saturated queue must respond immediately (429), not hang");
+
+        assert_eq!(
+            second.status().as_u16(),
+            429,
+            "the second request must be shed once the single admission slot is held"
+        );
+        assert_eq!(
+            second
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .expect("429 must carry Retry-After")
+                .to_str()
+                .unwrap(),
+            "3",
+            "Retry-After must carry this admission gate's configured value"
+        );
+
+        release.notify_one();
+        let first_resp = first
+            .await
+            .expect("first request task panicked")
+            .expect("first request must still complete once its slot is released");
+        assert_eq!(
+            first_resp.status().as_u16(),
+            200,
+            "the admitted request must succeed normally — shedding excess load must not \
+             break the request that was within budget"
+        );
+    }
+
+    /// Control case: sequential requests within the configured capacity never
+    /// see a 429 — the previous test's rejection is specifically about
+    /// exceeding the bound, not embed requests in general.
+    #[tokio::test]
+    async fn index_embed_succeeds_normally_when_within_admission_capacity() {
+        let embedder = super::super::EmbedderSlot::ready(Arc::new(MockEmbedder { dim: 4 }));
+        let (base, _db) = spawn_test_server_with_embed_and_admission(
+            embedder,
+            std::time::Duration::from_secs(60),
+            std::time::Duration::from_secs(60),
+            super::super::EmbedAdmission::new(2, 3),
+        )
+        .await;
+
+        let client = reqwest::Client::new();
+        for chunk_id in ["1", "2", "3"] {
+            let resp = client
+                .post(format!("{base}/v1/projects/timeout-test/index/embed"))
+                .json(&json!({"chunks": [{"chunk_id": chunk_id, "content": "fn f() {}"}]}))
+                .send()
+                .await
+                .expect("request within admission capacity must succeed");
+            assert_eq!(
+                resp.status().as_u16(),
+                200,
+                "a request within the admission bound must never be shed with 429"
+            );
+        }
     }
 }

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -4737,4 +4737,68 @@ mod tests {
             );
         }
     }
+
+    // ── add_note under a saturated embedder (spelunk-oss#262 scope check) ───
+    //
+    // `add_note`/`push_memory_batch` are deliberately NOT gated by
+    // `EmbedAdmission` (see the task's scope note: they "already catch any
+    // embed error and degrade to text-only storage"). That's true for an
+    // in-band `Err` from `embed()`, but a saturated embedder doesn't error
+    // quickly, it just makes the caller wait behind the `Mutex`. This proves
+    // what actually happens when the embedder is busy longer than the
+    // general request timeout, under the exact load pattern spelunk-oss#262
+    // targets for `index_embed`/`search`/`search_notes`.
+    #[tokio::test]
+    async fn add_note_under_saturated_embedder_is_cancelled_not_degraded() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let embedder = super::super::EmbedderSlot::ready(Arc::new(GatedEmbedder {
+            dim: 4,
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+        }));
+        // A short general request_timeout stands in for "the embedder is
+        // busy embedding a large index batch for longer than 30s in
+        // production" (`REQUEST_TIMEOUT`).
+        let (base, _db) = spawn_test_server_with_embed(
+            embedder,
+            std::time::Duration::from_millis(200),
+            std::time::Duration::from_secs(60),
+        )
+        .await;
+
+        let resp = reqwest::Client::new()
+            .post(format!("{base}/v1/projects/timeout-test/memory"))
+            .json(&json!({
+                "kind": "note",
+                "title": "saturation probe",
+                "body": "does add_note degrade or get cancelled while the embedder is busy?",
+            }))
+            .send()
+            .await
+            .expect("the request itself must complete (timeout layer responds, not a hang)");
+
+        // `add_note`'s own `match embedder.embed(...).await { Err(e) => ... }`
+        // arm never runs here: the enclosing `TimeoutLayer` races the whole
+        // handler future and cancels it first, so the note is dropped
+        // entirely (stored neither with nor without a vector) rather than
+        // degrading to text-only. Pre-existing behavior, unchanged by this
+        // fix (add_note was never gated before either) - not a regression -
+        // but it means the "already degrades gracefully" scope note overstates
+        // this specific failure mode; text-only degradation only covers an
+        // in-band embed error, not a saturated/slow embedder.
+        assert_eq!(
+            resp.status().as_u16(),
+            408,
+            "add_note under a saturated embedder is cancelled by the general request \
+             timeout, not degraded to text-only storage - if this ever starts returning \
+             201, the scope note's claim has become literally true and should be revisited"
+        );
+
+        // The handler future (and the `embed()` call inside it) was already
+        // cancelled by the timeout layer above; nothing is waiting on
+        // `release` any more. Fire it anyway so a future refactor that makes
+        // this not-cancelled can't turn this test into a silent hang.
+        release.notify_one();
+    }
 }

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -113,6 +113,8 @@ impl EmbedAdmission {
 #[cfg(test)]
 mod embed_admission_tests {
     use super::{AppError, EmbedAdmission};
+    use std::sync::Arc;
+    use std::time::Duration;
 
     /// A request within the configured bound must be admitted normally: no
     /// 429, and the permit can be held and dropped like any resource guard.
@@ -160,6 +162,104 @@ mod embed_admission_tests {
         assert!(
             reacquired.is_ok(),
             "the slot must be available again once the prior permit dropped"
+        );
+    }
+
+    /// A panic while a permit is held (e.g. the embed handler's task panics
+    /// mid-embed) must still free the slot: `OwnedSemaphorePermit`'s `Drop`
+    /// runs during unwind like any other destructor, and a panicking tokio
+    /// task is caught at the task boundary (converted to a `JoinError`) not
+    /// escalated to the process, so this is the realistic failure shape.
+    /// Without this, one panic would permanently shrink the effective queue
+    /// capacity by one slot until a server restart.
+    #[tokio::test]
+    async fn a_panic_while_holding_a_permit_still_frees_its_slot() {
+        let admission = EmbedAdmission::new(1, 5);
+
+        let admission_clone = admission.clone();
+        let handle = tokio::spawn(async move {
+            let Ok(_permit) = admission_clone.try_acquire() else {
+                panic!("the only slot is free");
+            };
+            panic!("simulated panic mid-embed, permit still held on this stack frame");
+        });
+        let result = handle.await;
+        assert!(
+            result.is_err(),
+            "the spawned task must have panicked (sanity check on the test itself)"
+        );
+
+        let reacquired = admission.try_acquire();
+        assert!(
+            reacquired.is_ok(),
+            "a panic while holding a permit must not leak the slot: the next acquire must \
+             succeed, not stay shed at capacity forever"
+        );
+    }
+
+    /// Boundary case under real concurrent load: fire exactly
+    /// `EMBED_QUEUE_CAPACITY` (production value) simultaneous holders plus
+    /// one more, all racing to acquire at once via a barrier (not
+    /// sequenced start-then-fire like the HTTP-level saturation test), and
+    /// prove exactly the capacity's worth are admitted and exactly one is
+    /// shed, regardless of scheduling order.
+    #[tokio::test]
+    async fn exactly_capacity_admitted_and_the_next_one_shed_under_true_concurrency() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let admission = EmbedAdmission::new(super::EMBED_QUEUE_CAPACITY, 5);
+        let attempts = super::EMBED_QUEUE_CAPACITY + 1;
+        let barrier = Arc::new(tokio::sync::Barrier::new(attempts));
+        let admitted = Arc::new(AtomicUsize::new(0));
+        let shed = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::with_capacity(attempts);
+        for _ in 0..attempts {
+            let admission = admission.clone();
+            let barrier = Arc::clone(&barrier);
+            let admitted = Arc::clone(&admitted);
+            let shed = Arc::clone(&shed);
+            handles.push(tokio::spawn(async move {
+                // Every task blocks here until all `attempts` tasks are ready,
+                // so the `try_acquire()` calls below race as concurrently as
+                // the runtime can make them, instead of one reliably winning
+                // by virtue of being spawned/polled first.
+                barrier.wait().await;
+                match admission.try_acquire() {
+                    Ok(permit) => {
+                        admitted.fetch_add(1, Ordering::SeqCst);
+                        // Hold the permit past the point every task has had a
+                        // chance to attempt its own acquire, so a slot freed
+                        // early can't accidentally admit the "one over" task
+                        // too, which would mask a capacity-enforcement bug.
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        drop(permit);
+                    }
+                    Err(_) => {
+                        // try_acquire's only error variant is EmbedderBusy;
+                        // AppError has no Debug impl, so match by absence of
+                        // Ok rather than destructuring the variant.
+                        shed.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            }));
+        }
+
+        for h in handles {
+            h.await.expect("no task should panic");
+        }
+
+        assert_eq!(
+            admitted.load(Ordering::SeqCst),
+            super::EMBED_QUEUE_CAPACITY,
+            "exactly EMBED_QUEUE_CAPACITY concurrent callers must be admitted, no more, no \
+             fewer, even when every attempt races at once"
+        );
+        assert_eq!(
+            shed.load(Ordering::SeqCst),
+            1,
+            "exactly the one caller past capacity must be shed with 429, regardless of which \
+             physical task the scheduler happened to run first"
         );
     }
 }

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -60,7 +60,7 @@ const GLOBAL_CONCURRENCY_LIMIT: usize = 256;
 
 /// Bound on how many embed requests may be admitted (in-flight + queued
 /// waiting on the embedder) before the server sheds load with `429` instead
-/// of letting a request join an unbounded wait (spelunk-oss#262).
+/// of letting a request join an unbounded wait.
 ///
 /// The embedder itself only ever runs one request at a time (see
 /// `NativeEmbedder`'s `Mutex` in `spelunk-embed`, intentional and correct —
@@ -129,8 +129,8 @@ mod embed_admission_tests {
 
     /// Once every slot is held, the next acquire is shed immediately with
     /// `429` + the configured `Retry-After` — never blocks waiting for a
-    /// slot to free up (spelunk-oss#262: an unbounded wait is exactly the
-    /// failure mode being fixed).
+    /// slot to free up: an unbounded wait is exactly the failure mode
+    /// being fixed.
     #[test]
     fn sheds_with_busy_error_once_capacity_is_exhausted() {
         let admission = EmbedAdmission::new(1, 9);
@@ -845,8 +845,7 @@ pub enum AppError {
     },
     /// The bounded embed admission queue ([`EmbedAdmission`]) is full: `429`
     /// with `Retry-After`, so a client sheds load explicitly instead of
-    /// joining an unbounded wait behind the mutex-serialized embedder
-    /// (spelunk-oss#262).
+    /// joining an unbounded wait behind the mutex-serialized embedder.
     EmbedderBusy {
         retry_after_secs: u64,
     },

--- a/crates/spelunk-server/src/lib.rs
+++ b/crates/spelunk-server/src/lib.rs
@@ -58,6 +58,112 @@ const DEFAULT_BODY_LIMIT_BYTES: usize = 2 * 1024 * 1024; // 2 MiB
 /// including the `/memory/stream` SSE poll loop.
 const GLOBAL_CONCURRENCY_LIMIT: usize = 256;
 
+/// Bound on how many embed requests may be admitted (in-flight + queued
+/// waiting on the embedder) before the server sheds load with `429` instead
+/// of letting a request join an unbounded wait (spelunk-oss#262).
+///
+/// The embedder itself only ever runs one request at a time (see
+/// `NativeEmbedder`'s `Mutex` in `spelunk-embed`, intentional and correct —
+/// GPU memory and CPU thread-budget reasons); this bound is unrelated to that
+/// concurrency-of-one, it caps how many callers are allowed to *wait* for
+/// their turn. A handful is enough for the normal case (one big index batch
+/// plus a couple of interactive `search`/`memory search` queries) without
+/// letting a slow index turn every other request into a silent hang.
+pub const EMBED_QUEUE_CAPACITY: usize = 4;
+
+/// `Retry-After` (seconds) sent with a `429` when the embed admission queue is
+/// full. Matches the `Retry-After: 5` already used for `EmbedderWarmingUp`'s
+/// transient case, so CLI clients have one retry cadence to reason about
+/// regardless of which transient embed condition they hit.
+pub const EMBED_BUSY_RETRY_AFTER_SECS: u64 = 5;
+
+/// A permit held for the duration of one embed request. Dropping it (end of
+/// the holding handler's scope) returns the slot to the queue.
+pub struct EmbedPermit(#[allow(dead_code)] tokio::sync::OwnedSemaphorePermit);
+
+/// Bounded admission control in front of the shared, mutex-serialized
+/// embedder. See [`EMBED_QUEUE_CAPACITY`].
+#[derive(Clone)]
+pub struct EmbedAdmission {
+    semaphore: Arc<tokio::sync::Semaphore>,
+    retry_after_secs: u64,
+}
+
+impl EmbedAdmission {
+    pub fn new(capacity: usize, retry_after_secs: u64) -> Self {
+        Self {
+            semaphore: Arc::new(tokio::sync::Semaphore::new(capacity)),
+            retry_after_secs,
+        }
+    }
+
+    /// Take a slot if one is free; otherwise `Err(AppError::EmbedderBusy)`
+    /// with this admission gate's configured `Retry-After`. Never waits: a
+    /// full queue is shed immediately, not joined.
+    pub fn try_acquire(&self) -> Result<EmbedPermit, AppError> {
+        match Arc::clone(&self.semaphore).try_acquire_owned() {
+            Ok(permit) => Ok(EmbedPermit(permit)),
+            Err(_) => Err(AppError::EmbedderBusy {
+                retry_after_secs: self.retry_after_secs,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod embed_admission_tests {
+    use super::{AppError, EmbedAdmission};
+
+    /// A request within the configured bound must be admitted normally: no
+    /// 429, and the permit can be held and dropped like any resource guard.
+    #[test]
+    fn admits_requests_within_capacity() {
+        let admission = EmbedAdmission::new(2, 5);
+        let p1 = admission.try_acquire();
+        assert!(p1.is_ok(), "first of 2 must be admitted");
+        let p2 = admission.try_acquire();
+        assert!(p2.is_ok(), "second of 2 must be admitted");
+    }
+
+    /// Once every slot is held, the next acquire is shed immediately with
+    /// `429` + the configured `Retry-After` — never blocks waiting for a
+    /// slot to free up (spelunk-oss#262: an unbounded wait is exactly the
+    /// failure mode being fixed).
+    #[test]
+    fn sheds_with_busy_error_once_capacity_is_exhausted() {
+        let admission = EmbedAdmission::new(1, 9);
+        let Ok(_permit) = admission.try_acquire() else {
+            panic!("the only slot is free");
+        };
+        let second = admission.try_acquire();
+        assert!(
+            matches!(
+                second,
+                Err(AppError::EmbedderBusy {
+                    retry_after_secs: 9
+                })
+            ),
+            "a second acquire past capacity 1 must be rejected with \
+             AppError::EmbedderBusy{{retry_after_secs: 9}}"
+        );
+    }
+
+    /// Dropping a held permit returns its slot to the pool immediately — the
+    /// mechanism that lets a drained embed queue recover without a restart.
+    #[test]
+    fn dropping_a_permit_frees_its_slot() {
+        let admission = EmbedAdmission::new(1, 5);
+        let permit = admission.try_acquire();
+        assert!(permit.is_ok(), "the only slot is free");
+        drop(permit);
+        let reacquired = admission.try_acquire();
+        assert!(
+            reacquired.is_ok(),
+            "the slot must be available again once the prior permit dropped"
+        );
+    }
+}
+
 /// Readiness state of the server-side embedder.
 ///
 /// The native embedder loads on a background task after the listener binds, so
@@ -186,6 +292,10 @@ pub struct AppState {
     /// `ready`; no embedder at all starts `disabled`. Handlers read the current
     /// state without blocking. See [`EmbedderSlot`].
     pub embedder: EmbedderSlot,
+    /// Bounded admission gate in front of the embedder, shared by every
+    /// embed-consuming handler (`/index/embed`, `/search`,
+    /// `/memory/search`). See [`EmbedAdmission`].
+    pub embed_admission: EmbedAdmission,
     /// Optional LLM backend for `/explore` and `/llm/complete`.
     pub llm: Option<Arc<dyn spelunk_core::llm::LlmBackend>>,
     /// Server-side hard ceiling for `max_tokens` on `/llm/complete`.
@@ -494,6 +604,28 @@ mod app_error_tests {
         (status, String::from_utf8_lossy(&bytes).into_owned())
     }
 
+    /// `AppError::EmbedderBusy` must map to `429` carrying the configured
+    /// `Retry-After` value verbatim, not the `503`/`Retry-After: 5` used by
+    /// `EmbedderWarmingUp` — a client must be able to tell "shed, come back
+    /// shortly" (429) apart from "not ready yet" (503).
+    #[tokio::test]
+    async fn embedder_busy_maps_to_429_with_configured_retry_after() {
+        let resp = AppError::EmbedderBusy {
+            retry_after_secs: 7,
+        }
+        .into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        let retry_after = resp
+            .headers()
+            .get(axum::http::header::RETRY_AFTER)
+            .expect("429 must carry a Retry-After header")
+            .to_str()
+            .unwrap();
+        assert_eq!(retry_after, "7");
+        let (_, body) = body_string(resp).await;
+        assert!(body.contains("busy"));
+    }
+
     /// A `DimensionMismatch` wrapped in `AppError::Internal` must map to a 400
     /// with the typed, safe message — not fall through to the generic 500.
     #[tokio::test]
@@ -611,6 +743,13 @@ pub enum AppError {
         terminal: bool,
         detail: String,
     },
+    /// The bounded embed admission queue ([`EmbedAdmission`]) is full: `429`
+    /// with `Retry-After`, so a client sheds load explicitly instead of
+    /// joining an unbounded wait behind the mutex-serialized embedder
+    /// (spelunk-oss#262).
+    EmbedderBusy {
+        retry_after_secs: u64,
+    },
     Internal(anyhow::Error),
 }
 
@@ -656,6 +795,18 @@ impl IntoResponse for AppError {
                         .into_response()
                 }
             }
+            AppError::EmbedderBusy { retry_after_secs } => (
+                StatusCode::TOO_MANY_REQUESTS,
+                [(
+                    axum::http::header::RETRY_AFTER,
+                    retry_after_secs.to_string(),
+                )],
+                Json(serde_json::json!({
+                    "error": "embedder busy, retry shortly",
+                    "state": "busy",
+                })),
+            )
+                .into_response(),
             AppError::Internal(e) => {
                 // Only a known, explicitly-typed user-facing error is ever
                 // surfaced to the client; everything else gets a generic

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -306,6 +306,10 @@ async fn run(budget: ThreadBudget) -> Result<()> {
         auth,
         conflict_threshold: args.conflict_threshold,
         embedder,
+        embed_admission: spelunk_server::EmbedAdmission::new(
+            spelunk_server::EMBED_QUEUE_CAPACITY,
+            spelunk_server::EMBED_BUSY_RETRY_AFTER_SECS,
+        ),
         llm,
         max_tokens_ceiling,
         rate_limiter,

--- a/crates/spelunk-server/tests/common/mod.rs
+++ b/crates/spelunk-server/tests/common/mod.rs
@@ -53,6 +53,10 @@ pub fn make_test_state(dim: usize, auth_key: Option<String>) -> spelunk_server::
         auth: std::sync::Arc::new(spelunk_server::auth::ApiKeyAuth::new(auth_key)),
         conflict_threshold: spelunk_server::default_conflict_threshold(),
         embedder: spelunk_server::EmbedderSlot::disabled(),
+        embed_admission: spelunk_server::EmbedAdmission::new(
+            spelunk_server::EMBED_QUEUE_CAPACITY,
+            spelunk_server::EMBED_BUSY_RETRY_AFTER_SECS,
+        ),
         llm: None,
         max_tokens_ceiling: 8192,
         rate_limiter: std::sync::Arc::new(spelunk_server::rate_limiter::RateLimiter::new(1000, 60)),

--- a/crates/spelunk-server/tests/integration_server.rs
+++ b/crates/spelunk-server/tests/integration_server.rs
@@ -359,6 +359,10 @@ async fn since_endpoint_returns_entries_after_timestamp() {
         auth: Arc::new(ApiKeyAuth::new(None)),
         conflict_threshold: spelunk_server::default_conflict_threshold(),
         embedder: spelunk_server::EmbedderSlot::disabled(),
+        embed_admission: spelunk_server::EmbedAdmission::new(
+            spelunk_server::EMBED_QUEUE_CAPACITY,
+            spelunk_server::EMBED_BUSY_RETRY_AFTER_SECS,
+        ),
         llm: None,
         max_tokens_ceiling: 8192,
         rate_limiter: Arc::new(RateLimiter::new(1000, 60)),

--- a/docs/architecture/server-api.md
+++ b/docs/architecture/server-api.md
@@ -135,7 +135,7 @@ If the server has no embedder configured, it returns `400`:
 ```
 
 **Response `429`:** the query embed shares the bounded admission queue in front
-of the mutex-serialized embedder with `/index/embed` (spelunk-oss#262); once
+of the mutex-serialized embedder with `/index/embed`; once
 that queue is full the request is shed immediately rather than queued behind a
 running index, with a `Retry-After` (seconds) header:
 
@@ -199,7 +199,7 @@ concurrently, see [Embedding CPU thread
 budget](../server-setup.md#embedding-cpu-thread-budget)), so a bounded
 admission queue sits in front of it. Once that queue is full the request is
 shed immediately with `429` and a `Retry-After` (seconds) header, instead of
-parking until the caller's own request timeout fires (spelunk-oss#262):
+parking until the caller's own request timeout fires:
 
 ```json
 { "error": "embedder busy, retry shortly", "state": "busy" }

--- a/docs/architecture/server-api.md
+++ b/docs/architecture/server-api.md
@@ -134,6 +134,15 @@ If the server has no embedder configured, it returns `400`:
 { "error": { "code": "bad_request", "message": "This server has no embedder configured. Semantic memory search is unavailable." } }
 ```
 
+**Response `429`:** the query embed shares the bounded admission queue in front
+of the mutex-serialized embedder with `/index/embed` (spelunk-oss#262); once
+that queue is full the request is shed immediately rather than queued behind a
+running index, with a `Retry-After` (seconds) header:
+
+```json
+{ "error": "embedder busy, retry shortly", "state": "busy" }
+```
+
 ---
 
 ## Endpoints added for CLI integration
@@ -183,6 +192,22 @@ If the server has no embedder, it returns 400:
 ```json
 { "error": { "code": "bad_request", "message": "index.embed requires an embedder. Configure SPELUNK_EMBEDDING_URL on the server." } }
 ```
+
+**Response `429`:** the embedder is serialized behind a single mutex (GPU
+memory limits and the CPU thread budget both rule out running batches
+concurrently, see [Embedding CPU thread
+budget](../server-setup.md#embedding-cpu-thread-budget)), so a bounded
+admission queue sits in front of it. Once that queue is full the request is
+shed immediately with `429` and a `Retry-After` (seconds) header, instead of
+parking until the caller's own request timeout fires (spelunk-oss#262):
+
+```json
+{ "error": "embedder busy, retry shortly", "state": "busy" }
+```
+
+The CLI's `spelunk index` embed phase retries the same batch after the given
+delay rather than shrinking it (queue depth says nothing about batch sizing);
+see [`spelunk index`](../commands.md#spelunk-index).
 
 ### `POST /v1/projects/{project_id}/explore`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -115,7 +115,11 @@ A batch that can't even reach the server (the local server is momentarily
 unresponsive, not just slow) is retried automatically at the same batch size
 with backoff, rather than being treated as a request that was too big; only
 once those retries are exhausted does the run stop and wait on a manual
-re-run.
+re-run. A batch that reaches the server but gets back `429` (the server's
+bounded embed queue is already full, e.g. another `index` or a `search` is
+mid-embed) is retried the same way, at the same batch size, but sleeping for
+the server's own `Retry-After` instead of the fixed backoff schedule; see
+`POST /index/embed` in `docs/architecture/server-api.md`.
 
 `spelunk init` always hands the embedding pass to a detached background worker,
 and `--detach-embed` opts a manual `spelunk index` run into the same behaviour:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -145,7 +145,7 @@
           "index"
         ],
         "summary": "Generate embeddings for code chunks. The server encodes each chunk and returns the\nvectors. **The server does not store the vectors** — the CLI is the only persistent\nstore for index data.",
-        "description": "Returns 400 if no embedder is configured.\nReturns 413 if the batch exceeds 256 chunks.",
+        "description": "Returns 400 if no embedder is configured.\nReturns 413 if the batch exceeds 256 chunks.\nReturns 429 (with `Retry-After`) if the embed admission queue is full.",
         "operationId": "index_embed",
         "parameters": [
           {
@@ -197,6 +197,16 @@
           },
           "413": {
             "description": "Batch exceeds 256 chunks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Embed admission queue full; retry after the given delay",
             "content": {
               "application/json": {
                 "schema": {
@@ -670,6 +680,16 @@
           },
           "404": {
             "description": "Project not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Embed admission queue full; retry after the given delay",
             "content": {
               "application/json": {
                 "schema": {
@@ -1184,6 +1204,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorBody"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Embed admission queue full; retry after the given delay",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -625,7 +625,7 @@ uses most of this budget on its own). A batch queuing behind a running index
 no longer waits silently until the caller's own timeout fires: once a bounded
 admission queue in front of the embedder is full, the server sheds the
 request immediately with `429` and a `Retry-After` header instead (see
-`POST /index/embed` in `architecture/server-api.md`, spelunk-oss#262).
+`POST /index/embed` in `architecture/server-api.md`).
 
 ### Non-loopback plaintext binds are refused, no override
 

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -618,6 +618,15 @@ the bounded default. A pre-set `RAYON_NUM_THREADS` is respected and never
 overridden. The resolved value and its source are logged at startup
 (`embed CPU thread budget resolved`). GPU (Metal/CUDA) builds are unaffected.
 
+This budget only bounds CPU contention *within* a single embed batch; embed
+requests themselves are still serialized behind a single mutex on both device
+paths (GPU concurrency would blow its memory limit, and a CPU batch already
+uses most of this budget on its own). A batch queuing behind a running index
+no longer waits silently until the caller's own timeout fires: once a bounded
+admission queue in front of the embedder is full, the server sheds the
+request immediately with `429` and a `Retry-After` header instead (see
+`POST /index/embed` in `architecture/server-api.md`, spelunk-oss#262).
+
 ### Non-loopback plaintext binds are refused, no override
 
 `spelunk-server` refuses to bind a non-loopback address over plaintext HTTP,


### PR DESCRIPTION
## Summary

During a large `spelunk index` run, embed requests (`/index/embed`, `/search`,
`/memory/search`) queue behind the single `Mutex`-serialized native embedder
(`NativeEmbedder::embed_with_cancel`, `crates/spelunk-embed/src/embedder_native.rs`).
That serialization is intentional and stays: on GPU/Metal, concurrent embeds
blow the memory boundary; on CPU, one embed call already fans across
`max(1, physical_cores - 2)` rayon/candle threads, so concurrent embeds add
contention rather than throughput.

The gap was that a saturated embedder had **no admission control**: a request
past the mutex just parked as a blocking-pool thread with an unbounded wait,
until the *client's own* timeout fired. From the client's point of view this
looked like "server stopped accepting connections" even though the socket and
`/v1/health` were fine the whole time — confirmed live during a background
`spelunk init` embed, where `spelunk search` reported "no results found" and
`spelunk status` reported the Offline tier against a server that was up and
became reachable again the instant the embed finished.

Direction (confirmed with the founder): keep the mutex serialization as-is;
add explicit admission control in front of it and return **HTTP 429** with
`Retry-After` when the queue is saturated, so clients back off deliberately
instead of silently timing out.

## What changed

### Server (`crates/spelunk-server`)
- `EmbedAdmission`: a bounded `tokio::sync::Semaphore` wrapping the embedder.
  `try_acquire()` never waits — once `EMBED_QUEUE_CAPACITY` (4) permits are
  held, the next request is shed immediately as `AppError::EmbedderBusy`,
  which maps to `429 Too Many Requests` + `Retry-After: 5` (matching the
  existing `EmbedderWarmingUp` cadence).
- Wired into `AppState` (`embed_admission` field) and gates the three
  embed-consuming handlers: `index_embed` (the batch endpoint behind the
  original large-index symptom), `project_search`, and `search_notes` (the
  query-embed paths that starved during a live background index).
- `add_note` / `push_memory_batch` are deliberately **not** gated — their
  embed calls already catch in-band errors and degrade to text-only storage,
  a different failure shape from a slow-but-not-erroring embedder (see "Known
  non-blocking follow-ups" below).
- GH#631's cancel-on-dequeue behavior is unchanged; 429 is the proactive
  admission-control complement to that reactive shedding, not a replacement.
- `docs/openapi.json` regenerated: 429 responses documented on all three
  gated endpoints, verified byte-identical against a fresh `ApiDoc` generation
  (zero drift).

### CLI (`crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs`)
- `embed_one_batch` classifies HTTP 429 as `EmbedBatchError::Saturated(Duration)`,
  parsing the server's `Retry-After` header (falls back to 5s if missing or
  malformed).
- The retry loop treats `Saturated` like a connect failure (retries the same
  batch, no shrink — queue depth says nothing about batch sizing) but sleeps
  for the server-specified `Retry-After` instead of the fixed connect-failure
  backoff schedule. Bounded by `MAX_SATURATION_RETRIES = 30` as a safety valve.
  This composes with the existing connect-retry/heartbeat mitigation: the
  server now sheds load explicitly, and the client paces itself accordingly.

### Tests
- `spelunk-server`: unit tests for `EmbedAdmission` (admits within capacity,
  sheds `EmbedderBusy` once exhausted, releases on permit drop), a panic
  test proving a permit is freed even if the holding task panics (RAII /
  tokio task-boundary safety, empirically confirmed), a true-concurrency
  boundary test (`EMBED_QUEUE_CAPACITY + 1` tasks racing via a `Barrier`),
  and real-TCP integration tests confirming 429 + `Retry-After` on saturation
  and normal success within capacity.
- `spelunk-cli`: unit tests for 429 classification and `Retry-After` parsing
  (including the missing-header fallback), plus integration tests for the
  retry-through-saturation path and the safety-valve give-up path.

### Docs
- `docs/architecture/server-api.md`: added the `429` response for
  `POST /index/embed` and `POST /memory/search`.
- `docs/server-setup.md`: clarified, next to the existing CPU-thread-budget
  note, that embed *requests* are separately serialized behind the mutex
  regardless of device, and that a full admission queue now sheds with 429
  rather than silently waiting out the caller's timeout.
- `docs/commands.md`: documented `spelunk index`'s new `Saturated`/429 retry
  behavior alongside the existing connect-failure backoff description.

## Known non-blocking follow-ups (verified, intentionally out of scope here)

1. **`add_note` doesn't gracefully degrade under a saturated (not erroring)
   embedder.** With a slow embedder past the general request timeout,
   `add_note` currently returns 408 (the router's `TimeoutLayer` cancels the
   whole handler before its own embed-error-degrades-to-text-only arm can
   run). This is pre-existing behavior, not a regression from this change,
   but worth a look at whether `add_note` / `push_memory_batch` should be
   gated by `EmbedAdmission` after all.
2. **The CLI's semantic-unavailable message doesn't distinguish "busy" from
   "unavailable."** `/v1/health` stays `ready` while `EmbedAdmission` sheds a
   `/search` call with 429, but `semantic_unavailable_message()` has no
   busy-specific wording and falls into the generic "semantic search
   unavailable on this server; using ast-grep" message. A live repro during
   a background index specifically wanted a "busy, retry shortly" distinction
   here; this PR fixes the false-negative "no server" framing to the extent
   that 429 now returns fast rather than the caller hanging into a timeout,
   but doesn't yet add busy-specific copy.

Both are documented with regression tests locking in current behavior, and
are UX/product calls rather than mechanical bugs.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace --features spelunk-server/embed-native` — all green.
- `SPELUNK_SECRET_STORE=file cargo test --workspace --no-default-features` — all green (mirrors the CI cell). One `wait_for_exit_false_for_live_process` failure was observed on a single run under load; reproduced clean in isolation (3/3) and on a full clean re-run (454/454), and the file it lives in (`crates/spelunk-cli/src/cli/cmd/server.rs`) is untouched by this branch — a pre-existing flake, not a regression from this change.
- `cargo clippy --all-targets --features spelunk-server/embed-native -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `docs/openapi.json` — regenerated via the `write_openapi_snapshot` test and diffed byte-for-byte against the committed file: zero drift.
- `cargo audit` — no new advisories introduced by this change (no dependency manifest changes in this diff); the one pre-existing `unmaintained` warning (`paste`, via `tokenizers`/`candle`) predates this branch.
