### PR TITLE
feat(memory/sync): push local relates_to edges to cloud on sync (knowledge-graph gap B)

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/mod.rs
@@ -164,6 +164,13 @@ pub async fn memory_sync(
     if pushed.without_local_vector > 0 {
         eprintln!("{}", unembedded_warning(pushed.without_local_vector));
     }
+    // Appended to the success summaries so relates_to propagation is visible
+    // without cluttering the (unchanged) failure/interrupted framing.
+    let edges_note = if pushed.edges_pushed > 0 {
+        format!(" Linked {} relationship edge(s).", pushed.edges_pushed)
+    } else {
+        String::new()
+    };
 
     if pushed.attempted == 0 {
         println!(
@@ -200,22 +207,24 @@ pub async fn memory_sync(
         );
     } else if pushed.failed > 0 {
         println!(
-            "Sync complete. Pushed {} entries (created {}, skipped {}, {} failed), applied {} new remote entries.{}",
+            "Sync complete. Pushed {} entries (created {}, skipped {}, {} failed), applied {} new remote entries.{}{}",
             pushed.attempted,
             pushed.created,
             pushed.skipped,
             pushed.failed,
             pulled,
-            local_embed_summary(&pushed)
+            local_embed_summary(&pushed),
+            edges_note
         );
     } else {
         println!(
-            "Sync complete. Pushed {} entries (created {}, skipped {}), applied {} new remote entries.{}",
+            "Sync complete. Pushed {} entries (created {}, skipped {}), applied {} new remote entries.{}{}",
             pushed.attempted,
             pushed.created,
             pushed.skipped,
             pulled,
-            local_embed_summary(&pushed)
+            local_embed_summary(&pushed),
+            edges_note
         );
     }
     Ok(())

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/edge_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/edge_tests.rs
@@ -1,0 +1,151 @@
+// `push_local` must propagate local `relates_to` edges to the cloud once both
+// endpoints have synced, via an edge-only `POST /memory/batch`, and must not
+// re-post them on a later no-op sync.
+
+use super::super::test_support::register_sqlite_vec;
+use super::*;
+
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+// Stand-in for the cloud batch route: echoes each pushed entry back as
+// `created` (with a cloud id, so the row is stamped and enters `just_synced`),
+// and acknowledges an edge-only batch as one `created` edge per element.
+struct BatchEcho;
+
+impl Respond for BatchEcho {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let body: Value = serde_json::from_slice(&request.body).unwrap_or_else(|_| json!({}));
+        let entries = body["entries"].as_array().cloned().unwrap_or_default();
+        if !entries.is_empty() {
+            let results: Vec<Value> = entries
+                .iter()
+                .map(|e| {
+                    let ext = e["external_id"].as_str().unwrap_or_default();
+                    json!({"status": "created", "external_id": ext, "id": format!("cloud-{ext}")})
+                })
+                .collect();
+            return ResponseTemplate::new(207).set_body_json(json!({
+                "created": results.len(), "skipped": 0, "failed": 0, "results": results
+            }));
+        }
+        let edges = body["edges"].as_array().cloned().unwrap_or_default();
+        let acks: Vec<Value> = edges.iter().map(|_| json!({"status": "created"})).collect();
+        ResponseTemplate::new(207).set_body_json(json!({ "edges": acks }))
+    }
+}
+
+// Every edge-only `/memory/batch` body the server received (entries empty, at
+// least one edge).
+fn edge_batch_bodies(reqs: &[Request]) -> Vec<Value> {
+    reqs.iter()
+        .filter_map(|r| {
+            let body: Value = serde_json::from_slice(&r.body).ok()?;
+            let edges = body.get("edges")?.as_array()?;
+            (!edges.is_empty()).then_some(body)
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn push_local_propagates_a_relates_to_edge_keyed_by_external_id() {
+    use tempfile::TempDir;
+
+    register_sqlite_vec();
+    let tmp = TempDir::new().unwrap();
+    let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+    // `memory add --relates-to <target>` records a directed edge linker ->
+    // target; mirror that shape here.
+    let (target, _) = store
+        .add_note("note", "Target", "target body", &[], &[], None, None)
+        .unwrap();
+    let (linker, _) = store
+        .add_note("note", "Linker", "linker body", &[], &[], None, None)
+        .unwrap();
+    store.add_edge(linker, target, "relates_to").unwrap();
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/projects/proj/memory/batch"))
+        .respond_with(BatchEcho)
+        .mount(&server)
+        .await;
+    let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+    let summary = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
+    assert_eq!(summary.attempted, 2, "both entries must be pushed");
+    assert_eq!(
+        summary.edges_pushed, 1,
+        "the relates_to edge must land once both endpoints synced in the same round"
+    );
+
+    // The push minted a stable uuid (the cloud external_id) for each endpoint.
+    let from_ext = store.uuid_for(linker).unwrap().unwrap();
+    let to_ext = store.uuid_for(target).unwrap().unwrap();
+
+    let reqs = server.received_requests().await.unwrap();
+    let bodies = edge_batch_bodies(&reqs);
+    assert_eq!(
+        bodies.len(),
+        1,
+        "exactly one edge-only batch must be posted"
+    );
+    assert_eq!(
+        bodies[0]["entries"].as_array().map(Vec::len),
+        Some(0),
+        "an edge batch carries no entries"
+    );
+    let edge = &bodies[0]["edges"][0];
+    assert_eq!(edge["kind"], "relates_to");
+    assert_eq!(edge["from_external_id"], Value::String(from_ext));
+    assert_eq!(edge["to_external_id"], Value::String(to_ext));
+}
+
+#[tokio::test]
+async fn a_second_push_with_nothing_new_does_not_repost_the_edge() {
+    use tempfile::TempDir;
+
+    register_sqlite_vec();
+    let tmp = TempDir::new().unwrap();
+    let store = MemoryStore::open(&tmp.path().join("memory.db")).unwrap();
+    let (target, _) = store
+        .add_note("note", "Target", "target body", &[], &[], None, None)
+        .unwrap();
+    let (linker, _) = store
+        .add_note("note", "Linker", "linker body", &[], &[], None, None)
+        .unwrap();
+    store.add_edge(linker, target, "relates_to").unwrap();
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/projects/proj/memory/batch"))
+        .respond_with(BatchEcho)
+        .mount(&server)
+        .await;
+    let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+
+    let first = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
+    assert_eq!(first.edges_pushed, 1);
+
+    // Nothing new to push: no entry landed this round, so no edge is (re-)posted.
+    let second = push_local(&store, &client, false, false, &LocalEmbedPolicy::Skip)
+        .await
+        .unwrap();
+    assert_eq!(second.attempted, 0, "no live entries remain");
+    assert_eq!(
+        second.edges_pushed, 0,
+        "a settled edge must not be re-posted"
+    );
+
+    let reqs = server.received_requests().await.unwrap();
+    assert_eq!(
+        edge_batch_bodies(&reqs).len(),
+        1,
+        "the edge must be posted exactly once across both pushes"
+    );
+}

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_routing_tests.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/embed_routing_tests.rs
@@ -503,6 +503,7 @@ fn the_summary_clause_reports_local_embedding_separately_from_push_results() {
         interrupted: None,
         embedded_locally: embedded,
         without_local_vector: missing,
+        edges_pushed: 0,
     };
     assert_eq!(
         local_embed_summary(&summary(0, 0)),

--- a/crates/spelunk-cli/src/cli/cmd/memory/sync/push/mod.rs
+++ b/crates/spelunk-cli/src/cli/cmd/memory/sync/push/mod.rs
@@ -1,9 +1,11 @@
 //! Push local memory entries to the cloud (`spelunk sync` and the one-way
 //! `spelunk memory push`).
 
+use std::collections::HashSet;
+
 use anyhow::Result;
 
-use crate::storage::{BatchPushItem, CloudSyncClient, MemoryStore};
+use crate::storage::{BatchPushItem, CloudSyncClient, MemoryStore, SyncEdgePush};
 
 mod local_embed;
 
@@ -62,6 +64,11 @@ pub(in crate::cli::cmd::memory) struct PushSummary {
     /// Drives the one counted warning the command layer emits. Always 0 when
     /// the repair does not apply ([`LocalEmbedPolicy::Skip`]).
     pub without_local_vector: usize,
+    /// `relates_to` edges the cloud confirmed it stored during this push (their
+    /// second endpoint reached the cloud this round). Best-effort and secondary
+    /// to entries: a failure to push them warns but never fails the push. See
+    /// [`push_relates_to_edges`].
+    pub edges_pushed: usize,
 }
 
 /// One-way push entry point reused by `spelunk memory push`.
@@ -149,6 +156,7 @@ async fn push_local_reporting(
             interrupted: None,
             embedded_locally: 0,
             without_local_vector: 0,
+            edges_pushed: 0,
         });
     }
 
@@ -157,6 +165,11 @@ async fn push_local_reporting(
     let mut created = 0u32;
     let mut skipped = 0u32;
     let mut failed = 0u32;
+    // Local row ids whose `remote_id` this push stamped: the entries that
+    // reached the cloud this round. A `relates_to` edge becomes pushable in the
+    // round its second endpoint lands, so only edges touching this set are new
+    // and worth posting (see `push_relates_to_edges`).
+    let mut just_synced: HashSet<i64> = HashSet::new();
     // Set once a chunk fails: the loop stops and the tombstone pass is skipped.
     let mut interrupted: Option<String> = None;
 
@@ -267,6 +280,7 @@ async fn push_local_reporting(
                 && let Some(row) = chunk.iter().find(|r| r.uuid == ext)
             {
                 local.set_remote_id(row.local_id, cloud_id)?;
+                just_synced.insert(row.local_id);
             }
             if item.status == "failed" {
                 eprintln!(
@@ -296,6 +310,22 @@ async fn push_local_reporting(
         }
     }
 
+    // Propagate local relates_to edges completed by this round's entry push.
+    // Best-effort and secondary to entries: a failure here warns but does not
+    // fail the push (the entries already landed). Skipped on an interrupted
+    // push, since the connection is already failing.
+    let edges_pushed = if interrupted.is_none() {
+        match push_relates_to_edges(local, client, &just_synced).await {
+            Ok(n) => n,
+            Err(e) => {
+                eprintln!("warning: failed to push relates_to edges to the cloud: {e:#}");
+                0
+            }
+        }
+    } else {
+        0
+    };
+
     Ok(PushSummary {
         attempted,
         created,
@@ -305,13 +335,58 @@ async fn push_local_reporting(
         interrupted,
         embedded_locally: repair.embedded,
         without_local_vector: repair.without_vector,
+        edges_pushed,
     })
+}
+
+/// Push the local `relates_to` edges completed by this round's entry push.
+///
+/// `just_synced` is the set of local row ids whose `remote_id` this push
+/// stamped (the entries that reached the cloud this round). An edge is
+/// propagated when it touches one of those rows and BOTH its endpoints are
+/// synced, so each edge is posted exactly in the round its second endpoint
+/// lands, never re-posted on a later no-op sync. `relates_to` is the only kind
+/// pushed: a `supersedes` edge rides its entry's lifecycle, and `contradicts`
+/// is server-generated. Server-side the batch route dedupes
+/// (`ON CONFLICT DO NOTHING`), so a redundant re-push is still harmless.
+///
+/// Since `memory add --relates-to` is the only producer of a `relates_to` edge
+/// and always mints a fresh (unsynced) entry as the edge's `from` endpoint,
+/// that endpoint is always in `just_synced` the round the edge first becomes
+/// pushable, so this never silently drops a genuinely new edge.
+///
+/// Returns the number of edges the server confirmed it stored (an `unresolved`
+/// edge is not counted; it is retried when its endpoint later syncs).
+async fn push_relates_to_edges(
+    local: &MemoryStore,
+    client: &CloudSyncClient,
+    just_synced: &HashSet<i64>,
+) -> Result<usize> {
+    if just_synced.is_empty() {
+        return Ok(0);
+    }
+    let edges: Vec<SyncEdgePush> = local
+        .relates_to_edges_for_sync()?
+        .into_iter()
+        .filter(|e| just_synced.contains(&e.from_local_id) || just_synced.contains(&e.to_local_id))
+        .map(|e| SyncEdgePush {
+            from_external_id: e.from_external_id,
+            to_external_id: e.to_external_id,
+            kind: "relates_to",
+        })
+        .collect();
+    if edges.is_empty() {
+        return Ok(0);
+    }
+    Ok(client.push_edges(edges).await?.applied())
 }
 
 #[cfg(test)]
 mod chunking_tests;
 #[cfg(test)]
 mod counting_tests;
+#[cfg(test)]
+mod edge_tests;
 #[cfg(test)]
 mod embed_routing_tests;
 #[cfg(test)]

--- a/crates/spelunk-cli/tests/memory_relates_to_edge_sync.rs
+++ b/crates/spelunk-cli/tests/memory_relates_to_edge_sync.rs
@@ -1,0 +1,251 @@
+// Subprocess-level coverage for `relates_to` edge propagation on `spelunk
+// sync`. `memory add --relates-to` writes a LOCAL `relates_to` edge; this pins
+// that the edge now also travels UP to the cloud on sync, via an edge-only
+// `POST /memory/batch` keyed by each endpoint's external_id.
+//
+// The real compiled `spelunk` binary (`assert_cmd`) drives `memory add
+// --relates-to` to build the local edge, then `sync` against a mock team
+// server. The mock echoes the entry push (so both endpoints get stamped and
+// enter this round's just-synced set) and captures the edge-only batch, which
+// this test asserts carries `kind: "relates_to"` and the two entries' uuids.
+// Following `memory_push_sync_partial_failure.rs` for the mock-server + config
+// harness, and `memory_relates_to_edge.rs` for the `memory add` driving.
+
+mod plumbing_helpers;
+use plumbing_helpers::{register_sqlite_vec, spelunk_bin_in, write_project_server_config};
+
+use std::path::Path;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+// A slug with no characters `encode_project_id` would percent-encode, so the
+// mocked route paths match literally.
+const PROJECT_SLUG: &str = "acme-widget";
+
+// Stand-in for the cloud batch route: echoes each pushed entry as `created`
+// (with a cloud id, so the local row is stamped and its edges become
+// pushable), and acknowledges an edge-only batch as one `created` edge each.
+struct BatchEcho;
+impl Respond for BatchEcho {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let body: serde_json::Value =
+            serde_json::from_slice(&request.body).unwrap_or(serde_json::json!({}));
+        let entries = body["entries"].as_array().cloned().unwrap_or_default();
+        if !entries.is_empty() {
+            let results: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|e| {
+                    let ext = e["external_id"].as_str().unwrap_or_default();
+                    serde_json::json!({
+                        "status": "created", "external_id": ext, "id": format!("cloud-{ext}")
+                    })
+                })
+                .collect();
+            return ResponseTemplate::new(207).set_body_json(serde_json::json!({
+                "created": results.len(), "skipped": 0, "failed": 0, "results": results
+            }));
+        }
+        let edges = body["edges"].as_array().cloned().unwrap_or_default();
+        let acks: Vec<serde_json::Value> = edges
+            .iter()
+            .map(|_| serde_json::json!({"status": "created"}))
+            .collect();
+        ResponseTemplate::new(207).set_body_json(serde_json::json!({ "edges": acks }))
+    }
+}
+
+async fn mount_health(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/v1/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "capabilities": ["memory"],
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_batch(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/projects/{PROJECT_SLUG}/memory/batch")))
+        .respond_with(BatchEcho)
+        .mount(server)
+        .await;
+}
+
+// The post-push pull half of `sync` must have something to talk to.
+async fn mount_since_empty(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path_regex(format!(
+            r"^/v1/projects/{PROJECT_SLUG}/memory/since$"
+        )))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "entries": [] })),
+        )
+        .mount(server)
+        .await;
+}
+
+// Global personal config: local memory writes, git-notes carrier off.
+fn write_global_config(dir: &Path) -> std::path::PathBuf {
+    let db_path = dir.join(".spelunk").join("index.db");
+    let config_path = dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "db_path = {db_path:?}\n\
+             llm_model = \"test-chat\"\n\
+             store_in_git_notes = false\n"
+        ),
+    )
+    .expect("write global config.toml");
+    config_path
+}
+
+// Run `memory add --kind note --title <title> --body … <extra…>` against a
+// local memory.db, from a neutral CWD (no project `.spelunk`, so `add` stays
+// local and never sees the team server_url). Returns the printed entry id.
+fn add_note(
+    home: &Path,
+    cwd: &Path,
+    cfg: &Path,
+    mem_db: &Path,
+    title: &str,
+    extra: &[&str],
+) -> i64 {
+    let mut cmd = spelunk_bin_in(home);
+    cmd.current_dir(cwd)
+        .env_remove("SPELUNK_SERVER_URL")
+        .arg("--config")
+        .arg(cfg)
+        .arg("memory")
+        .arg("--db")
+        .arg(mem_db)
+        .arg("add")
+        .arg("--kind")
+        .arg("note")
+        .arg("--title")
+        .arg(title)
+        .arg("--body")
+        .arg("body text with no secrets");
+    for a in extra {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("run memory add");
+    assert!(
+        out.status.success(),
+        "memory add failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    parse_stored_id(&String::from_utf8_lossy(&out.stdout))
+}
+
+fn parse_stored_id(stdout: &str) -> i64 {
+    let hash = stdout
+        .find('#')
+        .unwrap_or_else(|| panic!("no id marker in stored output: {stdout:?}"));
+    let rest = &stdout[hash + 1..];
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    rest[..end]
+        .parse()
+        .unwrap_or_else(|_| panic!("could not parse id from stored output: {stdout:?}"))
+}
+
+fn uuid_of(mem_db: &Path, id: i64) -> String {
+    register_sqlite_vec();
+    let conn = rusqlite::Connection::open(mem_db).expect("open memory db");
+    conn.query_row("SELECT uuid FROM notes WHERE id = ?1", [id], |r| {
+        r.get::<_, Option<String>>(0)
+    })
+    .expect("read uuid")
+    .expect("uuid must be minted after sync")
+}
+
+#[tokio::test]
+async fn sync_pushes_a_local_relates_to_edge_to_the_cloud() {
+    let server = MockServer::start().await;
+    mount_health(&server).await;
+    mount_batch(&server).await;
+    mount_since_empty(&server).await;
+
+    let home = TempDir::new().unwrap();
+    let proj = TempDir::new().unwrap();
+    let mem_dir = TempDir::new().unwrap();
+    let mem_db = mem_dir.path().join("memory.db");
+
+    let cfg = write_global_config(proj.path());
+    write_project_server_config(proj.path(), &server.uri(), PROJECT_SLUG);
+
+    // Build the local edge exactly as a user would: a target entry, then a
+    // linker entry that `--relates-to` it (records linker -> target).
+    let target = add_note(
+        home.path(),
+        mem_dir.path(),
+        &cfg,
+        &mem_db,
+        "Original observation",
+        &[],
+    );
+    let linker = add_note(
+        home.path(),
+        mem_dir.path(),
+        &cfg,
+        &mem_db,
+        "Follow-up observation",
+        &["--relates-to", &target.to_string()],
+    );
+
+    // Sync from the project dir, so `server_url` + `project_id` are discovered
+    // from its `.spelunk/config.toml`.
+    let assert = spelunk_bin_in(home.path())
+        .current_dir(proj.path())
+        .arg("--config")
+        .arg(&cfg)
+        .args(["sync", "--source"])
+        .arg(&mem_db)
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("Sync complete"),
+        "sync must succeed: {stdout:?}"
+    );
+
+    // The two entries' cloud external_ids (their local uuids, minted on sync).
+    let from_ext = uuid_of(&mem_db, linker);
+    let to_ext = uuid_of(&mem_db, target);
+
+    // Exactly one edge-only `/memory/batch` was posted, keyed by external_id.
+    let reqs = server.received_requests().await.unwrap();
+    let edge_bodies: Vec<serde_json::Value> = reqs
+        .iter()
+        .filter_map(|r| {
+            let body: serde_json::Value = serde_json::from_slice(&r.body).ok()?;
+            let edges = body.get("edges")?.as_array()?;
+            (!edges.is_empty()).then_some(body)
+        })
+        .collect();
+    assert_eq!(
+        edge_bodies.len(),
+        1,
+        "sync must post exactly one relates_to edge batch; requests: {:?}",
+        reqs.iter()
+            .map(|r| String::from_utf8_lossy(&r.body).into_owned())
+            .collect::<Vec<_>>()
+    );
+    let edge = &edge_bodies[0]["edges"][0];
+    assert_eq!(edge["kind"], "relates_to");
+    assert_eq!(
+        edge["from_external_id"],
+        serde_json::Value::String(from_ext)
+    );
+    assert_eq!(edge["to_external_id"], serde_json::Value::String(to_ext));
+    assert_eq!(
+        edge_bodies[0]["entries"].as_array().map(Vec::len),
+        Some(0),
+        "an edge batch carries no entries"
+    );
+}

--- a/crates/spelunk-core/src/storage/memory/mod.rs
+++ b/crates/spelunk-core/src/storage/memory/mod.rs
@@ -14,7 +14,7 @@ mod sync;
 
 pub use dedupe::DedupeSummary;
 pub use note_id::NoteId;
-pub use sync::SyncRow;
+pub use sync::{SyncEdge, SyncRow};
 
 #[cfg(test)]
 mod tests;

--- a/crates/spelunk-core/src/storage/memory/sync.rs
+++ b/crates/spelunk-core/src/storage/memory/sync.rs
@@ -42,6 +42,20 @@ pub struct SyncRow {
     pub archived: bool,
 }
 
+/// A local `relates_to` edge ready to propagate to the cloud.
+///
+/// Both endpoints are already synced (each carries a cloud `remote_id`), so the
+/// server knows them by their `external_id` (the entry's stable `uuid`), the
+/// only id the batch edge route resolves. The local row ids are kept so the
+/// caller can push only edges touching entries synced in the current round.
+#[derive(Debug, Clone)]
+pub struct SyncEdge {
+    pub from_local_id: i64,
+    pub to_local_id: i64,
+    pub from_external_id: String,
+    pub to_external_id: String,
+}
+
 impl MemoryStore {
     /// Assign a fresh UUIDv7 to `note_id` if it lacks one; return the entry's
     /// UUID. Idempotent. This is the Founder-decided backfill (§3) — a *fresh*
@@ -292,6 +306,39 @@ impl MemoryStore {
             .optional()?
             .flatten();
         Ok(cursor)
+    }
+
+    /// Every `relates_to` edge whose BOTH endpoints are already synced to the
+    /// cloud (each has a `remote_id`) and carry a stable `uuid`.
+    ///
+    /// Only `relates_to` is enumerated: a `supersedes` edge already travels
+    /// with its entry's lifecycle on push, and `contradicts` is server-derived
+    /// and never pushed up. An edge with an unsynced endpoint is omitted here,
+    /// so it is skipped until a later sync lands that endpoint. The row ids are
+    /// returned so the caller can narrow to edges touching entries synced in
+    /// the current round.
+    pub fn relates_to_edges_for_sync(&self) -> Result<Vec<SyncEdge>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT e.from_id, e.to_id, nf.uuid, nt.uuid \
+             FROM memory_edges e \
+             JOIN notes nf ON nf.id = e.from_id \
+             JOIN notes nt ON nt.id = e.to_id \
+             WHERE e.kind = 'relates_to' \
+               AND nf.remote_id IS NOT NULL AND nt.remote_id IS NOT NULL \
+               AND nf.uuid IS NOT NULL AND nt.uuid IS NOT NULL \
+             ORDER BY e.created_at, e.from_id, e.to_id",
+        )?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(SyncEdge {
+                    from_local_id: r.get(0)?,
+                    to_local_id: r.get(1)?,
+                    from_external_id: r.get(2)?,
+                    to_external_id: r.get(3)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
     }
 
     /// Count of active (non-archived) rows still in the push outbox

--- a/crates/spelunk-core/src/storage/memory/tests.rs
+++ b/crates/spelunk-core/src/storage/memory/tests.rs
@@ -250,6 +250,80 @@ fn add_edge_duplicate_silently_ignored() {
     );
 }
 
+// ── relates_to_edges_for_sync(): only fully-synced relates_to edges ───────────
+
+// The edge push enumerates only `relates_to` edges whose BOTH endpoints carry
+// a `remote_id` (so the cloud knows them by external_id) and a `uuid`. An edge
+// with an unsynced endpoint is withheld until a later sync lands it; the two
+// other edge kinds are never enumerated (supersedes rides its entry, and
+// contradicts is server-derived).
+#[test]
+fn relates_to_edges_for_sync_requires_both_endpoints_synced() {
+    let store = open_store();
+    let (a, _) = store
+        .add_note("note", "A", "", &[], &[], None, None)
+        .unwrap();
+    let (b, _) = store
+        .add_note("note", "B", "", &[], &[], None, None)
+        .unwrap();
+    // Mint uuids the way a push would, then wire a linker -> target edge.
+    store.ensure_uuid(a).unwrap();
+    store.ensure_uuid(b).unwrap();
+    store.add_edge(b, a, "relates_to").unwrap();
+
+    // Neither endpoint synced yet: nothing to push.
+    assert!(store.relates_to_edges_for_sync().unwrap().is_empty());
+
+    // Only one endpoint synced: still withheld.
+    store
+        .set_remote_id(a, "01890000-0000-7000-8000-0000000000a1")
+        .unwrap();
+    assert!(
+        store.relates_to_edges_for_sync().unwrap().is_empty(),
+        "an edge with one unsynced endpoint must not be pushable"
+    );
+
+    // Both synced: the edge is now pushable, keyed by each endpoint's uuid.
+    store
+        .set_remote_id(b, "01890000-0000-7000-8000-0000000000b2")
+        .unwrap();
+    let edges = store.relates_to_edges_for_sync().unwrap();
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].from_local_id, b);
+    assert_eq!(edges[0].to_local_id, a);
+    assert_eq!(
+        edges[0].from_external_id,
+        store.uuid_for(b).unwrap().unwrap()
+    );
+    assert_eq!(edges[0].to_external_id, store.uuid_for(a).unwrap().unwrap());
+}
+
+#[test]
+fn relates_to_edges_for_sync_ignores_supersedes_and_contradicts() {
+    let store = open_store();
+    let (a, _) = store
+        .add_note("note", "A", "", &[], &[], None, None)
+        .unwrap();
+    let (b, _) = store
+        .add_note("note", "B", "", &[], &[], None, None)
+        .unwrap();
+    store.ensure_uuid(a).unwrap();
+    store.ensure_uuid(b).unwrap();
+    store
+        .set_remote_id(a, "01890000-0000-7000-8000-0000000000a1")
+        .unwrap();
+    store
+        .set_remote_id(b, "01890000-0000-7000-8000-0000000000b2")
+        .unwrap();
+    store.add_edge(b, a, "supersedes").unwrap();
+    store.add_edge(b, a, "contradicts").unwrap();
+
+    assert!(
+        store.relates_to_edges_for_sync().unwrap().is_empty(),
+        "only relates_to edges are enumerated for push"
+    );
+}
+
 // ── UUID identity + cursor + idempotent apply ────────────────────────────────
 
 #[test]

--- a/crates/spelunk-core/src/storage/mod.rs
+++ b/crates/spelunk-core/src/storage/mod.rs
@@ -28,12 +28,12 @@ pub use git_notes::{
     ensure_notes_rewrite_ref, lock_notes, merge_tracking_notes, publish_notes,
 };
 pub use graph::GraphEdge;
-pub use memory::{DedupeSummary, MemoryEdge, MemoryStore, NoteId, SyncRow};
+pub use memory::{DedupeSummary, MemoryEdge, MemoryStore, NoteId, SyncEdge, SyncRow};
 pub use note_kind::{NOTE_KINDS, is_valid_note_kind, parse_note_kind};
 pub use note_record::{NoteRecord, now_millis, now_secs};
 pub use remote::{
-    BatchItemResult, BatchPushItem, BatchPushResult, CloudSyncClient, RemoteEntry,
-    RemoteMemoryBackend,
+    BatchItemResult, BatchPushItem, BatchPushResult, CloudSyncClient, EdgePushResult, RemoteEntry,
+    RemoteMemoryBackend, SyncEdgePush,
 };
 pub use specs::{SpecRecord, StaleSpec};
 pub use stats::{

--- a/crates/spelunk-core/src/storage/remote/mod.rs
+++ b/crates/spelunk-core/src/storage/remote/mod.rs
@@ -13,7 +13,10 @@ mod sync;
 mod wire_types;
 pub use cloud_api::CloudApiMemoryBackend;
 pub(super) use peer::{PeerDialect, detect_dialect};
-pub use sync::{BatchItemResult, BatchPushItem, BatchPushResult, CloudSyncClient, RemoteEntry};
+pub use sync::{
+    BatchItemResult, BatchPushItem, BatchPushResult, CloudSyncClient, EdgePushResult, RemoteEntry,
+    SyncEdgePush,
+};
 pub use wire_types::ConflictInfo;
 use wire_types::*;
 

--- a/crates/spelunk-core/src/storage/remote/sync.rs
+++ b/crates/spelunk-core/src/storage/remote/sync.rs
@@ -143,6 +143,63 @@ pub struct BatchPushResult {
     pub results: Vec<BatchItemResult>,
 }
 
+/// One relationship edge pushed to `POST /memory/batch` via the request's
+/// `edges[]` array.
+///
+/// Each endpoint is addressed by its `external_id` (the entry's stable uuid,
+/// the only id the batch edge route resolves), never the machine-local row id.
+/// `kind` is a fixed edge kind: sync pushes only `"relates_to"`, since a
+/// `supersedes` edge already travels with its entry's lifecycle and
+/// `contradicts` is server-generated. Mirrors cloud-api's batch `edges[]`
+/// element and `CloudApiMemoryBackend::supersede`'s single-edge post.
+#[derive(Debug, Serialize)]
+pub struct SyncEdgePush {
+    pub from_external_id: String,
+    pub to_external_id: String,
+    pub kind: &'static str,
+}
+
+/// An edge-only batch body: `entries` is required by the route but stays empty,
+/// so this posts edges without touching entries.
+#[derive(Debug, Serialize)]
+struct BatchEdgePushBody {
+    entries: [(); 0],
+    edges: Vec<SyncEdgePush>,
+}
+
+/// Per-edge acknowledgement in the 207 `edges[]` response.
+#[derive(Debug, Deserialize)]
+struct BatchEdgeAck {
+    status: String,
+}
+
+/// Result of an edge batch push: the per-edge acknowledgements the server
+/// returned in the 207 `edges[]` array.
+#[derive(Debug, Deserialize, Default)]
+pub struct EdgePushResult {
+    #[serde(default)]
+    edges: Vec<BatchEdgeAck>,
+}
+
+impl EdgePushResult {
+    /// Count of edges the server actually stored. An `unresolved` edge (an
+    /// endpoint the server does not know yet) is a no-op to retry on a later
+    /// sync, not a success, so it is not counted here: this matches
+    /// `CloudApiMemoryBackend`'s supersede `edge_applied`.
+    pub fn applied(&self) -> usize {
+        self.edges
+            .iter()
+            .filter(|e| matches!(e.status.as_str(), "created" | "applied" | "updated"))
+            .count()
+    }
+
+    /// Total edges the server acknowledged, applied or not (the length of the
+    /// returned `edges[]` array).
+    pub fn acknowledged(&self) -> usize {
+        self.edges.len()
+    }
+}
+
 /// One entry returned by `GET /memory/since`.
 ///
 /// Mirrors cloud-api's `EntryResponse`; the embedding vector is never sent by
@@ -291,6 +348,38 @@ impl CloudSyncClient {
         resp.json::<BatchPushResult>()
             .await
             .context("parsing /memory/batch response")
+    }
+
+    /// Push a batch of relationship edges via the same `POST /memory/batch`
+    /// route, carrying them in the request's `edges[]` array with an empty
+    /// `entries[]`.
+    ///
+    /// Idempotent server-side (the batch edge route dedupes on `ON CONFLICT DO
+    /// NOTHING`), so a re-push is harmless. An edge naming an endpoint the
+    /// server does not know yet comes back `unresolved`, which
+    /// [`EdgePushResult::applied`] reports as not-applied rather than an error:
+    /// the endpoint just is not synced yet, and a later sync retries it. An
+    /// empty input is a no-op with no request.
+    pub async fn push_edges(&self, edges: Vec<SyncEdgePush>) -> Result<EdgePushResult> {
+        if edges.is_empty() {
+            return Ok(EdgePushResult::default());
+        }
+        let body = BatchEdgePushBody { entries: [], edges };
+        let resp = self
+            .authed(self.client.post(self.url("memory/batch")))
+            .json(&body)
+            .send()
+            .await
+            .context("POST /memory/batch (edges)")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("POST /memory/batch edges failed ({status}): {text}");
+        }
+        resp.json::<EdgePushResult>()
+            .await
+            .context("parsing /memory/batch edges response")
     }
 
     /// Tombstone a cloud entry by its cloud-minted id (`DELETE /memory/{id}`).
@@ -539,6 +628,85 @@ mod tests {
         let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
         let res = client.push_batch(vec![]).await.unwrap();
         assert_eq!((res.created, res.skipped, res.failed), (0, 0, 0));
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    fn relates_edge(from: &str, to: &str) -> SyncEdgePush {
+        SyncEdgePush {
+            from_external_id: from.into(),
+            to_external_id: to.into(),
+            kind: "relates_to",
+        }
+    }
+
+    // A relates_to push must hit the same `/memory/batch` route the entry push
+    // uses, but as an edge-only body: `entries` empty, one `edges[]` element
+    // keyed by external_id. A 207 `{"edges":[{"status":"created"}]}` counts as
+    // applied.
+    #[tokio::test]
+    async fn push_edges_posts_an_edge_only_relates_to_batch_body() {
+        use wiremock::matchers::body_json;
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .and(body_json(serde_json::json!({
+                "entries": [],
+                "edges": [{
+                    "from_external_id": "ext-from",
+                    "to_external_id": "ext-to",
+                    "kind": "relates_to",
+                }],
+            })))
+            .respond_with(
+                ResponseTemplate::new(207)
+                    .set_body_json(serde_json::json!({"edges": [{"status": "created"}]})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+        let res = client
+            .push_edges(vec![relates_edge("ext-from", "ext-to")])
+            .await
+            .unwrap();
+        assert_eq!(res.applied(), 1, "a created edge must count as applied");
+    }
+
+    // An edge naming an endpoint the server does not know yet comes back
+    // `unresolved`. That is "not yet, retry later", not a failure: the call
+    // must succeed and simply not count the edge as applied.
+    #[tokio::test]
+    async fn an_unresolved_edge_push_is_graceful_and_not_counted_as_applied() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/projects/proj/memory/batch"))
+            .respond_with(
+                ResponseTemplate::new(207)
+                    .set_body_json(serde_json::json!({"edges": [{"status": "unresolved"}]})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+        let res = client
+            .push_edges(vec![relates_edge("ext-from", "ext-to")])
+            .await
+            .expect("an unresolved edge must not surface as an error");
+        assert_eq!(res.applied(), 0, "unresolved must not read as applied");
+        assert_eq!(
+            res.acknowledged(),
+            1,
+            "the edge was acknowledged, just not resolved"
+        );
+    }
+
+    #[tokio::test]
+    async fn push_edges_empty_is_a_noop_with_no_request() {
+        let server = MockServer::start().await;
+        let client = CloudSyncClient::new(&server.uri(), "proj", None, None).unwrap();
+        let res = client.push_edges(vec![]).await.unwrap();
+        assert_eq!(res.applied(), 0);
         assert!(server.received_requests().await.unwrap().is_empty());
     }
 


### PR DESCRIPTION
## Why

The web-app knowledge graph shows `answer` nodes unconnected to their `question` nodes. Since #817, `spelunk memory add --relates-to` writes the edge to the local SQLite graph — but the CLI never propagated `relates_to` edges to cloud-api, so they never reached the graph. This PR closes that (gap B).

Sibling **cloud-api** PR (gap C — accept + store the edge server-side): https://github.com/spelunk-cloud/cloud-api/pull/298.

## What

- New `CloudSyncClient::push_edges` — an edge-only `POST /memory/batch` mirroring `supersede()`'s wire shape (`{entries:[], edges:[BatchEdge{kind:"relates_to"}]}`, `207` → `applied()`).
  - **Seam note:** the live `spelunk sync` push path runs through `CloudSyncClient` (`remote/sync.rs`), **not** `CloudApiMemoryBackend::add_edge` (a no-op that isn't on that path); the edge-push seam was generalised onto the client.
- `MemoryStore::relates_to_edges_for_sync()` enumerates **only** `relates_to` edges whose **both** endpoints are already synced (external `uuid` resolved locally — no cloud round-trips).
- Invoked from `push_local` after entries land, filtered to edges touching rows stamped this round (`just_synced`). `sync` output now reports `edges_pushed`.
- Only `relates_to` is pushed; `supersedes` keeps its existing path; `contradicts` (server-generated) is never pushed.

## Idempotency / failure mode

No new state store: each edge posts in the round its second endpoint syncs; the server's `ON CONFLICT DO NOTHING` covers re-push. Edge push is **best-effort / non-fatal** (warns, never blocks the entry sync). A transient POST failure after entries land is not re-driven on a later *no-op* sync (self-heals on new memory activity). A per-edge `synced` marker column is the alternative if strict retry-on-failure is later required.

## Release ordering

Runtime-depends on the cloud-api sibling: **C must be in production before this is released** (a push against a pre-C cloud returns 422 and simply retries on a later sync — no data loss). Merge order is unconstrained.

## Tests

8 new (`SPELUNK_SECRET_STORE=file`): wiremock unit (`push_edges` body / unresolved / empty-noop), store gates (both-endpoints-synced; ignores supersedes/contradicts), CLI push-level (propagation + no-repost), and a real-binary integration test (`memory_relates_to_edge_sync`). Repo `verify` gates (fmt, clippy `--lib --bins --tests --benches`, build, tests, doctests, git-isolation, source hygiene) green.

Task: `spelunk-oss^337`. Opened as **draft**; flipping to ready-for-review after a fresh, independent verification run passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
