### PR TITLE
spelunk-server: air-gapped model provisioning via --model-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`spelunk-server --model-dir <PATH>` (or `SPELUNK_MODEL_DIR`) loads the
+  bundled F2LLM-v2-330M embedder from a pre-provisioned local directory, with
+  zero network access.** For hosts with no route to `huggingface.co` (an
+  air-gapped network, a strict corp firewall, a build image with no egress),
+  the previous online-only Hugging Face Hub fetch had no fallback. Provision
+  the flat directory (the GGUF plus `tokenizer.json`; `config.json` is
+  optional) on a connected machine first and transfer it over; see [Server
+  setup → Air-gapped / no-egress install](docs/server-setup.md#air-gapped--no-egress-install)
+  for the full fetch-and-transfer procedure. Unset by default, so the online
+  path is unchanged for the common case.
+
 ### Removed
 
 - **`spelunk-server --embedding-url` / `SPELUNK_EMBEDDING_URL` and the deprecated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5416,6 +5416,7 @@ dependencies = [
  "spelunk-embed",
  "sqlite-vec",
  "tempfile",
+ "tokenizers 0.23.1",
  "tokio",
  "tokio-stream",
  "tower",

--- a/crates/spelunk-cli/src/cli/cmd/server.rs
+++ b/crates/spelunk-cli/src/cli/cmd/server.rs
@@ -1091,10 +1091,13 @@ mod tests {
         }
     }
 
-    // NOTE: both `which_spelunk_server_*` tests mutate the process-global `PATH`.
-    // Cargo runs unit tests multi-threaded by default, so they are pinned to the
-    // same `#[serial(path_env)]` group to keep them from racing each other (and
-    // any future PATH-touching test in this crate).
+    // NOTE: both `which_spelunk_server_*` tests mutate the process-global `PATH`,
+    // including setting it to "" entirely. Cargo runs unit tests multi-threaded
+    // by default, so they are pinned to the `path_env` serial group, along with
+    // every test that spawns a `DummyProc::graceful()`/`ignores_sigterm()`
+    // subprocess: those resolve the bare command name "sleep" via PATH, so an
+    // empty PATH from a concurrently-running sibling makes the spawn itself
+    // fail with ENOENT, not just the assertion under test.
 
     #[test]
     #[serial(path_env)]
@@ -1733,7 +1736,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    #[serial(server_start_lock)]
+    #[serial(server_start_lock, path_env)]
     fn process_matches_server_false_for_unrelated_process() {
         let proc = DummyProc::graceful();
         assert!(
@@ -1768,7 +1771,7 @@ mod tests {
     /// happen.
     #[cfg(unix)]
     #[tokio::test]
-    #[serial(server_start_lock)]
+    #[serial(server_start_lock, path_env)]
     async fn wait_for_exit_false_for_live_process() {
         let proc = DummyProc::graceful();
         assert!(
@@ -1781,7 +1784,7 @@ mod tests {
     /// reported stopped once the PID is confirmed gone.
     #[cfg(unix)]
     #[tokio::test]
-    #[serial(server_start_lock)]
+    #[serial(server_start_lock, path_env)]
     async fn terminate_and_wait_stops_graceful_process() {
         let proc = DummyProc::graceful();
         assert!(pid_is_alive(proc.pid));
@@ -1795,7 +1798,7 @@ mod tests {
     /// falls back to for a wedged daemon.
     #[cfg(unix)]
     #[tokio::test]
-    #[serial(server_start_lock)]
+    #[serial(server_start_lock, path_env)]
     async fn force_kill_reaps_sigterm_ignoring_process() {
         let proc = DummyProc::ignores_sigterm();
         assert!(pid_is_alive(proc.pid));
@@ -1819,7 +1822,7 @@ mod tests {
     /// behaviour the fix is about — previously only exercised by hand.
     #[cfg(unix)]
     #[tokio::test]
-    #[serial(server_start_lock)]
+    #[serial(server_start_lock, path_env)]
     async fn terminate_and_wait_escalates_when_sigterm_ignored() {
         let proc = DummyProc::ignores_sigterm();
         assert!(pid_is_alive(proc.pid));

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -76,3 +76,7 @@ wiremock = { workspace = true }
 pretty_assertions = { workspace = true }
 serial_test = { workspace = true }
 utoipa = { version = "5", features = ["axum_extras"] }
+# Builds a minimal-but-valid tokenizer.json fixture for embed_hub's
+# corrupt-GGUF test, so it exercises the GGUF parse path instead of failing
+# earlier on tokenizer parsing like the corrupt-tokenizer test.
+tokenizers = { workspace = true }

--- a/crates/spelunk-server/src/embed_hub.rs
+++ b/crates/spelunk-server/src/embed_hub.rs
@@ -9,13 +9,18 @@
 //! `load_from_path`. This is the only place in `spelunk-server` — or the
 //! workspace — that depends on `hf-hub`.
 //!
+//! [`load_from_model_dir`] is the air-gapped counterpart: it resolves the
+//! same artifacts from an operator-provisioned directory instead of the Hub,
+//! with no `hf_hub` involvement at all (see "Air-gapped / no-egress install"
+//! in `docs/server-setup.md`).
+//!
 //! Everything here comes from `spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF`, a repo
 //! we own — there is no runtime dependency on the third-party upstream
 //! `codefuse-ai/F2LLM-v2-330M` repo. See `docs/third-party-models.md` for the
 //! Apache-2.0 attribution and the pinned upstream revision these artifacts
 //! were derived from.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use hf_hub::{Repo, RepoType, api::sync::ApiBuilder};
@@ -119,6 +124,64 @@ pub fn load_from_hub() -> Result<NativeEmbedder> {
         }
         tracing::info!("fetched pre-quantized model to {}", gguf_path.display());
     }
+
+    NativeEmbedder::load_from_path(&gguf_path, &tokenizer_path, &config_path)
+}
+
+/// Load the F2LLM-v2-330M embedder from a directory an operator provisioned
+/// out-of-band (`spelunk-server --model-dir <path>` /
+/// `SPELUNK_MODEL_DIR`), with zero network access. Unlike [`load_from_hub`],
+/// this function never references `hf_hub` — the offline path is a pure
+/// filesystem read, so there is no code path here for a corp firewall to
+/// block. See "Air-gapped / no-egress install" in `docs/server-setup.md` for
+/// the fetch-and-transfer procedure that produces this directory on a
+/// connected machine.
+///
+/// Expects `dir` to contain the two artifacts that vary per pinned model
+/// revision: the Q8_0 GGUF (see [`QUANT_GGUF`]) and `tokenizer.json`, exactly
+/// as fetched by [`load_from_hub`]. `config.json` never changes independent
+/// of the pinned revision (see [`CONFIG_JSON`]), so it's optional here: if
+/// present it's used as-is (an explicit override), otherwise the embedded
+/// default is written into `dir` so a second load from the same directory is
+/// fully self-contained from just those two transferred files.
+pub fn load_from_model_dir(dir: &Path) -> Result<NativeEmbedder> {
+    anyhow::ensure!(
+        dir.is_dir(),
+        "--model-dir {} is not a directory. See \"Air-gapped / no-egress install\" in \
+         docs/server-setup.md for the offline provisioning procedure.",
+        dir.display()
+    );
+
+    let gguf_path = dir.join(QUANT_GGUF);
+    let tokenizer_path = dir.join("tokenizer.json");
+    let config_path = dir.join("config.json");
+
+    anyhow::ensure!(
+        gguf_path.exists(),
+        "offline model artifact missing: {} not found in --model-dir {}. See \
+         \"Air-gapped / no-egress install\" in docs/server-setup.md for the fetch-and-transfer \
+         procedure.",
+        QUANT_GGUF,
+        dir.display()
+    );
+    anyhow::ensure!(
+        tokenizer_path.exists(),
+        "offline model artifact missing: tokenizer.json not found in --model-dir {}. See \
+         \"Air-gapped / no-egress install\" in docs/server-setup.md for the fetch-and-transfer \
+         procedure.",
+        dir.display()
+    );
+
+    if !config_path.exists() {
+        std::fs::write(&config_path, CONFIG_JSON).with_context(|| {
+            format!("writing embedded config.json to {}", config_path.display())
+        })?;
+    }
+
+    tracing::info!(
+        "loading F2LLM-v2-330M (Q8_0) from offline --model-dir {} (zero network access)",
+        dir.display()
+    );
 
     NativeEmbedder::load_from_path(&gguf_path, &tokenizer_path, &config_path)
 }
@@ -413,6 +476,235 @@ mod tests {
         assert!(
             cap <= 40_960,
             "token cap must not exceed MAX_SEQ_LEN: {cap}"
+        );
+    }
+
+    // ── Offline / air-gapped model-dir load ───────────────────────────────────
+
+    /// A `--model-dir` pointing at a plain file (not a directory) is a clear
+    /// misconfiguration error, not a panic or a silent Hub fallback.
+    #[test]
+    fn load_from_model_dir_rejects_non_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("not-a-dir");
+        std::fs::write(&file, b"").unwrap();
+
+        let msg = match load_from_model_dir(&file) {
+            Ok(_) => panic!("a file path must not be accepted as --model-dir"),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(msg.contains(&file.display().to_string()));
+        assert!(
+            msg.contains("server-setup.md"),
+            "error must point at the offline provisioning docs, got: {msg}"
+        );
+    }
+
+    /// An empty `--model-dir` (no artifacts provisioned yet) must fail with a
+    /// clear error naming the missing GGUF and pointing at the offline docs
+    /// section — never a bare Hugging Face Hub connection error, since this
+    /// path never touches `hf_hub` at all.
+    #[test]
+    fn load_from_model_dir_missing_gguf_names_file_and_docs() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let msg = match load_from_model_dir(dir.path()) {
+            Ok(_) => panic!("an empty --model-dir must be a load error"),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            msg.contains(QUANT_GGUF),
+            "error must name the missing file: {msg}"
+        );
+        assert!(
+            msg.contains("server-setup.md"),
+            "error must point at the offline docs: {msg}"
+        );
+        assert!(
+            !msg.contains("http") && !msg.contains("huggingface") && !msg.contains("downloading"),
+            "must not reference any network fetch, got: {msg}"
+        );
+    }
+
+    /// With the GGUF present but the tokenizer absent, the error names the
+    /// tokenizer specifically, not a generic "artifacts missing".
+    #[test]
+    fn load_from_model_dir_missing_tokenizer_names_file_and_docs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(QUANT_GGUF), b"not a real gguf").unwrap();
+
+        let msg = match load_from_model_dir(dir.path()) {
+            Ok(_) => panic!("a missing tokenizer must be a load error"),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            msg.contains("tokenizer.json"),
+            "error must name the missing file: {msg}"
+        );
+        assert!(
+            msg.contains("server-setup.md"),
+            "error must point at the offline docs: {msg}"
+        );
+    }
+
+    /// Both artifacts present but corrupt: the error must come from the local
+    /// parse (naming the specific bad file), matching `load_from_path`'s
+    /// existing per-file error behaviour — never a network error, never a
+    /// panic (proving "no crash loop" starts from a `Result`, not a `unwrap`).
+    #[test]
+    fn load_from_model_dir_corrupt_tokenizer_errors_locally() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(QUANT_GGUF), b"not a real gguf").unwrap();
+        std::fs::write(dir.path().join("tokenizer.json"), b"not valid json").unwrap();
+
+        let msg = match load_from_model_dir(dir.path()) {
+            Ok(_) => panic!("a corrupt tokenizer must be a load error"),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            msg.contains("tokenizer"),
+            "error must name the tokenizer as the failing artifact, got: {msg}"
+        );
+        assert!(
+            !msg.contains("http") && !msg.contains("huggingface") && !msg.contains("downloading"),
+            "corrupt-artifact error must not reference any network fetch, got: {msg}"
+        );
+    }
+
+    /// `load_from_model_dir` writes the embedded `config.json` into the
+    /// directory when missing, mirroring `load_from_hub`'s cache layout — so
+    /// an operator only ever needs to transfer the two revision-specific
+    /// files (GGUF + tokenizer) and a second load from the same directory is
+    /// fully self-contained.
+    #[test]
+    fn load_from_model_dir_writes_embedded_config_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(QUANT_GGUF), b"not a real gguf").unwrap();
+        std::fs::write(dir.path().join("tokenizer.json"), b"not valid json").unwrap();
+
+        // The load itself still fails (corrupt fixtures), but config.json must
+        // have been written before the failing tokenizer parse.
+        let _ = load_from_model_dir(dir.path());
+        let config_path = dir.path().join("config.json");
+        assert!(
+            config_path.exists(),
+            "embedded config.json must be written to --model-dir"
+        );
+        assert_eq!(std::fs::read_to_string(config_path).unwrap(), CONFIG_JSON);
+    }
+
+    /// Zero-egress guarantee under a hostile network: even with every standard
+    /// proxy env var pointed at an address nothing listens on,
+    /// `load_from_model_dir` must behave identically to a clean environment —
+    /// same error, and fast (no hang waiting on a dead proxy). The only way
+    /// that holds is if the code path never attempts a network request at
+    /// all. Guards against a future edit reintroducing an `hf_hub`/`reqwest`
+    /// call into this function.
+    #[test]
+    #[serial_test::serial(network_proxy_env)]
+    fn load_from_model_dir_ignores_hostile_network_env() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(QUANT_GGUF), b"not a real gguf").unwrap();
+        std::fs::write(dir.path().join("tokenizer.json"), b"not valid json").unwrap();
+
+        let err_msg = |dir: &std::path::Path| match load_from_model_dir(dir) {
+            Ok(_) => panic!("corrupt fixtures must be a load error"),
+            Err(e) => format!("{e:#}"),
+        };
+        let clean_msg = err_msg(dir.path());
+
+        // Point every standard proxy env var at a closed local port: any
+        // accidental network call in this path would fail differently (or
+        // hang) via the proxy, changing the message or the timing.
+        let proxy_vars = [
+            "http_proxy",
+            "https_proxy",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+        ];
+        // SAFETY: guarded by #[serial] so no other test reads/writes these
+        // vars concurrently; restored before returning.
+        let prev: Vec<Option<String>> = proxy_vars.iter().map(|v| std::env::var(v).ok()).collect();
+        for v in proxy_vars {
+            unsafe { std::env::set_var(v, "http://127.0.0.1:1") };
+        }
+
+        let started = std::time::Instant::now();
+        let hostile_msg = err_msg(dir.path());
+        let elapsed = started.elapsed();
+
+        for (v, val) in proxy_vars.iter().zip(prev) {
+            match val {
+                Some(v2) => unsafe { std::env::set_var(v, v2) },
+                None => unsafe { std::env::remove_var(v) },
+            }
+        }
+
+        assert_eq!(
+            clean_msg, hostile_msg,
+            "load_from_model_dir must behave identically regardless of network reachability"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "must fail on the local parse alone, never wait on a network call: {elapsed:?}"
+        );
+    }
+
+    /// End-to-end round-trip: the artifacts `load_from_hub` fetches onto a
+    /// connected machine must be exactly what `load_from_model_dir` accepts
+    /// once copied into a flat directory, and both load paths must produce
+    /// agreeing embeddings for the same input. This is the proof that the
+    /// documented fetch-and-transfer procedure (AC5) produces a directory this
+    /// offline path actually loads. Ignored by default: downloads the model.
+    ///
+    /// Run with:
+    ///   SPELUNK_SECRET_STORE=file cargo test -p spelunk-server \
+    ///     -- --ignored offline_model_dir_round_trips_with_hub_artifacts
+    #[test]
+    #[ignore = "downloads the F2LLM model"]
+    fn offline_model_dir_round_trips_with_hub_artifacts() {
+        use spelunk_core::embeddings::EmbeddingBackend;
+
+        // Prime the Hub cache, then locate the resolved files exactly as
+        // `load_from_path_embeds_896_dim` does above.
+        load_from_hub().expect("prime local cache via Hub");
+        let cache_dir = model_cache_dir().expect("cache dir");
+        let hub_gguf = cache_dir.join(QUANT_GGUF);
+        let hub_config = cache_dir.join("config.json");
+        let hub_tokenizer = std::fs::read_dir(
+            cache_dir
+                .join("models--spelunk-cloud--F2LLM-v2-330M-Q8_0-GGUF")
+                .join("snapshots"),
+        )
+        .expect("hf-hub snapshots dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path().join("tokenizer.json"))
+        .find(|p| p.exists())
+        .expect("cached tokenizer.json");
+
+        // Simulate the operator's transfer: copy just the two
+        // revision-specific files into a fresh flat directory.
+        let offline_dir = tempfile::tempdir().unwrap();
+        std::fs::copy(&hub_gguf, offline_dir.path().join(QUANT_GGUF)).unwrap();
+        std::fs::copy(&hub_tokenizer, offline_dir.path().join("tokenizer.json")).unwrap();
+        let _ = &hub_config; // config.json is embedded; the offline loader writes its own copy.
+
+        let hub_embedder = NativeEmbedder::load_from_path(&hub_gguf, &hub_tokenizer, &hub_config)
+            .expect("load via the Hub-resolved paths");
+        let offline_embedder =
+            load_from_model_dir(offline_dir.path()).expect("load via the offline model-dir path");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let text = "read the contents of a file from disk";
+        let hub_vec = rt.block_on(hub_embedder.embed(&[text])).expect("hub embed");
+        let offline_vec = rt
+            .block_on(offline_embedder.embed(&[text]))
+            .expect("offline embed");
+
+        assert_eq!(
+            hub_vec, offline_vec,
+            "the same artifacts loaded via either path must produce identical embeddings"
         );
     }
 }

--- a/crates/spelunk-server/src/embed_hub.rs
+++ b/crates/spelunk-server/src/embed_hub.rs
@@ -571,6 +571,97 @@ mod tests {
         );
     }
 
+    /// A minimal-but-valid `tokenizer.json`, built through the `tokenizers`
+    /// crate's own serializer rather than hand-typed JSON, so a corrupt-GGUF
+    /// test can get past tokenizer parsing and reach the GGUF parse itself
+    /// (`Qwen3EmbedWeights::from_gguf`), a different failure mode with a
+    /// different error path than the corrupt-tokenizer case above.
+    fn write_valid_tokenizer(path: &std::path::Path) {
+        let vocab: std::collections::HashMap<String, u32> =
+            [("<unk>".to_string(), 0u32)].into_iter().collect();
+        let model = tokenizers::models::wordlevel::WordLevel::builder()
+            .vocab(vocab.into_iter().collect())
+            .unk_token("<unk>".to_string())
+            .build()
+            .expect("valid WordLevel fixture model");
+        tokenizers::Tokenizer::new(model)
+            .save(path, false)
+            .expect("saving fixture tokenizer.json");
+    }
+
+    /// Corrupt GGUF with a *valid* tokenizer must fail inside GGUF parsing
+    /// (`Qwen3EmbedWeights::from_gguf`), not tokenizer parsing - proving the
+    /// two artifact-corruption cases take genuinely distinct error paths
+    /// rather than both happening to fail on whichever the code checks first.
+    #[test]
+    fn load_from_model_dir_corrupt_gguf_errors_locally() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(QUANT_GGUF), b"not a real gguf").unwrap();
+        write_valid_tokenizer(&dir.path().join("tokenizer.json"));
+        // No config.json: the real embedded config is auto-written, so the
+        // failure is attributable to the GGUF alone.
+
+        let msg = match load_from_model_dir(dir.path()) {
+            Ok(_) => panic!("a corrupt GGUF must be a load error"),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            !msg.contains("tokenizer") && !msg.contains("config.json"),
+            "error must not misattribute a GGUF failure to the tokenizer or config, got: {msg}"
+        );
+        assert!(
+            !msg.contains("http") && !msg.contains("huggingface") && !msg.contains("downloading"),
+            "corrupt-GGUF error must not reference any network fetch, got: {msg}"
+        );
+    }
+
+    /// A `--model-dir` containing only `tokenizer.json` (no GGUF at all) must
+    /// still name the GGUF as missing, the same as a fully empty directory -
+    /// proving the existence check order doesn't let a present tokenizer mask
+    /// the missing GGUF with a different (e.g. tokenizer-shaped) error.
+    #[test]
+    fn load_from_model_dir_tokenizer_only_still_names_missing_gguf() {
+        let dir = tempfile::tempdir().unwrap();
+        write_valid_tokenizer(&dir.path().join("tokenizer.json"));
+
+        let msg = match load_from_model_dir(dir.path()) {
+            Ok(_) => panic!("a tokenizer-only --model-dir must be a load error"),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            msg.contains(QUANT_GGUF),
+            "error must name the missing GGUF even with tokenizer.json present: {msg}"
+        );
+        assert!(
+            msg.contains("server-setup.md"),
+            "error must point at the offline docs: {msg}"
+        );
+    }
+
+    /// A `--model-dir` pointing at a path that doesn't exist at all (as
+    /// opposed to an existing non-directory file) must fail with the same
+    /// clear "not a directory" error naming the path, not a confusing
+    /// downstream OS error from inside file-open calls.
+    #[test]
+    fn load_from_model_dir_rejects_nonexistent_path() {
+        let parent = tempfile::tempdir().unwrap();
+        let missing = parent.path().join("does-not-exist");
+
+        let msg = match load_from_model_dir(&missing) {
+            Ok(_) => panic!("a nonexistent path must not be accepted as --model-dir"),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(msg.contains(&missing.display().to_string()));
+        assert!(
+            msg.contains("is not a directory"),
+            "error must clearly say the directory itself is missing, got: {msg}"
+        );
+        assert!(
+            msg.contains("server-setup.md"),
+            "error must point at the offline provisioning docs, got: {msg}"
+        );
+    }
+
     /// `load_from_model_dir` writes the embedded `config.json` into the
     /// directory when missing, mirroring `load_from_hub`'s cache layout — so
     /// an operator only ever needs to transfer the two revision-specific
@@ -591,6 +682,42 @@ mod tests {
             "embedded config.json must be written to --model-dir"
         );
         assert_eq!(std::fs::read_to_string(config_path).unwrap(), CONFIG_JSON);
+    }
+
+    /// A second server start against the same `--model-dir` (config.json now
+    /// present from the first run's auto-write) must behave identically to
+    /// the first: the existing file is used as-is, not re-written or treated
+    /// as a conflict, so the resulting error (from the still-corrupt GGUF /
+    /// tokenizer fixtures) is unchanged between runs.
+    #[test]
+    fn load_from_model_dir_second_start_reuses_written_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(QUANT_GGUF), b"not a real gguf").unwrap();
+        std::fs::write(dir.path().join("tokenizer.json"), b"not valid json").unwrap();
+
+        let first_msg = match load_from_model_dir(dir.path()) {
+            Ok(_) => panic!("corrupt fixtures must be a load error"),
+            Err(e) => format!("{e:#}"),
+        };
+        let config_path = dir.path().join("config.json");
+        assert!(config_path.exists(), "first run must write config.json");
+
+        // Simulate an operator restart: model-dir now has all three paths
+        // present, exactly like a second `spelunk-server --model-dir` start.
+        let second_msg = match load_from_model_dir(dir.path()) {
+            Ok(_) => panic!("corrupt fixtures must still be a load error on a second start"),
+            Err(e) => format!("{e:#}"),
+        };
+
+        assert_eq!(
+            first_msg, second_msg,
+            "a pre-existing config.json must not change the load outcome"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&config_path).unwrap(),
+            CONFIG_JSON,
+            "the pre-existing config.json must be left as the same embedded default, not corrupted by a second write"
+        );
     }
 
     /// Zero-egress guarantee under a hostile network: even with every standard

--- a/crates/spelunk-server/src/embed_hub.rs
+++ b/crates/spelunk-server/src/embed_hub.rs
@@ -131,7 +131,7 @@ pub fn load_from_hub() -> Result<NativeEmbedder> {
 /// Load the F2LLM-v2-330M embedder from a directory an operator provisioned
 /// out-of-band (`spelunk-server --model-dir <path>` /
 /// `SPELUNK_MODEL_DIR`), with zero network access. Unlike [`load_from_hub`],
-/// this function never references `hf_hub` — the offline path is a pure
+/// this function never references `hf_hub`: the offline path is a pure
 /// filesystem read, so there is no code path here for a corp firewall to
 /// block. See "Air-gapped / no-egress install" in `docs/server-setup.md` for
 /// the fetch-and-transfer procedure that produces this directory on a
@@ -502,7 +502,7 @@ mod tests {
 
     /// An empty `--model-dir` (no artifacts provisioned yet) must fail with a
     /// clear error naming the missing GGUF and pointing at the offline docs
-    /// section — never a bare Hugging Face Hub connection error, since this
+    /// section, never a bare Hugging Face Hub connection error, since this
     /// path never touches `hf_hub` at all.
     #[test]
     fn load_from_model_dir_missing_gguf_names_file_and_docs() {
@@ -549,7 +549,7 @@ mod tests {
 
     /// Both artifacts present but corrupt: the error must come from the local
     /// parse (naming the specific bad file), matching `load_from_path`'s
-    /// existing per-file error behaviour — never a network error, never a
+    /// existing per-file error behaviour: never a network error, never a
     /// panic (proving "no crash loop" starts from a `Result`, not a `unwrap`).
     #[test]
     fn load_from_model_dir_corrupt_tokenizer_errors_locally() {
@@ -663,7 +663,7 @@ mod tests {
     }
 
     /// `load_from_model_dir` writes the embedded `config.json` into the
-    /// directory when missing, mirroring `load_from_hub`'s cache layout — so
+    /// directory when missing, mirroring `load_from_hub`'s cache layout, so
     /// an operator only ever needs to transfer the two revision-specific
     /// files (GGUF + tokenizer) and a second load from the same directory is
     /// fully self-contained.
@@ -722,7 +722,7 @@ mod tests {
 
     /// Zero-egress guarantee under a hostile network: even with every standard
     /// proxy env var pointed at an address nothing listens on,
-    /// `load_from_model_dir` must behave identically to a clean environment —
+    /// `load_from_model_dir` must behave identically to a clean environment:
     /// same error, and fast (no hang waiting on a dead proxy). The only way
     /// that holds is if the code path never attempts a network request at
     /// all. Guards against a future edit reintroducing an `hf_hub`/`reqwest`

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -82,6 +82,16 @@ struct Args {
     #[arg(long, default_value_t = default_conflict_threshold())]
     conflict_threshold: f32,
 
+    /// Directory holding a pre-provisioned F2LLM-v2-330M GGUF + tokenizer (see
+    /// "Air-gapped / no-egress install" in docs/server-setup.md), for hosts
+    /// with no route to huggingface.co. When set, the bundled native embedder
+    /// loads from this directory instead of the Hugging Face Hub: zero
+    /// network access, at startup or at runtime. Only consulted when the
+    /// bundled native embedder is the active backend; ignored otherwise.
+    #[arg(long, env = "SPELUNK_MODEL_DIR", value_name = "PATH")]
+    model_dir: Option<PathBuf>,
+
+
     /// Base URL of an OpenAI-compatible chat completions server for LLM features
     /// (`/explore`). Overrides `SPELUNK_LLM_URL`.
     #[arg(long, env = "SPELUNK_LLM_URL")]
@@ -281,6 +291,7 @@ async fn run(budget: ThreadBudget) -> Result<()> {
     // Keep a handle to the embedder slot so the background load task can flip it
     // `loading → ready | unavailable` after the listener binds.
     let embedder_slot = state.embedder.clone();
+    let model_dir = args.model_dir.clone();
 
     let app = router(state);
     let addr: SocketAddr = format!("{}:{}", args.host, args.port)
@@ -326,15 +337,24 @@ async fn run(budget: ThreadBudget) -> Result<()> {
     tracing::info!("spelunk-server listening on {scheme}://{addr}");
 
     // Load the native embedder on a background task now that health is live.
-    // `embed_hub::load_from_hub()` is blocking/CPU-heavy, so run it on the blocking
-    // pool; publish the backend into the slot on success (state → ready) or
-    // record the failure (state → unavailable). Only the native path warms up
-    // here — a disabled slot (no embed-native feature) is already terminal.
+    // Both `embed_hub::load_from_hub()` (network) and `load_from_model_dir()`
+    // (offline, when `--model-dir`/`SPELUNK_MODEL_DIR` is set) are
+    // blocking/CPU-heavy, so run whichever applies on the blocking pool;
+    // publish the backend into the slot on success (state → ready) or record
+    // the failure (state → unavailable) either way: an offline host with no
+    // (or bad) provisioned artifacts reaches the same terminal `unavailable`
+    // state as a failed Hub download, just with an error naming the offline
+    // docs instead of a connection failure. Only the native path warms up
+    // here — disabled slots are already in a terminal state.
     #[cfg(feature = "embed-native")]
     if load_native {
         let slot = embedder_slot.clone();
         tokio::spawn(async move {
-            match tokio::task::spawn_blocking(embed_hub::load_from_hub).await {
+            let load = move || match model_dir {
+                Some(dir) => embed_hub::load_from_model_dir(&dir),
+                None => embed_hub::load_from_hub(),
+            };
+            match tokio::task::spawn_blocking(load).await {
                 Ok(Ok(native)) => {
                     tracing::info!("native embedding model loaded (dim={})", NATIVE_EMBED_DIM);
                     slot.set_ready(
@@ -360,7 +380,7 @@ async fn run(budget: ThreadBudget) -> Result<()> {
     }
     // Silence "unused" for the non-embed-native build (no background load).
     #[cfg(not(feature = "embed-native"))]
-    let _ = (load_native, &embedder_slot);
+    let _ = (load_native, &embedder_slot, &model_dir);
 
     let make_service = app.into_make_service_with_connect_info::<SocketAddr>();
     match tls_config {
@@ -1167,6 +1187,50 @@ mod arg_tests {
         assert_eq!(
             args.key_file.as_deref(),
             Some(std::path::Path::new("/etc/spelunk/server-key"))
+        );
+    }
+
+    // ── Offline / air-gapped model-dir ───────────────────────────────────────
+
+    /// `--model-dir` parses as a path arg, for the air-gapped load path.
+    #[test]
+    fn model_dir_flag_parses() {
+        let args = Args::parse_from(["spelunk-server", "--model-dir", "/srv/spelunk/models"]);
+        assert_eq!(
+            args.model_dir.as_deref(),
+            Some(std::path::Path::new("/srv/spelunk/models"))
+        );
+    }
+
+    /// Unset by default: the online Hugging Face Hub path stays the default
+    /// (no regression for the common case).
+    #[test]
+    fn model_dir_defaults_to_none() {
+        let args = Args::parse_from(["spelunk-server"]);
+        assert_eq!(args.model_dir, None);
+    }
+
+    /// `SPELUNK_MODEL_DIR` is a first-class equal source, not just a flag:
+    /// the same convention as `SPELUNK_SERVER_TLS_CERT`/`SPELUNK_LLM_URL`, so
+    /// a systemd unit or container entrypoint can set it without a flag.
+    #[test]
+    #[serial_test::serial(model_dir_env)]
+    fn model_dir_env_var_is_honoured() {
+        let prev = std::env::var("SPELUNK_MODEL_DIR").ok();
+        // SAFETY: guarded by #[serial] so no other test reads/writes this var
+        // concurrently; restored before returning.
+        unsafe { std::env::set_var("SPELUNK_MODEL_DIR", "/srv/spelunk/models") };
+
+        let args = Args::parse_from(["spelunk-server"]);
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("SPELUNK_MODEL_DIR", v) },
+            None => unsafe { std::env::remove_var("SPELUNK_MODEL_DIR") },
+        }
+
+        assert_eq!(
+            args.model_dir.as_deref(),
+            Some(std::path::Path::new("/srv/spelunk/models"))
         );
     }
 

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -344,7 +344,7 @@ async fn run(budget: ThreadBudget) -> Result<()> {
     // (or bad) provisioned artifacts reaches the same terminal `unavailable`
     // state as a failed Hub download, just with an error naming the offline
     // docs instead of a connection failure. Only the native path warms up
-    // here — disabled slots are already in a terminal state.
+    // here: disabled slots are already in a terminal state.
     #[cfg(feature = "embed-native")]
     if load_native {
         let slot = embedder_slot.clone();

--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -91,7 +91,6 @@ struct Args {
     #[arg(long, env = "SPELUNK_MODEL_DIR", value_name = "PATH")]
     model_dir: Option<PathBuf>,
 
-
     /// Base URL of an OpenAI-compatible chat completions server for LLM features
     /// (`/explore`). Overrides `SPELUNK_LLM_URL`.
     #[arg(long, env = "SPELUNK_LLM_URL")]
@@ -1205,8 +1204,23 @@ mod arg_tests {
     /// Unset by default: the online Hugging Face Hub path stays the default
     /// (no regression for the common case).
     #[test]
+    #[serial_test::serial(model_dir_env)]
     fn model_dir_defaults_to_none() {
+        // Serialized against model_dir_env_var_is_honoured: both read/write
+        // the real process env var, and cargo test runs in threads within one
+        // process, so an unguarded reader can observe another test's
+        // temporarily-set value.
+        let prev = std::env::var("SPELUNK_MODEL_DIR").ok();
+        // SAFETY: guarded by #[serial] so no other test reads/writes this var
+        // concurrently.
+        unsafe { std::env::remove_var("SPELUNK_MODEL_DIR") };
+
         let args = Args::parse_from(["spelunk-server"]);
+
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("SPELUNK_MODEL_DIR", v) };
+        }
+
         assert_eq!(args.model_dir, None);
     }
 

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -667,8 +667,8 @@ export SPELUNK_MODEL_DIR=/srv/spelunk/models
 spelunk-server
 ```
 
-Only consulted when the bundled native embedder is the active backend
-(`--embedding-url` unset); ignored otherwise.
+Only consulted when the bundled native embedder is enabled (the
+`embed-native` build feature); ignored otherwise.
 
 ### Directory layout
 

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -650,6 +650,94 @@ container) is a routable bind with `--tls-cert`/`--tls-key` and a key, where the
 server terminates HTTPS itself. Plaintext off-host stays refused with no
 override.
 
+## Air-gapped / no-egress install
+
+`spelunk-server` normally fetches the bundled F2LLM-v2-330M embedder from
+Hugging Face Hub the first time it's needed (see [Getting
+started](getting-started.md)). On a host with no route to `huggingface.co`,
+an air-gapped network, a strict corp firewall, a build image with no egress,
+that download has nothing to reach. `--model-dir` (or `SPELUNK_MODEL_DIR`)
+points the bundled native embedder at a directory you provisioned out of
+band instead, with zero network access at startup or at runtime:
+
+```bash
+spelunk-server --model-dir /srv/spelunk/models
+# or
+export SPELUNK_MODEL_DIR=/srv/spelunk/models
+spelunk-server
+```
+
+Only consulted when the bundled native embedder is the active backend
+(`--embedding-url` unset); ignored otherwise.
+
+### Directory layout
+
+`--model-dir` expects a flat directory, no nested subdirectories, containing:
+
+| File | Required | Notes |
+|---|---|---|
+| `f2llm-v2-330m-q8_0.gguf` | yes | pre-quantized Q8_0 embedder weights |
+| `tokenizer.json` | yes | matching tokenizer |
+| `config.json` | no | auto-written from an embedded copy if absent; supply it only to override that default |
+
+A missing directory, or a missing GGUF or tokenizer inside it, fails fast
+with an error naming the missing piece and pointing back at this section.
+
+### Fetch-and-transfer procedure
+
+Produce that directory on a machine that does have network access, then
+carry it to the air-gapped host:
+
+1. On the connected machine, run `spelunk-server` once with no `--model-dir`.
+   This populates the normal online cache at `~/.local/share/spelunk/models/`
+   (Linux: `$XDG_DATA_HOME/spelunk/models/`), which ends up holding:
+   - `f2llm-v2-330m-q8_0.gguf`
+   - `config.json`
+   - a nested `tokenizer.json`, under
+     `models--spelunk-cloud--F2LLM-v2-330M-Q8_0-GGUF/snapshots/<rev>/tokenizer.json`
+     (hf-hub's own cache layout)
+2. Copy the GGUF and that nested `tokenizer.json` into a new, flat directory.
+   `config.json` doesn't need to come along; a missing one is regenerated on
+   the air-gapped host.
+   ```bash
+   mkdir -p offline-model
+   cp ~/.local/share/spelunk/models/f2llm-v2-330m-q8_0.gguf offline-model/
+   cp ~/.local/share/spelunk/models/models--spelunk-cloud--F2LLM-v2-330M-Q8_0-GGUF/snapshots/*/tokenizer.json \
+      offline-model/
+   ```
+3. Transfer `offline-model/` to the air-gapped host by whatever out-of-band
+   means your environment allows (removable media, an internal artifact
+   store, etc.), and point `--model-dir` / `SPELUNK_MODEL_DIR` at it there.
+
+### Verifying integrity
+
+Both files come from the first-party `spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF`
+Hugging Face repo; see [Model attribution](model-attribution.md) for
+provenance and license. As fetched at time of writing, their SHA-256 sums are:
+
+| File | SHA-256 |
+|---|---|
+| `f2llm-v2-330m-q8_0.gguf` | `2c12aad2951f1d9a3b457f890a2586d1ee19b755b377c0fb424e856e615b8f2b` |
+| `tokenizer.json` | `7e295e5bb91a3d35335f92fa4294a6e4e0ab4aa586db853e14312a62135bfddc` |
+
+`spelunk-server` fetches from that repo's `main` branch rather than a pinned
+commit, so these values track whatever is currently published there. Treat
+them as a convenience check, not a permanent guarantee: for integrity
+verification on artifacts fetched later, recompute and compare against the
+source's own published hash instead of trusting this table indefinitely.
+
+```bash
+shasum -a 256 f2llm-v2-330m-q8_0.gguf tokenizer.json
+```
+
+Hugging Face also serves each file's hash directly, in the `x-linked-etag`
+response header:
+
+```bash
+curl -sI https://huggingface.co/spelunk-cloud/F2LLM-v2-330M-Q8_0-GGUF/resolve/main/f2llm-v2-330m-q8_0.gguf \
+  | grep -i x-linked-etag
+```
+
 ## Related
 
 - [Server API](architecture/server-api.md): the HTTP + SSE surface the server exposes

--- a/docs/third-party-models.md
+++ b/docs/third-party-models.md
@@ -100,9 +100,9 @@ artifacts, not a different model. See [Model attribution](model-attribution.md).
 
 ## Running with no network access at all
 
-`--embedding-url` above still calls out over the network, just to a
-different (self-hosted) endpoint. For a host with no route out at all, not
-even to an internal endpoint, `--model-dir` / `SPELUNK_MODEL_DIR` loads the
+`SPELUNK_EMBEDDER_GGUF_REPO` above still calls out over the network, just to a
+different (self-hosted) source. For a host with no route out at all, not
+even to an alternate source, `--model-dir` / `SPELUNK_MODEL_DIR` loads the
 bundled native embedder from a directory you provision ahead of time instead
 of fetching it from Hugging Face Hub. See [Server setup → Air-gapped /
 no-egress install](server-setup.md#air-gapped--no-egress-install) for the

--- a/docs/third-party-models.md
+++ b/docs/third-party-models.md
@@ -98,6 +98,16 @@ native embedder. `SPELUNK_EMBEDDER_GGUF_REPO` points that *bundled native*
 embedder at an alternate source for the same F2LLM-v2-330M GGUF and tokenizer
 artifacts, not a different model. See [Model attribution](model-attribution.md).
 
+## Running with no network access at all
+
+`--embedding-url` above still calls out over the network, just to a
+different (self-hosted) endpoint. For a host with no route out at all, not
+even to an internal endpoint, `--model-dir` / `SPELUNK_MODEL_DIR` loads the
+bundled native embedder from a directory you provision ahead of time instead
+of fetching it from Hugging Face Hub. See [Server setup → Air-gapped /
+no-egress install](server-setup.md#air-gapped--no-egress-install) for the
+directory layout and the fetch-and-transfer procedure.
+
 ## Related
 
 - [Server setup](server-setup.md): deploying `spelunk-server`, TLS, client configuration


### PR DESCRIPTION
## Summary

`spelunk-embed` already has a zero-network load path (`NativeEmbedder::load_from_path`), but nothing exposed it: `spelunk-server` always resolved the bundled F2LLM-v2-330M artifacts via the Hugging Face Hub, so a host with no route to `huggingface.co` (the core team-server audience, deployed behind a firewall) had no documented way to run semantic search.

This adds a supported, documented, tested offline path:

- `spelunk-server --model-dir <PATH>` / `SPELUNK_MODEL_DIR` loads the bundled embedder from an operator-provisioned directory instead of the Hub, with zero network access at startup or at runtime. The function never touches `hf_hub`, so there's no code path here for a firewall to block.
- Missing or malformed artifacts (missing directory, missing GGUF, missing tokenizer, corrupt GGUF, corrupt tokenizer) fail fast with an error naming the specific file and pointing at the new docs section, never a bare Hub connection error or a crash loop.
- Unset by default, so the existing online Hub path is unchanged for the common case.
- `docs/server-setup.md` gains an "Air-gapped / no-egress install" section with the directory layout, the fetch-and-transfer procedure for producing that directory on a connected machine, and checksums for the artifacts as fetched at time of writing.
- `docs/third-party-models.md` cross-references the new section for the no-network-at-all case.

## Test plan

- `SPELUNK_SECRET_STORE=file cargo test --workspace` — ran twice locally, both green (workspace-wide, including a previously-flaky PATH-mutation test now fixed by tightening `#[serial]` grouping in `crates/spelunk-cli/src/cli/cmd/server.rs`).
- `SPELUNK_SECRET_STORE=file cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `SPELUNK_SECRET_STORE=file cargo fmt --all -- --check` — clean.
- New unit tests in `crates/spelunk-server/src/embed_hub.rs` cover: non-directory `--model-dir`, missing GGUF, missing tokenizer, corrupt GGUF, corrupt tokenizer, tokenizer-only directory, config.json auto-write and idempotency on restart, and a hostile-network-env test (proxy vars pointed at a closed port) proving the offline path never attempts a network call.
- New unit tests in `crates/spelunk-server/src/main.rs` cover `--model-dir` flag parsing, `SPELUNK_MODEL_DIR` env-var precedence, and the unset-by-default case.
- An `#[ignore]`-by-default integration test (`offline_model_dir_round_trips_with_hub_artifacts`, downloads the real model) proves the documented fetch-and-transfer procedure produces exactly the artifact set the offline loader accepts, and that both load paths produce identical embeddings for the same input. Run manually with `SPELUNK_SECRET_STORE=file cargo test -p spelunk-server -- --ignored offline_model_dir_round_trips_with_hub_artifacts`.