### PR TITLE
fix(search): score --mode text as independent terms, not a phrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   upgrade the CLI to match. See `docs/version-skew.md`. The `GET
   /memory/since?t=` legacy mode is unchanged, and still returns a bare array.
 
+### Fixed
+
+- **`spelunk search --mode text` now scores query words as independent terms
+  instead of matching the whole query as a contiguous phrase.** A multi-word
+  query ranks chunks that contain the terms in **any order**, and a chunk
+  containing more of the terms ranks above one containing fewer (BM25
+  bag-of-words, as documented). Previously the raw query was passed to FTS5 as a
+  single quoted phrase, so word order alone decided whether there was a hit —
+  e.g. `leaky bucket` matched a chunk but `bucket leaky` returned nothing.
+  Matching stays case-insensitive and unstemmed (`bursts` matches `bursts`, not
+  `burst`), following the FTS tokenizer.
+
 ## [0.9.6] — 2026-07-31
 
 ### Added

--- a/crates/spelunk-core/src/storage/search.rs
+++ b/crates/spelunk-core/src/storage/search.rs
@@ -73,6 +73,14 @@ impl Database {
 
     /// FTS5 full-text search. Returns results ranked by BM25 (best match first).
     ///
+    /// The query's words are scored as **independent terms** (BM25 bag-of-words
+    /// via [`crate::utils::fts5_match_query`]): a multi-word query ranks chunks
+    /// that contain the terms regardless of their order or adjacency, and a
+    /// chunk containing more of the terms ranks above one containing fewer. It
+    /// is deliberately not matched as a contiguous phrase. Tokenisation follows
+    /// the `chunks_fts` tokenizer (default `unicode61`: case-folded, no
+    /// stemming).
+    ///
     /// BM25 in FTS5 returns negative values (more negative = better match).
     /// We negate the score so that higher `distance` values indicate better matches,
     /// consistent with the convention used in `SearchResult`.
@@ -94,7 +102,7 @@ impl Database {
              ORDER BY score
              LIMIT ?2",
         )?;
-        let fts_query = crate::utils::fts5_quote_literal(query);
+        let fts_query = crate::utils::fts5_match_query(query);
         let rows = stmt.query_map(rusqlite::params![fts_query, limit as i64], |row| {
             let bm25_score: f64 = row.get(8)?;
             Ok(crate::search::SearchResult {
@@ -282,5 +290,117 @@ mod tests {
         let result = db.search_text("content:nonexistent_term_xyz", 10);
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
+    }
+
+    // The documented `--mode text` contract is BM25 over independent terms: a
+    // multi-word query ranks chunks that contain the terms regardless of their
+    // order or adjacency. Before the fix the whole query was matched as a single
+    // quoted FTS5 phrase, so word order alone decided whether there was a hit.
+    #[test]
+    fn search_text_scores_terms_independent_of_order() {
+        let db = open_db();
+        seed_chunk(
+            &db,
+            "We chose a token bucket over a leaky bucket because bursts are expected.",
+        );
+
+        // The natural order and every reordering must hit the one chunk that
+        // contains all the terms — order and adjacency must not decide the hit.
+        for q in [
+            "leaky bucket",
+            "bucket leaky",
+            "bursts are expected",
+            "expected bursts",
+            "token bucket bursts",
+        ] {
+            let hits = db.search_text(q, 10).expect("search ok");
+            assert!(
+                !hits.is_empty(),
+                "query {q:?} must match the chunk containing all its terms, \
+                 regardless of word order"
+            );
+        }
+    }
+
+    // Partial-overlap ranking: a chunk containing more of the query terms ranks
+    // above one containing fewer, and the fewer-term chunk still appears (OR /
+    // bag-of-words semantics, ranked by BM25) rather than being dropped — which
+    // is what phrase matching did.
+    #[test]
+    fn search_text_ranks_more_term_overlap_higher() {
+        let db = open_db();
+
+        let all_terms = db
+            .upsert_file("src/all.rs", Some("rust"), "aaaa1111", 0)
+            .expect("upsert file");
+        db.insert_chunk(
+            all_terms,
+            "function",
+            Some("all"),
+            1,
+            5,
+            "token bucket bursts all three present here",
+            None,
+            8,
+        )
+        .expect("insert chunk");
+
+        let one_term = db
+            .upsert_file("src/one.rs", Some("rust"), "bbbb2222", 0)
+            .expect("upsert file");
+        db.insert_chunk(
+            one_term,
+            "function",
+            Some("one"),
+            1,
+            5,
+            "a single bucket and lots of unrelated padding padding padding",
+            None,
+            8,
+        )
+        .expect("insert chunk");
+
+        let hits = db.search_text("token bucket bursts", 10).expect("search ok");
+
+        // Both chunks share the term "bucket", so both are candidates under
+        // bag-of-words scoring.
+        assert!(
+            hits.len() >= 2,
+            "the chunk sharing only one term must still be a candidate: {:?}",
+            hits.iter().map(|h| &h.content).collect::<Vec<_>>()
+        );
+        assert!(
+            hits[0].content.contains("all three present"),
+            "the chunk containing all three query terms must rank first, got: {:?}",
+            hits.iter().map(|h| &h.content).collect::<Vec<_>>()
+        );
+        assert!(
+            hits.iter().any(|h| h.content.contains("single bucket")),
+            "the single-term chunk must still appear (ranked lower), not be excluded"
+        );
+    }
+
+    // Stemming decision, locked in: `--mode text` uses the table's default FTS5
+    // tokenizer (`unicode61`), which case-folds but does NOT stem. So `bursts`
+    // matches the literal token `bursts`; a query for `burst` does NOT match a
+    // chunk that only contains `bursts`; and matching is case-insensitive.
+    // If the tokenizer ever gains stemming, this test flags it.
+    #[test]
+    fn search_text_does_not_stem_and_is_case_insensitive() {
+        let db = open_db();
+        seed_chunk(&db, "the queue absorbs bursts of traffic");
+
+        assert!(
+            !db.search_text("bursts", 10).expect("ok").is_empty(),
+            "the exact token must match"
+        );
+        assert!(
+            db.search_text("burst", 10).expect("ok").is_empty(),
+            "unstemmed: a query for `burst` must NOT match a chunk containing only `bursts`"
+        );
+        assert!(
+            !db.search_text("BURSTS", 10).expect("ok").is_empty(),
+            "matching is case-insensitive (unicode61 case-folding)"
+        );
     }
 }

--- a/crates/spelunk-core/src/storage/search.rs
+++ b/crates/spelunk-core/src/storage/search.rs
@@ -360,7 +360,9 @@ mod tests {
         )
         .expect("insert chunk");
 
-        let hits = db.search_text("token bucket bursts", 10).expect("search ok");
+        let hits = db
+            .search_text("token bucket bursts", 10)
+            .expect("search ok");
 
         // Both chunks share the term "bucket", so both are candidates under
         // bag-of-words scoring.

--- a/crates/spelunk-core/src/utils/mod.rs
+++ b/crates/spelunk-core/src/utils/mod.rs
@@ -402,10 +402,7 @@ mod tests {
     fn fts5_match_multi_word_joins_literal_terms_with_or() {
         // Each word is a separate quoted literal combined with OR, so the query
         // matches the terms independently rather than as one ordered phrase.
-        assert_eq!(
-            fts5_match_query("leaky bucket"),
-            "\"leaky\" OR \"bucket\""
-        );
+        assert_eq!(fts5_match_query("leaky bucket"), "\"leaky\" OR \"bucket\"");
         assert_eq!(
             fts5_match_query("token bucket bursts"),
             "\"token\" OR \"bucket\" OR \"bursts\""
@@ -443,7 +440,10 @@ mod tests {
             fts5_match_query("say\"hi there"),
             "\"say\"\"hi\" OR \"there\""
         );
-        assert_eq!(fts5_match_query("be\0fore after"), "\"before\" OR \"after\"");
+        assert_eq!(
+            fts5_match_query("be\0fore after"),
+            "\"before\" OR \"after\""
+        );
     }
 
     // ── strip_ansi ────────────────────────────────────────────────────────────

--- a/crates/spelunk-core/src/utils/mod.rs
+++ b/crates/spelunk-core/src/utils/mod.rs
@@ -110,6 +110,40 @@ pub fn fts5_quote_literal(term: &str) -> String {
     out
 }
 
+/// Build an FTS5 `MATCH` expression that scores a multi-word query's terms
+/// **independently**, so it ranks documents that contain the terms regardless
+/// of their order or adjacency (BM25 over a bag of words) — rather than
+/// requiring the whole query to appear as one contiguous, ordered phrase.
+///
+/// The query is split into whitespace-separated terms; each term is quoted as a
+/// literal via [`fts5_quote_literal`] (so FTS5 query punctuation and the
+/// boolean/`NEAR` keywords inside user input stay literal and never parse as
+/// query syntax), and the quoted terms are combined with the FTS5 `OR`
+/// operator. `OR` — not `AND` — keeps a document that matches only some of the
+/// terms in the candidate set, so BM25 can rank a document matching more of the
+/// query terms above one matching fewer, instead of dropping the partial match
+/// entirely.
+///
+/// Tokenisation and stemming are exactly whatever the target table's FTS5
+/// tokenizer already applies — the default `unicode61` (case-folded, no
+/// stemming) — because every term is matched through that same tokenizer; this
+/// function never invents its own token rules.
+///
+/// A query with no terms (empty or all-whitespace) yields `""`, a valid FTS5
+/// literal that simply matches nothing — never a parse error.
+pub fn fts5_match_query(query: &str) -> String {
+    let mut terms = query.split_whitespace();
+    let Some(first) = terms.next() else {
+        return String::from("\"\"");
+    };
+    let mut out = fts5_quote_literal(first);
+    for term in terms {
+        out.push_str(" OR ");
+        out.push_str(&fts5_quote_literal(term));
+    }
+    out
+}
+
 /// Strip ANSI escape sequences and unsafe control characters from a string.
 ///
 /// Allows newline, carriage return, and tab. Strips all other C0 control
@@ -360,6 +394,56 @@ mod tests {
         let term = "before\0after";
         let quoted = fts5_quote_literal(term);
         assert_eq!(quoted, "\"beforeafter\"");
+    }
+
+    // ── fts5_match_query ──────────────────────────────────────────────────────
+
+    #[test]
+    fn fts5_match_multi_word_joins_literal_terms_with_or() {
+        // Each word is a separate quoted literal combined with OR, so the query
+        // matches the terms independently rather than as one ordered phrase.
+        assert_eq!(
+            fts5_match_query("leaky bucket"),
+            "\"leaky\" OR \"bucket\""
+        );
+        assert_eq!(
+            fts5_match_query("token bucket bursts"),
+            "\"token\" OR \"bucket\" OR \"bursts\""
+        );
+    }
+
+    #[test]
+    fn fts5_match_single_word_is_one_literal_no_or() {
+        assert_eq!(fts5_match_query("bucket"), "\"bucket\"");
+    }
+
+    #[test]
+    fn fts5_match_empty_or_whitespace_matches_nothing() {
+        // No terms → a single empty literal: valid FTS5 that matches nothing,
+        // never a parse error.
+        assert_eq!(fts5_match_query(""), "\"\"");
+        assert_eq!(fts5_match_query("   \t\n "), "\"\"");
+    }
+
+    #[test]
+    fn fts5_match_boolean_keywords_stay_literal_terms() {
+        // User words that look like FTS5 operators are quoted per-term, so only
+        // the injected separators are ever real OR operators.
+        assert_eq!(
+            fts5_match_query("a OR NOT b"),
+            "\"a\" OR \"OR\" OR \"NOT\" OR \"b\""
+        );
+    }
+
+    #[test]
+    fn fts5_match_escapes_and_strips_per_term() {
+        // Per-term delegation to fts5_quote_literal: internal quotes doubled,
+        // embedded NUL stripped.
+        assert_eq!(
+            fts5_match_query("say\"hi there"),
+            "\"say\"\"hi\" OR \"there\""
+        );
+        assert_eq!(fts5_match_query("be\0fore after"), "\"before\" OR \"after\"");
     }
 
     // ── strip_ansi ────────────────────────────────────────────────────────────

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -304,6 +304,13 @@ PageRank pipeline that improves multi-hop recall over raw KNN. `text` and
 index, so it needs `spelunk index` first; `ast-grep` and the `auto` default
 work with no index at all.
 
+`text` mode scores the query's words as **independent terms** (BM25): a
+multi-word query ranks chunks that contain the terms in **any order** — a chunk
+containing more of the terms ranks above one containing fewer — rather than
+requiring them to appear as one contiguous phrase. Matching is case-insensitive
+and not stemmed (`bursts` matches `bursts`, not `burst`), following the FTS
+tokenizer.
+
 In `ast-grep` mode (and the `auto` fallback used when there is no index or
 server), a plain-string query matches case-insensitively as a substring of
 identifiers and file text, so `Billing` finds `BillingEntity`. A query


### PR DESCRIPTION
## The bug

`spelunk search --mode text` matched a multi-word query as a single **contiguous, ordered FTS5 phrase** rather than scoring the words as independent BM25 terms (the documented behaviour: "FTS/BM25 over a prebuilt index"). Word order alone decided whether there was a hit.

For a chunk containing *"We chose a token bucket over a leaky bucket because bursts are expected."*:

| query | before | after |
|---|---|---|
| `leaky bucket` | hit | hit |
| `bucket leaky` | **no results** | hit |
| `bursts are expected` | hit | hit |
| `expected bursts` | **no results** | hit |
| `token bucket bursts` | **no results** | hit |

## Root cause

`Database::search_text` built the FTS5 `MATCH` expression with `fts5_quote_literal(query)`, which wraps the **entire** query in one double-quoted string. In FTS5 a double-quoted string is a phrase — every token must appear adjacent and in order. Verified directly against SQLite's FTS5: `MATCH '"bucket leaky"'` → 0 rows; the bareword form matches in any order.

## The fix

New helper `crate::utils::fts5_match_query`: split the query on whitespace, quote **each term** as a literal (via the existing `fts5_quote_literal`, so FTS5 syntax and boolean/`NEAR` keywords in user input stay literal), and combine the quoted terms with the FTS5 `OR` operator. `search_text` now uses it.

Why `OR` rather than `AND`: `OR` keeps a chunk that contains only *some* of the terms in the candidate set, so BM25 ranks a chunk matching more of the query terms above one matching fewer — the documented bag-of-words ranking — instead of dropping partial matches. (FTS5's implicit bareword operator is actually `AND`, which would exclude partial-overlap chunks entirely.)

The punctuation-safety contract is preserved: every user term is individually quoted, so only the injected ` OR ` separators are ever real operators. All existing "never surfaces a raw FTS5 parse error" tests still pass, and an empty/whitespace-only query yields `""` (matches nothing, no error).

## Stemming decision

**No stemming; case-insensitive.** `text` mode uses the `chunks_fts` table's default FTS5 tokenizer, `unicode61`, which case-folds but does not stem. So `bursts` matches the token `bursts` but **not** `burst`, and `BURSTS` matches `bursts`. This is the behaviour the existing tokenizer already implies (not a new invention), and it is now locked in by `search_text_does_not_stem_and_is_case_insensitive` so it cannot change silently.

## Tests

Added to `crates/spelunk-core/src/storage/search.rs`:
- `search_text_scores_terms_independent_of_order` — `bucket leaky`, `expected bursts`, `token bucket bursts` all hit the sample chunk (and the natural-order queries still do). *Red before the fix.*
- `search_text_ranks_more_term_overlap_higher` — a chunk containing all three query terms ranks above (and does not exclude) a chunk sharing only one term. *Red before the fix.*
- `search_text_does_not_stem_and_is_case_insensitive` — locks the no-stemming, case-folded tokenizer decision.

Added to `crates/spelunk-core/src/utils/mod.rs`: 5 unit tests for `fts5_match_query` (multi-word OR join, single word, empty/whitespace, boolean keywords stay literal, per-term escape/NUL-strip).

Run:

```
SPELUNK_SECRET_STORE=file CARGO_TARGET_DIR=/path/.worktree-target \
  cargo test -p spelunk-core --lib storage::search::tests
SPELUNK_SECRET_STORE=file CARGO_TARGET_DIR=/path/.worktree-target \
  cargo test -p spelunk-core --lib utils::tests
```

Full `spelunk-core` lib suite green: **582 passed, 0 failed**.

## Scope

Only the code-chunk search path (`--mode text`) is changed. The separate memory-notes FTS search (`storage/memory/search.rs`) still uses `fts5_quote_literal` and is intentionally left untouched. `docs/commands.md` and a `CHANGELOG.md` "Fixed" entry document the new behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)