### PR TITLE
Fix silent, permanent data loss on a client's first sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,20 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   in place of `Stored [kind] #id: title`. See [ADR-068's fourth
   amendment](docs/adr/068-zero-setup-onboarding-git-notes-memory-fallback.md).
 
+- **`spelunk sync` / `spelunk memory sync` no longer permanently skips a
+  teammate's older memory on a client's first sync.** The pull cursor is
+  derived from the newest `remote_id` known locally, and `memory_sync`
+  previously pushed before pulling, so a client's own brand-new push became
+  that newest id; any teammate content already on the server that this
+  client had never pulled was silently and permanently skipped, with no
+  error. This mainly hit a new team member's very first sync on a project
+  with prior history, but the same shape could also shadow a teammate's push
+  landing in the narrow window between a client's own pull and its own push
+  on any sync round. `memory_sync` now pulls, pushes, then pulls a second
+  time reusing the pre-push cursor, so a concurrent teammate push in that
+  window is caught within the same sync call or, at the latest, the next
+  one. No command, flag, or output format changed.
+
 ### Changed
 
 - **Chunk re-windowing is now token-aware, and windowed chunks keep their identity.**

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -176,6 +176,7 @@ pub async fn memory_sync(
 }
 
 /// Outcome of a push pass (shared by `sync` and the one-way `memory push`).
+#[derive(Debug)]
 pub(super) struct PushSummary {
     /// Rows actually sent to `push_batch` (the `live` set) — not the raw
     /// pre-filter row count, which would over-report when rows are already
@@ -415,6 +416,7 @@ async fn pull_and_apply_since(
 
 /// Outcome of one [`sync_round`]: the push summary plus the total newly
 /// applied entries across both pull passes.
+#[derive(Debug)]
 struct SyncRoundOutcome {
     pushed: PushSummary,
     pulled: usize,
@@ -460,7 +462,30 @@ async fn sync_round(
 
     let pushed = push_local(local, client, include_archived, accepts_pushed_vectors).await?;
 
-    let pulled_second = pull_and_apply_since(local, client, pre_round_cursor.as_deref()).await?;
+    // If this second pull errors (network blip, transient 5xx), the error
+    // propagates out of `sync_round` rather than being swallowed — `?`
+    // surfaces it to `memory_sync`, which reports a failure and a non-zero
+    // exit. That is correct (a real error must not be silently dropped), but
+    // by this point `pushed` already reflects a push that may have durably
+    // landed server-side (and stamped local `remote_id`s accordingly, inside
+    // `push_local`, before this call even runs) — the failure is scoped to
+    // the confirmation pull, not the push. Attach that context so the
+    // surfaced error doesn't read as "nothing happened": a caller shouldn't
+    // conclude their content was lost and try to force a re-push (harmless
+    // but pointless — already-stamped rows are excluded from `live` and
+    // skipped) instead of simply re-running sync, which retries the pull with
+    // an unaffected, freshly-derived cursor.
+    let pulled_second = pull_and_apply_since(local, client, pre_round_cursor.as_deref())
+        .await
+        .with_context(|| {
+            format!(
+                "confirmation pull failed after this round's push already reached \
+                 the server ({} attempted: {} created, {} skipped, {} failed) — \
+                 the push is not affected by this error; re-running sync will retry \
+                 the pull without re-pushing already-landed entries",
+                pushed.attempted, pushed.created, pushed.skipped, pushed.failed
+            )
+        })?;
 
     Ok(SyncRoundOutcome {
         pushed,
@@ -1689,5 +1714,80 @@ mod tests {
         // was just applied).
         let pulled_again = pull_and_apply(&store_c, &client_c).await.unwrap();
         assert_eq!(pulled_again, 0);
+    }
+
+    /// If the SECOND pull (the confirmation pull after this round's own push)
+    /// fails, `sync_round` must not silently swallow that error — but it also
+    /// must not lose or misrepresent the push that already succeeded. The
+    /// push already durably landed server-side and already stamped this
+    /// round's row with its `remote_id` (inside `push_local`, which returns
+    /// before the second pull ever runs), so: (1) the error surfaces instead
+    /// of being dropped, (2) its message says the push already reached the
+    /// server rather than reading as "nothing happened", and (3) local state
+    /// is left exactly as `push_local` left it — no corruption, no
+    /// re-attempt needed, just a retryable pull on the next sync.
+    #[tokio::test]
+    async fn sync_round_second_pull_failure_surfaces_the_error_without_losing_the_push() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let (_tmp, store) = fresh_store();
+        store
+            .add_note("decision", "T1", "own new entry", &[], &[], None, None)
+            .unwrap();
+        let ext = store.rows_for_sync(false).unwrap()[0].uuid.clone();
+        let cloud_id = "01890000-0000-7000-8000-0000000000b1";
+
+        let server = MockServer::start().await;
+        // First pull (pre-push, empty server): 200 empty.
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/proj/memory/since"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"entries": [], "count": 0})),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        // The push itself succeeds and durably lands.
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 1, "skipped": 0, "failed": 0,
+                "results": [{"status": "created", "external_id": ext, "id": cloud_id}]
+            })))
+            .mount(&server)
+            .await;
+        // The confirmation (second) pull hits a transient server error.
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/proj/memory/since"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+        let err = sync_round(&store, &client, false, false)
+            .await
+            .expect_err("a real second-pull error must not be swallowed as success");
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("push already reached the server") && msg.contains("1 created"),
+            "error must say the push already succeeded, not read as a total \
+             failure: {msg}"
+        );
+
+        // The push's own effect is untouched by the later pull error: the row
+        // is stamped with its cloud id, exactly as `push_local` left it.
+        assert!(
+            store.note_id_for_remote_id(cloud_id).unwrap().is_some(),
+            "the already-succeeded push must not be undone or left unstamped \
+             just because the confirmation pull afterward failed"
+        );
+        assert_eq!(
+            store.count().unwrap(),
+            1,
+            "no duplicate/corrupted local row"
+        );
     }
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync.rs
@@ -130,20 +130,17 @@ pub async fn memory_sync(
         cfg.server_ca.as_deref().map(std::path::Path::new),
     )?;
 
-    // ── Push local → cloud (batched, idempotent on UUID). Attaches the local
-    // fp32/896 vector when the server advertises `accepts_pushed_vectors`,
-    // otherwise text-only and the server re-embeds. ────────────────────────
+    // ── Two-phase reconciliation: pull, push, pull again off the same
+    // pre-round cursor. See `sync_round` for why a plain push-then-pull (or
+    // even pull-then-push) reorder is not sufficient. ───────────────────────
     let accepts_pushed_vectors = tier.caps().is_some_and(|c| c.accepts_pushed_vectors);
-    let pushed = push_local(
+    let SyncRoundOutcome { pushed, pulled } = sync_round(
         &local,
         &client,
         args.include_archived,
         accepts_pushed_vectors,
     )
     .await?;
-
-    // ── Pull cloud → local (delta after the UUID cursor, keep-both) ─────────
-    let pulled = pull_and_apply(&local, &client).await?;
 
     if pushed.attempted == 0 {
         println!(
@@ -373,10 +370,29 @@ async fn push_local(
 /// The cursor is derived from the store itself — `MAX(remote_id)` over local
 /// notes (decision #183) — so there is no persisted watermark to advance: the
 /// next run re-derives the cursor from the rows just applied. This is what makes
-/// the pull immune to clock drift and trivially resumable.
+/// the pull immune to clock drift and trivially resumable. Used as-is by the
+/// one-way `memory pull`; `sync_round` below instead calls
+/// [`pull_and_apply_since`] directly so it can pin an explicit cursor across
+/// its two pull passes.
 async fn pull_and_apply(local: &MemoryStore, client: &CloudSyncClient) -> Result<usize> {
     let cursor = local.max_remote_id()?;
-    let entries = client.pull_since(cursor.as_deref()).await?;
+    pull_and_apply_since(local, client, cursor.as_deref()).await
+}
+
+/// Pull remote entries after an explicit `since_id` cursor and apply them
+/// idempotently. Returns the number of newly-inserted local rows.
+///
+/// Applying an entry is idempotent regardless of how many times this is
+/// called with overlapping ranges: [`MemoryStore::apply_remote_note`] dedupes
+/// on `remote_id` (or reuses a matching row by `entity_id`), so re-fetching a
+/// row already known locally is a harmless no-op, not a duplicate insert or a
+/// double count.
+async fn pull_and_apply_since(
+    local: &MemoryStore,
+    client: &CloudSyncClient,
+    cursor: Option<&str>,
+) -> Result<usize> {
+    let entries = client.pull_since(cursor).await?;
 
     let mut applied = 0usize;
     for e in &entries {
@@ -395,6 +411,61 @@ async fn pull_and_apply(local: &MemoryStore, client: &CloudSyncClient) -> Result
         }
     }
     Ok(applied)
+}
+
+/// Outcome of one [`sync_round`]: the push summary plus the total newly
+/// applied entries across both pull passes.
+struct SyncRoundOutcome {
+    pushed: PushSummary,
+    pulled: usize,
+}
+
+/// Run one full two-way sync round: pull, then push, then pull again off the
+/// same pre-round cursor.
+///
+/// This is `spelunk sync`'s actual push+pull sequence, extracted into its own
+/// function so it can be exercised directly in tests against a real server:
+/// the command entry point (`memory_sync`) can't be unit-tested cheaply
+/// because of its config/tier-probe plumbing (`get_tier`'s per-process cache
+/// makes multiple differently-configured in-process probes unreliable within
+/// one test binary).
+///
+/// Neither a plain push-then-pull nor a plain pull-then-push reorder is
+/// sufficient here. The failure mode: the cursor is always `MAX(remote_id)`
+/// over local rows (decision #183, no persisted watermark), and this
+/// client's own push mints `remote_id`s stamped "now", chronologically the
+/// newest thing on the server. If a plain re-derived cursor were used for a
+/// second pull, this round's own just-pushed rows would become the new
+/// `MAX(remote_id)`, permanently shadowing (via the strict `>` comparison)
+/// any teammate entry that landed between this round's first pull and its
+/// own push.
+///
+/// The fix: capture the cursor once, before this round's own pull or push
+/// touches anything (`pre_round_cursor`), pull with it, push, then pull AGAIN
+/// reusing that SAME `pre_round_cursor`, not a freshly re-derived one. The
+/// second pull harmlessly re-fetches this round's own just-pushed rows (their
+/// `remote_id` is now `> pre_round_cursor`) alongside anything a teammate
+/// pushed in the gap; both are idempotent no-ops or genuine new applies via
+/// [`pull_and_apply_since`], so the combined count is never inflated by
+/// double-counting.
+async fn sync_round(
+    local: &MemoryStore,
+    client: &CloudSyncClient,
+    include_archived: bool,
+    accepts_pushed_vectors: bool,
+) -> Result<SyncRoundOutcome> {
+    let pre_round_cursor = local.max_remote_id()?;
+
+    let pulled_first = pull_and_apply_since(local, client, pre_round_cursor.as_deref()).await?;
+
+    let pushed = push_local(local, client, include_archived, accepts_pushed_vectors).await?;
+
+    let pulled_second = pull_and_apply_since(local, client, pre_round_cursor.as_deref()).await?;
+
+    Ok(SyncRoundOutcome {
+        pushed,
+        pulled: pulled_first + pulled_second,
+    })
 }
 
 /// Parse an ISO 8601 / RFC 3339 timestamp to Unix epoch seconds.
@@ -1379,5 +1450,244 @@ mod tests {
                 .all(|t| titles_c.contains(&t.to_string())),
             "client C must end up with all four entries exactly once each: {titles_c:?}"
         );
+    }
+
+    // ── sync_round: two-phase reconciliation ────────────────────────────────
+    // `sync_round` is `memory_sync`'s actual push+pull sequence, extracted so
+    // it can be driven directly against a real spawned server. `memory_sync`
+    // itself can't cheaply carry these scenarios: `capability::get_tier`
+    // caches its probe result in a per-process `OnceCell`, so several
+    // differently-configured in-process probes in one test binary would see
+    // stale tiers from whichever test's probe ran first.
+
+    /// Open a fresh local memory store in a new tempdir, returning both (the
+    /// tempdir must be kept alive by the caller for the store's lifetime).
+    fn fresh_store() -> (tempfile::TempDir, MemoryStore) {
+        register_sqlite_vec();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+        (tmp, store)
+    }
+
+    /// The primary repro, fixed: a client with local-only, never-pushed
+    /// content, running the actual `sync_round` sequence against a project
+    /// that already has a teammate's prior entry (pushed strictly before
+    /// this round begins),
+    /// ends the round with that teammate entry applied - not 0. This is
+    /// exactly the case the existing `two_established_clients_...` test
+    /// deliberately routes around (see its own comment) because, before this
+    /// fix, `memory_sync`'s push-then-pull order shadowed it permanently.
+    #[tokio::test]
+    async fn sync_round_pulls_teammates_prior_entry_on_a_first_round_with_local_content() {
+        let addr = spawn_spelunk_server().await;
+        let base_url = format!("http://{addr}");
+
+        // Teammate A establishes the project first, entirely before client
+        // C's own sync round begins.
+        let (_tmp_a, store_a) = fresh_store();
+        store_a
+            .add_note(
+                "decision",
+                "A1",
+                "teammate's prior entry",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        let client_a = CloudSyncClient::new(&base_url, "proj-primary", None, None).unwrap();
+        assert_eq!(
+            push_local(&store_a, &client_a, false, false)
+                .await
+                .unwrap()
+                .created,
+            1
+        );
+
+        // Client C has its own never-pushed local entry and has never synced.
+        let (_tmp_c, store_c) = fresh_store();
+        store_c
+            .add_note(
+                "decision",
+                "C1",
+                "client C's own new entry",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        let client_c = CloudSyncClient::new(&base_url, "proj-primary", None, None).unwrap();
+
+        let outcome = sync_round(&store_c, &client_c, false, false).await.unwrap();
+        assert_eq!(outcome.pushed.created, 1, "C's own entry must land");
+        assert_eq!(
+            outcome.pulled, 1,
+            "C must pull A's prior entry within this same round, not 0"
+        );
+        let titles: Vec<String> = store_c
+            .rows_for_sync(false)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert!(titles.contains(&"A1".to_string()) && titles.contains(&"C1".to_string()));
+    }
+
+    /// Idempotence + no double-counting: running `sync_round` twice back to
+    /// back with nothing new to push or pull is a no-op both times, and the
+    /// round's own just-pushed row (harmlessly re-fetched by the second,
+    /// pre-round-cursor pull) is never counted twice or duplicated locally.
+    #[tokio::test]
+    async fn sync_round_twice_with_nothing_new_is_idempotent_and_never_double_counts() {
+        let addr = spawn_spelunk_server().await;
+        let base_url = format!("http://{addr}");
+
+        let (_tmp, store) = fresh_store();
+        store
+            .add_note("decision", "A1", "own entry", &[], &[], None, None)
+            .unwrap();
+        let client = CloudSyncClient::new(&base_url, "proj-idem", None, None).unwrap();
+
+        let r1 = sync_round(&store, &client, false, false).await.unwrap();
+        assert_eq!(r1.pushed.created, 1);
+        assert_eq!(
+            r1.pulled, 0,
+            "the second pull re-fetches this round's own just-pushed row via \
+             the pre-round cursor, but it must not be double-counted"
+        );
+        assert_eq!(store.count().unwrap(), 1, "no duplicate local row");
+
+        let r2 = sync_round(&store, &client, false, false).await.unwrap();
+        assert_eq!(
+            (r2.pushed.attempted, r2.pushed.already_synced, r2.pulled),
+            (0, 1, 0),
+            "a second round with nothing new must be a full no-op"
+        );
+        assert_eq!(store.count().unwrap(), 1);
+    }
+
+    /// The race window a plain reorder cannot close: a teammate's push
+    /// that lands on the server strictly between this round's own first pull
+    /// and its own push must still be picked up within this same round (via
+    /// the second pull, reusing the pre-round cursor) rather than being
+    /// permanently shadowed by the round's own push becoming the new
+    /// `MAX(remote_id)`.
+    ///
+    /// Real network concurrency can't be forced deterministically in a unit
+    /// test, so this composes `sync_round`'s exact same three calls
+    /// (`pull_and_apply_since` / `push_local` / `pull_and_apply_since`,
+    /// reusing one `pre_round_cursor`) with the teammate's push manually
+    /// interleaved at the precise point the race window occupies.
+    #[tokio::test]
+    async fn sync_round_catches_a_teammate_push_landing_between_its_own_pull_and_push() {
+        let addr = spawn_spelunk_server().await;
+        let base_url = format!("http://{addr}");
+
+        let (_tmp, store) = fresh_store();
+        store
+            .add_note("decision", "Client1", "own new entry", &[], &[], None, None)
+            .unwrap();
+        let client = CloudSyncClient::new(&base_url, "proj-race", None, None).unwrap();
+
+        // Step 1 of sync_round: capture the cursor, then pull. Nothing on the
+        // server yet.
+        let pre_round_cursor = store.max_remote_id().unwrap();
+        let pulled_first = pull_and_apply_since(&store, &client, pre_round_cursor.as_deref())
+            .await
+            .unwrap();
+        assert_eq!(pulled_first, 0);
+
+        // The race window: a teammate pushes here, strictly between this
+        // round's own pull and its own push.
+        let (_tmp_b, store_b) = fresh_store();
+        store_b
+            .add_note(
+                "decision",
+                "B1",
+                "teammate's race-window entry",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        let client_b = CloudSyncClient::new(&base_url, "proj-race", None, None).unwrap();
+        assert_eq!(
+            push_local(&store_b, &client_b, false, false)
+                .await
+                .unwrap()
+                .created,
+            1
+        );
+
+        // Step 2 of sync_round: this round's own push.
+        let pushed = push_local(&store, &client, false, false).await.unwrap();
+        assert_eq!(pushed.created, 1);
+
+        // Step 3 of sync_round: the second pull, reusing pre_round_cursor
+        // (NOT a freshly re-derived max_remote_id(), which would now include
+        // this round's own push and shadow B1 forever).
+        let pulled_second = pull_and_apply_since(&store, &client, pre_round_cursor.as_deref())
+            .await
+            .unwrap();
+        assert_eq!(
+            pulled_second, 1,
+            "the race-window teammate push must be caught by the second pull, \
+             not permanently lost"
+        );
+
+        let titles: Vec<String> = store
+            .rows_for_sync(false)
+            .unwrap()
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert!(titles.contains(&"B1".to_string()));
+    }
+
+    /// `memory pull` (one-way, no push) is unaffected by the `sync_round`
+    /// two-phase reconciliation added for `sync`. It keeps
+    /// deriving a single cursor from the store itself via `pull_and_apply`,
+    /// unmodified.
+    #[tokio::test]
+    async fn pull_and_apply_one_way_pull_still_derives_its_own_single_cursor() {
+        let addr = spawn_spelunk_server().await;
+        let base_url = format!("http://{addr}");
+
+        let (_tmp_a, store_a) = fresh_store();
+        store_a
+            .add_note("decision", "A1", "first", &[], &[], None, None)
+            .unwrap();
+        let client_a = CloudSyncClient::new(&base_url, "proj-pull", None, None).unwrap();
+        assert_eq!(
+            push_local(&store_a, &client_a, false, false)
+                .await
+                .unwrap()
+                .created,
+            1
+        );
+        store_a
+            .add_note("decision", "A2", "second", &[], &[], None, None)
+            .unwrap();
+        assert_eq!(
+            push_local(&store_a, &client_a, false, false)
+                .await
+                .unwrap()
+                .created,
+            1
+        );
+
+        // A pull-only client with nothing local picks up both in one call.
+        let (_tmp_c, store_c) = fresh_store();
+        let client_c = CloudSyncClient::new(&base_url, "proj-pull", None, None).unwrap();
+        let pulled = pull_and_apply(&store_c, &client_c).await.unwrap();
+        assert_eq!(pulled, 2);
+
+        // A second, immediate pull is a no-op (cursor re-derived from what
+        // was just applied).
+        let pulled_again = pull_and_apply(&store_c, &client_c).await.unwrap();
+        assert_eq!(pulled_again, 0);
     }
 }

--- a/crates/spelunk-cli/tests/memory_push_sync_total_failure.rs
+++ b/crates/spelunk-cli/tests/memory_push_sync_total_failure.rs
@@ -181,6 +181,65 @@ async fn memory_sync_total_failure_exits_nonzero_and_does_not_print_sync_complet
     );
 }
 
+/// A total push failure still runs the full two-phase pull reconciliation
+/// (`sync_round`'s pull, push, pull-again sequence), and the failure
+/// message's pull count is the honest combined total across both passes,
+/// not just the first pass or zero.
+///
+/// Both pull calls in `sync_round` reuse the same pre-round cursor, so a
+/// stateless mock returning one remote entry for `/since` regardless of
+/// `since_id` is hit identically by both passes: the first applies it (new),
+/// the second re-fetches it but it's already known locally (dedup on
+/// `remote_id`), so the reported total is the true, non-doubled count.
+#[tokio::test]
+async fn memory_sync_total_failure_reports_the_full_two_pass_pull_count() {
+    let server = MockServer::start().await;
+    mount_health(&server).await;
+    mount_batch_total_failure(&server, 1).await;
+    Mock::given(method("GET"))
+        .and(path_regex(format!(
+            r"^/v1/projects/{PROJECT_SLUG}/memory/since$"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": [{
+                "id": "01890000-0000-7000-8000-000000000abc",
+                "kind": "decision",
+                "title": "Teammate",
+                "body": "already on the server",
+                "created_at": "2026-06-19T01:00:00Z"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_project(proj.path());
+    let config_path = write_config(proj.path(), &server.uri());
+    seed_one_note(home.path(), proj.path(), &config_path);
+
+    let assert = spelunk_bin_in(home.path())
+        .current_dir(proj.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("sync")
+        .assert()
+        .failure();
+
+    let out = assert.get_output();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Sync failed"),
+        "must still surface the push failure; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stderr.contains("pull still applied 1 new remote entries"),
+        "the pull count must reflect the one genuinely new entry across both \
+         reconciliation passes, not zero and not double-counted; stderr={stderr:?}"
+    );
+}
+
 /// Regression guard for the fix's OTHER side: a real success must still exit
 /// zero and print the "Done." success framing. Without this, a broken change
 /// that made every push exit non-zero unconditionally would still pass the

--- a/crates/spelunk-core/src/storage/remote/sync.rs
+++ b/crates/spelunk-core/src/storage/remote/sync.rs
@@ -285,6 +285,13 @@ impl CloudSyncClient {
     /// `None` (nothing synced yet) this is a full catch-up: the
     /// nil UUID `00000000-…` sorts before every UUIDv7, so it returns all
     /// entries.
+    ///
+    /// A project that does not exist on the server yet (404) is treated as
+    /// having nothing to pull, not an error: a spelunk-server-backed project
+    /// is only created lazily by the first push to it (`memory/batch`), so a
+    /// pull that runs before any push has ever landed for a brand new project
+    /// (e.g. `sync`'s own first pull pass, ahead of its own push) must not
+    /// fail the whole sync just because nobody has pushed yet.
     pub async fn pull_since(&self, since_id: Option<&str>) -> Result<Vec<RemoteEntry>> {
         // The all-zero UUID precedes every UUIDv7 in `id > $cursor` order, so it
         // is the natural "from the beginning" cursor for a first sync.
@@ -294,13 +301,17 @@ impl CloudSyncClient {
             .query(&[("since_id", cursor)])
             .send()
             .await
-            .context("GET /memory/since")?
+            .context("GET /memory/since")?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(vec![]);
+        }
+        let body = resp
             .error_for_status()
             .context("server returned error for GET /memory/since")?
             .json::<SinceBody>()
             .await
             .context("parsing /memory/since response")?;
-        Ok(resp.entries)
+        Ok(body.entries)
     }
 }
 
@@ -452,6 +463,24 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].id, "01890000-0000-7000-8000-000000000001");
         assert!(!entries[0].is_archived());
+    }
+
+    /// A project not yet created server-side (nobody has ever pushed to it)
+    /// must read as "nothing to pull", not an error: the two-phase sync
+    /// reconciliation pulls before the round's own push runs, so a brand
+    /// new project's very first sync must not fail just because it hasn't
+    /// been lazily created by a push yet.
+    #[tokio::test]
+    async fn pull_since_project_not_found_yet_is_treated_as_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/brand-new-proj/memory/since"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        let client = CloudSyncClient::new(&server.uri(), "brand-new-proj", None, None).unwrap();
+        let entries = client.pull_since(None).await.unwrap();
+        assert!(entries.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

A client's first `spelunk sync` (or any sync round where a teammate's push landed in a narrow timing window) could silently and permanently skip older teammate memory content already on the server, with no error or indication anything was missed.

### Root cause

`memory_sync` pushed local content before pulling. The pull cursor is derived live as `MAX(remote_id)` over locally-known rows, and a push mints `remote_id`s stamped with the current time, so a client's own brand-new push became the newest known id. The subsequent pull then only fetched entries strictly newer than that cursor, permanently skipping any older teammate content this client had never seen. Since the cursor only ever advances and comparisons are strict `>`, there was no way to recover the skipped data on a later sync either.

### The fix: two-phase reconciliation

`memory_sync` now runs a `sync_round()`:
1. Capture the pre-round cursor once (`MAX(remote_id)` over local rows), before any pull or push.
2. Pull using that cursor.
3. Push local content.
4. Pull again, reusing the *same* pre-round cursor (not a freshly re-derived one).

The second pull is what catches a teammate's push that landed on the server in the gap between this client's own pull and its own push — a race that a plain pull-then-push reorder alone would not close, since the cursor is always re-derived from local rows after the round.

Both pulls apply idempotently (dedup on `remote_id`), so the combined "applied" count is never double-counted, and running a round twice with nothing new is a full no-op.

### Two additional real bugs found and fixed along the way

- **404-on-first-sync:** Pulling before pushing means a brand-new project's very first sync now calls `GET /memory/since` before any push has lazily created that project server-side, which previously 404'd and failed the whole sync. `CloudSyncClient::pull_since` now treats a 404 as an empty pull (mirroring how `delete_remote` already treats 404 as success), scoped specifically to "project doesn't exist yet" — a real 401/other error still surfaces normally, since the 404 check happens before `error_for_status()` is even called.
- **Second-pull-failure error context:** If the confirmation (second) pull fails after the push already succeeded, the error now says the push already reached the server, rather than reading as if nothing happened — the push is not affected, and a caller can safely just re-run sync.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-core` — all green (473+ passed).
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli` — all green, including the new `sync_round_*` tests in `crates/spelunk-cli/src/cli/cmd/memory/sync.rs` and the new total-push-failure test in `crates/spelunk-cli/tests/memory_push_sync_total_failure.rs`.
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-server` — all green (covers the ADR-037 relay, which also calls `pull_since` and is confirmed unaffected/improved by the 404 fix).
- `SPELUNK_SECRET_STORE=file cargo fmt --all -- --check` — clean.
- `SPELUNK_SECRET_STORE=file cargo clippy --all-targets --features rich-formats -- -D warnings` — clean.
- `SPELUNK_SECRET_STORE=file cargo check -p spelunk-cli -p spelunk-core --no-default-features` — clean.
- Manually read `sync_round()` end-to-end and confirmed: the pre-round cursor is captured exactly once before any pull/push, the first pull uses it, and the second pull reuses the identical captured value rather than calling `max_remote_id()` again.
- Manually verified the race-window test (`sync_round_catches_a_teammate_push_landing_between_its_own_pull_and_push`) and the second-pull-failure test both exercise the scenarios their names claim, not just decomposed/relabeled simple cases.