### PR TITLE
Lower default chunk-token cap to 512, with re-index drift provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Default chunk-token cap (`MAX_CHUNK_TOKENS`) lowered from 2048 to 512.** A
+  quality/performance evaluation across a large gold-query corpus found
+  retrieval quality flat across 2048/1024/512/384 while 512 measurably speeds
+  up indexing, with second-order costs (vector count, storage) at the new cap
+  confirmed immaterial. `index_meta` now also tracks the chunker
+  configuration an index was built under, alongside the existing
+  `embedding_model`/`embedding_dim` provenance: opening an index that was
+  built under a different chunk-token cap prints a warning naming the drift
+  and pointing at `spelunk index --force` for a uniform re-index, rather than
+  silently leaving unchanged files on their old chunk boundaries forever. A
+  normal incremental run still proceeds after the warning: unlike an
+  embedding-model mismatch, a chunk-cap change is same-model/same-dimension
+  drift, not index corruption.
+
 ### Added
 
 - **`spelunk memory reindex` backfills local note embeddings that were never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,7 @@ enum so commands degrade gracefully when no server is configured.
 Tree-sitter extracts **named semantic nodes** (functions, structs, impls, etc.)
 rather than naive line splits. A token-aware sliding window is the fallback
 for unsupported file types and for re-windowing oversized semantic nodes:
-whole lines accumulate up to `MAX_CHUNK_TOKENS` (2048) with ~12.5% token
+whole lines accumulate up to `MAX_CHUNK_TOKENS` (512) with ~12.5% token
 overlap between windows, and the source node's `name`/`docstring`/
 `parent_scope` are copied onto every window it produces (so a re-windowed
 function still embeds with its symbol name instead of `title: none`). Markdown

--- a/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/embed_phase.rs
@@ -394,6 +394,19 @@ async fn run_embed_phase_with_backoff(
     // Refuse to append vectors from a different model into an existing index;
     // stamps provenance on a fresh/legacy DB.
     db.ensure_embedding_model(spelunk_core::embeddings::MODEL_ID)?;
+    // Same-model/same-dimension drift (e.g. a changed chunk-token cap) isn't
+    // corruption like a model mismatch, so this warns instead of bailing:
+    // unchanged files keep their old chunk boundaries until re-parsed, and
+    // nothing else would tell the user that `--force` is what fixes it.
+    let current_chunker_config = spelunk_core::indexer::chunker_config_id();
+    if let Some(recorded) = db.ensure_chunker_config(&current_chunker_config)? {
+        eprintln!(
+            "Warning: this index was built with chunker config '{recorded}', but the \
+             running build uses '{current_chunker_config}'. Unchanged files keep their old \
+             chunk boundaries until re-parsed, so the index now mixes chunk granularities. \
+             Run `spelunk index --force` to re-chunk everything under the current config.\n"
+        );
+    }
     let server_limits = tier.server_limits();
 
     // Ceiling the calibrated batch size may grow to (see `next_batch_size`),
@@ -1791,6 +1804,55 @@ mod tests {
 
         assert_eq!(embedded, 50);
         assert_eq!(db.stats().unwrap().embedding_count, 50);
+    }
+
+    #[tokio::test]
+    async fn chunker_config_drift_warns_but_does_not_block_the_embed_phase() {
+        // A DB stamped under an old chunker config (simulating an upgrade
+        // that changed the default chunk-token cap) must still complete a
+        // normal, non-`--force` embed phase: the mismatch is same-model/
+        // same-dimension drift, not corruption, so it's a warning, not a
+        // bailout.
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/v1/projects/.+/index/embed$"))
+            .respond_with(OkEmbedResponder)
+            .mount(&mock)
+            .await;
+
+        let (db, ids) = seed_chunks(5);
+        db.ensure_chunker_config("max_chunk_tokens=2048")
+            .expect("stamp an old chunker config, as an existing index.db would carry");
+
+        let chunk_ids_and_texts: Vec<(i64, String, usize)> = ids
+            .iter()
+            .map(|id| (*id, format!("text {id}"), 3))
+            .collect();
+
+        let cfg = Config::default();
+        let tier = server_tier(mock.uri());
+        let mp = MultiProgress::new();
+
+        let embedded = run_embed_phase(
+            chunk_ids_and_texts,
+            &db,
+            &cfg,
+            &tier,
+            std::path::Path::new("/tmp/proj"),
+            8,
+            &mp,
+        )
+        .await
+        .expect("a chunker-config mismatch must not fail the embed phase");
+
+        assert_eq!(embedded, 5, "incremental embedding still proceeds normally");
+        assert_eq!(db.stats().unwrap().embedding_count, 5);
+        // The stale stamp is left as-is: only a `--force` full re-chunk
+        // (outside this function's scope) would bring it back in sync.
+        assert_eq!(
+            db.chunker_config().unwrap().as_deref(),
+            Some("max_chunk_tokens=2048")
+        );
     }
 
     // ── run_embed_phase: honoring the server's 429 admission shedding ───────

--- a/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/parse_phase.rs
@@ -208,6 +208,16 @@ pub(super) fn run_parse_phase(
         chunk_ids_and_texts.push((chunk_id, text, tokens));
     }
 
+    // `--force` bypasses the hash-skip for every file processed above, so
+    // once this loop is done every stored chunk was cut under the current
+    // chunker config. Refresh the provenance stamp so a later normal run's
+    // `ensure_chunker_config` check stops warning about a drift that no
+    // longer exists; without this, the warning would persist forever even
+    // after the very re-index the message tells the user to run.
+    if args.force {
+        db.stamp_chunker_config(&spelunk_core::indexer::chunker_config_id())?;
+    }
+
     Ok(ParseResult {
         chunk_ids_and_texts,
         indexed,
@@ -904,6 +914,65 @@ mod tests {
         assert_eq!(
             texts_run2, texts_run1,
             "backfilled embedding text must match the parse-time embedding text byte-for-byte"
+        );
+    }
+
+    // ── --force refreshes the chunker-config provenance stamp ─────────────────
+
+    /// A `--force` run re-chunks every file under the current config, so it
+    /// must also refresh `index_meta`'s `chunker_config` stamp: otherwise
+    /// `ensure_chunker_config`'s drift warning (see `embed_phase.rs`) would
+    /// keep firing on every later normal run forever, even once `--force`
+    /// gave the user the exact uniform re-index its own message told them to
+    /// run. Drives the full sequence: stamp old → a normal run leaves the
+    /// drift alone → `--force` → the stamp updates → a later normal run
+    /// reports no drift.
+    #[test]
+    fn force_reindex_refreshes_the_chunker_config_stamp() {
+        let db = open_db();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "pub fn foo() -> i32 { 1 }\n").unwrap();
+
+        let stale = "max_chunk_tokens=999999";
+        db.ensure_chunker_config(stale).expect("stamp old config");
+
+        let mp = MultiProgress::new();
+        let cfg = crate::config::Config::default();
+        let current = spelunk_core::indexer::chunker_config_id();
+
+        // A normal (non-`--force`) run must not touch the stamp: the drift
+        // stays there for the embed phase to warn about.
+        let args = default_args(dir.path().to_path_buf());
+        run_parse_phase(dir.path(), &db, &args, &mp, &cfg).expect("normal parse phase");
+        assert_eq!(
+            db.chunker_config().unwrap().as_deref(),
+            Some(stale),
+            "a normal run must not silently clear the drift"
+        );
+        assert_eq!(
+            db.ensure_chunker_config(&current).expect("drift check"),
+            Some(stale.to_string()),
+            "the stale stamp must still be reported as drift before --force"
+        );
+
+        // `--force` re-chunks everything under the current config and must
+        // refresh the stamp.
+        let mut force_args = default_args(dir.path().to_path_buf());
+        force_args.force = true;
+        run_parse_phase(dir.path(), &db, &force_args, &mp, &cfg).expect("force parse phase");
+        assert_eq!(
+            db.chunker_config().unwrap().as_deref(),
+            Some(current.as_str()),
+            "a --force re-index must refresh the stamp to the current config"
+        );
+
+        // A later normal run now sees no drift: the whole point of running
+        // --force was to make the warning stop.
+        assert_eq!(
+            db.ensure_chunker_config(&current)
+                .expect("post-force drift check"),
+            None,
+            "after --force, the same config must no longer be reported as drift"
         );
     }
 

--- a/crates/spelunk-core/src/indexer/chunker.rs
+++ b/crates/spelunk-core/src/indexer/chunker.rs
@@ -77,7 +77,7 @@ impl Chunk {
 /// Soft ceiling for one chunk (tokens, chars/4 estimate). Oversized leaves are
 /// re-windowed and oversized containers suppressed in favour of their children.
 /// Distinct from the embedder's hard `token_cap` OOM guard.
-pub const MAX_CHUNK_TOKENS: usize = 2048;
+pub const MAX_CHUNK_TOKENS: usize = 512;
 
 /// Process-global cap, seeded from `MAX_CHUNK_TOKENS`. Only benchmark/eval
 /// harnesses call the setter; production code always runs on the default.
@@ -90,6 +90,15 @@ pub fn chunk_token_cap() -> usize {
 /// Test/benchmark use only; never call from a production indexing path.
 pub fn set_chunk_token_cap(tokens: usize) {
     CHUNK_TOKEN_CAP.store(tokens, Ordering::Relaxed);
+}
+
+/// Identifier for the chunk-boundary-affecting knobs, stamped into a DB's
+/// `index_meta` so a later run can detect that its stored chunks were cut
+/// under a different configuration (see `Database::ensure_chunker_config`).
+/// Only `MAX_CHUNK_TOKENS` (via `chunk_token_cap`) affects boundaries today;
+/// fold any future boundary-affecting knob into this string too.
+pub fn chunker_config_id() -> String {
+    format!("max_chunk_tokens={}", chunk_token_cap())
 }
 
 /// Split `source` into token-aware sliding-window chunks (fallback for
@@ -226,18 +235,21 @@ mod tests {
     #[test]
     #[serial]
     fn sliding_window_respects_the_injected_cap() {
-        // ~1000 estimated tokens (chars/4): one window at the 2048 default,
-        // several once capped to 100.
-        let source = (0..200)
-            .map(|i| format!("let line_{i:03} = 1;"))
-            .collect::<Vec<_>>()
-            .join("\n");
+        // Line count scaled off `MAX_CHUNK_TOKENS` (not a hardcoded literal)
+        // so this stays valid whatever the default cap is: comfortably under
+        // budget for the default-cap assertion, then split via an injected
+        // cap of 100.
+        let line = |i: usize| format!("let line_{i:03} = 1;");
+        let budget_chars = MAX_CHUNK_TOKENS * 4;
+        let chars_per_line = line(0).chars().count() + 1; // + newline
+        let fits_lines = (budget_chars / chars_per_line).saturating_sub(5).max(1);
+        let source = (0..fits_lines).map(line).collect::<Vec<_>>().join("\n");
 
         let default_chunks = sliding_window(&source, "f.rs", "rust", None, None, None);
         assert_eq!(
             default_chunks.len(),
             1,
-            "default 2048-token cap must fit this source in one window"
+            "source built to fit inside the default cap must stay one window"
         );
 
         with_cap(100, || {

--- a/crates/spelunk-core/src/indexer/mod.rs
+++ b/crates/spelunk-core/src/indexer/mod.rs
@@ -11,6 +11,8 @@ pub mod secrets;
 pub mod summariser;
 
 #[allow(unused_imports)]
-pub use chunker::{Chunk, ChunkKind, chunk_token_cap, set_chunk_token_cap, sliding_window};
+pub use chunker::{
+    Chunk, ChunkKind, chunk_token_cap, chunker_config_id, set_chunk_token_cap, sliding_window,
+};
 #[allow(unused_imports)]
 pub use parser::SourceParser;

--- a/crates/spelunk-core/src/indexer/parser/mod.rs
+++ b/crates/spelunk-core/src/indexer/parser/mod.rs
@@ -213,7 +213,6 @@ impl SourceParser {
 
         if chunks.is_empty() {
             tracing::debug!("{file_path}: no semantic nodes found, using sliding window");
-            // 120-line window fits comfortably in EmbeddingGemma's 2048-token budget.
             return Ok(sliding_window(
                 source, file_path, language, None, None, None,
             ));

--- a/crates/spelunk-core/src/storage/db.rs
+++ b/crates/spelunk-core/src/storage/db.rs
@@ -453,7 +453,8 @@ impl Database {
     /// Returns the stale recorded value on a mismatch so the caller can warn
     /// without failing the run; the stamp is left as-is (not overwritten) so
     /// the warning keeps firing until a `--force` run re-chunks everything
-    /// under the current config.
+    /// under the current config and calls
+    /// [`stamp_chunker_config`](Self::stamp_chunker_config) to refresh it.
     pub fn ensure_chunker_config(&self, config: &str) -> Result<Option<String>> {
         match self.chunker_config()? {
             Some(recorded) if recorded == config => Ok(None),
@@ -468,6 +469,22 @@ impl Database {
                 Ok(None)
             }
         }
+    }
+
+    /// Unconditionally record `config` as this DB's chunker-config provenance,
+    /// regardless of what (if anything) was previously stamped. A `--force`
+    /// re-index re-chunks every file, so once it finishes every stored chunk
+    /// was cut under `config`; refreshing the stamp here is what makes
+    /// [`ensure_chunker_config`](Self::ensure_chunker_config) stop warning on
+    /// the next normal run, until the config next changes.
+    pub fn stamp_chunker_config(&self, config: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "INSERT OR REPLACE INTO index_meta (key, value) VALUES ('chunker_config', ?1)",
+                rusqlite::params![config],
+            )
+            .context("stamping chunker config provenance")?;
+        Ok(())
     }
 
     /// Insert or replace an embedding for a chunk.
@@ -906,6 +923,42 @@ mod tests {
             .ensure_chunker_config("max_chunk_tokens=512")
             .expect("a config mismatch must be Ok, not an error");
         assert_eq!(warned.as_deref(), Some("max_chunk_tokens=2048"));
+    }
+
+    /// `stamp_chunker_config` is the refresh mechanism a `--force` re-index
+    /// uses to silence the drift warning: stamp old, detect the mismatch,
+    /// force-refresh, then confirm the same config no longer reports drift.
+    #[test]
+    fn stamp_chunker_config_silences_a_prior_mismatch() {
+        register_sqlite_vec();
+        let db = Database::open(std::path::Path::new(":memory:")).expect("open");
+        db.ensure_chunker_config("max_chunk_tokens=2048")
+            .expect("stamp old config");
+
+        // Drift is detected before the refresh.
+        assert_eq!(
+            db.ensure_chunker_config("max_chunk_tokens=512")
+                .expect("mismatch must not fail"),
+            Some("max_chunk_tokens=2048".to_string()),
+            "the old stamp must still be reported as drift before any refresh"
+        );
+
+        // A `--force` run re-chunks everything and refreshes the stamp,
+        // unconditionally, not just on a first-ever write.
+        db.stamp_chunker_config("max_chunk_tokens=512")
+            .expect("force refresh");
+        assert_eq!(
+            db.chunker_config().unwrap().as_deref(),
+            Some("max_chunk_tokens=512")
+        );
+
+        // The next normal (non-`--force`) run now sees a match: no drift.
+        assert_eq!(
+            db.ensure_chunker_config("max_chunk_tokens=512")
+                .expect("post-refresh check must not fail"),
+            None,
+            "after the refresh, the same config must no longer be reported as drift"
+        );
     }
 
     fn embedding_count(db: &Database) -> i64 {

--- a/crates/spelunk-core/src/storage/db.rs
+++ b/crates/spelunk-core/src/storage/db.rs
@@ -431,6 +431,45 @@ impl Database {
         }
     }
 
+    /// Read the recorded chunker config id (`chunker::chunker_config_id`), or
+    /// `None` if never stamped (a DB predating this provenance key).
+    pub fn chunker_config(&self) -> Result<Option<String>> {
+        self.conn
+            .query_row(
+                "SELECT value FROM index_meta WHERE key = 'chunker_config'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .context("reading chunker_config")
+    }
+
+    /// Compare the running build's chunker config against this DB's
+    /// provenance, stamping it on a fresh/legacy DB. Unlike
+    /// [`ensure_embedding_model`](Self::ensure_embedding_model), a mismatch
+    /// here is same-model/same-dimension drift (e.g. a changed chunk-token
+    /// cap), not a hard incompatibility: old and new chunks coexist in the
+    /// same vector space at different granularity, so this never errors.
+    /// Returns the stale recorded value on a mismatch so the caller can warn
+    /// without failing the run; the stamp is left as-is (not overwritten) so
+    /// the warning keeps firing until a `--force` run re-chunks everything
+    /// under the current config.
+    pub fn ensure_chunker_config(&self, config: &str) -> Result<Option<String>> {
+        match self.chunker_config()? {
+            Some(recorded) if recorded == config => Ok(None),
+            Some(recorded) => Ok(Some(recorded)),
+            None => {
+                self.conn
+                    .execute(
+                        "INSERT OR REPLACE INTO index_meta (key, value) VALUES ('chunker_config', ?1)",
+                        rusqlite::params![config],
+                    )
+                    .context("stamping chunker config provenance")?;
+                Ok(None)
+            }
+        }
+    }
+
     /// Insert or replace an embedding for a chunk.
     ///
     /// Takes the raw float vector; it is int8-quantised here for the
@@ -810,6 +849,63 @@ mod tests {
             msg.to_lowercase().contains("re-index"),
             "message must instruct re-index: {msg}"
         );
+    }
+
+    /// Chunker config provenance round-trips like `embedding_model`, but a
+    /// mismatch returns the stale value instead of erroring, and the run
+    /// keeps going (a chunk-cap change doesn't corrupt the vector space).
+    #[test]
+    fn chunker_config_stamp_and_warn_on_mismatch() {
+        register_sqlite_vec();
+        let db = Database::open(std::path::Path::new(":memory:")).expect("open");
+        // Absent → backfilled (no error).
+        assert!(db.chunker_config().unwrap().is_none());
+        assert_eq!(
+            db.ensure_chunker_config("max_chunk_tokens=512")
+                .expect("first stamp"),
+            None
+        );
+        assert_eq!(
+            db.chunker_config().unwrap().as_deref(),
+            Some("max_chunk_tokens=512")
+        );
+        // Same config → no-op, no warning.
+        assert_eq!(
+            db.ensure_chunker_config("max_chunk_tokens=512")
+                .expect("same config is fine"),
+            None
+        );
+        // Different config → the stale value comes back for the caller to
+        // warn with, not an error, and the stamp is left untouched.
+        let recorded = db
+            .ensure_chunker_config("max_chunk_tokens=2048")
+            .expect("mismatch must not fail")
+            .expect("mismatch must surface the recorded value");
+        assert_eq!(recorded, "max_chunk_tokens=512");
+        assert_eq!(
+            db.chunker_config().unwrap().as_deref(),
+            Some("max_chunk_tokens=512"),
+            "a mismatch must not overwrite the stamp"
+        );
+    }
+
+    /// A DB stamped under an old chunker config still lets normal
+    /// (non-`--force`) indexing proceed: `ensure_chunker_config` never
+    /// blocks the caller, it only reports the drift.
+    #[test]
+    fn chunker_config_mismatch_does_not_block_incremental_indexing() {
+        register_sqlite_vec();
+        let db = Database::open(std::path::Path::new(":memory:")).expect("open");
+        db.ensure_chunker_config("max_chunk_tokens=2048")
+            .expect("stamp old config");
+
+        // Simulates a build upgraded to the new default: the check reports
+        // the drift but returns `Ok`, so a normal `spelunk index` run keeps
+        // going (incremental skip-by-hash still applies to unchanged files).
+        let warned = db
+            .ensure_chunker_config("max_chunk_tokens=512")
+            .expect("a config mismatch must be Ok, not an error");
+        assert_eq!(warned.as_deref(), Some("max_chunk_tokens=2048"));
     }
 
     fn embedding_count(db: &Database) -> i64 {

--- a/crates/spelunk-core/tests/unit_chunker.rs
+++ b/crates/spelunk-core/tests/unit_chunker.rs
@@ -78,10 +78,15 @@ fn sliding_window_over_budget_single_line_becomes_its_own_window() {
 
 #[test]
 fn sliding_window_adjacent_windows_overlap() {
-    // Enough long lines to produce several windows; each window after the first
-    // must start on or before the previous window's last line (overlap), and
-    // start strictly after the previous window's start (forward progress).
-    let src = vec![line_of(300); 80].join("\n");
+    // Lines short relative to the cap (so the overlap budget, 1/8th of the
+    // window budget, still spans several lines regardless of the configured
+    // cap) and enough of them to span several windows. Each window after the
+    // first must start on or before the previous window's last line
+    // (overlap), and start strictly after the previous window's start
+    // (forward progress).
+    let line_len = 40;
+    let total_lines = (MAX_CHUNK_TOKENS * 4 / line_len) * 5;
+    let src = vec![line_of(line_len); total_lines].join("\n");
     let chunks = sliding_window(&src, "f.txt", "text", None, None, None);
     assert!(
         chunks.len() >= 3,
@@ -288,10 +293,19 @@ fn oversized_markdown_section_windows_keep_heading_as_name() {
 
 #[test]
 fn oversized_container_suppresses_own_chunk_keeps_children() {
-    // A module whose whole text is over the cap, but each child fn is under it.
+    // A module whose whole text is over the cap, but each child fn is under
+    // it. `body_lines` is derived from `MAX_CHUNK_TOKENS` (not a hardcoded
+    // line count) so both fixture properties keep holding regardless of the
+    // configured cap: one child alone must fit under it, five together must not.
+    let body_lines = ((MAX_CHUNK_TOKENS / 3) / 5).max(10);
+    assert!(
+        estimate_tokens(&big_rust_fn("f0", body_lines)) <= MAX_CHUNK_TOKENS,
+        "fixture assumption broken: a single child function must fit under the cap"
+    );
+
     let mut src = String::from("mod tests {\n");
     for i in 0..5 {
-        src.push_str(&big_rust_fn(&format!("f{i}"), 120));
+        src.push_str(&big_rust_fn(&format!("f{i}"), body_lines));
     }
     src.push_str("}\n");
     assert!(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,7 @@ Architectural decisions are recorded in [docs/adr/](adr/). Key ones:
 
 Tree-sitter parses source code into an AST and spelunk extracts named semantic nodes (functions, structs, classes, methods, traits, impls) as individual chunks. This means each chunk is a meaningful unit of code with a name, type, and scope — not an arbitrary 100-line window.
 
-Fallback: a token-aware sliding window for unsupported languages and for oversized semantic nodes that need re-windowing. Each window accumulates whole lines up to `MAX_CHUNK_TOKENS` (2048), with ~12.5% token overlap between adjacent windows (the ratio behind the historical 120-line/15-line-overlap split); a single line that alone exceeds the budget becomes its own window so the cap always binds. Re-windowed chunks carry the source node's `name`/`docstring`/`parent_scope` so they still embed with their symbol identity rather than `title: none`. Markdown uses heading-based chunking.
+Fallback: a token-aware sliding window for unsupported languages and for oversized semantic nodes that need re-windowing. Each window accumulates whole lines up to `MAX_CHUNK_TOKENS` (512), with ~12.5% token overlap between adjacent windows (the ratio behind the historical 120-line/15-line-overlap split); a single line that alone exceeds the budget becomes its own window so the cap always binds. Re-windowed chunks carry the source node's `name`/`docstring`/`parent_scope` so they still embed with their symbol identity rather than `title: none`. Markdown uses heading-based chunking.
 
 ### Storage: SQLite + sqlite-vec, nothing else
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -103,6 +103,14 @@ Summaries are the exception: a chunk whose summary failed (say the LLM was
 unreachable) is recorded as attempted rather than missing, so a plain re-run
 skips it. Use `--force` to retry those.
 
+The index also remembers the chunker configuration (currently just the
+`MAX_CHUNK_TOKENS` cap) it was built under. If a plain `spelunk index` detects
+that the running build's chunker config differs from what's recorded, it
+prints a warning and proceeds anyway rather than failing: unchanged files keep
+their old chunk boundaries until re-parsed, so the index temporarily mixes
+chunk granularities. Run `spelunk index --force` to re-chunk every file under
+the current config and clear the warning.
+
 The embed phase calibrates its own batch size instead of guessing: it times a
 1-chunk request, then a 4-chunk request, and sizes subsequent requests (and
 their timeouts) from the observed token-weighted rate: smaller batches on slow


### PR DESCRIPTION
## Summary

This is the headline v1 item: lowering the default chunk-token cap and co-shipping the re-index provenance mechanism it requires, in a single PR.

- **`MAX_CHUNK_TOKENS` 2048 → 512** (`crates/spelunk-core/src/indexer/chunker.rs`). A quality/performance evaluation across a 1195-query, full-`cloud-api`-corpus gold-query set found retrieval quality flat (within noise, ≤1.6pp) across 2048/1024/512/384 in both leaky and held-out arms, while 512 gives a real indexing-throughput win. Second-order costs at the new cap (extra vectors, storage, KNN latency) were measured and found immaterial at this scale.
- **`index_meta` gains chunker-config provenance**, tracked alongside the existing `embedding_model`/`embedding_dim` keys. A 512 default alone would silently produce mixed-chunk-boundary indexes: unchanged files (same blake3 hash) keep their old chunk boundaries forever on every future `spelunk index`, and nothing would prompt a user to re-index. Now, opening an index built under a different chunk-token cap prints a warning naming the drift and pointing at `spelunk index --force`, and a normal incremental run still proceeds — unlike an embedding-model mismatch, a chunk-cap change is same-model/same-dimension drift, not corruption, so it warns rather than hard-bails. `Database::ensure_embedding_model`'s existing hard-bail path is untouched; this is a new, orthogonal check.
- **`--force` now refreshes the provenance stamp.** A gap surfaced during the pipeline: the drift warning's own remedy (`--force`) didn't actually clear it, so the warning would persist on every subsequent normal run even after the user did exactly what it asked. Fixed by refreshing the stamp from `run_parse_phase` when `--force` is set (the parse phase already re-chunks every file under `--force`, independent of whether the embed phase runs in the same invocation).
- Docs (`CHANGELOG.md`, `CLAUDE.md`, `docs/architecture.md`, `docs/commands.md`) updated to describe the new default and the warning/`--force` behavior.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-core` — 478 lib tests + all integration suites, 0 failed.
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli` — 482 lib tests + all integration suites, 0 failed.
- `SPELUNK_SECRET_STORE=file cargo test --no-default-features` (full workspace) — 0 failed.
- `SPELUNK_SECRET_STORE=file cargo fmt --all -- --check` — clean.
- `SPELUNK_SECRET_STORE=file cargo clippy --all-targets --features rich-formats -- -D warnings` — clean.
- Manually traced the full provenance lifecycle across the new tests: fresh index (no prior stamp, no warning) → same-config reindex (no warning) → index opened under an old chunker config (warning fires, run proceeds) → `spelunk index --force` (stamp refreshes) → normal run afterward (no warning). Covered by `db.rs::chunker_config_stamp_and_warn_on_mismatch`, `db.rs::chunker_config_mismatch_does_not_block_incremental_indexing`, `db.rs::stamp_chunker_config_silences_a_prior_mismatch`, `embed_phase.rs::chunker_config_drift_warns_but_does_not_block_the_embed_phase`, and `parse_phase.rs::force_reindex_refreshes_the_chunker_config_stamp`.