### PR TITLE
ci: bump cargo cache key to v3 to shed pre-candle-drop target/ bloat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,12 +144,22 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          # `-v2` bump abandons the poisoned pre-2026-06-24 macOS caches that
-          # held stale native-embedder link directives. Keep restore-keys on the
-          # same `-v2-` prefix so we never fall back into a poisoned cache.
-          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.lock') }}
+          # `-v3` bump abandons the pre-2026-07-31 caches, which still carry
+          # `target/` artifacts for candle/candle-transformers linked into
+          # spelunk-cli (whole extra test binaries, on Windows a full
+          # companion `.pdb` per binary) from before that dependency edge was
+          # dropped: spelunk-cli now only reaches the embedder over HTTP. The
+          # `Cargo.lock` change that dropped it wasn't enough on its own to
+          # shed those artifacts, because `restore-keys` matches on prefix:
+          # every run kept rehydrating the same bloated `target/` and layering
+          # new output on top of it, since cargo has no built-in GC for
+          # artifacts of a dependency edge that no longer exists. Same reason
+          # as the earlier `-v1` -> `-v2` bump (poisoned macOS native-embedder
+          # caches): jump the prefix so restore-keys can't fall back into what
+          # it's meant to abandon.
+          key: ${{ runner.os }}-cargo-v3-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-v2-
+            ${{ runner.os }}-cargo-v3-
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2

--- a/.github/workflows/stability-contract.yml
+++ b/.github/workflows/stability-contract.yml
@@ -51,9 +51,11 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.lock') }}
+          # Shares the `Linux-cargo-v3-` namespace with ci.yml's `test` job;
+          # see the comment there for why the prefix jumped from `-v2-`.
+          key: ${{ runner.os }}-cargo-v3-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-v2-
+            ${{ runner.os }}-cargo-v3-
 
       # Runs first: if the checker itself stopped rejecting anything, the two
       # jobs below would pass while guaranteeing nothing.

--- a/.github/workflows/version-skew.yml
+++ b/.github/workflows/version-skew.yml
@@ -62,9 +62,11 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.lock') }}
+          # Shares the `Linux-cargo-v3-` namespace with ci.yml's `test` job;
+          # see the comment there for why the prefix jumped from `-v2-`.
+          key: ${{ runner.os }}-cargo-v3-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-v2-
+            ${{ runner.os }}-cargo-v3-
 
       # The previous release is "the newest published tag that is not the
       # version in this tree". Taking the newest tag unconditionally would


### PR DESCRIPTION
## Summary
Investigated why `ci.yml`'s `windows-latest` Test job's cargo cache runs ~4032 MB versus ~1254 MB on macOS and ~477 MB on Linux, making the restore/save (tar + upload) take nearly 10 minutes.

Two compounding causes, confirmed against real CI run logs (not just Cargo.toml reading):

- **Structural**: `cargo nextest run --tests` builds one binary *per integration test file* — 58 in `spelunk-cli`, 15 in `spelunk-core`, 9 in `spelunk-server` — and each statically links the full dependency graph. `windows-msvc` always emits a companion `.pdb` per linked binary, and MSVC's debug-info format is much larger than Linux's packed ELF/DWARF or macOS's split-object debug info for equivalent code. That multiplication (many binaries × large per-binary `.pdb`) is the dominant reason Windows' `target/` is disproportionately larger than the other two platforms for the same source.
- **A real cache-staleness bug**: [PR #802](https://github.com/spelunk-cloud/spelunk/pull/802) dropped `candle`/`candle-transformers` from `spelunk-cli`'s dependency edge (it now only reaches the embedder over HTTP), which changed `Cargo.lock` and should have shrunk `target/` substantially, Windows most of all given the point above. But the cache key's *version prefix* (`-v2-`) never changed — only the `Cargo.lock` hash suffix did — so `restore-keys: ${{ runner.os }}-cargo-v2-` still matched, and every run kept restoring the old, pre-drop `target/` as a base and layering new output on top. Cargo has no built-in GC for artifacts of a dependency edge that no longer exists. Confirmed directly in the logs: the first post-merge run on `main` still restored a 4032 MB Windows cache via `restore-key` fallback — unchanged from before the drop. This repo hit the identical failure mode once already (the existing `-v2` comment: *"abandons the poisoned pre-2026-06-24 macOS caches that held stale native-embedder link directives"*) and fixed it the same way then.

## Change
Bump the cache key version prefix to `-v3-` in `ci.yml`'s `test` job, plus `stability-contract.yml` and `version-skew.yml` (both share the same `Linux-cargo-v2-` namespace on `ubuntu-latest`), so `restore-keys` can't fall back into the bloated cache. This costs one full rebuild per platform on the next run of each workflow; after that, the cache should reflect the smaller post-#802 dependency graph.

## Test plan
- [x] Traced actual `Cache Size` numbers from recent CI job logs (`gh run view --log`) for windows/mac/linux, and confirmed via `git diff` on `Cargo.lock` around PR #802 that the dependency graph shrank without the cache key changing.
- [ ] CI: after merge, confirm the `test` job's Windows `Cache Size` drops substantially on the next couple of runs (first run pays a cache-miss rebuild; subsequent runs land on the new, smaller `-v3-` cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)