### PR TITLE
memory push/sync: embed the push set locally before shipping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,27 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`spelunk memory push` and `spelunk sync` now embed what they push, so a
+  pushed entry stays findable by `spelunk memory search` locally.** A push
+  shipped entries that had never been embedded (a `memory add` with no embedder
+  running, an import, a pulled entry) and left the local `memory.db` exactly as
+  it found it. The push reported `created`, and those rows remained invisible to
+  semantic `memory search` on your own machine, with nothing saying so and no
+  hint that `spelunk memory reindex` was the cure. Both commands now embed every
+  entry in the push set that lacks a usable local vector before the batch is
+  built, through the same local embedder and the same document text
+  `memory reindex` uses, and commit each vector as it completes. Note this
+  changes nothing about what travels: `kind`, `title`, and `body` were always
+  sent on every push, and the optional vector fields are additive. What changes
+  is that the local store is left correct, and that a destination advertising
+  `accepts_pushed_vectors` can now store the entry as-is instead of re-embedding
+  it. With no local embedder reachable the push still runs to completion exactly
+  as before, text-only, and says how many entries went out unembedded and how to
+  fix them; the summary line reports how many were embedded locally. Skipped in
+  `cloud_first` mode with a `server_url` set, where `memory.db` is not the store
+  of record and `memory reindex` does not apply either. Rows that were already
+  synced are outside the push set and are not embedded by this change.
+
 - **The local `spelunk-server` no longer goes unreachable while it is
   embedding.** During a `spelunk index` run, `/v1/health` could take seconds
   instead of well under a millisecond, `spelunk server status` reported a

--- a/crates/spelunk-cli/src/cli/cmd/memory/push.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/push.rs
@@ -23,7 +23,7 @@
 use anyhow::{Context, Result};
 
 use super::MemoryPushArgs;
-use super::sync::push_local_oneway;
+use super::sync::{LocalEmbedPolicy, local_embed_summary, push_local_oneway, unembedded_warning};
 use crate::{
     capability,
     cli::cmd::auth_api,
@@ -64,13 +64,18 @@ pub async fn memory_push(
     // Attach the local fp32/896 vector only when the server advertises it;
     // otherwise the push is text-only and the server re-embeds.
     let accepts_pushed_vectors = tier.caps().is_some_and(|c| c.accepts_pushed_vectors);
+    let local_embed = LocalEmbedPolicy::for_push(cfg, src_path);
     let summary = push_local_oneway(
         &local,
         &client,
         args.include_archived,
         accepts_pushed_vectors,
+        &local_embed,
     )
     .await?;
+    if summary.without_local_vector > 0 {
+        eprintln!("{}", unembedded_warning(summary.without_local_vector));
+    }
     if summary.attempted == 0 {
         if summary.already_synced > 0 {
             println!(
@@ -103,13 +108,20 @@ pub async fn memory_push(
         );
     } else if summary.failed > 0 {
         println!(
-            "Done. Pushed {} entries (created {}, skipped {}, {} failed).",
-            summary.attempted, summary.created, summary.skipped, summary.failed
+            "Done. Pushed {} entries (created {}, skipped {}, {} failed).{}",
+            summary.attempted,
+            summary.created,
+            summary.skipped,
+            summary.failed,
+            local_embed_summary(&summary)
         );
     } else {
         println!(
-            "Done. Pushed {} entries (created {}, skipped {}).",
-            summary.attempted, summary.created, summary.skipped
+            "Done. Pushed {} entries (created {}, skipped {}).{}",
+            summary.attempted,
+            summary.created,
+            summary.skipped,
+            local_embed_summary(&summary)
         );
     }
     Ok(())

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/mod.rs
@@ -51,7 +51,9 @@ mod test_support;
 
 pub(super) use pull::parse_iso_to_secs;
 use pull::pull_and_apply;
-pub(super) use push::push_local_oneway;
+pub(super) use push::{
+    LocalEmbedPolicy, local_embed_summary, push_local_oneway, unembedded_warning,
+};
 use round::{SyncRoundOutcome, sync_round};
 
 /// Resolve the project slug to sync into, or halt with actionable guidance.
@@ -150,13 +152,18 @@ pub async fn memory_sync(
     // pre-round cursor. See `sync_round` for why a plain push-then-pull (or
     // even pull-then-push) reorder is not sufficient. ───────────────────────
     let accepts_pushed_vectors = tier.caps().is_some_and(|c| c.accepts_pushed_vectors);
+    let local_embed = LocalEmbedPolicy::for_push(cfg, src_path);
     let SyncRoundOutcome { pushed, pulled } = sync_round(
         &local,
         &client,
         args.include_archived,
         accepts_pushed_vectors,
+        &local_embed,
     )
     .await?;
+    if pushed.without_local_vector > 0 {
+        eprintln!("{}", unembedded_warning(pushed.without_local_vector));
+    }
 
     if pushed.attempted == 0 {
         println!(
@@ -193,13 +200,22 @@ pub async fn memory_sync(
         );
     } else if pushed.failed > 0 {
         println!(
-            "Sync complete. Pushed {} entries (created {}, skipped {}, {} failed), applied {} new remote entries.",
-            pushed.attempted, pushed.created, pushed.skipped, pushed.failed, pulled
+            "Sync complete. Pushed {} entries (created {}, skipped {}, {} failed), applied {} new remote entries.{}",
+            pushed.attempted,
+            pushed.created,
+            pushed.skipped,
+            pushed.failed,
+            pulled,
+            local_embed_summary(&pushed)
         );
     } else {
         println!(
-            "Sync complete. Pushed {} entries (created {}, skipped {}), applied {} new remote entries.",
-            pushed.attempted, pushed.created, pushed.skipped, pulled
+            "Sync complete. Pushed {} entries (created {}, skipped {}), applied {} new remote entries.{}",
+            pushed.attempted,
+            pushed.created,
+            pushed.skipped,
+            pulled,
+            local_embed_summary(&pushed)
         );
     }
     Ok(())

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/pull.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/pull.rs
@@ -122,17 +122,17 @@ mod tests {
     // up the actual `spelunk-server` axum router, matching the pattern in
     // `outbox.rs`'s `spawn_spelunk_server`.
 
-    /// Reproduces the walk-the-store bug: a client that has already pushed
-    /// and synced once (an "established" client) never sees a teammate's
-    /// later entries on a subsequent sync, even though a fresh client would
-    /// pull the full set. Before the fix, client A's first push stamps its
-    /// own row's `remote_id` from the batch ack's `id` field, which the real
-    /// server (bug) fills with the raw autoincrement row id ("1", "2", ...)
-    /// instead of `sync_id`. That digit-string sorts lexically AFTER every
-    /// real UUIDv7 `sync_id` (which starts with a much smaller hex nibble for
-    /// any current timestamp), so `max_remote_id()`'s cursor becomes that row
-    /// id and `since_id=<cursor>` on the second pull matches nothing, even
-    /// though the server holds teammate B's newer entry.
+    // Reproduces the walk-the-store bug: a client that has already pushed
+    // and synced once (an "established" client) never sees a teammate's
+    // later entries on a subsequent sync, even though a fresh client would
+    // pull the full set. Before the fix, client A's first push stamps its
+    // own row's `remote_id` from the batch ack's `id` field, which the real
+    // server (bug) fills with the raw autoincrement row id ("1", "2", ...)
+    // instead of `sync_id`. That digit-string sorts lexically AFTER every
+    // real UUIDv7 `sync_id` (which starts with a much smaller hex nibble for
+    // any current timestamp), so `max_remote_id()`'s cursor becomes that row
+    // id and `since_id=<cursor>` on the second pull matches nothing, even
+    // though the server holds teammate B's newer entry.
     #[tokio::test]
     async fn established_client_pulls_teammates_entries_added_after_its_first_sync() {
         register_sqlite_vec();
@@ -202,21 +202,21 @@ mod tests {
         );
     }
 
-    /// Three-way steady state, each established client syncing across
-    /// multiple rounds: rules out an off-by-one in cursor advancement that a
-    /// two-client, single-extra-round test (see above) could miss (e.g. a
-    /// cursor that only "catches up" once and then drifts on a later round).
-    ///
-    /// Client C joins second, via a pull-only first sync (see the doc
-    /// comment on `store_c`'s setup below for why: joining via push+pull in
-    /// one round is a separate, real ordering issue, not this story's bug).
-    /// After that, both A and C are established clients holding a cursor
-    /// derived purely from pulls/pushes of their own already-caught-up
-    /// state, and teammate B pushes twice, in two separate rounds. Each of A
-    /// and C must pick up exactly the right delta on each of their own
-    /// subsequent pulls: never 0 (the bug this story fixes), never a
-    /// duplicate re-application, and never the other established client's
-    /// own entries re-surfacing.
+    // Three-way steady state, each established client syncing across
+    // multiple rounds: rules out an off-by-one in cursor advancement that a
+    // two-client, single-extra-round test (see above) could miss (e.g. a
+    // cursor that only "catches up" once and then drifts on a later round).
+    //
+    // Client C joins second, via a pull-only first sync (see the doc
+    // comment on `store_c`'s setup below for why: joining via push+pull in
+    // one round is a separate, real ordering issue, not this story's bug).
+    // After that, both A and C are established clients holding a cursor
+    // derived purely from pulls/pushes of their own already-caught-up
+    // state, and teammate B pushes twice, in two separate rounds. Each of A
+    // and C must pick up exactly the right delta on each of their own
+    // subsequent pulls: never 0 (the bug this story fixes), never a
+    // duplicate re-application, and never the other established client's
+    // own entries re-surfacing.
     #[tokio::test]
     async fn two_established_clients_each_pull_correctly_across_multiple_rounds() {
         register_sqlite_vec();
@@ -379,8 +379,8 @@ mod tests {
     // (including a full page at that request limit) without needing that
     // many real rows in a live server.
 
-    /// Deterministic, lexically-increasing ids so `since_id` cursors compare
-    /// the same way real UUIDv7 cloud ids do.
+    // Deterministic, lexically-increasing ids so `since_id` cursors compare
+    // the same way real UUIDv7 cloud ids do.
     fn page_ids(start: usize, count: usize) -> Vec<String> {
         (start..start + count)
             .map(|i| format!("01890000-0000-7000-8000-{i:012x}"))
@@ -405,10 +405,10 @@ mod tests {
 
     const NIL_UUID: &str = "00000000-0000-0000-0000-000000000000";
 
-    /// Mounts one `/memory/since` mock per page, matched by the exact
-    /// `since_id` it must be requested with (the prior page's last id, or the
-    /// nil UUID for the very first request). Each mock must be hit exactly
-    /// `times` times.
+    // Mounts one `/memory/since` mock per page, matched by the exact
+    // `since_id` it must be requested with (the prior page's last id, or the
+    // nil UUID for the very first request). Each mock must be hit exactly
+    // `times` times.
     async fn mount_pages_times(server: &wiremock::MockServer, pages: &[Vec<String>], times: u64) {
         use wiremock::matchers::{method, path, query_param};
         use wiremock::{Mock, ResponseTemplate};
@@ -432,8 +432,8 @@ mod tests {
         mount_pages_times(server, pages, 1).await;
     }
 
-    /// Item 1: a backlog smaller than one page is a single request, and every
-    /// entry lands.
+    // Item 1: a backlog smaller than one page is a single request, and every
+    // entry lands.
     #[tokio::test]
     async fn pull_and_apply_since_single_page_matches_prior_behavior() {
         let server = wiremock::MockServer::start().await;
@@ -448,9 +448,9 @@ mod tests {
         assert_eq!(server.received_requests().await.unwrap().len(), 1);
     }
 
-    /// Item 2: a backlog spanning exactly two pages (100 then 40, the
-    /// requested page limit) is fetched in two requests, the second cursor is
-    /// the first page's last id, and every entry is applied exactly once.
+    // Item 2: a backlog spanning exactly two pages (100 then 40, the
+    // requested page limit) is fetched in two requests, the second cursor is
+    // the first page's last id, and every entry is applied exactly once.
     #[tokio::test]
     async fn pull_and_apply_since_two_pages_advances_cursor_to_last_id_of_prior_page() {
         let server = wiremock::MockServer::start().await;
@@ -467,8 +467,8 @@ mod tests {
         assert_eq!(server.received_requests().await.unwrap().len(), 2);
     }
 
-    /// Item 3: three-plus pages (100 + 100 + 45) keep looping past two
-    /// iterations, not just handling the two-page case.
+    // Item 3: three-plus pages (100 + 100 + 45) keep looping past two
+    // iterations, not just handling the two-page case.
     #[tokio::test]
     async fn pull_and_apply_since_three_pages_loops_past_two_iterations() {
         let server = wiremock::MockServer::start().await;
@@ -485,10 +485,10 @@ mod tests {
         assert_eq!(server.received_requests().await.unwrap().len(), 3);
     }
 
-    /// Item 4: a page landing exactly on the limit is always followed by
-    /// exactly one more request (never assumed to be the last page), and
-    /// that follow-up returning short ends the loop immediately (never a
-    /// third, unnecessary request).
+    // Item 4: a page landing exactly on the limit is always followed by
+    // exactly one more request (never assumed to be the last page), and
+    // that follow-up returning short ends the loop immediately (never a
+    // third, unnecessary request).
     #[tokio::test]
     async fn pull_and_apply_since_full_page_triggers_exactly_one_more_request() {
         let server = wiremock::MockServer::start().await;
@@ -504,8 +504,8 @@ mod tests {
         assert_eq!(server.received_requests().await.unwrap().len(), 2);
     }
 
-    /// Item 5: an already fully-synced project (empty first page) terminates
-    /// after that one request instead of looping forever.
+    // Item 5: an already fully-synced project (empty first page) terminates
+    // after that one request instead of looping forever.
     #[tokio::test]
     async fn pull_and_apply_since_empty_first_page_terminates_after_one_request() {
         let server = wiremock::MockServer::start().await;
@@ -519,11 +519,11 @@ mod tests {
         assert_eq!(server.received_requests().await.unwrap().len(), 1);
     }
 
-    /// Item 6: `sync_round`'s reported `pulled` count (what `spelunk sync`'s
-    /// completion message prints) is the TRUE total across every page, not
-    /// just the first. `memory_sync` itself can't be driven directly in this
-    /// binary (see `sync_round`'s own doc comment on the per-process tier
-    /// cache), so this asserts on the exact value the message interpolates.
+    // Item 6: `sync_round`'s reported `pulled` count (what `spelunk sync`'s
+    // completion message prints) is the TRUE total across every page, not
+    // just the first. `memory_sync` itself can't be driven directly in this
+    // binary (see `sync_round`'s own doc comment on the per-process tier
+    // cache), so this asserts on the exact value the message interpolates.
     #[tokio::test]
     async fn sync_round_pulled_count_reflects_every_page_not_just_the_first() {
         let server = wiremock::MockServer::start().await;
@@ -570,11 +570,11 @@ mod tests {
         assert_eq!(store.count().unwrap(), 160);
     }
 
-    /// Item 7: the one-way `spelunk memory pull` entry point (`pull_and_apply`,
-    /// which derives its own cursor from the store rather than being handed
-    /// one) also paginates fully — proven through `pull_and_apply` directly,
-    /// not just through `sync_round`, since both merely wrap the same shared
-    /// `pull_and_apply_since`.
+    // Item 7: the one-way `spelunk memory pull` entry point (`pull_and_apply`,
+    // which derives its own cursor from the store rather than being handed
+    // one) also paginates fully, proven through `pull_and_apply` directly,
+    // not just through `sync_round`, since both merely wrap the same shared
+    // `pull_and_apply_since`.
     #[tokio::test]
     async fn pull_and_apply_one_way_also_paginates_fully() {
         let server = wiremock::MockServer::start().await;
@@ -590,12 +590,12 @@ mod tests {
         assert_eq!(server.received_requests().await.unwrap().len(), 2);
     }
 
-    /// Item 8: on a first sync (nothing local has ever pushed or pulled
-    /// before, so `sync_round` pushes first and runs a single post-push
-    /// pull), that post-push pull paginates fully on its own when it turns
-    /// up more than one page of results (e.g. a teammate already has a
-    /// 130-entry backlog on the project by the time this round's push
-    /// provisions it and the pull runs).
+    // Item 8: on a first sync (nothing local has ever pushed or pulled
+    // before, so `sync_round` pushes first and runs a single post-push
+    // pull), that post-push pull paginates fully on its own when it turns
+    // up more than one page of results (e.g. a teammate already has a
+    // 130-entry backlog on the project by the time this round's push
+    // provisions it and the pull runs).
     #[tokio::test]
     async fn sync_round_first_sync_post_push_pull_paginates_fully_on_its_own() {
         use wiremock::matchers::{method, path};
@@ -630,12 +630,12 @@ mod tests {
         assert_eq!(store.count().unwrap(), 130);
     }
 
-    /// Item 9: re-running a pull after an interrupted/partial prior run
-    /// (some entries already applied locally from an earlier page) must not
-    /// double-count `applied` for entries seen again — regression-guards the
-    /// existing dedupe-by-`remote_id` specifically under the new loop, since
-    /// a naive re-implementation could re-tally a page it had already
-    /// applied once before.
+    // Item 9: re-running a pull after an interrupted/partial prior run
+    // (some entries already applied locally from an earlier page) must not
+    // double-count `applied` for entries seen again: regression-guards the
+    // existing dedupe-by-`remote_id` specifically under the new loop, since
+    // a naive re-implementation could re-tally a page it had already
+    // applied once before.
     #[tokio::test]
     async fn pull_and_apply_since_rerun_after_partial_prior_run_does_not_double_count() {
         let server = wiremock::MockServer::start().await;
@@ -657,9 +657,9 @@ mod tests {
         assert_eq!(store.count().unwrap(), 140, "and never re-inserted");
     }
 
-    /// Item 10a: a project not yet created on the server (404 on the very
-    /// first page request) still applies 0 and returns success, not an
-    /// error, unchanged by the new loop.
+    // Item 10a: a project not yet created on the server (404 on the very
+    // first page request) still applies 0 and returns success, not an
+    // error, unchanged by the new loop.
     #[tokio::test]
     async fn pull_and_apply_since_404_on_first_page_is_still_zero_not_an_error() {
         use wiremock::matchers::{method, path};
@@ -679,9 +679,9 @@ mod tests {
         assert_eq!(applied, 0);
     }
 
-    /// Item 10b: a `None` cursor still starts the loop's first request from
-    /// the nil UUID (full catch-up), unchanged by the new loop wrapping the
-    /// cursor for its own subsequent iterations.
+    // Item 10b: a `None` cursor still starts the loop's first request from
+    // the nil UUID (full catch-up), unchanged by the new loop wrapping the
+    // cursor for its own subsequent iterations.
     #[tokio::test]
     async fn pull_and_apply_since_none_cursor_still_starts_at_nil_uuid() {
         let server = wiremock::MockServer::start().await;
@@ -694,18 +694,18 @@ mod tests {
         assert_eq!(applied, 5);
     }
 
-    /// If the post-push pull on a first sync (nothing local has ever pushed
-    /// or pulled before, so `sync_round` pushes first and runs a single pull
-    /// afterward) fails, `sync_round` must not silently swallow that error,
-    /// but it also must not lose or misrepresent the push that already
-    /// succeeded. The push already durably landed server-side and already
-    /// stamped this round's row with its `remote_id` (inside `push_local`,
-    /// which returns before the pull ever runs), so: (1) the error surfaces
-    /// instead of being dropped, (2) its message says the push already
-    /// reached the server rather than reading as "nothing happened", and
-    /// (3) local state is left exactly as `push_local` left it: no
-    /// corruption, no re-attempt needed, just a retryable pull on the next
-    /// sync.
+    // If the post-push pull on a first sync (nothing local has ever pushed
+    // or pulled before, so `sync_round` pushes first and runs a single pull
+    // afterward) fails, `sync_round` must not silently swallow that error,
+    // but it also must not lose or misrepresent the push that already
+    // succeeded. The push already durably landed server-side and already
+    // stamped this round's row with its `remote_id` (inside `push_local`,
+    // which returns before the pull ever runs), so: (1) the error surfaces
+    // instead of being dropped, (2) its message says the push already
+    // reached the server rather than reading as "nothing happened", and
+    // (3) local state is left exactly as `push_local` left it: no
+    // corruption, no re-attempt needed, just a retryable pull on the next
+    // sync.
     #[tokio::test]
     async fn sync_round_first_sync_post_push_pull_failure_surfaces_the_error_without_losing_the_push()
      {
@@ -763,12 +763,12 @@ mod tests {
         );
     }
 
-    /// A network/server failure on a LATER page (not the first) must not
-    /// corrupt or silently drop the pages that already succeeded: the loop
-    /// applies each page as it arrives, so a first-page success is durably
-    /// in the local store even though the overall call returns `Err`. A
-    /// naive rewrite (e.g. buffering all pages before applying any) would
-    /// instead lose the first page's entries when a later page fails.
+    // A network/server failure on a LATER page (not the first) must not
+    // corrupt or silently drop the pages that already succeeded: the loop
+    // applies each page as it arrives, so a first-page success is durably
+    // in the local store even though the overall call returns `Err`. A
+    // naive rewrite (e.g. buffering all pages before applying any) would
+    // instead lose the first page's entries when a later page fails.
     #[tokio::test]
     async fn pull_and_apply_since_error_on_a_later_page_keeps_earlier_pages_applied_and_is_retryable()
      {
@@ -842,14 +842,14 @@ mod tests {
         );
     }
 
-    /// A page whose entries fail to deserialize (here: an entry missing the
-    /// required `id` field, the value pagination advances the cursor from)
-    /// must fail the WHOLE page atomically rather than partially applying
-    /// the entries that happened to parse fine. `SinceBody`/`RemoteEntry`
-    /// deserialize the full response body before `pull_and_apply_since` ever
-    /// sees a single entry, so this is really a regression guard: a future
-    /// change that streamed/parsed entries one at a time could silently
-    /// apply a prefix before hitting the bad entry.
+    // A page whose entries fail to deserialize (here: an entry missing the
+    // required `id` field, the value pagination advances the cursor from)
+    // must fail the WHOLE page atomically rather than partially applying
+    // the entries that happened to parse fine. `SinceBody`/`RemoteEntry`
+    // deserialize the full response body before `pull_and_apply_since` ever
+    // sees a single entry, so this is really a regression guard: a future
+    // change that streamed/parsed entries one at a time could silently
+    // apply a prefix before hitting the bad entry.
     #[tokio::test]
     async fn pull_and_apply_since_malformed_entry_missing_id_fails_the_page_atomically() {
         use wiremock::matchers::{method, path};
@@ -887,12 +887,12 @@ mod tests {
         );
     }
 
-    /// The server's `count` field is documented (see `pull_since`'s wire
-    /// comment) as redundant with `entries.len()`, never a "more remain"
-    /// signal — so the loop's termination must be driven by the actual
-    /// number of entries returned, not by trusting `count`. A server (or a
-    /// test double) that reports an inflated `count` alongside a genuinely
-    /// short `entries` array must still be treated as the last page.
+    // The server's `count` field is documented (see `pull_since`'s wire
+    // comment) as redundant with `entries.len()`, never a "more remain"
+    // signal, so the loop's termination must be driven by the actual
+    // number of entries returned, not by trusting `count`. A server (or a
+    // test double) that reports an inflated `count` alongside a genuinely
+    // short `entries` array must still be treated as the last page.
     #[tokio::test]
     async fn pull_and_apply_since_terminates_on_actual_entries_len_not_a_lying_count_field() {
         use wiremock::matchers::{method, path};

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/pull.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/pull.rs
@@ -88,7 +88,7 @@ pub(in crate::cli::cmd::memory) fn parse_iso_to_secs(s: &str) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::super::push::push_local;
+    use super::super::push::{LocalEmbedPolicy, push_local};
     use super::super::round::sync_round;
     use super::super::test_support::{fresh_store, register_sqlite_vec, spawn_spelunk_server};
     use super::*;
@@ -156,7 +156,9 @@ mod tests {
             .unwrap();
         let client_a = CloudSyncClient::new(&base_url, "proj", None, None).unwrap();
 
-        let push1 = push_local(&store_a, &client_a, false, false).await.unwrap();
+        let push1 = push_local(&store_a, &client_a, false, false, &LocalEmbedPolicy::Skip)
+            .await
+            .unwrap();
         assert_eq!(
             push1.created, 1,
             "client A's own entry must land on the server"
@@ -172,7 +174,9 @@ mod tests {
             .add_note("decision", "B1", "teammate B's entry", &[], &[], None, None)
             .unwrap();
         let client_b = CloudSyncClient::new(&base_url, "proj", None, None).unwrap();
-        let push_b = push_local(&store_b, &client_b, false, false).await.unwrap();
+        let push_b = push_local(&store_b, &client_b, false, false, &LocalEmbedPolicy::Skip)
+            .await
+            .unwrap();
         assert_eq!(
             push_b.created, 1,
             "teammate B's entry must land on the server"
@@ -227,7 +231,7 @@ mod tests {
             .unwrap();
         let client_a = CloudSyncClient::new(&base_url, "proj3", None, None).unwrap();
         assert_eq!(
-            push_local(&store_a, &client_a, false, false)
+            push_local(&store_a, &client_a, false, false, &LocalEmbedPolicy::Skip)
                 .await
                 .unwrap()
                 .created,
@@ -257,7 +261,7 @@ mod tests {
             .add_note("decision", "C1", "client C's entry", &[], &[], None, None)
             .unwrap();
         assert_eq!(
-            push_local(&store_c, &client_c, false, false)
+            push_local(&store_c, &client_c, false, false, &LocalEmbedPolicy::Skip)
                 .await
                 .unwrap()
                 .created,
@@ -285,7 +289,7 @@ mod tests {
             .unwrap();
         let client_b = CloudSyncClient::new(&base_url, "proj3", None, None).unwrap();
         assert_eq!(
-            push_local(&store_b, &client_b, false, false)
+            push_local(&store_b, &client_b, false, false, &LocalEmbedPolicy::Skip)
                 .await
                 .unwrap()
                 .created,
@@ -321,7 +325,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            push_local(&store_b, &client_b, false, false)
+            push_local(&store_b, &client_b, false, false, &LocalEmbedPolicy::Skip)
                 .await
                 .unwrap()
                 .created,
@@ -552,7 +556,9 @@ mod tests {
 
         let (_tmp, store) = fresh_store();
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
-        let outcome = sync_round(&store, &client, false, false).await.unwrap();
+        let outcome = sync_round(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+            .await
+            .unwrap();
 
         assert_eq!(
             outcome.pulled, 160,
@@ -612,7 +618,9 @@ mod tests {
 
         let (_tmp, store) = fresh_store();
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
-        let outcome = sync_round(&store, &client, false, false).await.unwrap();
+        let outcome = sync_round(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+            .await
+            .unwrap();
 
         assert_eq!(outcome.pushed.attempted, 0);
         assert_eq!(
@@ -730,7 +738,7 @@ mod tests {
             .await;
 
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
-        let err = sync_round(&store, &client, false, false)
+        let err = sync_round(&store, &client, false, false, &LocalEmbedPolicy::Skip)
             .await
             .expect_err("a real post-push pull error must not be swallowed as success");
 

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/chunking_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/chunking_tests.rs
@@ -156,7 +156,9 @@ async fn push_chunks_cover_every_entry_exactly_once() {
         .await;
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-    let s = push_local(&store, &client, false, false).await.unwrap();
+    let s = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert_eq!(
         (s.attempted, s.created, s.skipped, s.failed),
         (120, 120, 0, 0)
@@ -212,7 +214,9 @@ async fn multi_chunk_push_threads_slug_into_every_request_path() {
         .await;
     let client = CloudSyncClient::new(&server.uri(), "acme/app", None, None).unwrap();
 
-    let s = push_local(&store, &client, false, false).await.unwrap();
+    let s = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert_eq!((s.attempted, s.created), (60, 60));
     assert!(s.interrupted.is_none());
 
@@ -251,7 +255,9 @@ async fn interrupted_push_stops_and_resumes_from_the_remainder() {
         .await;
     let client1 = CloudSyncClient::new(&server1.uri(), "proj", None, None).unwrap();
 
-    let s1 = push_local(&store, &client1, false, false).await.unwrap();
+    let s1 = push_local(&store, &client1, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert!(
         s1.interrupted.is_some(),
         "a mid-push failure marks the summary interrupted"
@@ -287,7 +293,9 @@ async fn interrupted_push_stops_and_resumes_from_the_remainder() {
         .await;
     let client2 = CloudSyncClient::new(&server2.uri(), "proj", None, None).unwrap();
 
-    let s2 = push_local(&store, &client2, false, false).await.unwrap();
+    let s2 = push_local(&store, &client2, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert!(s2.interrupted.is_none());
     assert_eq!(
         (s2.attempted, s2.created),
@@ -342,7 +350,9 @@ async fn interrupted_on_a_later_chunk_counts_only_the_chunks_that_landed() {
         .await;
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-    let s = push_local(&store, &client, false, false).await.unwrap();
+    let s = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert!(s.interrupted.is_some());
     assert_eq!(
         (s.attempted, s.created, s.skipped),
@@ -392,7 +402,9 @@ async fn interrupted_push_skips_the_tombstone_delete_pass() {
         .await;
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-    let s = push_local(&store, &client, true, false).await.unwrap();
+    let s = push_local(&store, &client, true, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert!(s.interrupted.is_some());
     assert_eq!(s.created, 0, "the only live chunk failed");
 
@@ -449,7 +461,9 @@ async fn overlapping_repush_tallies_skipped_and_leaves_no_duplicates() {
         .await;
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-    let s = push_local(&store, &client, false, false).await.unwrap();
+    let s = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert_eq!((s.attempted, s.created, s.skipped, s.failed), (4, 2, 2, 0));
     assert!(s.interrupted.is_none());
     assert!(
@@ -466,7 +480,9 @@ async fn overlapping_repush_tallies_skipped_and_leaves_no_duplicates() {
         "no local duplicates from the round trip"
     );
 
-    let s2 = push_local(&store, &client, false, false).await.unwrap();
+    let s2 = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert_eq!((s2.attempted, s2.already_synced), (0, 4));
     assert_eq!(
         server.received_requests().await.unwrap().len(),
@@ -491,9 +507,16 @@ async fn multi_chunk_push_reports_cumulative_progress_after_each_chunk() {
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
     let mut progress: Vec<(usize, usize)> = Vec::new();
-    let s = push_local_reporting(&store, &client, false, false, |done, total| {
-        progress.push((done, total));
-    })
+    let s = push_local_reporting(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::Skip,
+        |done, total| {
+            progress.push((done, total));
+        },
+    )
     .await
     .unwrap();
 
@@ -536,9 +559,16 @@ async fn single_chunk_push_is_one_request_and_emits_no_progress() {
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
     let mut calls = 0usize;
-    let s = push_local_reporting(&store, &client, false, false, |_, _| calls += 1)
-        .await
-        .unwrap();
+    let s = push_local_reporting(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::Skip,
+        |_, _| calls += 1,
+    )
+    .await
+    .unwrap();
     assert_eq!(calls, 0, "a single-chunk push emits no progress");
     assert_eq!(
         server.received_requests().await.unwrap().len(),
@@ -592,7 +622,9 @@ async fn push_local_stamps_remote_id_and_repush_is_idempotent() {
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
     // First push: creates both, persists the server-minted id on each row.
-    let s1 = push_local(&store, &client, false, false).await.unwrap();
+    let s1 = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert_eq!((s1.attempted, s1.created, s1.skipped), (2, 2, 0));
     assert_eq!(
         store.note_id_for_remote_id(cloud_a).unwrap(),
@@ -609,7 +641,9 @@ async fn push_local_stamps_remote_id_and_repush_is_idempotent() {
     // and no batch request is sent — the re-sync is a no-op. `attempted` must
     // reflect that (not the raw row count), so callers never report "Pushed
     // N" when nothing was sent.
-    let s2 = push_local(&store, &client, false, false).await.unwrap();
+    let s2 = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert_eq!((s2.attempted, s2.created, s2.already_synced), (0, 0, 2));
     assert_eq!(
         server.received_requests().await.unwrap().len(),

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/chunking_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/chunking_tests.rs
@@ -1,4 +1,4 @@
-//! Chunking, resumability, and progress-reporting tests for [`super::push_local`].
+// Chunking, resumability, and progress-reporting tests for `super::push_local`.
 
 use super::super::test_support::register_sqlite_vec;
 use super::*;

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/counting_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/counting_tests.rs
@@ -45,7 +45,9 @@ async fn push_local_does_not_stamp_remote_id_for_a_failed_status_item() {
         .await;
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-    let s1 = push_local(&store, &client, false, false).await.unwrap();
+    let s1 = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert_eq!((s1.attempted, s1.created, s1.skipped), (1, 0, 0));
 
     // The row must NOT carry the id the server handed back — it stays
@@ -106,7 +108,9 @@ async fn push_local_reconciles_counts_from_results_not_aggregate_ints() {
         .await;
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-    let s1 = push_local(&store, &client, false, false).await.unwrap();
+    let s1 = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     // Reconciled from `results[]`, not the misleading aggregate zeros.
     assert_eq!(
         (s1.attempted, s1.created, s1.skipped, s1.failed),
@@ -163,7 +167,9 @@ async fn push_local_partial_failure_reports_the_real_successes() {
         .await;
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-    let s1 = push_local(&store, &client, false, false).await.unwrap();
+    let s1 = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert_eq!(
         (s1.attempted, s1.created, s1.skipped, s1.failed),
         (2, 1, 0, 1),
@@ -227,7 +233,9 @@ async fn push_local_total_failure_reports_zero_created_and_skipped() {
         .await;
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
-    let s1 = push_local(&store, &client, false, false).await.unwrap();
+    let s1 = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
     assert_eq!(
         (s1.attempted, s1.created, s1.skipped, s1.failed),
         (2, 0, 0, 2),

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/counting_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/counting_tests.rs
@@ -1,6 +1,6 @@
-//! Stamping- and counting-honesty tests for [`super::push_local`]: `remote_id`
-//! is only stamped for durably-persisted statuses, and tallies reconcile
-//! against `results[]` rather than trusting the server's aggregate ints.
+// Stamping- and counting-honesty tests for `super::push_local`: `remote_id`
+// is only stamped for durably-persisted statuses, and tallies reconcile
+// against `results[]` rather than trusting the server's aggregate ints.
 
 use super::super::test_support::register_sqlite_vec;
 use super::*;

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_routing_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_routing_tests.rs
@@ -1,0 +1,407 @@
+//! Where the pre-batch local embed is allowed to go, and what happens when it
+//! cannot run at all.
+//!
+//! The load-bearing invariant here: the embed must reach the loopback embedder
+//! and never the configured team `server_url`. Routing it there would re-create
+//! the exact server-side re-embedding the repair exists to remove.
+
+use super::super::test_support::{fresh_store, spawn_loopback_embedder};
+use super::*;
+use crate::config::{Config, SyncMode};
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn add_note(store: &MemoryStore, title: &str) -> String {
+    store
+        .add_note("decision", title, "body", &[], &[], None, None)
+        .unwrap();
+    let rows = store.rows_for_sync(true).unwrap();
+    rows.iter()
+        .find(|r| r.title == title)
+        .expect("note added")
+        .uuid
+        .clone()
+}
+
+async fn mount_batch_created(server: &MockServer, uuid: &str) {
+    Mock::given(method("POST"))
+        .and(path("/v1/projects/proj/memory/batch"))
+        .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+            "created": 1, "skipped": 0, "failed": 0,
+            "results": [{"status": "created", "external_id": uuid, "id": "cloud-1"}]
+        })))
+        .mount(server)
+        .await;
+}
+
+fn paths(reqs: &[wiremock::Request]) -> Vec<String> {
+    reqs.iter().map(|r| r.url.path().to_string()).collect()
+}
+
+// ── the never-route-to-server_url invariant ─────────────────────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn embed_traffic_goes_to_loopback_and_never_to_the_team_server_url() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let uuid = add_note(&store, "Unembedded");
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &uuid).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    // A real team server_url, and a loopback embedder discovered alongside it.
+    let cfg = Config {
+        server_url: Some(team.uri()),
+        project_id: Some("proj".to_string()),
+        mode: None,
+        ..Default::default()
+    };
+    assert_eq!(cfg.resolve_mode(), SyncMode::LocalFirst);
+    let summary = push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(summary.embedded_locally, 1);
+    let team_paths = paths(&team.received_requests().await.unwrap());
+    assert!(
+        !team_paths.iter().any(|p| p.contains("embed")),
+        "no embed request may reach the configured team server: {team_paths:?}"
+    );
+    let loopback_paths = paths(&loopback.server.received_requests().await.unwrap());
+    assert_eq!(
+        loopback_paths
+            .iter()
+            .filter(|p| p.ends_with("/index/embed"))
+            .count(),
+        1,
+        "the embed must land on loopback instead: {loopback_paths:?}"
+    );
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn a_push_speaks_only_to_loopback_and_the_configured_team_server() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let uuid = add_note(&store, "Unembedded");
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &uuid).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = Config {
+        server_url: Some(team.uri()),
+        project_id: Some("proj".to_string()),
+        mode: None,
+        ..Default::default()
+    };
+    push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    for p in paths(&loopback.server.received_requests().await.unwrap()) {
+        assert!(
+            p == "/v1/health" || p == "/v1/projects/proj/index/embed",
+            "unexpected loopback destination: {p}"
+        );
+    }
+    for p in paths(&team.received_requests().await.unwrap()) {
+        assert!(
+            p == "/v1/projects/proj/memory/batch",
+            "unexpected team-server destination: {p}"
+        );
+    }
+    drop(loopback);
+}
+
+// ── no local embedder: degrade, never refuse ────────────────────────────────
+
+// `mode = "offline"` is the deterministic form of "no local embedder is
+// reachable": `get_inference_tier` short-circuits before any probe, so the
+// repair resolves no client at all, exactly as it would on a machine with no
+// `spelunk server` running.
+fn no_embedder_cfg(server_url: String) -> Config {
+    Config {
+        server_url: Some(server_url),
+        project_id: Some("proj".to_string()),
+        mode: Some(SyncMode::Offline),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn push_completes_text_only_when_no_local_embedder_is_available() {
+    let (tmp, store) = fresh_store();
+    let uuid = add_note(&store, "Unembedded");
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &uuid).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = no_embedder_cfg(team.uri());
+    let summary = push_local(
+        &store,
+        &client,
+        false,
+        true,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    // Same success shape as before the repair existed: nothing refused.
+    assert_eq!(
+        (summary.attempted, summary.created, summary.failed),
+        (1, 1, 0)
+    );
+    assert_eq!(
+        (summary.embedded_locally, summary.without_local_vector),
+        (0, 1)
+    );
+    let reqs = team.received_requests().await.unwrap();
+    let body = String::from_utf8(reqs[0].body.clone()).unwrap();
+    assert!(!body.contains("vector"), "must ship text-only: {body}");
+}
+
+#[tokio::test]
+async fn no_local_embedder_sends_no_embed_request_to_the_team_server() {
+    let (tmp, store) = fresh_store();
+    let uuid = add_note(&store, "Unembedded");
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &uuid).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = no_embedder_cfg(team.uri());
+    push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    let team_paths = paths(&team.received_requests().await.unwrap());
+    assert!(
+        !team_paths.iter().any(|p| p.contains("embed")),
+        "the absent local embedder must never degrade into a remote embed: {team_paths:?}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn one_row_embed_failure_leaves_the_rest_of_the_push_intact() {
+    let loopback = spawn_loopback_embedder("proj", Some("Poison")).await;
+    let (tmp, store) = fresh_store();
+    let bad = add_note(&store, "Poison");
+    let good = add_note(&store, "Fine");
+
+    let team = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/projects/proj/memory/batch"))
+        .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+            "created": 2, "skipped": 0, "failed": 0,
+            "results": [
+                {"status": "created", "external_id": bad, "id": "cloud-1"},
+                {"status": "created", "external_id": good, "id": "cloud-2"},
+            ]
+        })))
+        .mount(&team)
+        .await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = Config {
+        server_url: Some(team.uri()),
+        project_id: Some("proj".to_string()),
+        mode: None,
+        ..Default::default()
+    };
+    let summary = push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        (summary.attempted, summary.created, summary.failed),
+        (2, 2, 0),
+        "a failed embed must not abort or fail the push"
+    );
+    assert_eq!(
+        (summary.embedded_locally, summary.without_local_vector),
+        (1, 1)
+    );
+    let rows = store.rows_for_sync(false).unwrap();
+    for r in &rows {
+        let embedded = store.get_embedding(r.local_id).unwrap().is_some();
+        assert_eq!(
+            embedded,
+            r.title == "Fine",
+            "only the row whose embed succeeded may be embedded: {}",
+            r.title
+        );
+    }
+    drop(loopback);
+}
+
+// ── applicability ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn cloud_first_with_server_url_skips_the_repair_entirely() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let uuid = add_note(&store, "Unembedded");
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &uuid).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = Config {
+        server_url: Some(team.uri()),
+        project_id: Some("proj".to_string()),
+        mode: Some(SyncMode::CloudFirst),
+        ..Default::default()
+    };
+    let mem_path = tmp.path().join("memory.db");
+    assert!(
+        matches!(
+            LocalEmbedPolicy::for_push(&cfg, &mem_path),
+            LocalEmbedPolicy::Skip
+        ),
+        "memory.db is not the store of record here, so there is nothing to repair"
+    );
+
+    let summary = push_local(
+        &store,
+        &client,
+        false,
+        true,
+        &LocalEmbedPolicy::for_push(&cfg, &mem_path),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        (summary.embedded_locally, summary.without_local_vector),
+        (0, 0),
+        "a skipped repair must not report counts, or warn"
+    );
+    let rows = store.rows_for_sync(false).unwrap();
+    assert!(store.get_embedding(rows[0].local_id).unwrap().is_none());
+    let loopback_paths = paths(&loopback.server.received_requests().await.unwrap());
+    assert!(
+        !loopback_paths.iter().any(|p| p.ends_with("/index/embed")),
+        "no embed call may be made: {loopback_paths:?}"
+    );
+    let reqs = team.received_requests().await.unwrap();
+    let body = String::from_utf8(reqs[0].body.clone()).unwrap();
+    assert!(!body.contains("vector"), "wire payload unchanged: {body}");
+    drop(loopback);
+}
+
+#[test]
+fn cloud_first_without_server_url_still_repairs() {
+    // `open_memory_backend` only relocates the store of record when a
+    // `server_url` actually exists, so memory.db is still local truth here.
+    // `memory reindex` applies under exactly this condition too.
+    let cfg = Config {
+        server_url: None,
+        mode: Some(SyncMode::CloudFirst),
+        ..Default::default()
+    };
+    assert!(matches!(
+        LocalEmbedPolicy::for_push(&cfg, std::path::Path::new("/tmp/p/memory.db")),
+        LocalEmbedPolicy::Repair { .. }
+    ));
+}
+
+// ── reporting ───────────────────────────────────────────────────────────────
+
+#[test]
+fn wrong_dimension_stored_vector_counts_as_missing() {
+    // `note_embeddings` is a vec0 `FLOAT[896]` column that refuses a
+    // wrong-dimension insert outright (see `vector_tests.rs`), so this state is
+    // only reachable through a blob torn independently of any write. Pinned on
+    // the shared predicate both the repair pass and the batch build consult:
+    // "not exactly 896 floats" must mean "unembedded", so the row is re-embedded
+    // and the corrected vector is what ships.
+    use spelunk_core::embeddings::{EMBEDDING_DIM, vec_to_blob};
+
+    assert!(usable_vector(Some(vec_to_blob(&vec![1.0f32; 768]))).is_none());
+    assert!(usable_vector(Some(Vec::new())).is_none());
+    assert!(usable_vector(None).is_none());
+    // A torn write: a valid 896-dim blob with its tail cut off. Must filter
+    // out rather than panic or accept a garbage-padded length.
+    let full = vec_to_blob(&vec![1.0f32; EMBEDDING_DIM]);
+    assert!(usable_vector(Some(full[..full.len() - 10].to_vec())).is_none());
+    assert_eq!(
+        usable_vector(Some(vec_to_blob(&vec![1.0f32; EMBEDDING_DIM]))).map(|v| v.len()),
+        Some(EMBEDDING_DIM)
+    );
+}
+
+#[test]
+fn the_unembedded_warning_names_the_count_and_the_remedy() {
+    let msg = unembedded_warning(3);
+    assert!(msg.contains('3'), "must name the count: {msg}");
+    assert!(
+        msg.contains("spelunk memory reindex"),
+        "must name the remedy: {msg}"
+    );
+    assert!(
+        msg.contains("memory search"),
+        "must say what is actually broken: {msg}"
+    );
+    assert!(
+        unembedded_warning(1).contains("1 entry"),
+        "singular must not read as '1 entries'"
+    );
+}
+
+#[test]
+fn the_summary_clause_reports_local_embedding_separately_from_push_results() {
+    let summary = |embedded, missing| PushSummary {
+        attempted: 5,
+        created: 5,
+        skipped: 0,
+        failed: 0,
+        already_synced: 0,
+        interrupted: None,
+        embedded_locally: embedded,
+        without_local_vector: missing,
+    };
+    assert_eq!(
+        local_embed_summary(&summary(0, 0)),
+        "",
+        "an unaffected push must read exactly as it did before"
+    );
+    assert_eq!(local_embed_summary(&summary(2, 0)), " Embedded 2 locally.");
+    let both = local_embed_summary(&summary(2, 3));
+    assert!(
+        both.contains("Embedded 2 locally") && both.contains('3'),
+        "{both}"
+    );
+}

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_routing_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_routing_tests.rs
@@ -1,9 +1,9 @@
-//! Where the pre-batch local embed is allowed to go, and what happens when it
-//! cannot run at all.
-//!
-//! The load-bearing invariant here: the embed must reach the loopback embedder
-//! and never the configured team `server_url`. Routing it there would re-create
-//! the exact server-side re-embedding the repair exists to remove.
+// Where the pre-batch local embed is allowed to go, and what happens when it
+// cannot run at all.
+//
+// The load-bearing invariant here: the embed must reach the loopback embedder
+// and never the configured team `server_url`. Routing it there would re-create
+// the exact server-side re-embedding the repair exists to remove.
 
 use super::super::test_support::{fresh_store, spawn_loopback_embedder};
 use super::*;

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_routing_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_routing_tests.rs
@@ -179,6 +179,39 @@ async fn push_completes_text_only_when_no_local_embedder_is_available() {
     assert!(!body.contains("vector"), "must ship text-only: {body}");
 }
 
+#[test]
+fn a_failed_loopback_probe_leaves_no_embedder_rather_than_the_team_server() {
+    // The one case a live mock cannot pin without owning port 7777: loopback
+    // auto-discovery finding nothing while a team `server_url` IS configured.
+    // `probe_loopback` yields `Tier::Offline` there, whose `effective_config`
+    // is a no-op, and outside `cloud_first` `resolve_inference_url` reads
+    // `inference_url` alone. So the config the embedder is resolved from
+    // produces no client at all rather than falling back to `server_url`:
+    // the repair degrades to text-only instead of embedding remotely.
+    let cfg = Config {
+        server_url: Some("https://cloud.invalid.example:1".to_string()),
+        project_id: Some("proj".to_string()),
+        mode: None,
+        ..Default::default()
+    };
+    let eff =
+        crate::capability::Tier::Offline.effective_config(&cfg, std::path::Path::new("/tmp/proj"));
+    assert_eq!(
+        eff.server_url.as_deref(),
+        Some("https://cloud.invalid.example:1"),
+        "the sync destination is untouched: only inference routing is at issue"
+    );
+    assert_eq!(
+        eff.resolve_inference_url(),
+        None,
+        "a configured team server_url must never become the embed target"
+    );
+    assert!(
+        crate::server_client::ServerInferenceClient::from_config(&eff).is_none(),
+        "no loopback embedder must mean no embedder, not the team server"
+    );
+}
+
 #[tokio::test]
 async fn no_local_embedder_sends_no_embed_request_to_the_team_server() {
     let (tmp, store) = fresh_store();
@@ -320,6 +353,84 @@ async fn cloud_first_with_server_url_skips_the_repair_entirely() {
     let body = String::from_utf8(reqs[0].body.clone()).unwrap();
     assert!(!body.contains("vector"), "wire payload unchanged: {body}");
     drop(loopback);
+}
+
+// The repair and `memory reindex` must agree, config shape by config shape, on
+// when a local embedding is meaningful at all. They are two independent
+// expressions of the same condition today; without this they can drift apart
+// silently, leaving a push repairing a store `reindex` refuses to touch (or
+// vice versa).
+#[tokio::test]
+#[serial_test::serial]
+async fn the_repair_applies_exactly_where_reindex_does() {
+    use crate::cli::cmd::memory::MemoryReindexArgs;
+    use crate::cli::cmd::memory::reindex::memory_reindex;
+
+    let prev_no_server = std::env::var_os("SPELUNK_NO_SERVER");
+    unsafe { std::env::remove_var("SPELUNK_NO_SERVER") };
+
+    let team = "https://cloud.invalid.example:1".to_string();
+    let shapes = [
+        ("cloud_first + server_url", Some(SyncMode::CloudFirst), true),
+        (
+            "cloud_first, no server_url",
+            Some(SyncMode::CloudFirst),
+            false,
+        ),
+        ("local_first + server_url", Some(SyncMode::LocalFirst), true),
+        (
+            "local_first, no server_url",
+            Some(SyncMode::LocalFirst),
+            false,
+        ),
+        ("default mode + server_url", None, true),
+        ("offline + server_url", Some(SyncMode::Offline), true),
+    ];
+
+    for (label, mode, with_server_url) in shapes {
+        let (tmp, store) = fresh_store();
+        // `reindex` opens the path itself; nothing may hold a second handle.
+        drop(store);
+        let mem_path = tmp.path().join("memory.db");
+        let cfg = Config {
+            server_url: with_server_url.then(|| team.clone()),
+            project_id: Some("proj".to_string()),
+            mode,
+            ..Default::default()
+        };
+
+        let repair_skipped = matches!(
+            LocalEmbedPolicy::for_push(&cfg, &mem_path),
+            LocalEmbedPolicy::Skip
+        );
+        // `--dry-run` returns before any embedder is resolved, so this observes
+        // reindex's applicability check and nothing else.
+        let reindex_refused = memory_reindex(
+            MemoryReindexArgs {
+                force: false,
+                include_archived: false,
+                dry_run: true,
+                format: "json".to_string(),
+            },
+            &mem_path,
+            &cfg,
+            None,
+        )
+        .await
+        .is_err();
+
+        assert_eq!(
+            repair_skipped, reindex_refused,
+            "{label}: the push repair and `memory reindex` must apply under \
+             identical conditions"
+        );
+    }
+
+    unsafe {
+        if let Some(v) = prev_no_server {
+            std::env::set_var("SPELUNK_NO_SERVER", v);
+        }
+    }
 }
 
 #[test]

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_scope_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_scope_tests.rs
@@ -63,9 +63,17 @@ async fn an_empty_push_set_makes_no_embed_calls() {
         (summary.embedded_locally, summary.without_local_vector),
         (0, 0)
     );
-    assert_eq!(
-        embed_count(&loopback.server.received_requests().await.unwrap()),
-        0
+    // Stronger than "no embed call": the discovery probe (`GET /v1/health`)
+    // that resolving an embedder performs must not happen either, or an empty
+    // push would pay for an embedder it never needed.
+    assert!(
+        loopback
+            .server
+            .received_requests()
+            .await
+            .unwrap()
+            .is_empty(),
+        "an empty push set must not even probe for an embedder"
     );
     assert!(
         team.received_requests().await.unwrap().is_empty(),

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_scope_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_scope_tests.rs
@@ -1,5 +1,5 @@
-//! What the pre-batch local-embedding repair deliberately does NOT touch: rows
-//! outside the push set, and content handling it must leave alone.
+// What the pre-batch local-embedding repair deliberately does NOT touch: rows
+// outside the push set, and content handling it must leave alone.
 
 use super::super::test_support::{fresh_store, spawn_loopback_embedder};
 use super::*;

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_scope_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_scope_tests.rs
@@ -1,0 +1,249 @@
+//! What the pre-batch local-embedding repair deliberately does NOT touch: rows
+//! outside the push set, and content handling it must leave alone.
+
+use super::super::test_support::{fresh_store, spawn_loopback_embedder};
+use super::*;
+use crate::config::Config;
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn team_cfg(server_url: String) -> Config {
+    Config {
+        server_url: Some(server_url),
+        project_id: Some("proj".to_string()),
+        mode: None,
+        ..Default::default()
+    }
+}
+
+async fn mount_batch_ok(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/v1/projects/proj/memory/batch"))
+        .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+            "created": 0, "skipped": 0, "failed": 0, "results": []
+        })))
+        .mount(server)
+        .await;
+}
+
+fn embed_count(reqs: &[wiremock::Request]) -> usize {
+    reqs.iter()
+        .filter(|r| r.url.path().ends_with("/index/embed"))
+        .count()
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn an_empty_push_set_makes_no_embed_calls() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+
+    let team = MockServer::start().await;
+    mount_batch_ok(&team).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg(team.uri());
+    let summary = push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        (summary.attempted, summary.already_synced),
+        (0, 0),
+        "today's nothing-to-push shape is unchanged"
+    );
+    assert_eq!(
+        (summary.embedded_locally, summary.without_local_vector),
+        (0, 0)
+    );
+    assert_eq!(
+        embed_count(&loopback.server.received_requests().await.unwrap()),
+        0
+    );
+    assert!(
+        team.received_requests().await.unwrap().is_empty(),
+        "an empty push set sends nothing at all"
+    );
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn already_synced_rows_are_left_unembedded() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    store
+        .add_note("decision", "Synced", "body", &[], &[], None, None)
+        .unwrap();
+    let rows = store.rows_for_sync(false).unwrap();
+    let id = rows[0].local_id;
+    // Outside the push set: the cloud already has it. Repairing these rows is
+    // the pull-side follow-up, deliberately not this change.
+    store.set_remote_id(id, "cloud-1").unwrap();
+
+    let team = MockServer::start().await;
+    mount_batch_ok(&team).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg(team.uri());
+    let summary = push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!((summary.attempted, summary.already_synced), (0, 1));
+    assert_eq!(summary.embedded_locally, 0);
+    assert_eq!(
+        embed_count(&loopback.server.received_requests().await.unwrap()),
+        0
+    );
+    assert!(store.get_embedding(id).unwrap().is_none());
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn archived_rows_are_not_embedded_but_still_tombstone() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    store
+        .add_note("decision", "Gone", "body", &[], &[], None, None)
+        .unwrap();
+    let rows = store.rows_for_sync(false).unwrap();
+    let id = rows[0].local_id;
+    store.set_remote_id(id, "cloud-1").unwrap();
+    store.archive(id).unwrap();
+
+    let team = MockServer::start().await;
+    mount_batch_ok(&team).await;
+    Mock::given(method("DELETE"))
+        .and(path("/v1/projects/proj/memory/cloud-1"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&team)
+        .await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg(team.uri());
+    push_local(
+        &store,
+        &client,
+        true,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        embed_count(&loopback.server.received_requests().await.unwrap()),
+        0,
+        "an archived row is on its way out; embedding it is wasted work"
+    );
+    let team_paths: Vec<String> = team
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| format!("{} {}", r.method, r.url.path()))
+        .collect();
+    assert!(
+        team_paths
+            .iter()
+            .any(|p| p == "DELETE /v1/projects/proj/memory/cloud-1"),
+        "the tombstone must still propagate: {team_paths:?}"
+    );
+    assert!(store.get_embedding(id).unwrap().is_none());
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn vectors_land_in_the_store_that_was_pushed_not_the_project_default() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    // Two stores in separate directories: only the one handed to the push (what
+    // `--source <path>` selects) may be written to.
+    let (source_tmp, source) = fresh_store();
+    let (other_tmp, other) = fresh_store();
+    source
+        .add_note("decision", "Sourced", "body", &[], &[], None, None)
+        .unwrap();
+    other
+        .add_note("decision", "Untouched", "body", &[], &[], None, None)
+        .unwrap();
+    let source_id = source.rows_for_sync(false).unwrap()[0].local_id;
+    let other_id = other.rows_for_sync(false).unwrap()[0].local_id;
+
+    let team = MockServer::start().await;
+    mount_batch_ok(&team).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg(team.uri());
+    push_local(
+        &source,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &source_tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    assert!(source.get_embedding(source_id).unwrap().is_some());
+    assert!(
+        other.get_embedding(other_id).unwrap().is_none(),
+        "only the pushed store may be repaired"
+    );
+    drop(other_tmp);
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn the_repair_does_not_alter_or_re_screen_entry_content() {
+    // The secret gate lives at `memory add` time. This repair reads the stored
+    // title/body to build an embed document and writes back only a vector, so
+    // the bytes on the wire are exactly what a pre-repair push sent. Regression
+    // guard: no new pre-persistence scan requirement is introduced here.
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let body = "token AKIAIOSFODNN7EXAMPLE stored by the user";
+    store
+        .add_note("decision", "Creds", body, &[], &[], None, None)
+        .unwrap();
+
+    let team = MockServer::start().await;
+    mount_batch_ok(&team).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg(team.uri());
+    push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    let reqs = team.received_requests().await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+    assert_eq!(
+        json["entries"][0]["body"].as_str(),
+        Some(body),
+        "the repair must not redact, rewrite, or drop the entry it embeds"
+    );
+    drop(loopback);
+}

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_tests.rs
@@ -1,0 +1,383 @@
+//! Pre-batch local-embedding repair tests for [`super::push_local`]: a pushed
+//! row must not be left invisible to semantic `memory search` locally.
+
+use super::super::test_support::{fresh_store, spawn_loopback_embedder, stub_vector};
+use super::*;
+use crate::config::{Config, SyncMode};
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// A team `server_url` that is deliberately never mocked: any accidental
+// routing of the local embed to it surfaces as a connection error rather than
+// a silent pass.
+fn team_cfg() -> Config {
+    Config {
+        server_url: Some("https://cloud.invalid.example:1".to_string()),
+        project_id: Some("proj".to_string()),
+        mode: None,
+        ..Default::default()
+    }
+}
+
+fn add_note(store: &MemoryStore, title: &str, body: &str) -> (i64, String) {
+    store
+        .add_note("decision", title, body, &[], &[], None, None)
+        .unwrap();
+    let rows = store.rows_for_sync(true).unwrap();
+    let row = rows.iter().find(|r| r.title == title).expect("note added");
+    (row.local_id, row.uuid.clone())
+}
+
+async fn mount_batch_created(server: &MockServer, uuids: &[&str]) {
+    let results: Vec<serde_json::Value> = uuids
+        .iter()
+        .enumerate()
+        .map(|(i, u)| {
+            serde_json::json!({"status": "created", "external_id": u, "id": format!("cloud-{i}")})
+        })
+        .collect();
+    Mock::given(method("POST"))
+        .and(path("/v1/projects/proj/memory/batch"))
+        .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
+            "created": uuids.len(), "skipped": 0, "failed": 0, "results": results
+        })))
+        .mount(server)
+        .await;
+}
+
+fn embed_docs(reqs: &[wiremock::Request]) -> Vec<String> {
+    reqs.iter()
+        .filter(|r| r.url.path().ends_with("/index/embed"))
+        .map(|r| {
+            let json: serde_json::Value = serde_json::from_slice(&r.body).unwrap();
+            json["chunks"][0]["content"].as_str().unwrap().to_string()
+        })
+        .collect()
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn push_embeds_and_durably_stores_a_row_with_no_local_vector() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let (id, uuid) = add_note(&store, "Unembedded", "first");
+    assert!(store.get_embedding(id).unwrap().is_none());
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &[&uuid]).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg();
+    assert_eq!(cfg.resolve_mode(), SyncMode::LocalFirst);
+    let summary = push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        (summary.embedded_locally, summary.without_local_vector),
+        (1, 0)
+    );
+    // Durable: a store reopened from the same file still has the vector.
+    drop(store);
+    let reopened = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+    let blob = reopened
+        .get_embedding(id)
+        .unwrap()
+        .expect("push must leave the row embedded in memory.db");
+    assert_eq!(
+        spelunk_core::embeddings::blob_to_vec(&blob),
+        stub_vector(),
+        "the vector the local embedder returned must be what is stored"
+    );
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn push_embeds_the_same_document_string_reindex_does() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let (_id, uuid) = add_note(&store, "Cache policy", "we cache for 5m");
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &[&uuid]).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg();
+    push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    let docs = embed_docs(&loopback.server.received_requests().await.unwrap());
+    // `memory reindex` embeds exactly this string (reindex.rs), document-side.
+    // A query-side embed would carry F2LLM's `Instruct:/Query:` prefix and put
+    // the row in a different space from every other note in the store.
+    assert_eq!(docs, vec!["title: Cache policy | text: we cache for 5m"]);
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn push_does_not_re_embed_a_row_that_already_has_a_valid_vector() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let (id, uuid) = add_note(&store, "Already", "embedded");
+    store
+        .insert_embedding(id, &spelunk_core::embeddings::vec_to_blob(&stub_vector()))
+        .unwrap();
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &[&uuid]).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg();
+    let summary = push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(summary.embedded_locally, 0);
+    assert!(
+        embed_docs(&loopback.server.received_requests().await.unwrap()).is_empty(),
+        "a row with a usable vector must cost no embed call"
+    );
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn locally_embedded_row_ships_its_vector_when_the_server_accepts_vectors() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let (_id, uuid) = add_note(&store, "Unembedded", "first");
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &[&uuid]).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg();
+    push_local(
+        &store,
+        &client,
+        false,
+        true,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    let reqs = team.received_requests().await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+    let entry = &json["entries"][0];
+    assert_eq!(
+        entry["vector"].as_array().map(Vec::len),
+        Some(spelunk_core::embeddings::EMBEDDING_DIM),
+        "the vector minted before the batch was built must reach the wire: {entry}"
+    );
+    assert_eq!(entry["vector_model"], "F2LLM-v2-330M");
+    assert_eq!(entry["vector_precision"], "fp32");
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn local_vector_is_persisted_even_when_the_server_declines_vectors() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let (id, uuid) = add_note(&store, "Unembedded", "first");
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &[&uuid]).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg();
+    push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    let reqs = team.received_requests().await.unwrap();
+    let body = String::from_utf8(reqs[0].body.clone()).unwrap();
+    assert!(
+        !body.contains("vector"),
+        "a server without the capability must still get a text-only push: {body}"
+    );
+    assert!(
+        store.get_embedding(id).unwrap().is_some(),
+        "the local store must be repaired regardless of what the destination accepts"
+    );
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn a_row_with_an_empty_body_still_embeds_and_pushes() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let (id, uuid) = add_note(&store, "Title only", "");
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &[&uuid]).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg();
+    let summary = push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(summary.embedded_locally, 1);
+    assert_eq!(
+        embed_docs(&loopback.server.received_requests().await.unwrap()),
+        vec!["title: Title only | text: "],
+        "an empty body must still produce the well-formed document string"
+    );
+    assert!(store.get_embedding(id).unwrap().is_some());
+    let reqs = team.received_requests().await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+    assert!(
+        json["entries"][0].get("body").is_none_or(|b| b.is_null()),
+        "an empty body stays off the wire, as before: {json}"
+    );
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn a_second_push_run_issues_no_embed_calls() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let (_id, uuid) = add_note(&store, "Unembedded", "first");
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &[&uuid]).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+    let cfg = team_cfg();
+    let mem_path = tmp.path().join("memory.db");
+
+    push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &mem_path),
+    )
+    .await
+    .unwrap();
+    let after_first = embed_docs(&loopback.server.received_requests().await.unwrap()).len();
+
+    let second = push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &mem_path),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(after_first, 1);
+    assert_eq!(second.embedded_locally, 0);
+    assert_eq!(
+        embed_docs(&loopback.server.received_requests().await.unwrap()).len(),
+        after_first,
+        "a re-run must not re-embed rows the first run already repaired"
+    );
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn reindex_has_nothing_pending_for_rows_a_push_just_repaired() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let (_id, uuid) = add_note(&store, "Unembedded", "first");
+    assert_eq!(store.notes_missing_embeddings(false).unwrap().len(), 1);
+
+    let team = MockServer::start().await;
+    mount_batch_created(&team, &[&uuid]).await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg();
+    push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    // `memory reindex --dry-run` reports exactly this set as `would_embed`.
+    assert!(
+        store.notes_missing_embeddings(false).unwrap().is_empty(),
+        "a pushed row must no longer be pending a reindex"
+    );
+    drop(loopback);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn vectors_minted_before_an_interrupted_chunk_stay_durable() {
+    let loopback = spawn_loopback_embedder("proj", None).await;
+    let (tmp, store) = fresh_store();
+    let (id, _uuid) = add_note(&store, "Unembedded", "first");
+
+    // The batch route is never mounted, so `push_batch` fails and the push
+    // reports itself interrupted after the repair has already run.
+    let team = MockServer::start().await;
+    let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
+
+    let cfg = team_cfg();
+    let summary = push_local(
+        &store,
+        &client,
+        false,
+        false,
+        &LocalEmbedPolicy::for_push(&cfg, &tmp.path().join("memory.db")),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        summary.interrupted.is_some(),
+        "the push must report a failure"
+    );
+    assert_eq!((summary.created, summary.skipped), (0, 0));
+    drop(store);
+    let reopened = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+    assert!(
+        reopened.get_embedding(id).unwrap().is_some(),
+        "a vector minted before the failing chunk must survive it"
+    );
+    drop(loopback);
+}

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_tests.rs
@@ -1,5 +1,5 @@
-//! Pre-batch local-embedding repair tests for [`super::push_local`]: a pushed
-//! row must not be left invisible to semantic `memory search` locally.
+// Pre-batch local-embedding repair tests for `super::push_local`: a pushed
+// row must not be left invisible to semantic `memory search` locally.
 
 use super::super::test_support::{fresh_store, spawn_loopback_embedder, stub_vector};
 use super::*;

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_tests.rs
@@ -134,13 +134,16 @@ async fn push_embeds_the_same_document_string_reindex_does() {
 async fn push_does_not_re_embed_a_row_that_already_has_a_valid_vector() {
     let loopback = spawn_loopback_embedder("proj", None).await;
     let (tmp, store) = fresh_store();
-    let (id, uuid) = add_note(&store, "Already", "embedded");
-    store
-        .insert_embedding(id, &spelunk_core::embeddings::vec_to_blob(&stub_vector()))
-        .unwrap();
+    let (id_a, uuid_a) = add_note(&store, "Already", "embedded");
+    let (id_b, uuid_b) = add_note(&store, "Also already", "embedded");
+    for id in [id_a, id_b] {
+        store
+            .insert_embedding(id, &spelunk_core::embeddings::vec_to_blob(&stub_vector()))
+            .unwrap();
+    }
 
     let team = MockServer::start().await;
-    mount_batch_created(&team, &[&uuid]).await;
+    mount_batch_created(&team, &[&uuid_a, &uuid_b]).await;
     let client = CloudSyncClient::new(&team.uri(), "proj", None, None).unwrap();
 
     let cfg = team_cfg();
@@ -155,9 +158,19 @@ async fn push_does_not_re_embed_a_row_that_already_has_a_valid_vector() {
     .unwrap();
 
     assert_eq!(summary.embedded_locally, 0);
+    // Not just "no embed call": no traffic at all. Resolving the embedder is
+    // itself a discovery probe (`GET /v1/health`), so a push set that is
+    // already fully embedded must never reach the resolver in the first place.
+    // Asserting only on `/index/embed` would still pass if the client were
+    // resolved eagerly and then went unused.
     assert!(
-        embed_docs(&loopback.server.received_requests().await.unwrap()).is_empty(),
-        "a row with a usable vector must cost no embed call"
+        loopback
+            .server
+            .received_requests()
+            .await
+            .unwrap()
+            .is_empty(),
+        "a fully embedded push set must not even probe for an embedder"
     );
     drop(loopback);
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/local_embed.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/local_embed.rs
@@ -1,0 +1,192 @@
+//! The pre-batch local-embedding repair shared by `spelunk sync` and
+//! `spelunk memory push`.
+//!
+//! A push used to leave `memory.db` exactly as it found it, so an entry that
+//! had never been embedded stayed invisible to semantic `memory search` after a
+//! successful push, with nothing telling the user. This module embeds the push
+//! set locally first and commits each vector as it completes.
+
+use anyhow::Result;
+
+use super::PushSummary;
+use crate::{
+    capability,
+    config::{Config, SyncMode},
+    embeddings::vec_to_blob,
+    server_client::ServerInferenceClient,
+    storage::{MemoryStore, SyncRow},
+};
+
+/// Whether a push repairs the local store's missing embeddings before building
+/// the batch, and the config the local embedder is resolved from.
+///
+/// Constructed by the command layer via [`LocalEmbedPolicy::for_push`] so
+/// `spelunk sync` and `spelunk memory push` decide it identically.
+pub(in crate::cli::cmd::memory) enum LocalEmbedPolicy<'a> {
+    /// Embed every push-set row that lacks a usable local vector, through the
+    /// loopback embedder, and commit the result to `memory.db`.
+    Repair {
+        cfg: &'a Config,
+        project_root: std::path::PathBuf,
+    },
+    /// Leave local embeddings alone.
+    Skip,
+}
+
+impl<'a> LocalEmbedPolicy<'a> {
+    /// Decide the policy for a push against `mem_path`.
+    ///
+    /// `cloud_first` with a team `server_url` relocates the store of record off
+    /// `memory.db`, so there is nothing local to repair. This is the exact
+    /// condition `memory reindex` refuses under, and the two commands must not
+    /// disagree about when local embeddings are meaningful.
+    pub(in crate::cli::cmd::memory) fn for_push(
+        cfg: &'a Config,
+        mem_path: &std::path::Path,
+    ) -> Self {
+        if cfg.resolve_mode() == SyncMode::CloudFirst && cfg.server_url.is_some() {
+            return Self::Skip;
+        }
+        Self::Repair {
+            cfg,
+            project_root: mem_path.parent().unwrap_or(mem_path).to_path_buf(),
+        }
+    }
+}
+
+/// Counted outcome of the pre-batch local-embedding repair.
+pub(super) struct RepairCounts {
+    pub(super) embedded: usize,
+    pub(super) without_vector: usize,
+}
+
+/// The one user-facing warning for entries that were pushed with no local
+/// embedding. Emitted once per run by the command layer, which owns all
+/// user-facing output; the shared push pass only counts.
+pub(in crate::cli::cmd::memory) fn unembedded_warning(count: usize) -> String {
+    let entries = if count == 1 { "entry" } else { "entries" };
+    format!(
+        "warning: {count} {entries} pushed without a local embedding, so \
+         `spelunk memory search` cannot surface {} in this project until \
+         `spelunk memory reindex` is run.",
+        if count == 1 { "it" } else { "them" }
+    )
+}
+
+/// Local-embedding clause for a push/sync summary line. Empty when the repair
+/// neither minted nor missed a vector, so an unaffected push reads exactly as
+/// it did before.
+pub(in crate::cli::cmd::memory) fn local_embed_summary(summary: &PushSummary) -> String {
+    match (summary.embedded_locally, summary.without_local_vector) {
+        (0, 0) => String::new(),
+        (embedded, 0) => format!(" Embedded {embedded} locally."),
+        (embedded, missing) => {
+            format!(" Embedded {embedded} locally, {missing} without a local embedding.")
+        }
+    }
+}
+
+/// Decode a stored embedding blob into a vector usable for this push: `None`
+/// when the row has no embedding at all, or when the blob does not decode to
+/// exactly `EMBEDDING_DIM` floats (a torn write). A row with no usable vector
+/// is treated as unembedded by both the repair pass and the batch build.
+pub(super) fn usable_vector(blob: Option<Vec<u8>>) -> Option<Vec<f32>> {
+    blob.map(|b| spelunk_core::embeddings::blob_to_vec(&b))
+        .filter(|v| v.len() == spelunk_core::embeddings::EMBEDDING_DIM)
+}
+
+/// Resolve the embedder the repair pass runs through.
+///
+/// `get_inference_tier` (not `get_tier`) is what keeps this on the loopback
+/// embedder: outside `cloud_first` it probes loopback only, so the embed can
+/// never be routed to a configured team `server_url`. Routing it there would
+/// re-create the exact server-side re-embedding this repair exists to stop.
+async fn resolve_local_embedder(
+    cfg: &Config,
+    project_root: &std::path::Path,
+) -> Option<ServerInferenceClient> {
+    let tier = capability::get_inference_tier(cfg).await;
+    // An auto-discovered loopback server sets the tier without populating
+    // `server_url`, so bridge it into an effective config first (ADR-004),
+    // exactly as `memory reindex` does.
+    let eff_cfg = tier.effective_config(cfg, project_root);
+    ServerInferenceClient::from_config(&eff_cfg)
+}
+
+/// Embed every push-set row that lacks a usable local vector and commit it to
+/// `memory.db`, so a pushed row is searchable locally afterwards rather than
+/// silently invisible to semantic `memory search`.
+///
+/// Never fails the push: with no embedder reachable, or on a single row's embed
+/// error, the affected rows go out text-only and are counted for the caller's
+/// warning.
+pub(super) async fn repair_local_embeddings(
+    local: &MemoryStore,
+    live: &[&SyncRow],
+    policy: &LocalEmbedPolicy<'_>,
+) -> Result<RepairCounts> {
+    let (cfg, project_root) = match policy {
+        LocalEmbedPolicy::Skip => {
+            return Ok(RepairCounts {
+                embedded: 0,
+                without_vector: 0,
+            });
+        }
+        LocalEmbedPolicy::Repair { cfg, project_root } => (*cfg, project_root),
+    };
+
+    let mut missing: Vec<&SyncRow> = Vec::new();
+    for r in live {
+        if usable_vector(local.get_embedding(r.local_id)?).is_none() {
+            missing.push(r);
+        }
+    }
+    // Resolve the embedder only once a row actually needs one: an empty or
+    // fully-embedded push set must not pay for a discovery probe, and must not
+    // warn about an embedder it never needed.
+    if missing.is_empty() {
+        return Ok(RepairCounts {
+            embedded: 0,
+            without_vector: 0,
+        });
+    }
+
+    let Some(client) = resolve_local_embedder(cfg, project_root).await else {
+        // Text-only rather than a refusal: failing here would break scripted and
+        // CI pushes that work today and never needed a local embedder.
+        return Ok(RepairCounts {
+            embedded: 0,
+            without_vector: missing.len(),
+        });
+    };
+
+    let mut embedded = 0usize;
+    let mut without_vector = 0usize;
+    for r in missing {
+        // Byte-identical to `memory reindex` / `memory add`'s document string,
+        // embedded document-side (`embed_text`, never `embed_query`, which
+        // prepends the F2LLM `Instruct:/Query:` prefix): a vector minted here
+        // must be interchangeable with theirs or the repaired row is ranked
+        // against a different space.
+        let doc = format!("title: {} | text: {}", r.title, r.body);
+        match client.embed_text(&doc).await {
+            Ok(vec) => {
+                // Committed per row, so an interrupted push keeps every vector
+                // it minted and a re-run embeds only the remainder.
+                local.insert_embedding(r.local_id, &vec_to_blob(&vec))?;
+                embedded += 1;
+            }
+            Err(e) => {
+                // One row's embed failure must not abort a push that is
+                // otherwise fine; it ships text-only and is counted instead.
+                tracing::warn!("embedding note #{} before push failed: {e:#}", r.local_id);
+                without_vector += 1;
+            }
+        }
+    }
+
+    Ok(RepairCounts {
+        embedded,
+        without_vector,
+    })
+}

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/mod.rs
@@ -5,6 +5,13 @@ use anyhow::Result;
 
 use crate::storage::{BatchPushItem, CloudSyncClient, MemoryStore};
 
+mod local_embed;
+
+pub(in crate::cli::cmd::memory) use local_embed::{
+    LocalEmbedPolicy, local_embed_summary, unembedded_warning,
+};
+use local_embed::{repair_local_embeddings, usable_vector};
+
 /// How many entries go in each `POST /memory/batch` request. Kept small so even
 /// the worst case (text-only, the server re-embedding a full chunk on a cold
 /// embedder) finishes with wide margin under the request timeout, and a
@@ -46,6 +53,15 @@ pub(in crate::cli::cmd::memory) struct PushSummary {
     /// command layer report honest partial progress plus a resume hint and exit
     /// non-zero, instead of discarding the chunks that already landed.
     pub interrupted: Option<String>,
+    /// Push-set rows whose missing local vector this push minted and committed
+    /// to `memory.db`. Reported separately from `created`/`skipped`/`failed`,
+    /// which are all about what the *destination* did.
+    pub embedded_locally: usize,
+    /// Push-set rows that still have no usable local vector after the repair
+    /// pass: no local embedder was reachable, or that row's embed call failed.
+    /// Drives the one counted warning the command layer emits. Always 0 when
+    /// the repair does not apply ([`LocalEmbedPolicy::Skip`]).
+    pub without_local_vector: usize,
 }
 
 /// One-way push entry point reused by `spelunk memory push`.
@@ -59,12 +75,27 @@ pub(in crate::cli::cmd::memory) async fn push_local_oneway(
     client: &CloudSyncClient,
     include_archived: bool,
     accepts_pushed_vectors: bool,
+    local_embed: &LocalEmbedPolicy<'_>,
 ) -> Result<PushSummary> {
-    push_local(local, client, include_archived, accepts_pushed_vectors).await
+    push_local(
+        local,
+        client,
+        include_archived,
+        accepts_pushed_vectors,
+        local_embed,
+    )
+    .await
 }
 
 /// Push local entries to the cloud in batches, then propagate tombstones for any
-/// archived rows that exist cloud-side. Each entry is text-only unless
+/// archived rows that exist cloud-side.
+///
+/// Before the batch is built, `local_embed` decides whether push-set rows that
+/// lack a local vector are embedded through the loopback embedder and committed
+/// to `memory.db`: without that repair a pushed row stays invisible to semantic
+/// `memory search` locally, with nothing telling the user.
+///
+/// Each entry is text-only unless
 /// `accepts_pushed_vectors` is set and the row has a local fp32/896 embedding,
 /// in which case that vector is attached (the server stores it without
 /// re-embedding).
@@ -78,12 +109,14 @@ pub(super) async fn push_local(
     client: &CloudSyncClient,
     include_archived: bool,
     accepts_pushed_vectors: bool,
+    local_embed: &LocalEmbedPolicy<'_>,
 ) -> Result<PushSummary> {
     push_local_reporting(
         local,
         client,
         include_archived,
         accepts_pushed_vectors,
+        local_embed,
         |done, total| {
             // Transient cumulative status on stderr; the final one-line summary
             // stays on stdout in the command layer.
@@ -102,6 +135,7 @@ async fn push_local_reporting(
     client: &CloudSyncClient,
     include_archived: bool,
     accepts_pushed_vectors: bool,
+    local_embed: &LocalEmbedPolicy<'_>,
     mut on_progress: impl FnMut(usize, usize),
 ) -> Result<PushSummary> {
     let rows = local.rows_for_sync(include_archived)?;
@@ -113,6 +147,8 @@ async fn push_local_reporting(
             failed: 0,
             already_synced: 0,
             interrupted: None,
+            embedded_locally: 0,
+            without_local_vector: 0,
         });
     }
 
@@ -137,6 +173,10 @@ async fn push_local_reporting(
         .filter(|r| !r.archived && r.remote_id.is_some())
         .count();
     let attempted = live.len();
+    // Repair the local store BEFORE the batch is built, so a freshly-minted
+    // vector is available to `maybe_attach_vector` below and the pushed rows
+    // are searchable locally afterwards.
+    let repair = repair_local_embeddings(local, &live, local_embed).await?;
     // Progress is only worth emitting when the push actually spans multiple
     // chunks; a single-chunk push stays quiet (no noise on small pushes).
     let multi_chunk = attempted.div_ceil(PUSH_BATCH_CHUNK_SIZE) > 1;
@@ -151,10 +191,7 @@ async fn push_local_reporting(
             // wrong-length or missing embedding falls back to text-only rather
             // than poisoning the whole batch with a 4xx.
             let vector = if accepts_pushed_vectors {
-                local
-                    .get_embedding(r.local_id)?
-                    .map(|blob| spelunk_core::embeddings::blob_to_vec(&blob))
-                    .filter(|v| v.len() == spelunk_core::embeddings::EMBEDDING_DIM)
+                usable_vector(local.get_embedding(r.local_id)?)
             } else {
                 None
             };
@@ -266,6 +303,8 @@ async fn push_local_reporting(
         failed,
         already_synced,
         interrupted,
+        embedded_locally: repair.embedded,
+        without_local_vector: repair.without_vector,
     })
 }
 
@@ -273,5 +312,11 @@ async fn push_local_reporting(
 mod chunking_tests;
 #[cfg(test)]
 mod counting_tests;
+#[cfg(test)]
+mod embed_routing_tests;
+#[cfg(test)]
+mod embed_scope_tests;
+#[cfg(test)]
+mod embed_tests;
 #[cfg(test)]
 mod vector_tests;

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/vector_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/vector_tests.rs
@@ -49,7 +49,9 @@ async fn push_local_attaches_vector_when_server_accepts() {
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
     // accepts_pushed_vectors = true → the fp32/896 vector reaches the wire.
-    push_local(&store, &client, false, true).await.unwrap();
+    push_local(&store, &client, false, true, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
@@ -86,62 +88,15 @@ async fn push_local_stays_text_only_when_server_declines() {
     let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
 
     // accepts_pushed_vectors = false → text-only, despite a local vector.
-    push_local(&store, &client, false, false).await.unwrap();
+    push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
 
     let reqs = server.received_requests().await.unwrap();
     let body = String::from_utf8(reqs[0].body.clone()).unwrap();
     assert!(
         !body.contains("vector"),
         "server without the capability must get a text-only push: {body}"
-    );
-}
-
-/// A note queued for push with NO `note_embeddings` row at all (never
-/// embedded locally, or embedding failed) must fall back to a text-only
-/// push for that row — not crash, and not send an empty/malformed
-/// `vector` field — even though the server accepts pushed vectors.
-#[tokio::test]
-async fn push_local_falls_back_to_text_only_when_local_embedding_missing() {
-    use tempfile::TempDir;
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
-
-    register_sqlite_vec();
-    let tmp = TempDir::new().unwrap();
-    let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
-    // Deliberately no `insert_embedding` call — this note has never been
-    // embedded.
-    store
-        .add_note("decision", "Unembedded", "first", &[], &[], None, None)
-        .unwrap();
-    let rows = store.rows_for_sync(false).unwrap();
-    assert_eq!(rows.len(), 1);
-    let uuid = rows[0].uuid.clone();
-
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/v1/projects/proj/memory/batch"))
-        .respond_with(ResponseTemplate::new(207).set_body_json(serde_json::json!({
-            "created": 1, "skipped": 0, "failed": 0,
-            "results": [{"status": "created", "external_id": uuid, "id": "cloud-1"}]
-        })))
-        .mount(&server)
-        .await;
-    let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
-
-    // accepts_pushed_vectors = true, but no local embedding exists.
-    let summary = push_local(&store, &client, false, true).await.unwrap();
-    assert_eq!(
-        (summary.attempted, summary.created, summary.failed),
-        (1, 1, 0)
-    );
-
-    let reqs = server.received_requests().await.unwrap();
-    let body = String::from_utf8(reqs[0].body.clone()).unwrap();
-    assert!(
-        !body.contains("vector"),
-        "a note with no local embedding must fall back to text-only, \
-             not error or send a malformed vector: {body}"
     );
 }
 
@@ -177,49 +132,5 @@ async fn insert_embedding_rejects_wrong_dimension_vector() {
         "the vec0 FLOAT[896] column must refuse a 768-dim insert outright \
              (this is what makes a wrong-dimension row unreachable via any \
              application write path): {err}"
-    );
-}
-
-/// Since a wrong-dimension row can never be *written* (previous test),
-/// the only way `push_local`'s guard (`blob_to_vec` decode + a length
-/// check against `EMBEDDING_DIM` — the same two building blocks
-/// exercised inline at `sync.rs`'s vector-resolution site) could ever
-/// see a wrong-length vector is an on-disk blob corrupted or torn
-/// independently of any insert (disk fault, a crash mid-write). This
-/// pins that composed guard logic directly: it must never panic on a
-/// short/truncated/empty blob, and must always filter such a decode out
-/// rather than accept a spurious length or garbage-padded 896 vector.
-#[test]
-fn dim_guard_logic_rejects_short_truncated_and_empty_blobs() {
-    use spelunk_core::embeddings::{EMBEDDING_DIM, blob_to_vec, vec_to_blob};
-
-    let guarded = |blob: &[u8]| -> Option<Vec<f32>> {
-        Some(blob_to_vec(blob)).filter(|v| v.len() == EMBEDDING_DIM)
-    };
-
-    // A stale 768-float blob (wrong dimension, but cleanly decodable).
-    let stale_768 = vec_to_blob(&vec![1.0f32; 768]);
-    assert!(
-        guarded(&stale_768).is_none(),
-        "a 768-float blob must be filtered out, not accepted"
-    );
-
-    // A torn write: a valid 896-dim blob with its last few bytes cut off.
-    let full = vec_to_blob(&vec![1.0f32; EMBEDDING_DIM]);
-    let truncated = &full[..full.len() - 10];
-    assert_ne!(
-        blob_to_vec(truncated).len(),
-        EMBEDDING_DIM,
-        "sanity: a truncated blob must decode to a non-896 length"
-    );
-    assert!(
-        guarded(truncated).is_none(),
-        "a truncated blob must never pass the dimension guard"
-    );
-
-    // A zero-length blob (e.g. corrupted read).
-    assert!(
-        guarded(&[]).is_none(),
-        "an empty blob must be filtered out, not treated as a valid vector"
     );
 }

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/vector_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/vector_tests.rs
@@ -1,4 +1,4 @@
-//! Pushed-vector fast-path tests for [`super::push_local`].
+// Pushed-vector fast-path tests for `super::push_local`.
 
 use super::super::test_support::register_sqlite_vec;
 use super::*;
@@ -11,8 +11,8 @@ use super::*;
 // exercises the full `push_local` wiring: it reads the local embedding and
 // consults the gate, which the `maybe_attach_vector` unit test cannot.
 
-/// Insert an active note plus a valid L2-normalised fp32/896 embedding,
-/// returning its local id + external uuid.
+// Insert an active note plus a valid L2-normalised fp32/896 embedding,
+// returning its local id + external uuid.
 fn note_with_embedding(store: &MemoryStore) -> (i64, String) {
     store
         .add_note("decision", "One", "first", &[], &[], None, None)
@@ -100,17 +100,17 @@ async fn push_local_stays_text_only_when_server_declines() {
     );
 }
 
-/// `note_embeddings` is a `vec0` virtual table with a `FLOAT[896]` column
-/// (migration `004_memory.sql`) — sqlite-vec enforces that exact
-/// dimension AT INSERT TIME, for every write path (there is only one:
-/// `insert_embedding`). So a "leftover pre-896 768-dim row" — unlike the
-/// code-chunk `embeddings` table, which DID have a legacy 768-dim era
-/// with an explicit recreate-on-open migration in `db.rs` — can never
-/// actually be written for memory notes: there was never a 768-dim
-/// memory-embedding vintage to migrate from, and the store itself
-/// refuses the write. Confirmed here rather than assumed, since it is
-/// exactly the scenario `push_local`'s dimension guard names in its
-/// comment.
+// `note_embeddings` is a `vec0` virtual table with a `FLOAT[896]` column
+// (migration `004_memory.sql`): sqlite-vec enforces that exact
+// dimension AT INSERT TIME, for every write path (there is only one:
+// `insert_embedding`). So a "leftover pre-896 768-dim row" (unlike the
+// code-chunk `embeddings` table, which DID have a legacy 768-dim era
+// with an explicit recreate-on-open migration in `db.rs`) can never
+// actually be written for memory notes: there was never a 768-dim
+// memory-embedding vintage to migrate from, and the store itself
+// refuses the write. Confirmed here rather than assumed, since it is
+// exactly the scenario `push_local`'s dimension guard names in its
+// comment.
 #[tokio::test]
 async fn insert_embedding_rejects_wrong_dimension_vector() {
     use tempfile::TempDir;

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/round.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/round.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use crate::storage::{CloudSyncClient, MemoryStore};
 
 use super::pull::pull_and_apply_since;
-use super::push::{PushSummary, push_local};
+use super::push::{LocalEmbedPolicy, PushSummary, push_local};
 
 /// Outcome of one [`sync_round`]: the push summary plus the total newly
 /// applied entries across both pull passes.
@@ -58,16 +58,31 @@ pub(super) async fn sync_round(
     client: &CloudSyncClient,
     include_archived: bool,
     accepts_pushed_vectors: bool,
+    local_embed: &LocalEmbedPolicy<'_>,
 ) -> Result<SyncRoundOutcome> {
     let pre_round_cursor = local.max_remote_id()?;
 
     if pre_round_cursor.is_none() {
-        return sync_round_first(local, client, include_archived, accepts_pushed_vectors).await;
+        return sync_round_first(
+            local,
+            client,
+            include_archived,
+            accepts_pushed_vectors,
+            local_embed,
+        )
+        .await;
     }
 
     let pulled_first = pull_and_apply_since(local, client, pre_round_cursor.as_deref()).await?;
 
-    let pushed = push_local(local, client, include_archived, accepts_pushed_vectors).await?;
+    let pushed = push_local(
+        local,
+        client,
+        include_archived,
+        accepts_pushed_vectors,
+        local_embed,
+    )
+    .await?;
 
     // If this second pull errors (network blip, transient 5xx), the error
     // propagates out of `sync_round` rather than being swallowed: `?`
@@ -115,8 +130,16 @@ async fn sync_round_first(
     client: &CloudSyncClient,
     include_archived: bool,
     accepts_pushed_vectors: bool,
+    local_embed: &LocalEmbedPolicy<'_>,
 ) -> Result<SyncRoundOutcome> {
-    let pushed = push_local(local, client, include_archived, accepts_pushed_vectors).await?;
+    let pushed = push_local(
+        local,
+        client,
+        include_archived,
+        accepts_pushed_vectors,
+        local_embed,
+    )
+    .await?;
 
     // Mirrors the established-client confirmation pull's error handling: a
     // pull failure here must not read as "nothing happened" when the push
@@ -179,7 +202,7 @@ mod tests {
             .unwrap();
         let client_a = CloudSyncClient::new(&base_url, "proj-primary", None, None).unwrap();
         assert_eq!(
-            push_local(&store_a, &client_a, false, false)
+            push_local(&store_a, &client_a, false, false, &LocalEmbedPolicy::Skip)
                 .await
                 .unwrap()
                 .created,
@@ -201,7 +224,9 @@ mod tests {
             .unwrap();
         let client_c = CloudSyncClient::new(&base_url, "proj-primary", None, None).unwrap();
 
-        let outcome = sync_round(&store_c, &client_c, false, false).await.unwrap();
+        let outcome = sync_round(&store_c, &client_c, false, false, &LocalEmbedPolicy::Skip)
+            .await
+            .unwrap();
         assert_eq!(outcome.pushed.created, 1, "C's own entry must land");
         assert_eq!(
             outcome.pulled, 1,
@@ -231,7 +256,9 @@ mod tests {
             .unwrap();
         let client = CloudSyncClient::new(&base_url, "proj-idem", None, None).unwrap();
 
-        let r1 = sync_round(&store, &client, false, false).await.unwrap();
+        let r1 = sync_round(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+            .await
+            .unwrap();
         assert_eq!(r1.pushed.created, 1);
         assert_eq!(
             r1.pulled, 0,
@@ -240,7 +267,9 @@ mod tests {
         );
         assert_eq!(store.count().unwrap(), 1, "no duplicate local row");
 
-        let r2 = sync_round(&store, &client, false, false).await.unwrap();
+        let r2 = sync_round(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+            .await
+            .unwrap();
         assert_eq!(
             (r2.pushed.attempted, r2.pushed.already_synced, r2.pulled),
             (0, 1, 0),
@@ -296,7 +325,7 @@ mod tests {
             .unwrap();
         let client_b = CloudSyncClient::new(&base_url, "proj-race", None, None).unwrap();
         assert_eq!(
-            push_local(&store_b, &client_b, false, false)
+            push_local(&store_b, &client_b, false, false, &LocalEmbedPolicy::Skip)
                 .await
                 .unwrap()
                 .created,
@@ -304,7 +333,9 @@ mod tests {
         );
 
         // Step 2 of sync_round: this round's own push.
-        let pushed = push_local(&store, &client, false, false).await.unwrap();
+        let pushed = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+            .await
+            .unwrap();
         assert_eq!(pushed.created, 1);
 
         // Step 3 of sync_round: the second pull, reusing pre_round_cursor
@@ -343,7 +374,7 @@ mod tests {
             .unwrap();
         let client_a = CloudSyncClient::new(&base_url, "proj-pull", None, None).unwrap();
         assert_eq!(
-            push_local(&store_a, &client_a, false, false)
+            push_local(&store_a, &client_a, false, false, &LocalEmbedPolicy::Skip)
                 .await
                 .unwrap()
                 .created,
@@ -353,7 +384,7 @@ mod tests {
             .add_note("decision", "A2", "second", &[], &[], None, None)
             .unwrap();
         assert_eq!(
-            push_local(&store_a, &client_a, false, false)
+            push_local(&store_a, &client_a, false, false, &LocalEmbedPolicy::Skip)
                 .await
                 .unwrap()
                 .created,
@@ -466,7 +497,7 @@ mod tests {
             .await;
 
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
-        let outcome = sync_round(&store, &client, false, false)
+        let outcome = sync_round(&store, &client, false, false, &LocalEmbedPolicy::Skip)
             .await
             .expect("a first sync must not surface the pre-push pull's 400 to the user");
 
@@ -541,7 +572,9 @@ mod tests {
             .await;
 
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
-        sync_round(&store, &client, false, false).await.unwrap();
+        sync_round(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+            .await
+            .unwrap();
 
         let reqs = server.received_requests().await.unwrap();
         let methods: Vec<&str> = reqs.iter().map(|r| r.method.as_str()).collect();
@@ -615,7 +648,7 @@ mod tests {
             .await;
 
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
-        let outcome = sync_round(&store, &client, false, false)
+        let outcome = sync_round(&store, &client, false, false, &LocalEmbedPolicy::Skip)
             .await
             .expect("a skipped-not-created push must not be treated as a failure");
 
@@ -676,9 +709,11 @@ mod tests {
             .await;
 
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
-        let err = sync_round(&store, &client, false, false).await.expect_err(
-            "a pull failure after a totally failed push must still surface as an error",
-        );
+        let err = sync_round(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+            .await
+            .expect_err(
+                "a pull failure after a totally failed push must still surface as an error",
+            );
 
         assert!(
             format!("{err:#}").contains("post-push pull failed"),
@@ -781,8 +816,8 @@ mod tests {
         let client_y = CloudSyncClient::new(&server.uri(), "proj-race-first", None, None).unwrap();
 
         let (outcome_x, outcome_y) = tokio::join!(
-            sync_round(&store_x, &client_x, false, false),
-            sync_round(&store_y, &client_y, false, false),
+            sync_round(&store_x, &client_x, false, false, &LocalEmbedPolicy::Skip),
+            sync_round(&store_y, &client_y, false, false, &LocalEmbedPolicy::Skip),
         );
 
         assert_eq!(

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/round.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/round.rs
@@ -173,14 +173,14 @@ mod tests {
     // differently-configured in-process probes in one test binary would see
     // stale tiers from whichever test's probe ran first.
 
-    /// The primary repro, fixed: a client with local-only, never-pushed
-    /// content, running the actual `sync_round` sequence against a project
-    /// that already has a teammate's prior entry (pushed strictly before
-    /// this round begins),
-    /// ends the round with that teammate entry applied - not 0. This is
-    /// exactly the case the existing `two_established_clients_...` test
-    /// deliberately routes around (see its own comment) because, before this
-    /// fix, `memory_sync`'s push-then-pull order shadowed it permanently.
+    // The primary repro, fixed: a client with local-only, never-pushed
+    // content, running the actual `sync_round` sequence against a project
+    // that already has a teammate's prior entry (pushed strictly before
+    // this round begins),
+    // ends the round with that teammate entry applied - not 0. This is
+    // exactly the case the existing `two_established_clients_...` test
+    // deliberately routes around (see its own comment) because, before this
+    // fix, `memory_sync`'s push-then-pull order shadowed it permanently.
     #[tokio::test]
     async fn sync_round_pulls_teammates_prior_entry_on_a_first_round_with_local_content() {
         let addr = spawn_spelunk_server().await;
@@ -241,10 +241,10 @@ mod tests {
         assert!(titles.contains(&"A1".to_string()) && titles.contains(&"C1".to_string()));
     }
 
-    /// Idempotence + no double-counting: running `sync_round` twice back to
-    /// back with nothing new to push or pull is a no-op both times, and the
-    /// round's own just-pushed row (harmlessly re-fetched by the second,
-    /// pre-round-cursor pull) is never counted twice or duplicated locally.
+    // Idempotence + no double-counting: running `sync_round` twice back to
+    // back with nothing new to push or pull is a no-op both times, and the
+    // round's own just-pushed row (harmlessly re-fetched by the second,
+    // pre-round-cursor pull) is never counted twice or duplicated locally.
     #[tokio::test]
     async fn sync_round_twice_with_nothing_new_is_idempotent_and_never_double_counts() {
         let addr = spawn_spelunk_server().await;
@@ -278,18 +278,18 @@ mod tests {
         assert_eq!(store.count().unwrap(), 1);
     }
 
-    /// The race window a plain reorder cannot close: a teammate's push
-    /// that lands on the server strictly between this round's own first pull
-    /// and its own push must still be picked up within this same round (via
-    /// the second pull, reusing the pre-round cursor) rather than being
-    /// permanently shadowed by the round's own push becoming the new
-    /// `MAX(remote_id)`.
-    ///
-    /// Real network concurrency can't be forced deterministically in a unit
-    /// test, so this composes `sync_round`'s exact same three calls
-    /// (`pull_and_apply_since` / `push_local` / `pull_and_apply_since`,
-    /// reusing one `pre_round_cursor`) with the teammate's push manually
-    /// interleaved at the precise point the race window occupies.
+    // The race window a plain reorder cannot close: a teammate's push
+    // that lands on the server strictly between this round's own first pull
+    // and its own push must still be picked up within this same round (via
+    // the second pull, reusing the pre-round cursor) rather than being
+    // permanently shadowed by the round's own push becoming the new
+    // `MAX(remote_id)`.
+    //
+    // Real network concurrency can't be forced deterministically in a unit
+    // test, so this composes `sync_round`'s exact same three calls
+    // (`pull_and_apply_since` / `push_local` / `pull_and_apply_since`,
+    // reusing one `pre_round_cursor`) with the teammate's push manually
+    // interleaved at the precise point the race window occupies.
     #[tokio::test]
     async fn sync_round_catches_a_teammate_push_landing_between_its_own_pull_and_push() {
         let addr = spawn_spelunk_server().await;
@@ -359,10 +359,10 @@ mod tests {
         assert!(titles.contains(&"B1".to_string()));
     }
 
-    /// `memory pull` (one-way, no push) is unaffected by the `sync_round`
-    /// two-phase reconciliation added for `sync`. It keeps
-    /// deriving a single cursor from the store itself via `pull_and_apply`,
-    /// unmodified.
+    // `memory pull` (one-way, no push) is unaffected by the `sync_round`
+    // two-phase reconciliation added for `sync`. It keeps
+    // deriving a single cursor from the store itself via `pull_and_apply`,
+    // unmodified.
     #[tokio::test]
     async fn pull_and_apply_one_way_pull_still_derives_its_own_single_cursor() {
         let addr = spawn_spelunk_server().await;
@@ -412,11 +412,11 @@ mod tests {
     // provisions it, so the pre-push pull on a first sync has nothing valid
     // to query yet.
 
-    /// Mock `/memory/since` responder that fails like the real bug (400)
-    /// until this project has been provisioned by a push, then succeeds:
-    /// models "the project does not exist yet" without depending on the real
-    /// cloud-api's own id-resolution details, which are out of scope for
-    /// this client-side fix.
+    // Mock `/memory/since` responder that fails like the real bug (400)
+    // until this project has been provisioned by a push, then succeeds:
+    // models "the project does not exist yet" without depending on the real
+    // cloud-api's own id-resolution details, which are out of scope for
+    // this client-side fix.
     struct SinceUntilProvisioned {
         provisioned: std::sync::Arc<std::sync::atomic::AtomicBool>,
     }
@@ -433,9 +433,9 @@ mod tests {
         }
     }
 
-    /// Mock `/memory/batch` responder that marks the project provisioned as
-    /// it lands the push, so a subsequent `/memory/since` call (via
-    /// [`SinceUntilProvisioned`]) succeeds.
+    // Mock `/memory/batch` responder that marks the project provisioned as
+    // it lands the push, so a subsequent `/memory/since` call (via
+    // `SinceUntilProvisioned`) succeeds.
     struct BatchProvisions {
         provisioned: std::sync::Arc<std::sync::atomic::AtomicBool>,
         external_id: String,
@@ -729,10 +729,10 @@ mod tests {
     // provision the same project must not trip the pre-push-pull bug for
     // either of them ─────────────────────────────────────────────────────
 
-    /// Mock `/memory/batch` responder that provisions the project and echoes
-    /// back a generated cloud id per pushed `external_id`, so two different
-    /// clients pushing two different entries concurrently each get a
-    /// coherent per-item result rather than a hardcoded single id.
+    // Mock `/memory/batch` responder that provisions the project and echoes
+    // back a generated cloud id per pushed `external_id`, so two different
+    // clients pushing two different entries concurrently each get a
+    // coherent per-item result rather than a hardcoded single id.
     struct BatchProvisionsEcho {
         provisioned: std::sync::Arc<std::sync::atomic::AtomicBool>,
     }

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/test_support.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/test_support.rs
@@ -52,6 +52,103 @@ pub(super) async fn spawn_spelunk_server() -> std::net::SocketAddr {
     addr
 }
 
+// A mocked local spelunk-server standing in for the loopback embedder, wired
+// up the way auto-discovery actually finds one: a `server.port` file under
+// `SPELUNK_STATE_DIR` pointing at the mock. Going through the real discovery
+// path (rather than injecting an `inference_url`) is what makes the
+// "embed never reaches the team server_url" tests meaningful, and pins the
+// probe to this mock instead of whatever happens to listen on port 7777 on the
+// machine running the tests.
+//
+// Mutates process-global env, so every test using it must be `#[serial]`.
+pub(super) struct LoopbackEmbedder {
+    pub(super) server: wiremock::MockServer,
+    _state_dir: tempfile::TempDir,
+    prev_state_dir: Option<std::ffi::OsString>,
+    prev_no_server: Option<std::ffi::OsString>,
+}
+
+impl Drop for LoopbackEmbedder {
+    fn drop(&mut self) {
+        unsafe {
+            match self.prev_state_dir.take() {
+                Some(v) => std::env::set_var("SPELUNK_STATE_DIR", v),
+                None => std::env::remove_var("SPELUNK_STATE_DIR"),
+            }
+            match self.prev_no_server.take() {
+                Some(v) => std::env::set_var("SPELUNK_NO_SERVER", v),
+                None => std::env::remove_var("SPELUNK_NO_SERVER"),
+            }
+        }
+    }
+}
+
+/// The fp32 vector [`spawn_loopback_embedder`]'s `/index/embed` route returns.
+/// L2-normalised and 896-dim, so it survives the push's own dimension guard.
+pub(super) fn stub_vector() -> Vec<f32> {
+    let dim = spelunk_core::embeddings::EMBEDDING_DIM;
+    vec![1.0 / (dim as f32).sqrt(); dim]
+}
+
+/// Start a mocked loopback inference server for `project_id` and point
+/// auto-discovery at it. `failing_title_marker`, when given, makes the embed
+/// route 500 for any request whose body contains it, so a single row's embed
+/// failure can be exercised without failing the rest.
+pub(super) async fn spawn_loopback_embedder(
+    project_id: &str,
+    failing_title_marker: Option<&str>,
+) -> LoopbackEmbedder {
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "version": "0.9.5",
+            "capabilities": ["memory", "index.embed", "search.semantic"],
+            "instance_id": "00000000-0000-0000-0000-000000000001",
+            "started_by": null,
+            "embedding_dim": spelunk_core::embeddings::EMBEDDING_DIM,
+        })))
+        .mount(&server)
+        .await;
+    let embed_path = format!("/v1/projects/{project_id}/index/embed");
+    if let Some(marker) = failing_title_marker {
+        Mock::given(method("POST"))
+            .and(path(embed_path.clone()))
+            .and(body_string_contains(marker))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+    }
+    Mock::given(method("POST"))
+        .and(path(embed_path))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(spelunk_core::embeddings::vec_to_blob(&stub_vector())),
+        )
+        .mount(&server)
+        .await;
+
+    let port = server.address().port();
+    let state_dir = tempfile::TempDir::new().unwrap();
+    std::fs::write(state_dir.path().join("server.port"), format!("{port}\n")).unwrap();
+    let prev_state_dir = std::env::var_os("SPELUNK_STATE_DIR");
+    let prev_no_server = std::env::var_os("SPELUNK_NO_SERVER");
+    unsafe {
+        std::env::set_var("SPELUNK_STATE_DIR", state_dir.path());
+        std::env::remove_var("SPELUNK_NO_SERVER");
+    }
+    LoopbackEmbedder {
+        server,
+        _state_dir: state_dir,
+        prev_state_dir,
+        prev_no_server,
+    }
+}
+
 /// Open a fresh local memory store in a new tempdir, returning both (the
 /// tempdir must be kept alive by the caller for the store's lifetime).
 pub(super) fn fresh_store() -> (tempfile::TempDir, MemoryStore) {

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/test_support.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/test_support.rs
@@ -1,5 +1,5 @@
-//! Shared test fixtures for the `sync` module's submodule test suites
-//! ([`super::push`], [`super::pull`], [`super::round`]).
+// Shared test fixtures for the `sync` module's submodule test suites
+// (`super::push`, `super::pull`, `super::round`).
 
 use crate::storage::MemoryStore;
 
@@ -18,9 +18,9 @@ pub(super) fn register_sqlite_vec() {
     });
 }
 
-/// Spin up a real `spelunk-server` axum router (the production router) on
-/// an ephemeral loopback port, serving the team-hosting
-/// `/v1/projects/*/memory*` routes this test's `CloudSyncClient`s talk to.
+// Spin up a real `spelunk-server` axum router (the production router) on
+// an ephemeral loopback port, serving the team-hosting
+// `/v1/projects/*/memory*` routes this test's `CloudSyncClient`s talk to.
 pub(super) async fn spawn_spelunk_server() -> std::net::SocketAddr {
     register_sqlite_vec();
     let db_dir = tempfile::TempDir::new().unwrap();
@@ -83,17 +83,17 @@ impl Drop for LoopbackEmbedder {
     }
 }
 
-/// The fp32 vector [`spawn_loopback_embedder`]'s `/index/embed` route returns.
-/// L2-normalised and 896-dim, so it survives the push's own dimension guard.
+// The fp32 vector `spawn_loopback_embedder`'s `/index/embed` route returns.
+// L2-normalised and 896-dim, so it survives the push's own dimension guard.
 pub(super) fn stub_vector() -> Vec<f32> {
     let dim = spelunk_core::embeddings::EMBEDDING_DIM;
     vec![1.0 / (dim as f32).sqrt(); dim]
 }
 
-/// Start a mocked loopback inference server for `project_id` and point
-/// auto-discovery at it. `failing_title_marker`, when given, makes the embed
-/// route 500 for any request whose body contains it, so a single row's embed
-/// failure can be exercised without failing the rest.
+// Start a mocked loopback inference server for `project_id` and point
+// auto-discovery at it. `failing_title_marker`, when given, makes the embed
+// route 500 for any request whose body contains it, so a single row's embed
+// failure can be exercised without failing the rest.
 pub(super) async fn spawn_loopback_embedder(
     project_id: &str,
     failing_title_marker: Option<&str>,
@@ -149,8 +149,8 @@ pub(super) async fn spawn_loopback_embedder(
     }
 }
 
-/// Open a fresh local memory store in a new tempdir, returning both (the
-/// tempdir must be kept alive by the caller for the store's lifetime).
+// Open a fresh local memory store in a new tempdir, returning both (the
+// tempdir must be kept alive by the caller for the store's lifetime).
 pub(super) fn fresh_store() -> (tempfile::TempDir, MemoryStore) {
     register_sqlite_vec();
     let tmp = tempfile::TempDir::new().unwrap();

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -856,8 +856,10 @@ of adding a duplicate, so the printed pull count reflects only genuinely new
 rows. Pre-promotion, a pull can still add a distinct row alongside matching
 local content, same as `memory add`.
 
-**Backfilling missing embeddings:** a note's semantic vector is minted only at
-`memory add` time, so a note added while the embedder was down, or carried
+**Backfilling missing embeddings:** a note's semantic vector is minted at
+`memory add` time, and again by `memory push` / `sync` for any entry in the set
+they are about to push that still lacks one. A note that misses both, added
+while the embedder was down and never pushed, or carried
 through the 768→896 embedding-dimension upgrade (which drops the old vectors),
 stays present-but-unembedded: still found by text search, `list`, `timeline`,
 and `context`, but absent from semantic `memory search`. `spelunk memory
@@ -899,6 +901,25 @@ spelunk sync [--project <slug>] [--source <path>] [--include-archived]
 
 For a one-directional transfer, use `spelunk memory push` (local → server) or
 `spelunk memory pull` (server → local).
+
+**The push embeds what it pushes.** Before the batch is built, both `spelunk
+sync` and `spelunk memory push` embed every entry in the push set that has no
+usable local vector, through the local loopback embedder and using the same
+document text `spelunk memory reindex` uses, and commit each vector to
+`memory.db`. A pushed entry is then findable by semantic `memory search` locally
+without a separate `reindex`. This changes what is stored locally, not what is
+sent: `kind`, `title`, and `body` are serialised on every push and always were,
+and the vector fields are additive. The step is skipped in `cloud_first` mode
+with a `server_url` set, the same condition `memory reindex` declines under. With
+no local embedder reachable the push still completes, text-only, with the exit
+code it always had, and prints one warning naming how many entries went out
+without a local embedding and that `spelunk memory reindex` is the cure. The
+summary line reports the local embed count separately from `created` /
+`skipped` / `failed`, for example `Sync complete. Pushed 4 entries (created 4,
+skipped 0), applied 1 new remote entries. Embedded 2 locally.` Entries already
+synced, and entries arriving via `memory pull`, are outside the push set and are
+not embedded by this step. See [Backfilling missing
+embeddings](memory.md#backfilling-missing-embeddings).
 
 ---
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -159,7 +159,10 @@ synced at least once, the clause persists even after the outbox fully
 drains, for example `mode  local_first  ·  up to date, last synced 4m ago`.
 Use `spelunk sync` (or the one-way `spelunk memory push` / `spelunk memory
 pull`) whenever you want to force a synchronous reconcile with the server
-instead of waiting on the background drain.
+instead of waiting on the background drain. Both commands also embed the entries
+they push into the local `memory.db` first, so a pushed entry stays findable by
+semantic `memory search` on your own machine (see [Repair during push and
+sync](#repair-during-push-and-sync)).
 
 **`cloud_first`** makes the server authoritative: reads and writes go straight
 to it, and an unreachable or untrusted server is a hard error naming the cause
@@ -810,11 +813,14 @@ to be able to undo it).
 
 ## Backfilling missing embeddings
 
-A note's semantic vector is created only when the note is first added
-(`spelunk memory add`). If no embedder was reachable at that moment, or the
-store was upgraded across the 768→896 embedding-dimension change (which drops
-the old vectors and rebuilds `note_embeddings` empty), the note stays in
-`memory.db` **present but unembedded**. Such a note is still found by text
+A note's semantic vector is normally minted when the note is first added
+(`spelunk memory add`), and `spelunk memory push` / `spelunk sync` mint one for
+any entry in the set they are about to push that still lacks it (see [Repair
+during push and sync](#repair-during-push-and-sync)). A note that misses both
+moments, because no embedder was reachable, or because the store was upgraded
+across the 768→896 embedding-dimension change (which drops the old vectors and
+rebuilds `note_embeddings` empty), stays in `memory.db` **present but
+unembedded**. Such a note is still found by text
 search (`--mode text`), `memory list`, `memory timeline`, and `context`; it is
 only missing from *semantic* `memory search`, because semantic ranking is a KNN
 over the embedding vectors and this note has none.
@@ -867,6 +873,56 @@ a one-line notice naming the count and pointing at `spelunk memory reindex`, so
 the recall gap is discoverable without `RUST_LOG`. The notice is a pointer, not
 an auto-repair: it embeds nothing itself. Running `reindex` is what restores
 semantic recall.
+
+### Repair during push and sync
+
+`spelunk memory push` and `spelunk sync` embed what they are about to push.
+Before the batch is built, every entry in the push set that has no usable local
+vector is embedded through the local loopback embedder, using the same document
+text and the same document-side embedding call `spelunk memory reindex` uses,
+and each vector is committed to `memory.db` as it completes. A pushed entry is
+therefore findable by semantic `memory search` on your own machine afterwards,
+with no separate `reindex` step. Previously a push left `memory.db` exactly as
+it found it, so entries it had just pushed stayed invisible to local semantic
+search and nothing said so.
+
+This changes what is stored locally, not what is sent. `kind`, `title`, and
+`body` are serialised on every push and always were; the vector fields are
+additive, so the same entry text travels either way. What a local vector adds is
+that a destination advertising `accepts_pushed_vectors` can store the entry
+as-is instead of re-embedding it.
+
+Scope and limits:
+
+- Only the push set is repaired: entries that are active and not yet synced.
+  Entries already synced, and entries arriving through `spelunk memory pull`,
+  are outside it and still need `spelunk memory reindex`.
+- The embed always runs against the local loopback embedder, never against a
+  configured team `server_url`. This is the same way `reindex` resolves its
+  embedder.
+- Skipped entirely in `cloud_first` mode with a team `server_url` set, where
+  `memory.db` is not the store of record. That is the same condition
+  `spelunk memory reindex` declines under, so the two commands agree about when
+  local embeddings are meaningful.
+- With no local embedder reachable, the push still runs to completion and exits
+  exactly as it did before, every entry text-only. It prints one warning:
+
+  ```
+  warning: 2 entries pushed without a local embedding, so `spelunk memory search` cannot surface them in this project until `spelunk memory reindex` is run.
+  ```
+
+  A single entry's embed failure behaves the same way: that entry goes out
+  text-only and is counted in the warning, the rest of the push still gets
+  vectors, and the command does not abort.
+- The summary line reports how many entries were embedded locally, separately
+  from `created` / `skipped` / `failed`:
+
+  ```
+  Done. Pushed 4 entries (created 4, skipped 0). Embedded 2 locally.
+  ```
+
+  A push that neither minted nor missed a vector prints the summary line
+  unchanged.
 
 ## Using memory as context
 


### PR DESCRIPTION
`spelunk memory push` and `spelunk sync` now embed every entry in the push set
that lacks a usable local vector, through the local loopback embedder, and
commit each vector to `memory.db` before the batch is built. Previously a push
left the local store exactly as it found it: it reported `created`, and the rows
it had just pushed stayed invisible to semantic `spelunk memory search` on the
user's own machine, with nothing saying so and no hint that
`spelunk memory reindex` was the cure.

## What travels is unchanged

`kind`, `title`, and `body` were always serialised on every push, and the
optional `vector` / `vector_model` / `vector_precision` fields are additive. A
local embedding changes zero bytes of entry content on the wire. What changes is
that the local store is left correct, and that a destination advertising
`accepts_pushed_vectors` can store the entry as-is instead of re-embedding it.
The existing `maybe_attach_vector` gate is untouched.

## The guarantee

The local embed resolves through the inference tier (`get_inference_tier` plus
`effective_config`), exactly as `memory reindex` does. Outside `cloud_first`
that branch probes loopback and nothing else, and `resolve_inference_url` falls
back to `server_url` only under `cloud_first`, which is precisely the case the
repair skips. A configured team `server_url` is therefore structurally
unreachable from the embed path, so the fix cannot recreate the server-side
re-embedding it removes.

The document string and the document-side call are byte-identical to
`memory reindex`'s (`title: {title} | text: {body}`, via `embed_text`, never a
query-side prefix), so a vector minted during a push is interchangeable with a
reindexed one.

## Behaviour at the edges

- No local embedder reachable: the push runs to completion text-only with the
  exit code it always had, emits one warning naming how many entries went out
  unembedded and the remedy, and reports the count in the summary line.
- A single row's embed failure: that row ships text-only, the rest still get
  vectors, and the push does not abort.
- Skipped entirely in `cloud_first` with a `server_url` set, the same condition
  `memory reindex` declines under. The two are now pinned against each other
  across six mode / `server_url` shapes so neither can drift alone.
- Rows already synced, and archived rows, are outside the push set and are not
  embedded.
- Vectors commit per row, so an interrupted push keeps every vector it minted
  and a re-run embeds only the remainder.

## Docs

`docs/memory.md` and `docs/commands.md` both stated that a note's semantic
vector is minted only at `memory add` time. That is no longer true, and both are
corrected. A new "Repair during push and sync" section covers the behaviour and
its limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
