### PR TITLE
fix: batched, resumable memory push so a real-sized project no longer times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,20 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   in place of `Stored [kind] #id: title`. See [ADR-068's fourth
   amendment](docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md).
 
+- **`spelunk memory push` and `spelunk sync` can now push a real-sized project
+  instead of timing out.** Previously a project with more than a few dozen
+  entries was pushed in requests bounded by a fixed 30-second client timeout, so
+  the push timed out and nothing landed: the server project was never even
+  created. The push now splits entries into smaller per-request batches and
+  gives each request the longer, inference-class timeout the server needs to
+  re-embed them, so a push of hundreds of entries completes and the project is
+  created by the first batch. If a batch fails partway through (for example the
+  server is briefly overloaded), the push stops at that batch, reports how far
+  it got (`Pushed X of Y entries, then stopped: ...`) with a hint to re-run to
+  resume, and exits non-zero rather than reading as success. Batches that
+  already landed are recorded, so a re-run pushes only the remainder and any
+  entry the server already holds comes back skipped, never duplicated.
+
 ### Changed
 
 - **Chunk re-windowing is now token-aware, and windowed chunks keep their identity.**

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -80,6 +80,17 @@ pub async fn memory_push(
         } else {
             println!("No local memory entries to push.");
         }
+    } else if let Some(reason) = summary.interrupted.as_deref() {
+        // A chunk failed mid-push. Report what already landed and how to resume,
+        // then exit non-zero: earlier chunks are durably stamped, so a re-run
+        // pushes only the remainder and already-pushed entries return 207
+        // `skipped`. Must not read as success.
+        anyhow::bail!(
+            "Pushed {} of {} entries, then stopped: {reason}. \
+             Re-run to resume (already-pushed entries are skipped).",
+            summary.created + summary.skipped,
+            summary.attempted
+        );
     } else if summary.created == 0 && summary.skipped == 0 {
         // Total failure: nothing durably landed. Must not read as success —
         // a caller skimming for "Done" or checking only the exit code would

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -722,6 +722,25 @@ mod tests {
         }
     }
 
+    // Echoes `created` for the first `ok` requests, then 500s every later one.
+    // Unlike `FailAfterFirst`, the failure can be placed on any chunk, so a test
+    // can prove the interrupted summary counts every chunk that landed before the
+    // failure and that the loop halts exactly at the failed chunk.
+    struct FailAfterN {
+        ok: usize,
+        calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+    impl Respond for FailAfterN {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n < self.ok {
+                EchoCreated.respond(request)
+            } else {
+                ResponseTemplate::new(500).set_body_string("overloaded")
+            }
+        }
+    }
+
     #[test]
     fn push_batch_chunk_size_constant_is_50() {
         assert_eq!(PUSH_BATCH_CHUNK_SIZE, 50);
@@ -795,17 +814,19 @@ mod tests {
         let reqs = server.received_requests().await.unwrap();
         assert_eq!(reqs.len(), 3, "ceil(120 / 50) POSTs");
         let mut seen: Vec<String> = Vec::new();
+        let mut sizes: Vec<usize> = Vec::new();
         for req in &reqs {
             let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
             let entries = body["entries"].as_array().unwrap();
-            assert!(
-                entries.len() <= PUSH_BATCH_CHUNK_SIZE,
-                "no chunk carries more than N entries"
-            );
+            sizes.push(entries.len());
             for e in entries {
                 seen.push(e["external_id"].as_str().unwrap().to_string());
             }
         }
+        // A `<= N` check alone would pass an implementation chunking on the wrong
+        // size (e.g. 40), so pin the exact per-request counts: full chunks up to
+        // the constant, then the remainder. Requests arrive in push order.
+        assert_eq!(sizes, vec![50, 50, 20], "exact per-request entry counts");
         assert_eq!(seen.len(), 120, "no entry is pushed more than once");
         assert_eq!(
             seen.into_iter().collect::<HashSet<_>>(),
@@ -949,6 +970,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn interrupted_on_a_later_chunk_counts_only_the_chunks_that_landed() {
+        // The failure lands on chunk 3 of 7: `created` must equal exactly the two
+        // full chunks that landed before it (not one, not three), and the loop
+        // must issue no request past the failed chunk.
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        seed_notes(&store, 340); // ceil(340 / 50) = 7 chunks
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(FailAfterN {
+                ok: 2,
+                calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            })
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        let s = push_local(&store, &client, false, false).await.unwrap();
+        assert!(s.interrupted.is_some());
+        assert_eq!(
+            (s.attempted, s.created, s.skipped),
+            (340, 100, 0),
+            "created reflects exactly the two chunks that landed before the failure"
+        );
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            3,
+            "halts on the failed 3rd chunk; chunks 4 through 7 are never sent"
+        );
+        let unstamped = store
+            .rows_for_sync(false)
+            .unwrap()
+            .into_iter()
+            .filter(|r| r.remote_id.is_none())
+            .count();
+        assert_eq!(unstamped, 240, "only the 100 landed rows are stamped");
+    }
+
+    #[tokio::test]
+    async fn interrupted_push_skips_the_tombstone_delete_pass() {
+        // Once a live chunk fails the connection is already failing, so the
+        // archived-entry DELETEs must not be issued either. `delete_remote` treats
+        // a 404 as success, so only a request-count check catches a regression
+        // that dropped the interrupted gate on the tombstone pass.
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        // Three live, unstamped rows form the single push chunk that will fail.
+        seed_notes(&store, 3);
+        // Two archived rows that DO carry a remote_id: the tombstone pass would
+        // DELETE these if it were not skipped on an interrupted push.
+        for tag in ["A0", "A1"] {
+            let (id, _) = store
+                .add_note("note", tag, "body", &[], &[], None, None)
+                .unwrap();
+            store.set_remote_id(id, &format!("cloud-{tag}")).unwrap();
+            assert!(store.archive(id).unwrap());
+        }
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("overloaded"))
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        let s = push_local(&store, &client, true, false).await.unwrap();
+        assert!(s.interrupted.is_some());
+        assert_eq!(s.created, 0, "the only live chunk failed");
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(
+            reqs.len(),
+            1,
+            "only the failing batch POST is sent; no tombstone DELETEs follow"
+        );
+        assert!(
+            reqs[0].url.path().ends_with("/memory/batch"),
+            "the single request is the batch push, not a delete"
+        );
+    }
+
+    #[tokio::test]
     async fn overlapping_repush_tallies_skipped_and_leaves_no_duplicates() {
         // Models the committed-but-unstamped overlap: a prior push persisted rows
         // server-side but the client lost the response (no `remote_id` stamped).
@@ -1042,6 +1150,10 @@ mod tests {
             progress.iter().all(|&(done, total)| done <= total),
             "done never exceeds total: {progress:?}"
         );
+        assert!(
+            progress.windows(2).all(|w| w[0].0 <= w[1].0),
+            "cumulative done never regresses across chunks: {progress:?}"
+        );
         assert_eq!(
             progress.iter().map(|&(d, _)| d).collect::<Vec<_>>(),
             vec![50, 100, 120],
@@ -1082,6 +1194,10 @@ mod tests {
             "exactly one POST for a push of N or fewer entries"
         );
         assert_eq!(s.created, PUSH_BATCH_CHUNK_SIZE as u32);
+        assert!(
+            s.interrupted.is_none(),
+            "a clean single-chunk push is never marked interrupted"
+        );
     }
 
     #[tokio::test]

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -38,6 +38,17 @@ use crate::{
     storage::{BatchPushItem, CloudSyncClient, MemoryStore},
 };
 
+/// How many entries go in each `POST /memory/batch` request. Kept small so even
+/// the worst case (text-only, the server re-embedding a full chunk on a cold
+/// embedder) finishes with wide margin under the request timeout, and a
+/// with-vectors chunk (N x 896 fp32) is a sub-megabyte JSON body rather than
+/// multi-MB; still large enough that a few hundred entries is only a handful of
+/// requests. A finer chunk also bounds the loss on a mid-push failure to at most
+/// this many entries before the resumable re-run continues. Fixed, not
+/// configurable: no evidence a user needs to tune it, and a constant is trivial
+/// to adjust later.
+const PUSH_BATCH_CHUNK_SIZE: usize = 50;
+
 /// Resolve the project slug to sync into, or halt with actionable guidance.
 ///
 /// Precedence: an explicit `--project <slug>` overrides any configured
@@ -150,6 +161,20 @@ pub async fn memory_sync(
             "Nothing to push — {} entries already synced. Applied {} new remote entries.",
             pushed.already_synced, pulled
         );
+    } else if let Some(reason) = pushed.interrupted.as_deref() {
+        // A chunk failed mid-push. The pull half already ran (it is independently
+        // useful, so there is no reason to withhold remote changes), but the
+        // command must fail loud and tell the user how to resume: the chunks that
+        // landed are durably stamped, so a re-run pushes only the remainder and
+        // already-pushed entries come back as 207 `skipped`.
+        anyhow::bail!(
+            "Pushed {} of {} entries, then stopped: {reason}. \
+             Re-run to resume (already-pushed entries are skipped). \
+             Pull applied {} new remote entries.",
+            pushed.created + pushed.skipped,
+            pushed.attempted,
+            pulled
+        );
     } else if pushed.created == 0 && pushed.skipped == 0 {
         // Total push failure: nothing durably landed cloud-side. The pull
         // already ran (it's an independent, unconditionally useful step —
@@ -202,6 +227,11 @@ pub(super) struct PushSummary {
     /// synced and excluded from `attempted`. Lets callers report an honest
     /// "nothing to push" message instead of implying a push happened.
     pub already_synced: usize,
+    /// `Some(reason)` when a chunk failed mid-push and the loop stopped before
+    /// the remaining chunks (see [`push_local`]); `None` on a clean run. Lets the
+    /// command layer report honest partial progress plus a resume hint and exit
+    /// non-zero, instead of discarding the chunks that already landed.
+    pub interrupted: Option<String>,
 }
 
 /// One-way push entry point reused by `spelunk memory push`.
@@ -224,11 +254,41 @@ pub(super) async fn push_local_oneway(
 /// `accepts_pushed_vectors` is set and the row has a local fp32/896 embedding,
 /// in which case that vector is attached (the server stores it without
 /// re-embedding).
+///
+/// On a chunk-level failure the push stops at the first failed chunk and returns
+/// a summary marked `interrupted` (rather than `?`-propagating and discarding
+/// the chunks that already landed); the already-stamped chunks make the next run
+/// resume from the remainder. See [`push_local_reporting`].
 async fn push_local(
     local: &MemoryStore,
     client: &CloudSyncClient,
     include_archived: bool,
     accepts_pushed_vectors: bool,
+) -> Result<PushSummary> {
+    push_local_reporting(
+        local,
+        client,
+        include_archived,
+        accepts_pushed_vectors,
+        |done, total| {
+            // Transient cumulative status on stderr; the final one-line summary
+            // stays on stdout in the command layer.
+            eprintln!("Pushed {done}/{total}…");
+        },
+    )
+    .await
+}
+
+/// [`push_local`] with the per-chunk progress emission injected as `on_progress`
+/// (called with cumulative `done`/`total` after each chunk that lands), so tests
+/// can observe the progress sequence without capturing stderr. `push_local`
+/// passes the stderr-writing closure.
+async fn push_local_reporting(
+    local: &MemoryStore,
+    client: &CloudSyncClient,
+    include_archived: bool,
+    accepts_pushed_vectors: bool,
+    mut on_progress: impl FnMut(usize, usize),
 ) -> Result<PushSummary> {
     let rows = local.rows_for_sync(include_archived)?;
     if rows.is_empty() {
@@ -238,6 +298,7 @@ async fn push_local(
             skipped: 0,
             failed: 0,
             already_synced: 0,
+            interrupted: None,
         });
     }
 
@@ -246,6 +307,8 @@ async fn push_local(
     let mut created = 0u32;
     let mut skipped = 0u32;
     let mut failed = 0u32;
+    // Set once a chunk fails: the loop stops and the tombstone pass is skipped.
+    let mut interrupted: Option<String> = None;
 
     // Push set (decision #183): live entries not yet on the cloud — i.e.
     // `WHERE remote_id IS NULL`. Already-synced rows carry a `remote_id` and are
@@ -260,9 +323,12 @@ async fn push_local(
         .filter(|r| !r.archived && r.remote_id.is_some())
         .count();
     let attempted = live.len();
+    // Progress is only worth emitting when the push actually spans multiple
+    // chunks; a single-chunk push stays quiet (no noise on small pushes).
+    let multi_chunk = attempted.div_ceil(PUSH_BATCH_CHUNK_SIZE) > 1;
     // Map external_id (local uuid) → local_id so we can record the cloud-minted
     // id returned in the 207 result back onto the local row.
-    for chunk in live.chunks(200) {
+    for chunk in live.chunks(PUSH_BATCH_CHUNK_SIZE) {
         let mut items: Vec<BatchPushItem> = Vec::with_capacity(chunk.len());
         for r in chunk {
             // Only read the local embedding when the server can accept it. The
@@ -296,7 +362,20 @@ async fn push_local(
                 .maybe_attach_vector(accepts_pushed_vectors, vector),
             );
         }
-        let res = client.push_batch(items).await?;
+
+        // A chunk failure (timeout / transport / non-2xx) usually means the
+        // server is overloaded; pushing the remaining chunks would only make that
+        // worse, and the resumable design (already-stamped chunks are filtered
+        // out of `live` on the next run) means a re-run resumes from exactly
+        // here. So stop at the first failed chunk and return the progress that
+        // already landed instead of discarding it via `?`.
+        let res = match client.push_batch(items).await {
+            Ok(res) => res,
+            Err(e) => {
+                interrupted = Some(e.to_string());
+                break;
+            }
+        };
 
         // `created`/`skipped`/`failed` (aggregate ints) and `results[]`
         // (per-item) are independent fields on `BatchPushResult` — nothing on
@@ -345,12 +424,20 @@ async fn push_local(
                 );
             }
         }
+
+        if multi_chunk {
+            // `done` is the running durably-landed count (created + skipped),
+            // which never exceeds `attempted`; the final `done` equals
+            // `created + skipped`.
+            on_progress((created + skipped) as usize, attempted);
+        }
     }
 
     // Tombstone archived entries that the cloud already knows about. An archived
     // row with no `remote_id` was never pushed live, so there is nothing to
-    // delete cloud-side; we skip it.
-    if include_archived {
+    // delete cloud-side; we skip it. Skipped entirely on an interrupted push: the
+    // connection is already failing and the remaining live chunks were not sent.
+    if interrupted.is_none() && include_archived {
         for r in rows.iter().filter(|r| r.archived) {
             if let Some(remote_id) = r.remote_id.as_deref() {
                 client.delete_remote(remote_id).await?;
@@ -364,6 +451,7 @@ async fn push_local(
         skipped,
         failed,
         already_synced,
+        interrupted,
     })
 }
 
@@ -569,6 +657,431 @@ mod tests {
                 )));
             }
         });
+    }
+
+    // ── chunking, resumability, and progress (D1 / D4 / D5) ─────────────────
+
+    use std::collections::{HashMap, HashSet};
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    // Seed `n` distinct live notes: distinct titles give distinct entity_ids (no
+    // dedupe collision), and each is unstamped so all `n` land in the push set.
+    fn seed_notes(store: &MemoryStore, n: usize) {
+        for i in 0..n {
+            store
+                .add_note("note", &format!("T{i}"), "body", &[], &[], None, None)
+                .unwrap();
+        }
+    }
+
+    // Echoes every received entry back as `created` with a distinct cloud id, so
+    // `push_local` tallies and stamps exactly as a real 207 would, for any chunk
+    // size (a static body cannot, since the ids it must echo are minted per row).
+    struct EchoCreated;
+    impl Respond for EchoCreated {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap_or_default();
+            let results: Vec<serde_json::Value> = body["entries"]
+                .as_array()
+                .map(|entries| {
+                    entries
+                        .iter()
+                        .map(|e| {
+                            let ext = e["external_id"].as_str().unwrap_or_default();
+                            serde_json::json!({
+                                "status": "created",
+                                "external_id": ext,
+                                "id": format!("cloud-{ext}"),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": results.len(), "skipped": 0, "failed": 0, "results": results
+            }))
+        }
+    }
+
+    // First request lands (echoed created), every later request 500s. Models a
+    // server that accepts the first chunk then falls over. Keyed on call count so
+    // it does not depend on wiremock's ordering of same-path mocks.
+    struct FailAfterFirst {
+        calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+    impl Respond for FailAfterFirst {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n == 0 {
+                EchoCreated.respond(request)
+            } else {
+                ResponseTemplate::new(500).set_body_string("overloaded")
+            }
+        }
+    }
+
+    #[test]
+    fn push_batch_chunk_size_constant_is_50() {
+        assert_eq!(PUSH_BATCH_CHUNK_SIZE, 50);
+    }
+
+    #[test]
+    fn chunking_splits_live_set_on_the_constant() {
+        let n = PUSH_BATCH_CHUNK_SIZE;
+        // (total, expected chunk count, expected last-chunk len).
+        let cases = [
+            (0usize, 0usize, 0usize),
+            (1, 1, 1),
+            (n, 1, n),
+            (n + 1, 2, 1),
+            (3 * n, 3, n),
+            (2 * n + 7, 3, 7),
+        ];
+        for (total, want_chunks, want_last) in cases {
+            let items: Vec<usize> = (0..total).collect();
+            let chunks: Vec<&[usize]> = items.chunks(PUSH_BATCH_CHUNK_SIZE).collect();
+            assert_eq!(chunks.len(), want_chunks, "chunk count for total={total}");
+            assert!(
+                chunks.iter().all(|c| c.len() <= PUSH_BATCH_CHUNK_SIZE),
+                "no chunk exceeds N for total={total}"
+            );
+            if let Some((last, rest)) = chunks.split_last() {
+                assert!(
+                    rest.iter().all(|c| c.len() == PUSH_BATCH_CHUNK_SIZE),
+                    "every chunk but the last is exactly N for total={total}"
+                );
+                assert_eq!(last.len(), want_last, "last-chunk len for total={total}");
+            }
+            let flat: Vec<usize> = chunks.iter().flat_map(|c| c.iter().copied()).collect();
+            assert_eq!(
+                flat, items,
+                "chunks cover every entry exactly once for total={total}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn push_chunks_cover_every_entry_exactly_once() {
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        seed_notes(&store, 120); // ceil(120 / 50) = 3 chunks
+
+        let want: HashSet<String> = store
+            .rows_for_sync(false)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.uuid)
+            .collect();
+        assert_eq!(want.len(), 120);
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(EchoCreated)
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        let s = push_local(&store, &client, false, false).await.unwrap();
+        assert_eq!(
+            (s.attempted, s.created, s.skipped, s.failed),
+            (120, 120, 0, 0)
+        );
+        assert!(s.interrupted.is_none());
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 3, "ceil(120 / 50) POSTs");
+        let mut seen: Vec<String> = Vec::new();
+        for req in &reqs {
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+            let entries = body["entries"].as_array().unwrap();
+            assert!(
+                entries.len() <= PUSH_BATCH_CHUNK_SIZE,
+                "no chunk carries more than N entries"
+            );
+            for e in entries {
+                seen.push(e["external_id"].as_str().unwrap().to_string());
+            }
+        }
+        assert_eq!(seen.len(), 120, "no entry is pushed more than once");
+        assert_eq!(
+            seen.into_iter().collect::<HashSet<_>>(),
+            want,
+            "the union of pushed ids equals the full live set"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_chunk_push_threads_slug_into_every_request_path() {
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        seed_notes(&store, 60); // 2 chunks
+
+        let want: HashSet<String> = store
+            .rows_for_sync(false)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.uuid)
+            .collect();
+
+        // The mock ONLY matches the percent-encoded slug path, so an all-created
+        // push proves every chunk (the first included) carried the slug in the
+        // path, which is what lazily creates/reuses the project server-side.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/acme%2Fapp/memory/batch"))
+            .respond_with(EchoCreated)
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "acme/app", None, None).unwrap();
+
+        let s = push_local(&store, &client, false, false).await.unwrap();
+        assert_eq!((s.attempted, s.created), (60, 60));
+        assert!(s.interrupted.is_none());
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 2);
+        let seen: HashSet<String> = reqs
+            .iter()
+            .flat_map(|r| {
+                let body: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
+                body["entries"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|e| e["external_id"].as_str().unwrap().to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert_eq!(seen, want, "all entries observed across the batch requests");
+    }
+
+    #[tokio::test]
+    async fn interrupted_push_stops_and_resumes_from_the_remainder() {
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        seed_notes(&store, 120); // 3 chunks: 50, 50, 20
+
+        // ── Run 1: chunk 1 lands, chunk 2 fails (500), chunk 3 is never sent. ──
+        let server1 = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(FailAfterFirst {
+                calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            })
+            .mount(&server1)
+            .await;
+        let client1 = CloudSyncClient::new(&server1.uri(), "proj", None, None).unwrap();
+
+        let s1 = push_local(&store, &client1, false, false).await.unwrap();
+        assert!(
+            s1.interrupted.is_some(),
+            "a mid-push failure marks the summary interrupted"
+        );
+        assert_eq!(
+            (s1.attempted, s1.created, s1.skipped),
+            (120, 50, 0),
+            "only the first chunk landed"
+        );
+        assert_eq!(
+            server1.received_requests().await.unwrap().len(),
+            2,
+            "must stop at the first failed chunk, never push the remaining chunk"
+        );
+        let remaining: Vec<_> = store
+            .rows_for_sync(false)
+            .unwrap()
+            .into_iter()
+            .filter(|r| r.remote_id.is_none())
+            .collect();
+        assert_eq!(
+            remaining.len(),
+            70,
+            "the 50 landed rows are durably stamped"
+        );
+
+        // ── Run 2: a healthy server pushes ONLY the remainder. ──
+        let server2 = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(EchoCreated)
+            .mount(&server2)
+            .await;
+        let client2 = CloudSyncClient::new(&server2.uri(), "proj", None, None).unwrap();
+
+        let s2 = push_local(&store, &client2, false, false).await.unwrap();
+        assert!(s2.interrupted.is_none());
+        assert_eq!(
+            (s2.attempted, s2.created),
+            (70, 70),
+            "resume pushes only the remainder"
+        );
+        let reqs2 = server2.received_requests().await.unwrap();
+        let pushed2: usize = reqs2
+            .iter()
+            .map(|r| {
+                let body: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
+                body["entries"].as_array().unwrap().len()
+            })
+            .sum();
+        assert_eq!(
+            pushed2, 70,
+            "resume re-pushes exactly the previously-unstamped rows"
+        );
+        assert!(
+            store
+                .rows_for_sync(false)
+                .unwrap()
+                .iter()
+                .all(|r| r.remote_id.is_some()),
+            "every row is stamped after the resume"
+        );
+        assert_eq!(
+            store.count().unwrap(),
+            120,
+            "no local duplicates introduced"
+        );
+    }
+
+    #[tokio::test]
+    async fn overlapping_repush_tallies_skipped_and_leaves_no_duplicates() {
+        // Models the committed-but-unstamped overlap: a prior push persisted rows
+        // server-side but the client lost the response (no `remote_id` stamped).
+        // On re-push the server dedupes on external_id and returns 207 `skipped`
+        // for the overlap; the client must tally those as skipped (not created),
+        // stamp them, and add no local duplicates.
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        seed_notes(&store, 4);
+
+        let rows = store.rows_for_sync(false).unwrap();
+        // First two rows are the overlap (already server-side → skipped); the last
+        // two are genuinely new (created). Keyed by uuid, so row order is irrelevant.
+        let mut status: HashMap<String, &str> = HashMap::new();
+        status.insert(rows[0].uuid.clone(), "skipped");
+        status.insert(rows[1].uuid.clone(), "skipped");
+        status.insert(rows[2].uuid.clone(), "created");
+        status.insert(rows[3].uuid.clone(), "created");
+        let results: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "status": status[&r.uuid],
+                    "external_id": r.uuid,
+                    "id": format!("cloud-{}", r.uuid),
+                })
+            })
+            .collect();
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 2, "skipped": 2, "failed": 0, "results": results
+            })))
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        let s = push_local(&store, &client, false, false).await.unwrap();
+        assert_eq!((s.attempted, s.created, s.skipped, s.failed), (4, 2, 2, 0));
+        assert!(s.interrupted.is_none());
+        assert!(
+            store
+                .rows_for_sync(false)
+                .unwrap()
+                .iter()
+                .all(|r| r.remote_id.is_some()),
+            "overlap and new rows both end stamped"
+        );
+        assert_eq!(
+            store.count().unwrap(),
+            4,
+            "no local duplicates from the round trip"
+        );
+
+        let s2 = push_local(&store, &client, false, false).await.unwrap();
+        assert_eq!((s2.attempted, s2.already_synced), (0, 4));
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "a fully-stamped re-push sends no batch request"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_chunk_push_reports_cumulative_progress_after_each_chunk() {
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        seed_notes(&store, 120); // 3 chunks
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(EchoCreated)
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        let mut progress: Vec<(usize, usize)> = Vec::new();
+        let s = push_local_reporting(&store, &client, false, false, |done, total| {
+            progress.push((done, total));
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(progress.len(), 3, "one progress emission per chunk");
+        assert!(
+            progress.iter().all(|&(done, total)| done <= total),
+            "done never exceeds total: {progress:?}"
+        );
+        assert_eq!(
+            progress.iter().map(|&(d, _)| d).collect::<Vec<_>>(),
+            vec![50, 100, 120],
+            "done advances cumulatively by the landed count"
+        );
+        assert!(progress.iter().all(|&(_, total)| total == 120));
+        assert_eq!(
+            progress.last().unwrap().0 as u32,
+            s.created + s.skipped,
+            "final reported done equals created + skipped"
+        );
+        assert_eq!(s.created + s.skipped, 120);
+    }
+
+    #[tokio::test]
+    async fn single_chunk_push_is_one_request_and_emits_no_progress() {
+        register_sqlite_vec();
+        let tmp = TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        seed_notes(&store, PUSH_BATCH_CHUNK_SIZE); // exactly one chunk
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(EchoCreated)
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+        let mut calls = 0usize;
+        let s = push_local_reporting(&store, &client, false, false, |_, _| calls += 1)
+            .await
+            .unwrap();
+        assert_eq!(calls, 0, "a single-chunk push emits no progress");
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "exactly one POST for a push of N or fewer entries"
+        );
+        assert_eq!(s.created, PUSH_BATCH_CHUNK_SIZE as u32);
     }
 
     #[tokio::test]

--- a/crates/spelunk-cli/tests/memory_push_sync_partial_failure.rs
+++ b/crates/spelunk-cli/tests/memory_push_sync_partial_failure.rs
@@ -1,0 +1,214 @@
+//! Subprocess-level coverage for a mid-push (partial) failure: a multi-chunk
+//! `spelunk memory push` / `spelunk sync` whose later chunk fails must exit
+//! non-zero, print honest partial progress (`Pushed X of Y`) plus a resume hint,
+//! and never print success framing (`Done.` / `Sync complete.`).
+//!
+//! `push_local` (`crates/spelunk-cli/src/cli/cmd/memory/sync.rs`) stops at the
+//! first failed chunk, keeps the chunks that already landed durably stamped, and
+//! returns a summary marked `interrupted` rather than `?`-propagating; the
+//! command layer (`push.rs` / `sync.rs`) turns that into the partial-progress
+//! message and a non-zero exit via `bail!`. These tests spawn the real compiled
+//! `spelunk` binary (`assert_cmd`, following `memory_push_sync_total_failure.rs`)
+//! against a mock team server that serves the first chunk then 500s, so a
+//! regression in the command-layer framing or exit code is what fails here.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use std::path::Path;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+use spelunk_core::storage::MemoryStore;
+
+/// Project slug with no characters `encode_project_id` would percent-encode,
+/// so the mocked route paths below can be matched literally.
+const PROJECT_SLUG: &str = "acme-widget";
+
+/// Enough entries to span more than one push chunk (chunk size is 50), so a
+/// later chunk can fail after an earlier one has already landed.
+const SEED_COUNT: usize = 60;
+
+fn register_sqlite_vec() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite_vec::sqlite3_vec_init as *const (),
+            )));
+        }
+    });
+}
+
+/// The first `POST /memory/batch` (chunk 1) lands `created: 50`; every later
+/// request 500s (chunk 2 fails). Keyed on call count so it does not depend on
+/// wiremock's ordering of same-path mocks.
+struct FirstChunkThenFail {
+    calls: AtomicUsize,
+}
+impl Respond for FirstChunkThenFail {
+    fn respond(&self, _request: &Request) -> ResponseTemplate {
+        let n = self.calls.fetch_add(1, Ordering::SeqCst);
+        if n == 0 {
+            ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 50, "skipped": 0, "failed": 0, "results": []
+            }))
+        } else {
+            ResponseTemplate::new(500).set_body_string("overloaded")
+        }
+    }
+}
+
+async fn mount_health(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "capabilities": ["memory"],
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_batch_first_ok_then_fail(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/projects/{PROJECT_SLUG}/memory/batch")))
+        .respond_with(FirstChunkThenFail {
+            calls: AtomicUsize::new(0),
+        })
+        .mount(server)
+        .await;
+}
+
+/// The pull half of `spelunk sync` runs independently of the push outcome.
+async fn mount_since_empty(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path_regex(format!(
+            r"^/v1/projects/{PROJECT_SLUG}/memory/since$"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": []
+        })))
+        .mount(server)
+        .await;
+}
+
+// See `memory_push_sync_total_failure.rs::write_config` for why `server_url` /
+// `project_id` live in the project-level `.spelunk/config.toml` rather than the
+// `--config` file.
+fn write_config(dir: &Path, server_url: &str) -> std::path::PathBuf {
+    let db_path = dir.join(".spelunk").join("index.db");
+    let config_path = dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "db_path = {db_path:?}\n\
+             embedding_model = \"test-model\"\n\
+             llm_model = \"test-chat\"\n"
+        ),
+    )
+    .expect("write config.toml");
+    plumbing_helpers::write_project_server_config(dir, server_url, PROJECT_SLUG);
+    config_path
+}
+
+fn init_project(proj: &Path) {
+    std::fs::create_dir_all(proj.join(".spelunk")).expect("create .spelunk");
+}
+
+/// Seed a standalone memory.db with `SEED_COUNT` distinct live notes, directly
+/// via the library, so the push has a multi-chunk live set without spawning one
+/// `memory add` subprocess per note.
+fn seed_source_store(mem_path: &Path) {
+    register_sqlite_vec();
+    std::fs::create_dir_all(mem_path.parent().unwrap()).expect("create source dir");
+    let store = MemoryStore::open(mem_path).expect("open source memory.db");
+    for i in 0..SEED_COUNT {
+        store
+            .add_note("note", &format!("T{i}"), "body", &[], &[], None, None)
+            .expect("seed note");
+    }
+}
+
+#[tokio::test]
+async fn memory_push_mid_chunk_failure_exits_nonzero_with_resume_hint() {
+    let server = MockServer::start().await;
+    mount_health(&server).await;
+    mount_batch_first_ok_then_fail(&server).await;
+
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_project(proj.path());
+    let config_path = write_config(proj.path(), &server.uri());
+    let mem_path = proj.path().join("seed-memory.db");
+    seed_source_store(&mem_path);
+
+    let assert = spelunk_bin_in(home.path())
+        .current_dir(proj.path())
+        .arg("--config")
+        .arg(&config_path)
+        .args(["memory", "push", "--source"])
+        .arg(&mem_path)
+        .assert()
+        .failure();
+
+    let out = assert.get_output();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(&format!("Pushed 50 of {SEED_COUNT}")),
+        "must report honest partial progress; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stderr.contains("Re-run to resume"),
+        "must give a resume hint; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        !stdout.contains("Done.") && !stderr.contains("Done."),
+        "an interrupted push must never read as success; stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+#[tokio::test]
+async fn memory_sync_mid_chunk_failure_exits_nonzero_with_resume_hint() {
+    let server = MockServer::start().await;
+    mount_health(&server).await;
+    mount_batch_first_ok_then_fail(&server).await;
+    mount_since_empty(&server).await;
+
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_project(proj.path());
+    let config_path = write_config(proj.path(), &server.uri());
+    let mem_path = proj.path().join("seed-memory.db");
+    seed_source_store(&mem_path);
+
+    let assert = spelunk_bin_in(home.path())
+        .current_dir(proj.path())
+        .arg("--config")
+        .arg(&config_path)
+        .args(["sync", "--source"])
+        .arg(&mem_path)
+        .assert()
+        .failure();
+
+    let out = assert.get_output();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains(&format!("Pushed 50 of {SEED_COUNT}")),
+        "must report honest partial progress; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stderr.contains("Re-run to resume"),
+        "must give a resume hint; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        !stdout.contains("Sync complete.") && !stderr.contains("Sync complete."),
+        "an interrupted sync must never read as success; stdout={stdout:?} stderr={stderr:?}"
+    );
+}

--- a/crates/spelunk-cli/tests/memory_push_sync_partial_failure.rs
+++ b/crates/spelunk-cli/tests/memory_push_sync_partial_failure.rs
@@ -1,16 +1,16 @@
-//! Subprocess-level coverage for a mid-push (partial) failure: a multi-chunk
-//! `spelunk memory push` / `spelunk sync` whose later chunk fails must exit
-//! non-zero, print honest partial progress (`Pushed X of Y`) plus a resume hint,
-//! and never print success framing (`Done.` / `Sync complete.`).
-//!
-//! `push_local` (`crates/spelunk-cli/src/cli/cmd/memory/sync.rs`) stops at the
-//! first failed chunk, keeps the chunks that already landed durably stamped, and
-//! returns a summary marked `interrupted` rather than `?`-propagating; the
-//! command layer (`push.rs` / `sync.rs`) turns that into the partial-progress
-//! message and a non-zero exit via `bail!`. These tests spawn the real compiled
-//! `spelunk` binary (`assert_cmd`, following `memory_push_sync_total_failure.rs`)
-//! against a mock team server that serves the first chunk then 500s, so a
-//! regression in the command-layer framing or exit code is what fails here.
+// Subprocess-level coverage for a mid-push (partial) failure: a multi-chunk
+// `spelunk memory push` / `spelunk sync` whose later chunk fails must exit
+// non-zero, print honest partial progress (`Pushed X of Y`) plus a resume hint,
+// and never print success framing (`Done.` / `Sync complete.`).
+//
+// `push_local` (`crates/spelunk-cli/src/cli/cmd/memory/sync.rs`) stops at the
+// first failed chunk, keeps the chunks that already landed durably stamped, and
+// returns a summary marked `interrupted` rather than `?`-propagating; the
+// command layer (`push.rs` / `sync.rs`) turns that into the partial-progress
+// message and a non-zero exit via `bail!`. These tests spawn the real compiled
+// `spelunk` binary (`assert_cmd`, following `memory_push_sync_total_failure.rs`)
+// against a mock team server that serves the first chunk then 500s, so a
+// regression in the command-layer framing or exit code is what fails here.
 
 mod plumbing_helpers;
 use plumbing_helpers::spelunk_bin_in;
@@ -24,12 +24,12 @@ use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
 use spelunk_core::storage::MemoryStore;
 
-/// Project slug with no characters `encode_project_id` would percent-encode,
-/// so the mocked route paths below can be matched literally.
+// Project slug with no characters `encode_project_id` would percent-encode,
+// so the mocked route paths below can be matched literally.
 const PROJECT_SLUG: &str = "acme-widget";
 
-/// Enough entries to span more than one push chunk (chunk size is 50), so a
-/// later chunk can fail after an earlier one has already landed.
+// Enough entries to span more than one push chunk (chunk size is 50), so a
+// later chunk can fail after an earlier one has already landed.
 const SEED_COUNT: usize = 60;
 
 fn register_sqlite_vec() {
@@ -44,9 +44,9 @@ fn register_sqlite_vec() {
     });
 }
 
-/// The first `POST /memory/batch` (chunk 1) lands `created: 50`; every later
-/// request 500s (chunk 2 fails). Keyed on call count so it does not depend on
-/// wiremock's ordering of same-path mocks.
+// The first `POST /memory/batch` (chunk 1) lands `created: 50`; every later
+// request 500s (chunk 2 fails). Keyed on call count so it does not depend on
+// wiremock's ordering of same-path mocks.
 struct FirstChunkThenFail {
     calls: AtomicUsize,
 }
@@ -84,7 +84,7 @@ async fn mount_batch_first_ok_then_fail(server: &MockServer) {
         .await;
 }
 
-/// The pull half of `spelunk sync` runs independently of the push outcome.
+// The pull half of `spelunk sync` runs independently of the push outcome.
 async fn mount_since_empty(server: &MockServer) {
     Mock::given(method("GET"))
         .and(path_regex(format!(
@@ -120,9 +120,9 @@ fn init_project(proj: &Path) {
     std::fs::create_dir_all(proj.join(".spelunk")).expect("create .spelunk");
 }
 
-/// Seed a standalone memory.db with `SEED_COUNT` distinct live notes, directly
-/// via the library, so the push has a multi-chunk live set without spawning one
-/// `memory add` subprocess per note.
+// Seed a standalone memory.db with `SEED_COUNT` distinct live notes, directly
+// via the library, so the push has a multi-chunk live set without spawning one
+// `memory add` subprocess per note.
 fn seed_source_store(mem_path: &Path) {
     register_sqlite_vec();
     std::fs::create_dir_all(mem_path.parent().unwrap()).expect("create source dir");

--- a/crates/spelunk-core/src/storage/remote/sync.rs
+++ b/crates/spelunk-core/src/storage/remote/sync.rs
@@ -26,10 +26,22 @@
 //! never receives a vector and re-embeds — so text-only remains the universal
 //! fallback.
 
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use super::encode_project_id;
+
+/// Per-request timeout for the sync HTTP client. `POST /memory/batch` performs
+/// server-side embedding backfill, an inference-class operation: a cold embedder
+/// plus a large with-vectors payload can legitimately run well past the 30s
+/// per-entry CRUD ceiling while still making progress, so the sync path belongs
+/// in the inference timeout class instead. This is a client-level timeout, so it
+/// also raises the ceiling on `pull_since`/`delete_remote`: strictly better,
+/// since only a hung connection ever reaches it and a slow-but-progressing pull
+/// is no longer cut short at 30s.
+const SYNC_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Precision tag sent alongside a client-pushed memory vector. Memory vectors
 /// cross to the cloud, so they are ALWAYS full-precision fp32 — never the
@@ -183,14 +195,34 @@ impl CloudSyncClient {
         api_key: Option<&str>,
         server_ca: Option<&std::path::Path>,
     ) -> Result<Self> {
+        Self::with_timeout(
+            base_url,
+            project_id,
+            api_key,
+            server_ca,
+            SYNC_REQUEST_TIMEOUT,
+        )
+    }
+
+    /// Build a client with an explicit per-request timeout. Production always
+    /// uses [`SYNC_REQUEST_TIMEOUT`] via [`Self::new`]; a caller passes a short
+    /// timeout only to exercise the enforcement path without waiting on the 300s
+    /// production ceiling.
+    fn with_timeout(
+        base_url: &str,
+        project_id: &str,
+        api_key: Option<&str>,
+        server_ca: Option<&std::path::Path>,
+        timeout: Duration,
+    ) -> Result<Self> {
         // Fail closed before building the client: a bearer must never travel over
         // plaintext http to a non-loopback host. Keyless
-        // loopback-dev construction is unaffected — nothing to leak.
+        // loopback-dev construction is unaffected: nothing to leak.
         if api_key.is_some() {
             crate::config::validate_transport_url(base_url).map_err(anyhow::Error::msg)?;
         }
         let client = crate::config::apply_server_ca(reqwest::Client::builder(), server_ca)?
-            .timeout(std::time::Duration::from_secs(30))
+            .timeout(timeout)
             .build()
             .context("building sync HTTP client")?;
         Ok(Self {
@@ -332,6 +364,65 @@ mod tests {
 
     fn spelunk_core_embedding_dim() -> usize {
         crate::embeddings::EMBEDDING_DIM
+    }
+
+    // ── request timeout: inference-class, and actually enforced ──────────────
+
+    #[test]
+    fn sync_request_timeout_is_inference_class_not_the_old_cap() {
+        // Guards against a silent revert to the old 30s per-entry CRUD cap:
+        // `/memory/batch` re-embeds server-side, so the client timeout must stay
+        // in the inference class.
+        assert_eq!(SYNC_REQUEST_TIMEOUT, Duration::from_secs(300));
+        assert!(SYNC_REQUEST_TIMEOUT > Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn request_timeout_is_actually_enforced_per_request() {
+        // A response delayed past the client timeout must surface as a timeout
+        // error; the same slow response under a looser timeout must succeed. This
+        // proves the per-request timeout is wired to the client, exercised with a
+        // short injected value so it runs sub-second, decoupled from the 300s
+        // production literal.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(
+                ResponseTemplate::new(207)
+                    .set_body_json(serde_json::json!({
+                        "created": 1, "skipped": 0, "failed": 0,
+                        "results": [{"status": "created", "external_id": "e1", "id": "c1"}]
+                    }))
+                    .set_delay(Duration::from_millis(300)),
+            )
+            .mount(&server)
+            .await;
+
+        let tight = CloudSyncClient::with_timeout(
+            &server.uri(),
+            "proj",
+            None,
+            None,
+            Duration::from_millis(50),
+        )
+        .unwrap();
+        let err = tight.push_batch(vec![item("e1")]).await.unwrap_err();
+        let chain = format!("{err:#}").to_lowercase();
+        assert!(
+            chain.contains("time"),
+            "a response past the client timeout must surface as a timeout: {err:#}"
+        );
+
+        let loose = CloudSyncClient::with_timeout(
+            &server.uri(),
+            "proj",
+            None,
+            None,
+            Duration::from_secs(5),
+        )
+        .unwrap();
+        let res = loose.push_batch(vec![item("e1")]).await.unwrap();
+        assert_eq!(res.created, 1);
     }
 
     /// The push is text-only by default, and carries the fp32/896 vector + model

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -34,8 +34,9 @@ pub const MAX_SLUG_LEN: usize = 200;
 /// its calibrated batch without guessing (see `HealthResponse`).
 pub const MAX_EMBED_BATCH: usize = 256;
 /// Max number of entries accepted in a single `POST /memory/batch` request.
-/// Matches cloud-api's cap and the CLI's own push chunk size
-/// (`chunk.chunks(200)` in `sync.rs`), so a legitimate CLI push never trips it.
+/// Matches cloud-api's cap and comfortably exceeds the CLI's own push chunk
+/// size (`PUSH_BATCH_CHUNK_SIZE` in `sync.rs`), so a legitimate CLI push never
+/// trips it.
 pub const MAX_BATCH_ENTRIES: usize = 200;
 
 /// Reject a title/body pair that exceeds the configured caps. Shared by every


### PR DESCRIPTION
> **Stacked on #740.** This PR is stacked on the main test-build hotfix (PR #740) and is based on that branch, so its CI is green immediately. Merge #740 first: GitHub will retarget this PR's base to `main` automatically once #740 merges.

## What was broken

`spelunk memory push` and `spelunk sync` of a real-sized project (more than a few dozen memory entries) timed out and pushed nothing. Every batch request was bounded by a fixed 30-second client request timeout, but a batch large enough to matter makes the server re-embed each entry, which routinely runs past 30 seconds. The request timed out, the push aborted, and because the first batch is what creates the server-side project, the project was never created: the user saw a timeout and had nothing on the server.

## The fix

- **Smaller per-request batches.** Entries are chunked at `PUSH_BATCH_CHUNK_SIZE` (50) per `POST /memory/batch` instead of one oversized request, bounding both the JSON payload and the server-side embedding work per request.
- **Inference-class request timeout.** The sync HTTP client now uses `SYNC_REQUEST_TIMEOUT` (300s) instead of the 30-second per-entry CRUD ceiling, matching the class of work a batch actually performs (server-side embedding backfill). A push of hundreds of entries now completes, and the project is created by the first batch.
- **Honest partial progress on interruption.** If a batch fails partway through (for example the server is briefly overloaded), the push stops at that batch, prints `Pushed X of Y` plus a `Re-run to resume` hint, and exits non-zero instead of reading as success. Batches that already landed are stamped durably, so a re-run pushes only the remainder and any entry the server already holds comes back skipped, never duplicated.

## Test plan

Every cargo command was run with `SPELUNK_SECRET_STORE=file` (the file secret store, so no live macOS Keychain prompt).

- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-core -p spelunk-cli`: green. Covers the new chunking, resumability, and subprocess partial-failure tests, including `memory_push_mid_chunk_failure_exits_nonzero_with_resume_hint`, `memory_sync_mid_chunk_failure_exits_nonzero_with_resume_hint`, and the inline `chunking_splits_live_set_on_the_constant` / `interrupted_push_stops_and_resumes_from_the_remainder` suite.
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-core -p spelunk-cli --no-default-features`: green (60 test binaries, 0 failures). This is the configuration CI runs on Linux, Windows, and macOS.
- `SPELUNK_SECRET_STORE=file cargo clippy -p spelunk-core -p spelunk-cli --all-targets -- -D warnings`: clean.
- `SPELUNK_SECRET_STORE=file cargo fmt --all --check`: clean.
- The OpenAPI generator (`write_openapi_snapshot`) regenerates `docs/openapi.json` with no drift.

QA independently reverse-applied the fix and confirmed the core tests go red without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
