### PR TITLE
chore(release): bump to 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.5] — 2026-07-24
+
 ### Changed
 
 - **Default chunk-token cap (`MAX_CHUNK_TOKENS`) lowered from 2048 to 512.** A

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5322,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-embed"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-embed/Cargo.toml
+++ b/crates/spelunk-embed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-embed"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 description = "Native F2LLM-v2-330M embedder (candle) for spelunk"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Release-prep PR for v0.9.5. Bumps all four crate versions (`spelunk-core`, `spelunk-cli`, `spelunk-embed`, `spelunk-server`) 0.9.4 → 0.9.5 and regenerates `Cargo.lock` accordingly.
- Renames CHANGELOG's `## [Unreleased]` header to `## [0.9.5] — 2026-07-24` (em-dash matches existing headers, e.g. `## [0.9.3]`), with a fresh empty `## [Unreleased]` added above it. No CHANGELOG entry content was touched.
- Swept `docs/`/`README.md` for stray hardcoded old-version references; the only hits are generic illustrative examples in `docs/releasing.md` (e.g. `v0.9.0`/`v0.8.0` sample commands), not stale pins — nothing to fix.

**Not included:** the `v0.9.5` git tag is deliberately NOT created or pushed here. Tagging triggers the real release-build workflow (`release.yml`) and is a separate, more consequential step for Johan to trigger manually after this PR merges.

**Known pre-existing issue, out of scope:** the CHANGELOG's `## [0.9.4] — 2026-07-17` header was previously dropped by an earlier commit, so 0.9.4's entries currently sit undifferentiated under what was `[Unreleased]`. Not fixed here; tracked separately.

## Test plan
- `SPELUNK_SECRET_STORE=file cargo build --workspace` — succeeds, all four crates report 0.9.5.
- `SPELUNK_SECRET_STORE=file cargo check --workspace` — succeeds.
- `cargo metadata --no-deps` confirms `spelunk-core`, `spelunk-cli`, `spelunk-embed`, `spelunk-server` all at `0.9.5`.
- `SPELUNK_SECRET_STORE=file cargo fmt --all -- --check` — clean.
- `SPELUNK_SECRET_STORE=file cargo clippy --all-targets --features rich-formats -- -D warnings` — clean.
- Confirmed `git tag --list v0.9.5` is empty and no tag/release workflow was triggered.
- Diff scope verified against `origin/main`: only the 4 `Cargo.toml`s, `Cargo.lock`, and `CHANGELOG.md`'s header lines changed — no other files, no CHANGELOG entry content edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)