### PR TITLE
memory.db: adopt the forward-only, user_version-gated migration runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   `reconcile` and `explore`. `cloud_first` is unchanged. See [ADR-004's
   2026-07-23 amendment](docs/adr/004-unified-memory-storage.md).
 
+### Internal
+
+- **`memory.db` now opens through the same forward-only, `PRAGMA
+  user_version`-gated migration runner `index.db` already uses**, replacing
+  ad-hoc re-execution of the schema SQL with idempotency inferred from
+  `ALTER TABLE` error strings. A pre-existing store has its version inferred
+  once from table/column shape, then only the missing steps run; a store
+  stamped with a version newer than the binary supports refuses to open
+  instead of mis-running steps. No CLI flag, config key, or user-facing
+  behavior changed.
+
 ## [0.9.5] — 2026-07-24
 
 ### Changed

--- a/crates/spelunk-core/src/storage/memory/dedupe/test_support.rs
+++ b/crates/spelunk-core/src/storage/memory/dedupe/test_support.rs
@@ -31,8 +31,9 @@ pub(super) fn open_store() -> MemoryStore {
     let store = MemoryStore {
         conn,
         reembed_needed: None,
+        dropped_768: std::cell::Cell::new(false),
     };
-    store.migrate().expect("schema migration");
+    store.run_migrations().expect("schema migration");
     store
 }
 

--- a/crates/spelunk-core/src/storage/memory/entity_id_migration/test_support.rs
+++ b/crates/spelunk-core/src/storage/memory/entity_id_migration/test_support.rs
@@ -26,8 +26,9 @@ pub(super) fn open_store() -> MemoryStore {
     let store = MemoryStore {
         conn,
         reembed_needed: None,
+        dropped_768: std::cell::Cell::new(false),
     };
-    store.migrate().expect("schema migration");
+    store.run_migrations().expect("schema migration");
     store
 }
 

--- a/crates/spelunk-core/src/storage/memory/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension};
 use serde::Serialize;
+use std::cell::Cell;
 use std::path::Path;
 
 mod dedupe;
@@ -16,6 +17,17 @@ pub use sync::SyncRow;
 #[cfg(test)]
 mod tests;
 
+/// Latest local memory schema version. Append-only: never renumber an
+/// existing step. The runner in `MemoryStore::run_migrations` gates each
+/// migration on this via `PRAGMA user_version`; steps are numbered in the
+/// order they run (the field order), not filename order. Mirrors
+/// `storage::db::CURRENT_SCHEMA_VERSION` for `index.db`, kept as a distinct
+/// constant/name because the two DBs version independently.
+pub(super) const MEMORY_SCHEMA_VERSION: i32 = 9;
+
+/// One entry in the migration runner: (target version, migration body).
+type MemoryMigrationStep = (i32, fn(&MemoryStore) -> Result<()>);
+
 pub struct MemoryStore {
     pub(super) conn: Connection,
     /// Set by [`MemoryStore::open`] to the count of active notes that need
@@ -24,6 +36,13 @@ pub struct MemoryStore {
     /// `memory reindex` hint without `RUST_LOG` while keeping this library
     /// side-effect-free (nothing is printed here).
     pub reembed_needed: Option<usize>,
+    /// Set inside `apply_dim_upgrade_migration` only when THIS call actually
+    /// dropped a 768-dim `note_embeddings` table (not merely when the marker
+    /// was absent), so `open` can compute the one-time re-embed count. A
+    /// `Cell` because migration steps take `&self`, not `&mut self` (they
+    /// share the `MemoryMigrationStep` signature with every other step,
+    /// which only needs shared access to `conn`).
+    dropped_768: Cell<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -94,14 +113,19 @@ impl MemoryStore {
         let mut store = Self {
             conn,
             reembed_needed: None,
+            dropped_768: Cell::new(false),
         };
-        let migrated_768_to_896 = store.migrate()?;
+        store.run_migrations()?;
         // ADR-068 third amendment: Step A (unconditional backfill) then Step B
         // (conditional UNIQUE-index promotion). Neither ever hard-aborts open;
-        // see `entity_id_migration.rs`.
+        // see `entity_id_migration.rs`. Both run on every open rather than
+        // being gated to a single schema-version step: a later insert path
+        // can still leave `entity_id` NULL (Step A heals it), and Step B's
+        // duplicate scan can only turn clean after a `spelunk memory dedupe`
+        // run on some later open.
         store.backfill_entity_ids()?;
         store.promote_entity_id_unique_index()?;
-        if migrated_768_to_896 {
+        if store.dropped_768.get() {
             // The upgrade just discarded every prior note's vector, so every
             // active note now needs re-embedding; count them once so the CLI
             // can point the user at `memory reindex` (there is no catch-up path
@@ -114,19 +138,146 @@ impl MemoryStore {
         Ok(store)
     }
 
-    /// Returns `true` when the 768→896 `note_embeddings` upgrade dropped the old
-    /// vectors on this run (so [`MemoryStore::open`] can flag the re-embed need).
-    fn migrate(&self) -> Result<bool> {
+    /// Forward-only migration runner gated on `PRAGMA user_version`, mirroring
+    /// `Database::run_migrations` in `storage/db.rs`.
+    ///
+    /// A `user_version=0` DB is either brand-new (no user tables) or a
+    /// pre-`user_version` field DB: every `memory.db` on disk before this
+    /// runner existed, since `migrate()` never stamped a version. New DBs run
+    /// every step from 1. Field DBs have their true version inferred from
+    /// table/column shape, stamped, and only later steps run: blindly
+    /// re-running every step would still be safe (each step is idempotent),
+    /// but inference avoids redundant ALTER-then-catch round trips.
+    fn run_migrations(&self) -> Result<()> {
+        let mut version: i32 = self
+            .conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .context("reading user_version")?;
+
+        if version > MEMORY_SCHEMA_VERSION {
+            anyhow::bail!(
+                "memory.db schema version {version} is newer than this build of spelunk \
+                 supports (max {MEMORY_SCHEMA_VERSION}); upgrade spelunk to open this store."
+            );
+        }
+
+        if version == 0 && !self.is_fresh_db()? {
+            version = self.infer_legacy_version()?;
+        }
+
+        // Each entry: (target_version, migration body). Ordered by call order.
+        // Append new steps at the end; never renumber.
+        let steps: &[MemoryMigrationStep] = &[
+            (1, Self::apply_base_migration),
+            (2, Self::apply_lifecycle_migration),
+            (3, Self::apply_source_ref_migration),
+            (4, Self::apply_fts_migration),
+            (5, Self::apply_temporal_migration),
+            (6, Self::apply_edges_migration),
+            (7, Self::apply_uuid_migration),
+            (8, Self::apply_entity_id_column_migration),
+            (9, Self::apply_dim_upgrade_migration),
+        ];
+        debug_assert_eq!(
+            steps.last().map(|(v, _)| *v),
+            Some(MEMORY_SCHEMA_VERSION),
+            "steps table must end at MEMORY_SCHEMA_VERSION"
+        );
+
+        for (target, body) in steps {
+            if *target > version {
+                body(self)?;
+            }
+        }
+        // user_version is a header i32; the value is a code-controlled constant.
+        self.conn
+            .execute_batch(&format!("PRAGMA user_version = {MEMORY_SCHEMA_VERSION}"))
+            .context("stamping user_version")?;
+        Ok(())
+    }
+
+    /// True when the file has no user tables: a freshly created DB that must
+    /// run every migration from step 1.
+    fn is_fresh_db(&self) -> Result<bool> {
+        let n: i64 = self
+            .conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+                 WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+                [],
+                |r| r.get(0),
+            )
+            .context("counting user tables")?;
+        Ok(n == 0)
+    }
+
+    /// Infer the schema version of a pre-`user_version` field DB from its
+    /// table/column shapes. Walks the ladder top-down; the first unmet
+    /// predicate fixes the version. A conservative (one-low) result is safe:
+    /// the re-run step is a no-op guard (or a tolerated duplicate-column
+    /// error) that then advances the version.
+    fn infer_legacy_version(&self) -> Result<i32> {
+        let has_table = |name: &str| -> Result<bool> {
+            Ok(self
+                .conn
+                .query_row(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+                    rusqlite::params![name],
+                    |_| Ok(()),
+                )
+                .optional()
+                .context("probing table")?
+                .is_some())
+        };
+        let notes_has_column = |col: &str| -> Result<bool> {
+            let mut stmt = self.conn.prepare("PRAGMA table_info(notes)")?;
+            let mut rows = stmt.query([])?;
+            while let Some(row) = rows.next()? {
+                if row.get::<_, String>(1)? == col {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        };
+
+        let ladder: [(i32, bool); 9] = [
+            (1, has_table("notes")?),
+            (2, notes_has_column("status")?),
+            (3, notes_has_column("source_ref")?),
+            (4, has_table("memory_fts")?),
+            (5, notes_has_column("valid_at")?),
+            (6, has_table("memory_edges")?),
+            (7, notes_has_column("uuid")?),
+            (8, notes_has_column("entity_id")?),
+            (9, has_table("schema_v896_note_embeddings")?),
+        ];
+        // Highest version whose predicate and all lower ones hold.
+        let mut version = 0;
+        for (v, satisfied) in ladder {
+            if !satisfied {
+                break;
+            }
+            version = v;
+        }
+        Ok(version)
+    }
+
+    /// Create the base `notes` + `note_embeddings` tables. Idempotent
+    /// (`CREATE TABLE/VIRTUAL TABLE IF NOT EXISTS`).
+    fn apply_base_migration(&self) -> Result<()> {
         self.conn
             .execute_batch(include_str!("../../../migrations/004_memory.sql"))
-            .context("running memory migrations")?;
-        // Migration 005: lifecycle columns — ALTER TABLE doesn't support IF NOT EXISTS,
-        // so we ignore "duplicate column name" errors (idempotent re-open).
+            .context("running base memory migration")?;
+        Ok(())
+    }
+
+    /// Add lifecycle columns (`status`, `superseded_by`). `ALTER TABLE` has no
+    /// `IF NOT EXISTS`, so only the already-applied error is tolerated; a
+    /// genuine failure propagates.
+    fn apply_lifecycle_migration(&self) -> Result<()> {
         for stmt in [
             "ALTER TABLE notes ADD COLUMN status TEXT NOT NULL DEFAULT 'active'",
             "ALTER TABLE notes ADD COLUMN superseded_by INTEGER REFERENCES notes(id)",
-            // Migration 012: commit provenance
-            "ALTER TABLE notes ADD COLUMN source_ref TEXT",
         ] {
             match self.conn.execute_batch(stmt) {
                 Ok(_) => {}
@@ -134,15 +285,36 @@ impl MemoryStore {
                 Err(e) => return Err(e).context("running memory lifecycle migration"),
             }
         }
-        // Migration 012: FTS5 full-text index for memory notes.
+        Ok(())
+    }
+
+    /// Add `source_ref` (commit provenance for harvested entries).
+    fn apply_source_ref_migration(&self) -> Result<()> {
+        match self.conn.execute_batch(include_str!(
+            "../../../migrations/013_memory_source_ref.sql"
+        )) {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => return Err(e).context("running memory source_ref migration"),
+        }
+        Ok(())
+    }
+
+    /// Create the FTS5 full-text index over notes (and its sync triggers).
+    /// Idempotent (`CREATE VIRTUAL TABLE/TRIGGER IF NOT EXISTS`, `INSERT OR
+    /// IGNORE` backfill).
+    fn apply_fts_migration(&self) -> Result<()> {
         self.conn
             .execute_batch(include_str!("../../../migrations/012_memory_fts.sql"))
             .context("running memory FTS migration")?;
-        // Migration 014: temporal fields — valid_at and invalid_at.
+        Ok(())
+    }
+
+    /// Add temporal fields (`valid_at`, `invalid_at`) and their index.
+    fn apply_temporal_migration(&self) -> Result<()> {
         for stmt in [
             "ALTER TABLE notes ADD COLUMN valid_at INTEGER",
             "ALTER TABLE notes ADD COLUMN invalid_at INTEGER",
-            "CREATE INDEX IF NOT EXISTS idx_memory_invalid_at ON notes(invalid_at)",
         ] {
             match self.conn.execute_batch(stmt) {
                 Ok(_) => {}
@@ -150,14 +322,29 @@ impl MemoryStore {
                 Err(e) => return Err(e).context("running memory temporal migration"),
             }
         }
-        // Migration 015: memory edge table.
+        self.conn
+            .execute_batch("CREATE INDEX IF NOT EXISTS idx_memory_invalid_at ON notes(invalid_at)")
+            .context("creating memory temporal index")?;
+        Ok(())
+    }
+
+    /// Create the memory relationship-edges table. Idempotent (`CREATE TABLE/
+    /// INDEX IF NOT EXISTS`).
+    fn apply_edges_migration(&self) -> Result<()> {
         self.conn
             .execute_batch(include_str!("../../../migrations/015_memory_edges.sql"))
             .context("running memory edges migration")?;
-        // Migration 020: UUID identity columns (`uuid`, `remote_id`) for cloud sync.
-        // ALTER TABLE can't be IF NOT EXISTS; guard the duplicate-column case so
-        // re-opening an already-migrated store is a no-op. The unique indexes are
-        // CREATE … IF NOT EXISTS and safe to run unconditionally.
+        Ok(())
+    }
+
+    /// Add cross-store identity columns (`uuid`, `remote_id`) and their
+    /// partial unique indexes for cloud sync.
+    ///
+    /// No sync-state watermark table (decision #183): the pull cursor is
+    /// derived from `MAX(remote_id)` over `notes`, so there is no separate
+    /// watermark to persist. `idx_notes_remote_id` below is what makes that
+    /// cursor lookup and the `remote_id` dedupe cheap.
+    fn apply_uuid_migration(&self) -> Result<()> {
         for stmt in [
             "ALTER TABLE notes ADD COLUMN uuid TEXT",
             "ALTER TABLE notes ADD COLUMN remote_id TEXT",
@@ -176,13 +363,16 @@ impl MemoryStore {
                  ON notes(remote_id) WHERE remote_id IS NOT NULL;",
             )
             .context("creating memory uuid indexes")?;
-        // No sync-state watermark table (decision #183): the pull cursor is
-        // derived from `MAX(remote_id)` over `notes`, so there is no separate
-        // watermark to persist. The unique `idx_notes_remote_id` above is what
-        // makes that cursor lookup and the `remote_id` dedupe cheap.
+        Ok(())
+    }
 
-        // Migration 023 (ADR-068): content-addressed `entity_id`. Backfilled
-        // for existing rows by Step A below, right after `migrate()` returns.
+    /// Add the content-addressed `entity_id` column (ADR-068) and its
+    /// non-unique index: existing stores can hold rows with identical
+    /// kind/title/body, so a UNIQUE index here would abort the migration.
+    /// `entity_id_migration.rs`'s Step B promotes it to UNIQUE separately,
+    /// once a duplicate scan comes back clean; Step A backfills the column's
+    /// values, both on every open, not gated to this schema-version step.
+    fn apply_entity_id_column_migration(&self) -> Result<()> {
         match self
             .conn
             .execute_batch("ALTER TABLE notes ADD COLUMN entity_id TEXT")
@@ -191,19 +381,24 @@ impl MemoryStore {
             Err(e) if e.to_string().contains("duplicate column name") => {}
             Err(e) => return Err(e).context("running memory entity_id migration"),
         }
-        // Non-unique: existing stores can hold rows with identical
-        // kind/title/body. Step B promotes this to UNIQUE once a duplicate
-        // scan comes back clean.
         self.conn
             .execute_batch(
                 "CREATE INDEX IF NOT EXISTS idx_notes_entity_id \
                  ON notes(entity_id) WHERE entity_id IS NOT NULL;",
             )
             .context("creating memory entity_id index")?;
+        Ok(())
+    }
 
-        // Upgrade note_embeddings from 768-dim (Nomic) to 896-dim (F2LLM-v2-330M).
-        // Guarded by a marker table so re-opening an already-upgraded store is a no-op.
-        // Fresh stores get FLOAT[896] directly from 004_memory.sql above.
+    /// Upgrade `note_embeddings` from 768-dim (Nomic) to 896-dim
+    /// (F2LLM-v2-330M). Idempotent, guarded by the
+    /// `schema_v896_note_embeddings` marker table so re-opening an
+    /// already-upgraded store is a no-op; fresh stores already get
+    /// `FLOAT[896]` directly from `apply_base_migration`. Sets `dropped_768`
+    /// only when THIS call actually dropped a 768-dim table (not merely when
+    /// the marker was absent), so `open` can compute the re-embed count
+    /// exactly once per real drop.
+    fn apply_dim_upgrade_migration(&self) -> Result<()> {
         let already_v896: bool = self
             .conn
             .query_row(
@@ -215,42 +410,43 @@ impl MemoryStore {
             .optional()
             .context("checking v896 note_embeddings marker")?
             .is_some();
-        let mut dropped_768 = false;
-        if !already_v896 {
-            let needs_upgrade: bool = self
-                .conn
-                .query_row(
-                    "SELECT sql FROM sqlite_master \
-                     WHERE type='table' AND name='note_embeddings'",
-                    [],
-                    |row| row.get::<_, String>(0),
-                )
-                .optional()
-                .context("querying note_embeddings schema")?
-                .map(|sql| sql.contains("FLOAT[768]"))
-                .unwrap_or(false);
-            if needs_upgrade {
-                self.conn
-                    .execute_batch(
-                        "DROP TABLE IF EXISTS note_embeddings; \
-                         CREATE VIRTUAL TABLE note_embeddings USING vec0(\
-                             note_id INTEGER PRIMARY KEY, embedding FLOAT[896]\
-                         );",
-                    )
-                    .context("upgrading note_embeddings to 896-dim")?;
-                tracing::info!(
-                    "memory note_embeddings dim upgraded 768→896; \
-                     re-run `spelunk memory reindex` to rebuild embeddings"
-                );
-                dropped_768 = true;
-            }
+        if already_v896 {
+            return Ok(());
+        }
+
+        let needs_upgrade: bool = self
+            .conn
+            .query_row(
+                "SELECT sql FROM sqlite_master \
+                 WHERE type='table' AND name='note_embeddings'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .context("querying note_embeddings schema")?
+            .map(|sql| sql.contains("FLOAT[768]"))
+            .unwrap_or(false);
+        if needs_upgrade {
             self.conn
                 .execute_batch(
-                    "CREATE TABLE IF NOT EXISTS schema_v896_note_embeddings \
-                     (sentinel INTEGER PRIMARY KEY);",
+                    "DROP TABLE IF EXISTS note_embeddings; \
+                     CREATE VIRTUAL TABLE note_embeddings USING vec0(\
+                         note_id INTEGER PRIMARY KEY, embedding FLOAT[896]\
+                     );",
                 )
-                .context("creating v896 note_embeddings marker")?;
+                .context("upgrading note_embeddings to 896-dim")?;
+            tracing::info!(
+                "memory note_embeddings dim upgraded 768→896; \
+                 re-run `spelunk memory reindex` to rebuild embeddings"
+            );
+            self.dropped_768.set(true);
         }
-        Ok(dropped_768)
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS schema_v896_note_embeddings \
+                 (sentinel INTEGER PRIMARY KEY);",
+            )
+            .context("creating v896 note_embeddings marker")?;
+        Ok(())
     }
 }

--- a/crates/spelunk-core/src/storage/memory/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/mod.rs
@@ -215,7 +215,9 @@ impl MemoryStore {
     /// table/column shapes. Walks the ladder top-down; the first unmet
     /// predicate fixes the version. A conservative (one-low) result is safe:
     /// the re-run step is a no-op guard (or a tolerated duplicate-column
-    /// error) that then advances the version.
+    /// error) that then advances the version. Each predicate must therefore
+    /// cover every column/object its step adds, not just one: a partial
+    /// match would infer the step "done" and skip it forever.
     fn infer_legacy_version(&self) -> Result<i32> {
         let has_table = |name: &str| -> Result<bool> {
             Ok(self
@@ -240,14 +242,30 @@ impl MemoryStore {
             Ok(false)
         };
 
+        // Each predicate must cover every column/object its step adds, not just
+        // the first: steps 2, 5 and 7 each `ALTER TABLE ADD COLUMN` twice in
+        // one loop, and SQLite auto-commits each ALTER independently, so a
+        // process killed between the two statements is a real field state.
+        // Checking only the first column would infer that step "done" from a
+        // half-applied ALTER and skip it forever, leaving the second column
+        // permanently missing.
         let ladder: [(i32, bool); 9] = [
             (1, has_table("notes")?),
-            (2, notes_has_column("status")?),
+            (
+                2,
+                notes_has_column("status")? && notes_has_column("superseded_by")?,
+            ),
             (3, notes_has_column("source_ref")?),
             (4, has_table("memory_fts")?),
-            (5, notes_has_column("valid_at")?),
+            (
+                5,
+                notes_has_column("valid_at")? && notes_has_column("invalid_at")?,
+            ),
             (6, has_table("memory_edges")?),
-            (7, notes_has_column("uuid")?),
+            (
+                7,
+                notes_has_column("uuid")? && notes_has_column("remote_id")?,
+            ),
             (8, notes_has_column("entity_id")?),
             (9, has_table("schema_v896_note_embeddings")?),
         ];

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -1,4 +1,5 @@
 use super::MemoryStore;
+use rusqlite::OptionalExtension;
 use std::sync::OnceLock;
 
 /// Register the sqlite-vec extension exactly once per test process.
@@ -1747,4 +1748,273 @@ fn future_memory_schema_version_refuses_to_open() {
         msg.contains("newer") || msg.contains("upgrade spelunk"),
         "the error must explain the version mismatch clearly, got: {msg}"
     );
+}
+
+// `infer_legacy_version`'s ladder predicates for steps 2, 5 and 7 each only
+// probed the FIRST of two columns a real migration adds in one `ALTER TABLE`
+// loop (e.g. step 2 checked `status` but not `superseded_by`). Each `ALTER
+// TABLE ADD COLUMN` auto-commits independently in SQLite, so a process
+// killed between the two statements is a real partial-application window,
+// not a hypothetical one: exactly the crash-safety scenario this runner
+// exists to survive. A single-column predicate would infer the step as
+// "done" from the first column alone and skip it forever, leaving the
+// second column permanently missing. Cover all three two-column steps in
+// one table-driven test.
+#[test]
+fn legacy_db_missing_the_second_of_a_two_column_step_still_completes_it() {
+    register_sqlite_vec();
+
+    for (drop_col, other_col_in_same_step, dependent_index) in [
+        ("superseded_by", "status", None),
+        ("invalid_at", "valid_at", Some("idx_memory_invalid_at")),
+        ("remote_id", "uuid", Some("idx_notes_remote_id")),
+    ] {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let path = tmp.path().join("memory.db");
+
+        {
+            let store = MemoryStore::open(&path).expect("build current store");
+            if let Some(index) = dependent_index {
+                store
+                    .execute_batch(&format!("DROP INDEX {index}"))
+                    .unwrap_or_else(|e| panic!("drop index {index} depending on {drop_col}: {e}"));
+            }
+            store
+                .execute_batch(&format!(
+                    "ALTER TABLE notes DROP COLUMN {drop_col}; PRAGMA user_version = 0;"
+                ))
+                .unwrap_or_else(|e| {
+                    panic!("simulate a crash-interrupted step dropping {drop_col}: {e}")
+                });
+            assert!(
+                notes_has_column(&store, other_col_in_same_step),
+                "precondition: {other_col_in_same_step} must survive the drop"
+            );
+        }
+
+        let store = MemoryStore::open(&path)
+            .unwrap_or_else(|e| panic!("reopen a legacy db missing only {drop_col}: {e}"));
+        assert!(
+            notes_has_column(&store, drop_col),
+            "inferring the step's version from {other_col_in_same_step} alone must not \
+             permanently skip adding {drop_col}, the other column that step is responsible for"
+        );
+    }
+}
+
+// Criterion 3: a genuine (non-"duplicate column") failure partway through a
+// multi-statement step must not silently mark that step done, and the DDL
+// that already committed before the failure must not be re-applied
+// destructively on the next attempt once the fault is cleared. Force
+// `apply_edges_migration`'s single `execute_batch` (CREATE TABLE, then two
+// CREATE INDEX statements) to fail on its *second* statement by pre-creating
+// a colliding table where the first index should go: the CREATE TABLE
+// before it has already committed by the time the batch errors.
+#[test]
+fn genuine_mid_step_failure_leaves_recoverable_state_not_silent_progress() {
+    register_sqlite_vec();
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("memory.db");
+
+    {
+        let store = MemoryStore::open(&path).expect("build current store");
+        store
+            .execute_batch(
+                "DROP INDEX idx_memory_edges_from; \
+                 DROP INDEX idx_memory_edges_to; \
+                 DROP TABLE memory_edges; \
+                 PRAGMA user_version = 5;",
+            )
+            .expect("strip back to a pre-edges (v5) shape");
+        // Collide with the name of the first index apply_edges_migration
+        // creates, so its execute_batch fails partway through, after the
+        // CREATE TABLE statement ahead of it has already committed.
+        store
+            .execute_batch("CREATE TABLE idx_memory_edges_from (blocker INTEGER)")
+            .expect("plant a colliding table name");
+    }
+
+    let err = MemoryStore::open(&path)
+        .err()
+        .expect("a real naming collision must surface as an error, not succeed");
+    let msg = format!("{err:#}").to_lowercase();
+    assert!(
+        msg.contains("index") || msg.contains("table") || msg.contains("already"),
+        "expected a naming-collision error, got: {msg}"
+    );
+
+    // Verify the failure did NOT silently stamp the version, and that the
+    // statement before the failing one (CREATE TABLE memory_edges) really
+    // did commit despite the overall step returning Err.
+    let conn = rusqlite::Connection::open(&path).expect("raw reopen to inspect state");
+    let version: i32 = conn
+        .query_row("PRAGMA user_version", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        version, 5,
+        "a failed migration attempt must not advance user_version past the point of failure"
+    );
+    let edges_table_exists: bool = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_edges'",
+            [],
+            |_| Ok(true),
+        )
+        .optional()
+        .unwrap()
+        .is_some();
+    assert!(
+        edges_table_exists,
+        "the CREATE TABLE statement that ran before the failing CREATE INDEX must stay \
+         committed: SQLite DDL auto-commits per statement, it isn't rolled back by the later error"
+    );
+    drop(conn);
+
+    // Clear the induced fault and confirm the next open recovers cleanly:
+    // the already-applied CREATE TABLE is tolerated (IF NOT EXISTS), and the
+    // remaining steps complete normally.
+    {
+        let conn = rusqlite::Connection::open(&path).expect("raw reopen to fix the fault");
+        conn.execute_batch("DROP TABLE idx_memory_edges_from")
+            .expect("remove the blocker");
+    }
+    let recovered = MemoryStore::open(&path).expect("recovered open must succeed");
+    assert_eq!(user_version(&recovered), super::MEMORY_SCHEMA_VERSION);
+}
+
+// Criterion 4: `MemoryStore::open` sets no `busy_timeout` on its connection
+// (same as `Database::open` for index.db, see the analogous
+// `insert_embeddings_rolls_back_on_a_real_sqlite_error_not_just_bad_dimension`
+// test in `storage/db.rs`), so a second writer holding the file's write lock
+// during migration must surface as a loud `SQLITE_BUSY` error, not hang or
+// silently race on the `PRAGMA user_version` write.
+#[test]
+fn concurrent_open_during_migration_fails_loudly_not_silently() {
+    register_sqlite_vec();
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("memory.db");
+
+    {
+        let store = MemoryStore::open(&path).expect("build current store");
+        store
+            .execute_batch(
+                "DROP INDEX idx_memory_edges_from; \
+                 DROP INDEX idx_memory_edges_to; \
+                 DROP TABLE memory_edges; \
+                 PRAGMA user_version = 5;",
+            )
+            .expect("strip back to a pre-edges (v5) shape needing a real migration write");
+    }
+
+    let locker = rusqlite::Connection::open(&path).expect("second connection");
+    locker
+        .execute_batch("BEGIN IMMEDIATE; CREATE TABLE lock_probe (id INTEGER);")
+        .expect("acquire the write lock");
+
+    let err = MemoryStore::open(&path)
+        .err()
+        .expect("opening under a held write lock must fail, not hang or corrupt state");
+    let msg = format!("{err:#}").to_lowercase();
+    assert!(
+        msg.contains("lock") || msg.contains("busy"),
+        "expected a locking error, got: {msg}"
+    );
+
+    locker.execute_batch("COMMIT;").expect("release the lock");
+    let recovered =
+        MemoryStore::open(&path).expect("once the lock is released, migration completes");
+    assert_eq!(user_version(&recovered), super::MEMORY_SCHEMA_VERSION);
+}
+
+// Criterion 6: the engineer's legacy-inference tests used a single note, so
+// they couldn't distinguish "row content survives" from "row COUNT survives
+// but rows got cross-attributed" (e.g. an embedding landing on the wrong
+// `note_id`, or FTS text from one note leaking onto another). Use several
+// notes with distinct kind/title/body/tags and distinct embeddings, and
+// assert each note's own content, its own embedding, and its own FTS
+// match survive legacy re-inference attached to the correct row.
+#[test]
+fn legacy_inference_preserves_distinct_multi_row_content_not_just_row_count() {
+    register_sqlite_vec();
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("memory.db");
+
+    let rows = [
+        (
+            "decision",
+            "Alpha decision",
+            "alpha body text",
+            vec!["infra"],
+            0.11f32,
+        ),
+        (
+            "context",
+            "Beta context",
+            "beta body text",
+            vec!["billing"],
+            0.22f32,
+        ),
+        (
+            "requirement",
+            "Gamma requirement",
+            "gamma body text",
+            vec!["auth", "urgent"],
+            0.33f32,
+        ),
+    ];
+    let mut ids = Vec::new();
+    {
+        let store = MemoryStore::open(&path).expect("build via runner");
+        for (kind, title, body, tags, fill) in &rows {
+            let (id, _) = store
+                .add_note(kind, title, body, tags, &[], None, None)
+                .unwrap();
+            let vector = vec![*fill; crate::embeddings::EMBEDDING_DIM];
+            store
+                .insert_embedding(id, &crate::embeddings::vec_to_blob(&vector))
+                .unwrap();
+            ids.push(id);
+        }
+        store.execute_batch("PRAGMA user_version = 0").unwrap();
+    }
+
+    let store = MemoryStore::open(&path).expect("reopen legacy");
+    assert_eq!(user_version(&store), super::MEMORY_SCHEMA_VERSION);
+
+    for (id, (kind, title, body, tags, fill)) in ids.iter().zip(rows.iter()) {
+        let note = store
+            .get(*id)
+            .unwrap()
+            .unwrap_or_else(|| panic!("note {id} must survive re-inference"));
+        assert_eq!(&note.kind, kind, "note {id} kind must not cross-attribute");
+        assert_eq!(
+            &note.title, title,
+            "note {id} title must not cross-attribute"
+        );
+        assert_eq!(&note.body, body, "note {id} body must not cross-attribute");
+        assert_eq!(&note.tags, tags, "note {id} tags must not cross-attribute");
+
+        let embedding = store
+            .get_embedding(*id)
+            .unwrap()
+            .unwrap_or_else(|| panic!("note {id} embedding must survive re-inference"));
+        let vector = crate::embeddings::blob_to_vec(&embedding);
+        assert!(
+            vector.iter().all(|v| (*v - *fill).abs() < 1e-4),
+            "note {id} embedding content must be its own, not another note's"
+        );
+
+        let hits: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_fts WHERE memory_fts MATCH ?1",
+                rusqlite::params![title],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            hits, 1,
+            "note {id}'s own title must be findable via FTS after re-inference"
+        );
+    }
 }

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -2,7 +2,7 @@ use super::MemoryStore;
 use std::sync::OnceLock;
 
 /// Register the sqlite-vec extension exactly once per test process.
-/// `MemoryStore::migrate()` creates a `vec0` virtual table, which
+/// `MemoryStore::run_migrations()` creates a `vec0` virtual table, which
 /// requires the extension to be loaded before any connection is opened.
 fn register_sqlite_vec() {
     static INIT: OnceLock<()> = OnceLock::new();
@@ -1003,8 +1003,9 @@ fn entity_id_migration_backfills_but_does_not_collapse_duplicates() {
         let store = MemoryStore {
             conn,
             reembed_needed: None,
+            dropped_768: std::cell::Cell::new(false),
         };
-        store.migrate().expect("schema migration only");
+        store.run_migrations().expect("schema migration only");
         for created_at in [1_700_000_001_i64, 1_700_000_002] {
             store
                 .add_note_with_created_at(
@@ -1022,7 +1023,8 @@ fn entity_id_migration_backfills_but_does_not_collapse_duplicates() {
         store
             .execute_batch(
                 "DROP INDEX idx_notes_entity_id; \
-                 ALTER TABLE notes DROP COLUMN entity_id;",
+                 ALTER TABLE notes DROP COLUMN entity_id; \
+                 PRAGMA user_version = 0;",
             )
             .expect("drop column to simulate the older schema");
         let has_col: i64 = store
@@ -1540,5 +1542,209 @@ fn superseded_note_excluded_by_default_included_with_archived() {
     assert_eq!(
         got, want,
         "include_archived surfaces the superseded note for backfill"
+    );
+}
+
+// ── migration runner (schema version) ───────────────────────────────────────
+// `MemoryStore::run_migrations` is a forward-only runner gated on `PRAGMA
+// user_version`, mirroring `Database::run_migrations` in `storage/db.rs`.
+// These exercise the runner itself; the FTS/lifecycle/dim-upgrade tests
+// elsewhere in this file exercise what each individual step does.
+
+fn user_version(store: &MemoryStore) -> i32 {
+    store
+        .conn
+        .query_row("PRAGMA user_version", [], |r| r.get(0))
+        .unwrap()
+}
+
+fn notes_has_column(store: &MemoryStore, col: &str) -> bool {
+    let mut stmt = store.conn.prepare("PRAGMA table_info(notes)").unwrap();
+    let mut rows = stmt.query([]).unwrap();
+    while let Some(row) = rows.next().unwrap() {
+        if row.get::<_, String>(1).unwrap() == col {
+            return true;
+        }
+    }
+    false
+}
+
+// Acceptance criterion 1: a brand-new store runs every step and ends stamped
+// at the latest version.
+#[test]
+fn fresh_memory_db_stamps_current_version() {
+    let store = open_store();
+    assert_eq!(user_version(&store), super::MEMORY_SCHEMA_VERSION);
+}
+
+// Acceptance criterion 2: re-opening an already-migrated store is a clean
+// no-op that keeps the version and touches no existing row.
+#[test]
+fn reopen_memory_db_is_idempotent() {
+    register_sqlite_vec();
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("memory.db");
+
+    let store = MemoryStore::open(&path).expect("first open");
+    let (id, _) = store
+        .add_note("decision", "Keep", "body", &[], &[], None, None)
+        .unwrap();
+    drop(store);
+
+    let reopened = MemoryStore::open(&path).expect("second open");
+    assert_eq!(user_version(&reopened), super::MEMORY_SCHEMA_VERSION);
+    assert_eq!(
+        reopened.get(id).unwrap().map(|n| n.title),
+        Some("Keep".to_string()),
+        "re-opening an already-migrated store must not touch existing rows"
+    );
+}
+
+// Acceptance criterion 3: a field DB built by today's binary but stamped
+// `user_version = 0` (every store on disk before this runner shipped, since
+// nothing ever wrote the header before now) is inferred at the latest
+// version on next open, without destructively re-running any step: an
+// existing row, its embedding, and its FTS entry all survive.
+#[test]
+fn legacy_fully_migrated_memory_db_is_inferred_and_stamped_rows_survive() {
+    register_sqlite_vec();
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("memory.db");
+
+    let id = {
+        let store = MemoryStore::open(&path).expect("build via runner");
+        let (id, _) = store
+            .add_note("decision", "Survives", "body text", &[], &[], None, None)
+            .unwrap();
+        let vector = vec![0.1f32; crate::embeddings::EMBEDDING_DIM];
+        store
+            .insert_embedding(id, &crate::embeddings::vec_to_blob(&vector))
+            .unwrap();
+        // Simulate a pre-runner binary: reset the header stamp.
+        store.execute_batch("PRAGMA user_version = 0").unwrap();
+        id
+    };
+
+    let store = MemoryStore::open(&path).expect("reopen legacy");
+    assert_eq!(
+        user_version(&store),
+        super::MEMORY_SCHEMA_VERSION,
+        "a fully-migrated legacy store must be inferred at the latest version"
+    );
+
+    let note = store
+        .get(id)
+        .unwrap()
+        .expect("note must survive re-inference");
+    assert_eq!(note.title, "Survives");
+    assert!(
+        store.get_embedding(id).unwrap().is_some(),
+        "an existing embedding must not be dropped by a spurious re-run of the \
+         768→896 upgrade step"
+    );
+
+    let hits: i64 = store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM memory_fts WHERE memory_fts MATCH 'Survives'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(hits, 1, "the FTS index must survive re-inference intact");
+}
+
+// Acceptance criterion 4: a partially-old field DB (missing only the last two
+// steps' columns) is inferred at the version just below them, and only those
+// missing steps run.
+#[test]
+fn partially_migrated_legacy_memory_db_is_inferred_then_completed() {
+    register_sqlite_vec();
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("memory.db");
+
+    {
+        let store = MemoryStore::open(&path).expect("build");
+        // Strip back to a pre-uuid (v6) shape: drop the columns/indexes added
+        // by steps 7 (uuid) and 8 (entity_id), then reset the stamp so `open`
+        // must re-infer rather than trust it.
+        store
+            .execute_batch(
+                "DROP INDEX idx_notes_uuid; \
+                 DROP INDEX idx_notes_remote_id; \
+                 ALTER TABLE notes DROP COLUMN uuid; \
+                 ALTER TABLE notes DROP COLUMN remote_id; \
+                 DROP INDEX idx_notes_entity_id; \
+                 ALTER TABLE notes DROP COLUMN entity_id; \
+                 PRAGMA user_version = 0;",
+            )
+            .expect("strip to v6 shape");
+        assert_eq!(
+            MemoryStore::infer_legacy_version(&store).unwrap(),
+            6,
+            "precondition: stripping uuid/remote_id/entity_id must land inference at 6"
+        );
+    }
+
+    let store = MemoryStore::open(&path).expect("reopen partial");
+    assert_eq!(user_version(&store), super::MEMORY_SCHEMA_VERSION);
+    assert!(notes_has_column(&store, "uuid"), "step 7 must have re-run");
+    assert!(
+        notes_has_column(&store, "entity_id"),
+        "step 8 must have re-run"
+    );
+}
+
+// Acceptance criterion 5: a genuine step failure (not a tolerated
+// duplicate-column error) propagates out of `open` rather than being
+// swallowed by the "already applied" guard.
+#[test]
+fn genuine_memory_migration_failure_propagates_not_swallowed() {
+    register_sqlite_vec();
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    let store = MemoryStore {
+        conn,
+        reembed_needed: None,
+        dropped_768: std::cell::Cell::new(false),
+    };
+    // No `notes` table exists, so the ALTER fails with "no such table" rather
+    // than "duplicate column name": the one error the guard tolerates.
+    let err = store
+        .apply_lifecycle_migration()
+        .expect_err("a missing table must surface as an error, not a swallowed no-op");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("no such table") || msg.contains("lifecycle migration"),
+        "a real migration failure must propagate, got: {msg}"
+    );
+}
+
+// Acceptance criterion 6: a store stamped with a schema version newer than
+// this binary supports (e.g. opened by an older binary after a newer one
+// wrote it) refuses with a clear message instead of mis-running steps.
+#[test]
+fn future_memory_schema_version_refuses_to_open() {
+    register_sqlite_vec();
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("memory.db");
+
+    {
+        let store = MemoryStore::open(&path).expect("build current store");
+        store
+            .execute_batch(&format!(
+                "PRAGMA user_version = {}",
+                super::MEMORY_SCHEMA_VERSION + 1
+            ))
+            .expect("stamp a future version");
+    }
+
+    let err = match MemoryStore::open(&path) {
+        Ok(_) => panic!("an older binary must refuse a DB stamped with a newer schema version"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("newer") || msg.contains("upgrade spelunk"),
+        "the error must explain the version mismatch clearly, got: {msg}"
     );
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,8 +148,10 @@ to maintain, plus a forced memory re-embed/re-harvest on migration) buys nothing
 
 The dimension upgrade for pre-0.9 `FLOAT[768]` databases is handled **per store**:
 `Database::apply_dim_upgrade_migration` rebuilds the chunk table as
-`INT8[896]`, while `MemoryStore::migrate` rebuilds `note_embeddings` as
-`FLOAT[896]` (each guarded by its own marker table). There is no path that leaves
+`INT8[896]`, while `MemoryStore::apply_dim_upgrade_migration` (one step in
+`MemoryStore::run_migrations`, the same forward-only `PRAGMA user_version`-gated
+runner `index.db` uses) rebuilds `note_embeddings` as `FLOAT[896]` (each still
+guarded by its own marker table). There is no path that leaves
 memory stranded on the stale 768-dim layout. The `note_embeddings` rebuild is
 empty rather than converting the old vectors, so semantic recall on pre-upgrade
 notes is lost until they are re-embedded with `spelunk memory reindex`; a


### PR DESCRIPTION
## Summary

`memory.db` now opens through the same forward-only, `PRAGMA user_version`-gated migration runner `index.db` already uses (`Database::run_migrations` in `storage/db.rs`), replacing ad-hoc re-execution of the schema SQL and string-matching `ALTER TABLE` errors for idempotency.

- 9 discrete, numbered migration steps behind `MEMORY_SCHEMA_VERSION`, each gated on `target > version` instead of running unconditionally on every open.
- A `user_version = 0` database is either brand-new (runs every step) or a pre-runner field DB, in which case its true version is inferred from table/column shape, stamped once, and only the missing steps run.
- A database stamped with a version newer than the binary supports refuses to open with a clear error instead of mis-running steps.
- The 768→896 vector-discard upgrade and the ADR-068 entity-id backfill/promotion are unchanged in behavior — they still fire on every open, now just sequenced after the runner.
- Fixed a real gap in the legacy-version inference: 3 of the 9 predicates only checked the first column of a two-column `ALTER TABLE` step, so a store crash-interrupted between the two `ADD COLUMN` statements (SQLite auto-commits each independently) would have that step permanently misidentified as already applied, leaving the second column missing forever. All three predicates now check both columns.
- `docs/architecture.md` updated to reference the new method name; `CHANGELOG.md` has an entry.

No CLI flag, config key, or user-facing behavior changed.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace` — green, including 10 new tests exercising the runner directly: fresh-DB stamping, idempotent re-open, legacy full-shape inference with multi-row content/embedding/FTS fidelity checks, partial-shape inference, the two-column inference-gap regression (table-driven across all three affected steps), genuine migration-step failure propagation (both an immediate error and a failure partway through a multi-statement step, confirming the already-committed DDL isn't silently marked done), refusal on a future schema version, and concurrent-open (`SQLITE_BUSY`) behavior during migration.
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `SPELUNK_SECRET_STORE=file cargo fmt --all -- --check` — clean.