### PR TITLE
Make the test suite hermetic-by-construction against ambient git config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Git isolation lint
+        run: scripts/check-git-isolation.sh
+
       - name: Disk usage (baseline)
         run: df -h
 

--- a/crates/spelunk-cli/src/cli/cmd/test_support.rs
+++ b/crates/spelunk-cli/src/cli/cmd/test_support.rs
@@ -1,50 +1,10 @@
-//! Shared helper for unit tests under `cli::cmd`.
+//! Re-export of the shared git-isolation fixture for `cli::cmd`'s
+//! `#[cfg(test)]` unit tests.
 //!
-//! `tests/plumbing_helpers.rs` carries the same helper for the `tests/`
-//! integration binaries, but a unit test compiled into `src/` cannot reach a
-//! file under `tests/`, so this is the `src/`-side counterpart.
+//! `tests/plumbing_helpers.rs` re-exports the same underlying
+//! `spelunk_core::test_support::isolate_git_config` for the `tests/`
+//! integration binaries; a unit test compiled into `src/` cannot reach a
+//! file under `tests/`, so this is the `src/`-side path to the one
+//! definition.
 
-/// Drop the machine's global/system git config for every git this process
-/// spawns: a setup git a test runs directly, and any git the code under
-/// test spawns for itself. Must be process-wide, not per-`Command`: a
-/// helper that only sets env on the `Command` it builds itself never
-/// reaches a git spawned inside the function under test.
-///
-/// A temp repo's local config does not shadow an ambient value the repo
-/// never sets, so an ambient `core.hooksPath` (husky, lefthook, the
-/// pre-commit framework) fires a foreign hook inside a test's throwaway
-/// repo, and an ambient `commit.gpgsign` signs as an identity no
-/// contributor holds a key for.
-///
-/// `/dev/null` is not a Windows path, but git skips a scope whenever its
-/// var is set, whatever the path resolves to, so this isolates on Windows
-/// too.
-///
-/// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` only redirect config *files*;
-/// they don't touch `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`, which git
-/// consults before config and so override a test's own explicit `git config
-/// user.name`/`user.email` if the ambient process (a developer's shell, a
-/// CI runner's bot identity) happens to export them. Those are cleared too.
-pub(crate) fn isolate_git_config() {
-    static ONCE: std::sync::Once = std::sync::Once::new();
-    ONCE.call_once(|| {
-        // SAFETY: every caller here calls this first and `Once` blocks the
-        // rest until it returns, so no thread can be spawning git (reading
-        // environ) while these run.
-        unsafe {
-            std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
-            std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
-            for var in [
-                "GIT_AUTHOR_NAME",
-                "GIT_AUTHOR_EMAIL",
-                "GIT_AUTHOR_DATE",
-                "GIT_COMMITTER_NAME",
-                "GIT_COMMITTER_EMAIL",
-                "GIT_COMMITTER_DATE",
-                "EMAIL",
-            ] {
-                std::env::remove_var(var);
-            }
-        }
-    });
-}
+pub(crate) use spelunk_core::test_support::isolate_git_config;

--- a/crates/spelunk-cli/src/cli/cmd/test_support.rs
+++ b/crates/spelunk-cli/src/cli/cmd/test_support.rs
@@ -19,6 +19,12 @@
 /// `/dev/null` is not a Windows path, but git skips a scope whenever its
 /// var is set, whatever the path resolves to, so this isolates on Windows
 /// too.
+///
+/// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` only redirect config *files*;
+/// they don't touch `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`, which git
+/// consults before config and so override a test's own explicit `git config
+/// user.name`/`user.email` if the ambient process (a developer's shell, a
+/// CI runner's bot identity) happens to export them. Those are cleared too.
 pub(crate) fn isolate_git_config() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {
@@ -28,6 +34,17 @@ pub(crate) fn isolate_git_config() {
         unsafe {
             std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
             std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
+            for var in [
+                "GIT_AUTHOR_NAME",
+                "GIT_AUTHOR_EMAIL",
+                "GIT_AUTHOR_DATE",
+                "GIT_COMMITTER_NAME",
+                "GIT_COMMITTER_EMAIL",
+                "GIT_COMMITTER_DATE",
+                "EMAIL",
+            ] {
+                std::env::remove_var(var);
+            }
         }
     });
 }

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -21,6 +21,12 @@ use tempfile::TempDir;
 ///
 /// `/dev/null` is not a Windows path, but git skips a scope whenever its var
 /// is set, whatever the path resolves to, so this isolates on Windows too.
+///
+/// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` only redirect config *files*;
+/// they don't touch `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`, which git
+/// consults before config and so override this file's fabricated
+/// `user.name`/`user.email` if the ambient process (a developer's shell, a
+/// CI runner's bot identity) happens to export them. Those are cleared too.
 pub fn isolate_git_config() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {
@@ -30,6 +36,17 @@ pub fn isolate_git_config() {
         unsafe {
             std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
             std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
+            for var in [
+                "GIT_AUTHOR_NAME",
+                "GIT_AUTHOR_EMAIL",
+                "GIT_AUTHOR_DATE",
+                "GIT_COMMITTER_NAME",
+                "GIT_COMMITTER_EMAIL",
+                "GIT_COMMITTER_DATE",
+                "EMAIL",
+            ] {
+                std::env::remove_var(var);
+            }
         }
     });
 }

--- a/crates/spelunk-cli/tests/plumbing_helpers.rs
+++ b/crates/spelunk-cli/tests/plumbing_helpers.rs
@@ -3,53 +3,18 @@
 //! Every test that needs an indexed project DB should call
 //! `index_fixture_project()`.  Tests that need no index still share helpers
 //! for constructing `Command` instances.
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 use assert_cmd::Command;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
-/// Drop the machine's global/system git config for every git this process
-/// spawns, including a setup git a test runs directly. Must be process-wide,
-/// not per-`Command`: a helper only controls the git it spawns itself, never
-/// one the code under test spawns for itself.
-///
-/// A temp repo's local config does not shadow an ambient value the repo never
-/// sets. A global `commit.gpgsign = true` makes setup commits sign as the
-/// fabricated test identity below, which no contributor holds a key for, so
-/// the commit exits non-zero.
-///
-/// `/dev/null` is not a Windows path, but git skips a scope whenever its var
-/// is set, whatever the path resolves to, so this isolates on Windows too.
-///
-/// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` only redirect config *files*;
-/// they don't touch `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`, which git
-/// consults before config and so override this file's fabricated
-/// `user.name`/`user.email` if the ambient process (a developer's shell, a
-/// CI runner's bot identity) happens to export them. Those are cleared too.
-pub fn isolate_git_config() {
-    static ONCE: std::sync::Once = std::sync::Once::new();
-    ONCE.call_once(|| {
-        // SAFETY: every git-touching helper here calls this first and `Once`
-        // blocks the rest until it returns, so no thread can be spawning git
-        // (reading environ) while these run.
-        unsafe {
-            std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
-            std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
-            for var in [
-                "GIT_AUTHOR_NAME",
-                "GIT_AUTHOR_EMAIL",
-                "GIT_AUTHOR_DATE",
-                "GIT_COMMITTER_NAME",
-                "GIT_COMMITTER_EMAIL",
-                "GIT_COMMITTER_DATE",
-                "EMAIL",
-            ] {
-                std::env::remove_var(var);
-            }
-        }
-    });
-}
+// Git-config isolation lives once in `spelunk_core::test_support`, reached
+// here via the `test-support`-featured dev-dependency in this crate's
+// Cargo.toml. `scripts/check-git-isolation.sh` enforces that a test file
+// spawning `git` wires in `isolate_git_config`/`git_command`, however
+// qualified, including through this re-export.
+pub use spelunk_core::test_support::isolate_git_config;
 
 /// Create a git repo in `dir` with a fabricated identity and one initial
 /// commit, isolated from the developer's ambient git config.

--- a/crates/spelunk-core/src/lib.rs
+++ b/crates/spelunk-core/src/lib.rs
@@ -7,4 +7,6 @@ pub mod llm;
 pub mod registry;
 pub mod search;
 pub mod storage;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
 pub mod utils;

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -992,6 +992,13 @@ mod cat_file_batch {
     /// repo never sets, so an ambient `core.hooksPath` (husky, lefthook,
     /// the pre-commit framework) fires a foreign pre-commit hook on the
     /// commit below.
+    ///
+    /// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` only redirect config
+    /// *files*; they don't touch `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`,
+    /// which git consults before config and so override this module's own
+    /// explicit `user.name`/`user.email` if the ambient process (a
+    /// developer's shell, a CI runner's bot identity) happens to export
+    /// them. Those are cleared too.
     fn isolate_git_config() {
         static ONCE: std::sync::Once = std::sync::Once::new();
         ONCE.call_once(|| {
@@ -1001,6 +1008,17 @@ mod cat_file_batch {
             unsafe {
                 std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
                 std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
+                for var in [
+                    "GIT_AUTHOR_NAME",
+                    "GIT_AUTHOR_EMAIL",
+                    "GIT_AUTHOR_DATE",
+                    "GIT_COMMITTER_NAME",
+                    "GIT_COMMITTER_EMAIL",
+                    "GIT_COMMITTER_DATE",
+                    "EMAIL",
+                ] {
+                    std::env::remove_var(var);
+                }
             }
         });
     }

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -981,51 +981,9 @@ mod cat_file_batch {
         );
     }
 
-    /// Drop the machine's global/system git config for every git this
-    /// process spawns, including a setup git this test module runs
-    /// directly. Must be process-wide, not per-`Command`: a helper that
-    /// only sets env on the `Command` it builds itself never reaches git
-    /// spawned by the code under test (`run_git`/`run_git_with_stdin`
-    /// inherit the process environment like any other `Command`).
-    ///
-    /// A temp repo's local config does not shadow an ambient value the
-    /// repo never sets, so an ambient `core.hooksPath` (husky, lefthook,
-    /// the pre-commit framework) fires a foreign pre-commit hook on the
-    /// commit below.
-    ///
-    /// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` only redirect config
-    /// *files*; they don't touch `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`,
-    /// which git consults before config and so override this module's own
-    /// explicit `user.name`/`user.email` if the ambient process (a
-    /// developer's shell, a CI runner's bot identity) happens to export
-    /// them. Those are cleared too.
-    fn isolate_git_config() {
-        static ONCE: std::sync::Once = std::sync::Once::new();
-        ONCE.call_once(|| {
-            // SAFETY: every caller here calls this first and `Once` blocks
-            // the rest until it returns, so no thread can be spawning git
-            // (reading environ) while these run.
-            unsafe {
-                std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
-                std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
-                for var in [
-                    "GIT_AUTHOR_NAME",
-                    "GIT_AUTHOR_EMAIL",
-                    "GIT_AUTHOR_DATE",
-                    "GIT_COMMITTER_NAME",
-                    "GIT_COMMITTER_EMAIL",
-                    "GIT_COMMITTER_DATE",
-                    "EMAIL",
-                ] {
-                    std::env::remove_var(var);
-                }
-            }
-        });
-    }
-
     /// A repo carrying one note, and that note's blob sha.
     fn repo_with_one_note() -> (tempfile::TempDir, String) {
-        isolate_git_config();
+        crate::test_support::isolate_git_config();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let run = |args: &[&str]| {
             let out = std::process::Command::new("git")

--- a/crates/spelunk-core/src/test_support.rs
+++ b/crates/spelunk-core/src/test_support.rs
@@ -1,0 +1,67 @@
+//! Git-isolation fixture shared by every crate's tests.
+//!
+//! Gated like `config::secret_store::MemoryStore`: this crate's own
+//! `#[cfg(test)]` unit tests get it for free, and a downstream crate's tests
+//! (or this crate's own `tests/` integration binaries, via a self-referencing
+//! dev-dependency) reach it by enabling the `test-support` feature.
+
+use std::path::Path;
+use std::sync::Once;
+
+/// Drop the machine's global/system git config for every git this process
+/// spawns, including one the code under test spawns itself. Must be
+/// process-wide, not per-`Command`: a helper that only sets env on the
+/// `Command` it builds itself never reaches git spawned by the code under
+/// test.
+///
+/// A temp repo's local config does not shadow an ambient value the repo
+/// never sets: a global `notes.rewriteRef` reads back as already-covered, or
+/// a global `core.hooksPath` (husky, lefthook, the pre-commit framework)
+/// fires a foreign hook on a setup commit.
+///
+/// `/dev/null` is not a Windows path, but git skips a scope whenever its var
+/// is set, whatever the path resolves to, so this isolates on Windows too.
+///
+/// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` only redirect config *files*;
+/// they don't touch `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`, which git
+/// consults before config and so override a test's own explicit `git config
+/// user.name`/`user.email` if the ambient process (a developer's shell, a
+/// CI runner's bot identity) happens to export them. Those are cleared too.
+pub fn isolate_git_config() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: every caller here calls this first and `Once` blocks the
+        // rest until it returns, so no thread can be spawning git (reading
+        // environ) while these run.
+        unsafe {
+            std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
+            std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
+            for var in [
+                "GIT_AUTHOR_NAME",
+                "GIT_AUTHOR_EMAIL",
+                "GIT_AUTHOR_DATE",
+                "GIT_COMMITTER_NAME",
+                "GIT_COMMITTER_EMAIL",
+                "GIT_COMMITTER_DATE",
+                "EMAIL",
+            ] {
+                std::env::remove_var(var);
+            }
+        }
+    });
+}
+
+/// Build a `git` `Command` rooted at `cwd`, isolated from the developer's
+/// ambient global/system git config.
+///
+/// The sanctioned way to spawn `git` in a test: it always calls
+/// [`isolate_git_config`] first, so a caller cannot construct an
+/// un-isolated one by forgetting a separate setup step.
+/// `scripts/check-git-isolation.sh` enforces in CI that a test file spawning
+/// `git` wires this in.
+pub fn git_command(cwd: &Path) -> std::process::Command {
+    isolate_git_config();
+    let mut cmd = std::process::Command::new("git");
+    cmd.current_dir(cwd);
+    cmd
+}

--- a/crates/spelunk-core/tests/common/mod.rs
+++ b/crates/spelunk-core/tests/common/mod.rs
@@ -34,3 +34,44 @@ pub fn open_test_db() -> spelunk_core::storage::Database {
     spelunk_core::storage::Database::open(std::path::Path::new(":memory:"))
         .expect("failed to open in-memory database")
 }
+
+/// Drop the machine's global/system git config for every git this process
+/// spawns, including one the code under test spawns itself. Must be
+/// process-wide, not per-`Command`: a helper that only sets env on the
+/// `Command` it builds itself never reaches git spawned by the code under
+/// test.
+///
+/// A temp repo's local config does not shadow an ambient value the repo
+/// never sets: a global `notes.rewriteRef` reads back as already-covered, or
+/// a global `core.hooksPath` (husky, lefthook, the pre-commit framework)
+/// fires a foreign hook on a setup commit.
+///
+/// `/dev/null` is not a Windows path, but git skips a scope whenever its var
+/// is set, whatever the path resolves to, so this isolates on Windows too.
+pub fn isolate_git_config() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: every git-touching helper here calls this first and
+        // `Once` blocks the rest until it returns, so no thread can be
+        // spawning git (reading environ) while these run.
+        unsafe {
+            std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
+            std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
+        }
+    });
+}
+
+/// Build a `git` `Command` rooted at `cwd`, isolated from the developer's
+/// ambient global/system git config.
+///
+/// This is the sanctioned way for a `spelunk-core` integration test to spawn
+/// `git`: it always calls [`isolate_git_config`] first, so a caller cannot
+/// construct an un-isolated one by forgetting a separate setup step.
+/// `scripts/check-git-isolation.sh` enforces in CI that a test file spawning
+/// `git` wires this module in.
+pub fn git_command(cwd: &std::path::Path) -> std::process::Command {
+    isolate_git_config();
+    let mut cmd = std::process::Command::new("git");
+    cmd.current_dir(cwd);
+    cmd
+}

--- a/crates/spelunk-core/tests/common/mod.rs
+++ b/crates/spelunk-core/tests/common/mod.rs
@@ -48,6 +48,12 @@ pub fn open_test_db() -> spelunk_core::storage::Database {
 ///
 /// `/dev/null` is not a Windows path, but git skips a scope whenever its var
 /// is set, whatever the path resolves to, so this isolates on Windows too.
+///
+/// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` only redirect config *files*;
+/// they don't touch `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`, which git
+/// consults before config and so override a test's own explicit `git config
+/// user.name`/`user.email` if the ambient process (a developer's shell, a
+/// CI runner's bot identity) happens to export them. Those are cleared too.
 pub fn isolate_git_config() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {
@@ -57,6 +63,17 @@ pub fn isolate_git_config() {
         unsafe {
             std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
             std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
+            for var in [
+                "GIT_AUTHOR_NAME",
+                "GIT_AUTHOR_EMAIL",
+                "GIT_AUTHOR_DATE",
+                "GIT_COMMITTER_NAME",
+                "GIT_COMMITTER_EMAIL",
+                "GIT_COMMITTER_DATE",
+                "EMAIL",
+            ] {
+                std::env::remove_var(var);
+            }
         }
     });
 }

--- a/crates/spelunk-core/tests/common/mod.rs
+++ b/crates/spelunk-core/tests/common/mod.rs
@@ -35,25 +35,21 @@ pub fn open_test_db() -> spelunk_core::storage::Database {
         .expect("failed to open in-memory database")
 }
 
-/// Drop the machine's global/system git config for every git this process
-/// spawns, including one the code under test spawns itself. Must be
-/// process-wide, not per-`Command`: a helper that only sets env on the
-/// `Command` it builds itself never reaches git spawned by the code under
-/// test.
-///
-/// A temp repo's local config does not shadow an ambient value the repo
-/// never sets: a global `notes.rewriteRef` reads back as already-covered, or
-/// a global `core.hooksPath` (husky, lefthook, the pre-commit framework)
-/// fires a foreign hook on a setup commit.
-///
-/// `/dev/null` is not a Windows path, but git skips a scope whenever its var
-/// is set, whatever the path resolves to, so this isolates on Windows too.
-///
-/// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` only redirect config *files*;
-/// they don't touch `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`, which git
-/// consults before config and so override a test's own explicit `git config
-/// user.name`/`user.email` if the ambient process (a developer's shell, a
-/// CI runner's bot identity) happens to export them. Those are cleared too.
+// Drop the ambient global/system git config for every git this process
+// spawns, including one the code under test spawns itself: process-wide via
+// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`, guarded by `Once`. Also
+// clears `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`, which git resolves before
+// consulting config at all, so an ambient value there would otherwise
+// override a test's own explicit `user.name`/`user.email`.
+//
+// This is `spelunk-core`'s `tests/`-side copy of
+// `spelunk_core::test_support::isolate_git_config`. An integration test
+// binary links the crate externally, so it can't reach that `#[cfg(test)]`-
+// reachable definition directly without a self-referencing dev-dependency —
+// tried, and it breaks this repo's shared-`CARGO_TARGET_DIR`-across-
+// worktrees pre-commit hook (fails with `unresolved import` against a target
+// dir last built from a different Cargo.lock). This duplicate is the actual
+// floor, not the self-dependency trick.
 pub fn isolate_git_config() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {
@@ -78,14 +74,10 @@ pub fn isolate_git_config() {
     });
 }
 
-/// Build a `git` `Command` rooted at `cwd`, isolated from the developer's
-/// ambient global/system git config.
-///
-/// This is the sanctioned way for a `spelunk-core` integration test to spawn
-/// `git`: it always calls [`isolate_git_config`] first, so a caller cannot
-/// construct an un-isolated one by forgetting a separate setup step.
-/// `scripts/check-git-isolation.sh` enforces in CI that a test file spawning
-/// `git` wires this module in.
+// Build a `git` `Command` rooted at `cwd`, isolated via `isolate_git_config`
+// first, so a caller cannot construct an un-isolated one by forgetting a
+// separate setup step. `scripts/check-git-isolation.sh` enforces that a test
+// file spawning `git` wires this in.
 pub fn git_command(cwd: &std::path::Path) -> std::process::Command {
     isolate_git_config();
     let mut cmd = std::process::Command::new("git");

--- a/crates/spelunk-core/tests/common/mod.rs
+++ b/crates/spelunk-core/tests/common/mod.rs
@@ -45,7 +45,7 @@ pub fn open_test_db() -> spelunk_core::storage::Database {
 // This is `spelunk-core`'s `tests/`-side copy of
 // `spelunk_core::test_support::isolate_git_config`. An integration test
 // binary links the crate externally, so it can't reach that `#[cfg(test)]`-
-// reachable definition directly without a self-referencing dev-dependency —
+// reachable definition directly without a self-referencing dev-dependency:
 // tried, and it breaks this repo's shared-`CARGO_TARGET_DIR`-across-
 // worktrees pre-commit hook (fails with `unresolved import` against a target
 // dir last built from a different Cargo.lock). This duplicate is the actual

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -23,33 +23,15 @@ use spelunk_core::storage::MemoryBackend;
 use spelunk_core::storage::NoteInput;
 
 // ── helpers ──────────────────────────────────────────────────────────────────
-
-/// Drop the machine's global/system git config for every git this process
-/// spawns, including the ones the code under test spawns itself (`run_git`
-/// inherits our env, so a per-`Command` `.env()` would not reach them).
-/// An ambient value layers under the temp repo's local config and changes what
-/// the code under test reads: a global `notes.rewriteRef` reads back as
-/// already-covered and the repo never looks unconfigured.
-///
-/// `/dev/null` is not a Windows path, but git skips a scope whenever its var is
-/// set, whatever the path resolves to, so this isolates on Windows regardless.
-fn isolate_git_config() {
-    static ONCE: std::sync::Once = std::sync::Once::new();
-    ONCE.call_once(|| {
-        // SAFETY: every git-touching helper here calls this first and `Once`
-        // blocks the rest until it returns, so no thread can be spawning git
-        // (reading environ) while these run.
-        unsafe {
-            std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null");
-            std::env::set_var("GIT_CONFIG_SYSTEM", "/dev/null");
-        }
-    });
-}
+//
+// Git-config isolation (`isolate_git_config` / `git_command`) now lives in
+// `tests/common/mod.rs`, shared across every spelunk-core integration test
+// that spawns git rather than copy-pasted per file.
 
 /// Create a temporary git repo with one initial commit.
 /// Returns the path; the repo is cleaned up when the returned `TempDir` drops.
 fn make_temp_git_repo() -> tempfile::TempDir {
-    isolate_git_config();
+    common::isolate_git_config();
     let dir = tempfile::TempDir::new().expect("tempdir");
     let p = dir.path();
 
@@ -1554,7 +1536,7 @@ mod git_shim {
         fn drop(&mut self) {
             // SAFETY: every test in this binary is #[serial] (and nextest runs
             // one process per test), so nothing reads the environment
-            // concurrently. Same argument as `isolate_git_config` above.
+            // concurrently. Same argument as `common::isolate_git_config`.
             unsafe { std::env::set_var("PATH", &self.original_path) };
         }
     }
@@ -2271,6 +2253,28 @@ async fn ensure_notes_rewrite_ref_composes_with_a_users_existing_value() {
     );
 }
 
+/// Restores `GIT_CONFIG_GLOBAL` to `previous` on drop, including during a
+/// panic unwind. A plain "set, run, restore-before-assert" sequence only
+/// protects against a panic in the assertions: it still leaks the override
+/// into every later test in this process if the guarded call itself panics
+/// or the run is interrupted between the set and the restore.
+struct RestoreGitConfigGlobal(std::ffi::OsString);
+
+impl RestoreGitConfigGlobal {
+    fn to(previous: impl Into<std::ffi::OsString>) -> Self {
+        Self(previous.into())
+    }
+}
+
+impl Drop for RestoreGitConfigGlobal {
+    fn drop(&mut self) {
+        // SAFETY: every caller of this guard is #[serial] (and nextest
+        // gives each test its own process), so nothing reads the
+        // environment concurrently while this runs.
+        unsafe { std::env::set_var("GIT_CONFIG_GLOBAL", &self.0) };
+    }
+}
+
 /// The read is deliberately unscoped: a value the user set in *global* scope is
 /// theirs and must be honoured, so we add nothing on top of it. Pins the intent
 /// that `isolate_git_config` would otherwise hide from every test here.
@@ -2287,10 +2291,11 @@ async fn ensure_notes_rewrite_ref_honours_a_users_global_value() {
     // SAFETY: `#[serial]` keeps this the only running test under `cargo test`,
     // and nextest gives each test its own process.
     unsafe { std::env::set_var("GIT_CONFIG_GLOBAL", &global) };
+    let _restore = RestoreGitConfigGlobal::to("/dev/null");
     let status = ensure_notes_rewrite_ref(Some(root)).await;
-    // Restore before asserting: a panic below would otherwise leak the global
-    // value into every later test in this process.
-    unsafe { std::env::set_var("GIT_CONFIG_GLOBAL", "/dev/null") };
+    // The guard above restores on drop, unconditionally: it already ran (or
+    // will run at end of scope) whether or not the call above panicked.
+    drop(_restore);
 
     assert_eq!(
         status,
@@ -2300,6 +2305,30 @@ async fn ensure_notes_rewrite_ref_honours_a_users_global_value() {
     assert!(
         rewrite_ref_values(root).is_empty(),
         "honouring the global value means writing no local one"
+    );
+}
+
+/// Proves `RestoreGitConfigGlobal`'s `Drop` runs on unwind, not just on the
+/// happy path: forces a panic between the guard's construction and where the
+/// old set/restore code used to sit, then confirms the value is back
+/// afterward. Backs the panic-safety fix for
+/// `ensure_notes_rewrite_ref_honours_a_users_global_value` above.
+#[test]
+#[serial]
+fn restore_git_config_global_guard_restores_after_a_panic() {
+    common::isolate_git_config();
+    unsafe { std::env::set_var("GIT_CONFIG_GLOBAL", "sentinel-before-panic") };
+
+    let result = std::panic::catch_unwind(|| {
+        let _restore = RestoreGitConfigGlobal::to("/dev/null");
+        panic!("simulated failure inside the guarded scope");
+    });
+
+    assert!(result.is_err(), "the closure must have actually panicked");
+    assert_eq!(
+        std::env::var("GIT_CONFIG_GLOBAL").as_deref(),
+        Ok("/dev/null"),
+        "the guard's Drop must run during unwind and restore the isolated value"
     );
 }
 

--- a/crates/spelunk-core/tests/integration_git_notes.rs
+++ b/crates/spelunk-core/tests/integration_git_notes.rs
@@ -2253,11 +2253,11 @@ async fn ensure_notes_rewrite_ref_composes_with_a_users_existing_value() {
     );
 }
 
-/// Restores `GIT_CONFIG_GLOBAL` to `previous` on drop, including during a
-/// panic unwind. A plain "set, run, restore-before-assert" sequence only
-/// protects against a panic in the assertions: it still leaks the override
-/// into every later test in this process if the guarded call itself panics
-/// or the run is interrupted between the set and the restore.
+// Restores `GIT_CONFIG_GLOBAL` to `previous` on drop, including during a
+// panic unwind. A plain "set, run, restore-before-assert" sequence only
+// protects against a panic in the assertions: it still leaks the override
+// into every later test in this process if the guarded call itself panics
+// or the run is interrupted between the set and the restore.
 struct RestoreGitConfigGlobal(std::ffi::OsString);
 
 impl RestoreGitConfigGlobal {
@@ -2308,11 +2308,11 @@ async fn ensure_notes_rewrite_ref_honours_a_users_global_value() {
     );
 }
 
-/// Proves `RestoreGitConfigGlobal`'s `Drop` runs on unwind, not just on the
-/// happy path: forces a panic between the guard's construction and where the
-/// old set/restore code used to sit, then confirms the value is back
-/// afterward. Backs the panic-safety fix for
-/// `ensure_notes_rewrite_ref_honours_a_users_global_value` above.
+// Proves `RestoreGitConfigGlobal`'s `Drop` runs on unwind, not just on the
+// happy path: forces a panic between the guard's construction and where the
+// old set/restore code used to sit, then confirms the value is back
+// afterward. Backs the panic-safety fix for
+// `ensure_notes_rewrite_ref_honours_a_users_global_value` above.
 #[test]
 #[serial]
 fn restore_git_config_global_guard_restores_after_a_panic() {

--- a/crates/spelunk-core/tests/worktree_index_resolution.rs
+++ b/crates/spelunk-core/tests/worktree_index_resolution.rs
@@ -20,10 +20,16 @@ use spelunk_core::config::find_project_db;
 use spelunk_core::utils::resolve_main_worktree_root;
 
 fn git(cwd: &std::path::Path, args: &[&str]) -> std::process::Output {
-    common::git_command(cwd)
+    let out = common::git_command(cwd)
         .args(args)
         .output()
-        .expect("git command")
+        .expect("git command");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
 }
 
 /// Compare two paths after canonicalising both, so a symlinked temp prefix
@@ -60,14 +66,9 @@ fn real_git_worktree_resolves_to_main_index() {
 
     // Add a REAL linked worktree; wt_root/.git becomes a gitdir file pointing at
     // <main>/.git/worktrees/feat-branch — the layout gix::discover resolves.
-    let out = git(
+    git(
         &main_root,
         &["worktree", "add", wt_root.to_str().unwrap(), "-b", "feat"],
-    );
-    assert!(
-        out.status.success(),
-        "git worktree add failed: {}",
-        String::from_utf8_lossy(&out.stderr)
     );
     assert!(
         wt_root.join(".git").is_file(),
@@ -141,5 +142,79 @@ fn real_git_worktree_resolves_to_main_index_survives_a_hostile_ambient_hooks_pat
     assert!(
         status.success(),
         "the child test failed under a hostile ambient GIT_CONFIG_GLOBAL: isolation did not shadow it"
+    );
+}
+
+/// Commits in a fresh repo with an explicit local `user.name`/`user.email`,
+/// then asserts the commit's author and committer came from that config, not
+/// from whatever `GIT_AUTHOR_*`/`GIT_COMMITTER_*` the process happened to
+/// inherit. Git resolves identity as env-vars-before-config, so a fabricated
+/// local `user.email` alone proves nothing about isolation; the strong
+/// assertion is that the *env* did not win.
+///
+/// Runs standalone (covers the ordinary case: no ambient poisoning, still
+/// green) and is also re-exec'd by the driver test below under a poisoned
+/// ambient environment, where a real gap would make this specific assertion
+/// fail rather than some unrelated step.
+#[test]
+fn git_command_commit_identity_matches_local_config_not_ambient_env() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    git(root, &["init", "-b", "main"]);
+    git(root, &["config", "user.email", "test@example.com"]);
+    git(root, &["config", "user.name", "Test"]);
+    std::fs::write(root.join("f.txt"), "hi").unwrap();
+    git(root, &["add", "."]);
+    git(
+        root,
+        &[
+            "commit",
+            "--no-gpg-sign",
+            "-m",
+            "init",
+            "--allow-empty-message",
+        ],
+    );
+
+    let out = git(root, &["log", "-1", "--format=%an <%ae>%n%cn <%ce>"]);
+    let identity = String::from_utf8_lossy(&out.stdout);
+    let mut lines = identity.lines();
+    let author = lines.next().unwrap_or_default();
+    let committer = lines.next().unwrap_or_default();
+    assert_eq!(
+        author, "Test <test@example.com>",
+        "commit author must come from the repo's own config, not an ambient GIT_AUTHOR_* override"
+    );
+    assert_eq!(
+        committer, "Test <test@example.com>",
+        "commit committer must come from the repo's own config, not an ambient GIT_COMMITTER_* override"
+    );
+}
+
+/// Proves the assertion above is not vacuous: re-execs the test binary as a
+/// fresh child process with `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/
+/// `GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` poisoned in the *ambient*
+/// environment (the way a CI runner's bot identity or a developer's shell
+/// profile might export them), and confirms the commit identity assertion
+/// above still passes, i.e. `isolate_git_config` genuinely clears these
+/// before the child's first git spawn rather than merely redirecting config
+/// files. Needs a fresh process for the same reason as the hooks-path
+/// driver above: `isolate_git_config`'s `Once` cannot retroactively unpoison
+/// an environment it already observed.
+#[test]
+fn git_command_commit_identity_survives_a_hostile_ambient_author_committer_env() {
+    let exe = std::env::current_exe().expect("current test binary");
+    let status = std::process::Command::new(exe)
+        .arg("git_command_commit_identity_matches_local_config_not_ambient_env")
+        .arg("--exact")
+        .env("GIT_AUTHOR_NAME", "Ambient Poison")
+        .env("GIT_AUTHOR_EMAIL", "poison@evil.example")
+        .env("GIT_COMMITTER_NAME", "Ambient Poison")
+        .env("GIT_COMMITTER_EMAIL", "poison@evil.example")
+        .status()
+        .expect("run self as a child process");
+    assert!(
+        status.success(),
+        "the child test failed under a hostile ambient GIT_AUTHOR_*/GIT_COMMITTER_* env: isolation did not shadow it"
     );
 }

--- a/crates/spelunk-core/tests/worktree_index_resolution.rs
+++ b/crates/spelunk-core/tests/worktree_index_resolution.rs
@@ -98,19 +98,19 @@ fn real_git_worktree_resolves_to_main_index() {
     same_path(&resolve_main_worktree_root(&sub), &main_root);
 }
 
-/// Proves the "fully hermetic" claim above is real, not aspirational: even
-/// when the *ambient* environment (as set before this test binary starts,
-/// which `isolate_git_config`'s process-wide `Once` cannot retroactively
-/// undo for a call that already ran) points `GIT_CONFIG_GLOBAL` at a global
-/// config whose `core.hooksPath` hook always fails, `real_git_worktree_resolves_to_main_index`
-/// still passes. `isolate_git_config` runs inside the child and overwrites
-/// the inherited value before the child's first git spawn.
-///
-/// This has to re-exec the test binary as a child process: `isolate_git_config`
-/// is a one-shot `Once` per process, so simulating a hostile *ambient* value
-/// from within an already-running test (which may run after some other test
-/// already initialised isolation) cannot exercise the pre-isolation state the
-/// way a fresh child process, given a hostile environment at start, can.
+// Proves the "fully hermetic" claim above is real, not aspirational: even
+// when the *ambient* environment (as set before this test binary starts,
+// which `isolate_git_config`'s process-wide `Once` cannot retroactively
+// undo for a call that already ran) points `GIT_CONFIG_GLOBAL` at a global
+// config whose `core.hooksPath` hook always fails, `real_git_worktree_resolves_to_main_index`
+// still passes. `isolate_git_config` runs inside the child and overwrites
+// the inherited value before the child's first git spawn.
+//
+// This has to re-exec the test binary as a child process: `isolate_git_config`
+// is a one-shot `Once` per process, so simulating a hostile *ambient* value
+// from within an already-running test (which may run after some other test
+// already initialised isolation) cannot exercise the pre-isolation state the
+// way a fresh child process, given a hostile environment at start, can.
 #[test]
 fn real_git_worktree_resolves_to_main_index_survives_a_hostile_ambient_hooks_path() {
     let hostile = tempfile::TempDir::new().expect("tempdir");
@@ -145,17 +145,17 @@ fn real_git_worktree_resolves_to_main_index_survives_a_hostile_ambient_hooks_pat
     );
 }
 
-/// Commits in a fresh repo with an explicit local `user.name`/`user.email`,
-/// then asserts the commit's author and committer came from that config, not
-/// from whatever `GIT_AUTHOR_*`/`GIT_COMMITTER_*` the process happened to
-/// inherit. Git resolves identity as env-vars-before-config, so a fabricated
-/// local `user.email` alone proves nothing about isolation; the strong
-/// assertion is that the *env* did not win.
-///
-/// Runs standalone (covers the ordinary case: no ambient poisoning, still
-/// green) and is also re-exec'd by the driver test below under a poisoned
-/// ambient environment, where a real gap would make this specific assertion
-/// fail rather than some unrelated step.
+// Commits in a fresh repo with an explicit local `user.name`/`user.email`,
+// then asserts the commit's author and committer came from that config, not
+// from whatever `GIT_AUTHOR_*`/`GIT_COMMITTER_*` the process happened to
+// inherit. Git resolves identity as env-vars-before-config, so a fabricated
+// local `user.email` alone proves nothing about isolation; the strong
+// assertion is that the *env* did not win.
+//
+// Runs standalone (covers the ordinary case: no ambient poisoning, still
+// green) and is also re-exec'd by the driver test below under a poisoned
+// ambient environment, where a real gap would make this specific assertion
+// fail rather than some unrelated step.
 #[test]
 fn git_command_commit_identity_matches_local_config_not_ambient_env() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -191,16 +191,16 @@ fn git_command_commit_identity_matches_local_config_not_ambient_env() {
     );
 }
 
-/// Proves the assertion above is not vacuous: re-execs the test binary as a
-/// fresh child process with `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/
-/// `GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` poisoned in the *ambient*
-/// environment (the way a CI runner's bot identity or a developer's shell
-/// profile might export them), and confirms the commit identity assertion
-/// above still passes, i.e. `isolate_git_config` genuinely clears these
-/// before the child's first git spawn rather than merely redirecting config
-/// files. Needs a fresh process for the same reason as the hooks-path
-/// driver above: `isolate_git_config`'s `Once` cannot retroactively unpoison
-/// an environment it already observed.
+// Proves the assertion above is not vacuous: re-execs the test binary as a
+// fresh child process with `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL`/
+// `GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` poisoned in the *ambient*
+// environment (the way a CI runner's bot identity or a developer's shell
+// profile might export them), and confirms the commit identity assertion
+// above still passes, i.e. `isolate_git_config` genuinely clears these
+// before the child's first git spawn rather than merely redirecting config
+// files. Needs a fresh process for the same reason as the hooks-path
+// driver above: `isolate_git_config`'s `Once` cannot retroactively unpoison
+// an environment it already observed.
 #[test]
 fn git_command_commit_identity_survives_a_hostile_ambient_author_committer_env() {
     let exe = std::env::current_exe().expect("current test binary");

--- a/crates/spelunk-core/tests/worktree_index_resolution.rs
+++ b/crates/spelunk-core/tests/worktree_index_resolution.rs
@@ -8,16 +8,20 @@
 //! covered end to end. It also guards the real-path shape gix returns (e.g. the
 //! macOS `/var` → `/private/var` symlink), which string-only fixtures cannot.
 //!
-//! Requires `git` on PATH; fully hermetic (everything lives under a TempDir that
-//! is removed on drop, taking the linked worktree with it — no orphans).
+//! Requires `git` on PATH; fully hermetic: everything lives under a TempDir
+//! that is removed on drop, taking the linked worktree with it (no orphans),
+//! and every git spawn goes through `common::git_command`, which shadows the
+//! developer's ambient global/system git config, so an ambient `core.hooksPath`
+//! or `commit.gpgsign` can never reach these setup commands either.
+
+mod common;
 
 use spelunk_core::config::find_project_db;
 use spelunk_core::utils::resolve_main_worktree_root;
 
 fn git(cwd: &std::path::Path, args: &[&str]) -> std::process::Output {
-    std::process::Command::new("git")
+    common::git_command(cwd)
         .args(args)
-        .current_dir(cwd)
         .output()
         .expect("git command")
 }
@@ -91,4 +95,51 @@ fn real_git_worktree_resolves_to_main_index() {
     let sub = wt_root.join("nested").join("dir");
     std::fs::create_dir_all(&sub).unwrap();
     same_path(&resolve_main_worktree_root(&sub), &main_root);
+}
+
+/// Proves the "fully hermetic" claim above is real, not aspirational: even
+/// when the *ambient* environment (as set before this test binary starts,
+/// which `isolate_git_config`'s process-wide `Once` cannot retroactively
+/// undo for a call that already ran) points `GIT_CONFIG_GLOBAL` at a global
+/// config whose `core.hooksPath` hook always fails, `real_git_worktree_resolves_to_main_index`
+/// still passes. `isolate_git_config` runs inside the child and overwrites
+/// the inherited value before the child's first git spawn.
+///
+/// This has to re-exec the test binary as a child process: `isolate_git_config`
+/// is a one-shot `Once` per process, so simulating a hostile *ambient* value
+/// from within an already-running test (which may run after some other test
+/// already initialised isolation) cannot exercise the pre-isolation state the
+/// way a fresh child process, given a hostile environment at start, can.
+#[test]
+fn real_git_worktree_resolves_to_main_index_survives_a_hostile_ambient_hooks_path() {
+    let hostile = tempfile::TempDir::new().expect("tempdir");
+    let hooks_dir = hostile.path().join("hooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    for hook in ["pre-commit", "post-checkout", "post-commit"] {
+        let path = hooks_dir.join(hook);
+        std::fs::write(&path, "#!/bin/sh\nexit 1\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+    let global_config = hostile.path().join("gitconfig");
+    std::fs::write(
+        &global_config,
+        format!("[core]\n\thooksPath = {}\n", hooks_dir.display()),
+    )
+    .unwrap();
+
+    let exe = std::env::current_exe().expect("current test binary");
+    let status = std::process::Command::new(exe)
+        .arg("real_git_worktree_resolves_to_main_index")
+        .arg("--exact")
+        .env("GIT_CONFIG_GLOBAL", &global_config)
+        .status()
+        .expect("run self as a child process");
+    assert!(
+        status.success(),
+        "the child test failed under a hostile ambient GIT_CONFIG_GLOBAL: isolation did not shadow it"
+    );
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -159,10 +159,19 @@ ambient config exists.
 
 Every test that spawns git must call an `isolate_git_config()` helper
 first. It sets `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `/dev/null`
-for the whole process, guarded by `std::sync::Once` so it is safe to call
-from every test. The isolation must be process-wide, not scoped to one
-`Command`: a helper that only sets env on the `Command` it builds itself
-never reaches git that the code under test spawns for itself.
+for the whole process, and clears `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`:
+git resolves commit identity from those env vars before it consults config
+at all, so they can override a test's own explicit `git config
+user.name`/`user.email` unless cleared too. Guarded by `std::sync::Once` so
+it is safe to call from every test. The isolation must be process-wide, not
+scoped to one `Command`: a helper that only sets env on the `Command` it
+builds itself never reaches git that the code under test spawns for itself.
+
+For `spelunk-core` integration tests, prefer `common::git_command(cwd)` over
+calling `isolate_git_config()` and `std::process::Command::new("git")`
+separately: it bakes the isolation call into the `Command` it returns, so a
+new test file cannot construct an un-isolated one by forgetting the setup
+step.
 
 Four call sites carry a copy of the same helper, because a unit test
 compiled into `src/` cannot reach a file under `tests/`, and each `tests/`
@@ -173,12 +182,18 @@ integration binary is its own compilation unit:
 | `crates/spelunk-cli/tests/plumbing_helpers.rs` | `tests/` integration binaries for `spelunk-cli` |
 | `crates/spelunk-cli/src/cli/cmd/test_support.rs` | `src/` unit tests for `spelunk-cli` |
 | `crates/spelunk-core/src/storage/git_notes/mod.rs` (local to the `cat_file_batch` test module) | `spelunk-core` unit tests |
-| `crates/spelunk-core/tests/integration_git_notes.rs` | `spelunk-core`'s git-notes integration tests |
+| `crates/spelunk-core/tests/common/mod.rs` (also exports `git_command`) | `spelunk-core`'s `tests/` integration binaries |
 
-CI runners carry no ambient global config, so a missing call here never
-fails CI. It only surfaces as a local test failure for a contributor who
-has one of these settings configured globally, with no indication of the
-cause.
+`scripts/check-git-isolation.sh` runs as the first step of CI's Check & Lint
+job and fails the build if a test file spawns `git` (`Command::new("git")`,
+however wrapped, whitespaced, or aliased) without wiring in one of the
+above: a definition or call of `isolate_git_config`, a call to
+`git_command`, or a `mod common;`/`mod plumbing_helpers;` import of the
+fixture module. It's a grep-based heuristic, not a parser (see the script's
+own header comment for exact scope and known blind spots, e.g. it can't
+trace a spawn reached through a variable), but it catches the case that
+used to slip through silently: a new test file that spawns git and forgets
+isolation entirely.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -173,16 +173,32 @@ separately: it bakes the isolation call into the `Command` it returns, so a
 new test file cannot construct an un-isolated one by forgetting the setup
 step.
 
-Four call sites carry a copy of the same helper, because a unit test
-compiled into `src/` cannot reach a file under `tests/`, and each `tests/`
-integration binary is its own compilation unit:
+`isolate_git_config`/`git_command` have exactly two definitions, both in
+`spelunk-core`, one per side of the `src`/`tests` compilation boundary:
 
 | Location | Covers |
 |------|---------------|
-| `crates/spelunk-cli/tests/plumbing_helpers.rs` | `tests/` integration binaries for `spelunk-cli` |
-| `crates/spelunk-cli/src/cli/cmd/test_support.rs` | `src/` unit tests for `spelunk-cli` |
-| `crates/spelunk-core/src/storage/git_notes/mod.rs` (local to the `cat_file_batch` test module) | `spelunk-core` unit tests |
+| `crates/spelunk-core/src/test_support.rs` (module gated `#[cfg(any(test, feature = "test-support"))]`) | `spelunk-core`'s own `#[cfg(test)]` unit tests, and any downstream crate that enables the `test-support` feature |
 | `crates/spelunk-core/tests/common/mod.rs` (also exports `git_command`) | `spelunk-core`'s `tests/` integration binaries |
+
+`spelunk-cli` has no independent copy: `src/cli/cmd/test_support.rs` and
+`tests/plumbing_helpers.rs` both `pub use spelunk_core::test_support::isolate_git_config`,
+reaching it via a `spelunk-core = { path = "../spelunk-core", features =
+["test-support"] }` dev-dependency (the same pattern
+`config::secret_store::MemoryStore` already used for a src/tests-shared test
+double before this).
+
+Two, not one, because `spelunk-core`'s own `tests/` integration binaries link
+the crate externally and can't reach a `#[cfg(test)]`-gated `src/` item
+without a *self-referencing* dev-dependency
+(`spelunk-core = { path = ".", features = ["test-support"] }` inside
+`spelunk-core`'s own `Cargo.toml`). That was tried: it compiles and passes
+against an isolated target dir, but this repo's pre-commit hook points
+`CARGO_TARGET_DIR` at the shared `target/` used by every worktree, and
+building against that shared dir (last built from a different `Cargo.lock`)
+fails with `unresolved import spelunk_core::test_support`. The
+`tests/common/mod.rs` duplicate is the real floor given that constraint, not
+an oversight.
 
 `scripts/check-git-isolation.sh` runs as the first step of CI's Check & Lint
 job and fails the build if a test file spawns `git` (`Command::new("git")`,

--- a/scripts/check-git-isolation.sh
+++ b/scripts/check-git-isolation.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Fails if any test code spawns `git` (`Command::new("git")`) without wiring
+# in this repo's git-config isolation fixture first.
+#
+# Background: the test suite hides the developer's ambient global/system git
+# config from every `git` a test process spawns, via `GIT_CONFIG_GLOBAL` /
+# `GIT_CONFIG_SYSTEM=/dev/null` set process-wide behind a `std::sync::Once`
+# (see `isolate_git_config()` in the locations below). That mechanism is
+# sound, but nothing stops a *new* test file from spawning `git` and simply
+# forgetting to wire it in: `crates/spelunk-core/tests/worktree_index_resolution.rs`
+# did exactly that despite its own doc-comment claiming to be "fully
+# hermetic". This script is the structural backstop: it does not make an
+# un-isolated `git` spawn a compile error, but it does make it a CI failure.
+#
+# Scope and heuristic:
+#   - `crates/*/tests/*.rs` (excluding `tests/common/` and `tests/fixtures/`):
+#     each file is its own integration-test binary, entirely test code, so a
+#     whole-file check is sound: if it spawns git anywhere in the file, it
+#     must wire in isolation somewhere in the same file.
+#   - `crates/*/src/**/*.rs`: only a trailing `#[cfg(test)] mod tests { ... }`
+#     block is test code: the rest of the file is production code that
+#     legitimately spawns un-isolated git (e.g. the CLI's own `git notes`
+#     plumbing). This script checks from the first `#[cfg(test)]` line to
+#     EOF, which holds for every file in this repo today (the test module is
+#     always the last item) but is a heuristic, not a parser: a file that
+#     stops following that convention could produce a wrong verdict either
+#     way, so keep the test module last.
+#
+# "Wired in isolation" means the checked region contains one of:
+#   - a definition of `isolate_git_config` (the file itself IS a canonical
+#     helper), or
+#   - a call to it, however qualified (`isolate_git_config()`,
+#     `common::isolate_git_config()`, ...), or
+#   - a call to `common::git_command`/`git_command(` (a constructor that
+#     bakes the call in), or
+#   - `mod common;` or `mod plumbing_helpers;`, importing the shared
+#     fixture module, whose exported constructors call isolate_git_config
+#     internally.
+#
+# Usage:
+#   scripts/check-git-isolation.sh [root-dir]   # default root-dir: repo root
+#   scripts/check-git-isolation.sh --self-test  # regression-tests this script
+set -euo pipefail
+
+ISOLATION_MARKER='fn isolate_git_config|isolate_git_config\(|git_command\(|mod common;|mod plumbing_helpers;'
+
+# Prints an error and sets $fail=1 if `$region` spawns git without an
+# isolation marker. $1 is the human-readable label for the offending region.
+check_region() {
+  local label="$1" region="$2"
+
+  if ! grep -q 'Command::new("git")' <<<"$region"; then
+    return 0
+  fi
+  if grep -qE "$ISOLATION_MARKER" <<<"$region"; then
+    return 0
+  fi
+
+  echo "ERROR: $label spawns \`git\` via Command::new(\"git\") without wiring in git-config isolation" >&2
+  echo "  (expected a call to isolate_git_config()/git_command(), or a \`mod common;\`/\`mod plumbing_helpers;\` import of the shared fixture)" >&2
+  fail=1
+}
+
+run_check() {
+  local root="$1"
+  fail=0
+
+  # Integration test binaries: the whole file is test code.
+  while IFS= read -r -d '' f; do
+    check_region "$f" "$(cat "$f")"
+  done < <(find "$root/crates" -path '*/tests/*.rs' \
+    -not -path '*/tests/common/*' -not -path '*/tests/fixtures/*' \
+    -print0 2>/dev/null)
+
+  # In-crate unit tests: only the trailing `#[cfg(test)] mod tests { ... }`
+  # block is test code (see header comment for the "to EOF" assumption).
+  while IFS= read -r -d '' f; do
+    if grep -q '^#\[cfg(test)\]' "$f"; then
+      check_region "$f (#[cfg(test)] region)" "$(sed -n '/^#\[cfg(test)\]/,$p' "$f")"
+    fi
+  done < <(find "$root/crates" -path '*/src/*.rs' -print0 2>/dev/null)
+
+  return "$fail"
+}
+
+self_test() {
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp:-}"' EXIT
+
+  mkdir -p "$tmp/crates/fake-crate/tests" "$tmp/crates/fake-crate/src"
+
+  # Bad: spawns git, no isolation marker anywhere in the file.
+  cat >"$tmp/crates/fake-crate/tests/bad.rs" <<'EOF'
+#[test]
+fn spawns_git_unisolated() {
+    std::process::Command::new("git").arg("status").status().unwrap();
+}
+EOF
+
+  # Good: spawns git, but wires in the shared fixture module first.
+  cat >"$tmp/crates/fake-crate/tests/good.rs" <<'EOF'
+mod common;
+
+#[test]
+fn spawns_git_isolated() {
+    common::isolate_git_config();
+    std::process::Command::new("git").arg("status").status().unwrap();
+}
+EOF
+
+  # Unrelated: no git spawn at all, must never be flagged.
+  cat >"$tmp/crates/fake-crate/tests/unrelated.rs" <<'EOF'
+#[test]
+fn does_nothing_with_git() {
+    assert_eq!(2 + 2, 4);
+}
+EOF
+
+  # src/-side: production code spawns git freely above the test module;
+  # only the un-isolated spawn *inside* `#[cfg(test)]` must be flagged.
+  cat >"$tmp/crates/fake-crate/src/lib.rs" <<'EOF'
+pub fn production_git_spawn() {
+    std::process::Command::new("git").arg("rev-parse").status().unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn spawns_git_unisolated_in_test_module() {
+        std::process::Command::new("git").arg("status").status().unwrap();
+    }
+}
+EOF
+
+  local failures=0
+
+  if run_check "$tmp" 2>/tmp/self_test_out; then
+    echo "SELF-TEST FAIL: run_check should have failed on the bad fixtures, but exited 0" >&2
+    failures=1
+  else
+    if ! grep -q 'tests/bad.rs' /tmp/self_test_out; then
+      echo "SELF-TEST FAIL: bad.rs was not flagged" >&2
+      failures=1
+    fi
+    if ! grep -q 'src/lib.rs' /tmp/self_test_out; then
+      echo "SELF-TEST FAIL: the un-isolated #[cfg(test)] spawn in lib.rs was not flagged" >&2
+      failures=1
+    fi
+    if grep -q 'tests/good.rs' /tmp/self_test_out; then
+      echo "SELF-TEST FAIL: good.rs (isolated) was incorrectly flagged" >&2
+      failures=1
+    fi
+    if grep -q 'tests/unrelated.rs' /tmp/self_test_out; then
+      echo "SELF-TEST FAIL: unrelated.rs (no git spawn) was incorrectly flagged" >&2
+      failures=1
+    fi
+  fi
+
+  # Now remove the bad fixtures and confirm a clean tree passes.
+  rm "$tmp/crates/fake-crate/tests/bad.rs"
+  sed -i.bak '/^#\[cfg(test)\]/,$d' "$tmp/crates/fake-crate/src/lib.rs" && rm -f "$tmp/crates/fake-crate/src/lib.rs.bak"
+  if ! run_check "$tmp" 2>/tmp/self_test_out2; then
+    echo "SELF-TEST FAIL: run_check should pass once the un-isolated spawns are removed" >&2
+    cat /tmp/self_test_out2 >&2
+    failures=1
+  fi
+
+  if [ "$failures" -eq 0 ]; then
+    echo "check-git-isolation self-test: OK"
+    return 0
+  else
+    return 1
+  fi
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit $?
+fi
+
+root="${1:-.}"
+if run_check "$root"; then
+  echo "check-git-isolation: OK"
+  exit 0
+else
+  echo "" >&2
+  echo "See crates/spelunk-core/tests/common/mod.rs::isolate_git_config and crates/spelunk-cli/tests/plumbing_helpers.rs::isolate_git_config." >&2
+  exit 1
+fi

--- a/scripts/check-git-isolation.sh
+++ b/scripts/check-git-isolation.sh
@@ -10,7 +10,7 @@
 #     file, since each is entirely test code.
 #   - crates/*/src/**/*.rs: only the trailing `#[cfg(test)] mod tests { .. }`
 #     block, checked from the first `#[cfg(test)]` line to EOF. Assumes the
-#     test module is last in the file (true today) — keep it that way, or
+#     test module is last in the file (true today): keep it that way, or
 #     this can misjudge production code as tests or vice versa.
 #
 # Blind spot: a spawn reached through a variable (`let bin = "git";

--- a/scripts/check-git-isolation.sh
+++ b/scripts/check-git-isolation.sh
@@ -1,81 +1,39 @@
 #!/usr/bin/env bash
-# Fails if any test code spawns `git` (`Command::new("git")`) without wiring
-# in this repo's git-config isolation fixture first.
+# Fails if a test spawns `git` without wiring in this repo's isolation
+# fixture (`isolate_git_config`/`git_command` in `spelunk_core::test_support`).
+# Structural backstop for a gap that's otherwise silent: a missing call still
+# passes on a clean machine, and only misbehaves on one with an ambient
+# `core.hooksPath`/`commit.gpgsign`/etc.
 #
-# Background: the test suite hides the developer's ambient global/system git
-# config from every `git` a test process spawns, via `GIT_CONFIG_GLOBAL` /
-# `GIT_CONFIG_SYSTEM=/dev/null` set process-wide behind a `std::sync::Once`
-# (see `isolate_git_config()` in the locations below). That mechanism is
-# sound, but nothing stops a *new* test file from spawning `git` and simply
-# forgetting to wire it in: `crates/spelunk-core/tests/worktree_index_resolution.rs`
-# did exactly that despite its own doc-comment claiming to be "fully
-# hermetic". This script is the structural backstop: it does not make an
-# un-isolated `git` spawn a compile error, but it does make it a CI failure.
+# Scope:
+#   - crates/*/tests/*.rs (excluding tests/common, tests/fixtures): whole
+#     file, since each is entirely test code.
+#   - crates/*/src/**/*.rs: only the trailing `#[cfg(test)] mod tests { .. }`
+#     block, checked from the first `#[cfg(test)]` line to EOF. Assumes the
+#     test module is last in the file (true today) — keep it that way, or
+#     this can misjudge production code as tests or vice versa.
 #
-# Scope and heuristic:
-#   - `crates/*/tests/*.rs` (excluding `tests/common/` and `tests/fixtures/`):
-#     each file is its own integration-test binary, entirely test code, so a
-#     whole-file check is sound: if it spawns git anywhere in the file, it
-#     must wire in isolation somewhere in the same file.
-#   - `crates/*/src/**/*.rs`: only a trailing `#[cfg(test)] mod tests { ... }`
-#     block is test code: the rest of the file is production code that
-#     legitimately spawns un-isolated git (e.g. the CLI's own `git notes`
-#     plumbing). This script checks from the first `#[cfg(test)]` line to
-#     EOF, which holds for every file in this repo today (the test module is
-#     always the last item) but is a heuristic, not a parser: a file that
-#     stops following that convention could produce a wrong verdict either
-#     way, so keep the test module last.
-#
-# "Wired in isolation" means the checked region contains one of:
-#   - a definition of `isolate_git_config` (the file itself IS a canonical
-#     helper), or
-#   - a call to it, however qualified (`isolate_git_config()`,
-#     `common::isolate_git_config()`, ...), or
-#   - a call to `common::git_command`/`git_command(` (a constructor that
-#     bakes the call in), or
-#   - `mod common;` or `mod plumbing_helpers;`, importing the shared
-#     fixture module, whose exported constructors call isolate_git_config
-#     internally.
-#
-# Known limitation (accepted, not fixable by a grep-based lint): a spawn
-# reached through a variable or an argument built elsewhere, e.g.
-# `let bin = "git"; Command::new(bin)`, has no literal `"git"` string next to
-# the `new(` call and is invisible to this script. Catching that needs real
-# dataflow analysis (a clippy lint or similar), which the story this script
-# was added for explicitly scoped out ("a grep/xtask lint is enough, no need
-# for a custom clippy lint"). Detected instead: the `new("git")` call itself,
-# tolerant of whatever type path prefixes `::new` (`Command::new("git")`,
-# `std::process::Command::new("git")`, a renamed `use ... as X; X::new("git")`
-# import, ...) and of whitespace/line-wrapping between the tokens (e.g.
-# rustfmt breaking a long call across lines).
+# Blind spot: a spawn reached through a variable (`let bin = "git";
+# Command::new(bin)`) has no literal `"git"` next to `new(` and is invisible
+# to this grep-based check. Needs real dataflow analysis; out of scope here.
 #
 # Usage:
-#   scripts/check-git-isolation.sh [root-dir]   # default root-dir: repo root
+#   scripts/check-git-isolation.sh [root-dir]   # default: repo root
 #   scripts/check-git-isolation.sh --self-test  # regression-tests this script
 set -euo pipefail
 
 ISOLATION_MARKER='fn isolate_git_config|isolate_git_config\(|git_command\(|mod common;|mod plumbing_helpers;'
-# Matches `<AnyPath>::new("git")` regardless of the type-path prefix (so a
-# `use std::process::Command as Proc;` alias is still caught), after
-# whitespace/newlines between tokens have been collapsed to single spaces
-# below. `[A-Za-z_][A-Za-z0-9_]*::new` requires the call to end in `::new`,
-# which every `Command`-constructing path does (`Command::new`,
-# `process::Command::new`, `Proc::new`, ...). The trailing `,?` allows for
-# rustfmt's trailing comma when a single-argument call gets line-wrapped
-# (`Command::new(\n    "git",\n)`).
+
+# Matches `<Path>::new("git")` for any type-path prefix (covers a renamed
+# `Command` import), tolerant of whitespace/line-wraps from rustfmt.
 GIT_SPAWN_PATTERN='[A-Za-z_][A-Za-z0-9_]*::new *\( *"git" *,? *\)'
 
-# Prints an error and sets $fail=1 if `$region` spawns git without an
-# isolation marker. $1 is the human-readable label for the offending region.
+# Sets $fail=1 and prints an error if `$region` spawns git without an
+# isolation marker. Whitespace is collapsed before matching so a
+# rustfmt-wrapped call still matches as one line; markers are checked against
+# the original (uncollapsed) text.
 check_region() {
   local label="$1" region="$2"
-  # Collapse all whitespace (including newlines) to single spaces so a
-  # call split across lines by rustfmt, or with incidental extra spacing,
-  # still matches as a single-line pattern below. Isolation markers are
-  # checked against the original (uncollapsed) region: they're simple
-  # single-token/single-line calls in every case this repo uses, and
-  # collapsing would make the label/context in a future error message less
-  # useful for no benefit.
   local collapsed
   collapsed="$(tr -s '[:space:]' ' ' <<<"$region")"
 
@@ -119,7 +77,7 @@ self_test() {
 
   mkdir -p "$tmp/crates/fake-crate/tests" "$tmp/crates/fake-crate/src"
 
-  # Bad: spawns git, no isolation marker anywhere in the file.
+  # No isolation marker anywhere in the file: must be flagged.
   cat >"$tmp/crates/fake-crate/tests/bad.rs" <<'EOF'
 #[test]
 fn spawns_git_unisolated() {
@@ -127,9 +85,8 @@ fn spawns_git_unisolated() {
 }
 EOF
 
-  # Bad: same, but the call is wrapped across lines the way rustfmt would
-  # when the surrounding call gets long. A naive single-line literal-string
-  # grep for `Command::new("git")` misses this entirely.
+  # rustfmt-style line-wrapped call: a naive single-line literal-string grep
+  # misses this.
   cat >"$tmp/crates/fake-crate/tests/bad_multiline.rs" <<'EOF'
 #[test]
 fn spawns_git_unisolated_multiline() {
@@ -142,7 +99,7 @@ fn spawns_git_unisolated_multiline() {
 }
 EOF
 
-  # Bad: same, but with incidental extra whitespace inside the parens.
+  # Incidental extra whitespace inside the parens.
   cat >"$tmp/crates/fake-crate/tests/bad_whitespace.rs" <<'EOF'
 #[test]
 fn spawns_git_unisolated_whitespace() {
@@ -150,8 +107,7 @@ fn spawns_git_unisolated_whitespace() {
 }
 EOF
 
-  # Bad: same, but via a renamed import, so the literal substring
-  # `Command::new(` never appears in the file at all.
+  # Renamed import: the literal substring `Command::new(` never appears.
   cat >"$tmp/crates/fake-crate/tests/bad_alias.rs" <<'EOF'
 use std::process::Command as Proc;
 #[test]
@@ -160,7 +116,7 @@ fn spawns_git_unisolated_alias() {
 }
 EOF
 
-  # Good: spawns git, but wires in the shared fixture module first.
+  # Wires in the shared fixture module first: must not be flagged.
   cat >"$tmp/crates/fake-crate/tests/good.rs" <<'EOF'
 mod common;
 
@@ -171,7 +127,7 @@ fn spawns_git_isolated() {
 }
 EOF
 
-  # Unrelated: no git spawn at all, must never be flagged.
+  # No git spawn at all: must never be flagged.
   cat >"$tmp/crates/fake-crate/tests/unrelated.rs" <<'EOF'
 #[test]
 fn does_nothing_with_git() {
@@ -179,8 +135,8 @@ fn does_nothing_with_git() {
 }
 EOF
 
-  # src/-side: production code spawns git freely above the test module;
-  # only the un-isolated spawn *inside* `#[cfg(test)]` must be flagged.
+  # Production code spawns git freely above the test module; only the
+  # un-isolated spawn *inside* `#[cfg(test)]` must be flagged.
   cat >"$tmp/crates/fake-crate/src/lib.rs" <<'EOF'
 pub fn production_git_spawn() {
     std::process::Command::new("git").arg("rev-parse").status().unwrap();
@@ -262,6 +218,6 @@ if run_check "$root"; then
   exit 0
 else
   echo "" >&2
-  echo "See crates/spelunk-core/tests/common/mod.rs::isolate_git_config and crates/spelunk-cli/tests/plumbing_helpers.rs::isolate_git_config." >&2
+  echo "See crates/spelunk-core/src/test_support.rs::isolate_git_config (the one canonical definition)." >&2
   exit 1
 fi

--- a/scripts/check-git-isolation.sh
+++ b/scripts/check-git-isolation.sh
@@ -37,26 +37,56 @@
 #     fixture module, whose exported constructors call isolate_git_config
 #     internally.
 #
+# Known limitation (accepted, not fixable by a grep-based lint): a spawn
+# reached through a variable or an argument built elsewhere, e.g.
+# `let bin = "git"; Command::new(bin)`, has no literal `"git"` string next to
+# the `new(` call and is invisible to this script. Catching that needs real
+# dataflow analysis (a clippy lint or similar), which the story this script
+# was added for explicitly scoped out ("a grep/xtask lint is enough, no need
+# for a custom clippy lint"). Detected instead: the `new("git")` call itself,
+# tolerant of whatever type path prefixes `::new` (`Command::new("git")`,
+# `std::process::Command::new("git")`, a renamed `use ... as X; X::new("git")`
+# import, ...) and of whitespace/line-wrapping between the tokens (e.g.
+# rustfmt breaking a long call across lines).
+#
 # Usage:
 #   scripts/check-git-isolation.sh [root-dir]   # default root-dir: repo root
 #   scripts/check-git-isolation.sh --self-test  # regression-tests this script
 set -euo pipefail
 
 ISOLATION_MARKER='fn isolate_git_config|isolate_git_config\(|git_command\(|mod common;|mod plumbing_helpers;'
+# Matches `<AnyPath>::new("git")` regardless of the type-path prefix (so a
+# `use std::process::Command as Proc;` alias is still caught), after
+# whitespace/newlines between tokens have been collapsed to single spaces
+# below. `[A-Za-z_][A-Za-z0-9_]*::new` requires the call to end in `::new`,
+# which every `Command`-constructing path does (`Command::new`,
+# `process::Command::new`, `Proc::new`, ...). The trailing `,?` allows for
+# rustfmt's trailing comma when a single-argument call gets line-wrapped
+# (`Command::new(\n    "git",\n)`).
+GIT_SPAWN_PATTERN='[A-Za-z_][A-Za-z0-9_]*::new *\( *"git" *,? *\)'
 
 # Prints an error and sets $fail=1 if `$region` spawns git without an
 # isolation marker. $1 is the human-readable label for the offending region.
 check_region() {
   local label="$1" region="$2"
+  # Collapse all whitespace (including newlines) to single spaces so a
+  # call split across lines by rustfmt, or with incidental extra spacing,
+  # still matches as a single-line pattern below. Isolation markers are
+  # checked against the original (uncollapsed) region: they're simple
+  # single-token/single-line calls in every case this repo uses, and
+  # collapsing would make the label/context in a future error message less
+  # useful for no benefit.
+  local collapsed
+  collapsed="$(tr -s '[:space:]' ' ' <<<"$region")"
 
-  if ! grep -q 'Command::new("git")' <<<"$region"; then
+  if ! grep -qE "$GIT_SPAWN_PATTERN" <<<"$collapsed"; then
     return 0
   fi
   if grep -qE "$ISOLATION_MARKER" <<<"$region"; then
     return 0
   fi
 
-  echo "ERROR: $label spawns \`git\` via Command::new(\"git\") without wiring in git-config isolation" >&2
+  echo "ERROR: $label spawns \`git\` via a \`*::new(\"git\")\` call without wiring in git-config isolation" >&2
   echo "  (expected a call to isolate_git_config()/git_command(), or a \`mod common;\`/\`mod plumbing_helpers;\` import of the shared fixture)" >&2
   fail=1
 }
@@ -94,6 +124,39 @@ self_test() {
 #[test]
 fn spawns_git_unisolated() {
     std::process::Command::new("git").arg("status").status().unwrap();
+}
+EOF
+
+  # Bad: same, but the call is wrapped across lines the way rustfmt would
+  # when the surrounding call gets long. A naive single-line literal-string
+  # grep for `Command::new("git")` misses this entirely.
+  cat >"$tmp/crates/fake-crate/tests/bad_multiline.rs" <<'EOF'
+#[test]
+fn spawns_git_unisolated_multiline() {
+    std::process::Command::new(
+        "git",
+    )
+    .arg("status")
+    .status()
+    .unwrap();
+}
+EOF
+
+  # Bad: same, but with incidental extra whitespace inside the parens.
+  cat >"$tmp/crates/fake-crate/tests/bad_whitespace.rs" <<'EOF'
+#[test]
+fn spawns_git_unisolated_whitespace() {
+    std::process::Command::new( "git" ).arg("status").status().unwrap();
+}
+EOF
+
+  # Bad: same, but via a renamed import, so the literal substring
+  # `Command::new(` never appears in the file at all.
+  cat >"$tmp/crates/fake-crate/tests/bad_alias.rs" <<'EOF'
+use std::process::Command as Proc;
+#[test]
+fn spawns_git_unisolated_alias() {
+    Proc::new("git").arg("status").status().unwrap();
 }
 EOF
 
@@ -142,6 +205,18 @@ EOF
       echo "SELF-TEST FAIL: bad.rs was not flagged" >&2
       failures=1
     fi
+    if ! grep -q 'tests/bad_multiline.rs' /tmp/self_test_out; then
+      echo "SELF-TEST FAIL: bad_multiline.rs (line-wrapped call) was not flagged" >&2
+      failures=1
+    fi
+    if ! grep -q 'tests/bad_whitespace.rs' /tmp/self_test_out; then
+      echo "SELF-TEST FAIL: bad_whitespace.rs (extra spacing) was not flagged" >&2
+      failures=1
+    fi
+    if ! grep -q 'tests/bad_alias.rs' /tmp/self_test_out; then
+      echo "SELF-TEST FAIL: bad_alias.rs (renamed Command import) was not flagged" >&2
+      failures=1
+    fi
     if ! grep -q 'src/lib.rs' /tmp/self_test_out; then
       echo "SELF-TEST FAIL: the un-isolated #[cfg(test)] spawn in lib.rs was not flagged" >&2
       failures=1
@@ -157,7 +232,10 @@ EOF
   fi
 
   # Now remove the bad fixtures and confirm a clean tree passes.
-  rm "$tmp/crates/fake-crate/tests/bad.rs"
+  rm "$tmp/crates/fake-crate/tests/bad.rs" \
+    "$tmp/crates/fake-crate/tests/bad_multiline.rs" \
+    "$tmp/crates/fake-crate/tests/bad_whitespace.rs" \
+    "$tmp/crates/fake-crate/tests/bad_alias.rs"
   sed -i.bak '/^#\[cfg(test)\]/,$d' "$tmp/crates/fake-crate/src/lib.rs" && rm -f "$tmp/crates/fake-crate/src/lib.rs.bak"
   if ! run_check "$tmp" 2>/tmp/self_test_out2; then
     echo "SELF-TEST FAIL: run_check should pass once the un-isolated spawns are removed" >&2


### PR DESCRIPTION
## Summary

The test suite already isolated itself from a developer's ambient global/system
git config via `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null` env-var
redirection, but that mechanism was applied by convention only: a manually
invoked, four-times-copy-pasted `isolate_git_config()` helper with nothing
stopping a new test file from spawning `git` and forgetting to call it.
`crates/spelunk-core/tests/worktree_index_resolution.rs` had already done
exactly that, despite its own doc-comment claiming to be "fully hermetic."
Separately, one test's mid-test global-env patch-then-restore wasn't
panic-safe.

This closes those gaps:

- **Structural CI guard.** New `scripts/check-git-isolation.sh` fails the
  build if a test file spawns `git` (`Command::new("git")`, however wrapped,
  whitespaced, or aliased) without wiring in the isolation fixture. Wired in
  as the first step of CI's Check & Lint job (no cargo dependency, fails
  fast). Self-tests itself against 7 fixtures (`--self-test`).
- **`worktree_index_resolution.rs` fixed.** Now routes through a new
  `common::git_command(cwd)` constructor in `spelunk-core`'s
  `tests/common/mod.rs` that always calls `isolate_git_config()` first,
  making the "fully hermetic" doc-comment true rather than aspirational.
  Backed by a regression test that re-execs the binary under a hostile
  ambient `core.hooksPath` and confirms isolation shadows it.
- **Identity env vars also cleared.** `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`
  only redirect config *files*; they don't touch
  `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL`, which git resolves before
  consulting config at all. All four `isolate_git_config()` copies now clear
  those too, backed by a re-exec regression test proving a poisoned ambient
  identity env doesn't leak into a test's commits.
- **Panic-safe restore.** `ensure_notes_rewrite_ref_honours_a_users_global_value`'s
  manual set/restore-before-assert (which only protected against a panic in
  the assertions, not the awaited call itself) is replaced with an RAII
  `RestoreGitConfigGlobal` guard whose `Drop` restores unconditionally,
  including on unwind. Backed by a `catch_unwind`-based test proving the
  guard restores after a forced panic.
- **Consolidated.** `integration_git_notes.rs`'s private `isolate_git_config`
  moved into `spelunk-core`'s shared `tests/common/mod.rs`, so
  `worktree_index_resolution.rs`'s fix could reuse it instead of copy-pasting
  a third time. The remaining duplication (4 physical definitions, one per
  {crate, src/tests-boundary-side}) is the floor Rust's compilation
  boundaries allow — each is now the sole canonical copy for its pairing,
  not an independent copy-paste.
- **Docs synced.** `docs/testing.md`'s "Ambient git config in tests" section
  updated: the identity-var clearing, the moved call site, and the
  previously-true-but-now-false claim that "CI runners... a missing call
  here never fails CI" (the whole point of this PR is that it now does).
- **No CHANGELOG entry.** Pure test/CI-infrastructure change with no
  user-facing behavior change, consistent with this repo's existing
  precedent (CHANGELOG's only comparable prior entry, `0.8.3`'s
  `### Internal`, is the exception rather than the rule; most equivalent
  test/CI-only changes get none).

## Test plan

All commands run with `SPELUNK_SECRET_STORE=file` in the PR branch's worktree
(fresh/cold `target/`, so full recompiles):

- `cargo test --workspace` — exit 0. 70 "test result: ok" blocks across the
  workspace (`spelunk-core`, `spelunk-cli`, `spelunk-server`, doctests
  included), 0 FAILED.
- `cargo clippy --all-targets --features rich-formats -- -D warnings` — exit 0.
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` — exit 0.
- `cargo fmt --all -- --check` — exit 0, no diff.
- `./scripts/check-git-isolation.sh --self-test` — `OK` (7 fixtures: good,
  unrelated, 4 "bad" spawn-shapes including multiline/whitespace/aliased
  `Command::new`, and a src/-side `#[cfg(test)]`-only violation).
- `./scripts/check-git-isolation.sh .` against the current (fixed) tree —
  `OK`, zero violations.
- Manually confirmed the CI workflow step (`.github/workflows/ci.yml`) runs
  the lint as the very first step of the Check & Lint job, before any cargo
  invocation.

Additionally reviewed:
- Full diff read against `origin/main` and checked against every acceptance
  criterion in the task description — satisfied.
- Grepped the full diff for internal board/task-id references and em-dashes
  — none found.
- Verified the docs-writer's "no CHANGELOG entry" call by checking
  `CHANGELOG.md` directly for precedent (`0.8.3`'s lone `### Internal`
  section) — confirms the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)