### PR TITLE
fix(search): gate explicit --mode semantic/hybrid when no server reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   upgrade the CLI to match. See `docs/version-skew.md`. The `GET
   /memory/since?t=` legacy mode is unchanged, and still returns a bare array.
 
+### Fixed
+
+- **`spelunk search --mode semantic` (and `--mode hybrid`) now fail with an
+  actionable error when no server is reachable, instead of silently reporting
+  "No results found." and exiting 0.** These modes need a server to embed the
+  query, so with none reachable (including under `SPELUNK_NO_SERVER=1`) they now
+  emit the same locked-feature error as the other inference-backed commands
+  (`'spelunk search' requires spelunk-server. Run `spelunk server start` ...`)
+  and exit non-zero. Previously the empty fallback result read to an agent or
+  script as "this code does not exist" rather than "the feature is unavailable".
+  The default `auto` mode is unchanged: it still announces its degradation and
+  falls back to ast-grep.
+
 ## [0.9.6] — 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,7 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   actionable error when no server is reachable, instead of silently reporting
   "No results found." and exiting 0.** These modes need a server to embed the
   query, so with none reachable (including under `SPELUNK_NO_SERVER=1`) they now
-  emit the same locked-feature error as the other inference-backed commands
-  (`'spelunk search' requires spelunk-server. Run `spelunk server start` ...`)
-  and exit non-zero. Previously the empty fallback result read to an agent or
-  script as "this code does not exist" rather than "the feature is unavailable".
+  emit the same locked-feature error as the other inference-backed commands.
   The default `auto` mode is unchanged: it still announces its degradation and
   falls back to ast-grep.
 

--- a/crates/spelunk-cli/src/cli/cmd/search.rs
+++ b/crates/spelunk-cli/src/cli/cmd/search.rs
@@ -139,41 +139,22 @@ pub async fn search(args: SearchArgs, cfg: Config) -> Result<()> {
         maybe_warn_stale(&db_path);
     }
 
-    // ── Tier-0 fall-through for explicit semantic/hybrid modes (#303-F2 / #323) ──
+    // ── Fail-closed gate for explicit semantic/hybrid with no server ──────────
     //
-    // When the user explicitly requests `--mode semantic` or `--mode hybrid`
-    // but no server is reachable (Tier 0), automatically switch to FTS text
-    // search. Under ADR-004 inference-only routing (no explicit `server_url`),
-    // the fallback is silent — the user never configured a server, so there is
-    // nothing to warn about. The notice is only printed when `server_url` was
-    // explicitly set (the user expected a server and it is unreachable).
+    // An explicit `--mode semantic` / `--mode hybrid` needs a reachable
+    // inference server to embed the query. With no server — the
+    // `SPELUNK_NO_SERVER` kill-switch, or simply nothing reachable — surface the
+    // same actionable locked-feature error the other inference-gated commands
+    // emit (`memory search`, `memory timeline`, `plumbing embed`) via the shared
+    // `require_server_client` helper, rather than silently falling back to text
+    // search and returning "No results found." — an absence claim an agent or
+    // script reads as "no such code exists" instead of "feature unavailable".
     //
-    // The `auto` mode already degrades gracefully via the embed_query_vec error
-    // path below — this guard handles the explicit-mode case only.
-    if (mode == "semantic" || mode == "hybrid") && !tier.is_server() {
-        if cfg.server_url.is_some() {
-            eprintln!("[server unreachable — using text search]");
-        }
-        let sp = spinner("Searching (text)…");
-        let db = Database::open(&db_path)?;
-        let results = db
-            .search_text(&args.query, args.limit.min(100))
-            .unwrap_or_default();
-        sp.finish_and_clear();
-        if results.is_empty() {
-            println!("No results found.");
-            return Ok(());
-        }
-        match crate::utils::effective_format(&args.format) {
-            "json" => println!("{}", serde_json::to_string_pretty(&results)?),
-            "jsonl" => {
-                for item in &results {
-                    println!("{}", serde_json::to_string(item)?);
-                }
-            }
-            _ => print_results_text(&results),
-        }
-        return Ok(());
+    // Only the explicit modes are gated here: `auto` deliberately degrades to
+    // ast-grep with a visible notice (the embed_query_vec error path below),
+    // which is its contract and stays untouched.
+    if mode == "semantic" || mode == "hybrid" {
+        require_server_client(&cfg, "search")?;
     }
 
     // ── Embedding coverage is a first-class search input (chunk-shaped) ──────

--- a/crates/spelunk-cli/tests/search_semantic_no_server_gate.rs
+++ b/crates/spelunk-cli/tests/search_semantic_no_server_gate.rs
@@ -1,0 +1,142 @@
+// End-to-end coverage for the `search --mode semantic|hybrid` no-server gate.
+//
+// The bug: with no reachable server, an explicit `spelunk search --mode
+// semantic` (and `--mode hybrid`) silently fell back to FTS text search and, on
+// an empty match, printed "No results found." + exit 0. To an agent or a script
+// that reads as "no such code exists" rather than "the feature is unavailable" —
+// unlike every other inference-gated command (`memory search`, `explore`,
+// `memory timeline`), which fail closed with the actionable
+// "requires spelunk-server" locked-feature error.
+//
+// The fix routes the explicit inference modes through the same
+// `require_server_client` gate the other commands use, so they exit non-zero
+// with the shared message. `auto` (the default) is deliberately left to degrade
+// gracefully to ast-grep with a visible notice — that is its contract and must
+// not regress.
+
+mod plumbing_helpers;
+use plumbing_helpers::spelunk_bin_in;
+
+use std::path::Path;
+use tempfile::TempDir;
+
+// A distinctive symbol the auto-mode ast-grep fallback can match, so the auto
+// regression test proves a real fallback ran rather than an empty error path.
+const PROBE_SYMBOL: &str = "spelunk_gate_probe_marker";
+
+// Build a populated-but-unembedded project offline: `<proj>/.spelunk/index.db`
+// exists and holds chunks (chunk_count > 0), but zero embeddings — indexing
+// under `SPELUNK_NO_SERVER=1` parses source into chunks yet has no embedder, so
+// nothing is embedded. This is exactly the state the semantic/hybrid gate must
+// catch: a real index with no way to embed the query.
+fn init_populated_project_offline(home: &Path, proj: &Path) {
+    std::fs::create_dir_all(proj.join("src")).expect("create src dir");
+    std::fs::write(
+        proj.join("src").join("lib.rs"),
+        format!(
+            "pub fn {PROBE_SYMBOL}() -> i32 {{\n    42\n}}\n\n\
+             pub fn helper_add(a: i32, b: i32) -> i32 {{\n    a + b\n}}\n"
+        ),
+    )
+    .expect("write source file");
+
+    spelunk_bin_in(home)
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(proj)
+        .args(["index", "."])
+        .assert()
+        .success();
+
+    assert!(
+        proj.join(".spelunk").join("index.db").exists(),
+        "indexing must create the project index.db"
+    );
+}
+
+// Shared assertion: the explicit-mode failure carries the actionable
+// locked-feature error (never the silent empty-result path).
+fn assert_locked_feature_gate(stderr: &str, stdout: &str) {
+    assert!(
+        stderr.contains("requires spelunk-server"),
+        "must emit the shared locked-feature error; got stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("spelunk server start"),
+        "must point at the actionable resume command; got stderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("No results found."),
+        "must NOT silently report an empty result set; got stdout: {stdout}"
+    );
+}
+
+// `search --mode semantic` with no server: the exact bug report. Must exit
+// non-zero with the locked-feature error, not "No results found." / exit 0.
+#[test]
+fn search_mode_semantic_no_server_gates_with_locked_feature_error() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_populated_project_offline(home.path(), proj.path());
+
+    let assert = spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(proj.path())
+        .args(["search", "anything", "--mode", "semantic"])
+        .assert()
+        .failure();
+
+    let out = assert.get_output();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert_locked_feature_gate(&stderr, &stdout);
+}
+
+// `search --mode hybrid` shares the semantic path's embedding requirement, so it
+// must be gated identically. Covered independently since it is a distinct mode
+// string reaching the same branch.
+#[test]
+fn search_mode_hybrid_no_server_gates_with_locked_feature_error() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_populated_project_offline(home.path(), proj.path());
+
+    let assert = spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(proj.path())
+        .args(["search", "anything", "--mode", "hybrid"])
+        .assert()
+        .failure();
+
+    let out = assert.get_output();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert_locked_feature_gate(&stderr, &stdout);
+}
+
+// Regression guard: `search --mode auto` (the default) with no server must be
+// UNCHANGED — it announces its degradation and falls back to ast-grep, still
+// exiting 0. The silent-fallback gate is reserved for the explicit modes above.
+#[test]
+fn search_mode_auto_no_server_still_degrades_and_exits_zero() {
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    init_populated_project_offline(home.path(), proj.path());
+
+    let assert = spelunk_bin_in(home.path())
+        .env("SPELUNK_NO_SERVER", "1")
+        .current_dir(proj.path())
+        .args(["search", PROBE_SYMBOL, "--mode", "auto"])
+        .assert()
+        .success();
+
+    let out = assert.get_output();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        !stderr.contains("requires spelunk-server"),
+        "auto mode must never be gated with the locked-feature error; got stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("ast-grep"),
+        "auto mode must announce its degradation to ast-grep; got stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## The bug

With no server reachable, an explicit `spelunk search --mode semantic` (and `--mode hybrid`) failed **silently** instead of with the actionable locked-feature error every other inference-gated command gives:

```
SPELUNK_NO_SERVER=1 spelunk search "x" --mode semantic
#   No results found.
#   exit 0
```

To an agent or script, `No results found.` + exit 0 reads as "no such code exists", not "the feature is unavailable". Every sibling command (`memory search`, `explore`, `memory timeline`, `plumbing embed`) instead fails closed with `'... requires spelunk-server. Run \`spelunk server start\` ...` and a non-zero exit.

Only the *explicit* `semantic`/`hybrid` path was missing the gate. The default `auto` mode already degrades correctly (prints a notice, falls back to ast-grep).

## The fix

The explicit-mode block in `crates/spelunk-cli/src/cli/cmd/search.rs` used to silently switch to FTS text search when no server was reachable. It now routes those modes through the shared `require_server_client(&cfg, "search")` helper — the exact gate `memory search` / `memory timeline` / `plumbing embed` use — so the message wording and exit code stay consistent (no hand-rolled string). This covers both the `SPELUNK_NO_SERVER=1` kill-switch and the plain no-server-reachable case (both are Tier 0).

`auto` is deliberately untouched: it still announces its degradation and falls back to ast-grep with exit 0.

## Tests

New `crates/spelunk-cli/tests/search_semantic_no_server_gate.rs` (drives the real CLI against a populated-but-unembedded offline index):

- `search --mode semantic` with no server → exit non-zero + `requires spelunk-server` / `spelunk server start` on stderr; never `No results found.`
- `search --mode hybrid` with no server → same gate.
- `search --mode auto` with no server → unchanged: degrades to ast-grep, exit 0.

Verified the semantic/hybrid tests were **red before** the fix (`code=0`, `stdout="No results found."`) and green after. No regressions in `search_empty_index_mode`, `inference_server_message`, `egress_containment` (incl. server-backed `search_semantic_zero_egress`), or the `search` module unit tests. `cargo fmt --all -- --check` and `cargo clippy -p spelunk-cli --tests` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)