### PR TITLE
docs: fix stale 120-line chunker example in memory.md

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -424,8 +424,8 @@ Examples of things worth storing:
 
 ```bash
 # Quick note with body inline
-spelunk memory add --title "Chunker uses 120-line sliding window as fallback" \
-              --body "This applies to unsupported file types and binary-adjacent files." \
+spelunk memory add --title "Chunker uses a token-aware sliding window as fallback" \
+              --body "Applies to unsupported file types and oversized semantic nodes: whole lines accumulate up to MAX_CHUNK_TOKENS (2048), with ~12.5% overlap between windows." \
               --kind context \
               --tags chunker,indexer
 


### PR DESCRIPTION
## Summary
- The `spelunk memory add` example in `docs/memory.md` described the chunker fallback as a fixed "120-line sliding window," which is stale — the fallback is now token-aware (`MAX_CHUNK_TOKENS`-based with ~12.5% overlap), per `docs/architecture.md`.
- Updated the example title/body to describe current behavior accurately.

## Test plan
- [x] Confirmed current fallback behavior against `docs/architecture.md` and `crates/spelunk-core/src/indexer/chunker.rs` (MAX_CHUNK_TOKENS = 2048, ~12.5% overlap)
- [x] Docs-only change, no code affected