### PR TITLE
Parse the URL authority when deciding loopback, instead of prefix-matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,11 +197,15 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   `localhost` or an address literal the standard library parses and reports as
   loopback. The backslash is part of that delimiter set because the URL parser
   that opens the connection treats it as a path separator for `http`/`https`,
-  so `http://evil.example\@127.0.0.1` names `evil.example`, not loopback. As a side effect, non-canonical literals that previously rode in on
-  the `127.` prefix (`127.999.0.1`, `0127.0.0.1`) are rejected too. Unchanged,
-  and still deliberate: this check does no DNS resolution, so a `/etc/hosts`
-  alias that resolves to loopback but isn't spelled as a loopback literal is
-  still rejected rather than accepted.
+  so `http://evil.example\@127.0.0.1` names `evil.example`, not loopback.
+  One user-visible consequence: only a full dotted quad counts as a loopback
+  literal now, so IPv4 spellings that previously rode in on the `127.` prefix
+  are rejected, whether they were invalid (`127.999.0.1`), non-canonical
+  (`0127.0.0.1`, `127.0.0.001`) or merely abbreviated (`127.1`). Write the
+  address out as `127.0.0.1` if you were using one of those. Unchanged, and
+  still deliberate: this check does no DNS resolution, so a `/etc/hosts` alias
+  that resolves to loopback but isn't spelled as a loopback literal is still
+  rejected rather than accepted.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,30 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   crashes during first-sync push and concurrent first-sync attempts from
   multiple clients.
 
+### Security
+
+- **A `server_url` whose host only *looks* like loopback no longer clears the
+  plaintext-transport guard.** Deciding "is this loopback?" was a prefix test,
+  `host.starts_with("127.")`, applied to a string from which URL userinfo had
+  never been stripped. Two authority shapes therefore passed as loopback while
+  naming somebody else's host: `http://127.0.0.1.evil.example`, where the real
+  host is `evil.example` and only the leading label looks like an address, and
+  `http://127.0.0.1@evil.example`, where everything before the `@` is a
+  credential and the real host is again `evil.example`. Because that predicate
+  is what decides whether a bearer token may travel over plaintext `http://`,
+  configuring either shape sent the bearer in the clear to a host the operator
+  did not intend, at every call site that gates on it: opening a remote memory
+  backend, the sync client's keyed constructor, the CLI capability probe, and
+  the inference client. The authority is now parsed rather than pattern-matched:
+  it ends at the first `/`, `?` or `#`, userinfo is removed at the last `@`, the
+  port and IPv6 brackets are stripped, and the remaining host must be
+  `localhost` or an address literal the standard library parses and reports as
+  loopback. As a side effect, non-canonical literals that previously rode in on
+  the `127.` prefix (`127.999.0.1`, `0127.0.0.1`) are rejected too. Unchanged,
+  and still deliberate: this check does no DNS resolution, so a `/etc/hosts`
+  alias that resolves to loopback but isn't spelled as a loopback literal is
+  still rejected rather than accepted.
+
 ### Internal
 
 - **`memory.db` now opens through the same forward-only, `PRAGMA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,10 +192,12 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   did not intend, at every call site that gates on it: opening a remote memory
   backend, the sync client's keyed constructor, the CLI capability probe, and
   the inference client. The authority is now parsed rather than pattern-matched:
-  it ends at the first `/`, `?` or `#`, userinfo is removed at the last `@`, the
-  port and IPv6 brackets are stripped, and the remaining host must be
+  it ends at the first `/`, `?`, `#` or `\`, userinfo is removed at the last
+  `@`, the port and IPv6 brackets are stripped, and the remaining host must be
   `localhost` or an address literal the standard library parses and reports as
-  loopback. As a side effect, non-canonical literals that previously rode in on
+  loopback. The backslash is part of that delimiter set because the URL parser
+  that opens the connection treats it as a path separator for `http`/`https`,
+  so `http://evil.example\@127.0.0.1` names `evil.example`, not loopback. As a side effect, non-canonical literals that previously rode in on
   the `127.` prefix (`127.999.0.1`, `0127.0.0.1`) are rejected too. Unchanged,
   and still deliberate: this check does no DNS resolution, so a `/etc/hosts`
   alias that resolves to loopback but isn't spelled as a loopback literal is

--- a/crates/spelunk-cli/src/capability/probe.rs
+++ b/crates/spelunk-cli/src/capability/probe.rs
@@ -1298,4 +1298,21 @@ mod tests {
              transition, not return a value pinned by the first call; got {second:?}"
         );
     }
+
+    // A spoofed-loopback authority must be refused by the probe before any
+    // request leaves, exactly as a plainly non-loopback host is. No mock server
+    // is mounted: reaching the network at all would be the failure.
+    #[tokio::test]
+    async fn probe_url_rejects_spoofed_loopback_authorities() {
+        for url in [
+            "http://127.0.0.1.evil.example",
+            "http://127.0.0.1@evil.example",
+            "http://127.0.0.1:1234@evil.example",
+        ] {
+            let err = probe_url(url, std::time::Duration::from_millis(1), false, None)
+                .await
+                .expect_err("a host that only looks like loopback must be rejected");
+            assert!(err.contains("loopback"), "{url}: {err}");
+        }
+    }
 }

--- a/crates/spelunk-cli/src/server_client.rs
+++ b/crates/spelunk-cli/src/server_client.rs
@@ -1206,6 +1206,21 @@ mod tests {
         assert!(err.contains("https"));
     }
 
+    // The inference client gates on the same validator, so an authority that
+    // only looks like loopback must not reach the point of carrying a bearer.
+    #[test]
+    fn transport_validator_rejects_spoofed_loopback_authorities() {
+        for url in [
+            "http://127.0.0.1.evil.example",
+            "http://127.0.0.1@evil.example",
+            "http://127.0.0.1:1234@evil.example",
+        ] {
+            let err = spelunk_core::config::validate_transport_url(url)
+                .expect_err("a host that only looks like loopback must be rejected");
+            assert!(err.contains("loopback"), "{url}: {err}");
+        }
+    }
+
     #[test]
     #[serial_test::serial]
     fn from_config_accepts_loopback_http_inference_url() {

--- a/crates/spelunk-core/src/config/predicates.rs
+++ b/crates/spelunk-core/src/config/predicates.rs
@@ -9,33 +9,69 @@ pub fn no_server_env_set() -> bool {
     )
 }
 
-/// Return `true` if `url` targets a loopback address (`127.x.x.x`, `localhost`, `::1`).
+/// Return `true` if `url` targets a loopback address (`127.0.0.0/8`, `localhost`, `::1`).
 ///
-/// This is a lightweight string check — no DNS resolution.
+/// The authority is parsed, never prefix-matched: userinfo is removed, the port
+/// and IPv6 brackets are stripped, and what remains must be `localhost` or an
+/// address literal that the standard library parses and reports as loopback.
+/// Decoration around a loopback-looking host therefore cannot smuggle a
+/// different host past the check: `127.0.0.1.evil.example` and
+/// `127.0.0.1@evil.example` both name `evil.example` and are not loopback.
+///
+/// This is a lightweight string check: no DNS resolution.
 pub fn is_loopback_url(url: &str) -> bool {
-    // Strip scheme and authority prefix up to the host.
-    let host_part = url
-        .trim_start_matches("http://")
-        .trim_start_matches("https://");
+    url_host(url).is_some_and(host_is_loopback)
+}
 
-    // Extract the host (before any path or port).
-    let host = if let Some(idx) = host_part.find('/') {
-        &host_part[..idx]
-    } else {
-        host_part
-    };
-    // Drop port if present (handle IPv6 bracketed form too).
-    let host = if host.starts_with('[') {
-        // IPv6: [::1]:port or [::1]
-        host.trim_start_matches('[')
-            .split(']')
-            .next()
-            .unwrap_or(host)
-    } else {
-        host.split(':').next().unwrap_or(host)
+/// Extract the host from `url`: scheme, userinfo, port and IPv6 brackets removed.
+fn url_host(url: &str) -> Option<&str> {
+    let rest = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+        .unwrap_or(url);
+
+    // The authority ends at the first `/`, `?` or `#`. Without bounding it,
+    // an `@` later in the query would move the apparent host past the real
+    // one: `http://evil.example/?@127.0.0.1`.
+    let authority = match rest.find(['/', '?', '#']) {
+        Some(idx) => &rest[..idx],
+        None => rest,
     };
 
-    matches!(host, "localhost" | "127.0.0.1" | "::1") || host.starts_with("127.")
+    // Userinfo is everything before the *last* `@`: in `127.0.0.1:1234@host`
+    // the leading text is a credential shaped like `host:port`, not a host.
+    let host_port = match authority.rfind('@') {
+        Some(idx) => &authority[idx + 1..],
+        None => authority,
+    };
+
+    if let Some(after_bracket) = host_port.strip_prefix('[') {
+        return after_bracket.split(']').next();
+    }
+    // Several colons and no brackets means a bare IPv6 literal, which must not
+    // be truncated at the first colon the way `host:port` is.
+    if host_port.matches(':').count() > 1 {
+        return Some(host_port);
+    }
+    host_port.split(':').next()
+}
+
+/// `true` when `host` is exactly `localhost` or an address literal in
+/// `127.0.0.0/8` / `::1`.
+///
+/// Address literals go through the standard library's parsers, which reject the
+/// non-canonical forms a hand-rolled check tends to admit: `127.999.0.1` is out
+/// of range and `0127.0.0.1` has a leading zero, so neither parses, and neither
+/// can ride in on a `127.` prefix.
+fn host_is_loopback(host: &str) -> bool {
+    if host == "localhost" {
+        return true;
+    }
+    if let Ok(v4) = host.parse::<std::net::Ipv4Addr>() {
+        return v4.is_loopback();
+    }
+    host.parse::<std::net::Ipv6Addr>()
+        .is_ok_and(|v6| v6.is_loopback())
 }
 
 /// Return `true` when `url` targets a loopback host (see [`is_loopback_url`])
@@ -71,12 +107,20 @@ pub fn is_loopback_url_missing_port(url: &str) -> bool {
 /// clear. There is no opt-out env var: the fix is always "use https, or
 /// loopback".
 ///
-/// Like [`is_loopback_url`], this is a lightweight string check on the literal
-/// host — there is no DNS resolution. A `/etc/hosts` alias or other custom DNS
-/// entry that resolves to a loopback address but isn't spelled `127.x.x.x`,
-/// `::1`, or `localhost` is **not** recognised as loopback and is rejected;
-/// this is intentional (fail closed, not open) and the known limitation of a
-/// string-based check.
+/// Like [`is_loopback_url`], this is a lightweight check on the literal host
+/// with no DNS resolution. Two distinct consequences, which are easy to
+/// conflate:
+///
+/// * A `/etc/hosts` alias or other custom DNS entry that resolves to a loopback
+///   address but isn't spelled `127.x.x.x`, `::1`, or `localhost` is **not**
+///   recognised as loopback and is rejected. This is intentional (fail closed,
+///   not open) and the known limitation of a string-based check.
+/// * The authority is *parsed* rather than prefix-matched: userinfo is stripped
+///   at the last `@`, the authority ends at the first `/`, `?` or `#`, and the
+///   remaining host must parse as an exact literal. Decoration around a
+///   loopback-looking host cannot smuggle a different host past the check, so
+///   `http://127.0.0.1@evil.example` and `http://127.0.0.1.evil.example` are
+///   rejected as the non-loopback hosts they are.
 ///
 /// Returns `Ok(())` for a valid URL, or a one-line `Err` naming the fix.
 pub fn validate_transport_url(url: &str) -> Result<(), String> {
@@ -139,6 +183,73 @@ mod tests {
     fn is_loopback_url_rejects_address_with_127_in_path() {
         // Should NOT match just because "127" appears somewhere
         assert!(!is_loopback_url("http://example.com/proxy/127.0.0.1"));
+    }
+
+    #[test]
+    fn is_loopback_url_rejects_host_that_merely_starts_with_a_loopback_literal() {
+        assert!(!is_loopback_url("http://127.0.0.1.evil.example"));
+    }
+
+    #[test]
+    fn is_loopback_url_rejects_userinfo_that_looks_like_a_loopback_host() {
+        assert!(!is_loopback_url("http://127.0.0.1@evil.example"));
+    }
+
+    #[test]
+    fn is_loopback_url_rejects_userinfo_shaped_like_host_and_port() {
+        // The colon makes the credential look like `host:port` to a check that
+        // splits on `:` before it strips userinfo.
+        assert!(!is_loopback_url("http://127.0.0.1:1234@evil.example"));
+    }
+
+    #[test]
+    fn is_loopback_url_accepts_real_loopback_host_carrying_userinfo() {
+        // Stripping userinfo must not swing the other way and reject a
+        // genuinely loopback host that happens to carry credentials.
+        assert!(is_loopback_url("http://evil.example@127.0.0.1:7777"));
+        assert!(is_loopback_url("http://user:pass@localhost:7777"));
+    }
+
+    #[test]
+    fn is_loopback_url_splits_userinfo_on_the_last_at_sign() {
+        assert!(is_loopback_url("http://a@b@127.0.0.1:7777"));
+        assert!(!is_loopback_url("http://127.0.0.1@a@evil.example"));
+    }
+
+    #[test]
+    fn is_loopback_url_rejects_octet_out_of_range() {
+        assert!(!is_loopback_url("http://127.999.0.1"));
+    }
+
+    #[test]
+    fn is_loopback_url_rejects_non_canonical_leading_zero_octet() {
+        // Pinned deliberately: `0127.0.0.1` is not a canonical dotted quad, so
+        // it is rejected rather than normalised to 127.0.0.1.
+        assert!(!is_loopback_url("http://0127.0.0.1"));
+        assert!(!is_loopback_url("http://127.00.0.1"));
+    }
+
+    #[test]
+    fn is_loopback_url_rejects_at_sign_beyond_the_authority() {
+        // The query and fragment are not part of the authority, so an `@`
+        // inside them must not relocate the host.
+        assert!(!is_loopback_url("http://evil.example/?@127.0.0.1"));
+        assert!(!is_loopback_url("http://evil.example?@127.0.0.1"));
+        assert!(!is_loopback_url("http://evil.example#@127.0.0.1"));
+    }
+
+    #[test]
+    fn is_loopback_url_accepts_expanded_ipv6_loopback() {
+        // Consequence of parsing the literal instead of comparing it to the
+        // string "::1": every spelling the parser calls loopback is loopback.
+        assert!(is_loopback_url("http://[0:0:0:0:0:0:0:1]:7777"));
+    }
+
+    #[test]
+    fn is_loopback_url_rejects_partial_loopback_literals() {
+        assert!(!is_loopback_url("http://127.0.0"));
+        assert!(!is_loopback_url("http://127.0.0.1.2"));
+        assert!(!is_loopback_url("http://localhost.evil.example"));
     }
 
     // ── is_loopback_url_missing_port ─────────────────────────────────────────
@@ -239,5 +350,22 @@ mod tests {
     #[test]
     fn validate_transport_url_accepts_bare_ipv6_loopback_no_port() {
         assert!(validate_transport_url("http://[::1]/").is_ok());
+    }
+
+    // A bearer travels over plaintext http only to loopback, so an authority
+    // that merely looks like loopback must not clear this gate.
+    #[test]
+    fn validate_transport_url_rejects_spoofed_loopback_authorities() {
+        for url in [
+            "http://127.0.0.1.evil.example",
+            "http://127.0.0.1@evil.example",
+            "http://127.0.0.1:1234@evil.example",
+            "http://127.0.0.1.evil.example:7777/v1/health",
+        ] {
+            let err = validate_transport_url(url)
+                .expect_err("a host that only looks like loopback must be rejected");
+            assert!(err.contains("loopback"), "{url}: error must name the fix");
+            assert!(err.contains("https"), "{url}: error must name the fix");
+        }
     }
 }

--- a/crates/spelunk-core/src/config/predicates.rs
+++ b/crates/spelunk-core/src/config/predicates.rs
@@ -30,10 +30,13 @@ fn url_host(url: &str) -> Option<&str> {
         .or_else(|| url.strip_prefix("https://"))
         .unwrap_or(url);
 
-    // The authority ends at the first `/`, `?` or `#`. Without bounding it,
-    // an `@` later in the query would move the apparent host past the real
-    // one: `http://evil.example/?@127.0.0.1`.
-    let authority = match rest.find(['/', '?', '#']) {
+    // The authority ends at the first `/`, `?`, `#` or `\`. Without bounding
+    // it, an `@` later in the URL would move the apparent host past the real
+    // one: `http://evil.example/?@127.0.0.1`. The backslash belongs in that set
+    // because a WHATWG URL parser (which is what actually opens the
+    // connection) treats it as a path separator for http(s), so in
+    // `http://evil.example\@127.0.0.1` the host is `evil.example`.
+    let authority = match rest.find(['/', '?', '#', '\\']) {
         Some(idx) => &rest[..idx],
         None => rest,
     };
@@ -116,8 +119,8 @@ pub fn is_loopback_url_missing_port(url: &str) -> bool {
 ///   recognised as loopback and is rejected. This is intentional (fail closed,
 ///   not open) and the known limitation of a string-based check.
 /// * The authority is *parsed* rather than prefix-matched: userinfo is stripped
-///   at the last `@`, the authority ends at the first `/`, `?` or `#`, and the
-///   remaining host must parse as an exact literal. Decoration around a
+///   at the last `@`, the authority ends at the first `/`, `?`, `#` or `\`, and
+///   the remaining host must parse as an exact literal. Decoration around a
 ///   loopback-looking host cannot smuggle a different host past the check, so
 ///   `http://127.0.0.1@evil.example` and `http://127.0.0.1.evil.example` are
 ///   rejected as the non-loopback hosts they are.
@@ -236,6 +239,18 @@ mod tests {
         assert!(!is_loopback_url("http://evil.example/?@127.0.0.1"));
         assert!(!is_loopback_url("http://evil.example?@127.0.0.1"));
         assert!(!is_loopback_url("http://evil.example#@127.0.0.1"));
+    }
+
+    #[test]
+    fn is_loopback_url_rejects_backslash_delimited_authority() {
+        // A URL parser following the WHATWG rules ends the authority at a
+        // backslash for http(s), so the real host here is `evil.example` and
+        // everything from the backslash on is the path. Treating the backslash
+        // as an ordinary character would put `127.0.0.1` after the last `@` and
+        // read the whole thing as loopback.
+        assert!(!is_loopback_url(r"http://evil.example\@127.0.0.1"));
+        assert!(!is_loopback_url(r"http://evil.example\@127.0.0.1:7777"));
+        assert!(!is_loopback_url(r"http://evil.example\\@127.0.0.1"));
     }
 
     #[test]
@@ -361,6 +376,7 @@ mod tests {
             "http://127.0.0.1@evil.example",
             "http://127.0.0.1:1234@evil.example",
             "http://127.0.0.1.evil.example:7777/v1/health",
+            r"http://evil.example\@127.0.0.1",
         ] {
             let err = validate_transport_url(url)
                 .expect_err("a host that only looks like loopback must be rejected");

--- a/crates/spelunk-core/src/storage/backend_selection_tests.rs
+++ b/crates/spelunk-core/src/storage/backend_selection_tests.rs
@@ -672,6 +672,37 @@ async fn cloud_first_rejects_non_loopback_http() {
     assert!(msg.contains("https"), "error must name the fix; got: {msg}");
 }
 
+// The same guard, against authorities that only look like loopback. These
+// reached the remote backend before the authority was parsed rather than
+// prefix-matched, which put the bearer on the wire in the clear to the host
+// after the `@` or the suffix.
+#[tokio::test]
+#[serial_test::serial]
+async fn cloud_first_rejects_spoofed_loopback_http() {
+    clear_env();
+    for url in [
+        "http://127.0.0.1.evil.example:7777",
+        "http://127.0.0.1@evil.example:7777",
+        "http://127.0.0.1:1234@evil.example:7777",
+    ] {
+        let cfg = Config {
+            server_url: Some(url.to_string()),
+            project_id: Some("11111111-1111-1111-1111-111111111111".to_string()),
+            mode: Some(SyncMode::CloudFirst),
+            server_key: Some("secret".to_string()),
+            ..Default::default()
+        };
+        let err = open_memory_backend(&cfg, std::path::Path::new(":memory:"), None)
+            .await
+            .map(|_| ())
+            .expect_err("a host that only looks like loopback must be rejected");
+        assert!(
+            err.to_string().contains("loopback"),
+            "{url}: error must name the fix; got: {err}"
+        );
+    }
+}
+
 #[tokio::test]
 #[serial_test::serial]
 async fn no_server_kill_switch_forces_local() {

--- a/crates/spelunk-core/src/storage/remote/sync.rs
+++ b/crates/spelunk-core/src/storage/remote/sync.rs
@@ -779,6 +779,21 @@ mod tests {
     }
 
     #[test]
+    fn new_with_key_rejects_spoofed_loopback_authorities() {
+        for url in [
+            "http://127.0.0.1.evil.example",
+            "http://127.0.0.1@evil.example",
+            "http://127.0.0.1:1234@evil.example",
+        ] {
+            let err = match CloudSyncClient::new(url, "proj", Some("secret"), None) {
+                Err(e) => e.to_string(),
+                Ok(_) => panic!("{url} must not be accepted as loopback"),
+            };
+            assert!(err.contains("plaintext http"), "{url}: {err}");
+        }
+    }
+
+    #[test]
     fn new_keyless_construction_unaffected_by_transport() {
         // No bearer to leak, so even a non-loopback plaintext dev server is fine.
         assert!(CloudSyncClient::new("http://team-server:7777", "proj", None, None).is_ok());


### PR DESCRIPTION
## The bug

`is_loopback_url` decided loopback like this:

```rust
matches!(host, "localhost" | "127.0.0.1" | "::1") || host.starts_with("127.")
```

`host` was derived by stripping the scheme, the path, and the port, but **never the userinfo**, and the final test was a *prefix* match rather than an exact one. Two authority shapes therefore read as loopback while naming somebody else entirely:

| URL | Real host | Old verdict |
|---|---|---|
| `http://127.0.0.1.evil.example` | `evil.example` | loopback |
| `http://127.0.0.1@evil.example` | `evil.example` | loopback |
| `http://127.0.0.1:1234@evil.example` | `evil.example` | loopback |

`validate_transport_url` delegates to that predicate to decide whether a bearer token may travel over plaintext `http://`. So configuring any of those as `server_url` sent the credential **in the clear to an attacker-chosen host**, at every site that gates on it:

- `crates/spelunk-core/src/storage/mod.rs` (opening a remote memory backend)
- `crates/spelunk-core/src/storage/remote/sync.rs` (the `api_key.is_some()` guard)
- `crates/spelunk-cli/src/capability/probe.rs` (capability probe)
- `crates/spelunk-cli/src/server_client.rs` (`ServerClient::build`)

## The fix

Parse the authority rather than pattern-match the string:

1. Bound the authority at the first `/`, `?`, `#` or `\`.
2. Strip userinfo at the **last** `@` (in `127.0.0.1:1234@host` the leading text is a credential shaped like `host:port`, not a host and port).
3. Strip the port and IPv6 brackets.
4. Require what remains to be exactly `localhost`, or an address literal that `std`'s `Ipv4Addr`/`Ipv6Addr` parsers accept and report as loopback.

Step 1 exists **because of** step 2: once userinfo is stripped, an unbounded authority would let `http://evil.example/?@127.0.0.1` newly parse as loopback. That shape is a regression the fix itself would otherwise have introduced, and it has its own test.

The backslash belongs in that delimiter set for the same reason, and it is the subtler half. A WHATWG URL parser (which is what `reqwest` uses to actually open the connection) treats `\` as a path separator for `http`/`https`, so in `http://evil.example\@127.0.0.1` the host is `evil.example` and everything from the backslash on is the path. Bounding only at `/`, `?` and `#` left `127.0.0.1` sitting after the last `@`, and the authority read as loopback while the connection went to `evil.example`. This was verified by differential testing rather than by reading the spec: for a corpus of authority shapes, the predicate's verdict was compared against the host `reqwest::Url` actually resolves, and this was the one class where the predicate said loopback and the real host was not.

Using the standard library's parsers rather than a hand-rolled octet check also closes the non-canonical forms that rode in on the `127.` prefix: `127.999.0.1` (out of range) and `0127.0.0.1` (leading zero) are both rejected now.

**Deliberately unchanged:** this check still does no DNS resolution, so an `/etc/hosts` alias that resolves to loopback but is not *spelled* as a loopback literal is still rejected. That fail-closed limitation is pre-existing, correct, and still asserted by its original test. The same differential run found five shapes that a URL parser resolves to loopback but this predicate rejects (`127.1`, `0x7f.0.0.1`, `2130706433`, a trailing-dot `127.0.0.1.`, and uppercase `LOCALHOST`). All five fail closed, all five behave the same way on `main`, and the strictness is what the change is for, so none of them are loosened here. One accepted consequence in the other direction: expanded IPv6 loopback spellings such as `0:0:0:0:0:0:0:1` are now recognised, since they genuinely are loopback. That is pinned by a test so it is a stated decision rather than an accident.

## Acceptance criteria and evidence

| Criterion | Evidence |
|---|---|
| Suffix lookalike rejected | `is_loopback_url_rejects_host_that_merely_starts_with_a_loopback_literal` |
| Userinfo-prefixed authority rejected | `is_loopback_url_rejects_userinfo_that_looks_like_a_loopback_host` |
| Userinfo containing a colon rejected | `is_loopback_url_rejects_userinfo_shaped_like_host_and_port` |
| No false negative on a real loopback host carrying credentials | `is_loopback_url_accepts_real_loopback_host_carrying_userinfo` |
| Split on the last `@` | `is_loopback_url_splits_userinfo_on_the_last_at_sign` |
| `@` outside the authority does not relocate the host | `is_loopback_url_rejects_at_sign_beyond_the_authority` |
| Backslash-delimited authority | `is_loopback_url_rejects_backslash_delimited_authority` |
| Invalid octet rejected | `is_loopback_url_rejects_octet_out_of_range` |
| Leading-zero octet rejected (behaviour pinned) | `is_loopback_url_rejects_non_canonical_leading_zero_octet` |
| Existing loopback/non-loopback behaviour unchanged | the pre-existing `predicates.rs` tests, all still passing unmodified |
| DNS alias still fail-closed | `validate_transport_url_rejects_hostname_alias_even_if_it_would_resolve_to_loopback`, untouched |
| `validate_transport_url` rejects every spoofed shape | `validate_transport_url_rejects_spoofed_loopback_authorities` |
| Fix propagates to the remote-backend open path | `cloud_first_rejects_spoofed_loopback_http` |
| Fix propagates to the sync client | `new_with_key_rejects_spoofed_loopback_authorities` |
| Fix propagates to the capability probe | `probe_url_rejects_spoofed_loopback_authorities` |
| Fix propagates to the inference client | `transport_validator_rejects_spoofed_loopback_authorities` |
| Doc comment corrected | `validate_transport_url` doc comment now separates the parsed-authority guarantee from the still-true no-DNS fail-closed limitation |

## Tests are load-bearing, not decorative

Each was checked by mutation: break the behaviour, watch the right tests go red.

| Mutation | Result |
|---|---|
| Reintroduce `host.starts_with("127.")` | 5 failed, including both lookalike and both non-canonical-octet tests |
| Remove userinfo stripping | 4 failed, including the no-false-negative test |
| Unbound the authority (drop `?`/`#`) | 1 failed: `is_loopback_url_rejects_at_sign_beyond_the_authority` |

## Gate results

Rebased onto `main` at `c7f8180` and re-run there. Every cargo command carried `SPELUNK_SECRET_STORE=file`, and every test command additionally carried `SPELUNK_CONFIG_DIR=$(mktemp -d)` per the verification skill's isolation section.

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --all-targets --features rich-formats -- -D warnings` | pass, zero warnings |
| `cargo build --all-targets --features rich-formats` | pass |
| `cargo test --features rich-formats --no-fail-fast` | 1902 passed, 33 failed |
| `cargo test --doc --features rich-formats` | pass |
| `scripts/check-git-isolation.sh` | pass |
| Diff hygiene (tracker refs, em-dashes, doc-comments in tests) | clean |

`cargo nextest` is not installed on the machine this ran on, so `cargo test --no-fail-fast` stood in for it.

### About those 33 failures

They are **pre-existing and unrelated**, not caused by this change. The full suite was run on the merge base (`c7f8180`) in the same container, with the same environment and the same isolation, and the sets of failing test names are byte-identical:

```
branch failing tests: 33
main   failing tests: 33
regressions (fail on branch, pass on main): none
IDENTICAL FAILURE SETS
```

Passing counts differ by exactly the 16 tests this PR adds (1886 on main, 1902 here). The failures are CLI integration tests around colour output, `memory list`/`read-memory`/`push`/`sync`, `status`, and auto-start scope. They are worth a separate look, and they are not this change's to fix.

One container note that does not affect the change itself: the toolchain had to be moved to current stable, because 1.94.1 cannot build `libsqlite3-sys 0.38.1`, whose build script uses `cfg_select!`.