### PR TITLE
fix(logout): scope --server/--servers to server keys only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   upgrade the CLI to match. See `docs/version-skew.md`. The `GET
   /memory/since?t=` legacy mode is unchanged, and still returns a bare array.
 
+### Fixed
+
+- **`spelunk logout --server <url>` no longer signs you out of spelunk.cloud.**
+  It was clearing the cloud token pair (the `[auth]` block written by `spelunk
+  login`) as a side effect of clearing the one named self-hosted server key,
+  forcing an unnecessary browser device login to get back in. `--server <url>`
+  now clears only that one origin's key, `--servers` clears only every stored
+  server key, and both leave the cloud token pair intact; bare `spelunk logout`
+  still clears only the cloud pair. Each form now touches exactly one
+  credential store. The `--server`/`--servers` help text no longer says
+  "Also clear…", which implied the cloud pair was cleared too.
+
 ## [0.9.6] — 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,14 +26,6 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - **`spelunk logout --server <url>` no longer signs you out of spelunk.cloud.**
-  It was clearing the cloud token pair (the `[auth]` block written by `spelunk
-  login`) as a side effect of clearing the one named self-hosted server key,
-  forcing an unnecessary browser device login to get back in. `--server <url>`
-  now clears only that one origin's key, `--servers` clears only every stored
-  server key, and both leave the cloud token pair intact; bare `spelunk logout`
-  still clears only the cloud pair. Each form now touches exactly one
-  credential store. The `--server`/`--servers` help text no longer says
-  "Also clear…", which implied the cloud pair was cleared too.
 - **`spelunk memory list --as-of` and `spelunk memory search --as-of` now
   reconstruct the past correctly, without needing `--archived`.** A
   point-in-time query asks "what was the state of memory at instant T", so it

--- a/crates/spelunk-cli/src/cli/cmd/logout.rs
+++ b/crates/spelunk-cli/src/cli/cmd/logout.rs
@@ -6,10 +6,7 @@
 //! founder-review correction): a developer recovering from a broken cloud
 //! login should not silently lose the server key(s) they use on other
 //! projects. Clearing those is an explicit, separate action via `--servers`
-//! (all of them) or `--server <url>` (just one). The scoping is symmetric:
-//! those two forms clear **only** server keys and leave the cloud `[auth]`
-//! pair untouched, so clearing one self-hosted key never signs the developer
-//! out of spelunk.cloud. Each form touches exactly one credential store.
+//! (all of them) or `--server <url>` (just one).
 
 use anyhow::{Context as _, Result};
 use clap::Args;

--- a/crates/spelunk-cli/src/cli/cmd/logout.rs
+++ b/crates/spelunk-cli/src/cli/cmd/logout.rs
@@ -6,7 +6,10 @@
 //! founder-review correction): a developer recovering from a broken cloud
 //! login should not silently lose the server key(s) they use on other
 //! projects. Clearing those is an explicit, separate action via `--servers`
-//! (all of them) or `--server <url>` (just one).
+//! (all of them) or `--server <url>` (just one). The scoping is symmetric:
+//! those two forms clear **only** server keys and leave the cloud `[auth]`
+//! pair untouched, so clearing one self-hosted key never signs the developer
+//! out of spelunk.cloud. Each form touches exactly one credential store.
 
 use anyhow::{Context as _, Result};
 use clap::Args;
@@ -15,23 +18,23 @@ use spelunk_core::config::{self, server_keys};
 
 #[derive(Args, Debug)]
 pub struct LogoutArgs {
-    /// Also clear every stored self-hosted server key (the per-origin map
-    /// and any legacy entry).
+    /// Clear every stored self-hosted server key (the per-origin map and any
+    /// legacy entry) and nothing else; the cloud token pair is left intact.
     #[arg(long, conflicts_with = "server")]
     pub servers: bool,
 
-    /// Also clear the stored server key for this one server origin.
+    /// Clear the stored server key for this one server origin and nothing
+    /// else; the cloud token pair is left intact.
     #[arg(long)]
     pub server: Option<String>,
 }
 
 pub async fn logout(args: LogoutArgs) -> Result<()> {
-    config::remove_auth_tokens()
-        .context("removing [auth] tokens from ~/.config/spelunk/config.toml")?;
-    println!("Logged out. Stored spelunk.cloud credentials have been removed.");
-
     let store = config::default_secret_store()?;
 
+    // Each form clears exactly one credential store and leaves the other
+    // intact (see the module doc). Only the bare, no-flag form touches the
+    // cloud `[auth]` pair; `--server`/`--servers` are server-key-only.
     if args.servers {
         server_keys::clear_all(store.as_ref()).context("clearing the server_keys map")?;
         // Belt-and-braces: also clear the legacy flat entry and any plaintext
@@ -43,6 +46,10 @@ pub async fn logout(args: LogoutArgs) -> Result<()> {
             .context("clearing the stored server key")?;
         println!("Cleared the stored server key for {origin}.");
     } else {
+        config::remove_auth_tokens()
+            .context("removing [auth] tokens from ~/.config/spelunk/config.toml")?;
+        println!("Logged out. Stored spelunk.cloud credentials have been removed.");
+
         let n = server_keys::count(store.as_ref())?;
         if n > 0 {
             println!(

--- a/crates/spelunk-cli/tests/logout_credential_scope.rs
+++ b/crates/spelunk-cli/tests/logout_credential_scope.rs
@@ -1,0 +1,160 @@
+// `spelunk logout` credential-store scoping: each of the three forms must
+// touch exactly one credential store and leave the other intact.
+//
+// The cloud token pair lives in the `[auth]` table of
+// `~/.config/spelunk/config.toml`; per-origin self-hosted server keys live in
+// the secret store (here the file store, pinned via `SPELUNK_SECRET_STORE=file`
+// by `spelunk_bin_in`). These tests seed BOTH stores, run one `logout` form,
+// and assert which store changed and which survived — the assertion the older
+// server-key-only logout tests never made, which let `--server`/`--servers`
+// silently wipe the cloud pair.
+//
+// Each assertion spawns the real binary against an isolated `HOME` /
+// `SPELUNK_CONFIG_DIR`, so nothing here reaches the developer's real config or
+// the OS keychain.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+// Pipe `key` to `spelunk auth set-key --server <server>` over stdin (the only
+// supported way to set a per-origin key). Writes the secret store, not config.toml.
+fn set_key(home: &std::path::Path, server: &str, key: &str) {
+    spelunk_bin_in(home)
+        .arg("auth")
+        .arg("set-key")
+        .arg("--server")
+        .arg(server)
+        .write_stdin(format!("{key}\n"))
+        .assert()
+        .success();
+}
+
+// Seed a complete cloud `[auth]` token pair into `config.toml` directly — the
+// same on-disk shape `spelunk login` writes. `SPELUNK_CONFIG_DIR` (set by
+// `spelunk_bin_in`) resolves to `<home>/.config/spelunk`, so this is exactly
+// where the CLI reads and (on bare logout) rewrites it.
+fn seed_cloud_auth(home: &std::path::Path) {
+    let dir = home.join(".config").join("spelunk");
+    std::fs::create_dir_all(&dir).expect("create config dir");
+    std::fs::write(
+        dir.join("config.toml"),
+        "[auth]\n\
+         access_token = \"at-cloud-secret\"\n\
+         refresh_token = \"rt-cloud-secret\"\n\
+         expires_at = 4000000000\n\
+         org_id = \"org_test\"\n",
+    )
+    .expect("seed [auth] into config.toml");
+}
+
+// Current text of the seeded `config.toml` (empty string once the file has been
+// rewritten with no `[auth]` table).
+fn config_toml(home: &std::path::Path) -> String {
+    std::fs::read_to_string(home.join(".config").join("spelunk").join("config.toml"))
+        .unwrap_or_default()
+}
+
+// `logout --server <url>`: clears only that origin's server key. The cloud
+// `[auth]` pair and every other origin's key must survive.
+#[test]
+fn logout_server_flag_clears_that_origin_only_and_keeps_cloud_pair() {
+    let home = TempDir::new().unwrap();
+    seed_cloud_auth(home.path());
+    set_key(home.path(), "https://a.example:7777", "sk-a");
+    set_key(home.path(), "https://b.example:7777", "sk-b");
+
+    spelunk_bin_in(home.path())
+        .arg("logout")
+        .arg("--server")
+        .arg("https://a.example:7777")
+        .assert()
+        .success();
+
+    // Cloud pair untouched.
+    let cfg = config_toml(home.path());
+    assert!(
+        cfg.contains("access_token") && cfg.contains("refresh_token"),
+        "cloud [auth] pair must survive `logout --server`, config.toml was:\n{cfg}"
+    );
+
+    // Only the named origin cleared; the other survives.
+    let out = spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("list-servers")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    assert!(
+        !text.contains("a.example"),
+        "cleared origin still listed:\n{text}"
+    );
+    assert!(
+        text.contains("b.example"),
+        "untouched origin missing:\n{text}"
+    );
+}
+
+// Bare `logout` (no flags): clears only the cloud `[auth]` pair. Every stored
+// server key must survive.
+#[test]
+fn bare_logout_clears_cloud_pair_only_and_keeps_server_keys() {
+    let home = TempDir::new().unwrap();
+    seed_cloud_auth(home.path());
+    set_key(home.path(), "https://a.example:7777", "sk-a");
+    set_key(home.path(), "https://b.example:7777", "sk-b");
+
+    spelunk_bin_in(home.path()).arg("logout").assert().success();
+
+    // Cloud pair removed.
+    let cfg = config_toml(home.path());
+    assert!(
+        !cfg.contains("access_token") && !cfg.contains("refresh_token"),
+        "cloud [auth] pair must be cleared by bare `logout`, config.toml was:\n{cfg}"
+    );
+
+    // Both server keys survive.
+    spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("list-servers")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("a.example"))
+        .stdout(predicate::str::contains("b.example"));
+}
+
+// `logout --servers`: clears every stored server key. The cloud `[auth]` pair
+// must survive.
+#[test]
+fn logout_servers_flag_clears_all_server_keys_and_keeps_cloud_pair() {
+    let home = TempDir::new().unwrap();
+    seed_cloud_auth(home.path());
+    set_key(home.path(), "https://a.example:7777", "sk-a");
+    set_key(home.path(), "https://b.example:7777", "sk-b");
+
+    spelunk_bin_in(home.path())
+        .arg("logout")
+        .arg("--servers")
+        .assert()
+        .success();
+
+    // Cloud pair untouched.
+    let cfg = config_toml(home.path());
+    assert!(
+        cfg.contains("access_token") && cfg.contains("refresh_token"),
+        "cloud [auth] pair must survive `logout --servers`, config.toml was:\n{cfg}"
+    );
+
+    // No server keys remain.
+    spelunk_bin_in(home.path())
+        .arg("auth")
+        .arg("list-servers")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No server keys stored"));
+}


### PR DESCRIPTION
## The bug

`spelunk logout --server <url>` clears the named per-origin self-hosted server key **and also** deletes the spelunk.cloud credential pair (the `[auth]` block: `access_token`/`refresh_token`/`expires_at`/`org_id`). A user clearing one self-hosted key is silently signed out of spelunk.cloud and forced to redo a browser device login. `--servers` had the same side effect.

Root cause: in `crates/spelunk-cli/src/cli/cmd/logout.rs`, `config::remove_auth_tokens()` ran unconditionally at the top of `logout()`, before the flag check — so every form wiped the cloud pair.

## The fix

Move the cloud-pair clear into the bare, no-flag branch. Each `logout` form now touches exactly one credential store:

- `spelunk logout` (no flags): clears **only** the cloud `[auth]` token pair; all server keys survive.
- `spelunk logout --server <url>`: clears **only** that one origin's server key; cloud pair and other origins survive.
- `spelunk logout --servers`: clears **only** all per-origin server keys (map + legacy entry); cloud pair survives.

Storage model, for reference: the cloud token pair lives in the `[auth]` table of `~/.config/spelunk/config.toml`; per-origin self-hosted keys live in the secret store under the `server_keys` map (with a legacy flat `server_key` fallback).

Also tightened the now-misleading `--server`/`--servers` help text (dropped "Also clear…", which implied the cloud pair was cleared too) and the module doc.

## Tests

New `crates/spelunk-cli/tests/logout_credential_scope.rs` — three tests, one per form, each seeding **both** stores (a full `[auth]` pair + two server keys) and asserting which store changed and which survived:

- `logout_server_flag_clears_that_origin_only_and_keeps_cloud_pair`
- `bare_logout_clears_cloud_pair_only_and_keeps_server_keys`
- `logout_servers_flag_clears_all_server_keys_and_keeps_cloud_pair`

The two flag-form tests were red before the fix (cloud pair wiped) and are green after. The existing `auth_server_keys.rs` logout tests still pass — they only ever asserted the server-key side, which is why the regression slipped through.

Run:

```
SPELUNK_SECRET_STORE=file cargo test -p spelunk-cli --test logout_credential_scope --test auth_server_keys
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)