### PR TITLE
Fix: canonicalize repo root in claude code harvest

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/harvest_claude.rs
@@ -79,16 +79,14 @@ pub(super) async fn harvest_claude_code(
 
     // 3. Resolve current git repo root.
     let cwd = std::env::current_dir().context("getting current directory")?;
-    let repo_root = gix::discover(&cwd)
-        .context("Not inside a git repository — cannot determine project root for filtering.")?
-        .workdir()
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Not inside a git worktree — cannot determine project root for filtering."
-            )
-        })?
+    let repo = gix::discover(&cwd)
+        .context("Not inside a git repository — cannot determine project root for filtering.")?;
+    let workdir = repo.workdir().ok_or_else(|| {
+        anyhow::anyhow!("Not inside a git worktree — cannot determine project root for filtering.")
+    })?;
+    let repo_root = std::fs::canonicalize(workdir)
+        .context("canonicalizing repository root")?
         .to_string_lossy()
-        .trim_end_matches('/')
         .to_string();
 
     // 4. Parse --since into milliseconds threshold.


### PR DESCRIPTION
## Summary

Fixes the failing test `claude_code_harvest_splits_extraction_to_the_remote_and_embedding_to_the_loopback` that has been failing since PR #799.

The issue: On macOS, temp directories are symlinks. The test helper correctly canonicalizes the project path when writing to history.jsonl, but `harvest_claude.rs` was not canonicalizing the discovered repo root before comparing paths with `starts_with()`. This caused all sessions to be filtered out.

## Test plan

- ✅ The previously failing test now passes
- ✅ All 12 tests in `command_llm_routing` pass
- ✅ No other changes to API or behavior

🤖 Generated with Claude Code