### PR TITLE
fix: route spelunk index's embed phases through get_inference_tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`spelunk index`'s embed phase now embeds locally in `local_first` mode
+  even when a team `server_url` is configured.** Both the foreground (default)
+  embed phase and the `--detach-embed` background worker's embedder-readiness
+  poll resolved their embedding target from the raw tier-probing functions
+  (`get_tier`, `probe_tier_fresh`) instead of the mode-aware
+  `get_inference_tier`/`get_inference_tier_fresh`: a `local_first` project
+  with an explicit `server_url` sent every embed batch to that `server_url`
+  instead of the local, auto-discovered embedder, silently skipping embedding
+  when the configured server has no `/index/embed` route. Both call sites now
+  route through `get_inference_tier`/`get_inference_tier_fresh`, the same fix
+  already applied to `memory add`/`reindex`/`search`/`timeline`/`harvest`/
+  `reconcile` and `explore`. `cloud_first` is unchanged. See [ADR-004's
+  2026-07-23 amendment](docs/adr/004-unified-memory-storage.md).
+
 ## [0.9.5] — 2026-07-24
 
 ### Changed

--- a/crates/spelunk-cli/src/capability/mod.rs
+++ b/crates/spelunk-cli/src/capability/mod.rs
@@ -41,7 +41,7 @@ mod tier;
 pub use diagnostics::{ConnFailure, explicit_probe_failure};
 pub use guard::{inference_server_required_message, require_explicit_server_url, require_tier1};
 pub(crate) use probe::spelunk_state_dir;
-pub use probe::{get_inference_tier, get_tier, probe_tier_fresh};
+pub use probe::{get_inference_tier, get_inference_tier_fresh, get_tier};
 // `Capabilities` is only reached from outside this module by other crates'
 // `#[cfg(test)]` code (`Capabilities::all()`), so a non-test build sees this
 // re-export as unused.

--- a/crates/spelunk-cli/src/capability/probe.rs
+++ b/crates/spelunk-cli/src/capability/probe.rs
@@ -1230,4 +1230,72 @@ mod tests {
         let tier = get_inference_tier(&cfg).await;
         assert!(matches!(tier, Tier::Offline), "got {tier:?}");
     }
+
+    /// `get_inference_tier_fresh`'s `cloud_first` branch must re-probe the
+    /// server on every call, never freezing on an earlier observation. This
+    /// is the one behavioural difference from `get_inference_tier` (whose
+    /// `cloud_first` branch reuses `get_tier`'s process-lifetime cache) and
+    /// the entire reason `wait_for_embedder` uses the `_fresh` variant: a
+    /// bug that made this branch delegate to `get_tier` too (i.e. collapse
+    /// to being identical to `get_inference_tier`) would still pass every
+    /// other `get_inference_tier_fresh` test in this file, since those only
+    /// ever make a single call each. This test calls it twice against a
+    /// mock whose response changes between calls and asserts the second
+    /// call observes the change, directly at the tier-fetch level (not
+    /// indirected through `wait_for_embedder`'s poll loop).
+    ///
+    /// Deliberately does not touch `get_tier`/`TIER` (the process-wide
+    /// `OnceCell`) at all, unlike a test that called `get_inference_tier`'s
+    /// `Cached` branch would have to: that cell is shared by every test in
+    /// this binary with no reset hook, so asserting on it directly here
+    /// would make this test's pass/fail depend on unrelated test ordering.
+    #[tokio::test]
+    #[serial_test::serial(spelunk_no_server_env)]
+    async fn get_inference_tier_fresh_cloud_first_reprobes_every_call() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        unsafe { std::env::remove_var("SPELUNK_NO_SERVER") };
+
+        let server = MockServer::start().await;
+        // First health check: embedder still loading, no index.embed.
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(health_body_with_embedder("loading")),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        // Every call after the first: embedder ready.
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body(
+                &["memory", "index.embed", "search.semantic"],
+                spelunk_core::embeddings::EMBEDDING_DIM,
+            )))
+            .mount(&server)
+            .await;
+
+        let cfg = Config {
+            server_url: Some(server.uri()),
+            project_id: Some("team/proj".to_string()),
+            mode: Some(spelunk_core::config::SyncMode::CloudFirst),
+            ..Default::default()
+        };
+
+        let first = get_inference_tier_fresh(&cfg).await;
+        assert_eq!(
+            first.embedder_state(),
+            Some(EmbedderState::Loading),
+            "first call must observe the first mock response; got {first:?}"
+        );
+
+        let second = get_inference_tier_fresh(&cfg).await;
+        assert!(
+            matches!(second.caps(), Some(c) if c.index_embed),
+            "second call must re-probe and observe the loading -> ready \
+             transition, not return a value pinned by the first call; got {second:?}"
+        );
+    }
 }

--- a/crates/spelunk-cli/src/capability/probe.rs
+++ b/crates/spelunk-cli/src/capability/probe.rs
@@ -552,7 +552,7 @@ mod tests {
 
     // ── Embedding-dim pre-flight checks ──────────────────────────────────────
 
-    /// Helper: build a health JSON body with the given capabilities and dim.
+    // Helper: build a health JSON body with the given capabilities and dim.
     fn health_body(caps: &[&str], dim: usize) -> serde_json::Value {
         serde_json::json!({
             "status": "ok",
@@ -564,7 +564,7 @@ mod tests {
         })
     }
 
-    /// Auto-discovered loopback server with wrong dim → `Tier::Offline` (soft downgrade).
+    // Auto-discovered loopback server with wrong dim → `Tier::Offline` (soft downgrade).
     #[tokio::test]
     async fn probe_loopback_dim_mismatch_downgrades_to_offline() {
         use wiremock::matchers::{method, path};
@@ -588,7 +588,7 @@ mod tests {
         );
     }
 
-    /// Auto-discovered loopback server with correct dim → `Tier::Server`.
+    // Auto-discovered loopback server with correct dim → `Tier::Server`.
     #[tokio::test]
     async fn probe_loopback_dim_match_returns_server() {
         use wiremock::matchers::{method, path};
@@ -613,9 +613,9 @@ mod tests {
 
     // ── accepts_pushed_vectors (top-level health bool) ──────────────────────────
 
-    /// A server advertising `accepts_pushed_vectors: true` must parse into
-    /// `caps.accepts_pushed_vectors == true`: the gate the sync push reads
-    /// before attaching a client-computed vector.
+    // A server advertising `accepts_pushed_vectors: true` must parse into
+    // `caps.accepts_pushed_vectors == true`: the gate the sync push reads
+    // before attaching a client-computed vector.
     #[tokio::test]
     async fn probe_url_parses_accepts_pushed_vectors_true() {
         use wiremock::matchers::{method, path};
@@ -639,8 +639,8 @@ mod tests {
         );
     }
 
-    /// A server that omits the field (older server, or the OSS team server)
-    /// must default to `false`: the push stays text-only there.
+    // A server that omits the field (older server, or the OSS team server)
+    // must default to `false`: the push stays text-only there.
     #[tokio::test]
     async fn probe_url_accepts_pushed_vectors_defaults_false_when_absent() {
         use wiremock::matchers::{method, path};
@@ -668,9 +668,9 @@ mod tests {
 
     // ── ServerLimits parsing (/v1/health `limits` object) ──────────────────────
 
-    /// A server that DOES advertise `limits` must have it parsed into
-    /// `Tier::Server.server_limits`. This is the non-version-skew case: a
-    /// current-build server carrying the `/index/embed` timeout exemption.
+    // A server that DOES advertise `limits` must have it parsed into
+    // `Tier::Server.server_limits`. This is the non-version-skew case: a
+    // current-build server carrying the `/index/embed` timeout exemption.
     #[tokio::test]
     async fn probe_url_parses_server_limits_when_present() {
         use wiremock::matchers::{method, path};
@@ -703,11 +703,11 @@ mod tests {
         assert_eq!(limits.embedder_token_cap, Some(5792));
     }
 
-    /// A server that does NOT advertise `limits` (pre-dates the field) must
-    /// leave `Tier::Server.server_limits` as `None`: this is the exact
-    /// version-skew case: an old server still enforcing the legacy 30s
-    /// `/index/embed` budget with no exemption. `None` must never be
-    /// confused with "no limit" by a caller.
+    // A server that does NOT advertise `limits` (pre-dates the field) must
+    // leave `Tier::Server.server_limits` as `None`: this is the exact
+    // version-skew case: an old server still enforcing the legacy 30s
+    // `/index/embed` budget with no exemption. `None` must never be
+    // confused with "no limit" by a caller.
     #[tokio::test]
     async fn probe_url_server_limits_none_when_absent_legacy_server() {
         use wiremock::matchers::{method, path};
@@ -735,10 +735,10 @@ mod tests {
         );
     }
 
-    /// `embedder_token_cap` specifically must round-trip as `None` when the
-    /// server reports it as JSON `null` (e.g. embedder not ready, or an
-    /// external non-native backend with no known cap): distinct from the
-    /// whole `limits` object being absent.
+    // `embedder_token_cap` specifically must round-trip as `None` when the
+    // server reports it as JSON `null` (e.g. embedder not ready, or an
+    // external non-native backend with no known cap): distinct from the
+    // whole `limits` object being absent.
     #[tokio::test]
     async fn probe_url_parses_server_limits_with_null_token_cap() {
         use wiremock::matchers::{method, path};
@@ -764,8 +764,8 @@ mod tests {
         assert_eq!(limits.embedder_token_cap, None);
     }
 
-    /// Auto-discovered loopback server with no embedder (dim 0) → `Tier::Server`
-    /// (dim 0 means no `index.embed` check is relevant).
+    // Auto-discovered loopback server with no embedder (dim 0) → `Tier::Server`
+    // (dim 0 means no `index.embed` check is relevant).
     #[tokio::test]
     async fn probe_loopback_dim_zero_no_embedder_returns_server() {
         use wiremock::matchers::{method, path};
@@ -786,7 +786,7 @@ mod tests {
         );
     }
 
-    /// Explicit server_url with wrong dim → hard `Err` with an actionable message.
+    // Explicit server_url with wrong dim → hard `Err` with an actionable message.
     #[tokio::test]
     async fn probe_explicit_url_dim_mismatch_returns_error() {
         use wiremock::matchers::{method, path};
@@ -826,10 +826,10 @@ mod tests {
 
     // ── transport-scheme validation ──────────────────────────────────────────
 
-    /// A non-loopback `http://` URL must be rejected before any request is
-    /// sent: no mock is mounted, so a request would fail with "connection
-    /// refused" or similar rather than surfacing the validation error; the
-    /// assertion on the error message proves the reject happened pre-flight.
+    // A non-loopback `http://` URL must be rejected before any request is
+    // sent: no mock is mounted, so a request would fail with "connection
+    // refused" or similar rather than surfacing the validation error; the
+    // assertion on the error message proves the reject happened pre-flight.
     #[tokio::test]
     async fn probe_url_rejects_non_loopback_http_no_request_sent() {
         // Deliberately no MockServer / no listener on this address: if
@@ -841,8 +841,8 @@ mod tests {
         assert!(err.contains("https"), "got: {err}");
     }
 
-    /// Same rejection applies to the loopback auto-discovery path (defensive;
-    /// auto-discovery URLs are always loopback in practice).
+    // Same rejection applies to the loopback auto-discovery path (defensive;
+    // auto-discovery URLs are always loopback in practice).
     #[tokio::test]
     async fn probe_url_rejects_non_loopback_http_even_when_auto_discovered() {
         let result = probe_url(
@@ -855,8 +855,8 @@ mod tests {
         assert!(result.is_err());
     }
 
-    /// Loopback `http://` and `https://` URLs are accepted (proceed to the
-    /// actual health request against a mock server).
+    // Loopback `http://` and `https://` URLs are accepted (proceed to the
+    // actual health request against a mock server).
     #[tokio::test]
     async fn probe_url_accepts_loopback_http_and_https() {
         use wiremock::matchers::{method, path};
@@ -877,8 +877,8 @@ mod tests {
         );
     }
 
-    /// `/v1/health` must never carry an `Authorization` header: it is an
-    /// unauthenticated endpoint.
+    // `/v1/health` must never carry an `Authorization` header: it is an
+    // unauthenticated endpoint.
     #[tokio::test]
     async fn probe_url_health_request_carries_no_bearer_header() {
         use wiremock::matchers::{method, path};
@@ -904,7 +904,7 @@ mod tests {
         );
     }
 
-    /// Health body carrying the PR-A `embedder: { state, detail }` sub-object.
+    // Health body carrying the PR-A `embedder: { state, detail }` sub-object.
     fn health_body_with_embedder(state: &str) -> serde_json::Value {
         serde_json::json!({
             "status": "ok",
@@ -917,7 +917,7 @@ mod tests {
         })
     }
 
-    /// `probe_url` must surface the server's `embedder.state` on `Tier::Server`.
+    // `probe_url` must surface the server's `embedder.state` on `Tier::Server`.
     #[tokio::test]
     async fn probe_url_carries_embedder_state_loading() {
         use wiremock::matchers::{method, path};
@@ -958,7 +958,7 @@ mod tests {
         assert_eq!(tier.embedder_state(), Some(EmbedderState::Unavailable));
     }
 
-    /// A server that pre-dates the `embedder` field → `Unknown` (not an error).
+    // A server that pre-dates the `embedder` field → `Unknown` (not an error).
     #[tokio::test]
     async fn probe_url_absent_embedder_field_is_unknown() {
         use wiremock::matchers::{method, path};
@@ -980,12 +980,12 @@ mod tests {
 
     // ── get_tier process-cache semantics ─────────────────────────────────────
 
-    /// `TIER` is a `OnceCell`: `get_tier` must probe at most once per process
-    /// and every later call must return the identical cached `Tier`, not
-    /// re-probe. This is what makes `EXPLICIT_PROBE_FAILURE` safe to read from
-    /// `Tier::Offline` rendering: there is no later probe in the same process
-    /// that could silently swap a fresh success in underneath a stale failure
-    /// annotation (or vice versa).
+    // `TIER` is a `OnceCell`: `get_tier` must probe at most once per process
+    // and every later call must return the identical cached `Tier`, not
+    // re-probe. This is what makes `EXPLICIT_PROBE_FAILURE` safe to read from
+    // `Tier::Offline` rendering: there is no later probe in the same process
+    // that could silently swap a fresh success in underneath a stale failure
+    // annotation (or vice versa).
     #[tokio::test]
     #[serial_test::serial(explicit_probe_failure)]
     async fn get_tier_probes_at_most_once_and_caches_the_result() {
@@ -1021,9 +1021,9 @@ mod tests {
 
     // ── classification matrix: real reqwest errors, not hand-built chains ────
 
-    /// A genuine TCP connection-refused error through the real `reqwest`
-    /// client must classify as `Unreachable`, never `Tls`: no TLS layer is
-    /// ever reached, so `find_rustls_cause` must return `None` on it.
+    // A genuine TCP connection-refused error through the real `reqwest`
+    // client must classify as `Unreachable`, never `Tls`: no TLS layer is
+    // ever reached, so `find_rustls_cause` must return `None` on it.
     #[tokio::test]
     #[serial_test::serial(explicit_probe_failure)]
     async fn probe_url_explicit_connection_refused_sets_unreachable_not_tls() {
@@ -1042,9 +1042,9 @@ mod tests {
         );
     }
 
-    /// A genuine client-side timeout (the peer accepts the TCP connection but
-    /// never answers) must also classify as `Unreachable`, not `Tls`: a slow
-    /// or hung server is not a certificate problem.
+    // A genuine client-side timeout (the peer accepts the TCP connection but
+    // never answers) must also classify as `Unreachable`, not `Tls`: a slow
+    // or hung server is not a certificate problem.
     #[tokio::test]
     #[serial_test::serial(explicit_probe_failure)]
     async fn probe_url_explicit_timeout_sets_unreachable_not_tls() {
@@ -1070,10 +1070,10 @@ mod tests {
         );
     }
 
-    /// A reachable server that answers with a non-2xx status (e.g. a
-    /// misconfigured reverse proxy, a 500, garbage) is neither `[tls: ...]`
-    /// nor `[unreachable]`: the transport and TLS both worked fine. This
-    /// path must leave `EXPLICIT_PROBE_FAILURE` unset entirely.
+    // A reachable server that answers with a non-2xx status (e.g. a
+    // misconfigured reverse proxy, a 500, garbage) is neither `[tls: ...]`
+    // nor `[unreachable]`: the transport and TLS both worked fine. This
+    // path must leave `EXPLICIT_PROBE_FAILURE` unset entirely.
     #[tokio::test]
     #[serial_test::serial(explicit_probe_failure)]
     async fn probe_url_explicit_non_success_status_does_not_set_any_probe_failure() {
@@ -1103,11 +1103,11 @@ mod tests {
         );
     }
 
-    /// Auto-discovered (loopback) probe failures must never populate
-    /// `EXPLICIT_PROBE_FAILURE`: that cache exists only to annotate an
-    /// *explicit* `server_url` miss. A common "no local server running"
-    /// loopback miss must not leave behind a failure cause that a later
-    /// status render could misattribute to an unrelated explicit `server_url`.
+    // Auto-discovered (loopback) probe failures must never populate
+    // `EXPLICIT_PROBE_FAILURE`: that cache exists only to annotate an
+    // *explicit* `server_url` miss. A common "no local server running"
+    // loopback miss must not leave behind a failure cause that a later
+    // status render could misattribute to an unrelated explicit `server_url`.
     #[tokio::test]
     #[serial_test::serial(explicit_probe_failure)]
     async fn probe_url_auto_discovered_connection_refused_leaves_probe_failure_unset() {
@@ -1138,12 +1138,12 @@ mod tests {
     // `SPELUNK_NO_SERVER` internally, so it must never run concurrently with a
     // test that transiently sets it.
 
-    /// `local_first` (the default reached once `server_url` is set, with no
-    /// explicit `mode`) must probe the LOCAL loopback embedder for inference,
-    /// never the configured `server_url`. The loopback mock is discovered via
-    /// the `server.port` file (step 3a); `server_url` is left pointed at an
-    /// address nothing mounts anything on, so the test would fail loudly
-    /// (connection error, not a silent pass) if the code ever tried it.
+    // `local_first` (the default reached once `server_url` is set, with no
+    // explicit `mode`) must probe the LOCAL loopback embedder for inference,
+    // never the configured `server_url`. The loopback mock is discovered via
+    // the `server.port` file (step 3a); `server_url` is left pointed at an
+    // address nothing mounts anything on, so the test would fail loudly
+    // (connection error, not a silent pass) if the code ever tried it.
     #[tokio::test]
     #[serial_test::serial(spelunk_no_server_env)]
     async fn get_inference_tier_local_first_prefers_loopback_over_explicit_server_url() {
@@ -1207,18 +1207,18 @@ mod tests {
         );
     }
 
-    /// Explicit offline (`mode = "offline"`) must short-circuit before any
-    /// probe, exactly like `get_tier`. `server_url` is set to an address
-    /// nothing mounts anything on, so any attempted probe would hang/error
-    /// rather than silently returning `Offline` for the right reason.
-    ///
-    /// Uses `cfg.mode = Some(SyncMode::Offline)` rather than
-    /// `SPELUNK_NO_SERVER=1` deliberately: that env var is process-global and
-    /// read by every concurrently-running test's `probe()`/`get_tier()`
-    /// call (e.g. `get_tier_probes_at_most_once_and_caches_the_result`
-    /// above, which is not in this lock group), so mutating it here would
-    /// reintroduce the exact cross-test race this comment is warning about.
-    /// `mode` is per-`Config` and carries no such risk.
+    // Explicit offline (`mode = "offline"`) must short-circuit before any
+    // probe, exactly like `get_tier`. `server_url` is set to an address
+    // nothing mounts anything on, so any attempted probe would hang/error
+    // rather than silently returning `Offline` for the right reason.
+    //
+    // Uses `cfg.mode = Some(SyncMode::Offline)` rather than
+    // `SPELUNK_NO_SERVER=1` deliberately: that env var is process-global and
+    // read by every concurrently-running test's `probe()`/`get_tier()`
+    // call (e.g. `get_tier_probes_at_most_once_and_caches_the_result`
+    // above, which is not in this lock group), so mutating it here would
+    // reintroduce the exact cross-test race this comment is warning about.
+    // `mode` is per-`Config` and carries no such risk.
     #[tokio::test]
     async fn get_inference_tier_explicit_offline_short_circuits() {
         let cfg = Config {
@@ -1231,24 +1231,24 @@ mod tests {
         assert!(matches!(tier, Tier::Offline), "got {tier:?}");
     }
 
-    /// `get_inference_tier_fresh`'s `cloud_first` branch must re-probe the
-    /// server on every call, never freezing on an earlier observation. This
-    /// is the one behavioural difference from `get_inference_tier` (whose
-    /// `cloud_first` branch reuses `get_tier`'s process-lifetime cache) and
-    /// the entire reason `wait_for_embedder` uses the `_fresh` variant: a
-    /// bug that made this branch delegate to `get_tier` too (i.e. collapse
-    /// to being identical to `get_inference_tier`) would still pass every
-    /// other `get_inference_tier_fresh` test in this file, since those only
-    /// ever make a single call each. This test calls it twice against a
-    /// mock whose response changes between calls and asserts the second
-    /// call observes the change, directly at the tier-fetch level (not
-    /// indirected through `wait_for_embedder`'s poll loop).
-    ///
-    /// Deliberately does not touch `get_tier`/`TIER` (the process-wide
-    /// `OnceCell`) at all, unlike a test that called `get_inference_tier`'s
-    /// `Cached` branch would have to: that cell is shared by every test in
-    /// this binary with no reset hook, so asserting on it directly here
-    /// would make this test's pass/fail depend on unrelated test ordering.
+    // `get_inference_tier_fresh`'s `cloud_first` branch must re-probe the
+    // server on every call, never freezing on an earlier observation. This
+    // is the one behavioural difference from `get_inference_tier` (whose
+    // `cloud_first` branch reuses `get_tier`'s process-lifetime cache) and
+    // the entire reason `wait_for_embedder` uses the `_fresh` variant: a
+    // bug that made this branch delegate to `get_tier` too (i.e. collapse
+    // to being identical to `get_inference_tier`) would still pass every
+    // other `get_inference_tier_fresh` test in this file, since those only
+    // ever make a single call each. This test calls it twice against a
+    // mock whose response changes between calls and asserts the second
+    // call observes the change, directly at the tier-fetch level (not
+    // indirected through `wait_for_embedder`'s poll loop).
+    //
+    // Deliberately does not touch `get_tier`/`TIER` (the process-wide
+    // `OnceCell`) at all, unlike a test that called `get_inference_tier`'s
+    // `Cached` branch would have to: that cell is shared by every test in
+    // this binary with no reset hook, so asserting on it directly here
+    // would make this test's pass/fail depend on unrelated test ordering.
     #[tokio::test]
     #[serial_test::serial(spelunk_no_server_env)]
     async fn get_inference_tier_fresh_cloud_first_reprobes_every_call() {

--- a/crates/spelunk-cli/src/capability/probe.rs
+++ b/crates/spelunk-cli/src/capability/probe.rs
@@ -224,13 +224,48 @@ async fn probe_loopback() -> Tier {
 /// fresh loopback probe rather than reusing whatever `get_tier` already
 /// cached for `cfg.server_url` (a different, unrelated target in that mode).
 pub async fn get_inference_tier(cfg: &Config) -> Tier {
+    inference_tier(cfg, CloudBranchProbe::Cached).await
+}
+
+/// Fresh-probing counterpart to [`get_inference_tier`], for callers that must
+/// observe a *transition* rather than a point-in-time snapshot: the detached
+/// embed worker's readiness wait (`wait_for_embedder`) polls repeatedly for
+/// the embedder to flip from `loading` to `ready`, so it can never read
+/// through a value pinned by [`get_tier`]'s per-process `OnceCell`.
+///
+/// Routes identically to [`get_inference_tier`] (same mode-based branch,
+/// same explicit-offline short-circuit), except the `cloud_first` branch
+/// re-probes the configured `server_url` on every call via
+/// [`probe_tier_fresh`] instead of reading [`get_tier`]'s cache: the same
+/// relationship `probe_tier_fresh` already has to `get_tier`, applied one
+/// level up. The `local_first` branch needs no change here: it already calls
+/// `probe_loopback()` directly, which was never cached.
+pub async fn get_inference_tier_fresh(cfg: &Config) -> Tier {
+    inference_tier(cfg, CloudBranchProbe::Fresh).await
+}
+
+/// Which probe the `cloud_first` branch of [`inference_tier`] takes: the
+/// per-process cache ([`get_tier`], for one-shot callers) or a fresh probe
+/// ([`probe_tier_fresh`], for pollers that must observe a transition).
+enum CloudBranchProbe {
+    Cached,
+    Fresh,
+}
+
+/// Shared mode-based routing behind [`get_inference_tier`] and
+/// [`get_inference_tier_fresh`]; see their docs for the routing rules. The two
+/// differ only in which probe serves the `cloud_first` branch.
+async fn inference_tier(cfg: &Config, cloud_branch: CloudBranchProbe) -> Tier {
     let explicit_offline = spelunk_core::config::no_server_env_set()
         || cfg.mode == Some(spelunk_core::config::SyncMode::Offline);
     if explicit_offline {
         return Tier::Offline;
     }
     if cfg.resolve_mode() == spelunk_core::config::SyncMode::CloudFirst {
-        return get_tier(cfg).await.clone();
+        return match cloud_branch {
+            CloudBranchProbe::Cached => get_tier(cfg).await.clone(),
+            CloudBranchProbe::Fresh => probe_tier_fresh(cfg).await,
+        };
     }
     probe_loopback().await
 }

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -164,7 +164,13 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     }
 
     // ── Phase 2: embed chunks (Tier 1 only) ─────────────────────────────────
-    let tier = capability::get_tier(&cfg).await;
+    //
+    // `get_inference_tier` (not `get_tier`): local_first always prefers the
+    // local loopback embedder for inference, even with an explicit
+    // server_url set (2026-07-23 founder decision). `get_tier` alone would
+    // probe the explicit server_url and hand its (possibly wrong) tier
+    // straight to the batch-calibrated embed request loop below.
+    let tier = capability::get_inference_tier(&cfg).await;
 
     if result.chunk_ids_and_texts.is_empty() {
         let stats = db.stats()?;
@@ -195,7 +201,7 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     // arrives here with the embedder still `loading`. Gating the spawn on
     // `embed_ready` is exactly the no-op that ships a permanently unembedded
     // index on a cold machine.
-    if args.detach_embed && tier.is_server() && detach_embed_eligible(tier) {
+    if args.detach_embed && tier.is_server() && detach_embed_eligible(&tier) {
         let embed_log = background_log_path(&db_path);
         if let EmbedSpawn::Detached(log_in_use) =
             spawn_embed_subprocess(&args, embed_log.as_deref())?
@@ -227,7 +233,7 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
             result.chunk_ids_and_texts,
             &db,
             &cfg,
-            tier,
+            &tier,
             &project_root,
             args.batch_size,
             &mp,
@@ -235,7 +241,7 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         .await?;
         drop(worker_guard);
     } else {
-        eprint_embed_skipped_notice(tier, &cfg);
+        eprint_embed_skipped_notice(&tier, &cfg);
     }
 
     let stats = db.stats()?;
@@ -400,6 +406,12 @@ const EMBED_WAIT_MAX_OFFLINE_PROBES: u32 = 10;
 /// and `disabled` (or a server with no embedder at all) are terminal; each
 /// keeps its distinct notice via `eprint_embed_skipped_notice`. `loading` is
 /// never a reason to abandon durable queued work.
+///
+/// `get_inference_tier_fresh` (not `probe_tier_fresh`): local_first always
+/// prefers the local loopback embedder, even with an explicit server_url set
+/// (2026-07-23 founder decision), and this poller must keep re-observing
+/// that same local-vs-remote routing decision on every iteration rather than
+/// freezing on `get_tier`'s cached first probe of an unrelated server_url.
 async fn wait_for_embedder(
     cfg: &Config,
     initial_backoff: std::time::Duration,
@@ -409,7 +421,7 @@ async fn wait_for_embedder(
     let mut offline_probes = 0u32;
     let mut announced = false;
     loop {
-        let tier = capability::probe_tier_fresh(cfg).await;
+        let tier = capability::get_inference_tier_fresh(cfg).await;
         match &tier {
             capability::Tier::Server { .. } => {
                 if matches!(tier.caps(), Some(c) if c.index_embed) {
@@ -976,10 +988,21 @@ mod tests {
         })
     }
 
+    // `mode = "cloud_first"`: every test below drives the wait loop's polling
+    // logic (loading/ready/unavailable/disabled transitions, the offline
+    // give-up bound) by mocking `/v1/health` directly at `url` and expecting
+    // `wait_for_embedder` to probe exactly that URL. Under the default
+    // `local_first` mode, `get_inference_tier_fresh` routes inference to the
+    // local loopback embedder instead and never touches `server_url` at all
+    // (see `wait_for_embedder_local_first_routes_loopback_transition_not_server_url`
+    // below for that path); `cloud_first` is the mode where an explicit
+    // `server_url` legitimately serves inference, which is what every test
+    // here needs to still be exercising the polling logic against `url`.
     fn cfg_for(url: String) -> Config {
         Config {
             server_url: Some(url),
             project_id: Some("local/test".to_string()),
+            mode: Some(crate::config::SyncMode::CloudFirst),
             ..Default::default()
         }
     }
@@ -1137,6 +1160,85 @@ mod tests {
         assert!(
             started.elapsed() < std::time::Duration::from_secs(30),
             "the offline give-up must be bounded"
+        );
+    }
+
+    // ── wait_for_embedder: local_first routes to loopback, not server_url ────
+    //
+    // The routing-bug regression this story fixes: before, the wait loop
+    // probed `cfg.server_url` directly (`probe_tier_fresh`) regardless of
+    // mode, so a `local_first` project with an explicit `server_url` never
+    // reached its local embedder from the detached worker either.
+
+    #[tokio::test]
+    #[serial_test::serial(spelunk_no_server_env, server_state_dir_env)]
+    async fn wait_for_embedder_local_first_routes_loopback_transition_not_server_url() {
+        // Under `local_first` (the default once `server_url` is set, with no
+        // explicit `mode`), the wait loop must poll the LOCAL loopback
+        // embedder, never the configured `server_url` — even while observing
+        // a loading -> ready transition across several polls. `server_url` is
+        // deliberately unroutable, so an accidental fallback to it surfaces
+        // as a connection/DNS error, not a silent wrong-but-passing result.
+        unsafe { std::env::remove_var("SPELUNK_NO_SERVER") };
+
+        let loopback = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body("loading")))
+            .up_to_n_times(2)
+            .mount(&loopback)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/health"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(health_body("ready")))
+            .mount(&loopback)
+            .await;
+
+        let loopback_port: u16 = loopback
+            .uri()
+            .rsplit(':')
+            .next()
+            .expect("uri has a port")
+            .trim_end_matches('/')
+            .parse()
+            .expect("uri port is numeric");
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let state_dir = tmp.path().join("state");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(state_dir.join("server.port"), format!("{loopback_port}\n")).unwrap();
+
+        let prev_state_dir = std::env::var_os("SPELUNK_STATE_DIR");
+        // SAFETY: serialised via #[serial(server_state_dir_env)] against
+        // every other test touching this var.
+        unsafe { std::env::set_var("SPELUNK_STATE_DIR", &state_dir) };
+
+        let cfg = Config {
+            server_url: Some("https://cloud.invalid.example:1".to_string()),
+            project_id: Some("local/test".to_string()),
+            mode: None, // defaults to local_first because server_url is set
+            ..Default::default()
+        };
+        assert_eq!(cfg.resolve_mode(), crate::config::SyncMode::LocalFirst);
+
+        let tier = wait_for_embedder(&cfg, TEST_BACKOFF, TEST_BACKOFF).await;
+
+        unsafe {
+            match prev_state_dir {
+                Some(v) => std::env::set_var("SPELUNK_STATE_DIR", v),
+                None => std::env::remove_var("SPELUNK_STATE_DIR"),
+            }
+        }
+
+        assert!(
+            matches!(tier.caps(), Some(c) if c.index_embed),
+            "the wait must observe the loopback's loading -> ready transition; got {tier:?}"
+        );
+        assert_eq!(
+            tier.server_url(),
+            Some(format!("http://127.0.0.1:{loopback_port}")).as_deref(),
+            "local_first must route the wait loop to the loopback server, not the \
+             configured (and unreachable) server_url; got {tier:?}"
         );
     }
 

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -1163,6 +1163,32 @@ mod tests {
         );
     }
 
+    // ── wait_for_embedder backoff/give-up constants ──────────────────────────
+    //
+    // Every wait_for_embedder test above drives the function with
+    // `TEST_BACKOFF` (1ms) so the suite doesn't take the ~150s the real
+    // constants would need to reach the give-up bound. That substitution is
+    // only faithful to production if the constants it stands in for keep
+    // their documented values; pin them here so a silent edit (e.g. raising
+    // `EMBED_WAIT_MAX_OFFLINE_PROBES` past what the give-up test's runtime
+    // budget assumes) fails loudly instead of just changing real-world
+    // worker wait time unnoticed. Mirrors the `loopback_probe_timeout_is_250ms`
+    // -style constant pins in `capability/probe.rs`.
+    #[test]
+    fn embed_wait_initial_backoff_is_1s() {
+        assert_eq!(EMBED_WAIT_INITIAL_BACKOFF.as_secs(), 1);
+    }
+
+    #[test]
+    fn embed_wait_max_backoff_is_30s() {
+        assert_eq!(EMBED_WAIT_MAX_BACKOFF.as_secs(), 30);
+    }
+
+    #[test]
+    fn embed_wait_max_offline_probes_is_10() {
+        assert_eq!(EMBED_WAIT_MAX_OFFLINE_PROBES, 10);
+    }
+
     // ── wait_for_embedder: local_first routes to loopback, not server_url ────
     //
     // The routing-bug regression this story fixes: before, the wait loop

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -2274,7 +2274,17 @@ async fn test_search_auto_partial_coverage_emits_warmup_notice_on_stderr() {
     );
 
     // Pass 1: embed everything via the mock server (full coverage).
+    //
+    // This test's purpose is the partial-vs-zero coverage warmup notice, not
+    // local-vs-remote embed routing, so it needs an explicit `server_url` to
+    // legitimately serve embedding here. Under the default `local_first`
+    // mode that routing is now correctly refused (see the `get_inference_tier`
+    // routing fix) in favor of the local loopback embedder, which this test
+    // does not configure - so force `cloud_first` via env (a project-level
+    // `.spelunk/config.toml`, which `write_config_with_server` writes to,
+    // silently drops a `mode` key; see `write_project_server_config`).
     spelunk_bin_in(home.path())
+        .env("SPELUNK_MODE", "cloud_first")
         .current_dir(&project_dir)
         .arg("--config")
         .arg(&config_path)

--- a/crates/spelunk-cli/tests/e2e_cli.rs
+++ b/crates/spelunk-cli/tests/e2e_cli.rs
@@ -321,8 +321,18 @@ async fn test_index_encodes_project_id_with_slashes_as_single_segment() {
         write_project_server_config(&project_dir, &mock_server.uri(), project_id);
 
         // Index the project — must reach the embedding phase without a 404.
+        //
+        // This test's purpose is the project_id slash-encoding in the embed
+        // request path, not local-vs-remote embed routing, so it needs an
+        // explicit `server_url` to legitimately serve embedding. Under the
+        // default `local_first` mode that routing is now correctly refused
+        // (see the `get_inference_tier` routing fix), so force `cloud_first`
+        // here: `.spelunk/config.toml` doesn't recognize a `mode` key (see
+        // `write_project_server_config`), so this must go through the env
+        // var.
         spelunk_bin()
             .current_dir(&project_dir)
+            .env("SPELUNK_MODE", "cloud_first")
             .arg("--config")
             .arg(&config_path)
             .arg("index")

--- a/crates/spelunk-cli/tests/index_embed_tier_routing.rs
+++ b/crates/spelunk-cli/tests/index_embed_tier_routing.rs
@@ -1,19 +1,19 @@
-//! Regression tests for `spelunk index`'s primary embed phase local-vs-remote
-//! tier routing: the foreground embed phase (`index/mod.rs`'s phase 2) and
-//! the `--detach-embed` worker it can hand off to.
-//!
-//! Mirrors the loopback-vs-explicit-`server_url` routing bug already fixed
-//! for `spelunk explore` / `memory add` / `memory reindex` et al: under the
-//! default `local_first` mode, inference must always prefer the local
-//! loopback embedder, even when an explicit (here, deliberately unroutable)
-//! `server_url` is configured. `cloud_first` is the one mode where an
-//! explicit `server_url` legitimately serves inference too (test 2 is a
-//! regression guard for that path).
-//!
-//! The mock loopback server is wired in via `SPELUNK_STATE_DIR`/`server.port`
-//! (real auto-discovery), not `server_url`, so a routing regression surfaces
-//! as a genuine connection/DNS failure against the deliberately-unroutable
-//! `server_url` rather than a silently-passing test.
+// Regression tests for `spelunk index`'s primary embed phase local-vs-remote
+// tier routing: the foreground embed phase (`index/mod.rs`'s phase 2) and
+// the `--detach-embed` worker it can hand off to.
+//
+// Mirrors the loopback-vs-explicit-`server_url` routing bug already fixed
+// for `spelunk explore` / `memory add` / `memory reindex` et al: under the
+// default `local_first` mode, inference must always prefer the local
+// loopback embedder, even when an explicit (here, deliberately unroutable)
+// `server_url` is configured. `cloud_first` is the one mode where an
+// explicit `server_url` legitimately serves inference too (test 2 is a
+// regression guard for that path).
+//
+// The mock loopback server is wired in via `SPELUNK_STATE_DIR`/`server.port`
+// (real auto-discovery), not `server_url`, so a routing regression surfaces
+// as a genuine connection/DNS failure against the deliberately-unroutable
+// `server_url` rather than a silently-passing test.
 
 mod plumbing_helpers;
 use plumbing_helpers::{FIXTURE_PROJECT_ID, mount_health, mount_index_embed, spelunk_bin_in};
@@ -24,13 +24,13 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-/// Failsafe only: hit solely if the detached child never finishes.
+// Failsafe only: hit solely if the detached child never finishes.
 const CHILD_TIMEOUT: Duration = Duration::from_secs(60);
 
 // ── fixture project ───────────────────────────────────────────────────────
 
-/// A tiny project: enough source for a couple of chunks, so the embed phase
-/// has real work without slowing the suite down.
+// A tiny project: enough source for a couple of chunks, so the embed phase
+// has real work without slowing the suite down.
 fn write_project(dir: &Path) {
     std::fs::write(
         dir.join("Cargo.toml"),
@@ -47,12 +47,12 @@ fn write_project(dir: &Path) {
     .expect("write lib.rs");
 }
 
-/// Write `<project_dir>/.spelunk/config.toml` with `server_url` + `project_id`.
-///
-/// `ProjectConfig` (`spelunk-core/src/config/mod.rs`) only deserializes
-/// `server_url`/`project_id`/`server_ca`/`index` from this file; any other
-/// key (notably `mode`) is silently dropped by serde. `mode` must go through
-/// `SPELUNK_MODE` (or the personal global `--config` file) instead.
+// Write `<project_dir>/.spelunk/config.toml` with `server_url` + `project_id`.
+//
+// `ProjectConfig` (`spelunk-core/src/config/mod.rs`) only deserializes
+// `server_url`/`project_id`/`server_ca`/`index` from this file; any other
+// key (notably `mode`) is silently dropped by serde. `mode` must go through
+// `SPELUNK_MODE` (or the personal global `--config` file) instead.
 fn write_server_config(project_dir: &Path, server_url: &str) {
     let spelunk_dir = project_dir.join(".spelunk");
     std::fs::create_dir_all(&spelunk_dir).expect("create .spelunk dir");
@@ -60,8 +60,8 @@ fn write_server_config(project_dir: &Path, server_url: &str) {
     std::fs::write(spelunk_dir.join("config.toml"), cfg).expect("write project config");
 }
 
-/// Point loopback auto-discovery (`SPELUNK_STATE_DIR`/`server.port`, step 3a
-/// of `capability::probe`) at `url`.
+// Point loopback auto-discovery (`SPELUNK_STATE_DIR`/`server.port`, step 3a
+// of `capability::probe`) at `url`.
 fn write_loopback_state(state_dir: &Path, url: &str) {
     std::fs::create_dir_all(state_dir).expect("create state dir");
     let port: u16 = url
@@ -74,8 +74,8 @@ fn write_loopback_state(state_dir: &Path, url: &str) {
     std::fs::write(state_dir.join("server.port"), format!("{port}\n")).expect("write server.port");
 }
 
-/// `GET /v1/health` reporting an embedder still `loading` (no `index.embed`
-/// capability advertised yet).
+// `GET /v1/health` reporting an embedder still `loading` (no `index.embed`
+// capability advertised yet).
 async fn mount_health_loading(server: &MockServer) {
     Mock::given(method("GET"))
         .and(path("/v1/health"))
@@ -89,11 +89,11 @@ async fn mount_health_loading(server: &MockServer) {
         .await;
 }
 
-/// Build a `spelunk index --db <db> .` command against `project`, defensively
-/// scrubbed of every `SPELUNK_*` env var these tests care about isolating
-/// (an ambient value in the developer/CI shell must never leak into the
-/// child and quietly change which tier gets probed). Callers add back
-/// exactly the env each scenario needs.
+// Build a `spelunk index --db <db> .` command against `project`, defensively
+// scrubbed of every `SPELUNK_*` env var these tests care about isolating
+// (an ambient value in the developer/CI shell must never leak into the
+// child and quietly change which tier gets probed). Callers add back
+// exactly the env each scenario needs.
 fn index_cmd(home: &Path, project: &Path, db: &Path) -> assert_cmd::Command {
     let mut cmd = spelunk_bin_in(home);
     cmd.current_dir(project)
@@ -154,9 +154,9 @@ fn wait_for_embeddings(db_path: &Path) -> i64 {
 
 // ── foreground embed phase (mod.rs's phase 2) ────────────────────────────
 
-/// Test 1 (the routing bug): `local_first` (default) with an explicit
-/// unroutable `server_url` and a loopback mock present must embed via the
-/// loopback mock, never attempt the unroutable `server_url`.
+// Test 1 (the routing bug): `local_first` (default) with an explicit
+// unroutable `server_url` and a loopback mock present must embed via the
+// loopback mock, never attempt the unroutable `server_url`.
 #[tokio::test]
 async fn local_first_foreground_embeds_via_loopback_not_unroutable_server_url() {
     let loopback = MockServer::start().await;
@@ -186,9 +186,9 @@ async fn local_first_foreground_embeds_via_loopback_not_unroutable_server_url() 
     );
 }
 
-/// Test 2 (regression guard): `cloud_first` with an explicit `server_url`
-/// that DOES advertise `index.embed` must still route embedding to and
-/// succeed against that `server_url`, unchanged by this fix.
+// Test 2 (regression guard): `cloud_first` with an explicit `server_url`
+// that DOES advertise `index.embed` must still route embedding to and
+// succeed against that `server_url`, unchanged by this fix.
 #[tokio::test]
 async fn cloud_first_foreground_still_embeds_via_explicit_server_url() {
     let mock = MockServer::start().await;
@@ -233,9 +233,9 @@ async fn cloud_first_foreground_still_embeds_via_explicit_server_url() {
     );
 }
 
-/// Test 3 (unaffected): no `server_url` configured at all (pure loopback
-/// auto-discovery, the default no-team-server case) must embed via loopback
-/// exactly as before this fix.
+// Test 3 (unaffected): no `server_url` configured at all (pure loopback
+// auto-discovery, the default no-team-server case) must embed via loopback
+// exactly as before this fix.
 #[tokio::test]
 async fn no_server_url_configured_embeds_via_loopback_auto_discovery() {
     let loopback = MockServer::start().await;
@@ -262,9 +262,9 @@ async fn no_server_url_configured_embeds_via_loopback_auto_discovery() {
     );
 }
 
-/// Test 4 (unchanged): explicit offline (`SPELUNK_NO_SERVER=1`) skips the
-/// embed phase with the existing differentiated notice; no server is
-/// contacted.
+// Test 4 (unchanged): explicit offline (`SPELUNK_NO_SERVER=1`) skips the
+// embed phase with the existing differentiated notice; no server is
+// contacted.
 #[tokio::test]
 async fn explicit_offline_skips_embed_phase_with_no_server_configured() {
     let home = TempDir::new().unwrap();
@@ -293,9 +293,9 @@ async fn explicit_offline_skips_embed_phase_with_no_server_configured() {
     );
 }
 
-/// Test 5 (unchanged): a loopback server present but with the embedder still
-/// `loading` at index time keeps the existing "still loading, skipped"
-/// notice for the foreground path.
+// Test 5 (unchanged): a loopback server present but with the embedder still
+// `loading` at index time keeps the existing "still loading, skipped"
+// notice for the foreground path.
 #[tokio::test]
 async fn loopback_embedder_loading_skips_foreground_embed_with_warmup_notice() {
     let loopback = MockServer::start().await;
@@ -327,9 +327,9 @@ async fn loopback_embedder_loading_skips_foreground_embed_with_warmup_notice() {
 
 // ── detached-worker path (--detach-embed) ─────────────────────────────────
 
-/// Test 6 (the routing bug, detached path): the same scenario as test 1, but
-/// through `--detach-embed`/`--_embed-phases`: the detached worker must poll
-/// and embed via the loopback mock, not the explicit unroutable `server_url`.
+// Test 6 (the routing bug, detached path): the same scenario as test 1, but
+// through `--detach-embed`/`--_embed-phases`: the detached worker must poll
+// and embed via the loopback mock, not the explicit unroutable `server_url`.
 #[tokio::test]
 async fn local_first_detached_embed_routes_to_loopback_not_unroutable_server_url() {
     let loopback = MockServer::start().await;

--- a/crates/spelunk-cli/tests/index_embed_tier_routing.rs
+++ b/crates/spelunk-cli/tests/index_embed_tier_routing.rs
@@ -1,0 +1,359 @@
+//! Regression tests for `spelunk index`'s primary embed phase local-vs-remote
+//! tier routing: the foreground embed phase (`index/mod.rs`'s phase 2) and
+//! the `--detach-embed` worker it can hand off to.
+//!
+//! Mirrors the loopback-vs-explicit-`server_url` routing bug already fixed
+//! for `spelunk explore` / `memory add` / `memory reindex` et al: under the
+//! default `local_first` mode, inference must always prefer the local
+//! loopback embedder, even when an explicit (here, deliberately unroutable)
+//! `server_url` is configured. `cloud_first` is the one mode where an
+//! explicit `server_url` legitimately serves inference too (test 2 is a
+//! regression guard for that path).
+//!
+//! The mock loopback server is wired in via `SPELUNK_STATE_DIR`/`server.port`
+//! (real auto-discovery), not `server_url`, so a routing regression surfaces
+//! as a genuine connection/DNS failure against the deliberately-unroutable
+//! `server_url` rather than a silently-passing test.
+
+mod plumbing_helpers;
+use plumbing_helpers::{FIXTURE_PROJECT_ID, mount_health, mount_index_embed, spelunk_bin_in};
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Failsafe only: hit solely if the detached child never finishes.
+const CHILD_TIMEOUT: Duration = Duration::from_secs(60);
+
+// ── fixture project ───────────────────────────────────────────────────────
+
+/// A tiny project: enough source for a couple of chunks, so the embed phase
+/// has real work without slowing the suite down.
+fn write_project(dir: &Path) {
+    std::fs::write(
+        dir.join("Cargo.toml"),
+        "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+    let src = dir.join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("lib.rs"),
+        "pub fn greet(name: &str) -> String {\n    format!(\"hello, {name}\")\n}\n\
+         pub fn farewell(name: &str) -> String {\n    format!(\"bye, {name}\")\n}\n",
+    )
+    .expect("write lib.rs");
+}
+
+/// Write `<project_dir>/.spelunk/config.toml` with `server_url` + `project_id`.
+///
+/// `ProjectConfig` (`spelunk-core/src/config/mod.rs`) only deserializes
+/// `server_url`/`project_id`/`server_ca`/`index` from this file; any other
+/// key (notably `mode`) is silently dropped by serde. `mode` must go through
+/// `SPELUNK_MODE` (or the personal global `--config` file) instead.
+fn write_server_config(project_dir: &Path, server_url: &str) {
+    let spelunk_dir = project_dir.join(".spelunk");
+    std::fs::create_dir_all(&spelunk_dir).expect("create .spelunk dir");
+    let cfg = format!("server_url = {server_url:?}\nproject_id = {FIXTURE_PROJECT_ID:?}\n");
+    std::fs::write(spelunk_dir.join("config.toml"), cfg).expect("write project config");
+}
+
+/// Point loopback auto-discovery (`SPELUNK_STATE_DIR`/`server.port`, step 3a
+/// of `capability::probe`) at `url`.
+fn write_loopback_state(state_dir: &Path, url: &str) {
+    std::fs::create_dir_all(state_dir).expect("create state dir");
+    let port: u16 = url
+        .rsplit(':')
+        .next()
+        .expect("uri has a port")
+        .trim_end_matches('/')
+        .parse()
+        .expect("uri port is numeric");
+    std::fs::write(state_dir.join("server.port"), format!("{port}\n")).expect("write server.port");
+}
+
+/// `GET /v1/health` reporting an embedder still `loading` (no `index.embed`
+/// capability advertised yet).
+async fn mount_health_loading(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "version": "test",
+            "capabilities": ["memory"],
+            "embedder": { "state": "loading", "detail": null },
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Build a `spelunk index --db <db> .` command against `project`, defensively
+/// scrubbed of every `SPELUNK_*` env var these tests care about isolating
+/// (an ambient value in the developer/CI shell must never leak into the
+/// child and quietly change which tier gets probed). Callers add back
+/// exactly the env each scenario needs.
+fn index_cmd(home: &Path, project: &Path, db: &Path) -> assert_cmd::Command {
+    let mut cmd = spelunk_bin_in(home);
+    cmd.current_dir(project)
+        .env_remove("SPELUNK_SERVER_URL")
+        .env_remove("SPELUNK_MODE")
+        .env_remove("SPELUNK_PROJECT_ID")
+        .env_remove("SPELUNK_NO_SERVER")
+        .env_remove("SPELUNK_STATE_DIR")
+        .arg("index")
+        .arg("--db")
+        .arg(db)
+        .arg(".");
+    cmd
+}
+
+fn ensure_sqlite_vec() {
+    use std::sync::OnceLock;
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite_vec::sqlite3_vec_init as *const (),
+            )));
+        }
+    });
+}
+
+fn count_embeddings(db_path: &Path) -> i64 {
+    ensure_sqlite_vec();
+    let conn = rusqlite::Connection::open(db_path).expect("open db");
+    conn.query_row("SELECT COUNT(*) FROM embeddings", [], |r| r.get(0))
+        .expect("count embeddings")
+}
+
+fn count_chunks(db_path: &Path) -> i64 {
+    ensure_sqlite_vec();
+    let conn = rusqlite::Connection::open(db_path).expect("open db");
+    conn.query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+        .expect("count chunks")
+}
+
+fn wait_for_embeddings(db_path: &Path) -> i64 {
+    let deadline = Instant::now() + CHILD_TIMEOUT;
+    loop {
+        if db_path.exists() {
+            let n = count_embeddings(db_path);
+            if n > 0 {
+                return n;
+            }
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for embeddings to land in {db_path:?}");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+// ── foreground embed phase (mod.rs's phase 2) ────────────────────────────
+
+/// Test 1 (the routing bug): `local_first` (default) with an explicit
+/// unroutable `server_url` and a loopback mock present must embed via the
+/// loopback mock, never attempt the unroutable `server_url`.
+#[tokio::test]
+async fn local_first_foreground_embeds_via_loopback_not_unroutable_server_url() {
+    let loopback = MockServer::start().await;
+    mount_health(&loopback).await;
+    mount_index_embed(&loopback).await;
+
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    write_project(project.path());
+    // Deliberately unroutable: local_first must never fall back to this. An
+    // accidental fallback surfaces as a connection/DNS error, not a silent
+    // unembedded index.
+    write_server_config(project.path(), "https://cloud.invalid.example:1");
+    let state_dir = home.path().join("state");
+    write_loopback_state(&state_dir, &loopback.uri());
+
+    let db = project.path().join("index.db");
+    index_cmd(home.path(), project.path(), &db)
+        .env("SPELUNK_STATE_DIR", &state_dir)
+        .assert()
+        .success();
+
+    assert!(
+        count_embeddings(&db) > 0,
+        "local_first must embed via the loopback mock, not skip because the \
+         unreachable explicit server_url was probed instead"
+    );
+}
+
+/// Test 2 (regression guard): `cloud_first` with an explicit `server_url`
+/// that DOES advertise `index.embed` must still route embedding to and
+/// succeed against that `server_url`, unchanged by this fix.
+#[tokio::test]
+async fn cloud_first_foreground_still_embeds_via_explicit_server_url() {
+    let mock = MockServer::start().await;
+    mount_health(&mock).await;
+    mount_index_embed(&mock).await;
+
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    write_project(project.path());
+    write_server_config(project.path(), &mock.uri());
+    // `mode` is not a recognized `.spelunk/config.toml` project-level field
+    // (see `write_server_config`); set it via env so `cloud_first` actually
+    // takes effect, rather than silently falling back to `local_first`.
+    let state_dir = home.path().join("state"); // never written to: no server.port
+
+    let db = project.path().join("index.db");
+    index_cmd(home.path(), project.path(), &db)
+        .env("SPELUNK_MODE", "cloud_first")
+        // Defensive: an isolated, empty state dir means any accidental
+        // fallback to `local_first`'s loopback probe fails loudly (nothing
+        // listens on the default port from this dir), instead of silently
+        // hitting a real spelunk-server daemon that happens to be running on
+        // this machine's default port 7777.
+        .env("SPELUNK_STATE_DIR", &state_dir)
+        .assert()
+        .success();
+
+    assert!(
+        count_embeddings(&db) > 0,
+        "cloud_first must still embed via the explicit server_url"
+    );
+    let requests = mock.received_requests().await.expect("requests recorded");
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.url.path().contains("/index/embed")),
+        "the configured server_url must have actually been used for embedding; got: {:?}",
+        requests
+            .iter()
+            .map(|r| (r.method.to_string(), r.url.path().to_string()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Test 3 (unaffected): no `server_url` configured at all (pure loopback
+/// auto-discovery, the default no-team-server case) must embed via loopback
+/// exactly as before this fix.
+#[tokio::test]
+async fn no_server_url_configured_embeds_via_loopback_auto_discovery() {
+    let loopback = MockServer::start().await;
+    mount_health(&loopback).await;
+    mount_index_embed(&loopback).await;
+
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    write_project(project.path());
+    // No `.spelunk/config.toml` at all: no server_url, no project_id.
+    let state_dir = home.path().join("state");
+    write_loopback_state(&state_dir, &loopback.uri());
+
+    let db = project.path().join("index.db");
+    index_cmd(home.path(), project.path(), &db)
+        .env("SPELUNK_STATE_DIR", &state_dir)
+        .assert()
+        .success();
+
+    assert!(
+        count_embeddings(&db) > 0,
+        "a project with no server_url at all must still embed via loopback \
+         auto-discovery, unaffected by this fix"
+    );
+}
+
+/// Test 4 (unchanged): explicit offline (`SPELUNK_NO_SERVER=1`) skips the
+/// embed phase with the existing differentiated notice; no server is
+/// contacted.
+#[tokio::test]
+async fn explicit_offline_skips_embed_phase_with_no_server_configured() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    write_project(project.path());
+
+    let db = project.path().join("index.db");
+    let assert = index_cmd(home.path(), project.path(), &db)
+        .env("SPELUNK_NO_SERVER", "1")
+        .assert()
+        .success();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+
+    assert!(
+        stderr.contains("spelunk server start"),
+        "explicit offline must still print the no-server skip notice: {stderr}"
+    );
+    assert_eq!(
+        count_embeddings(&db),
+        0,
+        "explicit offline must never embed"
+    );
+    assert!(
+        count_chunks(&db) > 0,
+        "chunks must still be indexed for text/ast-grep search"
+    );
+}
+
+/// Test 5 (unchanged): a loopback server present but with the embedder still
+/// `loading` at index time keeps the existing "still loading, skipped"
+/// notice for the foreground path.
+#[tokio::test]
+async fn loopback_embedder_loading_skips_foreground_embed_with_warmup_notice() {
+    let loopback = MockServer::start().await;
+    mount_health_loading(&loopback).await;
+
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    write_project(project.path());
+    let state_dir = home.path().join("state");
+    write_loopback_state(&state_dir, &loopback.uri());
+
+    let db = project.path().join("index.db");
+    let assert = index_cmd(home.path(), project.path(), &db)
+        .env("SPELUNK_STATE_DIR", &state_dir)
+        .assert()
+        .success();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+
+    assert!(
+        stderr.contains("warming up"),
+        "a loading embedder must print the warm-up notice: {stderr}"
+    );
+    assert_eq!(
+        count_embeddings(&db),
+        0,
+        "a loading embedder must not be embedded against"
+    );
+}
+
+// ── detached-worker path (--detach-embed) ─────────────────────────────────
+
+/// Test 6 (the routing bug, detached path): the same scenario as test 1, but
+/// through `--detach-embed`/`--_embed-phases`: the detached worker must poll
+/// and embed via the loopback mock, not the explicit unroutable `server_url`.
+#[tokio::test]
+async fn local_first_detached_embed_routes_to_loopback_not_unroutable_server_url() {
+    let loopback = MockServer::start().await;
+    mount_health(&loopback).await;
+    mount_index_embed(&loopback).await;
+
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    write_project(project.path());
+    write_server_config(project.path(), "https://cloud.invalid.example:1");
+    let state_dir = home.path().join("state");
+    write_loopback_state(&state_dir, &loopback.uri());
+
+    let db = project.path().join("index.db");
+    index_cmd(home.path(), project.path(), &db)
+        .env("SPELUNK_STATE_DIR", &state_dir)
+        .arg("--detach-embed")
+        .assert()
+        .success();
+
+    let n = wait_for_embeddings(&db);
+    assert!(
+        n > 0,
+        "the detached worker must embed via the loopback mock, not skip \
+         because the unreachable explicit server_url was polled instead"
+    );
+}

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -347,8 +347,18 @@ pub fn index_project_dir(project_dir: &Path) -> (TempDir, PathBuf, PathBuf) {
     // `.current_dir(tmp.path())`: the project-level config discovery walks up
     // from CWD, not from the `project_dir` positional arg (which may be an
     // unrelated source tree, e.g. the shared fixture).
+    //
+    // `SPELUNK_MODE=cloud_first`: this fixture's whole point is a Tier 1
+    // index with real embeddings landed via the mock `server_url` above, not
+    // exercising local-vs-remote routing. Under the default `local_first`
+    // mode an explicit `server_url` with no loopback embedder configured is
+    // now correctly refused, which would leave chunks unembedded and every
+    // KNN-dependent consumer of this fixture broken. `.spelunk/config.toml`
+    // doesn't recognize a `mode` key (see `write_project_server_config`), so
+    // this must go through the env var.
     spelunk_bin_in(tmp.path())
         .current_dir(tmp.path())
+        .env("SPELUNK_MODE", "cloud_first")
         .arg("--config")
         .arg(&config_path)
         .arg("index")


### PR DESCRIPTION
## Summary

`spelunk index`'s embed phases resolved their embedding target from the raw, mode-agnostic tier-probing functions (`get_tier`, `probe_tier_fresh`) instead of the mode-aware `get_inference_tier`/`get_inference_tier_fresh`. In `local_first` mode with an explicit team `server_url` configured, this sent embed batches to that `server_url` instead of the local, auto-discovered embedder — the same routing bug class as spelunk-oss^280, on the most-used command (`spelunk index`), affecting both call sites:

- Foreground/primary embed phase (`crates/spelunk-cli/src/cli/cmd/index/mod.rs:167`): now uses `capability::get_inference_tier`.
- Detached-worker readiness poll (`wait_for_embedder`, `mod.rs:412`): now uses a new `capability::get_inference_tier_fresh` (added in `capability/probe.rs`), which mirrors `get_inference_tier`'s mode-based routing but re-probes on every call for the `cloud_first` branch — required because this is a poller that must observe a `loading` → `ready` transition, not a point-in-time snapshot.

Also fixes two pre-existing tests (`e2e_cli.rs::test_index_encodes_project_id_with_slashes_as_single_segment` and the shared fixture `plumbing_helpers.rs::index_project_dir()`, which backs `plumbing_knn_returns_valid_chunk_ids` and five other integration tests) that baked in the old mode-agnostic routing assumption — both now set `SPELUNK_MODE=cloud_first` so their explicit `server_url` legitimately serves embedding again.

Adds a `CHANGELOG.md` entry under `[Unreleased]`. See `docs/adr/004-unified-memory-storage.md`'s 2026-07-23 amendment (the same decision spelunk-oss^280 implemented for `memory add`/`reindex`/`search`/`timeline`/`harvest`/`reconcile`/`explore`).

## Test plan

Ran independently in this worktree, not just the prior stages' scoped subsets:

- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli -p spelunk-core --no-fail-fast` — exit 0, 62/62 `test result: ok` blocks, zero `FAILED`. Confirmed both previously-regressed tests now pass: `test_index_encodes_project_id_with_slashes_as_single_segment ... ok` and `plumbing_knn_returns_valid_chunk_ids ... ok`.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets --features rich-formats -- -D warnings` — clean.
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` — clean.
- `git diff origin/main..HEAD -- crates/spelunk-cli/src/` reviewed line by line: only the two intended call-site changes plus the new `get_inference_tier_fresh`/`inference_tier` helper in `probe.rs` and their unit tests — no accidental changes to unrelated production code.
- Confirmed the fixup commit (`6c51db6d2`) touches only `crates/spelunk-cli/tests/e2e_cli.rs` and `crates/spelunk-cli/tests/plumbing_helpers.rs` — no production code.
- New coverage: `crates/spelunk-cli/tests/index_embed_tier_routing.rs` (6 E2E tests), plus unit tests in `capability/probe.rs` and `cli/cmd/index/mod.rs`'s test module for the fresh-vs-cached distinction and the wait-loop transition cases.

Relates to spelunk-oss^280 (origin fix establishing the `get_inference_tier` pattern) and spelunk-oss^279.