### PR TITLE
Derive SPELUNK_CONFIG_DIR from each test's own HOME instead of inheriting it

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -65,13 +65,14 @@ the PR.
 `SPELUNK_CONFIG_DIR` overrides the whole config directory, so a fresh temp dir gives the suite the
 default configuration instead of yours.
 
-A test only escapes your own config if the helper that spawns the process pins `SPELUNK_CONFIG_DIR`
-itself (`plumbing_helpers::spelunk_bin_in` and the handful of files that build their own `Command`);
-anything else inherits `~/.config/spelunk/config.toml`.
+A spawned `spelunk` escapes your own config by one of two routes: the helper that spawns it pins
+`SPELUNK_CONFIG_DIR` itself (`plumbing_helpers::spelunk_bin_in`, and the handful of files that build
+their own `Command`), or you export `SPELUNK_CONFIG_DIR` for the whole run as above and the child
+inherits that. With neither, the child reads `~/.config/spelunk/config.toml`.
 So if you have configured spelunk for your own use, particularly a `server_url` with
-`mode = "cloud_first"`, the suite picks that up and starts talking to a real server. That has
-already interfered with real runs: tests that should be hermetic fail, hang, or pass for the wrong
-reason depending on whether that server happens to be healthy.
+`mode = "cloud_first"`, a run without the export picks that up and starts talking to a real server.
+That has already interfered with real runs: tests that should be hermetic fail, hang, or pass for
+the wrong reason depending on whether that server happens to be healthy.
 
 Your own `spelunk` usage and the repo's test runs are different concerns and must not share
 configuration. Pointing the suite at a throwaway directory is the cheapest way to keep them apart,

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -65,7 +65,9 @@ the PR.
 `SPELUNK_CONFIG_DIR` overrides the whole config directory, so a fresh temp dir gives the suite the
 default configuration instead of yours.
 
-Only five test files set it themselves; every other test inherits `~/.config/spelunk/config.toml`.
+A test only escapes your own config if the helper that spawns the process pins `SPELUNK_CONFIG_DIR`
+itself (`plumbing_helpers::spelunk_bin_in` and the handful of files that build their own `Command`);
+anything else inherits `~/.config/spelunk/config.toml`.
 So if you have configured spelunk for your own use, particularly a `server_url` with
 `mode = "cloud_first"`, the suite picks that up and starts talking to a real server. That has
 already interfered with real runs: tests that should be hermetic fail, hang, or pass for the wrong

--- a/crates/spelunk-cli/tests/hooks_path_resolution.rs
+++ b/crates/spelunk-cli/tests/hooks_path_resolution.rs
@@ -28,10 +28,26 @@ use std::path::{Path, PathBuf};
 use std::process::Output;
 use tempfile::TempDir;
 
-/// A `git` invocation in `dir` with an isolated identity and config.
-fn git_cmd(dir: &Path) -> std::process::Command {
+// A `git` invocation in `dir` with an isolated identity and config.
+//
+// `git push` and `git commit` here can run an installed spelunk hook, which
+// execs a spelunk child. Anything this helper leaves unset is inherited from
+// the test process, so the child's config dir and secret store have to be
+// pinned on the git command itself: pinning them on the spelunk commands a test
+// runs directly leaves the hook's child ambient.
+//
+// `HOME` alone is not enough, because `spelunk_config_dir()` returns
+// `SPELUNK_CONFIG_DIR` before it consults `dirs::home_dir()`. A runner that
+// exports `SPELUNK_CONFIG_DIR` to isolate the suite from a developer's own
+// config would otherwise win over `HOME` and point the hook's child at a
+// directory no test seeded.
+fn git_cmd(home: &Path, dir: &Path) -> std::process::Command {
     let mut cmd = std::process::Command::new("git");
     cmd.current_dir(dir)
+        .env("HOME", home)
+        .env("SPELUNK_CONFIG_DIR", home.join(".config").join("spelunk"))
+        .env("SPELUNK_SECRET_STORE", "file")
+        .env_remove("XDG_CONFIG_HOME")
         .env("GIT_AUTHOR_NAME", "t")
         .env("GIT_AUTHOR_EMAIL", "t@example.com")
         .env("GIT_COMMITTER_NAME", "t")
@@ -41,12 +57,12 @@ fn git_cmd(dir: &Path) -> std::process::Command {
     cmd
 }
 
-fn git_out(dir: &Path, args: &[&str]) -> Output {
-    git_cmd(dir).args(args).output().expect("spawn git")
+fn git_out(home: &Path, dir: &Path, args: &[&str]) -> Output {
+    git_cmd(home, dir).args(args).output().expect("spawn git")
 }
 
-fn git(dir: &Path, args: &[&str]) -> Output {
-    let out = git_out(dir, args);
+fn git(home: &Path, dir: &Path, args: &[&str]) -> Output {
+    let out = git_out(home, dir, args);
     assert!(
         out.status.success(),
         "git {args:?} failed: {}",
@@ -55,17 +71,17 @@ fn git(dir: &Path, args: &[&str]) -> Output {
     out
 }
 
-fn git_stdout(dir: &Path, args: &[&str]) -> String {
-    String::from_utf8_lossy(&git_out(dir, args).stdout)
+fn git_stdout(home: &Path, dir: &Path, args: &[&str]) -> String {
+    String::from_utf8_lossy(&git_out(home, dir, args).stdout)
         .trim()
         .to_string()
 }
 
-/// The hooks directory git itself resolves for `dir` (honors `core.hooksPath`
-/// and worktrees). The independent reference the tests check installs
-/// against, rather than re-deriving spelunk's own resolution logic.
-fn git_hooks_dir(dir: &Path) -> PathBuf {
-    let raw = git_stdout(dir, &["rev-parse", "--git-path", "hooks"]);
+// The hooks directory git itself resolves for `dir` (honors `core.hooksPath`
+// and worktrees). The independent reference the tests check installs
+// against, rather than re-deriving spelunk's own resolution logic.
+fn git_hooks_dir(home: &Path, dir: &Path) -> PathBuf {
+    let raw = git_stdout(home, dir, &["rev-parse", "--git-path", "hooks"]);
     let path = PathBuf::from(raw);
     if path.is_absolute() {
         path
@@ -74,14 +90,14 @@ fn git_hooks_dir(dir: &Path) -> PathBuf {
     }
 }
 
-/// A repo with a real identity and one commit.
-fn init_repo(dir: &Path) {
-    git(dir, &["init", "-q", "-b", "main"]);
-    git(dir, &["config", "user.email", "t@example.com"]);
-    git(dir, &["config", "user.name", "Test"]);
+// A repo with a real identity and one commit.
+fn init_repo(home: &Path, dir: &Path) {
+    git(home, dir, &["init", "-q", "-b", "main"]);
+    git(home, dir, &["config", "user.email", "t@example.com"]);
+    git(home, dir, &["config", "user.name", "Test"]);
     std::fs::write(dir.join("f.txt"), "x\n").unwrap();
-    git(dir, &["add", "."]);
-    git(dir, &["commit", "-q", "-m", "init"]);
+    git(home, dir, &["add", "."]);
+    git(home, dir, &["commit", "-q", "-m", "init"]);
 }
 
 /// A `spelunk` command with an isolated HOME and no server contact.
@@ -122,8 +138,9 @@ fn install_post_commit_lands_at_the_core_hooks_path_location() {
     let custom_hooks = tmp.path().join("external-hooks");
     std::fs::create_dir_all(&repo).unwrap();
     std::fs::create_dir_all(&custom_hooks).unwrap();
-    init_repo(&repo);
+    init_repo(home.path(), &repo);
     git(
+        home.path(),
         &repo,
         &["config", "core.hooksPath", custom_hooks.to_str().unwrap()],
     );
@@ -131,7 +148,7 @@ fn install_post_commit_lands_at_the_core_hooks_path_location() {
     // Setup control: confirm git itself resolves hooks to the custom dir, so
     // the assertions below are about the real target, not a guess.
     assert_eq!(
-        git_hooks_dir(&repo),
+        git_hooks_dir(home.path(), &repo),
         custom_hooks,
         "setup: git must resolve hooks to the custom dir"
     );
@@ -167,11 +184,20 @@ fn pre_push_hook_installed_at_core_hooks_path_is_actually_invoked_by_git_push() 
     std::fs::create_dir_all(&dev).unwrap();
     std::fs::create_dir_all(&custom_hooks).unwrap();
 
-    git(&origin, &["init", "-q", "--bare", "-b", "main"]);
-    init_repo(&dev);
-    git(&dev, &["remote", "add", "origin", origin.to_str().unwrap()]);
-    git(&dev, &["push", "-q", "-u", "origin", "main"]);
     git(
+        home.path(),
+        &origin,
+        &["init", "-q", "--bare", "-b", "main"],
+    );
+    init_repo(home.path(), &dev);
+    git(
+        home.path(),
+        &dev,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+    git(home.path(), &dev, &["push", "-q", "-u", "origin", "main"]);
+    git(
+        home.path(),
         &dev,
         &["config", "core.hooksPath", custom_hooks.to_str().unwrap()],
     );
@@ -192,15 +218,15 @@ fn pre_push_hook_installed_at_core_hooks_path_is_actually_invoked_by_git_push() 
 
     memory_add(home.path(), &dev, "custom-hooks-path-decision");
     std::fs::write(dev.join("f2.txt"), "y\n").unwrap();
-    git(&dev, &["add", "."]);
-    git(&dev, &["commit", "-q", "-m", "second"]);
-    git(&dev, &["push", "-q", "origin", "main"]);
+    git(home.path(), &dev, &["add", "."]);
+    git(home.path(), &dev, &["commit", "-q", "-m", "second"]);
+    git(home.path(), &dev, &["push", "-q", "origin", "main"]);
 
     // The proof that matters: git actually ran the hook from the custom
     // location, so the notes ref reached origin. A hook that only exists on
     // disk but is never invoked would leave this ref absent.
     assert!(
-        git_out(&origin, &["rev-parse", "refs/notes/spelunk"])
+        git_out(home.path(), &origin, &["rev-parse", "refs/notes/spelunk"])
             .status
             .success(),
         "the pre-push hook installed at the core.hooksPath location must \
@@ -223,8 +249,9 @@ fn init_summary_agrees_with_pre_push_installer_when_core_hooks_path_is_set() {
     let custom_hooks = tmp.path().join("external-hooks");
     std::fs::create_dir_all(&repo).unwrap();
     std::fs::create_dir_all(&custom_hooks).unwrap();
-    init_repo(&repo);
+    init_repo(home.path(), &repo);
     git(
+        home.path(),
         &repo,
         &["config", "core.hooksPath", custom_hooks.to_str().unwrap()],
     );
@@ -276,8 +303,8 @@ fn install_refuses_when_core_hooks_path_is_inside_the_tracked_working_tree() {
     let tmp = TempDir::new().unwrap();
     let repo = tmp.path().join("repo");
     std::fs::create_dir_all(&repo).unwrap();
-    init_repo(&repo);
-    git(&repo, &["config", "core.hooksPath", ".husky"]);
+    init_repo(home.path(), &repo);
+    git(home.path(), &repo, &["config", "core.hooksPath", ".husky"]);
 
     let out = bin(home.path(), &repo)
         .args(["hooks", "install"])
@@ -311,8 +338,9 @@ fn install_still_succeeds_when_core_hooks_path_is_outside_the_repository() {
     let custom_hooks = tmp.path().join("outside-hooks");
     std::fs::create_dir_all(&repo).unwrap();
     std::fs::create_dir_all(&custom_hooks).unwrap();
-    init_repo(&repo);
+    init_repo(home.path(), &repo);
     git(
+        home.path(),
         &repo,
         &["config", "core.hooksPath", custom_hooks.to_str().unwrap()],
     );
@@ -350,10 +378,11 @@ fn hooks_resolve_to_the_shared_main_repo_hooks_dir_from_a_linked_worktree() {
     let base = spelunk_core::utils::canonicalize(tmp.path());
     let main_root = base.join("main");
     std::fs::create_dir_all(&main_root).unwrap();
-    init_repo(&main_root);
+    init_repo(home.path(), &main_root);
 
     let linked = base.join("linked");
     git(
+        home.path(),
         &main_root,
         &[
             "worktree",
@@ -367,7 +396,7 @@ fn hooks_resolve_to_the_shared_main_repo_hooks_dir_from_a_linked_worktree() {
 
     // Setup control: confirm git itself shares the hooks dir across worktrees.
     assert_eq!(
-        git_hooks_dir(&linked),
+        git_hooks_dir(home.path(), &linked),
         main_root.join(".git").join("hooks"),
         "setup: git must resolve a linked worktree's hooks to the main repo's"
     );

--- a/crates/spelunk-cli/tests/index_background_log.rs
+++ b/crates/spelunk-cli/tests/index_background_log.rs
@@ -81,6 +81,14 @@ fn index_command(project: &Path) -> std::process::Command {
     cmd.current_dir(project)
         .env("SPELUNK_SECRET_STORE", "file")
         .env("HOME", project)
+        // Derived from this test's own `HOME` rather than inherited: an ambient
+        // `SPELUNK_CONFIG_DIR` wins over `HOME`, so without this every test in
+        // the file would share one config and secret store instead of getting
+        // an isolated one.
+        .env(
+            "SPELUNK_CONFIG_DIR",
+            project.join(".config").join("spelunk"),
+        )
         .env("SPELUNK_MODE", "cloud_first")
         .env_remove("XDG_CONFIG_HOME")
         .arg("index")

--- a/crates/spelunk-cli/tests/index_summary_completion.rs
+++ b/crates/spelunk-cli/tests/index_summary_completion.rs
@@ -52,6 +52,11 @@ fn index_command(home: &Path, config: &Path, db: &Path, project: &Path) -> Comma
     let mut cmd = Command::new(assert_cmd::cargo::cargo_bin("spelunk"));
     cmd.env("SPELUNK_SECRET_STORE", "file")
         .env("HOME", home)
+        // Derived from this test's own `HOME` rather than inherited: an ambient
+        // `SPELUNK_CONFIG_DIR` wins over `HOME`, so without this every test in
+        // the file would share one config and secret store instead of getting
+        // an isolated one.
+        .env("SPELUNK_CONFIG_DIR", home.join(".config").join("spelunk"))
         .env("SPELUNK_MODE", "cloud_first")
         .env_remove("XDG_CONFIG_HOME")
         // Project-level config discovery walks up from CWD; every caller here

--- a/crates/spelunk-cli/tests/pre_push_hook.rs
+++ b/crates/spelunk-cli/tests/pre_push_hook.rs
@@ -449,15 +449,13 @@ fn failed_notes_push_does_not_block_the_branch_push() {
 /// mode reaches users through the keychain, the default store when
 /// `SPELUNK_SECRET_STORE` is unset, so no malformed file of their own is needed.
 ///
-/// Unix-only because the seeded config has to be the *ambient* one, which is the
-/// case the hook's child hits: it takes no `--config`. `spelunk_config_dir()`
-/// resolves that path through `dirs::home_dir()`, which reads `$HOME` on unix but
-/// calls `SHGetKnownFolderPath(FOLDERID_Profile)` on Windows, consulting no
-/// environment at all. There is no var to pin there, and seeding the real profile
-/// would break every other test in this suite.
-/// [`a_broken_config_is_tolerated_for_a_best_effort_publish`] covers the same
-/// arm on every platform through `--config`.
-#[cfg(unix)]
+// The seeded config has to be the *ambient* one, which is the case the hook's
+// child hits: it takes no `--config`. `git_cmd` pins `SPELUNK_CONFIG_DIR` at the
+// seeded directory and `spelunk_config_dir()` returns that before it consults
+// `dirs::home_dir()`, so the premise holds on every platform. That pin is what
+// makes this reachable on Windows, where `dirs::home_dir()` calls
+// `SHGetKnownFolderPath(FOLDERID_Profile)` and reads no environment variable, so
+// a `HOME` redirect alone would leave the child on the real profile.
 #[test]
 fn an_unloadable_config_does_not_block_the_branch_push() {
     let home = TempDir::new().unwrap();
@@ -506,12 +504,11 @@ fn an_unloadable_config_does_not_block_the_branch_push() {
     );
 }
 
-/// The `--best-effort` config tolerance itself, on every platform.
-///
-/// The end-to-end guard above can only isolate an ambient config on unix, so the
-/// arm that keeps a hook's push alive would otherwise go unexercised on Windows.
-/// `--config` reaches the same branch: the command ignores `cfg`, so the publish
-/// still runs and the exit stays 0.
+// The `--best-effort` config tolerance reached through `--config` rather than an
+// ambient config dir. The guard above drives the ambient path the hook's child
+// actually takes; this pins the same arm to the explicit flag, so a regression in
+// either route is caught on its own. The command ignores `cfg`, so the publish
+// still runs and the exit stays 0.
 #[test]
 fn a_broken_config_is_tolerated_for_a_best_effort_publish() {
     let home = TempDir::new().unwrap();

--- a/crates/spelunk-cli/tests/pre_push_hook.rs
+++ b/crates/spelunk-cli/tests/pre_push_hook.rs
@@ -46,26 +46,29 @@ fn spelunk_exe() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_spelunk"))
 }
 
-/// A `git` invocation in `dir` with an isolated identity and config.
-///
-/// `git push` runs the pre-push hook, which execs a spelunk child. That child
-/// runs `Config::load`, which reads `<HOME>/.config/spelunk/config.toml` and
-/// resolves a secret store, defaulting to the OS keychain when
-/// `SPELUNK_SECRET_STORE` is unset. git is the only thing standing between a
-/// test and that child, so both have to be pinned here: pinning them on the
-/// spelunk commands a test runs directly leaves the hook's child ambient.
-///
-/// `HOME` redirects that config dir on unix only. `spelunk_config_dir()` goes
-/// through `dirs::home_dir()`, which on Windows is
-/// `SHGetKnownFolderPath(FOLDERID_Profile)` and reads no environment variable,
-/// so there is nothing to pin: a test whose premise needs the *ambient* config
-/// to be the seeded one has to be `#[cfg(unix)]`. `SPELUNK_SECRET_STORE=file`
-/// still keeps the child off the keychain everywhere, which is what the rest of
-/// this suite needs.
+// A `git` invocation in `dir` with an isolated identity and config.
+//
+// `git push` runs the pre-push hook, which execs a spelunk child. That child
+// runs `Config::load`, which reads a config dir and resolves a secret store,
+// defaulting to the OS keychain when `SPELUNK_SECRET_STORE` is unset. git is
+// the only thing standing between a test and that child, so all of it has to be
+// pinned here: pinning it on the spelunk commands a test runs directly leaves
+// the hook's child ambient.
+//
+// `HOME` alone does not pin the config dir, because `spelunk_config_dir()`
+// returns `SPELUNK_CONFIG_DIR` before it consults `dirs::home_dir()`. Anything
+// this helper does not set is inherited from the test process, so a runner that
+// exports `SPELUNK_CONFIG_DIR` (the documented way to isolate the suite from a
+// developer's own config) silently wins over `HOME` and points the hook's child
+// at a directory no test seeded. `SPELUNK_CONFIG_DIR` is therefore derived from
+// `home` and set explicitly, the same way `spelunk_bin_in` does it for the
+// direct-spawn path. That also makes the pin work on Windows, where
+// `dirs::home_dir()` reads no environment variable at all.
 fn git_cmd(home: &Path, dir: &Path) -> std::process::Command {
     let mut cmd = std::process::Command::new("git");
     cmd.current_dir(dir)
         .env("HOME", home)
+        .env("SPELUNK_CONFIG_DIR", home.join(".config").join("spelunk"))
         .env("SPELUNK_SECRET_STORE", "file")
         .env_remove("XDG_CONFIG_HOME")
         .env("SPELUNK_NO_SERVER", "1")
@@ -127,13 +130,19 @@ fn bin(home: &Path, cwd: &Path) -> Command {
     cmd
 }
 
-/// Like [`bin`], but runs an arbitrary copy of the binary rather than the one
-/// cargo built. Used to control the path the shim embeds.
+// Like `bin`, but runs an arbitrary copy of the binary rather than the one
+// cargo built. Used to control the path the shim embeds.
+//
+// This cannot go through `spelunk_bin_in`, which always resolves the
+// cargo-built binary, so it repeats that helper's isolation by hand and has to
+// keep `SPELUNK_CONFIG_DIR` among it: without the pin this spawn inherits the
+// runner's ambient value, which wins over `HOME`.
 fn bin_at(exe: &Path, home: &Path, cwd: &Path) -> Command {
     let mut cmd = Command::new(exe);
     cmd.current_dir(cwd)
         .env("SPELUNK_SECRET_STORE", "file")
         .env("HOME", home)
+        .env("SPELUNK_CONFIG_DIR", home.join(".config").join("spelunk"))
         .env_remove("XDG_CONFIG_HOME")
         .env("GIT_CONFIG_GLOBAL", "/dev/null")
         .env("GIT_CONFIG_SYSTEM", "/dev/null")

--- a/crates/spelunk-cli/tests/pre_push_hook.rs
+++ b/crates/spelunk-cli/tests/pre_push_hook.rs
@@ -442,13 +442,13 @@ fn failed_notes_push_does_not_block_the_branch_push() {
     );
 }
 
-/// A config that will not load must not cost the user their branch push either.
-///
-/// The config loads before the command dispatch, so a broken one aborted the
-/// push with a bare `?` before `--best-effort` was ever consulted. The failure
-/// mode reaches users through the keychain, the default store when
-/// `SPELUNK_SECRET_STORE` is unset, so no malformed file of their own is needed.
-///
+// A config that will not load must not cost the user their branch push either.
+//
+// The config loads before the command dispatch, so a broken one aborted the
+// push with a bare `?` before `--best-effort` was ever consulted. The failure
+// mode reaches users through the keychain, the default store when
+// `SPELUNK_SECRET_STORE` is unset, so no malformed file of their own is needed.
+//
 // The seeded config has to be the *ambient* one, which is the case the hook's
 // child hits: it takes no `--config`. `git_cmd` pins `SPELUNK_CONFIG_DIR` at the
 // seeded directory and `spelunk_config_dir()` returns that before it consults


### PR DESCRIPTION
## The bug

`spelunk_config_dir()` returns `SPELUNK_CONFIG_DIR` **before** it consults `dirs::home_dir()`:

```rust
pub(in crate::config) fn spelunk_config_dir() -> PathBuf {
    if let Some(dir) = std::env::var_os("SPELUNK_CONFIG_DIR") {
        return PathBuf::from(dir);
    }
    dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")).join(".config").join("spelunk")
}
```

So pinning `HOME` on a spawned command does not pin the config directory. Anything a test helper leaves unset is inherited from the test process, which means a runner that exports `SPELUNK_CONFIG_DIR` to isolate the suite from a developer's own configuration silently wins over `HOME` and points the spawned `spelunk` at a directory no test seeded.

`pre_push_hook.rs::an_unloadable_config_does_not_block_the_branch_push` fails exactly that way. It seeds a deliberately broken `config.toml` under its temp `HOME`, runs a real `git push`, and expects the pre-push hook's `spelunk` child to warn about it. With an ambient config directory in play the child reads that instead, never warns, and only the final stderr assertion fails while the push still succeeds. The hook silently short-circuited rather than tolerating anything, which is precisely the failure mode that test exists to catch.

Reproduced before changing a line:

| Invocation | Exit |
|---|---|
| `cargo test -p spelunk-cli --test pre_push_hook an_unloadable_config` | 0 |
| same, plus `SPELUNK_CONFIG_DIR=$(mktemp -d)` | 101 |

## The fix

Pin the config directory alongside `HOME`, derived from the same temp directory, the way `spelunk_bin_in` already does it for the direct-spawn path. Five sites:

| File | Helper | Was pinned | Why it can reach a `spelunk` child |
|---|---|---|---|
| `pre_push_hook.rs` | `git_cmd` | `HOME` only | backs every `git` call in the file, so every push that can run an installed hook |
| `pre_push_hook.rs` | `bin_at` | `HOME` only | runs an arbitrary copy of the binary, so it cannot use `spelunk_bin_in` and repeats its isolation by hand |
| `hooks_path_resolution.rs` | `git_cmd` | neither | installs a real pre-push hook and triggers it with a real `git push` |
| `index_background_log.rs` | `index_command` | `HOME` only | spawns the binary directly |
| `index_summary_completion.rs` | `index_command` | `HOME` only | spawns the binary directly |

`home` is threaded through the git helpers in `hooks_path_resolution.rs` so the pin is derivable there, matching the shape `pre_push_hook.rs` already uses.

The last two were not failing: neither file seeds or reads config-directory content. They are included because under a single shared config directory for the whole run, every test in both files would share one configuration and secret store instead of getting an isolated one.

**`spelunk_config_dir()` itself is unchanged and correct.** The override winning over `HOME` is deliberate and load-bearing on Windows, where `dirs::home_dir()` calls `SHGetKnownFolderPath` and reads no environment variable at all. This is a test-only change; no production path is touched. The `an_unloadable_config` stderr assertion is untouched, since relaxing it would defeat the point of the test.

## `bin_at` was not in the original diagnosis, and only one check finds it

Worth stating plainly, because it changes how this should be verified in future.

The mandated `$(mktemp -d)` is an **empty** directory, which yields a working default configuration. A spawn that wrongly reads it therefore looks perfectly healthy. Running the target test under the mandated invocation, under no `SPELUNK_CONFIG_DIR`, and as a full-file sweep all passed with `bin_at` still unpinned.

What exposed it was pointing `SPELUNK_CONFIG_DIR` at a third directory containing a **rival** `config.toml`. Then an unpinned spawn behaves differently from a pinned one, and the failure named `install_pre_push_from` directly. A merely unrelated empty third directory would have gone green and shipped the gap.

That check is the one that proves the helpers derive their config directory from their own `HOME` rather than tolerating one particular ambient value, so it is the one worth keeping in the loop.

## Verification

Every exit code below was captured from cargo directly, not through a pipe. `SPELUNK_SECRET_STORE=file` on every cargo command.

| Check | Result |
|---|---|
| target test, mandated invocation | exit 0 |
| target test, `SPELUNK_CONFIG_DIR` unset | exit 0 |
| target test, hostile third-party config dir | exit 0 (was 101) |
| full `pre_push_hook.rs` | exit 0, 24 passed |
| full `hooks_path_resolution.rs` | exit 0, 6 passed |
| `index_background_log.rs` / `index_summary_completion.rs` | exit 0, 7 and 3 passed |
| `crash_safety.rs` / `upgrade_corpus.rs` regression check, unchanged files | exit 0, 13 and 7 passed |

### Gates

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --all-targets --features rich-formats -- -D warnings` | pass, zero warnings |
| `cargo build --all-targets --features rich-formats` | pass |
| `cargo nextest run` (full workspace) | 1917 run, 1882 passed, 35 failed, 12 skipped |
| `cargo test --doc` | pass |
| `scripts/check-git-isolation.sh` | pass |
| Diff hygiene (tracker refs, em-dashes, doc-comments in tests) | clean |

### About those 35 failures

They are pre-existing and unrelated, and this was measured rather than assumed. The same suite was run on the merge-base (`c7f8180`) in the same container:

```
branch failing: 33   (spelunk-cli)
main   failing: 34   (spelunk-cli)
regressions (fail on branch, pass on main): NONE
fixed  (fail on main, pass on branch):      an_unloadable_config_does_not_block_the_branch_push
```

The failure-set difference between branch and main is exactly the one test this change repairs. The two remaining workspace failures are in `spelunk-core` (`server_keys` and `backend_selection_tests`), which this diff cannot reach; both were confirmed failing identically on the merge-base. The rest cluster around colour output, `memory list`/`read-memory`/`push`/`sync`, `status` and auto-start scope, and look container-driven rather than genuine breakage.

### Hermeticity

Two back-to-back full runs with two separately minted `SPELUNK_CONFIG_DIR` values produced **identical failure sets** (33 each), so no test's outcome depends on that directory's prior contents or on it being reused across runs.

## Container notes, not repository problems

Two things had to be fixed in the environment before any gate could run, both likely to recur on a fresh container:

- The pinned toolchain was stable 1.94.1, but a transitive dependency (`constant_time_eq` 0.5.0) now requires 1.95.0, so no cargo command would run at all. The repo pins `channel = "stable"` and CI installs it fresh, so the image was simply stale; `rustup update stable` moved it to 1.97.1.
- `cargo-nextest` was absent and `get.nexte.st` is blocked by the network policy, so it was built from crates.io rather than substituting `cargo test`. That distinction matters for this change specifically: nextest runs one process per test, which is the execution model an environment-inheritance fix needs to be validated under.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EXDChPRkrWfrQ2mEutt9gZ)_