### PR TITLE
chore: release 0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.7] — 2026-08-05
+
+### Added
+
+- **`spelunk sync` now propagates `relates_to` links to a hosted project.**
+  `memory add --relates-to` records the link locally, but sync never sent it
+  upstream, so a shared knowledge graph showed related entries as unconnected
+  nodes. Sync now pushes those links as part of the normal push, once both ends
+  of a link have themselves synced, and posts nothing when there is nothing new.
+  Link push is best-effort: a failure warns and is retried on a later sync
+  rather than failing the entry push. `supersedes` links continue to travel with
+  their entry, and `contradicts` links are still generated server-side.
+
 ### Changed
 
 - **The team `spelunk-server`'s memory read endpoints now return an object
@@ -25,6 +38,14 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Symbols with non-ASCII characters are now reachable from `spelunk graph`.**
+  A reference to a symbol such as `café` was split at the first non-ASCII
+  character into a fragment that matched nothing, so non-ASCII identifiers
+  produced no graph edges and were invisible to reverse lookups, even though
+  their definitions were indexed correctly. Identifiers now accept Unicode
+  alphanumerics, and the length bound counts characters rather than bytes so
+  multibyte names are bounded the same way as ASCII ones. Re-index to pick up
+  edges for existing code.
 - **`spelunk links check` / `spelunk links list` no longer report a freshly
   indexed linked project as stale.** The cross-project freshness probe resolved
   each linked index's stored (root-relative) file paths against the *linking*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-embed"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-embed/Cargo.toml
+++ b/crates/spelunk-embed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-embed"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2024"
 description = "Native F2LLM-v2-330M embedder (candle) for spelunk"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"


### PR DESCRIPTION
Release prep for **0.9.7**. Version bump plus the changelog roll-up; no code changes.

## What is in it

The `Unreleased` notes were already written by the fixes that landed since 0.9.6, so this mostly promotes them to a `0.9.7` section. Two user-facing changes had no entry and have been added:

- **`spelunk sync` propagates `relates_to` links to a hosted project.** Recorded locally but never sent upstream, so a shared knowledge graph showed related entries as unconnected nodes.
- **Symbols with non-ASCII characters are reachable from `spelunk graph`.** A reference to a name like `café` was split at the first non-ASCII character, so those identifiers produced no graph edges and were invisible to reverse lookups.

Everything else in the section is the fixes already merged since 0.9.6: text-search term scoring, `--as-of` point-in-time reconstruction, `memory timeline` topic filtering, `--relates-to` edge creation, `--kind` validation, `logout --server` scoping, partial `[auth]` table tolerance and config parse errors, `--mode semantic`/`hybrid` failing loudly with no server, `memory list --source-ref`, `plumbing embed` server detection, `memory harvest` on short histories, `links check` freshness, `check --format porcelain` stdout, `explore` in `--help`, the index lock gitignore entries, and the teammate-memory read path.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --lib --bins --tests --benches --features rich-formats`, and `scripts/check-git-isolation.sh` all pass on this branch.

The full test suite was not run locally: this branch changes no Rust source, and every version string is read from `CARGO_PKG_VERSION` rather than hardcoded, so no test is pinned to the literal. Left to CI.

## Notes

- All four workspace crates are bumped together, keeping them version-locked as the release workflow expects.
- `scripts/release-dry-run.sh` has not been run; it needs Docker.
- `docs/releasing.md` pins `v0.9.0` in its example download URLs. Pre-existing, and better handled as its own change than folded into a release PR.