### PR TITLE
docs(community): CONTRIBUTING, issue templates, platform support matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,6 +36,7 @@ body:
         - Release tarball / zip
         - Debian package (.deb)
         - Built from source
+        - Package manager (brew / scoop)
         - Other
     validations:
       required: true
@@ -46,7 +47,7 @@ body:
       description: Which tier were you using when this happened?
       options:
         - Local only (no server)
-        - Local with auto-started loopback server
+        - Local with auto-started server (Default)
         - Team server (explicit server_url)
         - Cloud
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug report
+description: Something doesn't work the way it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. **Security issues do not belong here** — please use
+        [private vulnerability reporting](https://github.com/spelunk-cloud/spelunk/security/advisories/new) instead.
+  - type: input
+    id: version
+    attributes:
+      label: spelunk version
+      description: Output of `spelunk --version`
+      placeholder: spelunk 1.0.0
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel, built from source)
+        - Linux x86_64
+        - Linux arm64
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How did you install spelunk?
+      options:
+        - Release tarball / zip
+        - Debian package (.deb)
+        - Built from source
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: setup
+    attributes:
+      label: Setup
+      description: Which tier were you using when this happened?
+      options:
+        - Local only (no server)
+        - Local with auto-started loopback server
+        - Team server (explicit server_url)
+        - Cloud
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. spelunk init
+        2. spelunk index .
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: >
+        Paste the output of `spelunk status` and `spelunk check`. If a server is
+        involved, add `spelunk server status` and any relevant lines from
+        `spelunk server logs`. Re-running the failing command with
+        `RUST_LOG=debug` often captures the useful detail. Please redact
+        anything sensitive — file paths and repo names are fine to keep.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/spelunk-cloud/spelunk/security/advisories/new
+    about: Please report security issues privately — never as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest an improvement or new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: >
+        Describe the situation where spelunk falls short — the workflow, not
+        the solution. "When I do X, I can't Y" is more useful than a proposed
+        design.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution (optional)
+      description: If you have a specific idea, sketch it here.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+      description: Workarounds you're using today, or other approaches that could solve it.
+    validations:
+      required: false
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Would you be interested in implementing this?
+      options:
+        - "Yes, with guidance"
+        - "Yes, independently"
+        - "No"
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to spelunk
+
+Thanks for your interest in contributing. spelunk is a local-first code
+intelligence CLI (plus an optional self-hosted server), and contributions of
+all kinds are welcome: bug reports, docs fixes, features, and performance work.
+
+## Getting set up
+
+```bash
+git clone https://github.com/spelunk-cloud/spelunk.git
+cd spelunk
+cargo build            # builds all four workspace crates
+cargo test             # runs the full test suite
+```
+
+The Rust toolchain is pinned to `stable` via `rust-toolchain.toml` — rustup
+picks it up automatically. Platform-specific notes (Metal on macOS, Linux
+containers, Windows) are in [docs/building.md](docs/building.md).
+
+## Before you open a PR
+
+CI enforces formatting, lints, and tests. Run the same checks locally:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --features rich-formats -- -D warnings
+cargo test
+```
+
+Guidelines:
+
+- **Keep PRs focused.** One change per PR; unrelated cleanups belong in their
+  own PR.
+- **Add tests.** Bug fixes need a test that fails without the fix; features
+  need coverage for the happy path and the error paths.
+- **Update docs in the same PR.** If a change alters commands, flags, config
+  keys, or server endpoints, update the relevant page under `docs/` (and
+  `docs/openapi.json` for server API changes).
+- **Commit messages** follow the conventional style used in the log:
+  `fix(index): …`, `feat(memory): …`, `docs: …`, `ci(tooling): …`.
+- **Don't break stable surfaces.** CLI flags, plumbing JSONL output, exit
+  codes, config keys, on-disk formats, and the server `/v1` API are
+  compatibility surfaces. Additive changes are fine; breaking changes need
+  discussion in an issue first.
+
+## Architectural changes
+
+Significant design decisions go through an ADR (architecture decision record)
+in [docs/adr/](docs/adr/). Open an issue describing the problem first; an
+accepted ADR is immutable once merged, so the discussion happens before, not
+after. Living architecture notes go in `docs/architecture/`.
+
+## Working on spelunk with an AI agent
+
+This repository is itself indexed with spelunk, and [CLAUDE.md](CLAUDE.md)
+documents the agent workflow (search before reading, store decisions in
+`spelunk memory`). If you contribute using a coding agent, pointing it at
+CLAUDE.md will make it noticeably more effective — and PRs remain judged on
+the same bar either way: focused, tested, documented.
+
+## Reporting bugs
+
+Use the bug report template — it asks for `spelunk --version`, your platform,
+install method, and `spelunk status` / `spelunk check` output, which is
+usually the difference between a same-day fix and a week of back-and-forth.
+For anything security-sensitive, **do not open a public issue** — see
+[SECURITY.md](SECURITY.md) for private reporting.
+
+## License
+
+spelunk is [MIT](LICENSE) licensed. By contributing, you agree that your
+contributions are licensed under the same terms (inbound = outbound). The
+bundled embedding model has its own attribution — see
+[docs/model-attribution.md](docs/model-attribution.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 codeanalysis contributors
+Copyright (c) 2025 spelunk contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 spelunk contributors
+Copyright (c) 2026 spelunk contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -181,7 +181,10 @@ cargo test                    # test all crates
 
 ## Contributing
 
-Contributions welcome. See [Building from source](docs/building.md) for setup instructions.
+Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the
+workflow and [Building from source](docs/building.md) for setup instructions.
+Supported platforms and host requirements are listed in
+[docs/support.md](docs/support.md).
 
 ## License
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,48 @@
+# Supported platforms & requirements
+
+What spelunk v1 runs on, what it needs from the host system, and which
+versions receive fixes.
+
+## Prebuilt binaries
+
+| Platform | Requirement | Notes |
+|----------|-------------|-------|
+| macOS (Apple Silicon) | — | Embedding runs GPU-accelerated via Metal |
+| Linux x86_64 (glibc) | glibc 2.31+ (Debian 11 / Ubuntu 20.04 era or newer) | Release binaries are built in a Debian 11 container |
+| Linux arm64 (glibc) | glibc 2.31+ | Same baseline as x86_64 |
+| Windows x86_64 | — | `.zip` archive with `.exe` binaries |
+
+Intel Macs are not shipped as prebuilt binaries; they build from source — see
+[Building from source](building.md). Musl-based distributions (Alpine) are
+untested; build from source and report what you find.
+
+Download URLs and archive formats are listed in [Releasing](releasing.md).
+
+## Host requirements
+
+- **git** — spelunk shells out to `git` for memory (git-notes), worktree
+  handling, and hooks. Any maintained git 2.x works; there is no exotic
+  feature floor. Memory features require the project to be a git repository.
+- **SQLite** — none required. SQLite and the `sqlite-vec` extension are
+  bundled into the binaries; there is no system dependency.
+- **Network** — none required for the core local flows. The bundled embedding
+  model (~339 MB) is downloaded once on first server start; after that,
+  semantic search runs entirely on-machine. Full-text search, the code graph,
+  and memory work with no server and no network at all.
+- **Disk** — the index lives in `.spelunk/` inside your project; expect it to
+  be a fraction of the source tree's size, plus the one-time model download in
+  the model cache directory.
+
+## Version support policy
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | Bug fixes and security fixes |
+| Older releases | Best-effort backports for critical security issues only |
+
+See [SECURITY.md](../SECURITY.md) for how to report vulnerabilities privately.
+
+Compatibility between the CLI and a team `spelunk-server` of a different
+version: within the v1 line the server API under `/v1/` evolves additively.
+Run matching versions where you can; adjacent versions are expected to
+interoperate for the memory workflows.


### PR DESCRIPTION
## What

Community/support scaffolding for the v1 release — the pieces missing alongside the existing SECURITY.md / CHANGELOG / LICENSE:

- **CONTRIBUTING.md** — dev setup (stable toolchain via rust-toolchain.toml), the exact fmt/clippy/test commands CI runs, PR expectations (focused, tested, docs-in-same-PR, conventional commit style), the ADR process, a warning about stable compatibility surfaces, and a pointer to CLAUDE.md for agent-assisted contributions.
- **Issue forms** — bug report front-loads triage data (`spelunk --version`, platform, install method, local/loopback/team/cloud tier, `spelunk status` + `spelunk check` output, RUST_LOG hint, redaction reminder); feature request is problem-first; `config.yml` adds a private-vulnerability-reporting contact link.
- **docs/support.md** — user-facing platform matrix (glibc 2.31+ floor stated from the Debian 11 build container; Intel Mac + musl = build from source), host requirements (any git 2.x, SQLite bundled so no system dep, network needed only for the one-time model download), and the version support policy consistent with SECURITY.md.
- **README** — Contributing section now links CONTRIBUTING.md + support.md.
- **LICENSE** — copyright line still named the pre-rename project ("codeanalysis contributors") → now "spelunk contributors". Flagging explicitly since it's a license-text edit.

## Required repo-settings change (not doable from this PR)

**Private vulnerability reporting is currently DISABLED** on this repo (`security_and_analysis.private_vulnerability_reporting: null`), but SECURITY.md and these templates direct reporters to it. Enable before announcing:

```
gh api --method PUT repos/spelunk-cloud/spelunk/private-vulnerability-reporting
```

(or Settings → Advanced Security → Private vulnerability reporting → Enable.)

Labels used by the forms (`bug`, `enhancement`) already exist. Discussions is disabled, so nothing links to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)