### PR TITLE
docs(index): fix --no-summaries gating condition (server_url, not llm_model)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -28,7 +28,7 @@ pub struct IndexArgs {
     #[arg(long)]
     pub recount: bool,
 
-    /// Skip LLM summary generation even when llm_model is configured
+    /// Skip LLM summary generation even when server_url is configured
     #[arg(long)]
     pub no_summaries: bool,
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -88,7 +88,7 @@ spelunk index <path> [options]
 | `--batch-size <n>` | 0 (auto) | Cap on the embedding batch size (chunks per server request); the embed phase calibrates the actual size from measured throughput, up to this cap. 0 leaves the cap at the server's own 256-chunk limit |
 | `--force` | false | Force full re-index (ignore change detection) |
 | `--recount` | false | Backfill `token_count` for existing chunks and exit |
-| `--no-summaries` | false | Skip LLM summary generation even when `llm_model` is configured |
+| `--no-summaries` | false | Skip LLM summary generation even when `server_url` is configured |
 | `--summary-batch-size <n>` | 10 | Chunks per LLM summary request |
 | `--detach` | false | Re-exec in the background and return immediately (used by git hooks) |
 | `--detach-embed` | false | Parse in the foreground, then run the embedding phase in a detached background process and return the prompt (`spelunk init` does this automatically) |


### PR DESCRIPTION
## Summary
- `--no-summaries`'s description in `docs/commands.md` and the matching doc-comment on `IndexArgs::no_summaries` claimed index-time summaries are gated on `llm_model` being configured. Per `summaries.rs`'s own doc-comment ("If `server_url` is not configured or `no_summaries` is true, returns early") and the call site in `index/mod.rs`, the actual gate is an explicitly configured `server_url` — `llm_model` plays no role here (it only controls whether `spelunk explore` is hidden from `--help`).
- Found incidentally while doing a consistency pass on `docs/config-reference.md` (unrelated story); scoped out to this standalone fix.
- Cross-checked `docs/getting-started.md` and `docs/third-party-models.md` for the same claim — both already correctly describe the `server_url` gating, so no changes needed there.

## Test plan
- [x] `cargo fmt --check` and `cargo clippy` passed via pre-commit hook on `git commit`.
- [x] Verified the fix against `crates/spelunk-cli/src/cli/cmd/index/summaries.rs:14` and its call site in `index/mod.rs`; no behavior change, doc/comment-only.