### PR TITLE
Add spelunk memory reindex to backfill unembedded memory notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`spelunk memory reindex` backfills local note embeddings that were never
+  minted, so semantic `memory search` can surface those notes again.** A note's
+  vector is created only at `memory add` time; if no embedder was reachable
+  then, or the store was upgraded across the 768→896 embedding-dimension change
+  (which drops the old vectors), the note stays present-but-unembedded with no
+  catch-up path and is invisible to semantic KNN (it is still reachable via text
+  search, `list`, `timeline`, and `context`). `reindex` re-embeds those notes
+  through the same local embed path `memory add` uses, committing each vector as
+  it completes so an interrupted run resumes on re-run rather than starting over.
+  By default it embeds only active notes missing a vector; `--force` re-embeds
+  every active note, replacing any existing vector (useful after a model or
+  dimension change); `--include-archived` also covers archived notes; `--dry-run`
+  reports the count and writes nothing; and `--format json` emits a
+  machine-readable summary. When no embedder is reachable it fails with an
+  actionable error and writes nothing. After the 768→896 upgrade drops old
+  vectors, memory commands print a one-line notice pointing at `spelunk memory
+  reindex` so the recall regression is discoverable without `RUST_LOG`.
+
 - **`local_first` writes now queue and drain automatically; you no longer
   need to run `spelunk sync` by hand in the normal path.** A write (`memory
   add`/`archive`/`supersede`) with a team `server_url` configured still

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -51,6 +51,8 @@ pub enum MemoryCommand {
     Failures(MemoryFailuresArgs),
     /// Import unique notes from server.db into the local memory.db (recovery / migration tool)
     Reconcile(MemoryReconcileArgs),
+    /// Backfill missing local embeddings so semantic search can find notes left unembedded (recovery tool)
+    Reindex(MemoryReindexArgs),
     /// Collapse duplicate-entity_id groups already resident in local memory.db (recovery tool)
     Dedupe(MemoryDedupeArgs),
 }
@@ -354,6 +356,25 @@ pub struct MemoryReconcileArgs {
 }
 
 #[derive(Args, Debug)]
+pub struct MemoryReindexArgs {
+    /// Re-embed every active note, replacing existing vectors (e.g. after a model or dimension change)
+    #[arg(long)]
+    pub force: bool,
+
+    /// Also re-embed archived notes (default: active notes only)
+    #[arg(long)]
+    pub include_archived: bool,
+
+    /// Report how many notes would be embedded, then exit without writing anything
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Output format: text or json
+    #[arg(long, default_value = "text")]
+    pub format: String,
+}
+
+#[derive(Args, Debug)]
 pub struct MemoryDedupeArgs {
     /// Detect and report duplicate entity_id groups without collapsing anything
     #[arg(long)]
@@ -378,6 +399,7 @@ mod list;
 pub(crate) mod outbox;
 pub mod push;
 pub(crate) mod reconcile;
+mod reindex;
 mod search;
 mod show;
 mod since;
@@ -396,6 +418,7 @@ pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> 
     // carrier mode downstream (add skips the absent SQLite primary; list reads
     // from `refs/notes/spelunk`). Store priority is otherwise unchanged (ADR-004).
     let (mem_path, pre_init_notes) = resolve_memory_store(&args, &cfg, be).await?;
+    maybe_emit_reembed_notice(&mem_path, pre_init_notes, be);
     match args.command {
         MemoryCommand::Add(a) => add::memory_add(a, &mem_path, &cfg, be, pre_init_notes).await,
         MemoryCommand::Search(a) => search::memory_search(a, &mem_path, &cfg, be).await,
@@ -413,7 +436,34 @@ pub async fn memory(args: MemoryArgs, cfg: crate::config::Config) -> Result<()> 
         MemoryCommand::Watch(a) => watch::memory_watch(a, &cfg).await,
         MemoryCommand::Failures(a) => failures::memory_failures(a, &mem_path, &cfg, be).await,
         MemoryCommand::Reconcile(a) => reconcile::memory_reconcile(a, &mem_path, &cfg).await,
+        MemoryCommand::Reindex(a) => reindex::memory_reindex(a, &mem_path, &cfg, be).await,
         MemoryCommand::Dedupe(a) => dedupe::memory_dedupe(a, &mem_path).await,
+    }
+}
+
+/// One-line, `RUST_LOG`-free notice pointing the user at `memory reindex` when
+/// the 768→896 store upgrade just dropped their prior note vectors (D5(b)).
+///
+/// `MemoryStore::open` sets `reembed_needed` only on the single open where that
+/// drop ran, so this fires once, not on every command. Skipped for the
+/// git-notes carrier / `--backend git-notes` paths (no local sqlite store) and
+/// for a path that does not yet exist, so we never create a store just to check
+/// (the CloudFirst placeholder path never has a local store to open here).
+fn maybe_emit_reembed_notice(
+    mem_path: &std::path::Path,
+    pre_init_notes: bool,
+    be: Option<&'static str>,
+) {
+    if pre_init_notes || be == Some("git-notes") || !mem_path.exists() {
+        return;
+    }
+    if let Ok(store) = crate::storage::MemoryStore::open(mem_path)
+        && let Some(n) = store.reembed_needed
+    {
+        eprintln!(
+            "[spelunk] {n} note(s) need re-embedding for semantic search; \
+             run 'spelunk memory reindex'."
+        );
     }
 }
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/reindex.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/reindex.rs
@@ -1,0 +1,167 @@
+//! `spelunk memory reindex`: backfill missing local note embeddings.
+//!
+//! A note's vector is minted only at `memory add` time. When no embedder was
+//! reachable then, or the 768→896 store upgrade discarded every prior vector,
+//! the note stays present-but-unembedded and semantic `memory search` can no
+//! longer surface it, with no catch-up path. This command re-embeds those notes
+//! through the same LOCAL embed path `add` uses, committing each vector as it
+//! completes so an interrupted run resumes on re-run.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use super::super::helpers::require_server_client;
+use super::MemoryReindexArgs;
+use crate::{capability, config::Config, embeddings::vec_to_blob, storage::MemoryStore};
+
+/// Counts partition the store: `total_active == already_embedded + missing_before`.
+/// `remaining` is how many of the targeted notes are still unembedded after the
+/// run (0 on full success). `would_embed` is populated under `--dry-run` only.
+#[derive(Debug, Serialize)]
+struct ReindexSummary {
+    total_active: usize,
+    missing_before: usize,
+    already_embedded: usize,
+    embedded: usize,
+    remaining: usize,
+    would_embed: usize,
+    include_archived: bool,
+    force: bool,
+}
+
+enum Outcome {
+    DryRun,
+    NothingToDo,
+    Done,
+}
+
+pub(super) async fn memory_reindex(
+    args: MemoryReindexArgs,
+    mem_path: &std::path::Path,
+    cfg: &Config,
+    backend_override: Option<&str>,
+) -> Result<()> {
+    // Embeddings are a sqlite-vec concern; git notes hold no vectors.
+    if backend_override == Some("git-notes") {
+        anyhow::bail!(
+            "This operation requires the sqlite backend. \
+             Re-run without --backend git-notes."
+        );
+    }
+
+    let json = crate::utils::effective_format(&args.format) == "json";
+
+    let store = MemoryStore::open(mem_path)
+        .with_context(|| format!("opening memory.db at {}", mem_path.display()))?;
+
+    let total_active = store.count().context("counting active notes")? as usize;
+    // `missing_before` is always the active-notes-missing count, independent of
+    // the flags, so the summary partitions cleanly regardless of --force /
+    // --include-archived.
+    let missing_before = store
+        .notes_missing_embeddings(false)
+        .context("finding notes missing embeddings")?
+        .len();
+    let already_embedded = total_active.saturating_sub(missing_before);
+
+    let candidates = if args.force {
+        store
+            .all_active_notes_for_reembed(args.include_archived)
+            .context("listing notes to re-embed")?
+    } else {
+        store
+            .notes_missing_embeddings(args.include_archived)
+            .context("finding notes missing embeddings")?
+    };
+
+    let mut summary = ReindexSummary {
+        total_active,
+        missing_before,
+        already_embedded,
+        embedded: 0,
+        remaining: 0,
+        would_embed: 0,
+        include_archived: args.include_archived,
+        force: args.force,
+    };
+
+    // Dry-run and nothing-to-do both exit 0 without touching the embedder, so a
+    // count/no-op never requires a running server.
+    if args.dry_run {
+        summary.would_embed = candidates.len();
+        emit_summary(&summary, json, Outcome::DryRun);
+        return Ok(());
+    }
+    if candidates.is_empty() {
+        emit_summary(&summary, json, Outcome::NothingToDo);
+        return Ok(());
+    }
+
+    // Reuse add's LOCAL embed path so reindex works with no explicit server_url:
+    // an auto-discovered loopback server sets the tier without populating
+    // `server_url`, so bridge it into an effective config first (ADR-004),
+    // exactly as `memory add` / `memory search` do (`project_root` is the store's
+    // parent).
+    let project_root = mem_path.parent().unwrap_or(mem_path);
+    let tier = capability::get_tier(cfg).await;
+    let eff_cfg = tier.effective_config(cfg, project_root);
+    // No embedder reachable → actionable error + non-zero exit, before any
+    // write. Deliberately unlike reconcile (which imports without embeddings):
+    // here embedding IS the point, so silence-and-succeed would recreate the bug.
+    let client = require_server_client(&eff_cfg, "memory reindex")?;
+
+    let total = candidates.len();
+    let mut embedded = 0usize;
+    for (id, title, body) in &candidates {
+        // Byte-identical to add.rs's document string: a backfilled vector must
+        // match an add-time one, so this format must not drift. `embed_text`
+        // embeds the raw document (NOT `embed_query`, which prepends the F2LLM
+        // `Instruct:/Query:` prefix and would produce a query-side vector).
+        let doc = format!("title: {title} | text: {body}");
+        let vec = match client.embed_text(&doc).await {
+            Ok(v) => v,
+            Err(e) => {
+                // Every note embedded so far is already durably committed
+                // (`insert_embedding` commits per call), so a re-run resumes the
+                // remainder rather than starting over.
+                return Err(e.context(format!(
+                    "embedding note #{id} ({embedded} of {total} done and durably stored; \
+                     re-run 'spelunk memory reindex' to resume the rest)"
+                )));
+            }
+        };
+        let blob = vec_to_blob(&vec);
+        store
+            .insert_embedding(*id, &blob)
+            .with_context(|| format!("storing embedding for note #{id}"))?;
+        embedded += 1;
+        eprintln!("[spelunk] embedded {embedded}/{total}…");
+    }
+
+    summary.embedded = embedded;
+    summary.remaining = total - embedded;
+    emit_summary(&summary, json, Outcome::Done);
+    Ok(())
+}
+
+fn emit_summary(s: &ReindexSummary, json: bool, outcome: Outcome) {
+    if json {
+        println!("{}", serde_json::to_string(s).unwrap_or_default());
+        return;
+    }
+    match outcome {
+        Outcome::DryRun => println!(
+            "Dry run: {} note(s) would be embedded ({} active total, {} already embedded). \
+             Nothing written.",
+            s.would_embed, s.total_active, s.already_embedded
+        ),
+        Outcome::NothingToDo => println!(
+            "Nothing to reindex: all {} active note(s) already embedded.",
+            s.total_active
+        ),
+        Outcome::Done => println!(
+            "Reindex complete: {} embedded, {} remaining ({} missing before, {} active total).",
+            s.embedded, s.remaining, s.missing_before, s.total_active
+        ),
+    }
+}

--- a/crates/spelunk-cli/tests/memory_reindex.rs
+++ b/crates/spelunk-cli/tests/memory_reindex.rs
@@ -1,0 +1,592 @@
+// End-to-end tests for `spelunk memory reindex` against the built CLI binary.
+//
+// The command re-embeds memory notes left without a local vector (the 768→896
+// store upgrade dropped them, or no embedder was reachable at add time). These
+// tests drive the real binary with the embed endpoint mocked via wiremock, so
+// none of them depend on the in-process native embedder (the `--no-default-
+// features` gate stays valid). The no-embedder case uses `SPELUNK_NO_SERVER=1`.
+
+mod plumbing_helpers;
+use plumbing_helpers::{
+    FIXTURE_PROJECT_ID, mount_health, spelunk_bin, write_project_server_config,
+};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ── sqlite-vec registration for direct memory.db inspection ──────────────────
+
+fn ensure_sqlite_vec() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite_vec::sqlite3_vec_init as *const (),
+            )));
+        }
+    });
+}
+
+// ── mock embed endpoint (records request bodies; can inject a failure) ────────
+
+// Custom responder for `POST /v1/projects/{id}/index/embed`. Returns the server
+// wire format (raw little-endian f32 bytes, one `value`-filled 896-dim vector
+// per request chunk), records each request body for parity assertions, and can
+// start returning 503 once `calls >= fail_after` to simulate a mid-run outage.
+#[derive(Clone)]
+struct EmbedResponder {
+    value: f32,
+    fail_after: Option<usize>,
+    calls: Arc<AtomicUsize>,
+    bodies: Arc<Mutex<Vec<String>>>,
+}
+
+impl EmbedResponder {
+    fn new(value: f32) -> Self {
+        Self {
+            value,
+            fail_after: None,
+            calls: Arc::new(AtomicUsize::new(0)),
+            bodies: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn failing_after(value: f32, limit: usize) -> Self {
+        Self {
+            fail_after: Some(limit),
+            ..Self::new(value)
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    fn recorded_bodies(&self) -> Vec<String> {
+        self.bodies.lock().expect("bodies mutex").clone()
+    }
+}
+
+impl wiremock::Respond for EmbedResponder {
+    fn respond(&self, request: &wiremock::Request) -> ResponseTemplate {
+        let idx = self.calls.fetch_add(1, Ordering::SeqCst);
+        self.bodies
+            .lock()
+            .expect("bodies mutex")
+            .push(String::from_utf8_lossy(&request.body).to_string());
+
+        if let Some(limit) = self.fail_after
+            && idx >= limit
+        {
+            return ResponseTemplate::new(503).set_body_json(serde_json::json!({
+                "error": "embedder unavailable",
+                "state": "unavailable",
+                "detail": "injected mid-run failure",
+            }));
+        }
+
+        let n_chunks = serde_json::from_slice::<serde_json::Value>(&request.body)
+            .ok()
+            .and_then(|v| v.get("chunks").and_then(|c| c.as_array()).map(|a| a.len()))
+            .unwrap_or(1);
+        let mut bytes = Vec::with_capacity(n_chunks * 896 * 4);
+        for _ in 0..n_chunks {
+            for _ in 0..896 {
+                bytes.extend_from_slice(&self.value.to_le_bytes());
+            }
+        }
+        ResponseTemplate::new(200)
+            .insert_header("content-type", "application/octet-stream")
+            .set_body_bytes(bytes)
+    }
+}
+
+// A running mock spelunk-server with the health probe and embed endpoint
+// mounted. `rt` and `server` are kept alive by the returned struct for the
+// duration of a `.assert()` against the child process.
+struct MockServerHandle {
+    _rt: tokio::runtime::Runtime,
+    server: MockServer,
+    embed: EmbedResponder,
+}
+
+impl MockServerHandle {
+    fn uri(&self) -> String {
+        self.server.uri()
+    }
+}
+
+fn start_mock(embed: EmbedResponder) -> MockServerHandle {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let server = rt.block_on(async {
+        let server = MockServer::start().await;
+        mount_health(&server).await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+            .respond_with(embed.clone())
+            .mount(&server)
+            .await;
+        server
+    });
+    MockServerHandle {
+        _rt: rt,
+        server,
+        embed,
+    }
+}
+
+// ── test project fixture ─────────────────────────────────────────────────────
+
+struct Fixture {
+    _tmp: TempDir,
+    project_dir: PathBuf,
+    mem_path: PathBuf,
+    global_config: PathBuf,
+}
+
+// A temp project with a global `--config` (no server_url; `store_in_git_notes =
+// false` so seeding never touches git notes) and a `.spelunk/` dir where memory
+// and the project-level server config live.
+fn fixture() -> Fixture {
+    let tmp = TempDir::new().expect("tempdir");
+    let project_dir = tmp.path().to_path_buf();
+    let spelunk_dir = project_dir.join(".spelunk");
+    std::fs::create_dir_all(&spelunk_dir).expect("create .spelunk");
+    let mem_path = spelunk_dir.join("memory.db");
+    let index_db = spelunk_dir.join("index.db");
+    let global_config = project_dir.join("global-config.toml");
+    std::fs::write(
+        &global_config,
+        format!(
+            "db_path = {:?}\nstore_in_git_notes = false\nllm_model = \"test-model\"\n",
+            index_db.display().to_string()
+        ),
+    )
+    .expect("write global config");
+    Fixture {
+        _tmp: tmp,
+        project_dir,
+        mem_path,
+        global_config,
+    }
+}
+
+// Seed one unembedded note via the real `memory add`. `SPELUNK_NO_SERVER=1` plus
+// the absence of a project server config means the add path stores no vector.
+fn seed(f: &Fixture, kind: &str, title: &str, body: &str) {
+    spelunk_bin()
+        .current_dir(&f.project_dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&f.global_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&f.mem_path)
+        .arg("add")
+        .arg("--kind")
+        .arg(kind)
+        .arg("--title")
+        .arg(title)
+        .arg("--body")
+        .arg(body)
+        .assert()
+        .success();
+}
+
+// Point the project's `.spelunk/config.toml` at `url` so reindex reaches the
+// mock embedder there (discovered by walking up from the child's CWD).
+fn set_server(f: &Fixture, url: &str) {
+    write_project_server_config(&f.project_dir, url, FIXTURE_PROJECT_ID);
+}
+
+// Remove the project server config so `seed` stores notes unembedded: an
+// explicit `server_url` is honored even under `SPELUNK_NO_SERVER`, so seeding
+// an unembedded note after a server has been configured requires clearing it.
+fn clear_server(f: &Fixture) {
+    let p = f.project_dir.join(".spelunk").join("config.toml");
+    if p.exists() {
+        std::fs::remove_file(&p).expect("remove project config");
+    }
+}
+
+// Build a `spelunk memory reindex` command against the fixture.
+fn reindex_cmd(f: &Fixture) -> Command {
+    let mut cmd = spelunk_bin();
+    cmd.current_dir(&f.project_dir)
+        .arg("--config")
+        .arg(&f.global_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&f.mem_path)
+        .arg("reindex");
+    cmd
+}
+
+// Build a genuine pre-0.9 store: a FLOAT[768] `note_embeddings` vec0 table with
+// `n` notes and no v896 sentinel, exactly what an upgraded user's memory.db
+// looks like before the first 0.9 open.
+fn make_pre_v896_store(mem_path: &Path, n: usize) {
+    ensure_sqlite_vec();
+    let conn = Connection::open(mem_path).expect("open raw pre-v896 store");
+    conn.execute_batch(
+        "CREATE TABLE notes (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            kind          TEXT    NOT NULL DEFAULT 'note',
+            title         TEXT    NOT NULL,
+            body          TEXT    NOT NULL,
+            tags          TEXT,
+            linked_files  TEXT,
+            created_at    INTEGER NOT NULL DEFAULT (unixepoch())
+        );
+        CREATE VIRTUAL TABLE note_embeddings USING vec0(
+            note_id INTEGER PRIMARY KEY, embedding FLOAT[768]
+        );",
+    )
+    .expect("create pre-v896 schema");
+    for i in 0..n {
+        conn.execute(
+            "INSERT INTO notes (kind, title, body) VALUES ('note', ?1, ?2)",
+            rusqlite::params![format!("t{i}"), format!("b{i}")],
+        )
+        .expect("seed note");
+    }
+}
+
+fn note_id_by_title(mem_path: &Path, title: &str) -> i64 {
+    let conn = Connection::open(mem_path).expect("open memory.db");
+    conn.query_row(
+        "SELECT id FROM notes WHERE title = ?1",
+        rusqlite::params![title],
+        |r| r.get(0),
+    )
+    .expect("note id by title")
+}
+
+fn embedded_note_ids(mem_path: &Path) -> Vec<i64> {
+    ensure_sqlite_vec();
+    let conn = Connection::open(mem_path).expect("open memory.db");
+    let mut stmt = conn
+        .prepare("SELECT note_id FROM note_embeddings ORDER BY note_id")
+        .expect("prepare");
+    stmt.query_map([], |r| r.get::<_, i64>(0))
+        .expect("query")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("collect")
+}
+
+fn embedding_blob(mem_path: &Path, note_id: i64) -> Vec<u8> {
+    ensure_sqlite_vec();
+    let conn = Connection::open(mem_path).expect("open memory.db");
+    conn.query_row(
+        "SELECT embedding FROM note_embeddings WHERE note_id = ?1",
+        rusqlite::params![note_id],
+        |r| r.get::<_, Vec<u8>>(0),
+    )
+    .expect("embedding blob")
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+// A store with missing embeddings is fully backfilled: every note gains an
+// 896-dim vector, the run exits 0 and reports counts, and a second run embeds
+// nothing (idempotent).
+#[test]
+fn reindex_embeds_missing_and_is_idempotent() {
+    let f = fixture();
+    seed(&f, "decision", "one", "body one");
+    seed(&f, "note", "two", "body two");
+    seed(&f, "requirement", "three", "body three");
+    assert!(
+        embedded_note_ids(&f.mem_path).is_empty(),
+        "seeded notes must start unembedded"
+    );
+
+    let mock = start_mock(EmbedResponder::new(0.1));
+    set_server(&f, &mock.uri());
+
+    reindex_cmd(&f)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("3 embedded"));
+
+    let ids = embedded_note_ids(&f.mem_path);
+    assert_eq!(ids.len(), 3, "all three notes must be embedded");
+    for id in &ids {
+        assert_eq!(
+            embedding_blob(&f.mem_path, *id).len(),
+            896 * 4,
+            "each stored vector must be 896 f32 values"
+        );
+    }
+
+    // Second run: nothing missing, no vectors written, exit 0.
+    let before = mock.embed.call_count();
+    reindex_cmd(&f)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Nothing to reindex"));
+    assert_eq!(
+        embedded_note_ids(&f.mem_path).len(),
+        3,
+        "idempotent: still exactly three embeddings"
+    );
+    assert_eq!(
+        mock.embed.call_count(),
+        before,
+        "a fully-embedded store must make no further embed calls"
+    );
+}
+
+// The embed request carries the exact add-time document string
+// (`title: {t} | text: {b}`) and is NOT wrapped in the F2LLM `Instruct:/Query:`
+// query prefix, so a backfilled vector matches an add-time one.
+#[test]
+fn reindex_embed_text_matches_add_time_document() {
+    let f = fixture();
+    seed(&f, "decision", "Title A", "Body B");
+
+    let mock = start_mock(EmbedResponder::new(0.1));
+    set_server(&f, &mock.uri());
+
+    reindex_cmd(&f).assert().success();
+
+    let bodies = mock.embed.recorded_bodies();
+    assert_eq!(bodies.len(), 1, "exactly one embed call for one note");
+    let sent: serde_json::Value = serde_json::from_str(&bodies[0]).expect("embed body is json");
+    let content = sent["chunks"][0]["content"]
+        .as_str()
+        .expect("chunk content string");
+    assert_eq!(
+        content, "title: Title A | text: Body B",
+        "reindex must embed the identical add-time document string"
+    );
+    assert!(
+        !content.contains("Instruct:") && !content.contains("Query:"),
+        "documents must not be sent with the F2LLM query instruction prefix: {content:?}"
+    );
+}
+
+// An interrupted run is resumable: after embedding J of K, a re-run embeds only
+// the remaining K−J with no duplicate rows and a final count of K.
+#[test]
+fn reindex_resumes_after_midrun_failure() {
+    let f = fixture();
+    for i in 0..4 {
+        seed(&f, "note", &format!("n{i}"), &format!("body {i}"));
+    }
+
+    // Run 1: the embedder serves two notes then fails; reindex stops and exits
+    // non-zero with two durably-committed vectors.
+    let mock_a = start_mock(EmbedResponder::failing_after(0.1, 2));
+    set_server(&f, &mock_a.uri());
+    reindex_cmd(&f).assert().failure();
+    assert_eq!(
+        embedded_note_ids(&f.mem_path).len(),
+        2,
+        "the two notes embedded before the failure must be durable"
+    );
+
+    // Run 2: a healthy embedder; reindex embeds only the remaining two.
+    let mock_b = start_mock(EmbedResponder::new(0.1));
+    set_server(&f, &mock_b.uri());
+    reindex_cmd(&f).assert().success();
+
+    let ids = embedded_note_ids(&f.mem_path);
+    assert_eq!(ids.len(), 4, "all four notes embedded after resume");
+    let mut unique = ids.clone();
+    unique.dedup();
+    assert_eq!(unique.len(), 4, "no duplicate note_embeddings rows");
+    assert_eq!(
+        mock_b.embed.call_count(),
+        2,
+        "resume must only re-embed the two notes still missing"
+    );
+}
+
+// No embedder reachable: reindex fails with the actionable inference-server
+// message, exits non-zero, and writes no vectors (no partial success).
+#[test]
+fn reindex_without_embedder_errors_and_writes_nothing() {
+    let f = fixture();
+    seed(&f, "decision", "one", "body one");
+    seed(&f, "note", "two", "body two");
+    // No project server config set: no server_url anywhere.
+
+    reindex_cmd(&f)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("requires spelunk-server"));
+
+    assert!(
+        embedded_note_ids(&f.mem_path).is_empty(),
+        "a no-embedder run must write no vectors"
+    );
+}
+
+// `--force` re-embeds already-embedded notes, replacing the stored vector in
+// place (no duplicate rows).
+#[test]
+fn reindex_force_replaces_existing_vectors() {
+    let f = fixture();
+    seed(&f, "decision", "only", "the body");
+    let id = note_id_by_title(&f.mem_path, "only");
+
+    // First embed with a distinguishable constant vector.
+    let mock1 = start_mock(EmbedResponder::new(0.1));
+    set_server(&f, &mock1.uri());
+    reindex_cmd(&f).assert().success();
+    let blob_before = embedding_blob(&f.mem_path, id);
+
+    // --force with a different vector must overwrite the existing row.
+    let mock2 = start_mock(EmbedResponder::new(0.5));
+    set_server(&f, &mock2.uri());
+    reindex_cmd(&f).arg("--force").assert().success();
+
+    let blob_after = embedding_blob(&f.mem_path, id);
+    assert_ne!(
+        blob_before, blob_after,
+        "--force must replace the already-embedded note's vector"
+    );
+    assert_eq!(
+        embedded_note_ids(&f.mem_path),
+        vec![id],
+        "--force must replace in place, not duplicate the row"
+    );
+}
+
+// The `--format json` summary partitions the store honestly: total_active ==
+// embedded + already_embedded, embedded == missing_before, no count exceeds the
+// total.
+#[test]
+fn reindex_json_summary_partitions_counts() {
+    let f = fixture();
+    for i in 0..3 {
+        seed(&f, "note", &format!("first{i}"), &format!("b{i}"));
+    }
+
+    let mock = start_mock(EmbedResponder::new(0.1));
+    set_server(&f, &mock.uri());
+    // Embed the first three.
+    reindex_cmd(&f).assert().success();
+
+    // Two more unembedded notes (seeded with the server config cleared so add
+    // stores no vector), then a JSON reindex over the mixed store.
+    clear_server(&f);
+    seed(&f, "note", "later0", "later b0");
+    seed(&f, "note", "later1", "later b1");
+    set_server(&f, &mock.uri());
+
+    let output = reindex_cmd(&f)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let summary: serde_json::Value =
+        serde_json::from_slice(&output).expect("json summary on stdout");
+
+    let total_active = summary["total_active"].as_u64().unwrap();
+    let missing_before = summary["missing_before"].as_u64().unwrap();
+    let already_embedded = summary["already_embedded"].as_u64().unwrap();
+    let embedded = summary["embedded"].as_u64().unwrap();
+
+    assert_eq!(total_active, 5, "five active notes total");
+    assert_eq!(
+        total_active,
+        embedded + already_embedded,
+        "counts must partition the store"
+    );
+    assert_eq!(
+        embedded, missing_before,
+        "on success everything missing before is embedded"
+    );
+    assert_eq!(missing_before, 2, "only the two later notes were missing");
+    assert!(
+        embedded <= total_active && already_embedded <= total_active,
+        "no count exceeds the total"
+    );
+}
+
+// `--dry-run` reports the would-embed count, contacts the embedder zero times,
+// writes no vectors, and exits 0.
+#[test]
+fn reindex_dry_run_counts_and_writes_nothing() {
+    let f = fixture();
+    seed(&f, "decision", "one", "body one");
+    seed(&f, "note", "two", "body two");
+
+    let mock = start_mock(EmbedResponder::new(0.1));
+    set_server(&f, &mock.uri());
+
+    reindex_cmd(&f)
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("2 note(s) would be embedded"));
+
+    assert!(
+        embedded_note_ids(&f.mem_path).is_empty(),
+        "--dry-run must write no vectors"
+    );
+    assert_eq!(
+        mock.embed.call_count(),
+        0,
+        "--dry-run must not contact the embedder"
+    );
+}
+
+// D5(b): after the 768→896 upgrade drops old vectors, a memory command surfaces
+// the one-line reindex notice once (without RUST_LOG), and the migrated notes
+// are then present-but-unembedded.
+#[test]
+fn migration_notice_fires_once_after_768_upgrade() {
+    let f = fixture();
+    make_pre_v896_store(&f.mem_path, 3);
+
+    // First memory command after the upgrade: the notice fires on stderr.
+    spelunk_bin()
+        .current_dir(&f.project_dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&f.global_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&f.mem_path)
+        .arg("list")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains(
+            "3 note(s) need re-embedding for semantic search",
+        ));
+
+    // The migrated notes are present-but-unembedded (the 768 vectors were
+    // dropped), so reindex has exactly 3 to backfill.
+    assert!(embedded_note_ids(&f.mem_path).is_empty());
+
+    // The sentinel is now set: a second command must NOT repeat the notice.
+    spelunk_bin()
+        .current_dir(&f.project_dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&f.global_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&f.mem_path)
+        .arg("list")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("need re-embedding").not());
+}

--- a/crates/spelunk-cli/tests/memory_reindex.rs
+++ b/crates/spelunk-cli/tests/memory_reindex.rs
@@ -231,6 +231,34 @@ fn reindex_cmd(f: &Fixture) -> Command {
     cmd
 }
 
+// Archive a seeded note via the real `memory archive`. Runs with no server so
+// it stays a purely local status change (no git-notes carry: global config
+// pins store_in_git_notes = false).
+fn archive_note(f: &Fixture, id: i64) {
+    spelunk_bin()
+        .current_dir(&f.project_dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(&f.global_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&f.mem_path)
+        .arg("archive")
+        .arg(id.to_string())
+        .assert()
+        .success();
+}
+
+// Extract the embed document string a recorded `/index/embed` body carried.
+fn embed_content(body: &str) -> String {
+    let sent: serde_json::Value = serde_json::from_str(body).expect("embed body is json");
+    sent["chunks"][0]["content"]
+        .as_str()
+        .expect("chunk content string")
+        .to_string()
+}
+
 // Build a genuine pre-0.9 store: a FLOAT[768] `note_embeddings` vec0 table with
 // `n` notes and no v896 sentinel, exactly what an upgraded user's memory.db
 // looks like before the first 0.9 open.
@@ -316,7 +344,9 @@ fn reindex_embeds_missing_and_is_idempotent() {
     reindex_cmd(&f)
         .assert()
         .success()
-        .stdout(predicates::str::contains("3 embedded"));
+        .stdout(predicates::str::contains("3 embedded"))
+        // Progress goes to stderr so the machine summary on stdout stays clean.
+        .stderr(predicates::str::contains("embedded 3/3"));
 
     let ids = embedded_note_ids(&f.mem_path);
     assert_eq!(ids.len(), 3, "all three notes must be embedded");
@@ -385,10 +415,16 @@ fn reindex_resumes_after_midrun_failure() {
     }
 
     // Run 1: the embedder serves two notes then fails; reindex stops and exits
-    // non-zero with two durably-committed vectors.
+    // non-zero with two durably-committed vectors. The failure must report the
+    // honest partial count (not just fail silently) and point at a re-run, so a
+    // user knows work was saved and how to finish it.
     let mock_a = start_mock(EmbedResponder::failing_after(0.1, 2));
     set_server(&f, &mock_a.uri());
-    reindex_cmd(&f).assert().failure();
+    reindex_cmd(&f)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("2 of 4 done and durably stored"))
+        .stderr(predicates::str::contains("re-run 'spelunk memory reindex'"));
     assert_eq!(
         embedded_note_ids(&f.mem_path).len(),
         2,
@@ -502,8 +538,13 @@ fn reindex_json_summary_partitions_counts() {
     let missing_before = summary["missing_before"].as_u64().unwrap();
     let already_embedded = summary["already_embedded"].as_u64().unwrap();
     let embedded = summary["embedded"].as_u64().unwrap();
+    let remaining = summary["remaining"].as_u64().unwrap();
 
     assert_eq!(total_active, 5, "five active notes total");
+    assert_eq!(
+        remaining, 0,
+        "on full success nothing targeted is left unembedded"
+    );
     assert_eq!(
         total_active,
         embedded + already_embedded,
@@ -577,6 +618,96 @@ fn migration_notice_fires_once_after_768_upgrade() {
     assert!(embedded_note_ids(&f.mem_path).is_empty());
 
     // The sentinel is now set: a second command must NOT repeat the notice.
+    spelunk_bin()
+        .current_dir(&f.project_dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("--config")
+        .arg(&f.global_config)
+        .arg("memory")
+        .arg("--db")
+        .arg(&f.mem_path)
+        .arg("list")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("need re-embedding").not());
+}
+
+// Every note (not just the first) is embedded via its own add-time document
+// string, in id order, with no F2LLM query prefix. Guards against a partial
+// wrong-format bug that a single-note parity check would miss.
+#[test]
+fn reindex_embeds_every_note_with_its_own_document() {
+    let f = fixture();
+    seed(&f, "decision", "First Title", "First Body");
+    seed(&f, "note", "Second Title", "Second Body");
+
+    let mock = start_mock(EmbedResponder::new(0.1));
+    set_server(&f, &mock.uri());
+    reindex_cmd(&f).assert().success();
+
+    let bodies = mock.embed.recorded_bodies();
+    assert_eq!(bodies.len(), 2, "one embed call per note");
+    let contents: Vec<String> = bodies.iter().map(|b| embed_content(b)).collect();
+    // Candidate order is `ORDER BY note id`, which is the seed order here.
+    assert_eq!(
+        contents,
+        vec![
+            "title: First Title | text: First Body".to_string(),
+            "title: Second Title | text: Second Body".to_string(),
+        ],
+        "each note must embed its own document, in id order"
+    );
+    for c in &contents {
+        assert!(
+            !c.contains("Instruct:") && !c.contains("Query:"),
+            "no document may carry the F2LLM query prefix: {c:?}"
+        );
+    }
+}
+
+// `--include-archived` is load-bearing: a default run skips archived notes, and
+// only `--include-archived` backfills them. Without the flag an archived note
+// stays vectorless (missing from timeline semantic recall).
+#[test]
+fn reindex_include_archived_covers_archived_only_with_the_flag() {
+    let f = fixture();
+    seed(&f, "note", "active-note", "active body");
+    seed(&f, "note", "archived-note", "archived body");
+    let active_id = note_id_by_title(&f.mem_path, "active-note");
+    let archived_id = note_id_by_title(&f.mem_path, "archived-note");
+    archive_note(&f, archived_id);
+
+    let mock = start_mock(EmbedResponder::new(0.1));
+    set_server(&f, &mock.uri());
+
+    // Default: only the active note is embedded; the archived one is skipped.
+    reindex_cmd(&f).assert().success();
+    assert_eq!(
+        embedded_note_ids(&f.mem_path),
+        vec![active_id],
+        "default reindex must not touch archived notes"
+    );
+
+    // With the flag the archived note gets its vector too.
+    reindex_cmd(&f).arg("--include-archived").assert().success();
+    let mut ids = embedded_note_ids(&f.mem_path);
+    ids.sort();
+    let mut want = vec![active_id, archived_id];
+    want.sort();
+    assert_eq!(
+        ids, want,
+        "--include-archived backfills the archived note as well"
+    );
+}
+
+// A store created by `memory add` is a fresh FLOAT[896] store that never went
+// through the 768 drop, so no command may print the re-embed notice. Pins the
+// CLI-layer negative end-to-end, not just the library flag.
+#[test]
+fn no_reembed_notice_on_fresh_store() {
+    let f = fixture();
+    seed(&f, "note", "one", "body one");
+
     spelunk_bin()
         .current_dir(&f.project_dir)
         .env("SPELUNK_NO_SERVER", "1")

--- a/crates/spelunk-core/src/storage/memory/dedupe/test_support.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/test_support.rs
@@ -28,7 +28,10 @@ pub(super) fn open_store() -> MemoryStore {
     register_sqlite_vec();
     let conn = rusqlite::Connection::open(std::path::Path::new(":memory:"))
         .expect("open in-memory sqlite");
-    let store = MemoryStore { conn };
+    let store = MemoryStore {
+        conn,
+        reembed_needed: None,
+    };
     store.migrate().expect("schema migration");
     store
 }

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/test_support.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/test_support.rs
@@ -23,7 +23,10 @@ pub(super) fn open_store() -> MemoryStore {
     register_sqlite_vec();
     let conn = rusqlite::Connection::open(std::path::Path::new(":memory:"))
         .expect("open in-memory sqlite");
-    let store = MemoryStore { conn };
+    let store = MemoryStore {
+        conn,
+        reembed_needed: None,
+    };
     store.migrate().expect("schema migration");
     store
 }

--- a/crates/spelunk-core/src/storage/memory/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/mod.rs
@@ -18,6 +18,12 @@ mod tests;
 
 pub struct MemoryStore {
     pub(super) conn: Connection,
+    /// Set by [`MemoryStore::open`] to the count of active notes that need
+    /// re-embedding when the 768→896 migration dropped their vectors on THIS
+    /// open; `None` on every other open. Lets the CLI surface a one-line
+    /// `memory reindex` hint without `RUST_LOG` while keeping this library
+    /// side-effect-free (nothing is printed here).
+    pub reembed_needed: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -85,17 +91,32 @@ impl MemoryStore {
         }
         let conn = Connection::open(path)
             .with_context(|| format!("opening memory DB at {}", path.display()))?;
-        let store = Self { conn };
-        store.migrate()?;
+        let mut store = Self {
+            conn,
+            reembed_needed: None,
+        };
+        let migrated_768_to_896 = store.migrate()?;
         // ADR-068 third amendment: Step A (unconditional backfill) then Step B
         // (conditional UNIQUE-index promotion). Neither ever hard-aborts open;
         // see `entity_id_migration.rs`.
         store.backfill_entity_ids()?;
         store.promote_entity_id_unique_index()?;
+        if migrated_768_to_896 {
+            // The upgrade just discarded every prior note's vector, so every
+            // active note now needs re-embedding; count them once so the CLI
+            // can point the user at `memory reindex` (there is no catch-up path
+            // otherwise).
+            let n = store.notes_missing_embeddings(false)?.len();
+            if n > 0 {
+                store.reembed_needed = Some(n);
+            }
+        }
         Ok(store)
     }
 
-    fn migrate(&self) -> Result<()> {
+    /// Returns `true` when the 768→896 `note_embeddings` upgrade dropped the old
+    /// vectors on this run (so [`MemoryStore::open`] can flag the re-embed need).
+    fn migrate(&self) -> Result<bool> {
         self.conn
             .execute_batch(include_str!("../../../migrations/004_memory.sql"))
             .context("running memory migrations")?;
@@ -194,6 +215,7 @@ impl MemoryStore {
             .optional()
             .context("checking v896 note_embeddings marker")?
             .is_some();
+        let mut dropped_768 = false;
         if !already_v896 {
             let needs_upgrade: bool = self
                 .conn
@@ -218,8 +240,9 @@ impl MemoryStore {
                     .context("upgrading note_embeddings to 896-dim")?;
                 tracing::info!(
                     "memory note_embeddings dim upgraded 768→896; \
-                     re-run `spelunk memory harvest` to rebuild embeddings"
+                     re-run `spelunk memory reindex` to rebuild embeddings"
                 );
+                dropped_768 = true;
             }
             self.conn
                 .execute_batch(
@@ -228,6 +251,6 @@ impl MemoryStore {
                 )
                 .context("creating v896 note_embeddings marker")?;
         }
-        Ok(())
+        Ok(dropped_768)
     }
 }

--- a/crates/spelunk-core/src/storage/memory/notes.rs
+++ b/crates/spelunk-core/src/storage/memory/notes.rs
@@ -335,6 +335,72 @@ impl MemoryStore {
         Ok(())
     }
 
+    /// Active notes (and archived ones too when `include_archived`) that have no
+    /// row in the `note_embeddings` vec0 table: the set `memory reindex`
+    /// backfills. Mirrors `Database::chunks_missing_embeddings` for the code
+    /// index and uses the same `LEFT JOIN <vec0> ... WHERE ... IS NULL` idiom,
+    /// which is proven to filter correctly against a vec0 virtual table.
+    ///
+    /// Returns `(note_id, title, body)`: exactly the fields the add-time embed
+    /// document (`title: {title} | text: {body}`) is rebuilt from, so a
+    /// backfilled vector matches an add-time one. `ORDER BY n.id` is
+    /// deterministic, so a resumed re-query is stable.
+    pub fn notes_missing_embeddings(
+        &self,
+        include_archived: bool,
+    ) -> Result<Vec<(i64, String, String)>> {
+        // Only string literals are interpolated here; there are no user-supplied
+        // values in this query, so no bind params are needed.
+        let status_clause = if include_archived {
+            ""
+        } else {
+            "AND n.status = 'active'"
+        };
+        let sql = format!(
+            "SELECT n.id, n.title, n.body \
+             FROM notes n \
+             LEFT JOIN note_embeddings e ON e.note_id = n.id \
+             WHERE e.note_id IS NULL {status_clause} \
+             ORDER BY n.id"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+            ))
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// Every active note (and archived too when `include_archived`), regardless
+    /// of whether it already has an embedding: the `--force` candidate set for
+    /// `memory reindex`. `insert_embedding`'s atomic delete-then-insert replaces
+    /// any existing vector in place, so re-embedding here is last-write-wins.
+    pub fn all_active_notes_for_reembed(
+        &self,
+        include_archived: bool,
+    ) -> Result<Vec<(i64, String, String)>> {
+        let status_clause = if include_archived {
+            ""
+        } else {
+            "WHERE status = 'active'"
+        };
+        let sql = format!("SELECT id, title, body FROM notes {status_clause} ORDER BY id");
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+            ))
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
     /// List notes, optionally filtered by kind, newest first.
     /// When `include_archived` is false only active entries are returned.
     pub fn list(

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -1000,7 +1000,10 @@ fn entity_id_migration_backfills_but_does_not_collapse_duplicates() {
     // a genuinely pre-023 DB.
     {
         let conn = rusqlite::Connection::open(&path).expect("open raw");
-        let store = MemoryStore { conn };
+        let store = MemoryStore {
+            conn,
+            reembed_needed: None,
+        };
         store.migrate().expect("schema migration only");
         for created_at in [1_700_000_001_i64, 1_700_000_002] {
             store
@@ -1243,5 +1246,229 @@ fn insert_embedding_joins_callers_transaction_and_rolls_back_with_it() {
         "rollback must restore the pre-transaction (first) vector — if the \
          delete+insert had committed independently of the caller's \
          transaction, the row would still hold `second` here"
+    );
+}
+
+// ── notes_missing_embeddings / reindex candidate queries ─────────────────────
+
+// Give `note_id` a valid 896-dim embedding so it drops out of the missing set.
+fn embed(store: &MemoryStore, note_id: i64) {
+    let blob = crate::embeddings::vec_to_blob(&[0.1f32; 896]);
+    store
+        .insert_embedding(note_id, &blob)
+        .expect("insert embedding");
+}
+
+fn missing_ids(store: &MemoryStore, include_archived: bool) -> Vec<i64> {
+    store
+        .notes_missing_embeddings(include_archived)
+        .expect("query missing")
+        .into_iter()
+        .map(|(id, ..)| id)
+        .collect()
+}
+
+// Seed one active note, return its id.
+fn add_active(store: &MemoryStore, title: &str) -> i64 {
+    store
+        .add_note(
+            "note",
+            title,
+            &format!("body of {title}"),
+            &[],
+            &[],
+            None,
+            None,
+        )
+        .expect("add note")
+        .0
+}
+
+#[test]
+fn notes_missing_embeddings_returns_only_active_unembedded_by_default() {
+    let store = open_store();
+    let a = add_active(&store, "a");
+    let b = add_active(&store, "b");
+    let c = add_active(&store, "c");
+    // Embed exactly one of the three.
+    embed(&store, b);
+
+    let mut got = missing_ids(&store, false);
+    got.sort();
+    let mut want = vec![a, c];
+    want.sort();
+    assert_eq!(
+        got, want,
+        "only the two active-unembedded notes are returned"
+    );
+}
+
+#[test]
+fn notes_missing_embeddings_excludes_embedded_and_archived_by_default() {
+    let store = open_store();
+    let embedded = add_active(&store, "active-embedded");
+    embed(&store, embedded);
+    let unembedded = add_active(&store, "active-unembedded");
+    let archived = add_active(&store, "archived-unembedded");
+    assert!(store.archive(archived).expect("archive"));
+
+    assert_eq!(
+        missing_ids(&store, false),
+        vec![unembedded],
+        "default mode returns only the active, unembedded note"
+    );
+}
+
+#[test]
+fn notes_missing_embeddings_boundaries_all_and_none_embedded() {
+    let store = open_store();
+    let a = add_active(&store, "a");
+    let b = add_active(&store, "b");
+
+    // None embedded: both returned in id order.
+    assert_eq!(missing_ids(&store, false), vec![a, b]);
+
+    // All embedded: empty.
+    embed(&store, a);
+    embed(&store, b);
+    assert!(
+        missing_ids(&store, false).is_empty(),
+        "a fully embedded store has nothing missing"
+    );
+}
+
+#[test]
+fn notes_missing_embeddings_include_archived_covers_archived() {
+    let store = open_store();
+    let active = add_active(&store, "active");
+    let archived = add_active(&store, "archived");
+    assert!(store.archive(archived).expect("archive"));
+
+    let mut got = missing_ids(&store, true);
+    got.sort();
+    let mut want = vec![active, archived];
+    want.sort();
+    assert_eq!(
+        got, want,
+        "include_archived surfaces the unembedded archived note too"
+    );
+}
+
+#[test]
+fn insert_embedding_drops_note_out_and_force_query_keeps_all() {
+    let store = open_store();
+    let a = add_active(&store, "a");
+    let b = add_active(&store, "b");
+
+    assert_eq!(missing_ids(&store, false), vec![a, b]);
+    embed(&store, a);
+    assert_eq!(
+        missing_ids(&store, false),
+        vec![b],
+        "an embedded note drops out of notes_missing_embeddings"
+    );
+
+    // The force-path query returns every active note regardless of embedding.
+    let force: Vec<i64> = store
+        .all_active_notes_for_reembed(false)
+        .expect("force query")
+        .into_iter()
+        .map(|(id, ..)| id)
+        .collect();
+    assert_eq!(
+        force,
+        vec![a, b],
+        "the --force candidate set is every active note, embedded or not"
+    );
+}
+
+#[test]
+fn notes_missing_embeddings_returns_title_and_body_for_embed_text() {
+    let store = open_store();
+    let id = store
+        .add_note("decision", "My Title", "the body", &[], &[], None, None)
+        .expect("add")
+        .0;
+    let rows = store.notes_missing_embeddings(false).expect("query");
+    assert_eq!(
+        rows,
+        vec![(id, "My Title".to_string(), "the body".to_string())]
+    );
+}
+
+// ── D5: 768→896 migration flags the re-embed need once ───────────────────────
+
+// Build a genuine pre-0.9 store on disk: a `note_embeddings` vec0 table declared
+// FLOAT[768] with N notes and NO `schema_v896_note_embeddings` sentinel, exactly
+// what an upgraded user's store looks like before the first 0.9 open.
+fn make_pre_v896_store(path: &std::path::Path, n: usize) {
+    register_sqlite_vec();
+    let conn = rusqlite::Connection::open(path).expect("open raw pre-v896 store");
+    conn.execute_batch(
+        "CREATE TABLE notes (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            kind          TEXT    NOT NULL DEFAULT 'note',
+            title         TEXT    NOT NULL,
+            body          TEXT    NOT NULL,
+            tags          TEXT,
+            linked_files  TEXT,
+            created_at    INTEGER NOT NULL DEFAULT (unixepoch())
+        );
+        CREATE VIRTUAL TABLE note_embeddings USING vec0(
+            note_id INTEGER PRIMARY KEY, embedding FLOAT[768]
+        );",
+    )
+    .expect("create pre-v896 schema");
+    for i in 0..n {
+        conn.execute(
+            "INSERT INTO notes (kind, title, body) VALUES ('note', ?1, ?2)",
+            rusqlite::params![format!("t{i}"), format!("b{i}")],
+        )
+        .expect("seed note");
+    }
+}
+
+#[test]
+fn open_after_768_upgrade_flags_reembed_count_once() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("memory.db");
+    make_pre_v896_store(&path, 3);
+
+    let store = MemoryStore::open(&path).expect("open upgrades 768→896");
+    assert_eq!(
+        store.reembed_needed,
+        Some(3),
+        "the drop must flag all 3 prior notes as needing re-embedding"
+    );
+    assert_eq!(
+        store.notes_missing_embeddings(false).expect("query").len(),
+        3,
+        "after the drop every prior note is present-but-unembedded"
+    );
+
+    // The sentinel is now set: a second open must NOT re-flag (the notice fires
+    // once, not on every command), and the notes stay present-but-unembedded.
+    drop(store);
+    let reopened = MemoryStore::open(&path).expect("reopen");
+    assert_eq!(
+        reopened.reembed_needed, None,
+        "a store already at v896 must not re-flag the re-embed need"
+    );
+    assert_eq!(
+        reopened
+            .notes_missing_embeddings(false)
+            .expect("query")
+            .len(),
+        3,
+        "the notes are still unembedded until reindex runs"
+    );
+}
+
+#[test]
+fn open_fresh_store_does_not_flag_reembed() {
+    let store = open_store();
+    assert_eq!(
+        store.reembed_needed, None,
+        "a fresh FLOAT[896] store never triggered the 768 drop"
     );
 }

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -1472,3 +1472,73 @@ fn open_fresh_store_does_not_flag_reembed() {
         "a fresh FLOAT[896] store never triggered the 768 drop"
     );
 }
+
+fn force_ids(store: &MemoryStore, include_archived: bool) -> Vec<i64> {
+    store
+        .all_active_notes_for_reembed(include_archived)
+        .expect("force query")
+        .into_iter()
+        .map(|(id, ..)| id)
+        .collect()
+}
+
+// The --force candidate set must widen to archived notes under
+// include_archived, and must NOT include them otherwise. Without this, a
+// `--force --include-archived` run would silently skip archived notes and a
+// wrong WHERE clause (still filtering status = 'active') would go unnoticed.
+#[test]
+fn all_active_notes_for_reembed_include_archived_covers_archived_and_embedded() {
+    let store = open_store();
+    let active = add_active(&store, "active");
+    let archived = add_active(&store, "archived");
+    assert!(store.archive(archived).expect("archive"));
+    // Embed the active one: the force set must still return it (embedded or
+    // not) so --force re-embeds everything.
+    embed(&store, active);
+
+    assert_eq!(
+        force_ids(&store, false),
+        vec![active],
+        "default force set is active notes only, regardless of embedding"
+    );
+
+    let mut got = force_ids(&store, true);
+    got.sort();
+    let mut want = vec![active, archived];
+    want.sort();
+    assert_eq!(
+        got, want,
+        "include_archived force set covers the archived note too"
+    );
+}
+
+// A superseded note is archived (supersede sets status = 'archived'), so it
+// must drop out of the default missing set and reappear only under
+// include_archived. Pins the superseded-handling half of the query contract:
+// reindex must not re-embed a note the user has explicitly superseded unless
+// they opt in.
+#[test]
+fn superseded_note_excluded_by_default_included_with_archived() {
+    let store = open_store();
+    let old = add_active(&store, "old");
+    let new = add_active(&store, "new");
+    assert!(store.supersede(old, new).expect("supersede"));
+
+    // Default: the superseded (now archived) note is gone; only the active
+    // successor is missing.
+    assert_eq!(
+        missing_ids(&store, false),
+        vec![new],
+        "a superseded note is archived, so default reindex skips it"
+    );
+
+    // include_archived: both the successor and the superseded note surface.
+    let mut got = missing_ids(&store, true);
+    got.sort();
+    let mut want = vec![old, new];
+    want.sort();
+    assert_eq!(
+        got, want,
+        "include_archived surfaces the superseded note for backfill"
+    );
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,7 +150,10 @@ The dimension upgrade for pre-0.9 `FLOAT[768]` databases is handled **per store*
 `Database::apply_dim_upgrade_migration` rebuilds the chunk table as
 `INT8[896]`, while `MemoryStore::migrate` rebuilds `note_embeddings` as
 `FLOAT[896]` (each guarded by its own marker table). There is no path that leaves
-memory stranded on the stale 768-dim layout.
+memory stranded on the stale 768-dim layout. The `note_embeddings` rebuild is
+empty rather than converting the old vectors, so semantic recall on pre-upgrade
+notes is lost until they are re-embedded with `spelunk memory reindex`; a
+one-line notice after the upgrade points the user at that command.
 
 ### Backend abstraction
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -788,6 +788,7 @@ spelunk memory sync                         # two-way: push local + pull remote 
 spelunk memory watch                        # stream new entries from the server (SSE)
 spelunk memory reconcile [--dry-run] [--all-projects] [--source-db <path>]
 spelunk memory dedupe [--dry-run] [--format text|json]
+spelunk memory reindex [--force] [--include-archived] [--dry-run] [--format text|json]
 ```
 
 All `memory` subcommands accept `--backend sqlite|git-notes` (default `sqlite`)
@@ -835,6 +836,20 @@ a pulled entry matching an existing local row's identity merges into that row
 of adding a duplicate, so the printed pull count reflects only genuinely new
 rows. Pre-promotion, a pull can still add a distinct row alongside matching
 local content, same as `memory add`.
+
+**Backfilling missing embeddings:** a note's semantic vector is minted only at
+`memory add` time, so a note added while the embedder was down, or carried
+through the 768→896 embedding-dimension upgrade (which drops the old vectors),
+stays present-but-unembedded: still found by text search, `list`, `timeline`,
+and `context`, but absent from semantic `memory search`. `spelunk memory
+reindex` re-embeds those notes against the local embedder (the same path
+`memory add` uses), so it needs a reachable embedder and exits non-zero if none
+is; it commits each vector as it goes, so an interrupted run resumes on re-run.
+`--force` re-embeds every active note (replacing existing vectors), `--include-archived`
+also covers archived notes, and `--dry-run` reports counts without writing or
+contacting the embedder. This is separate from `spelunk index`, which re-embeds
+the code index. See
+[Backfilling missing embeddings](memory.md#backfilling-missing-embeddings).
 
 ---
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -25,8 +25,9 @@ GIT_NOTES_REF=refs/notes/spelunk git notes show HEAD
 **Carrier and index.** Think of `refs/notes/spelunk` as the durable *carrier*
 for memory and `.spelunk/memory.db` as the queryable *index* built over it. Every
 `memory add` appends its entry to the carrier through one write-through path;
-`spelunk init` hydrates the index by importing those notes, adding the embeddings
-semantic search needs. Both live in the repo, and the store of record stays local
+`spelunk init` hydrates the index by importing those notes: `memory list` and
+text search see them immediately, and `spelunk memory reindex` adds the
+embeddings semantic search needs. Both live in the repo, and the store of record stays local
 unless you configure a team `server_url` with `mode = "cloud_first"` (see [Team
 server and sync modes](#team-server-and-sync-modes)). The carrier reaches teammates only once
 the notes ref is pushed and fetched (see [Sharing memory across clones via
@@ -334,7 +335,9 @@ init` **hydrates** the new `memory.db` from those notes: every entry not already
 present is imported, and `spelunk memory list` then shows the repo's recorded
 history. The import is idempotent (re-running `init` imports nothing) and copies
 entry content only, not embeddings, so imported entries appear in `memory list`
-and full-text search right away. This is a local import: the notes must already
+and full-text search right away; semantic `memory search` finds them once they
+are embedded, which you can do with
+[`spelunk memory reindex`](#backfilling-missing-embeddings). This is a local import: the notes must already
 be present in your clone. Their cross-machine arrival still depends on your git
 notes refspec, since git does not fetch `refs/notes/*` by default (see above).
 git-notes is the durable carrier here and `memory.db` is a local index rebuilt
@@ -804,6 +807,60 @@ failure partway through leaves the store exactly as it was rather than
 half-collapsed. Deleting the losing rows is destructive and not reversible by
 spelunk itself (back up `memory.db`, or your git-notes ref, first if you want
 to be able to undo it).
+
+## Backfilling missing embeddings
+
+A note's semantic vector is created only when the note is first added
+(`spelunk memory add`). If no embedder was reachable at that moment, or the
+store was upgraded across the 768→896 embedding-dimension change (which drops
+the old vectors and rebuilds `note_embeddings` empty), the note stays in
+`memory.db` **present but unembedded**. Such a note is still found by text
+search (`--mode text`), `memory list`, `memory timeline`, and `context`; it is
+only missing from *semantic* `memory search`, because semantic ranking is a KNN
+over the embedding vectors and this note has none.
+
+`spelunk memory reindex` is the recovery command: it embeds the notes that have
+no vector, using the same local embedder `memory add` uses (the auto-discovered
+loopback `spelunk-server`, or a configured `server_url`). Reach for it after
+upgrading across the 768→896 change, or when notes were added while the embedder
+was down.
+
+```bash
+# Embed every active note that is missing a vector
+spelunk memory reindex
+
+# Report how many notes would be embedded, without writing or contacting the embedder
+spelunk memory reindex --dry-run
+
+# Re-embed every active note, replacing existing vectors (e.g. after a model or dimension change)
+spelunk memory reindex --force
+
+# Also backfill archived notes (default is active notes only)
+spelunk memory reindex --include-archived
+
+# Machine-readable summary
+spelunk memory reindex --format json
+```
+
+Because embedding **is** the point of this command, it needs a reachable
+embedder: with none, it prints an actionable error and exits non-zero without
+writing anything (unlike `reconcile`, which imports note text even when the
+embedder is down). Each note's vector is committed as it completes, so an
+interrupted run is resumable: re-running embeds only the notes still missing,
+with no duplicate rows, and a run against a fully-embedded store embeds nothing
+and exits 0. Progress is printed to stderr; the machine summary (`--format
+json`) goes to stdout. Notes are embedded one at a time, so a large backlog
+takes a while; `--dry-run` tells you how many are pending first.
+
+`reindex` covers the **memory** store only. The code index has its own re-embed
+path (`spelunk index`, which re-embeds changed files' chunks); the two operate
+on separate stores and neither substitutes for the other.
+
+After the 768→896 upgrade drops the old vectors, the first memory command prints
+a one-line notice naming the count and pointing at `spelunk memory reindex`, so
+the recall gap is discoverable without `RUST_LOG`. The notice is a pointer, not
+an auto-repair: it embeds nothing itself. Running `reindex` is what restores
+semantic recall.
 
 ## Using memory as context
 


### PR DESCRIPTION
## What

Adds `spelunk memory reindex`: a recovery command that re-embeds memory notes left without a local vector, so semantic `memory search` can surface them again.

A note's embedding is minted only at `memory add` time. Two situations leave a note present-but-unembedded with no catch-up path:

- the embedder was unreachable when the note was added, or
- the store was upgraded across the 768 to 896 embedding-dimension change, which drops every prior `note_embeddings` vector and rebuilds the table empty.

Such notes stay reachable via text search, `list`, `timeline`, and `context`, but are invisible to semantic KNN. `reindex` embeds them through the same local embed path `memory add` uses (the auto-discovered loopback `spelunk-server`, or a configured `server_url`), embedding the identical add-time document string `title: {title} | text: {body}` via `embed_text` (no F2LLM `Instruct:/Query:` query prefix), so a backfilled vector matches an add-time one.

Behavior:

- Default: embeds only active notes missing a vector.
- `--force`: re-embeds every active note, replacing existing vectors (useful after a model or dimension change).
- `--include-archived`: also backfills archived notes.
- `--dry-run`: reports the count, contacts the embedder zero times, writes nothing, exits 0.
- `--format json`: machine-readable summary on stdout; progress goes to stderr.
- Resumable: each vector is committed as it completes, so an interrupted run resumes on re-run with no duplicate rows; a fully-embedded store embeds nothing and exits 0.
- Requires a reachable embedder: with none it prints an actionable error and exits non-zero without writing anything (embedding is the point, so silence-and-succeed would recreate the bug).

Plus a one-line, `RUST_LOG`-free notice after the 768 to 896 upgrade drops old vectors, printed once from the CLI layer, pointing the user at `spelunk memory reindex` so the recall gap is discoverable.

## For review (two items to decide)

1. **The post-migration notice (D5(b)).** The 768 to 896 upgrade is the case that hits real upgraders: they silently lose semantic recall with no cue to fix it. This PR includes a low-risk one-line notice (emitted once from the CLI dispatch layer, library stays side-effect-free, no auto-backfill-on-open). It is cleanly deferrable to a fast-follow if you would rather ship just the command in v1. Your call whether it lands here or later.

2. **Summary partition shape under `--force` / `--include-archived`.** The default-run summary partitions cleanly: `total_active == embedded + already_embedded`. Under `--include-archived` or `--force`, `embedded` counts archived and/or already-embedded notes too, so it can exceed `total_active` and the partition is loose. Each field is individually honest (they are separate counts, not a strict partition); flagging in case you want a tighter summary shape.

## Test plan

All cargo commands run with `SPELUNK_SECRET_STORE=file`. Nothing here depends on the in-process native embedder: the end-to-end tests mock the `/index/embed` HTTP endpoint with wiremock, and the no-embedder case uses `SPELUNK_NO_SERVER=1`, so the `--no-default-features` gate stays valid.

- `cargo fmt --all --check` -> clean (exit 0).
- `cargo clippy -p spelunk-core -p spelunk-cli --all-targets -- -D warnings` -> clean (exit 0).
- `cargo test -p spelunk-core -p spelunk-cli` -> all green. The 11 subprocess tests in `tests/memory_reindex.rs` pass (missing-backfill + idempotent, embed-text parity, per-note document parity, resume-after-midrun-failure, no-embedder error, `--force` replace-in-place, `--dry-run`, `--include-archived`, json summary partition, migration notice fires once, no-notice on fresh store), plus the store-level `notes_missing_embeddings` / `all_active_notes_for_reembed` / 768-upgrade-flag tests in `storage/memory/tests.rs`.
- `cargo test -p spelunk-core -p spelunk-cli --no-default-features` -> all green; the 11 `memory_reindex` tests run and pass (native embedder absent, embed reached over HTTP).

Reverse-apply regression proof (the tests actually pin the crux):

- With the embed-text format temporarily changed to prepend the F2LLM `Instruct:/Query:` prefix (simulating the `embed_query` mistake), `cargo test -p spelunk-cli --test memory_reindex reindex_embed` -> `reindex_embed_text_matches_add_time_document` and `reindex_embeds_every_note_with_its_own_document` both FAIL on the exact-string assertion (`reindex_embeds_missing_and_is_idempotent` still passes, as expected: it asserts counts and 896-dim, not the document string).
- Reverting the one-line change -> `git diff` clean, same three tests pass (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
