### PR TITLE
index: confirm the continuation child wins the run lock before claiming the handoff succeeded

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/crash_test_hook.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/crash_test_hook.rs
@@ -6,8 +6,15 @@
 // it while it is parked here. Reading from a pipe the harness never writes
 // to blocks until the harness closes it (by killing us) or writes a byte (to
 // release us without a crash, used by tests that need a held write window
-// rather than a kill). A no-op for every real invocation: the env var this
-// checks is never set outside the test harness.
+// rather than a kill).
+//
+// Gated on `debug_assertions` rather than `cfg(test)`: the harness spawns the
+// real `spelunk` binary as a subprocess (see `assert_cmd::cargo_bin` in
+// crash_safety.rs), which never gets `cfg(test)` even under `cargo test`.
+// `debug_assertions` is the one signal both builds agree on: on for the dev
+// profile the test harness spawns, off for `--release`, so this body carries
+// no reachable code path in a release binary.
+#[cfg(debug_assertions)]
 pub(super) fn pause_at(point: &str, subject: &str) {
     let Ok(target) = std::env::var("SPELUNK_TEST_CRASH_POINT") else {
         return;
@@ -20,3 +27,6 @@ pub(super) fn pause_at(point: &str, subject: &str) {
     let mut buf = [0u8; 1];
     let _ = std::io::Read::read(&mut std::io::stdin(), &mut buf);
 }
+
+#[cfg(not(debug_assertions))]
+pub(super) fn pause_at(_point: &str, _subject: &str) {}

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -228,26 +228,53 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     if args.detach_embed && tier.is_server() && detach_embed_eligible(&tier) {
         let embed_log = background_log_path(&db_path);
         // Release before spawning: the child re-acquires this same lock on
-        // entry, and dropping first (rather than after `spawn()` returns) is
-        // what makes that a race-free handoff instead of a timing-dependent
-        // one - the child starts running concurrently with us the instant
-        // `spawn()` is called, so releasing any later can lose the race.
+        // entry, and dropping first (rather than after `spawn()` returns)
+        // closes the corruption race - the child never interleaves writes
+        // with us. It does not by itself guarantee the *child* is what wins
+        // the reacquire: an unrelated third `spelunk index` on this project
+        // can land in the gap and take the lock first, in which case the
+        // child bails clean (see run_lock.rs) but the work it was meant to
+        // do would go silently missing. `wait_for_holder_pid` below closes
+        // that second gap by confirming the spawned pid, specifically,
+        // becomes the recorded holder before telling the user work is
+        // running in the background.
         drop(run_lock.take());
-        if let EmbedSpawn::Detached(log_in_use) =
-            spawn_embed_subprocess(&args, embed_log.as_deref())?
+        crash_test_hook::pause_at("after_run_lock_drop", "embed");
+        if let EmbedSpawn::Detached {
+            log_in_use,
+            child_pid,
+        } = spawn_embed_subprocess(&args, embed_log.as_deref())?
         {
             let stats = db.stats()?;
             let pending = stats.chunk_count - stats.embedding_count;
-            println!(
-                "Index: {} files, {} chunks. Embedding {} chunk(s) in the background\u{2026}",
-                stats.file_count, stats.chunk_count, pending,
-            );
-            if !embed_ready {
-                println!("The embedder is still loading; the background worker waits for it.");
-            }
-            println!("Run `spelunk status` to check progress.");
-            if let Some(p) = log_in_use {
-                println!("  Log: {}", p.display());
+            if run_lock::wait_for_holder_pid(
+                &spelunk_dir,
+                child_pid,
+                HANDOFF_CONFIRM_TIMEOUT,
+                HANDOFF_POLL_INTERVAL,
+            ) {
+                println!(
+                    "Index: {} files, {} chunks. Embedding {} chunk(s) in the background\u{2026}",
+                    stats.file_count, stats.chunk_count, pending,
+                );
+                if !embed_ready {
+                    println!("The embedder is still loading; the background worker waits for it.");
+                }
+                println!("Run `spelunk status` to check progress.");
+                if let Some(p) = log_in_use {
+                    println!("  Log: {}", p.display());
+                }
+            } else {
+                println!(
+                    "Index: {} files, {} chunks. Started a background process to embed {} \
+                     chunk(s), but another `spelunk index` run claimed this project's lock \
+                     before it could take over.",
+                    stats.file_count, stats.chunk_count, pending,
+                );
+                println!(
+                    "Those chunks may be left unembedded. Run `spelunk index` again once the \
+                     other run finishes to pick them up."
+                );
             }
             return Ok(());
         }
@@ -295,17 +322,36 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
         if let Some(p) = in_use {
             eprintln!("  Log: {}", p.display());
         }
-        // Release before spawning, same reasoning as the detach-embed site
-        // above: the child re-acquires this lock on entry, and only
-        // dropping first makes that race-free.
+        // Release before spawning: closes the corruption race (see the
+        // detach-embed site above for the full reasoning, including why this
+        // alone does not guarantee the child specifically wins the reacquire).
         drop(run_lock.take());
-        if cmd.spawn().is_ok() {
-            return Ok(());
+        crash_test_hook::pause_at("after_run_lock_drop", "background_phases");
+        match cmd.spawn() {
+            Ok(child) => {
+                if run_lock::wait_for_holder_pid(
+                    &spelunk_dir,
+                    child.id(),
+                    HANDOFF_CONFIRM_TIMEOUT,
+                    HANDOFF_POLL_INTERVAL,
+                ) {
+                    return Ok(());
+                }
+                eprintln!(
+                    "Warning: another `spelunk index` run claimed this project's lock before \
+                     the background job could take over; graph rank, spec discovery, and \
+                     summaries were not completed. Run `spelunk index` again once the other run \
+                     finishes."
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                // Fall through and run phases 3-5 inline as fallback,
+                // unprotected by the run lock already dropped above (see the
+                // detach-embed site's comment on this same tradeoff).
+                tracing::warn!("failed to spawn background indexer; running inline: {e}");
+            }
         }
-        // Fall through and run phases 3-5 inline as fallback, unprotected by
-        // the run lock already dropped above (see the detach-embed site's
-        // comment on this same tradeoff).
-        tracing::warn!("failed to spawn background indexer; running inline");
     }
 
     run_phases_3_to_5(&args, &cfg, &db, &root_canonical, &db_path).await
@@ -350,9 +396,13 @@ fn redirect_to_background_log<'a>(
 enum EmbedSpawn<'a> {
     /// Spawn failed; caller embeds inline.
     Inline,
-    /// Running detached, with the diagnostics log actually in use (if any) so
-    /// the caller can point the user at it.
-    Detached(Option<&'a std::path::Path>),
+    /// Running detached: the diagnostics log actually in use (if any) so the
+    /// caller can point the user at it, and the child's pid so the caller can
+    /// confirm it (and not a racing third process) became the lock's holder.
+    Detached {
+        log_in_use: Option<&'a std::path::Path>,
+        child_pid: u32,
+    },
 }
 
 /// Build the argv shared by every detached re-exec that continues indexing in
@@ -403,7 +453,10 @@ fn spawn_embed_subprocess<'a>(
     cmd.args(["--batch-size", &args.batch_size.to_string()]);
     let in_use = redirect_to_background_log(&mut cmd, log);
     match cmd.spawn() {
-        Ok(_) => Ok(EmbedSpawn::Detached(in_use)),
+        Ok(child) => Ok(EmbedSpawn::Detached {
+            log_in_use: in_use,
+            child_pid: child.id(),
+        }),
         Err(e) => {
             tracing::warn!("failed to spawn detached embed process; embedding inline: {e}");
             Ok(EmbedSpawn::Inline)
@@ -433,6 +486,18 @@ const EMBED_WAIT_MAX_BACKOFF: std::time::Duration = std::time::Duration::from_se
 /// Consecutive offline probes tolerated before the worker concludes the server
 /// is gone (crashed after spawning us) rather than momentarily unreachable.
 const EMBED_WAIT_MAX_OFFLINE_PROBES: u32 = 10;
+
+/// How long a parent waits, after releasing the run lock and spawning a
+/// continuation child (`--_embed-phases` / `--_background-phases`), to see
+/// that child recorded as the lock's new holder before reporting the handoff
+/// as a background success. The release-then-spawn gap an unrelated third
+/// `spelunk index` process can win is normally low-single-digit
+/// milliseconds; this is bounded well above that plus typical re-exec
+/// startup cost, without meaningfully delaying the common case where the
+/// child wins on its very first poll.
+const HANDOFF_CONFIRM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+/// Poll interval for `HANDOFF_CONFIRM_TIMEOUT`.
+const HANDOFF_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(20);
 
 /// Wait until the server's embedder can serve, polling `/v1/health` with a
 /// bounded backoff. Returns the final observed tier; the caller re-derives
@@ -1226,6 +1291,16 @@ mod tests {
     #[test]
     fn embed_wait_max_offline_probes_is_10() {
         assert_eq!(EMBED_WAIT_MAX_OFFLINE_PROBES, 10);
+    }
+
+    #[test]
+    fn handoff_confirm_timeout_is_2s() {
+        assert_eq!(HANDOFF_CONFIRM_TIMEOUT.as_secs(), 2);
+    }
+
+    #[test]
+    fn handoff_poll_interval_is_20ms() {
+        assert_eq!(HANDOFF_POLL_INTERVAL.as_millis(), 20);
     }
 
     // ── wait_for_embedder: local_first routes to loopback, not server_url ────

--- a/crates/spelunk-cli/src/cli/cmd/index/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mod.rs
@@ -227,17 +227,11 @@ pub async fn index(args: IndexArgs, cfg: Config) -> Result<()> {
     // index on a cold machine.
     if args.detach_embed && tier.is_server() && detach_embed_eligible(&tier) {
         let embed_log = background_log_path(&db_path);
-        // Release before spawning: the child re-acquires this same lock on
-        // entry, and dropping first (rather than after `spawn()` returns)
-        // closes the corruption race - the child never interleaves writes
-        // with us. It does not by itself guarantee the *child* is what wins
-        // the reacquire: an unrelated third `spelunk index` on this project
-        // can land in the gap and take the lock first, in which case the
-        // child bails clean (see run_lock.rs) but the work it was meant to
-        // do would go silently missing. `wait_for_holder_pid` below closes
-        // that second gap by confirming the spawned pid, specifically,
-        // becomes the recorded holder before telling the user work is
-        // running in the background.
+        // Dropping the lock before spawning closes the corruption race (the
+        // child never interleaves writes with us), but a third `spelunk
+        // index` can still win the reacquire in the gap; `wait_for_holder_pid`
+        // below confirms the spawned pid, specifically, becomes the holder
+        // before we report success.
         drop(run_lock.take());
         crash_test_hook::pause_at("after_run_lock_drop", "embed");
         if let EmbedSpawn::Detached {
@@ -487,14 +481,12 @@ const EMBED_WAIT_MAX_BACKOFF: std::time::Duration = std::time::Duration::from_se
 /// is gone (crashed after spawning us) rather than momentarily unreachable.
 const EMBED_WAIT_MAX_OFFLINE_PROBES: u32 = 10;
 
-/// How long a parent waits, after releasing the run lock and spawning a
-/// continuation child (`--_embed-phases` / `--_background-phases`), to see
-/// that child recorded as the lock's new holder before reporting the handoff
-/// as a background success. The release-then-spawn gap an unrelated third
-/// `spelunk index` process can win is normally low-single-digit
-/// milliseconds; this is bounded well above that plus typical re-exec
-/// startup cost, without meaningfully delaying the common case where the
-/// child wins on its very first poll.
+/// How long the parent waits, after releasing the run lock and spawning a
+/// continuation child, to see it recorded as the lock's new holder before
+/// reporting the handoff as a background success. The release-then-spawn gap
+/// a racing `spelunk index` can win is normally low-single-digit
+/// milliseconds, so this bounds well above that without delaying the common
+/// case where the child wins on its first poll.
 const HANDOFF_CONFIRM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 /// Poll interval for `HANDOFF_CONFIRM_TIMEOUT`.
 const HANDOFF_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(20);

--- a/crates/spelunk-cli/src/cli/cmd/index/run_lock.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/run_lock.rs
@@ -83,7 +83,7 @@ pub fn try_acquire(spelunk_dir: &Path) -> Result<LockOutcome> {
 /// every successful acquire, so it reflects the most recent holder even
 /// after that holder has since released.
 fn read_recorded_pid(spelunk_dir: &Path) -> Option<u32> {
-    std::fs::read_to_string(spelunk_dir.join(LOCK_FILE_NAME))
+    std::fs::read_to_string(spelunk_dir.join(LOCK_PID_FILE_NAME))
         .ok()
         .and_then(|s| s.trim().parse().ok())
 }

--- a/crates/spelunk-cli/src/cli/cmd/index/run_lock.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/run_lock.rs
@@ -13,6 +13,7 @@
 use anyhow::Result;
 use std::fs::{File, OpenOptions, TryLockError};
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 const LOCK_FILE_NAME: &str = "index.lock";
 /// Holder pid, written and read separately from `LOCK_FILE_NAME` itself:
@@ -77,6 +78,40 @@ pub fn try_acquire(spelunk_dir: &Path) -> Result<LockOutcome> {
     }
 }
 
+/// Best-effort read of the pid last written to the lock file, regardless of
+/// whether the lock is currently held: `try_acquire` (re)writes this on
+/// every successful acquire, so it reflects the most recent holder even
+/// after that holder has since released.
+fn read_recorded_pid(spelunk_dir: &Path) -> Option<u32> {
+    std::fs::read_to_string(spelunk_dir.join(LOCK_FILE_NAME))
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+}
+
+/// Poll for `expected_pid` to appear as the lock file's recorded holder,
+/// giving up after `timeout`. A caller that just dropped its own hold and
+/// spawned a continuation process uses this to confirm that process -
+/// specifically - became the new holder, rather than an unrelated third
+/// process that raced into the gap between the drop and the continuation's
+/// own acquire attempt, before reporting the handoff as a success.
+pub fn wait_for_holder_pid(
+    spelunk_dir: &Path,
+    expected_pid: u32,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if read_recorded_pid(spelunk_dir) == Some(expected_pid) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(poll_interval);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,6 +160,68 @@ mod tests {
         assert!(
             matches!(second, LockOutcome::Acquired(_)),
             "once the first guard drops, a fresh acquire must succeed"
+        );
+    }
+
+    // ── wait_for_holder_pid: handoff-confirmation polling ────────────────────
+
+    #[test]
+    fn wait_for_holder_pid_returns_true_once_content_already_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let _held = try_acquire(dir.path()).expect("acquire");
+        assert!(wait_for_holder_pid(
+            dir.path(),
+            std::process::id(),
+            Duration::from_millis(200),
+            Duration::from_millis(5),
+        ));
+    }
+
+    #[test]
+    fn wait_for_holder_pid_times_out_when_the_recorded_pid_never_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        // Records our own pid - stands in for the "some other process holds
+        // it" case: the pid polled for below is never the one recorded.
+        let _held = try_acquire(dir.path()).expect("acquire");
+
+        let started = Instant::now();
+        let confirmed = wait_for_holder_pid(
+            dir.path(),
+            std::process::id().wrapping_add(1),
+            Duration::from_millis(150),
+            Duration::from_millis(10),
+        );
+        assert!(
+            !confirmed,
+            "must not confirm a pid that was never the recorded holder"
+        );
+        assert!(
+            started.elapsed() >= Duration::from_millis(150),
+            "must wait out the full timeout rather than returning early"
+        );
+    }
+
+    #[test]
+    fn wait_for_holder_pid_detects_a_holder_that_appears_after_a_delay() {
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let pid = std::process::id();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(80));
+            let held = try_acquire(&dir_path).expect("delayed acquire");
+            std::thread::sleep(Duration::from_millis(500));
+            drop(held);
+        });
+
+        assert!(
+            wait_for_holder_pid(
+                dir.path(),
+                pid,
+                Duration::from_millis(500),
+                Duration::from_millis(10),
+            ),
+            "must detect a holder that appears mid-poll, not just one already present at the \
+             first check"
         );
     }
 }

--- a/crates/spelunk-cli/tests/crash_safety.rs
+++ b/crates/spelunk-cli/tests/crash_safety.rs
@@ -1061,17 +1061,12 @@ fn losing_child_continuation_mode_fails_clean_without_touching_the_db() {
 
 #[test]
 fn parent_reports_the_handoff_honestly_when_a_third_process_wins_the_lock_race() {
-    // The gap the previous test's drill doesn't cover: it drives the losing
-    // child directly, never the real parent-releases/parent-spawns handoff,
-    // so it cannot see what the *parent* tells the user. Before this fix, the
-    // parent printed "Embedding N chunk(s) in the background" unconditionally
-    // once `spawn()` returned `Ok`, regardless of whether the spawned child
-    // actually won the lock back or lost it to an unrelated third
-    // `spelunk index` racing into the release-then-spawn gap - so a user
-    // could be told work was proceeding when it had already silently failed.
-    // `wait_for_holder_pid` closes that by confirming the *spawned child's*
-    // pid, specifically, becomes the lock's recorded holder before the
-    // parent claims success.
+    // The previous test drives the losing child directly, never the real
+    // parent-releases/parent-spawns handoff, so it cannot see what the
+    // *parent* tells the user. This test does: the parent must not claim
+    // "embedding in the background" unless the spawned child, specifically,
+    // became the run lock's recorded holder - `wait_for_holder_pid` is what
+    // confirms that before the parent reports success.
     //
     // Reproduced deterministically (rather than by racing wall-clock timing)
     // the same way the test above does: pause the parent right after it

--- a/crates/spelunk-cli/tests/crash_safety.rs
+++ b/crates/spelunk-cli/tests/crash_safety.rs
@@ -1058,3 +1058,83 @@ fn losing_child_continuation_mode_fails_clean_without_touching_the_db() {
     assert_integrity_ok(&db_path);
     kill_and_reap(paused);
 }
+
+#[test]
+fn parent_reports_the_handoff_honestly_when_a_third_process_wins_the_lock_race() {
+    // The gap the previous test's drill doesn't cover: it drives the losing
+    // child directly, never the real parent-releases/parent-spawns handoff,
+    // so it cannot see what the *parent* tells the user. Before this fix, the
+    // parent printed "Embedding N chunk(s) in the background" unconditionally
+    // once `spawn()` returned `Ok`, regardless of whether the spawned child
+    // actually won the lock back or lost it to an unrelated third
+    // `spelunk index` racing into the release-then-spawn gap - so a user
+    // could be told work was proceeding when it had already silently failed.
+    // `wait_for_holder_pid` closes that by confirming the *spawned child's*
+    // pid, specifically, becomes the lock's recorded holder before the
+    // parent claims success.
+    //
+    // Reproduced deterministically (rather than by racing wall-clock timing)
+    // the same way the test above does: pause the parent right after it
+    // releases the lock and before it spawns its continuation child, let an
+    // entirely separate `spelunk index` process win and hold the lock in
+    // that window, then resume the parent and inspect what it told the user.
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let f = embed_fixture(&rt);
+
+    let mut cmd = spelunk_command(f._home.path());
+    cmd.current_dir(f.project.path())
+        .env("SPELUNK_MODE", "cloud_first")
+        .arg("index")
+        .arg(".")
+        .arg("--detach-embed")
+        .arg("--no-summaries");
+    let paused_parent = spawn_paused_at(cmd, "after_run_lock_drop:embed");
+    let parent_stdout = paused_parent.stdout_so_far.clone();
+
+    // The parent's own parse phase (upstream of the pause point above) has
+    // already hashed `one.py`/`two.py`, so a third `spelunk index` run over
+    // them now would see unchanged hashes and skip straight past the
+    // hash-write pause point without ever hitting it. A brand new file the
+    // parent never saw gives the third process something to actually hash.
+    std::fs::write(
+        f.project.path().join("three.py"),
+        "def three():\n    return 3\n",
+    )
+    .expect("write third file");
+
+    // The parent has released the lock but not yet spawned its continuation
+    // child. A genuinely separate process wins it here and holds it well
+    // past the child's own (bounded) confirmation window below.
+    let mut third_cmd = spelunk_command(f._home.path());
+    third_cmd
+        .current_dir(f.project.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .arg("index")
+        .arg(".");
+    let paused_third = spawn_paused_at(third_cmd, "after_index_hash_write:three.py");
+
+    let status = release_and_wait(paused_parent);
+    assert!(
+        status.success(),
+        "the parent must still exit cleanly even though its handoff was raced away"
+    );
+
+    let stdout = parent_stdout.lock().unwrap().clone();
+    assert!(
+        !stdout.contains("in the background"),
+        "must not claim embedding is proceeding in the background when the spawned child never \
+         confirmed it took over the lock: {stdout}"
+    );
+    assert!(
+        stdout.contains("claimed this project's lock"),
+        "must tell the user why the background handoff could not be confirmed: {stdout}"
+    );
+    assert!(
+        stdout.contains("Run `spelunk index` again"),
+        "must give the user a concrete recovery step rather than leaving the chunks silently \
+         unembedded forever: {stdout}"
+    );
+
+    kill_and_reap(paused_third);
+    assert_integrity_ok(&f.db_path);
+}


### PR DESCRIPTION
## Summary

Stacked on #764 (`task/story-295-20260726-0940`): closes the narrower follow-on gap that PR's own description explicitly flagged as "filed separately, not fixed here" (spelunk-oss^298).

`index()` releases the per-project run lock right before spawning a continuation child (`--_embed-phases` for `--detach-embed`, `--_background-phases` for the >100-file spawn), so the child can re-acquire it itself rather than inherit a held lock. That release-then-spawn ordering closes the *corruption* race - the child never interleaves writes with the parent - but there is a narrower timing gap in the handoff itself: between the parent's release and the child's own acquire, an unrelated third `spelunk index` on the same project can win the lock first.

When that happens, the losing child bails cleanly (no corruption - already covered by PR #764's `losing_child_continuation_mode_fails_clean_without_touching_the_db` test). But the parent had already committed to telling the user its work was proceeding in the background ("Embedding N chunk(s) in the background…"), before it had any way to know whether that was true. The work the child was supposed to do is then silently dropped: not retried, and not picked up by the third process either (traced through `chunk_ids_and_texts.is_empty()`'s early return in phase 2, which only sees files *that* process itself just parsed).

## Fix

No new IPC, no FD inheritance, no DB-wide catch-up scan (all considered and rejected as overbuilding a low-probability, narrow race). Instead: reuse the lock file's existing holder-pid bookkeeping (`run_lock.rs` already writes the acquiring pid on every successful acquire, for the "already running (pid N)" error message).

After spawning a continuation child, the parent now polls (`run_lock::wait_for_holder_pid`, bounded at 2s / 20ms interval) for *that specific spawned pid* to appear as the lock's recorded holder before printing the confident "in the background" message. If it never does within the window - because a third process won the race, or the child failed to start for any other reason - the parent instead tells the user the handoff could not be confirmed and to re-run `spelunk index`, rather than asserting success it can't back up. Exit code stays 0 (consistent with the existing embed-skipped-notice precedent: a narrow miss on a background hint is not the same as the index run itself failing).

On the (overwhelming) common path, the child wins the lock within the first poll or two and the existing messaging is unchanged - verified against the pre-existing `index_background_log.rs` suite, which exercises the real happy-path spawn end to end.

## Test plan

- New unit tests for `run_lock::wait_for_holder_pid` (`crates/spelunk-cli/src/cli/cmd/index/run_lock.rs`): confirms immediately when content already matches, detects a holder that appears mid-poll (not just one present at the first check), and times out (waiting out the full budget) when the recorded pid never matches.
- New integration test `parent_reports_honest_message_when_a_third_process_wins_the_lock_handoff` (`crates/spelunk-cli/tests/crash_safety.rs`): deterministically reproduces the exact race (same pause-and-hold technique as the existing `losing_child_continuation_mode_fails_clean_without_touching_the_db` drill) by pausing the parent right after its `drop(run_lock.take())` via a new `crash_test_hook::pause_at("after_run_lock_drop", …)` point, letting a real separate `spelunk index` process win and hold the lock, then asserting on what the parent actually printed to the user (not the confident message) and that the DB stays integrity-clean.
- `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli --no-default-features` - full crate suite green (514+ tests, 0 failures), including the full `crash_safety` and `index_background_log` suites.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean (enforced by this repo's pre-commit hook).

## Scope note

Base branch is `task/story-295-20260726-0940` (PR #764), not `main` - this fix depends on the `run_lock.rs` module #764 introduces. Merge order: #764 first, then this.