### PR TITLE
docs(embed): tripwire on MODEL_ID — memory.db provenance stamping must precede any model change

### DIFF
--- a/crates/spelunk-embed/src/lib.rs
+++ b/crates/spelunk-embed/src/lib.rs
@@ -28,6 +28,13 @@ pub use backend::EmbeddingBackend;
 /// Exact-match token: never parse it. Requantization or a hardware-portability
 /// rebuild of the same model must NOT change this — only a genuine model swap
 /// (different weights / vector space) does, which forces a re-index.
+///
+/// Before changing this value, ship memory.db embedding-provenance stamping
+/// first: unstamped `note_embeddings` vectors are assumed to be this model
+/// (backfill rule "unstamped ⇒ F2LLM-v2-330M@896"), an invariant that only
+/// holds while this is the sole model ever shipped. See the 2026-07-26
+/// `requirement` entry in spelunk memory and task spelunk-oss^286 for the
+/// acceptance criteria that work must meet.
 pub const MODEL_ID: &str = "F2LLM-v2-330M@896";
 
 mod embedder_native;


### PR DESCRIPTION
## Why

Closing spelunk-oss^286 as wont_do (founder decision 2026-07-26) established that memory.db `note_embeddings` intentionally carry no embedding-model provenance: with `F2LLM-v2-330M@896` pinned product-wide, unstamped vectors are unambiguously that model, so provenance stamping can ship losslessly in whatever release introduces a second embedder (backfill rule: unstamped ⇒ F2LLM-v2-330M@896).

That deferral is only safe if whoever swaps the model knows stamping is a prerequisite. `MODEL_ID` is the one constant any genuine model swap must touch, so the doc comment now records the constraint and points at the durable references (the 2026-07-26 `requirement` entry in spelunk memory, and spelunk-oss^286 for the acceptance-criteria list that work must meet).

## What

Doc-comment only — no behavior change. One paragraph added to `spelunk_embed::MODEL_ID`.

Related: spelunk-oss^287 (memory.db user_version migration runner), spelunk-oss^288 (remove vestigial external-embedding options).

🤖 Generated with [Claude Code](https://claude.com/claude-code)