### PR TITLE
fix(tests): unbreak main test build (AppState literal + semantic_unavailable_message call)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -1116,6 +1116,10 @@ mod tests {
             auth: std::sync::Arc::new(spelunk_server::auth::ApiKeyAuth::new(None)),
             conflict_threshold: spelunk_server::default_conflict_threshold(),
             embedder: spelunk_server::EmbedderSlot::disabled(),
+            embed_admission: spelunk_server::EmbedAdmission::new(
+                spelunk_server::EMBED_QUEUE_CAPACITY,
+                spelunk_server::EMBED_BUSY_RETRY_AFTER_SECS,
+            ),
             llm: None,
             max_tokens_ceiling: 8192,
             rate_limiter: std::sync::Arc::new(spelunk_server::rate_limiter::RateLimiter::new(

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -1049,7 +1049,7 @@ mod tests {
     /// `search_query` is a product/UX call, not a mechanical hardening fix.
     #[test]
     fn notice_ready_embedder_still_says_unavailable_not_busy() {
-        let msg = semantic_unavailable_message(Some(EmbedderState::Ready), true, None);
+        let msg = semantic_unavailable_message(Some(EmbedderState::Ready), None, None, true);
         assert!(
             msg.contains("unavailable"),
             "documents current behavior: a Ready-but-saturated embedder gets the generic \


### PR DESCRIPTION
## What and why

`main`'s test build does not compile, which turns the CI `Test (ubuntu/macos/windows)` and `Check & Lint` jobs red on `main` and therefore blocks every open PR (they all run their CI against this base). The release/`cargo build` path is fine; only `cargo test` / `--all-targets` / clippy break.

Root cause is a sibling-merge hazard: two PRs were each green in isolation but conflict once both land, because neither reconciled the other's test-code impact.

1. One PR added a required field `embed_admission: EmbedAdmission` to `spelunk_server::AppState` and changed `semantic_unavailable_message` to a four-argument signature.
2. Another PR added a test helper that builds `spelunk_server::AppState { .. }` as a struct literal, which now omits the new field (`E0063`), and left a stale unit test calling `semantic_unavailable_message` with the old three-argument signature and a `bool` where an `Option<&str>` is now expected (`E0061`).

## Fix (test code only, no production change)

- Add `embed_admission` to the `AppState` literal in the CLI sync tests, mirroring the canonical construction used by the server's own `main.rs` and its handler test builders (`EmbedAdmission::new(EMBED_QUEUE_CAPACITY, EMBED_BUSY_RETRY_AFTER_SECS)`).
- Update the `search.rs` test call to the current four-argument signature. The test still passes a `Ready` embedder and asserts it yields the generic "unavailable" notice (not a busy/retry one), so its original intent is preserved; the new `server_url` parameter is `None` and does not affect the exercised branch.

## Test plan

All commands run with `SPELUNK_SECRET_STORE=file` (avoids a live macOS Keychain prompt).

- `cargo test -p spelunk-cli -p spelunk-server -p spelunk-core` — green (this is what was red).
- `cargo test -p spelunk-cli -p spelunk-server -p spelunk-core --no-default-features` — green (the CI cell that runs on all three OSes).
- `cargo clippy -p spelunk-cli -p spelunk-server -p spelunk-core --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)