### PR TITLE
fix(memory): correct point-in-time --as-of reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   upgrade the CLI to match. See `docs/version-skew.md`. The `GET
   /memory/since?t=` legacy mode is unchanged, and still returns a bare array.
 
+### Fixed
+
+- **`spelunk memory list --as-of` and `spelunk memory search --as-of` now
+  reconstruct the past correctly, without needing `--archived`.** A
+  point-in-time query asks "what was the state of memory at instant T", so it
+  must return every entry that was live at T regardless of its status today.
+  Two defects broke that. An entry superseded or archived *after* T was hidden
+  unless you also passed `--archived`, so the then-current decision went
+  missing from the very query meant to surface it. And an entry created with no
+  explicit `--valid-at` stored a NULL validity start, which the filter read as
+  "valid since forever", so entries created *after* T still appeared in queries
+  about the past. The as-of window is now exactly `valid_at <= T AND
+  (invalid_at IS NULL OR invalid_at > T)`, with a missing `valid_at` defaulting
+  to the entry's creation time, evaluated independently of archived status
+  across list, text, semantic, and hybrid search. `--archived` again controls
+  only the current-state view, orthogonal to `--as-of`.
+
 ## [0.9.6] — 2026-07-31
 
 ### Added

--- a/crates/spelunk-core/src/storage/git_notes/mod.rs
+++ b/crates/spelunk-core/src/storage/git_notes/mod.rs
@@ -800,10 +800,12 @@ impl GitNotesBackend {
             if kind_filter.is_some_and(|k| record.kind != k) {
                 return false;
             }
-            if !include_archived && record.status == "archived" {
-                return false;
-            }
             if let Some(ts) = as_of {
+                // A point-in-time query is governed entirely by the temporal
+                // window, independent of archived status: an entry archived or
+                // superseded AFTER T was live at T and must be returned. So the
+                // archived gate below is skipped whenever `as_of` is set, and
+                // `include_archived` only affects the current-view listing.
                 let effective = record.valid_at.unwrap_or(record.created_at);
                 if effective > ts {
                     return false;
@@ -811,6 +813,10 @@ impl GitNotesBackend {
                 if record.invalid_at.is_some_and(|ia| ia <= ts) {
                     return false;
                 }
+                return true;
+            }
+            if !include_archived && record.status == "archived" {
+                return false;
             }
             true
         });

--- a/crates/spelunk-core/src/storage/memory/notes.rs
+++ b/crates/spelunk-core/src/storage/memory/notes.rs
@@ -423,7 +423,12 @@ impl MemoryStore {
         as_of: Option<i64>,
     ) -> Result<Vec<Note>> {
         let limit = limit.min(500);
-        let status_clause = if include_archived {
+        // A point-in-time (`as_of`) query is governed entirely by the temporal
+        // window below, independent of archived status: an entry archived or
+        // superseded AFTER T was live at T and must be listed, so the
+        // active-only gate is dropped whenever `as_of` is set. `include_archived`
+        // then only affects the current-view listing (`as_of` = None).
+        let status_clause = if include_archived || as_of.is_some() {
             ""
         } else {
             "AND status = 'active'"
@@ -444,8 +449,12 @@ impl MemoryStore {
             params.push(Box::new(format!("{prefix}%")));
         }
         if let Some(ts) = as_of {
+            // `valid_at` is stored NULL when no explicit --valid-at was given;
+            // such an entry became valid at created_at, so COALESCE makes the
+            // lower boundary use created_at rather than treating NULL as "valid
+            // since forever" (which let future-dated entries leak into the past).
             conditions.push_str(&format!(
-                " AND (valid_at IS NULL OR valid_at <= ?{p}) AND (invalid_at IS NULL OR invalid_at > ?{p})",
+                " AND COALESCE(valid_at, created_at) <= ?{p} AND (invalid_at IS NULL OR invalid_at > ?{p})",
                 p = params.len() + 1
             ));
             params.push(Box::new(ts));

--- a/crates/spelunk-core/src/storage/memory/search.rs
+++ b/crates/spelunk-core/src/storage/memory/search.rs
@@ -8,10 +8,16 @@ impl MemoryStore {
     /// When `as_of` is `Some(ts)`, only entries valid at that Unix timestamp are returned.
     pub fn search(&self, query_blob: &[u8], limit: usize, as_of: Option<i64>) -> Result<Vec<Note>> {
         let limit = limit.min(100);
-        let as_of_clause = if as_of.is_some() {
-            "AND (n.valid_at IS NULL OR n.valid_at <= ?2) AND (n.invalid_at IS NULL OR n.invalid_at > ?2)"
+        // A point-in-time query is governed entirely by the temporal window,
+        // independent of archived status: an entry superseded/archived AFTER T
+        // was live at T and must be returned. So with `as_of` set the
+        // active-only gate is dropped and the window alone filters. COALESCE
+        // reads a NULL valid_at (no explicit --valid-at) as created_at rather
+        // than treating NULL as "valid since forever".
+        let where_clause = if as_of.is_some() {
+            "WHERE COALESCE(n.valid_at, n.created_at) <= ?2 AND (n.invalid_at IS NULL OR n.invalid_at > ?2)"
         } else {
-            ""
+            "WHERE n.status = 'active'"
         };
         let sql = format!(
             "WITH knn AS (
@@ -25,8 +31,7 @@ impl MemoryStore {
                     n.valid_at, n.invalid_at, CAST(k.distance AS REAL)
              FROM   knn k
              JOIN   notes n ON n.id = k.note_id
-             WHERE  n.status = 'active'
-             {as_of_clause}
+             {where_clause}
              ORDER  BY k.distance"
         );
         let mut stmt = self.conn.prepare(&sql)?;
@@ -45,10 +50,13 @@ impl MemoryStore {
     /// When `as_of` is `Some(ts)`, only entries valid at that Unix timestamp are returned.
     pub fn search_text(&self, query: &str, limit: usize, as_of: Option<i64>) -> Result<Vec<Note>> {
         let limit = limit.min(1_000);
-        let as_of_clause = if as_of.is_some() {
-            "AND (n.valid_at IS NULL OR n.valid_at <= ?2) AND (n.invalid_at IS NULL OR n.invalid_at > ?2)"
+        // See `search`: with `as_of` set the temporal window filters on its own,
+        // independent of archived status, so a since-superseded entry live at T
+        // is still retrieved; COALESCE reads a NULL valid_at as created_at.
+        let live_clause = if as_of.is_some() {
+            "COALESCE(n.valid_at, n.created_at) <= ?2 AND (n.invalid_at IS NULL OR n.invalid_at > ?2)"
         } else {
-            ""
+            "n.status = 'active'"
         };
         let sql = format!(
             "SELECT n.id, n.kind, n.title, n.body, n.tags, n.linked_files,
@@ -57,8 +65,7 @@ impl MemoryStore {
              FROM memory_fts
              JOIN notes n ON memory_fts.rowid = n.id
              WHERE memory_fts MATCH ?1
-               AND n.status = 'active'
-             {as_of_clause}
+               AND {live_clause}
              ORDER BY bm25_score
              LIMIT {limit}"
         );

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -1696,6 +1696,155 @@ fn partially_migrated_legacy_memory_db_is_inferred_then_completed() {
     );
 }
 
+// ── point-in-time (`--as-of`) reconstruction ────────────────────────────────
+// The as-of filter must return exactly the entries live at instant T:
+//     COALESCE(valid_at, created_at) <= T AND (invalid_at IS NULL OR invalid_at > T)
+// independent of archived status. Two boundaries are pinned here:
+//   * an entry invalidated AFTER T (a since-superseded decision) is present at
+//     T without needing include_archived (the then-current decision);
+//   * an entry whose valid_at is AFTER T is absent — including the case where
+//     valid_at is inherited from created_at (stored NULL), which must be read
+//     as created_at, not as "always valid".
+// The `--archived` dimension must not change which historically-live entries
+// appear, so the list case is asserted with include_archived both false and
+// true.
+
+const DAY: i64 = 86_400;
+// 2026-01-01T00:00:00Z, the base every date below is offset from.
+const Y2026: i64 = 1_767_225_600;
+const JAN_15: i64 = Y2026 + 14 * DAY; // superseded decision becomes valid
+const MAR_01_NOON: i64 = Y2026 + 59 * DAY + 12 * 3_600; // probe, before the supersede
+const MAY_01: i64 = Y2026 + 120 * DAY; // probe, still before the supersede
+const JUN_20: i64 = Y2026 + 170 * DAY; // supersede instant: old.invalid_at, new.valid_at
+const JUL_01: i64 = Y2026 + 181 * DAY; // probe, after the supersede
+const AUG_04: i64 = Y2026 + 215 * DAY; // "today": the created-today entry's created_at
+
+fn id_set(notes: &[super::Note]) -> std::collections::BTreeSet<i64> {
+    notes.iter().filter_map(|n| n.id.as_i64()).collect()
+}
+
+// Seed a real supersede chain plus one entry created "today" with no explicit
+// valid_at. Returns (old_decision, new_decision, created_today). All three
+// share the FTS term "quorum" so search_text can retrieve every one.
+//
+//   old_decision   valid JAN_15, superseded → status archived, invalid_at JUN_20
+//   new_decision   valid JUN_20, active successor
+//   created_today  created AUG_04, valid_at stored NULL (inherits created_at)
+fn seed_as_of_chain(store: &MemoryStore) -> (i64, i64, i64) {
+    let (old_id, _) = store
+        .add_note(
+            "decision",
+            "Cache writes synchronously",
+            "quorum write-through",
+            &[],
+            &[],
+            None,
+            Some(JAN_15),
+        )
+        .unwrap();
+    let (new_id, _) = store
+        .add_note_superseding(
+            "decision",
+            "Cache writes asynchronously",
+            "quorum write-behind",
+            &[],
+            &[],
+            Some(JUN_20),
+            old_id,
+        )
+        .unwrap();
+    // add_note_superseding stamps the old entry's invalid_at with wall-clock
+    // now(); pin it to the historical supersede instant so the point-in-time
+    // boundary is deterministic. This is exactly the archived + invalid_at
+    // state a reconciled/harvested supersede leaves behind.
+    store
+        .conn
+        .execute(
+            "UPDATE notes SET invalid_at = ?1 WHERE id = ?2",
+            rusqlite::params![JUN_20, old_id],
+        )
+        .unwrap();
+    // Created "today" with no --valid-at: valid_at is stored NULL and the
+    // as-of filter must treat it as created_at, not as "always valid".
+    let (today_id, _) = store
+        .add_note_with_created_at(
+            "decision",
+            "Cache eviction policy",
+            "quorum lru",
+            &[],
+            &[],
+            None,
+            "active",
+            AUG_04,
+        )
+        .unwrap();
+    (old_id, new_id, today_id)
+}
+
+// list --as-of must reconstruct the exact set live at T, and that set must not
+// depend on include_archived (the archived flag controls the *current* view,
+// never which historically-live entries a point-in-time query returns).
+#[test]
+fn list_as_of_reconstructs_point_in_time_ignoring_archived() {
+    let store = open_store();
+    let (old_id, new_id, today_id) = seed_as_of_chain(&store);
+
+    // (as_of, expected live ids) for a `--kind decision` listing.
+    let cases: &[(i64, &[i64])] = &[
+        // Before the supersede: the old decision is the then-current one; the
+        // successor is not yet valid and the created-today entry is future.
+        (MAR_01_NOON, &[old_id]),
+        (MAY_01, &[old_id]),
+        // After the supersede: the old decision is gone (invalid_at <= T), the
+        // successor is live, the created-today entry is still future.
+        (JUL_01, &[new_id]),
+        // "Today": the created-today entry finally becomes valid; the old
+        // decision stays gone.
+        (AUG_04, &[new_id, today_id]),
+    ];
+
+    for (as_of, expected) in cases {
+        let want: std::collections::BTreeSet<i64> = expected.iter().copied().collect();
+        for include_archived in [false, true] {
+            let got = id_set(
+                &store
+                    .list_filtered(Some("decision"), None, 100, include_archived, Some(*as_of))
+                    .unwrap(),
+            );
+            assert_eq!(
+                got, want,
+                "as_of={as_of} include_archived={include_archived}: point-in-time \
+                 set must match and must not depend on archived status"
+            );
+        }
+    }
+}
+
+// search --as-of (text mode) must apply the same corrected filter: a
+// since-superseded (archived) entry live at T is returned, and an entry whose
+// inherited valid_at is after T is not. search_text has no include_archived
+// flag, so as_of alone must surface the archived-but-then-live entry.
+#[test]
+fn search_text_as_of_reconstructs_point_in_time_ignoring_archived() {
+    let store = open_store();
+    let (old_id, new_id, today_id) = seed_as_of_chain(&store);
+
+    let cases: &[(i64, &[i64])] = &[
+        (MAR_01_NOON, &[old_id]),
+        (JUL_01, &[new_id]),
+        (AUG_04, &[new_id, today_id]),
+    ];
+    for (as_of, expected) in cases {
+        let want: std::collections::BTreeSet<i64> = expected.iter().copied().collect();
+        let got = id_set(&store.search_text("quorum", 50, Some(*as_of)).unwrap());
+        assert_eq!(
+            got, want,
+            "search_text as_of={as_of}: point-in-time set must match regardless \
+             of archived status"
+        );
+    }
+}
+
 // Acceptance criterion 5: a genuine step failure (not a tolerated
 // duplicate-column error) propagates out of `open` rather than being
 // swallowed by the "already applied" guard.


### PR DESCRIPTION
## Problem

`spelunk memory list --as-of <T>` and `spelunk memory search --as-of <T>` reconstructed the wrong past. A point-in-time query should return exactly the entries that were live at instant `T`, but two defects broke that:

1. **Superseded/archived entries were hidden unless `--archived` was also passed.** An entry that was superseded or archived *after* `T` was live at `T`, yet the query dropped it because it filtered `status = 'active'`. The then-current decision went missing from the very query meant to surface it, and `--archived` (a current-view control) is not mentioned in the `--as-of` docs.

2. **Entries with an inherited `valid_at` leaked into past queries.** When no explicit `--valid-at` is given, `valid_at` is stored `NULL` and the entry becomes valid at `created_at`. The filter's `valid_at IS NULL OR valid_at <= T` treated `NULL` as "valid since forever", so an entry created *after* `T` (e.g. created today) still appeared in every past query. Entries with an explicit `valid_at` were filtered correctly, which pinpointed the `NULL` handling.

## Fix

The as-of window is now exactly:

```
valid_at <= T AND (invalid_at IS NULL OR invalid_at > T)
```

- `valid_at` defaults to `created_at` in the comparison via `COALESCE(valid_at, created_at)` (chosen over a write-time default so existing rows with a `NULL` `valid_at` are handled without a data migration).
- The `status = 'active'` gate is dropped whenever `as_of` is set; the temporal window alone decides membership, so archived status is orthogonal to `--as-of`. `--archived` again controls only the current-state view.

Applied across every point-in-time path: `list_filtered` (list), and `search` / `search_text` / `search_hybrid` (semantic, text, hybrid search) on the SQLite store. The git-notes backend already coalesced `valid_at` but shared the archived-gating defect, so it is corrected the same way to keep the two backends consistent.

## Tests

Table-driven point-in-time tests over a real supersede chain plus an entry created "today" with no explicit `valid_at`, asserting both boundaries and archived-orthogonality:

- `list_as_of_reconstructs_point_in_time_ignoring_archived`
- `search_text_as_of_reconstructs_point_in_time_ignoring_archived`

Each verifies that an entry invalidated after `T` is present at `T` without `--archived`, that an entry whose (inherited) `valid_at` is after `T` is absent, and (for list) that the result set is identical with and without `include_archived`. Both were confirmed red before the fix and green after.

Run:

```
SPELUNK_SECRET_STORE=file CARGO_TARGET_DIR=/path/to/target \
  cargo test -p spelunk-core --lib storage::memory
```

Full `spelunk-core` lib suite: 576 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)