### PR TITLE
fix: keep the local server responsive while it is embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,19 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The local `spelunk-server` no longer goes unreachable while it is
+  embedding.** During a `spelunk index` run, `/v1/health` could take seconds
+  instead of well under a millisecond, `spelunk server status` reported a
+  perfectly healthy server as `(unreachable)`, and unrelated endpoints stopped
+  answering too. The liveness probe read the embedder's per-chunk token cap
+  through the same lock the embedder holds for a whole batch of forward
+  passes, and because that read was synchronous inside an async handler it
+  tied up a request-serving thread rather than releasing it, so each
+  concurrent probe made the stall worse. The cap is fixed at model load and
+  never changes, so it no longer sits behind that lock: liveness probes,
+  `spelunk server status`, and any other endpoint now stay responsive for the
+  whole index. The `/v1/health` payload is unchanged, `limits.embedder_token_cap`
+  included.
 - **`spelunk index` no longer skips a crash-half-indexed file forever.** If a
   previous run was killed after recording a file's new content hash but
   before writing its chunks, the hash-only skip check treated the file as

--- a/crates/spelunk-embed/src/embedder_native.rs
+++ b/crates/spelunk-embed/src/embedder_native.rs
@@ -1063,6 +1063,14 @@ mod tests {
     // it blocks a tokio worker rather than yielding it. These tests build an
     // embedder with a dummy inner (no model, no forward pass ever run) purely so
     // the accessor can be exercised against a genuinely held lock.
+    //
+    // These are the only tests in the workspace that fail if the accessor goes
+    // back behind that mutex. The server-side liveness suite runs against a
+    // mock backend and stays green through such a change, so do not weaken or
+    // delete these on the assumption that something downstream is watching.
+    // `embedder_with_cap` constructs `NativeEmbedder` by struct literal on
+    // purpose: moving `token_cap` back into `EmbedderInner` breaks this file at
+    // compile time rather than silently.
 
     fn dummy_weights() -> Qwen3EmbedWeights {
         let device = Device::Cpu;
@@ -1191,14 +1199,36 @@ mod tests {
             "0 means 'no extra cap': only the MAX_SEQ_LEN ceiling applies"
         );
         assert_eq!(
+            effective_token_cap(1),
+            1,
+            "the smallest cap `derive_token_cap` can produce must survive verbatim, not be \
+             rounded up or treated like the 0 sentinel"
+        );
+        assert_eq!(
             effective_token_cap(5792),
             5792,
             "a cap below the ceiling wins"
         );
         assert_eq!(
+            effective_token_cap(MAX_SEQ_LEN),
+            MAX_SEQ_LEN,
+            "a cap exactly at the ceiling is not off-by-one clamped below it"
+        );
+        assert_eq!(
+            effective_token_cap(MAX_SEQ_LEN - 1),
+            MAX_SEQ_LEN - 1,
+            "one below the ceiling is still the cap, not the ceiling"
+        );
+        assert_eq!(
             effective_token_cap(MAX_SEQ_LEN + 1),
             MAX_SEQ_LEN,
             "a cap above the ceiling must be clamped to MAX_SEQ_LEN"
+        );
+        assert_eq!(
+            effective_token_cap(usize::MAX),
+            MAX_SEQ_LEN,
+            "no cap value can push the truncation length past the model's position-embedding \
+             ceiling"
         );
     }
 

--- a/crates/spelunk-embed/src/embedder_native.rs
+++ b/crates/spelunk-embed/src/embedder_native.rs
@@ -68,6 +68,17 @@ fn derive_token_cap(budget_bytes: u64, n_head: usize) -> usize {
     cap.clamp(1, MAX_SEQ_LEN)
 }
 
+/// The per-chunk truncation length actually applied to a tokenized input:
+/// the load-time `token_cap` clamped by the model's `MAX_SEQ_LEN` ceiling.
+/// A `token_cap` of 0 (unit-test fixtures) means "no extra cap".
+fn effective_token_cap(token_cap: usize) -> usize {
+    if token_cap == 0 {
+        MAX_SEQ_LEN
+    } else {
+        token_cap.min(MAX_SEQ_LEN)
+    }
+}
+
 /// Total physical system RAM in bytes, best-effort and cross-platform.
 ///
 /// macOS uses the `hw.memsize` sysctl; Linux reads `MemTotal` from
@@ -116,16 +127,24 @@ fn total_system_ram() -> u64 {
 
 pub struct NativeEmbedder {
     inner: Arc<Mutex<EmbedderInner>>,
+    /// Max tokens per single chunk before the attention scratch would exceed the
+    /// memory budget. Oversized chunks are truncated to this length (see
+    /// `derive_token_cap` / `single_chunk_budget`). 0 means "no extra cap"
+    /// (only the `MAX_SEQ_LEN` ceiling applies) — used in unit tests.
+    ///
+    /// Deliberately a plain field and not part of [`EmbedderInner`]: `inner` is
+    /// held for a request's entire batch, and `token_cap()` is read by
+    /// `/v1/health` on every liveness probe from a synchronous lock inside an
+    /// `async fn`, which blocks a tokio worker rather than yielding it. Putting
+    /// this back behind that mutex makes a liveness probe wait out a full
+    /// forward-pass batch and takes the whole server down with it. Written once
+    /// at load and never mutated, so it needs no synchronisation at all.
+    token_cap: usize,
 }
 
 struct EmbedderInner {
     weights: Qwen3EmbedWeights,
     tokenizer: Tokenizer,
-    /// Max tokens per single chunk before the attention scratch would exceed the
-    /// memory budget. Oversized chunks are truncated to this length (see
-    /// `derive_token_cap` / `single_chunk_budget`). 0 means "no extra cap"
-    /// (only the `MAX_SEQ_LEN` ceiling applies) — used in unit tests.
-    token_cap: usize,
 }
 
 // ── no-KV-cache Qwen3 embedder (Q8_0 quantized) ───────────────────────────────
@@ -579,11 +598,8 @@ impl NativeEmbedder {
         );
 
         Ok(Self {
-            inner: Arc::new(Mutex::new(EmbedderInner {
-                weights,
-                tokenizer,
-                token_cap,
-            })),
+            inner: Arc::new(Mutex::new(EmbedderInner { weights, tokenizer })),
+            token_cap,
         })
     }
 }
@@ -647,6 +663,7 @@ impl crate::EmbeddingBackend for NativeEmbedder {
     ) -> anyhow::Result<Vec<Vec<f32>>> {
         let owned: Vec<String> = texts.iter().map(|s| s.to_string()).collect();
         let inner = Arc::clone(&self.inner);
+        let effective_cap = effective_token_cap(self.token_cap);
 
         tokio::task::spawn_blocking(move || {
             let guard = inner
@@ -672,11 +689,6 @@ impl crate::EmbeddingBackend for NativeEmbedder {
             // RAM; a ~40 k-token chunk would otherwise allocate ~100 GB and OOM
             // the whole index, so truncate (preserving the leading signal).
             // (token_cap == 0 in unit-test fixtures means "no extra cap".)
-            let effective_cap = if guard.token_cap == 0 {
-                MAX_SEQ_LEN
-            } else {
-                guard.token_cap.min(MAX_SEQ_LEN)
-            };
             let mut id_vecs: Vec<Vec<u32>> = Vec::with_capacity(owned.len());
             for text in &owned {
                 let encoding = guard
@@ -765,8 +777,11 @@ impl crate::EmbeddingBackend for NativeEmbedder {
     /// batch's total token budget realistically. `None` when running under
     /// the `token_cap == 0` test fixture ("no extra cap").
     fn token_cap(&self) -> Option<usize> {
-        let cap = self.inner.lock().ok()?.token_cap;
-        if cap == 0 { None } else { Some(cap) }
+        if self.token_cap == 0 {
+            None
+        } else {
+            Some(self.token_cap)
+        }
     }
 }
 
@@ -1037,6 +1052,172 @@ mod tests {
         assert!(
             expected_cap <= MAX_SEQ_LEN,
             "derived cap must not exceed the model's position-embedding ceiling"
+        );
+    }
+
+    // ── token_cap must not depend on the forward-pass mutex ───────────────────
+    //
+    // `/v1/health` reads `token_cap()` on every liveness probe. The forward-pass
+    // mutex is held for a request's entire batch (up to 32 sequential passes),
+    // and it is taken synchronously from an `async fn`, so a probe that waits on
+    // it blocks a tokio worker rather than yielding it. These tests build an
+    // embedder with a dummy inner (no model, no forward pass ever run) purely so
+    // the accessor can be exercised against a genuinely held lock.
+
+    fn dummy_weights() -> Qwen3EmbedWeights {
+        let device = Device::Cpu;
+        Qwen3EmbedWeights {
+            embed_tokens: Embedding::new(
+                Tensor::zeros((2, 2), DType::F16, &device).expect("embed table"),
+                2,
+            ),
+            layers: Vec::new(),
+            final_norm: RmsNorm::new(Tensor::ones(2, DType::F32, &device).expect("norm"), 1e-6),
+            rope_cos: Tensor::zeros((2, 1), DType::F32, &device).expect("rope cos"),
+            rope_sin: Tensor::zeros((2, 1), DType::F32, &device).expect("rope sin"),
+            n_head: N_HEAD,
+            n_kv_head: 8,
+            head_dim: 64,
+            device,
+        }
+    }
+
+    fn embedder_with_cap(token_cap: usize) -> NativeEmbedder {
+        NativeEmbedder {
+            inner: Arc::new(Mutex::new(EmbedderInner {
+                weights: dummy_weights(),
+                tokenizer: Tokenizer::new(tokenizers::models::bpe::BPE::default()),
+            })),
+            token_cap,
+        }
+    }
+
+    // Hold the forward-pass mutex on a separate thread until the returned
+    // sender is used, exactly as an in-flight embed batch does.
+    fn hold_forward_pass_lock(
+        embedder: &Arc<NativeEmbedder>,
+    ) -> (std::sync::mpsc::Sender<()>, std::thread::JoinHandle<()>) {
+        let holder = Arc::clone(embedder);
+        let (taken_tx, taken_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let handle = std::thread::spawn(move || {
+            let _guard = holder.inner.lock().expect("forward-pass mutex");
+            taken_tx.send(()).expect("signal that the lock is held");
+            let _ = release_rx.recv();
+        });
+        taken_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("holder thread must acquire the forward-pass mutex");
+        (release_tx, handle)
+    }
+
+    // Read the cap on its own thread so a re-coupled accessor fails the bound
+    // instead of hanging the whole test suite.
+    fn token_cap_within(
+        embedder: &Arc<NativeEmbedder>,
+        bound: std::time::Duration,
+    ) -> Option<usize> {
+        use crate::EmbeddingBackend;
+
+        let reader = Arc::clone(embedder);
+        let (cap_tx, cap_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = cap_tx.send(reader.token_cap());
+        });
+        cap_rx.recv_timeout(bound).unwrap_or_else(|_| {
+            panic!(
+                "token_cap() did not return within {bound:?} while the forward-pass mutex was \
+                 held: the accessor is back behind the embed lock"
+            )
+        })
+    }
+
+    #[test]
+    fn token_cap_returns_while_the_forward_pass_lock_is_held() {
+        let embedder = Arc::new(embedder_with_cap(5792));
+        let (release, holder) = hold_forward_pass_lock(&embedder);
+
+        let cap = token_cap_within(&embedder, std::time::Duration::from_millis(250));
+        assert_eq!(
+            cap,
+            Some(5792),
+            "the advertised cap must be readable while a batch holds the forward-pass mutex"
+        );
+
+        release.send(()).expect("release the holder thread");
+        holder.join().expect("holder thread");
+    }
+
+    #[test]
+    fn token_cap_is_independent_of_embedder_busyness() {
+        use crate::EmbeddingBackend;
+
+        let embedder = Arc::new(embedder_with_cap(8192));
+        let at_rest = embedder.token_cap();
+
+        let (release, holder) = hold_forward_pass_lock(&embedder);
+        let while_busy = token_cap_within(&embedder, std::time::Duration::from_millis(250));
+        release.send(()).expect("release the holder thread");
+        holder.join().expect("holder thread");
+
+        assert_eq!(at_rest, Some(8192), "cap at rest");
+        assert_eq!(
+            while_busy, at_rest,
+            "the reported cap must not change with embedder busyness"
+        );
+    }
+
+    #[test]
+    fn zero_cap_fixture_reports_none_and_a_real_cap_reports_some() {
+        use crate::EmbeddingBackend;
+
+        assert_eq!(
+            embedder_with_cap(0).token_cap(),
+            None,
+            "the 0 fixture means 'no extra cap' and must stay `None`"
+        );
+        assert_eq!(
+            embedder_with_cap(5792).token_cap(),
+            Some(5792),
+            "a real host-derived cap must be reported verbatim"
+        );
+    }
+
+    #[test]
+    fn effective_cap_is_the_smaller_of_the_token_cap_and_max_seq_len() {
+        assert_eq!(
+            effective_token_cap(0),
+            MAX_SEQ_LEN,
+            "0 means 'no extra cap': only the MAX_SEQ_LEN ceiling applies"
+        );
+        assert_eq!(
+            effective_token_cap(5792),
+            5792,
+            "a cap below the ceiling wins"
+        );
+        assert_eq!(
+            effective_token_cap(MAX_SEQ_LEN + 1),
+            MAX_SEQ_LEN,
+            "a cap above the ceiling must be clamped to MAX_SEQ_LEN"
+        );
+    }
+
+    #[test]
+    fn host_derived_cap_survives_the_move_off_the_forward_pass_mutex() {
+        use crate::EmbeddingBackend;
+
+        let derived = derive_token_cap(single_chunk_budget(total_system_ram()), N_HEAD);
+        let embedder = embedder_with_cap(derived);
+
+        assert_eq!(
+            embedder.token_cap(),
+            Some(derived),
+            "the accessor must surface exactly the cap derived at load time"
+        );
+        assert_eq!(
+            effective_token_cap(derived),
+            derived.min(MAX_SEQ_LEN),
+            "truncation must still use min(token_cap, MAX_SEQ_LEN)"
         );
     }
 }

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -4842,8 +4842,20 @@ mod tests {
     // race. `cap_location` is the mock's one degree of freedom, and
     // `harness_detects_a_cap_read_behind_the_forward_pass_mutex` uses it to
     // prove these bounds actually catch the coupling they guard against.
-    // The real `NativeEmbedder` accessor is pinned in `spelunk-embed`, which a
-    // mock cannot cover.
+    //
+    // Know what this module does NOT do before you rely on it. Every test here
+    // runs against `ParkingEmbedder`, so re-coupling the real
+    // `NativeEmbedder::token_cap()` to its forward-pass mutex leaves all of
+    // them green: verified by mutation, all pass with the accessor put back
+    // behind the lock. That is structural and not fixable here, because these
+    // tests cannot construct a `NativeEmbedder` without a model on disk. What
+    // this module gates is the server-side property (health, and endpoints
+    // that need no embedder, stay prompt given a backend whose cap read is
+    // lock-free) plus the sensitivity of the bound itself. The regression
+    // guard for the accessor is `spelunk_embed::embedder_native`'s
+    // `token_cap_returns_while_the_forward_pass_lock_is_held` and
+    // `token_cap_is_independent_of_embedder_busyness`. If you change the cap's
+    // storage, those are the tests that must fail.
     mod liveness_under_embed {
         use std::sync::{Arc, Condvar, Mutex};
         use std::time::{Duration, Instant};

--- a/crates/spelunk-server/src/handlers.rs
+++ b/crates/spelunk-server/src/handlers.rs
@@ -4825,4 +4825,472 @@ mod tests {
         // this not-cancelled can't turn this test into a silent hang.
         release.notify_one();
     }
+
+    // ── Liveness while an embed is in flight ─────────────────────────────────
+    //
+    // A liveness probe must never be able to wait on the embedder's
+    // forward-pass mutex. That mutex is held for a whole batch and is taken
+    // synchronously from inside an `async fn`, so a probe that waits on it
+    // blocks a tokio worker instead of yielding it: enough concurrent probes
+    // park enough workers that unrelated endpoints stop being polled and the
+    // server reads as unreachable.
+    //
+    // `ParkingEmbedder` reproduces the backend's structure rather than its
+    // timing: `embed()` takes a forward-pass mutex inside `spawn_blocking` and
+    // parks there on a test-controlled gate, so "an embed is in flight" is a
+    // state these tests can assert against, with no sleeps and no wall-clock
+    // race. `cap_location` is the mock's one degree of freedom, and
+    // `harness_detects_a_cap_read_behind_the_forward_pass_mutex` uses it to
+    // prove these bounds actually catch the coupling they guard against.
+    // The real `NativeEmbedder` accessor is pinned in `spelunk-embed`, which a
+    // mock cannot cover.
+    mod liveness_under_embed {
+        use std::sync::{Arc, Condvar, Mutex};
+        use std::time::{Duration, Instant};
+
+        use axum::{
+            body::Body,
+            http::{self, Request},
+        };
+        use serde_json::{Value, json};
+        use tower::ServiceExt;
+
+        use super::{make_app_with_slot, post_note};
+
+        // ~400x the sub-millisecond at-rest cost and ~19x below the seconds-long
+        // stall a whole-batch wait produces, so it can neither flake on a slow
+        // runner nor pass while the probe is coupled to the embed lock.
+        const LIVENESS_BOUND: Duration = Duration::from_millis(250);
+        const MOCK_DIM: usize = 4;
+        const MOCK_TOKEN_CAP: usize = 5792;
+        const PROJECT: &str = "liveness";
+
+        // Counting rendezvous between the test and the embedder: `queued` rises
+        // when a call enters the embedder and starts contending for the
+        // forward-pass mutex, `entered` when it has the mutex and is parked.
+        struct EmbedGate {
+            queued: (Mutex<usize>, Condvar),
+            entered: (Mutex<usize>, Condvar),
+            released: (Mutex<bool>, Condvar),
+        }
+
+        impl EmbedGate {
+            fn new() -> Arc<Self> {
+                Arc::new(Self {
+                    queued: (Mutex::new(0), Condvar::new()),
+                    entered: (Mutex::new(0), Condvar::new()),
+                    released: (Mutex::new(false), Condvar::new()),
+                })
+            }
+
+            fn bump(counter: &(Mutex<usize>, Condvar)) {
+                let (lock, cv) = counter;
+                *lock.lock().expect("gate counter") += 1;
+                cv.notify_all();
+            }
+
+            fn await_at_least(counter: &(Mutex<usize>, Condvar), target: usize, what: &str) {
+                let (lock, cv) = counter;
+                let mut count = lock.lock().expect("gate counter");
+                while *count < target {
+                    let (next, timed_out) = cv
+                        .wait_timeout(count, Duration::from_secs(10))
+                        .expect("gate wait");
+                    assert!(
+                        !timed_out.timed_out(),
+                        "timed out waiting for {target} embed call(s) to be {what}"
+                    );
+                    count = next;
+                }
+            }
+
+            fn wait_for_release(&self) {
+                let (lock, cv) = &self.released;
+                let mut done = lock.lock().expect("release flag");
+                while !*done {
+                    let (next, timed_out) = cv
+                        .wait_timeout(done, Duration::from_secs(30))
+                        .expect("release wait");
+                    assert!(
+                        !timed_out.timed_out(),
+                        "a parked embed was never released by the test"
+                    );
+                    done = next;
+                }
+            }
+
+            fn release(&self) {
+                let (lock, cv) = &self.released;
+                *lock.lock().expect("release flag") = true;
+                cv.notify_all();
+            }
+        }
+
+        #[derive(Clone, Copy)]
+        enum CapLocation {
+            // Where the backend keeps it: a plain field, read without touching
+            // the forward-pass mutex.
+            LockFreeField,
+            // The regression: read through the same mutex a batch holds end to
+            // end.
+            BehindForwardPassLock,
+        }
+
+        struct ParkingEmbedder {
+            dim: usize,
+            token_cap: usize,
+            cap_location: CapLocation,
+            forward_pass: Arc<Mutex<()>>,
+            gate: Arc<EmbedGate>,
+        }
+
+        #[async_trait::async_trait]
+        impl spelunk_core::embeddings::EmbeddingBackend for ParkingEmbedder {
+            async fn embed(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+                let count = texts.len();
+                let dim = self.dim;
+                let forward_pass = Arc::clone(&self.forward_pass);
+                let gate = Arc::clone(&self.gate);
+                tokio::task::spawn_blocking(move || {
+                    EmbedGate::bump(&gate.queued);
+                    let _guard = forward_pass.lock().expect("forward-pass mutex");
+                    EmbedGate::bump(&gate.entered);
+                    gate.wait_for_release();
+                    vec![vec![0.0_f32; dim]; count]
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("parking embedder blocking task failed: {e}"))
+            }
+
+            fn dimension(&self) -> usize {
+                self.dim
+            }
+
+            fn token_cap(&self) -> Option<usize> {
+                if let CapLocation::BehindForwardPassLock = self.cap_location {
+                    let _guard = self.forward_pass.lock().ok()?;
+                }
+                if self.token_cap == 0 {
+                    None
+                } else {
+                    Some(self.token_cap)
+                }
+            }
+        }
+
+        fn parked_app(cap_location: CapLocation) -> (axum::Router, Arc<EmbedGate>) {
+            let gate = EmbedGate::new();
+            let embedder = ParkingEmbedder {
+                dim: MOCK_DIM,
+                token_cap: MOCK_TOKEN_CAP,
+                cap_location,
+                forward_pass: Arc::new(Mutex::new(())),
+                gate: Arc::clone(&gate),
+            };
+            let app = make_app_with_slot(MOCK_DIM, crate::EmbedderSlot::ready(Arc::new(embedder)));
+            (app, gate)
+        }
+
+        fn spawn_embed(app: &axum::Router) -> tokio::task::JoinHandle<http::StatusCode> {
+            let app = app.clone();
+            tokio::spawn(async move {
+                let body = json!({"chunks": [{"chunk_id": "c0", "content": "fn parked() {}"}]});
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/projects/{PROJECT}/index/embed"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap();
+                app.oneshot(req).await.unwrap().status()
+            })
+        }
+
+        // Block until `target` embed call(s) hold the forward-pass mutex, off
+        // the async runtime so no worker is parked doing the waiting.
+        async fn await_parked(gate: &Arc<EmbedGate>, target: usize) {
+            let gate = Arc::clone(gate);
+            tokio::task::spawn_blocking(move || {
+                EmbedGate::await_at_least(&gate.entered, target, "parked in the embedder");
+            })
+            .await
+            .expect("gate wait task");
+        }
+
+        // Block until `target` embed call(s) have entered the embedder, whether
+        // or not they have won the forward-pass mutex yet.
+        async fn await_queued(gate: &Arc<EmbedGate>, target: usize) {
+            let gate = Arc::clone(gate);
+            tokio::task::spawn_blocking(move || {
+                EmbedGate::await_at_least(&gate.queued, target, "inside the embedder");
+            })
+            .await
+            .expect("gate wait task");
+        }
+
+        async fn probe_health(app: &axum::Router) -> (http::StatusCode, Duration, Value) {
+            let req = Request::builder()
+                .method("GET")
+                .uri("/v1/health")
+                .body(Body::empty())
+                .unwrap();
+            let started = Instant::now();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            let elapsed = started.elapsed();
+            let status = resp.status();
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let json: Value = serde_json::from_slice(&bytes).expect("health must return JSON");
+            (status, elapsed, json)
+        }
+
+        // Every field a client reads off `/v1/health`, so a "fix" that drops or
+        // nulls one to dodge the lock fails instead of passing.
+        fn wire_contract(body: &Value) -> Value {
+            json!({
+                "status": body["status"],
+                "version": body["version"],
+                "capabilities": body["capabilities"],
+                "instance_id": body["instance_id"],
+                "embedding_dim": body["embedding_dim"],
+                "embedder_state": body["embedder"]["state"],
+                "embed_request_timeout_secs": body["limits"]["embed_request_timeout_secs"],
+                "max_batch_chunks": body["limits"]["max_batch_chunks"],
+                "embedder_token_cap": body["limits"]["embedder_token_cap"],
+            })
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn health_responds_promptly_while_an_embed_is_parked() {
+            let (app, gate) = parked_app(CapLocation::LockFreeField);
+            let embed = spawn_embed(&app);
+            await_parked(&gate, 1).await;
+
+            let (status, elapsed, _) = probe_health(&app).await;
+            assert_eq!(
+                status,
+                http::StatusCode::OK,
+                "health must answer while the embedder is busy"
+            );
+            assert!(
+                elapsed < LIVENESS_BOUND,
+                "health took {elapsed:?} with an embed parked in the embedder; \
+                 a liveness probe must not wait on the forward-pass mutex"
+            );
+
+            gate.release();
+            assert_eq!(embed.await.expect("embed task"), http::StatusCode::OK);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn concurrent_health_probes_all_respond_promptly_while_an_embed_is_parked() {
+            let (app, gate) = parked_app(CapLocation::LockFreeField);
+            let embed = spawn_embed(&app);
+            await_parked(&gate, 1).await;
+
+            // More probes than worker threads: if each one parked a worker on
+            // the embed lock, the runtime would run out of threads to poll the
+            // rest, which is the "server is unreachable" amplification.
+            let probes: Vec<_> = (0..8)
+                .map(|_| {
+                    let app = app.clone();
+                    tokio::spawn(async move { probe_health(&app).await })
+                })
+                .collect();
+
+            for (i, probe) in probes.into_iter().enumerate() {
+                let (status, elapsed, _) = probe.await.expect("probe task");
+                assert_eq!(status, http::StatusCode::OK, "concurrent probe {i}");
+                assert!(
+                    elapsed < LIVENESS_BOUND,
+                    "concurrent probe {i} took {elapsed:?}; concurrent liveness probes must \
+                     not exhaust the runtime's workers"
+                );
+            }
+
+            gate.release();
+            assert_eq!(embed.await.expect("embed task"), http::StatusCode::OK);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn health_body_is_unchanged_while_an_embed_is_parked() {
+            let (app, gate) = parked_app(CapLocation::LockFreeField);
+            let (_, _, at_rest) = probe_health(&app).await;
+
+            let embed = spawn_embed(&app);
+            await_parked(&gate, 1).await;
+            let (status, _, while_parked) = probe_health(&app).await;
+
+            assert_eq!(status, http::StatusCode::OK);
+            assert_eq!(
+                wire_contract(&while_parked),
+                wire_contract(&at_rest),
+                "the health payload must be byte-identical whether or not the embedder is busy"
+            );
+            assert_eq!(
+                while_parked["limits"]["embedder_token_cap"],
+                json!(MOCK_TOKEN_CAP),
+                "the advertised cap is a client contract: it must be reported in full while \
+                 an embed is in flight, not omitted or nulled"
+            );
+
+            gate.release();
+            assert_eq!(embed.await.expect("embed task"), http::StatusCode::OK);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn an_endpoint_that_needs_no_embedder_responds_while_an_embed_is_parked() {
+            let (app, gate) = parked_app(CapLocation::LockFreeField);
+            let embed = spawn_embed(&app);
+            await_parked(&gate, 1).await;
+
+            let req = Request::builder()
+                .method("GET")
+                .uri("/v1/projects")
+                .body(Body::empty())
+                .unwrap();
+            let started = Instant::now();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            let elapsed = started.elapsed();
+
+            assert_eq!(resp.status(), http::StatusCode::OK);
+            assert!(
+                elapsed < LIVENESS_BOUND,
+                "GET /v1/projects took {elapsed:?} with an embed parked; an endpoint that \
+                 never touches the embedder must be unaffected by it"
+            );
+
+            gate.release();
+            assert_eq!(embed.await.expect("embed task"), http::StatusCode::OK);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn memory_search_queued_behind_a_parked_embed_still_answers_well_formed() {
+            let (app, gate) = parked_app(CapLocation::LockFreeField);
+            let (created, _) =
+                post_note(app.clone(), PROJECT, "seed", vec![1.0, 0.0, 0.0, 0.0]).await;
+            assert_eq!(created, http::StatusCode::CREATED, "seed the project");
+
+            let embed = spawn_embed(&app);
+            await_parked(&gate, 1).await;
+
+            let search_app = app.clone();
+            let search = tokio::spawn(async move {
+                let body = json!({"query": "seed", "limit": 5});
+                let req = Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/projects/{PROJECT}/memory/search"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap();
+                let resp = search_app.oneshot(req).await.unwrap();
+                let retry_after = resp
+                    .headers()
+                    .get(http::header::RETRY_AFTER)
+                    .map(|v| v.to_str().unwrap().to_string());
+                (resp.status(), retry_after)
+            });
+
+            // `search_notes` embeds its query on the same serialized model, so
+            // it must queue behind the in-flight batch. The bar is a
+            // well-formed response, not an instant one: wait until it is
+            // provably contending for the forward-pass mutex, then let both
+            // through.
+            await_queued(&gate, 2).await;
+            gate.release();
+
+            let (status, retry_after) = search.await.expect("search task");
+            let well_formed = status == http::StatusCode::OK
+                || (status == http::StatusCode::TOO_MANY_REQUESTS && retry_after.is_some());
+            assert!(
+                well_formed,
+                "memory search during an index must return 200, or 429 with Retry-After; \
+                 got {status} (Retry-After: {retry_after:?})"
+            );
+
+            assert_eq!(embed.await.expect("embed task"), http::StatusCode::OK);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn health_returns_to_its_at_rest_behaviour_once_the_embed_completes() {
+            let (app, gate) = parked_app(CapLocation::LockFreeField);
+            let (_, _, at_rest) = probe_health(&app).await;
+
+            let embed = spawn_embed(&app);
+            await_parked(&gate, 1).await;
+            gate.release();
+            assert_eq!(embed.await.expect("embed task"), http::StatusCode::OK);
+
+            let (status, elapsed, after) = probe_health(&app).await;
+            assert_eq!(status, http::StatusCode::OK);
+            assert!(
+                elapsed < LIVENESS_BOUND,
+                "health took {elapsed:?} after the embed completed: a leaked lock"
+            );
+            assert_eq!(
+                wire_contract(&after),
+                wire_contract(&at_rest),
+                "the health payload must match the at-rest baseline once the embed is done"
+            );
+
+            // A completed embed must have returned its admission permit; if it
+            // leaked, this second request is shed with 429 instead of served.
+            assert_eq!(
+                spawn_embed(&app).await.expect("embed task"),
+                http::StatusCode::OK,
+                "a further embed must still be admitted: the completed request's permit \
+                 must have been returned"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn health_stays_prompt_when_a_parked_embed_is_cancelled() {
+            let (app, gate) = parked_app(CapLocation::LockFreeField);
+            let embed = spawn_embed(&app);
+            await_parked(&gate, 1).await;
+
+            // Client disconnect / timeout: the handler future is dropped while
+            // its blocking task is still parked inside the embedder.
+            embed.abort();
+            assert!(
+                embed.await.unwrap_err().is_cancelled(),
+                "the embed request was cancelled"
+            );
+
+            let (status, elapsed, _) = probe_health(&app).await;
+            assert_eq!(status, http::StatusCode::OK);
+            assert!(
+                elapsed < LIVENESS_BOUND,
+                "health took {elapsed:?} after the parked embed was cancelled"
+            );
+
+            gate.release();
+            let (status, elapsed, _) = probe_health(&app).await;
+            assert_eq!(status, http::StatusCode::OK);
+            assert!(
+                elapsed < LIVENESS_BOUND,
+                "health took {elapsed:?} once the abandoned embed drained"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn harness_detects_a_cap_read_behind_the_forward_pass_mutex() {
+            let (app, gate) = parked_app(CapLocation::BehindForwardPassLock);
+            let embed = spawn_embed(&app);
+            await_parked(&gate, 1).await;
+
+            let probe_app = app.clone();
+            let probe = tokio::spawn(async move { probe_health(&probe_app).await });
+            let outcome = tokio::time::timeout(LIVENESS_BOUND, probe).await;
+            assert!(
+                outcome.is_err(),
+                "a probe that reads the cap through the forward-pass mutex cannot answer \
+                 while a batch holds it: if this completes in time, the bound above no \
+                 longer proves anything"
+            );
+
+            gate.release();
+            assert_eq!(embed.await.expect("embed task"), http::StatusCode::OK);
+        }
+    }
 }

--- a/crates/spelunk-server/tests/health_under_index_load.rs
+++ b/crates/spelunk-server/tests/health_under_index_load.rs
@@ -1,0 +1,323 @@
+//! Real-hardware confirmation that the local server stays usable while it is
+//! embedding, run against the actual native embedder rather than a mock.
+//!
+//! **Not a CI gate.** It is `#[ignore]`d: it needs the F2LLM model artifacts on
+//! disk (downloading them on first run), real GPU/CPU inference, and it
+//! measures wall-clock latency, none of which belong on a shared runner. The
+//! deterministic gate for the same property is
+//! `handlers::tests::liveness_under_embed` (mock embedder parked on a
+//! test-controlled signal, no model, no timing race), plus
+//! `spelunk_embed::embedder_native`'s accessor tests.
+//!
+//! Run it with:
+//!   SPELUNK_SECRET_STORE=file cargo test -p spelunk-server \
+//!     --test health_under_index_load -- --ignored --nocapture
+//!
+//! Tunable via env:
+//!   SPELUNK_HEALTH_LOAD_REPO    repo to draw real text from (default: this workspace)
+//!   SPELUNK_HEALTH_LOAD_CHUNKS  how many chunks to embed (default: 2048)
+//!
+//! This drives the HTTP surface directly rather than shelling out to the CLI.
+//! `/v1/health` is the sole endpoint `spelunk server status` reads (it renders
+//! "reachable" from `instance_id` + `version`), and `POST
+//! /v1/projects/{id}/memory/search` is the request `spelunk memory search`
+//! issues, so the assertions below are the same contract those commands see.
+
+#![cfg(feature = "embed-native")]
+
+mod common;
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+
+/// Every liveness sample must come back inside this. Measured at rest is
+/// sub-millisecond; a probe that waits on the embedder's forward-pass mutex
+/// takes seconds.
+const LIVENESS_BOUND: Duration = Duration::from_millis(250);
+/// Gap between liveness samples for the whole embed phase.
+const SAMPLE_INTERVAL: Duration = Duration::from_millis(500);
+/// Chunks per `/index/embed` request, matching what the index phase sends.
+const BATCH_CHUNKS: usize = 256;
+const DIM: usize = spelunk_core::embeddings::EMBEDDING_DIM;
+const PROJECT: &str = "health-under-load";
+
+fn repo_root() -> PathBuf {
+    if let Ok(dir) = std::env::var("SPELUNK_HEALTH_LOAD_REPO") {
+        return PathBuf::from(dir);
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn chunk_budget() -> usize {
+    std::env::var("SPELUNK_HEALTH_LOAD_CHUNKS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2048)
+}
+
+/// Collect real source text from `root`, windowed into chunk-sized pieces.
+fn collect_chunks(root: &Path, budget: usize) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if chunks.len() >= budget {
+            break;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with('.') || name == "target" || name == "node_modules" {
+                continue;
+            }
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let is_text = matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("rs" | "md" | "toml" | "ts" | "py" | "go")
+            );
+            if !is_text {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let words: Vec<&str> = content.split_whitespace().collect();
+            for window in words.chunks(200) {
+                if chunks.len() >= budget {
+                    return chunks;
+                }
+                let text = window.join(" ");
+                if text.len() > 32 {
+                    chunks.push(text);
+                }
+            }
+        }
+    }
+    chunks
+}
+
+async fn spawn_server(embedder: spelunk_server::EmbedderSlot) -> String {
+    common::register_sqlite_vec();
+    let db = spelunk_server::db::ServerDb::open(Path::new(":memory:"), DIM, "test-model")
+        .expect("open in-memory server db");
+    let instance_id = db.get_or_create_instance_id().expect("instance_id");
+    let state = spelunk_server::AppState {
+        db: Arc::new(tokio::sync::Mutex::new(db)),
+        auth: Arc::new(spelunk_server::auth::ApiKeyAuth::new(None)),
+        conflict_threshold: spelunk_server::default_conflict_threshold(),
+        embedder,
+        embed_admission: spelunk_server::EmbedAdmission::new(
+            spelunk_server::EMBED_QUEUE_CAPACITY,
+            spelunk_server::EMBED_BUSY_RETRY_AFTER_SECS,
+        ),
+        llm: None,
+        max_tokens_ceiling: 8192,
+        rate_limiter: Arc::new(spelunk_server::rate_limiter::RateLimiter::new(100_000, 60)),
+        instance_id,
+        started_by: None,
+        relay: spelunk_server::relay::RelayRegistry::new(),
+    };
+    let app = spelunk_server::router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral loopback port");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .expect("serve");
+    });
+    format!("http://{addr}")
+}
+
+/// A single liveness sample: the latency, and the two fields
+/// `spelunk server status` needs to print a server as reachable.
+struct HealthSample {
+    latency: Duration,
+    instance_id: String,
+    version: String,
+    token_cap: Value,
+}
+
+async fn sample_health(client: &reqwest::Client, base: &str) -> HealthSample {
+    let started = Instant::now();
+    let resp = client
+        .get(format!("{base}/v1/health"))
+        .send()
+        .await
+        .expect("health must always answer: a failed request is the 'unreachable' symptom");
+    let latency = started.elapsed();
+    assert_eq!(resp.status().as_u16(), 200, "health must return 200");
+    let body: Value = resp.json().await.expect("health must return JSON");
+    HealthSample {
+        latency,
+        instance_id: body["instance_id"].as_str().unwrap_or_default().to_string(),
+        version: body["version"].as_str().unwrap_or_default().to_string(),
+        token_cap: body["limits"]["embedder_token_cap"].clone(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires the F2LLM model and real inference hardware; not a CI gate"]
+async fn health_and_memory_search_stay_usable_throughout_a_real_index() {
+    let embedder = spelunk_server::embed_hub::load_from_hub().expect("load F2LLM-v2-330M");
+    let base = spawn_server(spelunk_server::EmbedderSlot::ready(Arc::new(embedder))).await;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("http client");
+
+    // Seed the project with an explicit vector so this setup step does not
+    // itself queue on the embedder.
+    let seed = client
+        .post(format!("{base}/v1/projects/{PROJECT}/memory"))
+        .json(&json!({
+            "kind": "note",
+            "title": "seed",
+            "body": "seed entry for the concurrent memory search probe",
+            "embedding": vec![0.0_f32; DIM],
+        }))
+        .send()
+        .await
+        .expect("seed note");
+    assert_eq!(seed.status().as_u16(), 201, "seed note must be created");
+
+    let chunks = collect_chunks(&repo_root(), chunk_budget());
+    assert!(
+        chunks.len() >= BATCH_CHUNKS,
+        "need at least one full batch of real text to embed, got {}",
+        chunks.len()
+    );
+    println!("embedding {} chunks from {:?}", chunks.len(), repo_root());
+
+    // The index phase: sequential full-size batches, exactly as `spelunk index`
+    // issues them.
+    let index_client = client.clone();
+    let index_base = base.clone();
+    let index = tokio::spawn(async move {
+        for batch in chunks.chunks(BATCH_CHUNKS) {
+            let body = json!({
+                "chunks": batch
+                    .iter()
+                    .enumerate()
+                    .map(|(i, c)| json!({"chunk_id": format!("c{i}"), "content": c}))
+                    .collect::<Vec<_>>()
+            });
+            let resp = index_client
+                .post(format!("{index_base}/v1/projects/{PROJECT}/index/embed"))
+                .timeout(Duration::from_secs(1800))
+                .json(&body)
+                .send()
+                .await
+                .expect("embed batch request");
+            assert_eq!(resp.status().as_u16(), 200, "embed batch must succeed");
+        }
+    });
+
+    // Concurrent `memory search`, honouring Retry-After on a shed 429. It
+    // embeds its query on the same serialized model, so it queues rather than
+    // returning instantly; the bar is that it always gets a well-formed
+    // response and eventually succeeds.
+    let search_client = client.clone();
+    let search_base = base.clone();
+    let search = tokio::spawn(async move {
+        let mut succeeded = false;
+        for _ in 0..20 {
+            let resp = search_client
+                .post(format!("{search_base}/v1/projects/{PROJECT}/memory/search"))
+                .json(&json!({"query": "how does indexing work", "limit": 5}))
+                .send()
+                .await
+                .expect("memory search must return a response, never a dropped connection");
+            match resp.status().as_u16() {
+                200 => {
+                    succeeded = true;
+                    break;
+                }
+                429 => {
+                    let retry_after = resp
+                        .headers()
+                        .get(reqwest::header::RETRY_AFTER)
+                        .and_then(|v| v.to_str().ok())
+                        .and_then(|v| v.parse::<u64>().ok())
+                        .expect("a shed 429 must carry a parseable Retry-After");
+                    tokio::time::sleep(Duration::from_secs(retry_after)).await;
+                }
+                other => panic!("memory search returned an unexpected status {other}"),
+            }
+        }
+        succeeded
+    });
+
+    // Sample liveness for the whole embed phase.
+    let mut samples = 0usize;
+    let mut max_latency = Duration::ZERO;
+    let mut first: Option<(String, String)> = None;
+    while !index.is_finished() {
+        let sample = sample_health(&client, &base).await;
+        samples += 1;
+        max_latency = max_latency.max(sample.latency);
+
+        assert!(
+            sample.latency < LIVENESS_BOUND,
+            "liveness sample {samples} took {:?}, over the {LIVENESS_BOUND:?} bound, \
+             while the embedder was busy",
+            sample.latency
+        );
+        assert_eq!(
+            sample.instance_id.len(),
+            36,
+            "every sample must carry the full instance id, the field `server status` \
+             renders as reachable"
+        );
+        assert!(
+            !sample.version.is_empty(),
+            "every sample must carry the server version"
+        );
+        assert!(
+            sample.token_cap.is_u64(),
+            "the advertised token cap must stay populated while the embedder is busy, got {}",
+            sample.token_cap
+        );
+        let identity = (sample.instance_id, sample.version);
+        match &first {
+            None => first = Some(identity),
+            Some(expected) => assert_eq!(
+                &identity, expected,
+                "server identity must be stable across the run"
+            ),
+        }
+
+        tokio::time::sleep(SAMPLE_INTERVAL).await;
+    }
+
+    index.await.expect("index phase");
+    assert!(
+        samples >= 4,
+        "the embed phase finished too fast to prove anything ({samples} samples); \
+         raise SPELUNK_HEALTH_LOAD_CHUNKS"
+    );
+    assert!(
+        search.await.expect("search task"),
+        "concurrent memory search must complete successfully within the run"
+    );
+
+    println!("liveness samples: {samples}, max latency: {max_latency:?}");
+}

--- a/crates/spelunk-server/tests/health_under_index_load.rs
+++ b/crates/spelunk-server/tests/health_under_index_load.rs
@@ -1,27 +1,27 @@
-//! Real-hardware confirmation that the local server stays usable while it is
-//! embedding, run against the actual native embedder rather than a mock.
-//!
-//! **Not a CI gate.** It is `#[ignore]`d: it needs the F2LLM model artifacts on
-//! disk (downloading them on first run), real GPU/CPU inference, and it
-//! measures wall-clock latency, none of which belong on a shared runner. The
-//! deterministic gate for the same property is
-//! `handlers::tests::liveness_under_embed` (mock embedder parked on a
-//! test-controlled signal, no model, no timing race), plus
-//! `spelunk_embed::embedder_native`'s accessor tests.
-//!
-//! Run it with:
-//!   SPELUNK_SECRET_STORE=file cargo test -p spelunk-server \
-//!     --test health_under_index_load -- --ignored --nocapture
-//!
-//! Tunable via env:
-//!   SPELUNK_HEALTH_LOAD_REPO    repo to draw real text from (default: this workspace)
-//!   SPELUNK_HEALTH_LOAD_CHUNKS  how many chunks to embed (default: 2048)
-//!
-//! This drives the HTTP surface directly rather than shelling out to the CLI.
-//! `/v1/health` is the sole endpoint `spelunk server status` reads (it renders
-//! "reachable" from `instance_id` + `version`), and `POST
-//! /v1/projects/{id}/memory/search` is the request `spelunk memory search`
-//! issues, so the assertions below are the same contract those commands see.
+// Real-hardware confirmation that the local server stays usable while it is
+// embedding, run against the actual native embedder rather than a mock.
+//
+// **Not a CI gate.** It is `#[ignore]`d: it needs the F2LLM model artifacts on
+// disk (downloading them on first run), real GPU/CPU inference, and it
+// measures wall-clock latency, none of which belong on a shared runner. The
+// deterministic gate for the same property is
+// `handlers::tests::liveness_under_embed` (mock embedder parked on a
+// test-controlled signal, no model, no timing race), plus
+// `spelunk_embed::embedder_native`'s accessor tests.
+//
+// Run it with:
+//   SPELUNK_SECRET_STORE=file cargo test -p spelunk-server \
+//     --test health_under_index_load -- --ignored --nocapture
+//
+// Tunable via env:
+//   SPELUNK_HEALTH_LOAD_REPO    repo to draw real text from (default: this workspace)
+//   SPELUNK_HEALTH_LOAD_CHUNKS  how many chunks to embed (default: 2048)
+//
+// This drives the HTTP surface directly rather than shelling out to the CLI.
+// `/v1/health` is the sole endpoint `spelunk server status` reads (it renders
+// "reachable" from `instance_id` + `version`), and `POST
+// /v1/projects/{id}/memory/search` is the request `spelunk memory search`
+// issues, so the assertions below are the same contract those commands see.
 
 #![cfg(feature = "embed-native")]
 
@@ -34,14 +34,19 @@ use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
 
-/// Every liveness sample must come back inside this. Measured at rest is
-/// sub-millisecond; a probe that waits on the embedder's forward-pass mutex
-/// takes seconds.
+// Every liveness sample must come back inside this. Measured at rest is
+// sub-millisecond; a probe that waits on the embedder's forward-pass mutex
+// takes seconds.
 const LIVENESS_BOUND: Duration = Duration::from_millis(250);
-/// Gap between liveness samples for the whole embed phase.
+// Gap between liveness samples for the whole embed phase.
 const SAMPLE_INTERVAL: Duration = Duration::from_millis(500);
-/// Chunks per `/index/embed` request, matching what the index phase sends.
+// Chunks per `/index/embed` request, matching what the index phase sends.
 const BATCH_CHUNKS: usize = 256;
+// Mirrors the server's own non-embed request timeout, which is crate-private.
+// Client deadlines are set relative to it so the server always gets to answer
+// first: a client-side cutoff would be indistinguishable here from the dropped
+// connection this test exists to rule out.
+const SERVER_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const DIM: usize = spelunk_core::embeddings::EMBEDDING_DIM;
 const PROJECT: &str = "health-under-load";
 
@@ -63,7 +68,7 @@ fn chunk_budget() -> usize {
         .unwrap_or(2048)
 }
 
-/// Collect real source text from `root`, windowed into chunk-sized pieces.
+// Collect real source text from `root`, windowed into chunk-sized pieces.
 fn collect_chunks(root: &Path, budget: usize) -> Vec<String> {
     let mut chunks = Vec::new();
     let mut stack = vec![root.to_path_buf()];
@@ -146,8 +151,8 @@ async fn spawn_server(embedder: spelunk_server::EmbedderSlot) -> String {
     format!("http://{addr}")
 }
 
-/// A single liveness sample: the latency, and the two fields
-/// `spelunk server status` needs to print a server as reachable.
+// A single liveness sample: the latency, and the two fields
+// `spelunk server status` needs to print a server as reachable.
 struct HealthSample {
     latency: Duration,
     instance_id: String,
@@ -235,7 +240,16 @@ async fn health_and_memory_search_stay_usable_throughout_a_real_index() {
     // embeds its query on the same serialized model, so it queues rather than
     // returning instantly; the bar is that it always gets a well-formed
     // response and eventually succeeds.
-    let search_client = client.clone();
+    //
+    // Its own client, with a timeout deliberately above the server's own
+    // request timeout: a search that queues behind an in-flight batch can
+    // legitimately outlast the probe client's short deadline, and cutting it
+    // off here would report a client-side deadline as the dropped connection
+    // this test exists to rule out.
+    let search_client = reqwest::Client::builder()
+        .timeout(SERVER_REQUEST_TIMEOUT + Duration::from_secs(15))
+        .build()
+        .expect("search http client");
     let search_base = base.clone();
     let search = tokio::spawn(async move {
         let mut succeeded = false;
@@ -260,6 +274,17 @@ async fn health_and_memory_search_stay_usable_throughout_a_real_index() {
                         .expect("a shed 429 must carry a parseable Retry-After");
                     tokio::time::sleep(Duration::from_secs(retry_after)).await;
                 }
+                // The server answered, but only after its own request timeout
+                // expired while the query waited its turn on the shared model.
+                // That is admission-control fairness under a saturated index,
+                // a separate concern from the liveness property under test:
+                // report it as such rather than as an unreachable server.
+                408 => panic!(
+                    "memory search was still queued on the embedder when the server's own \
+                     request timeout expired. Liveness is not the problem here (the server \
+                     answered); this is queue fairness in front of the shared model, and it \
+                     needs its own task rather than a wider change here"
+                ),
                 other => panic!("memory search returned an unexpected status {other}"),
             }
         }

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -606,9 +606,9 @@ environment.
 ### Embedding CPU thread budget
 
 On a CPU-only host the bundled native embedder (candle) would otherwise fan a
-single embed batch across every core, briefly starving the server's own request
-handling (`/v1/health` can go unresponsive during a large index). To leave
-headroom, the server caps candle's thread count at startup.
+single embed batch across every core, leaving the server's own request handling
+to compete with it for CPU. To leave headroom, the server caps candle's thread
+count at startup.
 
 | Env | Default | Purpose |
 |---|---|---|
@@ -618,6 +618,11 @@ Precedence: `SPELUNK_EMBED_THREADS` > an already-set `RAYON_NUM_THREADS` >
 the bounded default. A pre-set `RAYON_NUM_THREADS` is respected and never
 overridden. The resolved value and its source are logged at startup
 (`embed CPU thread budget resolved`). GPU (Metal/CUDA) builds are unaffected.
+
+This budget is not what keeps the server answering while an embedder is busy,
+and lowering it will not make a slow probe fast. `/v1/health` and every other
+endpoint that does not itself embed never touch the embedder's forward pass, so
+they stay responsive for the whole of an index whatever this value is set to.
 
 This budget only bounds CPU contention *within* a single embed batch; embed
 requests themselves are still serialized behind a single mutex on both device


### PR DESCRIPTION
During a `spelunk index` run the local `spelunk-server` became unreachable for
the whole embed phase. `/v1/health` took seconds instead of well under a
millisecond, `spelunk server status` reported a perfectly healthy server as
`(unreachable)`, and endpoints with nothing to do with embedding stopped
answering too. Everything recovered the instant the index completed.

## Cause

`/v1/health` read the embedder's per-chunk token cap through
`EmbeddingBackend::token_cap()`, and `NativeEmbedder::token_cap()` locked the
same `Arc<Mutex<EmbedderInner>>` that `embed_with_cancel` holds for a request's
entire batch (up to 32 sequential forward passes). Because that lock is
synchronous inside an `async fn`, it blocked a tokio worker rather than
yielding it, so each concurrent probe parked another worker until tasks for
unrelated endpoints could no longer be polled. That is the escalation from
"health is slow" to "the whole server is unreachable".

## Fix

The cap is derived once at model load and never mutated, so it is now a plain
field on `NativeEmbedder` and the accessor is a field read. `embed_with_cancel`
resolves the effective cap before entering its `spawn_blocking` closure.
Structurally there is no longer any path from a liveness probe to the
forward-pass mutex.

The embedder's own behaviour is untouched: batches are still serialized behind
that mutex, the thread budget is unchanged, and admission control is unchanged.

## Compatibility

The `/v1/health` wire format is unchanged and `limits.embedder_token_cap`
reports the same value as before, so existing clients need no change. The
health handler itself is byte-for-byte identical.

## Tests

Three deliberately separate groups:

- `spelunk-embed` pins the accessor against a genuinely held forward-pass
  mutex, using a fixture embedder that needs no model on disk. The read runs on
  its own thread behind a bounded `recv_timeout`, so a re-coupled accessor
  fails the bound instead of hanging the suite. These two tests are the
  regression guard, and the fixture builds the struct by literal so moving the
  field back fails at compile time.
- `spelunk-server` is the deterministic gate: a mock embedder parks inside
  `spawn_blocking` holding a forward-pass mutex on a condvar gate, so "an embed
  is in flight" is an asserted state rather than a timing race. No model, GPU,
  repo, network, or sleeps. Covers a single probe, eight concurrent probes
  (worker-thread exhaustion), the full response body, an embedder-free
  endpoint, `memory search` queueing behind the batch, recovery after
  completion, and a cancelled embed. One test proves the 250 ms bound actually
  catches the coupling it guards against.
- An `#[ignore]`d real-hardware run samples `/v1/health` every 500 ms across a
  real embed load, asserting every sample stays under the bound with a stable
  server identity. Explicitly not a CI gate.

The module comment states plainly that the server-side tests run against a mock
and therefore stay green if the real accessor is re-coupled, and names the two
tests that do guard it.

## Docs

The "Embedding CPU thread budget" section of `docs/server-setup.md` justified
the knob by claiming a CPU-only host's embed batch could make `/v1/health` go
unresponsive. The symptom was real but the cause was not CPU fan-out, so an
operator following that rationale would have tuned a knob that could never have
helped. The section now describes what the budget actually bounds and says
outright that it is not what keeps liveness probes answering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
