### PR TITLE
Index non-ASCII identifiers as mention edges

### DIFF
--- a/crates/spelunk-cli/src/cli/cmd/index/mentions.rs
+++ b/crates/spelunk-cli/src/cli/cmd/index/mentions.rs
@@ -277,7 +277,7 @@ pub(super) fn extract_mention_tokens(content: &str, language: &str) -> Vec<Strin
 
     for i in 0..=n {
         let ch = if i < n { chars[i] } else { ' ' };
-        let is_ident = ch.is_ascii_alphanumeric() || ch == '_';
+        let is_ident = ch.is_alphanumeric() || ch == '_';
 
         if is_ident {
             if start.is_none() {
@@ -285,9 +285,11 @@ pub(super) fn extract_mention_tokens(content: &str, language: &str) -> Vec<Strin
             }
         } else if let Some(s) = start.take() {
             let tok: String = chars[s..i].iter().collect();
-            // Keep tokens that look like symbols: 3-50 chars, not all digits, not a stopword
-            if tok.len() >= 3
-                && tok.len() <= 50
+            // Keep tokens that look like symbols: 3-50 chars, not all digits, not a stopword.
+            // Length is counted in chars, not bytes, so multibyte identifiers are bounded
+            // the same as ASCII ones.
+            let len = tok.chars().count();
+            if (3..=50).contains(&len)
                 && !tok.chars().all(|c| c.is_ascii_digit())
                 && !stop.contains(tok.as_str())
                 && seen.insert(tok.clone())
@@ -407,6 +409,42 @@ fn getDirectoryTree(dirPath: string) { const subTree = walk(dirPath); return sub
         for stopword in ["fn", "let", "pub", "self"] {
             assert!(!tokens.iter().any(|t| t == stopword));
         }
+    }
+
+    #[test]
+    fn extract_mention_tokens_keeps_non_ascii_identifiers() {
+        let content = "fn función() { let número = 1; procesar(número); } fn 日本語() {}";
+        let tokens = extract_mention_tokens(content, "rust");
+        for real in ["función", "número", "procesar", "日本語"] {
+            assert!(
+                tokens.iter().any(|t| t == real),
+                "missing expected token: {real}"
+            );
+        }
+        // The old ASCII-only scanner split these at the first non-ASCII byte,
+        // yielding these fragments instead of the whole identifier.
+        for fragment in ["funci", "mero"] {
+            assert!(
+                !tokens.iter().any(|t| t == fragment),
+                "unexpected truncated token: {fragment}"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_mention_tokens_char_length_bound_and_digits() {
+        let content = "let n = 12345; call(日本, café);";
+        let tokens = extract_mention_tokens(content, "rust");
+        assert!(tokens.iter().any(|t| t == "café"));
+        assert!(tokens.iter().any(|t| t == "call"));
+        assert!(
+            !tokens.iter().any(|t| t == "日本"),
+            "two-char identifier is below the 3-char minimum"
+        );
+        assert!(
+            !tokens.iter().any(|t| t == "12345"),
+            "all-digit tokens are dropped"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Background

This started as an evaluation of GitHub's [`casefold` crate / blog post](https://github.blog/engineering/architecture-optimization/dont-stop-early-case-folding-source-code-at-memory-speed/) for spelunk's search and indexing. Conclusion: **do not adopt `casefold`.**

- FTS keyword search (`chunks_fts`) and memory search (`memory_fts`) are already Unicode case-insensitive via SQLite's default `unicode61` tokenizer (`migrations/007_fts.sql`, `012_memory_fts.sql`); a Rust folder is redundant and pre-folding would corrupt stored casing.
- Symbol/graph search (`storage/graph.rs`) is deliberately case-sensitive exact matching; folding would merge distinct identifiers (`Foo` vs `foo`).
- The only self-rolled case-insensitive path is live substring search (`search/live.rs` via `to_lowercase()`), where `casefold`'s simple (1-to-1) folds are behaviorally identical to `to_lowercase()` for ASCII code, do not fix the headline `ß` case (a full fold the crate omits), and where the memory-bandwidth performance story does not apply to a single-repo tool.

The review did surface a genuine, unrelated Unicode bug, which this PR fixes.

## The bug

`extract_mention_tokens` in `crates/spelunk-cli/src/cli/cmd/index/mentions.rs` builds the identifier tokens that become graph "mention edges" (which chunks reference a symbol; powers `spelunk graph <symbol>` reverse lookup). It only accepted ASCII identifier characters:

```rust
let is_ident = ch.is_ascii_alphanumeric() || ch == '_';
```

So a reference to a non-ASCII symbol like `café` was split at `é` into a bogus `caf` fragment that never matched the real symbol. Tree-sitter stores the symbol name verbatim, so the symbol existed in the graph but had no mention edges pointing at it, making it invisible to reverse-mention lookups.

## The change

Confined to `crates/spelunk-cli/src/cli/cmd/index/mentions.rs`:

- Widen the identifier character class to Unicode alphanumerics (`char::is_alphanumeric() || ch == '_'`). Still accepts everything the old ASCII check did, plus non-ASCII letters/digits. Dependency-free.
- Count the documented "3-50 chars" bound in chars, not bytes, so multibyte identifiers are bounded the same as ASCII ones (a 2-char CJK token is now correctly rejected as too short; an 18-char one is no longer wrongly rejected at 54 bytes).

Everything downstream is unchanged: the ASCII-keyword stopword set never contains non-ASCII tokens so it still filters correctly; comment/string stripping already scans `Vec<char>`; mention edges match symbol names case-sensitively and verbatim, which is exactly what we now enable for non-ASCII symbols. NFD-decomposed identifiers still split at combining marks, consistent with the codebase's deliberate no-implicit-normalization stance (`storage/entity_id.rs`); source code is overwhelmingly NFC.

## Testing

- `cargo fmt --all -- --check`: clean
- `cargo clippy --lib --bins --tests --benches --features rich-formats -- -D warnings`: clean (compiles the whole workspace including all test targets)
- `cargo test -p spelunk-cli --bins`: 638 passed, 0 failed, including two new tests (`extract_mention_tokens_keeps_non_ascii_identifiers`, `extract_mention_tokens_char_length_bound_and_digits`) and all existing `mentions` tests
- `scripts/check-git-isolation.sh`: OK

Note: the full cross-crate `cargo test` and doctest run could not be executed to completion in this environment: linking the full set of integration-test binaries exhausts the fixed session disk allowance (`ld` bus error). This is an environment limit, not related to a pure-function change; clippy has already verified every test target compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hmkwTeuXAQeMmEigib1m3

---
_Generated by [Claude Code](https://claude.ai/code/session_013hmkwTeuXAQeMmEigib1m3)_