### PR TITLE
spelunk-server: gate embedder_load_failure_message behind embed-native feature

### DIFF
--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -429,6 +429,7 @@ async fn run(budget: ThreadBudget) -> Result<()> {
 /// reads unambiguously as terminal: the underlying `anyhow::Context` message
 /// (e.g. "creating model cache dir ...") otherwise reads like in-progress
 /// bootstrap text rather than a failure.
+#[cfg(feature = "embed-native")]
 fn embedder_load_failure_message(context: impl std::fmt::Display) -> String {
     format!("failed: {context}")
 }
@@ -954,6 +955,7 @@ mod arg_tests {
     /// `anyhow::Context` message, e.g. "creating model cache dir ...", reads
     /// like progress on its own).
     #[test]
+    #[cfg(feature = "embed-native")]
     fn embedder_load_failure_message_is_prefixed() {
         assert_eq!(
             super::embedder_load_failure_message(


### PR DESCRIPTION
## Summary
- `embedder_load_failure_message` (crates/spelunk-server/src/main.rs) is only called from `#[cfg(feature = "embed-native")]`-gated arms in `run()`, so it (and its unit test) become dead code under `--no-default-features`, tripping `-D warnings` clippy locally.
- Gate the function and its unit test with `#[cfg(feature = "embed-native")]` to match their only call sites.

## Test plan
- `SPELUNK_SECRET_STORE=file cargo clippy -p spelunk-server --no-default-features --all-targets -- -D warnings` — clean.
- `SPELUNK_SECRET_STORE=file cargo clippy -p spelunk-server --all-targets -- -D warnings` (default features) — clean, no regression.
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-server --no-default-features` — passes; gated test correctly excluded.
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-server` (default features) — passes; gated test `arg_tests::embedder_load_failure_message_is_prefixed` runs.
- `SPELUNK_SECRET_STORE=file cargo fmt --check` — clean.

Closes spelunk-oss^276.