### PR TITLE
fix(memory): reject unknown `memory add --kind` instead of silently storing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,7 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 - **`spelunk memory add --kind` now rejects an unknown kind instead of silently
   storing it.** Previously any string was accepted, so a typo (`--kind
-  decisions`, `--kind desicion`) stored an entry that no retrieval path —
-  `memory list --kind decision`, `spelunk context`, `memory failures` — could
-  ever surface, even though the command printed `Stored [...]` and exited 0.
-  `memory add` now validates `--kind` against the nine canonical kinds
-  (`decision`, `context`, `requirement`, `note`, `question`, `answer`,
-  `handoff`, `intent`, `antipattern`) and exits non-zero with a message naming
-  the offending value and listing the valid kinds; nothing is written. The
+  decisions`, `--kind desicion`) stored an entry with no retrieval path. The
   default (`note`) and every valid kind are unaffected.
 
 ## [0.9.6] — 2026-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   upgrade the CLI to match. See `docs/version-skew.md`. The `GET
   /memory/since?t=` legacy mode is unchanged, and still returns a bare array.
 
+### Fixed
+
+- **`spelunk memory add --kind` now rejects an unknown kind instead of silently
+  storing it.** Previously any string was accepted, so a typo (`--kind
+  decisions`, `--kind desicion`) stored an entry that no retrieval path —
+  `memory list --kind decision`, `spelunk context`, `memory failures` — could
+  ever surface, even though the command printed `Stored [...]` and exited 0.
+  `memory add` now validates `--kind` against the nine canonical kinds
+  (`decision`, `context`, `requirement`, `note`, `question`, `answer`,
+  `handoff`, `intent`, `antipattern`) and exits non-zero with a message naming
+  the offending value and listing the valid kinds; nothing is written. The
+  default (`note`) and every valid kind are unaffected.
+
 ## [0.9.6] — 2026-07-31
 
 ### Added

--- a/crates/spelunk-cli/src/cli/cmd/context.rs
+++ b/crates/spelunk-cli/src/cli/cmd/context.rs
@@ -399,6 +399,32 @@ mod tests {
         }
     }
 
+    // Anti-drift guard: every kind a retrieval path selects on must be a
+    // canonical kind that `memory add --kind` accepts. Retrieval selects on a
+    // subset of NOTE_KINDS (not every valid kind appears in the default context
+    // view), so this asserts membership, not equality — but it means a kind
+    // that `context` filters on can never be one `memory add` would reject,
+    // which is exactly the silent-drop the kind-validation fix closes.
+    #[test]
+    fn every_retrieval_kind_is_a_canonical_kind() {
+        use spelunk_core::storage::is_valid_note_kind;
+        for section in SECTIONS {
+            assert!(
+                is_valid_note_kind(section.kind),
+                "context section kind {:?} is not a canonical memory kind",
+                section.kind
+            );
+        }
+        for kind in PACK_PRIORITY {
+            assert!(
+                is_valid_note_kind(kind),
+                "pack-priority kind {kind:?} is not a canonical memory kind"
+            );
+        }
+        // `memory failures` selects on this kind; it must be canonical too.
+        assert!(is_valid_note_kind("antipattern"));
+    }
+
     #[test]
     fn default_limits_are_small_for_every_section() {
         // Regression: question/requirement defaults were once 500.

--- a/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/mod.rs
@@ -96,8 +96,15 @@ pub struct MemoryAddArgs {
     #[arg(long)]
     pub from_url: Option<String>,
 
-    /// Kind: decision, context, requirement, note, question, answer, handoff, intent, antipattern
-    #[arg(short, long, default_value = "note")]
+    /// Kind: decision, context, requirement, note, question, answer, handoff, intent, antipattern.
+    /// An unknown kind is rejected (it would be invisible to `memory list`,
+    /// `context`, and `memory failures`).
+    #[arg(
+        short,
+        long,
+        default_value = "note",
+        value_parser = spelunk_core::storage::parse_note_kind
+    )]
     pub kind: String,
 
     /// Comma-separated tags (e.g. auth,database)

--- a/crates/spelunk-cli/tests/memory_add_kind_validation.rs
+++ b/crates/spelunk-cli/tests/memory_add_kind_validation.rs
@@ -1,0 +1,185 @@
+// Integration tests for `spelunk memory add --kind` validation.
+//
+// The bug: `memory add --kind <anything>` silently accepted any string as the
+// kind, printed `Stored [<anything>]`, and exited 0 — so a typo'd kind (e.g.
+// `decisions`) stored an entry that no retrieval path (`memory list --kind
+// decision`, `spelunk context`, `memory failures`) could ever surface, yet the
+// command reported success.
+//
+// Acceptance covered here:
+// - each of the nine canonical kinds is accepted; omitting --kind defaults to note
+// - an unknown kind (bogus, and realistic typos) is rejected with a non-zero
+//   exit and a message that names the offending value and lists the valid
+//   kinds, and stores NO entry.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+// The nine canonical kinds. Mirrors `spelunk_core::storage::NOTE_KINDS` but is
+// kept as a literal here so this end-to-end test pins the user-visible contract
+// independently of the library constant.
+const VALID_KINDS: [&str; 9] = [
+    "decision",
+    "context",
+    "requirement",
+    "note",
+    "question",
+    "answer",
+    "handoff",
+    "intent",
+    "antipattern",
+];
+
+// store_in_git_notes = false so no git repo is needed and the only store is the
+// SQLite memory.db that `--db` points at.
+fn write_config(dir: &Path, mem_db: &Path) -> PathBuf {
+    let content = format!(
+        "db_path = {:?}\nllm_model = \"x\"\nstore_in_git_notes = false\n",
+        mem_db,
+    );
+    let cfg = dir.join("config.toml");
+    std::fs::write(&cfg, content).expect("write config.toml");
+    cfg
+}
+
+// Build `spelunk --config <cfg> memory --db <mem_db> add …`. Callers append the
+// `--kind`/`--title`/`--body` args. SPELUNK_NO_SERVER keeps the embed phase
+// offline and deterministic (a note is still stored, just without a vector).
+fn memory_add_cmd(dir: &Path, cfg: &Path, mem_db: &Path) -> Command {
+    let mut cmd = spelunk_bin();
+    cmd.current_dir(dir)
+        .env("SPELUNK_NO_SERVER", "1")
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(cfg)
+        .arg("memory")
+        .arg("--db")
+        .arg(mem_db)
+        .arg("add");
+    cmd
+}
+
+// Count memory rows in `mem_db`. Returns 0 if the DB doesn't exist yet.
+fn row_count(mem_db: &Path) -> i64 {
+    if !mem_db.exists() {
+        return 0;
+    }
+    let conn = rusqlite::Connection::open(mem_db).expect("open memory db");
+    conn.query_row("SELECT COUNT(*) FROM notes", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(0)
+}
+
+// ── each canonical kind is accepted and stored ────────────────────────────────
+
+#[test]
+fn each_canonical_kind_is_accepted_and_stored() {
+    for kind in VALID_KINDS {
+        let tmp = TempDir::new().unwrap();
+        let mem_db = tmp.path().join("memory.db");
+        let cfg = write_config(tmp.path(), &mem_db);
+
+        memory_add_cmd(tmp.path(), &cfg, &mem_db)
+            .arg("--kind")
+            .arg(kind)
+            .arg("--title")
+            .arg("a title")
+            .arg("--body")
+            .arg("a body")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(format!("Stored [{kind}]")));
+
+        assert_eq!(
+            row_count(&mem_db),
+            1,
+            "kind {kind} should store exactly one row"
+        );
+    }
+}
+
+// ── omitting --kind still defaults to note ────────────────────────────────────
+
+#[test]
+fn omitting_kind_defaults_to_note() {
+    let tmp = TempDir::new().unwrap();
+    let mem_db = tmp.path().join("memory.db");
+    let cfg = write_config(tmp.path(), &mem_db);
+
+    memory_add_cmd(tmp.path(), &cfg, &mem_db)
+        .arg("--title")
+        .arg("a title")
+        .arg("--body")
+        .arg("a body")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stored [note]"));
+
+    assert_eq!(row_count(&mem_db), 1);
+}
+
+// ── an unknown kind is rejected, names the value, lists valid kinds, stores 0 ──
+
+#[test]
+fn unknown_kind_is_rejected_and_stores_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let mem_db = tmp.path().join("memory.db");
+    let cfg = write_config(tmp.path(), &mem_db);
+
+    memory_add_cmd(tmp.path(), &cfg, &mem_db)
+        .arg("--kind")
+        .arg("bogus")
+        .arg("--title")
+        .arg("a title")
+        .arg("--body")
+        .arg("a body")
+        .assert()
+        .failure()
+        // Names the offending value …
+        .stderr(predicate::str::contains("bogus"))
+        // … and lists the valid kinds so the user can correct it.
+        .stderr(predicate::str::contains("decision"))
+        .stderr(predicate::str::contains("note"))
+        .stderr(predicate::str::contains("antipattern"));
+
+    assert_eq!(
+        row_count(&mem_db),
+        0,
+        "an unknown kind must store no row"
+    );
+}
+
+// ── realistic typos are rejected (the exact silent-drop the bug caused) ────────
+
+#[test]
+fn realistic_typo_kinds_are_rejected_and_store_nothing() {
+    // `decisions` (plural) and `desicion` (misspelling) are the exact typos that
+    // silently dropped a decision out of every retrieval path before the fix.
+    for typo in ["decisions", "desicion"] {
+        let tmp = TempDir::new().unwrap();
+        let mem_db = tmp.path().join("memory.db");
+        let cfg = write_config(tmp.path(), &mem_db);
+
+        memory_add_cmd(tmp.path(), &cfg, &mem_db)
+            .arg("--kind")
+            .arg(typo)
+            .arg("--title")
+            .arg("a title")
+            .arg("--body")
+            .arg("a body")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(typo))
+            .stderr(predicate::str::contains("decision"));
+
+        assert_eq!(
+            row_count(&mem_db),
+            0,
+            "typo kind {typo} must store no row"
+        );
+    }
+}

--- a/crates/spelunk-cli/tests/memory_add_kind_validation.rs
+++ b/crates/spelunk-cli/tests/memory_add_kind_validation.rs
@@ -146,11 +146,7 @@ fn unknown_kind_is_rejected_and_stores_nothing() {
         .stderr(predicate::str::contains("note"))
         .stderr(predicate::str::contains("antipattern"));
 
-    assert_eq!(
-        row_count(&mem_db),
-        0,
-        "an unknown kind must store no row"
-    );
+    assert_eq!(row_count(&mem_db), 0, "an unknown kind must store no row");
 }
 
 // ── realistic typos are rejected (the exact silent-drop the bug caused) ────────
@@ -176,10 +172,6 @@ fn realistic_typo_kinds_are_rejected_and_store_nothing() {
             .stderr(predicate::str::contains(typo))
             .stderr(predicate::str::contains("decision"));
 
-        assert_eq!(
-            row_count(&mem_db),
-            0,
-            "typo kind {typo} must store no row"
-        );
+        assert_eq!(row_count(&mem_db), 0, "typo kind {typo} must store no row");
     }
 }

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -3,6 +3,7 @@ pub mod db;
 pub mod entity_id;
 pub mod git_notes;
 pub mod memory;
+pub mod note_kind;
 pub mod note_record;
 pub mod remote;
 
@@ -28,6 +29,7 @@ pub use git_notes::{
 };
 pub use graph::GraphEdge;
 pub use memory::{DedupeSummary, MemoryEdge, MemoryStore, NoteId, SyncRow};
+pub use note_kind::{NOTE_KINDS, is_valid_note_kind, parse_note_kind};
 pub use note_record::{NoteRecord, now_millis, now_secs};
 pub use remote::{
     BatchItemResult, BatchPushItem, BatchPushResult, CloudSyncClient, RemoteEntry,

--- a/crates/spelunk-core/src/storage/note_kind.rs
+++ b/crates/spelunk-core/src/storage/note_kind.rs
@@ -102,7 +102,10 @@ mod tests {
     #[test]
     fn parse_rejects_unknown_naming_value_and_listing_kinds() {
         let err = parse_note_kind("decisions").expect_err("must reject");
-        assert!(err.contains("decisions"), "must name the offending value: {err}");
+        assert!(
+            err.contains("decisions"),
+            "must name the offending value: {err}"
+        );
         for kind in NOTE_KINDS {
             assert!(err.contains(kind), "must list valid kind {kind}: {err}");
         }

--- a/crates/spelunk-core/src/storage/note_kind.rs
+++ b/crates/spelunk-core/src/storage/note_kind.rs
@@ -1,0 +1,110 @@
+//! Canonical set of memory-entry kinds and the strict parser that guards
+//! `spelunk memory add --kind`.
+//!
+//! A memory entry's `kind` steers every retrieval path: `spelunk context`
+//! selects handoffs/questions/decisions/requirements by kind, `memory failures`
+//! selects `antipattern`, and `memory list --kind` filters on an exact match.
+//! An entry stored under a kind outside this set (a typo like `decisions`, or a
+//! bogus value) is therefore invisible to all of them. This module is the
+//! single source of truth for which kinds are valid, so a kind added here
+//! becomes storable — and, once a retrieval path selects on it, retrievable —
+//! everywhere.
+
+/// The nine canonical kinds a memory entry may have.
+///
+/// Retrieval paths (`spelunk context`, `memory failures`) deliberately select
+/// on a *subset* of these — not every valid kind appears in the default context
+/// view — but every kind they select on must be a member here, so validation
+/// and retrieval cannot drift (guarded by tests).
+pub const NOTE_KINDS: [&str; 9] = [
+    "decision",
+    "context",
+    "requirement",
+    "note",
+    "question",
+    "answer",
+    "handoff",
+    "intent",
+    "antipattern",
+];
+
+/// Whether `kind` is one of the canonical [`NOTE_KINDS`].
+pub fn is_valid_note_kind(kind: &str) -> bool {
+    NOTE_KINDS.contains(&kind)
+}
+
+/// Strict parser for a user-supplied `--kind`.
+///
+/// Returns the kind unchanged when it is canonical, or an error that names the
+/// offending value and lists every valid kind. Shaped as a clap value parser
+/// (`Fn(&str) -> Result<String, String>`) so an invalid `--kind` is rejected at
+/// argument-parse time — before any store is opened — with a non-zero exit.
+pub fn parse_note_kind(kind: &str) -> Result<String, String> {
+    if is_valid_note_kind(kind) {
+        Ok(kind.to_string())
+    } else {
+        Err(format!(
+            "unknown kind '{kind}' — valid kinds are: {}",
+            NOTE_KINDS.join(", ")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The canonical set is exactly the nine documented kinds — pins the
+    /// contract so neither an accidental addition nor a removal slips through.
+    #[test]
+    fn canonical_set_is_exactly_the_nine_documented_kinds() {
+        let mut got = NOTE_KINDS.to_vec();
+        got.sort_unstable();
+        let mut want = vec![
+            "answer",
+            "antipattern",
+            "context",
+            "decision",
+            "handoff",
+            "intent",
+            "note",
+            "question",
+            "requirement",
+        ];
+        want.sort_unstable();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn every_canonical_kind_is_valid() {
+        for kind in NOTE_KINDS {
+            assert!(is_valid_note_kind(kind), "{kind} should be valid");
+        }
+    }
+
+    #[test]
+    fn unknown_and_typo_kinds_are_invalid() {
+        for kind in ["", "bogus", "decisions", "desicion", "Decision", "notes"] {
+            assert!(!is_valid_note_kind(kind), "{kind:?} should be invalid");
+        }
+    }
+
+    #[test]
+    fn parse_accepts_every_canonical_kind_unchanged() {
+        for kind in NOTE_KINDS {
+            assert_eq!(parse_note_kind(kind).as_deref(), Ok(kind));
+        }
+    }
+
+    /// The rejection message must name the offending value and list every valid
+    /// kind, so the CLI (and any other caller) can surface a self-correcting
+    /// error.
+    #[test]
+    fn parse_rejects_unknown_naming_value_and_listing_kinds() {
+        let err = parse_note_kind("decisions").expect_err("must reject");
+        assert!(err.contains("decisions"), "must name the offending value: {err}");
+        for kind in NOTE_KINDS {
+            assert!(err.contains(kind), "must list valid kind {kind}: {err}");
+        }
+    }
+}

--- a/crates/spelunk-core/src/storage/note_kind.rs
+++ b/crates/spelunk-core/src/storage/note_kind.rs
@@ -54,8 +54,8 @@ pub fn parse_note_kind(kind: &str) -> Result<String, String> {
 mod tests {
     use super::*;
 
-    /// The canonical set is exactly the nine documented kinds — pins the
-    /// contract so neither an accidental addition nor a removal slips through.
+    // The canonical set is exactly the nine documented kinds — pins the
+    // contract so neither an accidental addition nor a removal slips through.
     #[test]
     fn canonical_set_is_exactly_the_nine_documented_kinds() {
         let mut got = NOTE_KINDS.to_vec();
@@ -96,9 +96,9 @@ mod tests {
         }
     }
 
-    /// The rejection message must name the offending value and list every valid
-    /// kind, so the CLI (and any other caller) can surface a self-correcting
-    /// error.
+    // The rejection message must name the offending value and list every valid
+    // kind, so the CLI (and any other caller) can surface a self-correcting
+    // error.
     #[test]
     fn parse_rejects_unknown_naming_value_and_listing_kinds() {
         let err = parse_note_kind("decisions").expect_err("must reject");


### PR DESCRIPTION
## The bug

`spelunk memory add --kind <anything>` accepted any string as the kind, printed `Stored [...]`, and exited 0:

```
$ spelunk memory add --kind decisions --title x --body y
Stored [decisions] #11: x        # exit 0
```

Because every retrieval path filters on an exact kind — `memory list --kind decision`, `spelunk context` (which selects handoffs/questions/decisions/requirements by kind), and `memory failures` (which selects `antipattern`) — a typo like `--kind decisions` or `--kind desicion` stored an entry that none of them could ever surface, silently dropping agent-recorded decisions out of every retrieval path while reporting success.

## The fix

Introduce a single canonical source of truth in `spelunk-core`, `storage::note_kind`:

- `NOTE_KINDS` — the nine valid kinds (`decision`, `context`, `requirement`, `note`, `question`, `answer`, `handoff`, `intent`, `antipattern`).
- `is_valid_note_kind` / `parse_note_kind` — membership check and a strict parser whose error names the offending value and lists the valid kinds.

`parse_note_kind` is wired as the clap `value_parser` for `memory add --kind`, so an unknown kind is rejected **at argument-parse time, before any store is opened**, with a non-zero exit and no write:

```
$ spelunk memory add --kind decisions --title x --body y
error: invalid value 'decisions' for '--kind <KIND>': unknown kind 'decisions' — valid kinds are: decision, context, requirement, note, question, answer, handoff, intent, antipattern
# exit 2
```

The default (`note`) and all nine valid kinds are unchanged.

## Where validation lives / drift

`memory add --kind` is the only place user-supplied kinds enter, so validation is enforced there (the clap value parser), reading from the one canonical `NOTE_KINDS` list. Retrieval paths deliberately select on a *subset* of those kinds, so there is no pre-existing "retrieval canon" to assert equality against; instead a guard test asserts every kind `context` and `memory failures` select on is a member of `NOTE_KINDS`, so validation and retrieval can't silently diverge (a retrieval kind can never be one `memory add` would reject). Legacy/remote/harvested entries are not revalidated — only user-supplied `--kind` on `memory add` is gated.

## Tests

- `spelunk-core` unit (`storage::note_kind::tests`): canonical set is exactly the nine kinds; every canonical kind is valid; unknown/typo kinds are invalid; `parse_note_kind` accepts each valid kind unchanged and rejects unknowns with a message naming the value and listing the kinds.
- CLI e2e (`tests/memory_add_kind_validation.rs`): each of the nine kinds is accepted and stored; omitting `--kind` defaults to `note`; `--kind bogus` and realistic typos (`decisions`, `desicion`) are rejected with a non-zero exit, a message naming the value and listing the kinds, and **no** row written.
- CLI guard (`context::tests::every_retrieval_kind_is_a_canonical_kind`): every retrieval kind is a canonical kind.

New tests fail before the fix (an unknown kind is accepted and stored) and pass after; the existing memory/context/help-text suites remain green with no regressions.

## Follow-up (out of scope)

No opt-in/extensibility escape hatch was added, per the task scope. If teams later need project-specific kinds, a deliberate config-driven extension of `NOTE_KINDS` would be the place to add it — flagged here rather than built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)