### PR TITLE
Fix memory sync 400 on a never-synced project's first sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   already applied to `memory add`/`reindex`/`search`/`timeline`/`harvest`/
   `reconcile` and `explore`. `cloud_first` is unchanged. See [ADR-004's
   2026-07-23 amendment](docs/adr/004-unified-memory-storage.md).
+- **`spelunk sync` and `spelunk memory push` now succeed on the first sync of a
+  project that has never synced before.** A sync round always pulled before
+  pushing to avoid shadowing a concurrent write, but on a project that never
+  existed server-side yet, the pre-push pull failed with an HTTP 400 against
+  the unprovisioned project. On a first sync (detected by checking whether any
+  local entry has ever synced), the sequence now reverses: push first to
+  provision the project server-side, then run a post-push pull to converge with
+  any backlog already on the server. The fix also handles adversarial server
+  crashes during first-sync push and concurrent first-sync attempts from
+  multiple clients.
 
 ### Internal
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/pull.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/pull.rs
@@ -584,39 +584,28 @@ mod tests {
         assert_eq!(server.received_requests().await.unwrap().len(), 2);
     }
 
-    /// Item 8: `sync_round`'s SECOND (confirmation) pull pass paginates fully
-    /// on its own when it independently has more than one page of results
-    /// (e.g. a teammate pushed a large batch in the gap between this round's
-    /// first pull and its push) — not just the first pull pass.
+    /// Item 8: on a first sync (nothing local has ever pushed or pulled
+    /// before, so `sync_round` pushes first and runs a single post-push
+    /// pull), that post-push pull paginates fully on its own when it turns
+    /// up more than one page of results (e.g. a teammate already has a
+    /// 130-entry backlog on the project by the time this round's push
+    /// provisions it and the pull runs).
     #[tokio::test]
-    async fn sync_round_second_pull_pass_paginates_fully_on_its_own() {
+    async fn sync_round_first_sync_post_push_pull_paginates_fully_on_its_own() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
         let server = wiremock::MockServer::start().await;
-        {
-            use wiremock::matchers::{method, path, query_param};
-            use wiremock::{Mock, ResponseTemplate};
-            // First pull pass (pre-push): nothing yet.
-            Mock::given(method("GET"))
-                .and(path("/v1/projects/proj/memory/since"))
-                .and(query_param("since_id", NIL_UUID))
-                .respond_with(
-                    ResponseTemplate::new(200)
-                        .set_body_json(serde_json::json!({ "entries": [], "count": 0 })),
-                )
-                .up_to_n_times(1)
-                .mount(&server)
-                .await;
-            // This round's own push (empty local store: nothing to push).
-            Mock::given(method("POST"))
-                .and(path("/v1/projects/proj/memory/batch"))
-                .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
-                    "created": 0, "skipped": 0, "failed": 0, "results": []
-                })))
-                .mount(&server)
-                .await;
-        }
-        // Second (confirmation) pull pass reuses the SAME pre-round cursor
-        // (nil UUID, since nothing was applied by the first pass): a
-        // teammate landed a 650-entry batch in the gap, spanning two pages.
+        // This round's own push (empty local store: nothing to push).
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 0, "skipped": 0, "failed": 0, "results": []
+            })))
+            .mount(&server)
+            .await;
+        // The single post-push pull starts from the nil UUID (no prior sync
+        // history) and must exhaust both pages.
         let page1 = page_ids(0, 100);
         let page2 = page_ids(100, 30);
         mount_pages(&server, &[page1, page2]).await;
@@ -628,7 +617,7 @@ mod tests {
         assert_eq!(outcome.pushed.attempted, 0);
         assert_eq!(
             outcome.pulled, 130,
-            "the confirmation pull pass must exhaust its own pagination too"
+            "the post-push pull on a first sync must exhaust its own pagination too"
         );
         assert_eq!(store.count().unwrap(), 130);
     }
@@ -697,18 +686,21 @@ mod tests {
         assert_eq!(applied, 5);
     }
 
-    /// If the SECOND pull (the confirmation pull after this round's own push)
-    /// fails, `sync_round` must not silently swallow that error — but it also
-    /// must not lose or misrepresent the push that already succeeded. The
-    /// push already durably landed server-side and already stamped this
-    /// round's row with its `remote_id` (inside `push_local`, which returns
-    /// before the second pull ever runs), so: (1) the error surfaces instead
-    /// of being dropped, (2) its message says the push already reached the
-    /// server rather than reading as "nothing happened", and (3) local state
-    /// is left exactly as `push_local` left it — no corruption, no
-    /// re-attempt needed, just a retryable pull on the next sync.
+    /// If the post-push pull on a first sync (nothing local has ever pushed
+    /// or pulled before, so `sync_round` pushes first and runs a single pull
+    /// afterward) fails, `sync_round` must not silently swallow that error,
+    /// but it also must not lose or misrepresent the push that already
+    /// succeeded. The push already durably landed server-side and already
+    /// stamped this round's row with its `remote_id` (inside `push_local`,
+    /// which returns before the pull ever runs), so: (1) the error surfaces
+    /// instead of being dropped, (2) its message says the push already
+    /// reached the server rather than reading as "nothing happened", and
+    /// (3) local state is left exactly as `push_local` left it: no
+    /// corruption, no re-attempt needed, just a retryable pull on the next
+    /// sync.
     #[tokio::test]
-    async fn sync_round_second_pull_failure_surfaces_the_error_without_losing_the_push() {
+    async fn sync_round_first_sync_post_push_pull_failure_surfaces_the_error_without_losing_the_push()
+     {
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -720,17 +712,8 @@ mod tests {
         let cloud_id = "01890000-0000-7000-8000-0000000000b1";
 
         let server = MockServer::start().await;
-        // First pull (pre-push, empty server): 200 empty.
-        Mock::given(method("GET"))
-            .and(path("/v1/projects/proj/memory/since"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(serde_json::json!({"entries": [], "count": 0})),
-            )
-            .up_to_n_times(1)
-            .mount(&server)
-            .await;
-        // The push itself succeeds and durably lands.
+        // The push itself succeeds and durably lands, provisioning the
+        // project.
         Mock::given(method("POST"))
             .and(path("/v1/projects/proj/memory/batch"))
             .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
@@ -739,7 +722,7 @@ mod tests {
             })))
             .mount(&server)
             .await;
-        // The confirmation (second) pull hits a transient server error.
+        // The single post-push pull hits a transient server error.
         Mock::given(method("GET"))
             .and(path("/v1/projects/proj/memory/since"))
             .respond_with(ResponseTemplate::new(500))
@@ -749,7 +732,7 @@ mod tests {
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
         let err = sync_round(&store, &client, false, false)
             .await
-            .expect_err("a real second-pull error must not be swallowed as success");
+            .expect_err("a real post-push pull error must not be swallowed as success");
 
         let msg = format!("{err:#}");
         assert!(

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/round.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/round.rs
@@ -551,4 +551,253 @@ mod tests {
             "an established client must still pull, then push, then pull again: {methods:?}"
         );
     }
+
+    // ── crash-before-record edge case: `max_remote_id()` reads only local
+    // state, never the server ───────────────────────────────────────────────
+
+    // `pre_round_cursor.is_none()` cannot distinguish "this project has never
+    // been synced by anyone" from "this row was already pushed and the
+    // server durably has it, but the local `remote_id` stamp never landed"
+    // (a process crash between the server's 207 response and `push_local`'s
+    // own `set_remote_id` write). `max_remote_id()` only ever reads the local
+    // `notes` table (see its doc comment), so it cannot tell these apart. The
+    // branch does not need to: a retry's push re-sends the same stable
+    // `external_id`, the server dedupes and answers `skipped` rather than a
+    // fresh `created`, and `push_local` stamps `remote_id` from a `skipped`
+    // result exactly like a `created` one, so the store still converges to
+    // established within this very round, without ever needing a pre-push
+    // pull to have run.
+    #[tokio::test]
+    async fn sync_round_first_sync_recovers_a_push_that_landed_before_a_crash() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let (_tmp, store) = fresh_store();
+        store
+            .add_note(
+                "decision",
+                "T1",
+                "pushed once, crashed before the local remote_id was recorded",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        let ext = store.rows_for_sync(false).unwrap()[0].uuid.clone();
+        assert!(
+            store.max_remote_id().unwrap().is_none(),
+            "the crash means this row's remote_id was never durably stamped locally"
+        );
+
+        let server = MockServer::start().await;
+        // The project is already provisioned (the crashed run's push landed
+        // server-side), so `/memory/since` succeeds unconditionally here,
+        // unlike the never-provisioned case above.
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/proj/memory/since"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "entries": [], "count": 0 })),
+            )
+            .mount(&server)
+            .await;
+        // The retry's push re-sends the same external_id; the server already
+        // has it, so it comes back `skipped` with the SAME cloud id it
+        // minted the first time around, not a fresh `created`.
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 0, "skipped": 1, "failed": 0,
+                "results": [{"status": "skipped", "external_id": ext, "id": "cloud-t1-preexisting"}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+        let outcome = sync_round(&store, &client, false, false)
+            .await
+            .expect("a skipped-not-created push must not be treated as a failure");
+
+        assert_eq!(
+            outcome.pushed.skipped, 1,
+            "the retry sees its own earlier push as already known to the server"
+        );
+        assert!(
+            store
+                .note_id_for_remote_id("cloud-t1-preexisting")
+                .unwrap()
+                .is_some(),
+            "a skipped result must still stamp remote_id, recovering the crash-lost state"
+        );
+        assert!(
+            store.max_remote_id().unwrap().is_some(),
+            "the store must now be established, so the next sync takes the pull-push-pull path"
+        );
+    }
+
+    // ── total push failure on a first sync: the follow-up pull's failure
+    // must still surface cleanly, not panic or get silently swallowed ──────
+
+    // When the push itself never lands (a transport-level failure on the
+    // only chunk, not a per-item 4xx), nothing is provisioned server-side and
+    // no `remote_id` is stamped. `sync_round_first` still runs its post-push
+    // pull unconditionally, which then hits the exact never-provisioned 400
+    // the original bug exhibited. That compound failure must come back as a
+    // real `Err` naming the pull failure, not panic, not silently succeed,
+    // and not leave the store looking established when nothing landed.
+    #[tokio::test]
+    async fn sync_round_first_sync_surfaces_pull_error_when_push_never_lands() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let (_tmp, store) = fresh_store();
+        store
+            .add_note("decision", "T1", "never lands", &[], &[], None, None)
+            .unwrap();
+
+        let server = MockServer::start().await;
+        // The push chunk itself fails outright: nothing is provisioned and
+        // no result item exists to stamp a remote_id from.
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        // The project is still unprovisioned, so the post-push pull gets the
+        // same 400 a pre-push pull would have.
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/proj/memory/since"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_string("invalid project id: expected a UUID, got a slug"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+        let err = sync_round(&store, &client, false, false).await.expect_err(
+            "a pull failure after a totally failed push must still surface as an error",
+        );
+
+        assert!(
+            format!("{err:#}").contains("post-push pull failed"),
+            "the error must carry the first-sync pull-failure context: {err:#}"
+        );
+        assert!(
+            store.max_remote_id().unwrap().is_none(),
+            "nothing landed, so a retry must still take the first-sync branch"
+        );
+    }
+
+    // ── concurrent first syncs: two never-before-synced clients racing to
+    // provision the same project must not trip the pre-push-pull bug for
+    // either of them ─────────────────────────────────────────────────────
+
+    /// Mock `/memory/batch` responder that provisions the project and echoes
+    /// back a generated cloud id per pushed `external_id`, so two different
+    /// clients pushing two different entries concurrently each get a
+    /// coherent per-item result rather than a hardcoded single id.
+    struct BatchProvisionsEcho {
+        provisioned: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl wiremock::Respond for BatchProvisionsEcho {
+        fn respond(&self, request: &wiremock::Request) -> wiremock::ResponseTemplate {
+            self.provisioned
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+            let entries = body["entries"].as_array().cloned().unwrap_or_default();
+            let results: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|e| {
+                    let ext = e["external_id"].as_str().unwrap_or_default();
+                    serde_json::json!({
+                        "status": "created", "external_id": ext, "id": format!("cloud-{ext}")
+                    })
+                })
+                .collect();
+            wiremock::ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": results.len(), "skipped": 0, "failed": 0, "results": results
+            }))
+        }
+    }
+
+    // Each client's own `sync_round_first` always pushes before it pulls, so
+    // each one's own pull only ever runs after its own push has already set
+    // `provisioned`; interleaving with the other client cannot reopen the
+    // pre-push-pull window for either. This exercises that under genuine
+    // concurrent execution (both rounds polled together via `tokio::join!`,
+    // sharing one mock server and one `provisioned` flag) rather than
+    // asserting it only holds sequentially.
+    #[tokio::test]
+    async fn sync_round_two_concurrent_first_syncs_both_succeed_without_pre_push_pull() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer};
+
+        let (_tmp_x, store_x) = fresh_store();
+        store_x
+            .add_note(
+                "decision",
+                "X1",
+                "client X's own new entry",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        let (_tmp_y, store_y) = fresh_store();
+        store_y
+            .add_note(
+                "decision",
+                "Y1",
+                "client Y's own new entry",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+
+        let provisioned = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/proj-race-first/memory/since"))
+            .respond_with(SinceUntilProvisioned {
+                provisioned: provisioned.clone(),
+            })
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj-race-first/memory/batch"))
+            .respond_with(BatchProvisionsEcho {
+                provisioned: provisioned.clone(),
+            })
+            .mount(&server)
+            .await;
+
+        let client_x = CloudSyncClient::new(&server.uri(), "proj-race-first", None, None).unwrap();
+        let client_y = CloudSyncClient::new(&server.uri(), "proj-race-first", None, None).unwrap();
+
+        let (outcome_x, outcome_y) = tokio::join!(
+            sync_round(&store_x, &client_x, false, false),
+            sync_round(&store_y, &client_y, false, false),
+        );
+
+        assert_eq!(
+            outcome_x
+                .expect("X's round must not surface the pre-push-pull 400")
+                .pushed
+                .created,
+            1
+        );
+        assert_eq!(
+            outcome_y
+                .expect("Y's round must not surface the pre-push-pull 400")
+                .pushed
+                .created,
+            1
+        );
+    }
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/round.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/round.rs
@@ -16,7 +16,8 @@ pub(super) struct SyncRoundOutcome {
 }
 
 /// Run one full two-way sync round: pull, then push, then pull again off the
-/// same pre-round cursor.
+/// same pre-round cursor, except on a genuinely first sync, which pushes
+/// first (see [`sync_round_first`]).
 ///
 /// This is `spelunk sync`'s actual push+pull sequence, extracted into its own
 /// function so it can be exercised directly in tests against a real server:
@@ -26,23 +27,32 @@ pub(super) struct SyncRoundOutcome {
 /// one test binary).
 ///
 /// Neither a plain push-then-pull nor a plain pull-then-push reorder is
-/// sufficient here. The failure mode: the cursor is always `MAX(remote_id)`
-/// over local rows (decision #183, no persisted watermark), and this
-/// client's own push mints `remote_id`s stamped "now", chronologically the
-/// newest thing on the server. If a plain re-derived cursor were used for a
-/// second pull, this round's own just-pushed rows would become the new
-/// `MAX(remote_id)`, permanently shadowing (via the strict `>` comparison)
-/// any teammate entry that landed between this round's first pull and its
-/// own push.
+/// sufficient for an established client (one with real sync history). The
+/// failure mode: the cursor is always `MAX(remote_id)` over local rows
+/// (decision #183, no persisted watermark), and this client's own push mints
+/// `remote_id`s stamped "now", chronologically the newest thing on the
+/// server. If a plain re-derived cursor were used for a second pull, this
+/// round's own just-pushed rows would become the new `MAX(remote_id)`,
+/// permanently shadowing (via the strict `>` comparison) any teammate entry
+/// that landed between this round's first pull and its own push.
 ///
-/// The fix: capture the cursor once, before this round's own pull or push
-/// touches anything (`pre_round_cursor`), pull with it, push, then pull AGAIN
-/// reusing that SAME `pre_round_cursor`, not a freshly re-derived one. The
-/// second pull harmlessly re-fetches this round's own just-pushed rows (their
-/// `remote_id` is now `> pre_round_cursor`) alongside anything a teammate
-/// pushed in the gap; both are idempotent no-ops or genuine new applies via
-/// [`pull_and_apply_since`], so the combined count is never inflated by
-/// double-counting.
+/// The fix for that case: capture the cursor once, before this round's own
+/// pull or push touches anything (`pre_round_cursor`), pull with it, push,
+/// then pull AGAIN reusing that SAME `pre_round_cursor`, not a freshly
+/// re-derived one. The second pull harmlessly re-fetches this round's own
+/// just-pushed rows (their `remote_id` is now `> pre_round_cursor`) alongside
+/// anything a teammate pushed in the gap; both are idempotent no-ops or
+/// genuine new applies via [`pull_and_apply_since`], so the combined count is
+/// never inflated by double-counting.
+///
+/// A first sync (`pre_round_cursor` is `None`, meaning nothing has ever
+/// pulled or pushed for this store) is a different case entirely: there is
+/// nothing to pull yet, since the project cannot exist server-side until
+/// this round's own push provisions it, and no shadowing risk, since nothing
+/// local has ever synced before to be shadowed. Pulling first there sends a
+/// pull request the server has no way to answer (nothing has provisioned
+/// the project yet), so that case pushes first instead; see
+/// [`sync_round_first`].
 pub(super) async fn sync_round(
     local: &MemoryStore,
     client: &CloudSyncClient,
@@ -51,21 +61,25 @@ pub(super) async fn sync_round(
 ) -> Result<SyncRoundOutcome> {
     let pre_round_cursor = local.max_remote_id()?;
 
+    if pre_round_cursor.is_none() {
+        return sync_round_first(local, client, include_archived, accepts_pushed_vectors).await;
+    }
+
     let pulled_first = pull_and_apply_since(local, client, pre_round_cursor.as_deref()).await?;
 
     let pushed = push_local(local, client, include_archived, accepts_pushed_vectors).await?;
 
     // If this second pull errors (network blip, transient 5xx), the error
-    // propagates out of `sync_round` rather than being swallowed — `?`
+    // propagates out of `sync_round` rather than being swallowed: `?`
     // surfaces it to `memory_sync`, which reports a failure and a non-zero
     // exit. That is correct (a real error must not be silently dropped), but
     // by this point `pushed` already reflects a push that may have durably
     // landed server-side (and stamped local `remote_id`s accordingly, inside
-    // `push_local`, before this call even runs) — the failure is scoped to
+    // `push_local`, before this call even runs), so the failure is scoped to
     // the confirmation pull, not the push. Attach that context so the
     // surfaced error doesn't read as "nothing happened": a caller shouldn't
     // conclude their content was lost and try to force a re-push (harmless
-    // but pointless — already-stamped rows are excluded from `live` and
+    // but pointless: already-stamped rows are excluded from `live` and
     // skipped) instead of simply re-running sync, which retries the pull with
     // an unaffected, freshly-derived cursor.
     let pulled_second = pull_and_apply_since(local, client, pre_round_cursor.as_deref())
@@ -73,7 +87,7 @@ pub(super) async fn sync_round(
         .with_context(|| {
             format!(
                 "confirmation pull failed after this round's push already reached \
-                 the server ({} attempted: {} created, {} skipped, {} failed) — \
+                 the server ({} attempted: {} created, {} skipped, {} failed) - \
                  the push is not affected by this error; re-running sync will retry \
                  the pull without re-pushing already-landed entries",
                 pushed.attempted, pushed.created, pushed.skipped, pushed.failed
@@ -84,6 +98,42 @@ pub(super) async fn sync_round(
         pushed,
         pulled: pulled_first + pulled_second,
     })
+}
+
+/// The first-sync half of [`sync_round`]: a store that has never pulled or
+/// pushed before (`local.max_remote_id()` is `None`).
+///
+/// A brand new project only comes into existence server-side via this
+/// round's own push (`push_local`, which provisions it and caches its id per
+/// ADR-005). Pulling before that push runs has nothing to fetch and nowhere
+/// valid to fetch it from, so this pushes first, then runs a single pull
+/// (there is no pre-round cursor to preserve, and no earlier round's state
+/// that a freshly re-derived cursor could shadow, since nothing has ever
+/// synced before this round).
+async fn sync_round_first(
+    local: &MemoryStore,
+    client: &CloudSyncClient,
+    include_archived: bool,
+    accepts_pushed_vectors: bool,
+) -> Result<SyncRoundOutcome> {
+    let pushed = push_local(local, client, include_archived, accepts_pushed_vectors).await?;
+
+    // Mirrors the established-client confirmation pull's error handling: a
+    // pull failure here must not read as "nothing happened" when the push
+    // already durably landed.
+    let pulled = pull_and_apply_since(local, client, None)
+        .await
+        .with_context(|| {
+            format!(
+                "post-push pull failed on this project's first sync, after the push already \
+                 reached the server ({} attempted: {} created, {} skipped, {} failed) - \
+                 the push is not affected by this error; re-running sync will retry \
+                 the pull without re-pushing already-landed entries",
+                pushed.attempted, pushed.created, pushed.skipped, pushed.failed
+            )
+        })?;
+
+    Ok(SyncRoundOutcome { pushed, pulled })
 }
 
 #[cfg(test)]
@@ -320,5 +370,185 @@ mod tests {
         // was just applied).
         let pulled_again = pull_and_apply(&store_c, &client_c).await.unwrap();
         assert_eq!(pulled_again, 0);
+    }
+
+    // ── first-sync regression: no pre-push pull against an unprovisioned
+    // project ─────────────────────────────────────────────────────────────
+    // A production regression hit on a project that had never synced to the
+    // cloud before: the pre-push pull sent the project slug to an endpoint
+    // that only accepts an already-resolved id, which fails until something
+    // has provisioned the project. A first sync's own push is what
+    // provisions it, so the pre-push pull on a first sync has nothing valid
+    // to query yet.
+
+    /// Mock `/memory/since` responder that fails like the real bug (400)
+    /// until this project has been provisioned by a push, then succeeds:
+    /// models "the project does not exist yet" without depending on the real
+    /// cloud-api's own id-resolution details, which are out of scope for
+    /// this client-side fix.
+    struct SinceUntilProvisioned {
+        provisioned: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl wiremock::Respond for SinceUntilProvisioned {
+        fn respond(&self, _request: &wiremock::Request) -> wiremock::ResponseTemplate {
+            if self.provisioned.load(std::sync::atomic::Ordering::SeqCst) {
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "entries": [], "count": 0 }))
+            } else {
+                wiremock::ResponseTemplate::new(400)
+                    .set_body_string("invalid project id: expected a UUID, got a slug")
+            }
+        }
+    }
+
+    /// Mock `/memory/batch` responder that marks the project provisioned as
+    /// it lands the push, so a subsequent `/memory/since` call (via
+    /// [`SinceUntilProvisioned`]) succeeds.
+    struct BatchProvisions {
+        provisioned: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        external_id: String,
+    }
+
+    impl wiremock::Respond for BatchProvisions {
+        fn respond(&self, _request: &wiremock::Request) -> wiremock::ResponseTemplate {
+            self.provisioned
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            wiremock::ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 1, "skipped": 0, "failed": 0,
+                "results": [{"status": "created", "external_id": self.external_id, "id": "cloud-t1"}]
+            }))
+        }
+    }
+
+    // The exact repro: a never-pushed project's first sync must not send a
+    // pre-push pull at all. `/memory/since` fails (400) for as long as the
+    // project is unprovisioned, which is exactly the state a pre-push pull
+    // would see; that the round still succeeds, with the entry pushed and
+    // provisioned and no error surfaced, proves the pre-push pull was
+    // skipped rather than happening to tolerate the error.
+    #[tokio::test]
+    async fn sync_round_first_sync_skips_the_pre_push_pull_and_succeeds() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer};
+
+        let (_tmp, store) = fresh_store();
+        store
+            .add_note(
+                "decision",
+                "T1",
+                "first entry, never synced",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+        let ext = store.rows_for_sync(false).unwrap()[0].uuid.clone();
+
+        let provisioned = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/proj/memory/since"))
+            .respond_with(SinceUntilProvisioned {
+                provisioned: provisioned.clone(),
+            })
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(BatchProvisions {
+                provisioned: provisioned.clone(),
+                external_id: ext,
+            })
+            .mount(&server)
+            .await;
+
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+        let outcome = sync_round(&store, &client, false, false)
+            .await
+            .expect("a first sync must not surface the pre-push pull's 400 to the user");
+
+        assert_eq!(outcome.pushed.created, 1, "the entry must be pushed");
+        assert!(
+            store.note_id_for_remote_id("cloud-t1").unwrap().is_some(),
+            "the project must be provisioned and the entry stamped locally"
+        );
+    }
+
+    // ── established-client regression: pull-before-push order unregressed ──
+
+    // An established client (real sync history, a non-`None` cursor) must
+    // keep the pull-before-push-before-pull order the first-sync branch
+    // above does not use. Verified by observing the actual HTTP call
+    // sequence rather than timing a real race: a first-sync round makes
+    // exactly two calls (push, then one pull), while an established round
+    // makes three (pull, push, pull), so seeing three calls in this exact
+    // order, for a store seeded with a real cursor, proves the established
+    // path was taken and its ordering is unchanged.
+    #[tokio::test]
+    async fn sync_round_established_client_keeps_pull_before_push_order() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let (_tmp, store) = fresh_store();
+        // Seed a real cursor directly (as if an earlier sync had already
+        // landed this row), without a real HTTP round trip.
+        store
+            .apply_remote_note(
+                "01890000-0000-7000-8000-000000000001",
+                "decision",
+                "Seed",
+                "seeds a real sync cursor",
+                None,
+                crate::storage::now_secs(),
+                false,
+            )
+            .unwrap();
+        assert!(
+            store.max_remote_id().unwrap().is_some(),
+            "the store must now be an established client"
+        );
+        store
+            .add_note(
+                "decision",
+                "A2",
+                "new local entry this round",
+                &[],
+                &[],
+                None,
+                None,
+            )
+            .unwrap();
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/projects/proj/memory/since"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "entries": [], "count": 0 })),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": 1, "skipped": 0, "failed": 0,
+                "results": [{"status": "created", "external_id": "a2-ext", "id": "cloud-a2"}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+        sync_round(&store, &client, false, false).await.unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        let methods: Vec<&str> = reqs.iter().map(|r| r.method.as_str()).collect();
+        assert_eq!(
+            methods,
+            vec!["GET", "POST", "GET"],
+            "an established client must still pull, then push, then pull again: {methods:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes `spelunk sync` / `spelunk memory push` returning an HTTP 400 on the very first sync of a project that has never synced to the cloud before.

A sync round always pulled before pushing, to avoid shadowing a concurrent teammate write with a freshly re-derived cursor. On a genuinely first sync there is nothing local has ever pulled or pushed (`max_remote_id()` is `None`), and the project does not exist server-side yet, so that pre-push pull hit `/memory/since` before anything had provisioned the project and got a 400 back.

The fix adds a `sync_round_first` branch taken only when `pre_round_cursor` is `None`: push first (which provisions the project server-side and stamps local `remote_id`s), then run a single pull to converge with anything already on the server. Established clients (any real sync history) are unaffected and keep the existing pull-then-push-then-pull sequence.

Also handles: a crash between a landed push and its local `remote_id` stamp (retried push comes back `skipped`, not `created`, and still stamps correctly), a total push failure on a first sync (the follow-up pull's failure surfaces as a real error, not a silent swallow), and two never-synced clients racing to provision the same project concurrently.

## Test plan

- Read the full diff against `origin/main` (`git diff origin/main...HEAD`): the only production-code change is the new `sync_round_first` branch and the `pre_round_cursor.is_none()` dispatch in `crates/spelunk-cli/src/cli/cmd/memory/sync/round.rs`; `pull.rs` changes are test-only (renamed/reworded existing tests to reflect the new single post-push pull instead of a "confirmation" second pull).
- Ran `SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli --no-default-features`: 511 passed, 0 failed in the main unit-test binary, plus all integration binaries (secret_scanner, server_key_resolution_e2e, tls_trust, etc.) green. Specifically exercised and passing:
  - `sync_round_first_sync_skips_the_pre_push_pull_and_succeeds` — the exact repro: `/memory/since` 400s until provisioned, round still succeeds.
  - `sync_round_established_client_keeps_pull_before_push_order` — verifies the established-client path still makes the pull, push, pull HTTP sequence in that order.
  - `sync_round_first_sync_recovers_a_push_that_landed_before_a_crash` — a crash between server 207 and the local `remote_id` write recovers via a `skipped` response on retry.
  - `sync_round_first_sync_surfaces_pull_error_when_push_never_lands` — a totally failed push (503) plus the still-unprovisioned pull's 400 surfaces as a real `Err`, not a panic or silent success.
  - `sync_round_two_concurrent_first_syncs_both_succeed_without_pre_push_pull` — two clients racing to provision the same project via `tokio::join!` both succeed.
- Ran `SPELUNK_SECRET_STORE=file cargo clippy --all-targets -- -D warnings`: clean, no warnings.
- Ran `cargo fmt --check`: clean.
- Confirmed the branch merges cleanly against current `origin/main` (`git merge-tree --write-tree HEAD origin/main` produces a tree with no conflicts): `origin/main` picked up unrelated `spelunk index` crash-safety and lock changes since this branch's base, none of which touch `sync/round.rs` or `sync/pull.rs`.
- Grepped the full diff for board/task-id patterns (`#[0-9]+`, `\^[0-9]+`) and em-dashes: none in any added line (only pre-existing `decision #183` context and a pre-existing em-dash in text being *removed*, both already on `origin/main`).
