### PR TITLE
Add a standalone tool that exports local stores to a portable dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`spelunk-export`, a standalone tool that writes a portable dump of a local
+  store.** Everything the product records lives in local SQLite databases with
+  no supported way to get it out, so backing it up, inspecting it, moving it to
+  another machine or leaving the product all required writing SQL by hand
+  against a schema that has changed ten times. The dump is line-delimited JSON,
+  one record per line, expressed as entities and relationships rather than as a
+  copy of any table, and readable without special tooling. Stores are opened
+  read-only and are never modified. Only authored data is carried: full-text
+  indexes, embeddings and import cursors all regenerate, so carrying them would
+  only risk carrying stale state forward. The tool makes no network request and
+  needs no SQLite installed on the host. An `inventory` subcommand reports what
+  a store holds without touching it.
+
+  Every table is read inside a single read transaction, so a dump is a
+  consistent point-in-time view of the whole store. Reading each table
+  separately would let a writer that commits an entry and then a link to it land
+  between the two reads, producing a link that appears to point at nothing:
+  live data that would be dropped, blamed on a broken store, and certified as a
+  clean export. A link whose endpoint really is missing from the store, which
+  data written before foreign keys were enforced can still contain, is reported
+  and left out, and the run states how many links that was alongside what it
+  carried.
+
 ## [0.9.7] — 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,33 +12,15 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **`spelunk-export`, a standalone tool that writes a portable dump of a local
-  store.** Everything the product records lives in local SQLite databases with
-  no supported way to get it out, so backing it up, inspecting it, moving it to
-  another machine or leaving the product all required writing SQL by hand
-  against a schema that has changed ten times. The dump is line-delimited JSON,
-  one record per line, expressed as entities and relationships rather than as a
-  copy of any table, and readable without special tooling. Stores are opened
-  read-only and are never modified. Only authored data is carried: full-text
-  indexes, embeddings and import cursors all regenerate, so carrying them would
-  only risk carrying stale state forward. The tool makes no network request and
-  needs no SQLite installed on the host. An `inventory` subcommand reports what
-  a store holds without touching it.
+  store.** The dump is line-delimited JSON, one record per line, expressed as
+  entities and relationships rather than as a copy of any table, and readable
+  without special tooling. Stores are opened read-only and are never modified.
+  Only authored data is carried: full-text indexes, embeddings and import
+  cursors all regenerate, so carrying them would only risk carrying stale state
+  forward. Every table is read inside a single read transaction, so a dump is a
+  consistent point-in-time view of the whole store.
 
-  Nothing on disk is overwritten either. The dump is built in a temporary beside
-  the output and moved into place only once it has been read back and matched,
-  and that temporary is created exclusively: a file already sitting at its path
-  stops the run with a message naming it, rather than being overwritten and then
-  removed.
-
-  Every table is read inside a single read transaction, so a dump is a
-  consistent point-in-time view of the whole store. Reading each table
-  separately would let a writer that commits an entry and then a link to it land
-  between the two reads, producing a link that appears to point at nothing:
-  live data that would be dropped, blamed on a broken store, and certified as a
-  clean export. A link whose endpoint really is missing from the store, which
-  data written before foreign keys were enforced can still contain, is reported
-  and left out, and the run states how many links that was alongside what it
-  carried.
+  An `inventory` subcommand reports what a store holds without touching it.
 
 ## [0.9.7] — 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ spelunk uses [Semantic Versioning](https://semver.org/).
   needs no SQLite installed on the host. An `inventory` subcommand reports what
   a store holds without touching it.
 
+  Nothing on disk is overwritten either. The dump is built in a temporary beside
+  the output and moved into place only once it has been read back and matched,
+  and that temporary is created exclusively: a file already sitting at its path
+  stops the run with a message naming it, rather than being overwritten and then
+  removed.
+
   Every table is read inside a single read transaction, so a dump is a
   consistent point-in-time view of the whole store. Reading each table
   separately would let a writer that commits an entry and then a link to it land

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ You search with spelunk, then reason over the results yourself.
 
 ## Workspace Structure
 
-This is a Cargo workspace with four crates:
+This is a Cargo workspace with five crates:
 
 ```
 Cargo.toml                    — workspace root; [workspace.dependencies] for shared versions
@@ -67,6 +67,8 @@ crates/
   spelunk-cli/                — `spelunk` binary; depends on spelunk-core
   spelunk-embed/              — library: native F2LLM-v2-330M embedder (candle); depends on spelunk-core
   spelunk-server/             — `spelunk-server` binary + lib; depends on spelunk-core + spelunk-embed
+  spelunk-export/             — `spelunk-export` binary: reads local stores and writes a portable
+                                dump; depends on no other crate in this workspace
 ```
 
 ## Module Map

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5291,6 +5291,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "spelunk-export"
+version = "0.9.7"
+dependencies = [
+ "anyhow",
+ "clap",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
+]
+
+[[package]]
 name = "spelunk-server"
 version = "0.9.7"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5296,6 +5296,7 @@ version = "0.9.7"
 dependencies = [
  "anyhow",
  "clap",
+ "flate2",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/spelunk-core",
     "crates/spelunk-cli",
     "crates/spelunk-embed",
+    "crates/spelunk-export",
     "crates/spelunk-server",
 ]
 resolver = "2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,26 @@
 # loopback can't be handed to a same-host proxy the way a bare-metal
 # process's can.
 
-# ── Stage 1: build ────────────────────────────────────────────────────────────
+# ── Stage 1: workspace skeleton ───────────────────────────────────────────────
+# Everything the dependency cache below needs to load the workspace, and nothing
+# else: every member's manifest, plus a placeholder source for the targets each
+# one declares. Reducing the real tree here, rather than naming each crate in a
+# COPY, is what keeps adding a workspace member from breaking this image. Docker
+# cannot copy `crates/*/Cargo.toml` while preserving the directory each came
+# from, so the tree is copied whole and pruned.
+FROM rust:1.97.1-slim AS skeleton
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY crates crates
+RUN find crates -mindepth 2 -maxdepth 2 ! -name Cargo.toml -exec rm -rf {} + && \
+    for c in crates/*/; do \
+        mkdir -p "$c/src" && \
+        : > "$c/src/lib.rs" && \
+        echo 'fn main(){}' > "$c/src/main.rs"; \
+    done
+
+# ── Stage 2: build ────────────────────────────────────────────────────────────
 FROM rust:1.97.1-slim AS builder
 
 WORKDIR /build
@@ -51,24 +70,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Cache dependency compilation separately from source changes. This is a
 # virtual Cargo workspace (no root package), so prime the cache from the
-# workspace manifests plus a placeholder source per member crate; the heavy
-# third-party deps (candle, etc.) then land in a layer that only busts when a
-# Cargo.toml / Cargo.lock changes. Every member manifest must be present and
-# its declared target source must exist, or cargo refuses to load the
-# workspace — even members the server bin doesn't depend on.
-COPY Cargo.toml Cargo.lock ./
-COPY crates/spelunk-core/Cargo.toml   crates/spelunk-core/Cargo.toml
-COPY crates/spelunk-cli/Cargo.toml    crates/spelunk-cli/Cargo.toml
-COPY crates/spelunk-embed/Cargo.toml  crates/spelunk-embed/Cargo.toml
-COPY crates/spelunk-server/Cargo.toml crates/spelunk-server/Cargo.toml
-RUN mkdir -p crates/spelunk-core/src crates/spelunk-cli/src \
-             crates/spelunk-embed/src crates/spelunk-server/src && \
-    : > crates/spelunk-core/src/lib.rs && \
-    : > crates/spelunk-embed/src/lib.rs && \
-    : > crates/spelunk-server/src/lib.rs && \
-    echo 'fn main(){}' > crates/spelunk-cli/src/main.rs && \
-    echo 'fn main(){}' > crates/spelunk-server/src/main.rs && \
-    cargo build --release --bin spelunk-server && \
+# skeleton above; the heavy third-party deps (candle, etc.) then land in a layer
+# that only busts when a manifest or Cargo.lock changes, because that is all the
+# skeleton contains. Every member manifest must be present and its declared
+# target source must exist, or cargo refuses to load the workspace, even members
+# the server bin doesn't depend on.
+COPY --from=skeleton /build /build
+RUN cargo build --release --bin spelunk-server && \
     rm -rf crates/*/src
 
 # Now copy the real source and build properly. BuildKit normalizes COPY mtimes
@@ -79,7 +87,7 @@ COPY . .
 RUN find crates -name '*.rs' -exec touch {} + && \
     cargo build --release --bin spelunk-server
 
-# ── Stage 2: runtime ──────────────────────────────────────────────────────────
+# ── Stage 3: runtime ──────────────────────────────────────────────────────────
 FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/crates/spelunk-export/Cargo.toml
+++ b/crates/spelunk-export/Cargo.toml
@@ -24,4 +24,8 @@ serde_json = { workspace = true }
 sha2 = "0.11"
 
 [dev-dependencies]
+# The authorizer callback is a test-only need: it is the only way to pin a
+# concurrent write to an exact point inside a multi-table read instead of
+# racing for it. It is not compiled into the binary.
+rusqlite = { workspace = true, features = ["hooks"] }
 tempfile = { workspace = true }

--- a/crates/spelunk-export/Cargo.toml
+++ b/crates/spelunk-export/Cargo.toml
@@ -29,3 +29,6 @@ sha2 = "0.11"
 # racing for it. It is not compiled into the binary.
 rusqlite = { workspace = true, features = ["hooks"] }
 tempfile = { workspace = true }
+# The corpus of artifacts written by released binaries is stored gzipped,
+# because a captured database is mostly preallocated zeros.
+flate2 = "1"

--- a/crates/spelunk-export/Cargo.toml
+++ b/crates/spelunk-export/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "spelunk-export"
+version = "0.9.7"
+edition = "2024"
+description = "spelunk: export local stores to a portable dump"
+license = "MIT"
+repository = "https://github.com/spelunk-cloud/spelunk"
+homepage = "https://github.com/spelunk-cloud/spelunk"
+
+[[bin]]
+name = "spelunk-export"
+path = "src/main.rs"
+
+# Deliberately depends on no other crate in this workspace. The point of a
+# standalone reader is that it opens stores with plain SQL and column probing
+# instead of the product's schema ladder, so it keeps working against every
+# shape ever written and carries none of the product's runtime.
+[dependencies]
+anyhow = { workspace = true }
+clap = { version = "4", features = ["derive"] }
+rusqlite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = "0.11"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/spelunk-export/src/dump.rs
+++ b/crates/spelunk-export/src/dump.rs
@@ -1,0 +1,363 @@
+//! The portable dump format: record types, serialisation, and integrity.
+//!
+//! The format is line-delimited JSON and is expressed as **entities and
+//! relationships**, never as a copy of any database's tables. Tables are an
+//! implementation detail that moves between releases; entities and
+//! relationships are what the data is. That choice is what lets a reader of
+//! this format be written against the format alone, with no knowledge of the
+//! store that produced it.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const FORMAT: &str = "portable-dump";
+pub const FORMAT_VERSION: u32 = 1;
+
+/// Records are digested individually and then folded into a whole-file digest.
+///
+/// Every record *preceding* the footer contributes, header included, so a
+/// tampered header is caught by the same check as a tampered entity. The fold
+/// is over the hex digests in file order, which makes the result sensitive to
+/// record order as well as content: a reordered dump is a different dump.
+#[derive(Default)]
+pub struct Digester {
+    per_record: Vec<String>,
+}
+
+impl Digester {
+    pub fn push_line(&mut self, line: &str) {
+        let mut h = Sha256::new();
+        h.update(line.as_bytes());
+        self.per_record.push(hex(&h.finalize()));
+    }
+
+    pub fn per_record(&self) -> &[String] {
+        &self.per_record
+    }
+
+    pub fn finish(&self) -> String {
+        let mut h = Sha256::new();
+        for d in &self.per_record {
+            h.update(d.as_bytes());
+        }
+        format!("sha256:{}", hex(&h.finalize()))
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Header {
+    pub record: String,
+    pub format: String,
+    pub format_version: u32,
+    pub generated_at: i64,
+    pub generator: String,
+}
+
+impl Header {
+    pub fn new(generated_at: i64) -> Self {
+        Self {
+            record: "header".into(),
+            format: FORMAT.into(),
+            format_version: FORMAT_VERSION,
+            generated_at,
+            generator: format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
+        }
+    }
+}
+
+/// A memory entry.
+///
+/// `reference` is unique within one dump and exists only to wire relationships.
+/// It is not identity, it is not stable across dumps, and a reader must not
+/// persist it.
+///
+/// `uuid` is carried verbatim when the source row has one and omitted when it
+/// does not. This tool never mints an identifier: identity policy belongs to
+/// whatever reads the dump, and `created_at` is mandatory precisely so a reader
+/// can seed a time ordered identifier from the entry's own creation time rather
+/// than from the clock at import.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct MemoryEntry {
+    pub record: String,
+    #[serde(rename = "type")]
+    pub kind_tag: String,
+    #[serde(rename = "ref")]
+    pub reference: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    pub kind: String,
+    pub title: String,
+    pub body: String,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub linked_files: Vec<String>,
+    pub created_at: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invalid_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entity_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+}
+
+/// A registered project.
+///
+/// The store path the registry keeps beside the root is deliberately absent:
+/// every production registration derives it from the root, so carrying it would
+/// carry a path that is wrong for any reader that lays its stores out
+/// differently. A reader derives it.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct Project {
+    pub record: String,
+    #[serde(rename = "type")]
+    pub kind_tag: String,
+    #[serde(rename = "ref")]
+    pub reference: String,
+    pub root_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registered_at: Option<i64>,
+}
+
+/// One recorded command invocation.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct CommandUsage {
+    pub record: String,
+    #[serde(rename = "type")]
+    pub kind_tag: String,
+    #[serde(rename = "ref")]
+    pub reference: String,
+    pub command: String,
+    pub at: i64,
+}
+
+/// A link between two entities, by their dump local references.
+///
+/// `supersedes` is oriented **from successor to predecessor**, matching the
+/// edge table's own orientation. The lifecycle column that encodes the same
+/// fact sits on the predecessor and points the other way, so it is inverted on
+/// the way out. A writer that emitted both without inverting one would produce
+/// two contradictory edges for a single fact, and a fixture carrying only one
+/// of the two encodings would not notice.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
+pub struct Relationship {
+    pub record: String,
+    #[serde(rename = "type")]
+    pub kind_tag: String,
+    pub from: String,
+    pub to: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<i64>,
+}
+
+impl Relationship {
+    pub fn new(kind: &str, from: String, to: String, created_at: Option<i64>) -> Self {
+        Self {
+            record: "relationship".into(),
+            kind_tag: kind.into(),
+            from,
+            to,
+            created_at,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Footer {
+    pub record: String,
+    pub counts: Counts,
+    pub digest: String,
+}
+
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug)]
+pub struct Counts {
+    pub entity: BTreeMap<String, usize>,
+    pub relationship: BTreeMap<String, usize>,
+}
+
+impl Counts {
+    pub fn add_entity(&mut self, kind: &str) {
+        *self.entity.entry(kind.to_string()).or_default() += 1;
+    }
+    pub fn add_relationship(&mut self, kind: &str) {
+        *self.relationship.entry(kind.to_string()).or_default() += 1;
+    }
+}
+
+/// Everything one dump carries, in the order it is written.
+#[derive(Default)]
+pub struct Dump {
+    pub entries: Vec<MemoryEntry>,
+    pub projects: Vec<Project>,
+    pub usage: Vec<CommandUsage>,
+    pub relationships: Vec<Relationship>,
+}
+
+impl Dump {
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+            && self.projects.is_empty()
+            && self.usage.is_empty()
+            && self.relationships.is_empty()
+    }
+
+    pub fn counts(&self) -> Counts {
+        let mut c = Counts::default();
+        for e in &self.entries {
+            c.add_entity(&e.kind_tag);
+        }
+        for p in &self.projects {
+            c.add_entity(&p.kind_tag);
+        }
+        for u in &self.usage {
+            c.add_entity(&u.kind_tag);
+        }
+        for r in &self.relationships {
+            c.add_relationship(&r.kind_tag);
+        }
+        c
+    }
+
+    /// Serialise to the exact bytes of the dump file, alongside the per record
+    /// digests that back the footer.
+    pub fn render(&self, generated_at: i64) -> Result<(String, Vec<String>, Footer)> {
+        let mut out = String::new();
+        let mut dig = Digester::default();
+
+        let push = |out: &mut String, dig: &mut Digester, line: String| {
+            dig.push_line(&line);
+            out.push_str(&line);
+            out.push('\n');
+        };
+
+        push(
+            &mut out,
+            &mut dig,
+            serde_json::to_string(&Header::new(generated_at))?,
+        );
+        for e in &self.entries {
+            push(&mut out, &mut dig, serde_json::to_string(e)?);
+        }
+        for p in &self.projects {
+            push(&mut out, &mut dig, serde_json::to_string(p)?);
+        }
+        for u in &self.usage {
+            push(&mut out, &mut dig, serde_json::to_string(u)?);
+        }
+        for r in &self.relationships {
+            push(&mut out, &mut dig, serde_json::to_string(r)?);
+        }
+
+        let footer = Footer {
+            record: "footer".into(),
+            counts: self.counts(),
+            digest: dig.finish(),
+        };
+        out.push_str(&serde_json::to_string(&footer)?);
+        out.push('\n');
+        Ok((out, dig.per_record().to_vec(), footer))
+    }
+}
+
+/// What re-reading a dump file establishes: that it is structurally whole, that
+/// its footer agrees with its contents, and what each record hashed to.
+#[derive(Debug)]
+pub struct ReadBack {
+    pub per_record: Vec<String>,
+    pub counts: Counts,
+}
+
+/// Re-read a rendered dump, recomputing everything the footer claims.
+///
+/// A dump is refused whole or accepted whole. There is no partial read: the
+/// failure this guards against is silent partial loss, so anything less than a
+/// loud refusal defeats the purpose.
+pub fn verify_rendered(text: &str) -> Result<ReadBack> {
+    let mut lines = text.lines();
+    let Some(header_line) = lines.next() else {
+        bail!("dump is empty: expected a header record");
+    };
+    let header: Header =
+        serde_json::from_str(header_line).map_err(|e| anyhow::anyhow!("unreadable header: {e}"))?;
+    if header.record != "header" {
+        bail!("first record is '{}', expected 'header'", header.record);
+    }
+    if header.format != FORMAT {
+        bail!("unknown dump format '{}'", header.format);
+    }
+    if header.format_version != FORMAT_VERSION {
+        bail!(
+            "dump format version {} is not supported by this build (supports {FORMAT_VERSION})",
+            header.format_version
+        );
+    }
+
+    let mut dig = Digester::default();
+    dig.push_line(header_line);
+    let mut counts = Counts::default();
+    let mut footer: Option<Footer> = None;
+
+    for line in lines {
+        if footer.is_some() {
+            bail!("records follow the footer; the dump is not whole");
+        }
+        let value: serde_json::Value =
+            serde_json::from_str(line).map_err(|e| anyhow::anyhow!("unreadable record: {e}"))?;
+        match value.get("record").and_then(|v| v.as_str()) {
+            Some("footer") => {
+                footer = Some(serde_json::from_str(line)?);
+            }
+            Some("entity") => {
+                let t = value
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| anyhow::anyhow!("entity record without a type"))?;
+                counts.add_entity(t);
+                dig.push_line(line);
+            }
+            Some("relationship") => {
+                let t = value
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| anyhow::anyhow!("relationship record without a type"))?;
+                counts.add_relationship(t);
+                dig.push_line(line);
+            }
+            other => bail!("unknown record kind {other:?}"),
+        }
+    }
+
+    let Some(footer) = footer else {
+        bail!("dump has no footer; it is truncated");
+    };
+    if footer.counts != counts {
+        bail!("footer counts do not match the records present");
+    }
+    if footer.digest != dig.finish() {
+        bail!("dump digest does not match its contents");
+    }
+    Ok(ReadBack {
+        per_record: dig.per_record().to_vec(),
+        counts,
+    })
+}

--- a/crates/spelunk-export/src/dump.rs
+++ b/crates/spelunk-export/src/dump.rs
@@ -7,7 +7,7 @@
 //! this format be written against the format alone, with no knowledge of the
 //! store that produced it.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
@@ -292,6 +292,12 @@ pub struct ReadBack {
 /// A dump is refused whole or accepted whole. There is no partial read: the
 /// failure this guards against is silent partial loss, so anything less than a
 /// loud refusal defeats the purpose.
+///
+/// Unique references and resolvable endpoints are checked here rather than
+/// trusted to the writer that just ran. Both hold by construction today, which
+/// is exactly why the check belongs in the reader: a writer change that broke
+/// either would otherwise publish a dump whose relationships point at nothing,
+/// and the self-verification would call it proved.
 pub fn verify_rendered(text: &str) -> Result<ReadBack> {
     let mut lines = text.lines();
     let Some(header_line) = lines.next() else {
@@ -316,6 +322,8 @@ pub fn verify_rendered(text: &str) -> Result<ReadBack> {
     dig.push_line(header_line);
     let mut counts = Counts::default();
     let mut footer: Option<Footer> = None;
+    let mut refs: Vec<String> = Vec::new();
+    let mut endpoints: Vec<String> = Vec::new();
 
     for line in lines {
         if footer.is_some() {
@@ -332,6 +340,11 @@ pub fn verify_rendered(text: &str) -> Result<ReadBack> {
                     .get("type")
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| anyhow::anyhow!("entity record without a type"))?;
+                let reference = value
+                    .get("ref")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| anyhow::anyhow!("entity record without a ref"))?;
+                refs.push(reference.to_string());
                 counts.add_entity(t);
                 dig.push_line(line);
             }
@@ -340,6 +353,13 @@ pub fn verify_rendered(text: &str) -> Result<ReadBack> {
                     .get("type")
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| anyhow::anyhow!("relationship record without a type"))?;
+                for end in ["from", "to"] {
+                    let r = value
+                        .get(end)
+                        .and_then(|v| v.as_str())
+                        .ok_or_else(|| anyhow::anyhow!("relationship record without a '{end}'"))?;
+                    endpoints.push(r.to_string());
+                }
                 counts.add_relationship(t);
                 dig.push_line(line);
             }
@@ -356,6 +376,22 @@ pub fn verify_rendered(text: &str) -> Result<ReadBack> {
     if footer.digest != dig.finish() {
         bail!("dump digest does not match its contents");
     }
+
+    // After the digest, deliberately. A dump that has lost a byte will often
+    // also have lost a reference, and reporting that as a broken link would
+    // send a reader looking at the writer instead of at the file.
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for r in &refs {
+        if !seen.insert(r) {
+            bail!("two entities share the reference '{r}'");
+        }
+    }
+    // Resolved over the whole file rather than as each link is read: the format
+    // places no ordering constraint between entities and relationships.
+    if let Some(dangling) = endpoints.iter().find(|r| !seen.contains(r.as_str())) {
+        bail!("a relationship names '{dangling}', which is not an entity in this dump");
+    }
+
     Ok(ReadBack {
         per_record: dig.per_record().to_vec(),
         counts,

--- a/crates/spelunk-export/src/inventory.rs
+++ b/crates/spelunk-export/src/inventory.rs
@@ -1,0 +1,86 @@
+//! Describing what is on the machine without touching any of it.
+//!
+//! Every field here is answerable by opening a file read-only or by asking the
+//! filesystem, and nothing in this module writes. That is the whole contract:
+//! a caller can run it against a live installation and be sure it changed
+//! nothing, which is what makes it safe to run before deciding anything.
+
+use std::path::Path;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::source;
+
+#[derive(Serialize)]
+pub struct StoreReport {
+    pub path: String,
+    pub exists: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<i64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub contents: Vec<TableReport>,
+    /// Present when the file exists but could not be read. A store that cannot
+    /// be opened is reported rather than aborting the whole inventory: the
+    /// caller usually has several stores and one unreadable file should not
+    /// cost them the report on the rest.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unreadable: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct TableReport {
+    pub table: String,
+    pub rows: i64,
+}
+
+/// Only authored tables are counted. Derived tables are excluded here for the
+/// same reason they are excluded from a dump: reporting them would invite a
+/// caller to believe they need carrying.
+const AUTHORED: &[&str] = &[
+    "notes",
+    "memory_edges",
+    "note_edges",
+    "projects",
+    "project_deps",
+    "usage",
+];
+
+pub fn describe(path: &Path) -> StoreReport {
+    let mut report = StoreReport {
+        path: path.display().to_string(),
+        exists: path.exists(),
+        bytes: None,
+        schema_version: None,
+        contents: Vec::new(),
+        unreadable: None,
+    };
+    if !report.exists {
+        return report;
+    }
+    report.bytes = std::fs::metadata(path).ok().map(|m| m.len());
+    match inspect(path, &mut report) {
+        Ok(()) => {}
+        Err(e) => report.unreadable = Some(e.to_string()),
+    }
+    report
+}
+
+fn inspect(path: &Path, report: &mut StoreReport) -> Result<()> {
+    let conn = source::open_read_only(path)?;
+    report.schema_version = Some(source::schema_version(&conn)?);
+    for table in AUTHORED {
+        // A missing table is the normal case for every store: each one holds a
+        // different subset. Only a present-but-unreadable table is a problem,
+        // and that surfaces as the count query failing on the next store.
+        if let Ok(rows) = source::count(&conn, table) {
+            report.contents.push(TableReport {
+                table: (*table).to_string(),
+                rows,
+            });
+        }
+    }
+    Ok(())
+}

--- a/crates/spelunk-export/src/lib.rs
+++ b/crates/spelunk-export/src/lib.rs
@@ -86,10 +86,32 @@ pub fn export(store: &Path, out: &Path, generated_at: i64) -> Result<ExportOutco
 /// store is read inside one transaction, so a second read returns the same rows
 /// by construction. The comparison that can still fail, and therefore the only
 /// one worth making, is between the file and what was rendered.
+///
+/// The temporary is created exclusively, so anything already at that path stops
+/// the run instead of being overwritten and then unlinked on the way out. This
+/// is the one tool in the system whose contract is that it destroys nothing,
+/// and a file it did not create is a file it does not own, whatever its name.
 pub fn write_verified(text: &str, expected: &[String], out: &Path) -> Result<()> {
+    use std::io::Write as _;
+
     let temp = out.with_extension("partial");
-    std::fs::write(&temp, text.as_bytes())
-        .with_context(|| format!("writing {}", temp.display()))?;
+    let mut handle = std::fs::File::create_new(&temp).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::AlreadyExists {
+            anyhow::anyhow!(
+                "{} already exists; this run will not overwrite it. Move it aside, or \
+                 export to a different --out.",
+                temp.display()
+            )
+        } else {
+            anyhow::Error::new(e).context(format!("creating {}", temp.display()))
+        }
+    })?;
+    let put = handle.write_all(text.as_bytes());
+    drop(handle);
+    if let Err(e) = put {
+        let _ = std::fs::remove_file(&temp);
+        return Err(anyhow::Error::new(e).context(format!("writing {}", temp.display())));
+    }
 
     let checked = (|| -> Result<()> {
         let written = std::fs::read_to_string(&temp)

--- a/crates/spelunk-export/src/lib.rs
+++ b/crates/spelunk-export/src/lib.rs
@@ -20,21 +20,73 @@ pub struct ExportOutcome {
     pub warnings: Vec<String>,
 }
 
+impl ExportOutcome {
+    /// What the run tells the user it did.
+    ///
+    /// The claim has to be exactly as strong as what was established and no
+    /// stronger. A dump that omits links whose endpoint is missing from the
+    /// store is still a faithful dump of everything the format can express, but
+    /// a run that says only "verified" invites the reader to conclude nothing
+    /// was left behind. So the omissions are counted on the same screen as the
+    /// success, not left to a warning stream that a caller may not be reading.
+    pub fn summary(&self, out: &Path) -> String {
+        let mut s = format!("Wrote {}\n", out.display());
+        if self.counts.entity.is_empty() && self.counts.relationship.is_empty() {
+            s.push_str("  the store held nothing to carry\n");
+        } else {
+            for (kind, n) in &self.counts.entity {
+                s.push_str(&format!("  {n} {kind}\n"));
+            }
+            for (kind, n) in &self.counts.relationship {
+                s.push_str(&format!("  {n} {kind}\n"));
+            }
+            s.push_str("  the dump reads back as exactly what was read from the store\n");
+        }
+        if !self.warnings.is_empty() {
+            let n = self.warnings.len();
+            s.push_str(&format!(
+                "  {n} link(s) were NOT carried: each names an entry that is not in the store. \
+                 The store was read as of a single point in time, so this is damage in the \
+                 store itself, not a write that arrived mid-export. See the warnings above.\n"
+            ));
+        }
+        s
+    }
+}
+
 /// Read `store`, write a dump at `out`, and prove the dump matches the store
 /// before leaving it in place.
-///
-/// The dump is written to a sibling temporary file and renamed only once it has
-/// been read back and checked, so a failure at any point leaves no dump at all
-/// rather than a plausible-looking partial one. Silent partial loss is the risk
-/// this whole tool exists to avoid, so a half-written file is worse than none.
 pub fn export(store: &Path, out: &Path, generated_at: i64) -> Result<ExportOutcome> {
     let conn = source::open_read_only(store)?;
     // An empty store is not an error. A caller sweeping several stores should
     // get a valid dump for each, and a valid empty dump is what tells a reader
     // "there was nothing here" rather than "this was never exported".
-    let extracted = source::extract(&conn)?;
+    let extracted =
+        source::extract(&conn).with_context(|| format!("reading {}", store.display()))?;
     let (text, per_record, footer) = extracted.dump.render(generated_at)?;
 
+    write_verified(&text, &per_record, out)?;
+
+    Ok(ExportOutcome {
+        counts: footer.counts,
+        warnings: extracted.warnings,
+    })
+}
+
+/// Put `text` at `out`, but only once the bytes that actually landed have been
+/// read back and shown to be those bytes.
+///
+/// The dump goes to a sibling temporary file and is renamed only after it reads
+/// back as a whole, self-consistent dump whose records hash to `expected`, so a
+/// failure at any point leaves no dump at all rather than a plausible-looking
+/// partial one. Silent partial loss is the risk this whole tool exists to
+/// avoid, and a truncated file that no one is told about is exactly that.
+///
+/// Re-reading the store instead of the rendered bytes would add nothing: the
+/// store is read inside one transaction, so a second read returns the same rows
+/// by construction. The comparison that can still fail, and therefore the only
+/// one worth making, is between the file and what was rendered.
+pub fn write_verified(text: &str, expected: &[String], out: &Path) -> Result<()> {
     let temp = out.with_extension("partial");
     std::fs::write(&temp, text.as_bytes())
         .with_context(|| format!("writing {}", temp.display()))?;
@@ -43,20 +95,8 @@ pub fn export(store: &Path, out: &Path, generated_at: i64) -> Result<ExportOutco
         let written = std::fs::read_to_string(&temp)
             .with_context(|| format!("reading back {}", temp.display()))?;
         let read_back = dump::verify_rendered(&written)?;
-        if read_back.per_record != per_record {
+        if read_back.per_record != expected {
             bail!("the dump on disk does not match what was read from the store");
-        }
-
-        // Re-read the store and re-render, so the check compares the file
-        // against the store rather than against the in-memory value that
-        // produced it. This catches a store that moved underneath the export
-        // and every way the write itself can go wrong. It cannot catch a
-        // systematic misreading of the store, because a second read repeats it;
-        // that is what the fixture corpus is for.
-        let again = source::extract(&conn)?;
-        let (_, again_records, _) = again.dump.render(generated_at)?;
-        if again_records != per_record {
-            bail!("the store changed while it was being exported; nothing was written");
         }
         Ok(())
     })();
@@ -67,10 +107,5 @@ pub fn export(store: &Path, out: &Path, generated_at: i64) -> Result<ExportOutco
     }
 
     std::fs::rename(&temp, out)
-        .with_context(|| format!("moving the verified dump into place at {}", out.display()))?;
-
-    Ok(ExportOutcome {
-        counts: footer.counts,
-        warnings: extracted.warnings,
-    })
+        .with_context(|| format!("moving the verified dump into place at {}", out.display()))
 }

--- a/crates/spelunk-export/src/lib.rs
+++ b/crates/spelunk-export/src/lib.rs
@@ -1,0 +1,76 @@
+//! Export local stores to a portable dump.
+//!
+//! This is a standalone reader. It depends on no other crate in this
+//! workspace, opens every store read-only, and discovers each store's shape
+//! from the file rather than from a compiled-in schema version. That is what
+//! lets one binary read stores written by any past release, and what keeps it
+//! from carrying the product's runtime around with it.
+
+pub mod dump;
+pub mod inventory;
+pub mod source;
+
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+
+#[derive(Debug)]
+pub struct ExportOutcome {
+    pub counts: dump::Counts,
+    pub warnings: Vec<String>,
+}
+
+/// Read `store`, write a dump at `out`, and prove the dump matches the store
+/// before leaving it in place.
+///
+/// The dump is written to a sibling temporary file and renamed only once it has
+/// been read back and checked, so a failure at any point leaves no dump at all
+/// rather than a plausible-looking partial one. Silent partial loss is the risk
+/// this whole tool exists to avoid, so a half-written file is worse than none.
+pub fn export(store: &Path, out: &Path, generated_at: i64) -> Result<ExportOutcome> {
+    let conn = source::open_read_only(store)?;
+    // An empty store is not an error. A caller sweeping several stores should
+    // get a valid dump for each, and a valid empty dump is what tells a reader
+    // "there was nothing here" rather than "this was never exported".
+    let extracted = source::extract(&conn)?;
+    let (text, per_record, footer) = extracted.dump.render(generated_at)?;
+
+    let temp = out.with_extension("partial");
+    std::fs::write(&temp, text.as_bytes())
+        .with_context(|| format!("writing {}", temp.display()))?;
+
+    let checked = (|| -> Result<()> {
+        let written = std::fs::read_to_string(&temp)
+            .with_context(|| format!("reading back {}", temp.display()))?;
+        let read_back = dump::verify_rendered(&written)?;
+        if read_back.per_record != per_record {
+            bail!("the dump on disk does not match what was read from the store");
+        }
+
+        // Re-read the store and re-render, so the check compares the file
+        // against the store rather than against the in-memory value that
+        // produced it. This catches a store that moved underneath the export
+        // and every way the write itself can go wrong. It cannot catch a
+        // systematic misreading of the store, because a second read repeats it;
+        // that is what the fixture corpus is for.
+        let again = source::extract(&conn)?;
+        let (_, again_records, _) = again.dump.render(generated_at)?;
+        if again_records != per_record {
+            bail!("the store changed while it was being exported; nothing was written");
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = checked {
+        let _ = std::fs::remove_file(&temp);
+        return Err(e);
+    }
+
+    std::fs::rename(&temp, out)
+        .with_context(|| format!("moving the verified dump into place at {}", out.display()))?;
+
+    Ok(ExportOutcome {
+        counts: footer.counts,
+        warnings: extracted.warnings,
+    })
+}

--- a/crates/spelunk-export/src/main.rs
+++ b/crates/spelunk-export/src/main.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-use spelunk_export::{dump, export, inventory};
+use spelunk_export::{export, inventory};
 
 #[derive(Parser)]
 #[command(
@@ -61,7 +61,7 @@ fn run() -> Result<()> {
             for w in &outcome.warnings {
                 eprintln!("warning: {w}");
             }
-            report(&outcome.counts, &out);
+            print!("{}", outcome.summary(&out));
             Ok(())
         }
         Command::Inventory { stores } => {
@@ -70,19 +70,4 @@ fn run() -> Result<()> {
             Ok(())
         }
     }
-}
-
-fn report(counts: &dump::Counts, out: &std::path::Path) {
-    println!("Wrote {}", out.display());
-    if counts.entity.is_empty() && counts.relationship.is_empty() {
-        println!("  the store held nothing to carry");
-        return;
-    }
-    for (kind, n) in &counts.entity {
-        println!("  {n} {kind}");
-    }
-    for (kind, n) in &counts.relationship {
-        println!("  {n} {kind}");
-    }
-    println!("  verified against the store: counts and per-record checksums match");
 }

--- a/crates/spelunk-export/src/main.rs
+++ b/crates/spelunk-export/src/main.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use spelunk_export::{dump, export, inventory};
+
+#[derive(Parser)]
+#[command(
+    name = "spelunk-export",
+    about = "Export local spelunk stores to a portable dump",
+    long_about = "Reads local stores and writes a portable, documented dump: line-delimited \
+                  JSON, one record per line, readable without any special tooling.\n\n\
+                  Stores are opened read-only and are never modified. Only authored data is \
+                  carried; derived state such as full-text indexes and embeddings is left out \
+                  because it regenerates. No network access is made at any point.",
+    version
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Write a portable dump of one store.
+    Export {
+        /// The store to read. Opened read-only and never modified.
+        #[arg(long)]
+        store: PathBuf,
+        /// Where to write the dump. Written only once it has been verified
+        /// against the store.
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Report what a store holds, without touching it.
+    Inventory {
+        /// One or more stores to describe. Missing paths are reported as
+        /// missing rather than treated as an error.
+        #[arg(long = "store", num_args = 1..)]
+        stores: Vec<PathBuf>,
+    },
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("error: {e:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    match Cli::parse().command {
+        Command::Export { store, out } => {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or_default();
+            let outcome = export(&store, &out, now)?;
+            for w in &outcome.warnings {
+                eprintln!("warning: {w}");
+            }
+            report(&outcome.counts, &out);
+            Ok(())
+        }
+        Command::Inventory { stores } => {
+            let reports: Vec<_> = stores.iter().map(|p| inventory::describe(p)).collect();
+            println!("{}", serde_json::to_string_pretty(&reports)?);
+            Ok(())
+        }
+    }
+}
+
+fn report(counts: &dump::Counts, out: &std::path::Path) {
+    println!("Wrote {}", out.display());
+    if counts.entity.is_empty() && counts.relationship.is_empty() {
+        println!("  the store held nothing to carry");
+        return;
+    }
+    for (kind, n) in &counts.entity {
+        println!("  {n} {kind}");
+    }
+    for (kind, n) in &counts.relationship {
+        println!("  {n} {kind}");
+    }
+    println!("  verified against the store: counts and per-record checksums match");
+}

--- a/crates/spelunk-export/src/source.rs
+++ b/crates/spelunk-export/src/source.rs
@@ -25,14 +25,31 @@ pub struct Extract {
     pub warnings: Vec<String>,
 }
 
+/// Open a store for reading and nothing else.
+///
+/// A URI with `immutable=1` would avoid touching the directory at all, but it
+/// lies to SQLite about a file another process may be writing, and a store in
+/// write-ahead-log mode keeps committed rows in the log: reading it as
+/// immutable would silently return a stale database. So the content guarantee
+/// is that no byte of the database or its log is changed, not that the
+/// directory gains no file. Reading a log-mode store nobody has open brings
+/// SQLite's shared-memory index and an empty log into being, and a read-only
+/// connection has no way to decline that.
 pub fn open_read_only(path: &Path) -> Result<Connection> {
-    // A URI with `immutable=1` would be faster but lies to SQLite about a file
-    // another process may be writing. READ_ONLY plus the default locking keeps
-    // the promise that this tool never modifies the source, including its
-    // journal and WAL sidecars.
-    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-        .with_context(|| format!("opening {} read-only", path.display()))
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("opening {} read-only", path.display()))?;
+    // A store in the older rollback journal mode locks out readers while a
+    // writer commits. Holding the read open across every table means such a
+    // writer can now block the export where it previously could not, so wait
+    // out a passing one rather than refusing. A store that is locked for longer
+    // than this is held by something that is not passing, and the right answer
+    // there is to stop with a reason.
+    conn.busy_timeout(WRITER_PATIENCE)
+        .context("configuring how long to wait for a writer")?;
+    Ok(conn)
 }
+
+const WRITER_PATIENCE: std::time::Duration = std::time::Duration::from_secs(5);
 
 fn tables(conn: &Connection) -> Result<BTreeSet<String>> {
     let mut stmt = conn.prepare("SELECT name FROM sqlite_master WHERE type='table'")?;
@@ -71,14 +88,34 @@ fn list(value: Option<String>) -> Vec<String> {
     }
 }
 
-/// Read every authored surface the file happens to contain.
+/// Read every authored surface the file happens to contain, as of a single
+/// point in time.
 ///
 /// Content is detected from table shape rather than declared by the caller, so
 /// one code path covers the per project store, the registry, the accumulated
 /// command counts that live beside a code index, and a multi project server
 /// store. A caller that had to name the kind would be a caller that has to be
 /// kept in step with every historic layout.
+///
+/// Every table is read inside one read transaction. Without it each statement
+/// gets its own snapshot, so entries come from one instant and links from a
+/// later one, and a writer committing an entry and then a link referencing it
+/// lands between them. The link then names an entry the read never returned,
+/// which is indistinguishable from a link whose endpoint really is gone: the
+/// live data would be dropped, reported as a broken store, and the export would
+/// still succeed. One transaction is what makes a reported broken link true.
 pub fn extract(conn: &Connection) -> Result<Extract> {
+    let snapshot = conn
+        .unchecked_transaction()
+        .context("opening a read transaction over the store")?;
+    let extracted = extract_snapshot(&snapshot)?;
+    snapshot
+        .rollback()
+        .context("closing the read transaction")?;
+    Ok(extracted)
+}
+
+fn extract_snapshot(conn: &Connection) -> Result<Extract> {
     let tables = tables(conn)?;
     let mut dump = Dump::default();
     let mut warnings = Vec::new();
@@ -229,8 +266,8 @@ fn read_entries(
     for (successor, predecessor) in supersedes {
         if !present.contains(&successor) {
             warnings.push(format!(
-                "entry {predecessor} names a successor ({successor}) that no longer exists; \
-                 the supersede link is not carried"
+                "entry {predecessor} names a successor ({successor}) that is not in the \
+                 store; the supersede link is not carried"
             ));
             continue;
         }
@@ -362,8 +399,8 @@ fn read_namespaced_entries(
     for (successor, predecessor) in supersedes {
         if !present.contains(&successor) {
             warnings.push(format!(
-                "entry {predecessor} names a successor ({successor}) that no longer exists; \
-                 the supersede link is not carried"
+                "entry {predecessor} names a successor ({successor}) that is not in the \
+                 store; the supersede link is not carried"
             ));
             continue;
         }
@@ -419,8 +456,8 @@ fn read_edges(
         let (from, to, kind, created_at) = row?;
         if !present.contains(&from) || !present.contains(&to) {
             warnings.push(format!(
-                "a '{kind}' link between {from} and {to} names an entry that no longer exists; \
-                 it is not carried"
+                "a '{kind}' link between {from} and {to} names an entry that is not in the \
+                 store; it is not carried"
             ));
             continue;
         }

--- a/crates/spelunk-export/src/source.rs
+++ b/crates/spelunk-export/src/source.rs
@@ -1,0 +1,540 @@
+//! Reading a local store, at any shape it has ever had.
+//!
+//! Every store is opened read-only and read with plain SQL over probed
+//! columns. There is no schema ladder here and no version constant: the shape
+//! is discovered from the file, so a store written by any past release reads
+//! the same way as one written yesterday, and a store written by a future
+//! release loses only the columns this build has never heard of.
+//!
+//! Nothing derived is read. Full text indexes, embeddings, import cursors,
+//! marker tables and engine shadow tables are all reconstructible from the
+//! authored rows or from the user's own source tree, and reading them would
+//! only create a way to carry stale state forward.
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OpenFlags};
+
+use crate::dump::{CommandUsage, Dump, MemoryEntry, Project, Relationship};
+
+/// What a store turned out to contain, and anything the read could not honour.
+pub struct Extract {
+    pub dump: Dump,
+    pub warnings: Vec<String>,
+}
+
+pub fn open_read_only(path: &Path) -> Result<Connection> {
+    // A URI with `immutable=1` would be faster but lies to SQLite about a file
+    // another process may be writing. READ_ONLY plus the default locking keeps
+    // the promise that this tool never modifies the source, including its
+    // journal and WAL sidecars.
+    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("opening {} read-only", path.display()))
+}
+
+fn tables(conn: &Connection) -> Result<BTreeSet<String>> {
+    let mut stmt = conn.prepare("SELECT name FROM sqlite_master WHERE type='table'")?;
+    let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
+    Ok(rows.collect::<rusqlite::Result<_>>()?)
+}
+
+fn columns(conn: &Connection, table: &str) -> Result<BTreeSet<String>> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let rows = stmt.query_map([], |r| r.get::<_, String>(1))?;
+    Ok(rows.collect::<rusqlite::Result<_>>()?)
+}
+
+pub fn schema_version(conn: &Connection) -> Result<i64> {
+    Ok(conn.query_row("PRAGMA user_version", [], |r| r.get(0))?)
+}
+
+pub fn count(conn: &Connection, table: &str) -> Result<i64> {
+    Ok(conn.query_row(&format!("SELECT count(*) FROM {table}"), [], |r| r.get(0))?)
+}
+
+/// Split the comma joined representation the stores use for lists.
+///
+/// Reproduces the product's own splitting exactly, including that a value
+/// containing a comma is indistinguishable from two values. That ambiguity is
+/// in the stored data, not introduced here, and the format cannot resolve it
+/// without inventing information.
+fn list(value: Option<String>) -> Vec<String> {
+    match value.as_deref() {
+        None | Some("") => vec![],
+        Some(s) => s
+            .split(',')
+            .map(|p| p.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+    }
+}
+
+/// Read every authored surface the file happens to contain.
+///
+/// Content is detected from table shape rather than declared by the caller, so
+/// one code path covers the per project store, the registry, the accumulated
+/// command counts that live beside a code index, and a multi project server
+/// store. A caller that had to name the kind would be a caller that has to be
+/// kept in step with every historic layout.
+pub fn extract(conn: &Connection) -> Result<Extract> {
+    let tables = tables(conn)?;
+    let mut dump = Dump::default();
+    let mut warnings = Vec::new();
+
+    if tables.contains("notes") {
+        let cols = columns(conn, "notes")?;
+        if cols.contains("project_id") {
+            read_namespaced_entries(conn, &cols, &tables, &mut dump, &mut warnings)?;
+        } else {
+            read_entries(conn, &cols, &tables, &mut dump, &mut warnings)?;
+        }
+    }
+
+    if tables.contains("projects") && columns(conn, "projects")?.contains("root_path") {
+        read_projects(conn, &tables, &mut dump, &mut warnings)?;
+    }
+
+    if tables.contains("usage") {
+        read_usage(conn, &mut dump)?;
+    }
+
+    Ok(Extract { dump, warnings })
+}
+
+struct EntryCols {
+    has: BTreeSet<String>,
+}
+
+impl EntryCols {
+    fn optional(&self, name: &str) -> bool {
+        self.has.contains(name)
+    }
+
+    /// The select list, with absent columns replaced by NULL so the row reader
+    /// can index by a fixed position regardless of the store's age.
+    fn select(&self, base: &[&str], optional: &[&str]) -> String {
+        let mut parts: Vec<String> = base.iter().map(|c| (*c).to_string()).collect();
+        for c in optional {
+            if self.optional(c) {
+                parts.push((*c).to_string());
+            } else {
+                parts.push(format!("NULL AS {c}"));
+            }
+        }
+        parts.join(", ")
+    }
+}
+
+const ENTRY_OPTIONAL: &[&str] = &[
+    "status",
+    "superseded_by",
+    "source_ref",
+    "valid_at",
+    "invalid_at",
+    "uuid",
+    "remote_id",
+    "entity_id",
+];
+
+fn require(cols: &BTreeSet<String>, needed: &[&str]) -> Result<()> {
+    let missing: Vec<&str> = needed
+        .iter()
+        .copied()
+        .filter(|c| !cols.contains(*c))
+        .collect();
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "the 'notes' table is missing required columns: {}",
+            missing.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn read_entries(
+    conn: &Connection,
+    cols: &BTreeSet<String>,
+    tables: &BTreeSet<String>,
+    dump: &mut Dump,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    require(cols, &["id", "kind", "title", "body", "created_at"])?;
+    let ec = EntryCols { has: cols.clone() };
+    let has_tags = ec.optional("tags");
+    let has_linked = ec.optional("linked_files");
+    let sql = format!(
+        "SELECT id, kind, title, body, {}, {}, created_at, {} FROM notes ORDER BY id",
+        if has_tags { "tags" } else { "NULL AS tags" },
+        if has_linked {
+            "linked_files"
+        } else {
+            "NULL AS linked_files"
+        },
+        ec.select(&[], ENTRY_OPTIONAL)
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, i64>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+            r.get::<_, String>(3)?,
+            r.get::<_, Option<String>>(4)?,
+            r.get::<_, Option<String>>(5)?,
+            r.get::<_, i64>(6)?,
+            r.get::<_, Option<String>>(7)?,
+            r.get::<_, Option<i64>>(8)?,
+            r.get::<_, Option<String>>(9)?,
+            r.get::<_, Option<i64>>(10)?,
+            r.get::<_, Option<i64>>(11)?,
+            r.get::<_, Option<String>>(12)?,
+            r.get::<_, Option<String>>(13)?,
+            r.get::<_, Option<String>>(14)?,
+        ))
+    })?;
+
+    let mut supersedes: Vec<(i64, i64)> = Vec::new();
+    let mut present: HashSet<i64> = HashSet::new();
+    for row in rows {
+        let row = row?;
+        present.insert(row.0);
+        if let Some(successor) = row.8 {
+            supersedes.push((successor, row.0));
+        }
+        dump.entries.push(MemoryEntry {
+            record: "entity".into(),
+            kind_tag: "memory_entry".into(),
+            reference: entry_ref(row.0),
+            uuid: row.12,
+            kind: row.1,
+            title: row.2,
+            body: row.3,
+            tags: list(row.4),
+            linked_files: list(row.5),
+            created_at: row.6,
+            status: row.7,
+            source_ref: row.9,
+            valid_at: row.10,
+            invalid_at: row.11,
+            entity_id: row.14,
+            remote_id: row.13,
+            namespace: None,
+        });
+    }
+
+    let mut rels: BTreeSet<Relationship> = BTreeSet::new();
+    for (successor, predecessor) in supersedes {
+        if !present.contains(&successor) {
+            warnings.push(format!(
+                "entry {predecessor} names a successor ({successor}) that no longer exists; \
+                 the supersede link is not carried"
+            ));
+            continue;
+        }
+        rels.insert(Relationship::new(
+            "supersedes",
+            entry_ref(successor),
+            entry_ref(predecessor),
+            None,
+        ));
+    }
+
+    if tables.contains("memory_edges") {
+        read_edges(
+            conn,
+            "memory_edges",
+            &present,
+            entry_ref,
+            &mut rels,
+            warnings,
+        )?;
+    }
+    dump.relationships.extend(rels);
+    Ok(())
+}
+
+/// A multi project store keys its entries by an internal project id; the
+/// portable form names the project instead, because an internal id means
+/// nothing outside the file it came from.
+fn read_namespaced_entries(
+    conn: &Connection,
+    cols: &BTreeSet<String>,
+    tables: &BTreeSet<String>,
+    dump: &mut Dump,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    require(cols, &["id", "kind", "title", "body", "created_at"])?;
+    let ec = EntryCols { has: cols.clone() };
+    let mut slugs: HashMap<i64, String> = HashMap::new();
+    if tables.contains("projects") && columns(conn, "projects")?.contains("slug") {
+        let mut stmt = conn.prepare("SELECT id, slug FROM projects")?;
+        let rows = stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)))?;
+        for row in rows {
+            let (id, slug) = row?;
+            slugs.insert(id, slug);
+        }
+    }
+
+    let has_tags = ec.optional("tags");
+    let has_linked = ec.optional("linked_files");
+    // `uuid` is deliberately not selected even when a column of that name
+    // exists on a multi project store: the identifiers such a store mints are
+    // arrival ordered rather than creation ordered, so presenting one as the
+    // entry's stable identity would hand a reader an ordering it did not
+    // choose. Absent identity is assigned by the reader, seeded from the
+    // entry's own creation time.
+    let sql = format!(
+        "SELECT id, project_id, kind, title, body, {}, {}, created_at, {} FROM notes ORDER BY id",
+        if has_tags { "tags" } else { "NULL AS tags" },
+        if has_linked {
+            "linked_files"
+        } else {
+            "NULL AS linked_files"
+        },
+        ec.select(
+            &[],
+            &[
+                "status",
+                "superseded_by",
+                "source_ref",
+                "valid_at",
+                "invalid_at",
+                "remote_id",
+                "entity_id",
+            ]
+        )
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, i64>(0)?,
+            r.get::<_, Option<i64>>(1)?,
+            r.get::<_, String>(2)?,
+            r.get::<_, String>(3)?,
+            r.get::<_, String>(4)?,
+            r.get::<_, Option<String>>(5)?,
+            r.get::<_, Option<String>>(6)?,
+            r.get::<_, i64>(7)?,
+            r.get::<_, Option<String>>(8)?,
+            r.get::<_, Option<i64>>(9)?,
+            r.get::<_, Option<String>>(10)?,
+            r.get::<_, Option<i64>>(11)?,
+            r.get::<_, Option<i64>>(12)?,
+            r.get::<_, Option<String>>(13)?,
+            r.get::<_, Option<String>>(14)?,
+        ))
+    })?;
+
+    let mut supersedes: Vec<(i64, i64)> = Vec::new();
+    let mut present: HashSet<i64> = HashSet::new();
+    for row in rows {
+        let row = row?;
+        present.insert(row.0);
+        if let Some(successor) = row.9 {
+            supersedes.push((successor, row.0));
+        }
+        dump.entries.push(MemoryEntry {
+            record: "entity".into(),
+            kind_tag: "memory_entry".into(),
+            reference: namespaced_ref(row.0),
+            uuid: None,
+            kind: row.2,
+            title: row.3,
+            body: row.4,
+            tags: list(row.5),
+            linked_files: list(row.6),
+            created_at: row.7,
+            status: row.8,
+            source_ref: row.10,
+            valid_at: row.11,
+            invalid_at: row.12,
+            entity_id: row.14,
+            remote_id: row.13,
+            namespace: row.1.and_then(|pid| slugs.get(&pid).cloned()),
+        });
+    }
+
+    let mut rels: BTreeSet<Relationship> = BTreeSet::new();
+    for (successor, predecessor) in supersedes {
+        if !present.contains(&successor) {
+            warnings.push(format!(
+                "entry {predecessor} names a successor ({successor}) that no longer exists; \
+                 the supersede link is not carried"
+            ));
+            continue;
+        }
+        rels.insert(Relationship::new(
+            "supersedes",
+            namespaced_ref(successor),
+            namespaced_ref(predecessor),
+            None,
+        ));
+    }
+
+    if tables.contains("note_edges") {
+        read_edges(
+            conn,
+            "note_edges",
+            &present,
+            namespaced_ref,
+            &mut rels,
+            warnings,
+        )?;
+    }
+    dump.relationships.extend(rels);
+    Ok(())
+}
+
+fn read_edges(
+    conn: &Connection,
+    table: &'static str,
+    present: &HashSet<i64>,
+    make_ref: fn(i64) -> String,
+    rels: &mut BTreeSet<Relationship>,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let has_created = columns(conn, table)?.contains("created_at");
+    let sql = format!(
+        "SELECT from_id, to_id, kind, {} FROM {table} ORDER BY from_id, to_id, kind",
+        if has_created {
+            "created_at"
+        } else {
+            "NULL AS created_at"
+        }
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, i64>(0)?,
+            r.get::<_, i64>(1)?,
+            r.get::<_, String>(2)?,
+            r.get::<_, Option<i64>>(3)?,
+        ))
+    })?;
+    for row in rows {
+        let (from, to, kind, created_at) = row?;
+        if !present.contains(&from) || !present.contains(&to) {
+            warnings.push(format!(
+                "a '{kind}' link between {from} and {to} names an entry that no longer exists; \
+                 it is not carried"
+            ));
+            continue;
+        }
+        // Insertion order matters only for the earliest timestamp to win, and
+        // a set keyed on the whole record would keep both. Replace an existing
+        // link only when this one carries a timestamp and the stored one does
+        // not, so a lifecycle-derived link never shadows a recorded one.
+        let candidate = Relationship::new(&kind, make_ref(from), make_ref(to), created_at);
+        let existing = rels
+            .iter()
+            .find(|r| {
+                r.kind_tag == candidate.kind_tag && r.from == candidate.from && r.to == candidate.to
+            })
+            .cloned();
+        match existing {
+            Some(prev) if prev.created_at.is_none() && candidate.created_at.is_some() => {
+                rels.remove(&prev);
+                rels.insert(candidate);
+            }
+            Some(_) => {}
+            None => {
+                rels.insert(candidate);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn read_projects(
+    conn: &Connection,
+    tables: &BTreeSet<String>,
+    dump: &mut Dump,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let cols = columns(conn, "projects")?;
+    let has_registered = cols.contains("registered_at");
+    let sql = format!(
+        "SELECT id, root_path, {} FROM projects ORDER BY id",
+        if has_registered {
+            "registered_at"
+        } else {
+            "NULL AS registered_at"
+        }
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, i64>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, Option<i64>>(2)?,
+        ))
+    })?;
+    let mut present: HashSet<i64> = HashSet::new();
+    for row in rows {
+        let (id, root_path, registered_at) = row?;
+        present.insert(id);
+        dump.projects.push(Project {
+            record: "entity".into(),
+            kind_tag: "project".into(),
+            reference: project_ref(id),
+            root_path,
+            registered_at,
+        });
+    }
+
+    if tables.contains("project_deps") {
+        let mut stmt = conn
+            .prepare("SELECT project_id, dep_id FROM project_deps ORDER BY project_id, dep_id")?;
+        let rows = stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))?;
+        for row in rows {
+            let (from, to) = row?;
+            if !present.contains(&from) || !present.contains(&to) {
+                warnings.push(format!(
+                    "a dependency between projects {from} and {to} names a project that is not \
+                     registered; it is not carried"
+                ));
+                continue;
+            }
+            dump.relationships.push(Relationship::new(
+                "depends_on",
+                project_ref(from),
+                project_ref(to),
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn read_usage(conn: &Connection, dump: &mut Dump) -> Result<()> {
+    let mut stmt =
+        conn.prepare("SELECT command, called_at FROM usage ORDER BY called_at, rowid")?;
+    let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))?;
+    for (n, row) in rows.enumerate() {
+        let (command, at) = row?;
+        dump.usage.push(CommandUsage {
+            record: "entity".into(),
+            kind_tag: "command_usage".into(),
+            reference: format!("u{n}"),
+            command,
+            at,
+        });
+    }
+    Ok(())
+}
+
+fn entry_ref(id: i64) -> String {
+    format!("e{id}")
+}
+
+fn namespaced_ref(id: i64) -> String {
+    format!("n{id}")
+}
+
+fn project_ref(id: i64) -> String {
+    format!("p{id}")
+}

--- a/crates/spelunk-export/tests/concurrency.rs
+++ b/crates/spelunk-export/tests/concurrency.rs
@@ -1,0 +1,204 @@
+// A store that is being written while it is read must still export as one
+// coherent thing.
+//
+// Every table an export reads is read separately, so without a snapshot the
+// entries come from one instant and the links from a later one. A writer that
+// commits an entry and then a link referencing it, in two transactions, lands
+// between those reads and produces a link whose endpoint appears not to exist.
+// That link is indistinguishable from one whose endpoint really is gone, so it
+// gets dropped and reported, and the export still succeeds. The data is real,
+// the loss is not detectable afterwards, and the dump certifies itself.
+//
+// These tests pin the interleave exactly rather than racing for it.
+
+mod support;
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use rusqlite::Connection;
+use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
+use spelunk_export::{export, source};
+use support::{LATEST, add_entry, memory_store_at, wal_memory_store_at};
+
+const WAIT: Duration = Duration::from_secs(30);
+
+// Commit an entry, then a link referencing it, as two separate transactions.
+// This is what any ordinary write of a superseding entry looks like from
+// outside: the product writes the entry, then the edge.
+fn commit_entry_then_link(path: &std::path::Path) -> rusqlite::Result<i64> {
+    let conn = Connection::open(path)?;
+    conn.busy_timeout(WAIT)?;
+    conn.execute(
+        "INSERT INTO notes (kind, title, body, created_at) VALUES ('decision', 'late', 'b', 9000)",
+        [],
+    )?;
+    let id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO memory_edges (from_id, to_id, kind, created_at) VALUES (?1, 1, 'supersedes', 9000)",
+        rusqlite::params![id],
+    )?;
+    Ok(id)
+}
+
+// Drive `extract` to the point where it is about to read the link table, let a
+// writer commit both of its transactions there, and then let the read continue.
+//
+// The authorizer fires while the link query is being prepared, which is after
+// the entry query has been fully consumed. That is precisely the window the
+// concurrent writer has to hit by luck, so pinning it here turns an occasional
+// failure into a deterministic one.
+fn extract_with_a_write_between_the_tables(
+    store: &std::path::Path,
+) -> (spelunk_export::source::Extract, i64) {
+    let (want_tx, want_rx) = mpsc::channel::<()>();
+    let (done_tx, done_rx) = mpsc::channel::<rusqlite::Result<i64>>();
+
+    let path = store.to_path_buf();
+    let writer = std::thread::spawn(move || {
+        if want_rx.recv().is_err() {
+            return;
+        }
+        let _ = done_tx.send(commit_entry_then_link(&path));
+    });
+
+    let conn = source::open_read_only(store).unwrap();
+    let mut fired = false;
+    conn.authorizer(Some(move |ctx: AuthContext<'_>| {
+        if let AuthAction::Read { table_name, .. } = ctx.action
+            && table_name == "memory_edges"
+            && !fired
+        {
+            fired = true;
+            want_tx
+                .send(())
+                .expect("the writer thread should be waiting");
+            done_rx
+                .recv_timeout(WAIT)
+                .expect("the writer thread should finish")
+                .expect("the concurrent write should succeed");
+        }
+        Authorization::Allow
+    }))
+    .unwrap();
+
+    let extracted = source::extract(&conn).unwrap();
+    // Dropping the connection drops the authorizer and with it the sender the
+    // writer is waiting on, so a run where the interleave never fired ends in a
+    // failed assertion rather than a hang.
+    drop(conn);
+    writer.join().unwrap();
+
+    let after = Connection::open(store).unwrap();
+    let written: i64 = after
+        .query_row("SELECT count(*) FROM memory_edges", [], |r| r.get(0))
+        .unwrap();
+    (extracted, written)
+}
+
+#[test]
+fn a_write_landing_between_two_tables_cannot_manufacture_a_missing_endpoint() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = dir.path().join("memory.db");
+    {
+        let conn = wal_memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "first", 1_000);
+        add_entry(&conn, LATEST, "second", 2_000);
+    }
+
+    let (extracted, links_in_store) = extract_with_a_write_between_the_tables(&store);
+    assert_eq!(links_in_store, 1, "the concurrent write must have landed");
+
+    assert!(
+        extracted.warnings.is_empty(),
+        "a committed write is not a broken store, so nothing may be reported as \
+         missing: {:?}",
+        extracted.warnings
+    );
+
+    let present: std::collections::HashSet<&str> = extracted
+        .dump
+        .entries
+        .iter()
+        .map(|e| e.reference.as_str())
+        .collect();
+    for link in &extracted.dump.relationships {
+        assert!(
+            present.contains(link.from.as_str()) && present.contains(link.to.as_str()),
+            "link {} -> {} names an entry the same read did not return",
+            link.from,
+            link.to
+        );
+    }
+
+    let carried_the_entry = extracted.dump.entries.iter().any(|e| e.title == "late");
+    let carried_the_link = !extracted.dump.relationships.is_empty();
+    assert_eq!(
+        carried_the_entry, carried_the_link,
+        "the entry and the link it is an endpoint of were written together and \
+         must be read together"
+    );
+}
+
+// Holding the read open across every table means a writer on an older
+// rollback-journal store can now lock the export out, where before each
+// statement took its own momentary lock. A store held that way is refused with
+// its own name and leaves nothing behind, rather than producing a dump of
+// whatever it managed to read.
+#[test]
+fn a_store_locked_by_another_writer_is_refused_by_name_and_leaves_no_partial_dump() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    let holder = memory_store_at(&store, LATEST);
+    add_entry(&holder, LATEST, "only", 1_000);
+    holder.execute_batch("BEGIN EXCLUSIVE").unwrap();
+
+    let err = export(&store, &out, 1_700_000_000).unwrap_err();
+
+    assert!(
+        format!("{err:#}").contains("memory.db"),
+        "the refusal must name the store it could not read: {err:#}"
+    );
+    assert!(!out.exists());
+    assert!(!out.with_extension("partial").exists());
+    holder.execute_batch("ROLLBACK").unwrap();
+}
+
+#[test]
+fn a_dump_written_under_a_concurrent_writer_verifies_and_is_whole() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = wal_memory_store_at(&store, LATEST);
+        for n in 0..200 {
+            add_entry(&conn, LATEST, &format!("entry {n}"), 1_000 + n);
+        }
+    }
+
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let path = store.clone();
+    let flag = stop.clone();
+    let writer = std::thread::spawn(move || {
+        let mut written = 0;
+        while !flag.load(std::sync::atomic::Ordering::Relaxed) {
+            if commit_entry_then_link(&path).is_ok() {
+                written += 1;
+            }
+        }
+        written
+    });
+
+    let outcome = export(&store, &out, 1_700_000_000).unwrap();
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    let written = writer.join().unwrap();
+    assert!(written > 0, "the writer must have committed something");
+
+    assert!(
+        outcome.warnings.is_empty(),
+        "nothing in the store was ever broken: {:?}",
+        outcome.warnings
+    );
+    spelunk_export::dump::verify_rendered(&std::fs::read_to_string(&out).unwrap()).unwrap();
+}

--- a/crates/spelunk-export/tests/corpus.rs
+++ b/crates/spelunk-export/tests/corpus.rs
@@ -1,0 +1,377 @@
+// Export from artifacts written by actual released binaries.
+//
+// The ladder fixtures next door cover what the schema *is* at each version.
+// They cannot cover what a released binary put in a file, and they are a hand
+// copy of a ladder that lives somewhere else: a copy drifts and no test
+// notices. These artifacts were captured by running downloaded releases, and
+// the expectations they are checked against were read out of them with plain
+// SQL at capture time, before any current-build code opened them. That makes
+// this the only evidence here that is independent of the branch it is testing.
+//
+// The corpus is shared with the CLI's own upgrade suite and is reached by path.
+// This crate still depends on no other crate in the workspace.
+//
+// Regenerate with scripts/upgrade-corpus/generate.sh.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use spelunk_export::{ExportOutcome, dump, export};
+
+#[derive(Deserialize)]
+struct Manifest {
+    wings: Vec<Wing>,
+}
+
+#[derive(Deserialize)]
+struct Wing {
+    id: String,
+    producer: String,
+    kind: String,
+    artifact: String,
+    sha256: String,
+    #[serde(default)]
+    expect: Expect,
+}
+
+// Only the fields this suite reads. The CLI's upgrade suite reads the rest.
+#[derive(Default, Deserialize)]
+struct Expect {
+    #[serde(default)]
+    note_count: usize,
+    #[serde(default)]
+    active_note_count: usize,
+    #[serde(default)]
+    archived_title: String,
+    #[serde(default)]
+    superseded_title: String,
+    #[serde(default)]
+    successor_title: String,
+    #[serde(default)]
+    entity_id_present: bool,
+    #[serde(default)]
+    project_count: usize,
+    #[serde(default)]
+    dep_count: usize,
+}
+
+fn corpus_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("spelunk-cli")
+        .join("tests")
+        .join("fixtures")
+        .join("upgrade-corpus")
+}
+
+fn manifest() -> Manifest {
+    let path = corpus_root().join("MANIFEST.json");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("reading corpus manifest {}: {e}", path.display()));
+    serde_json::from_str(&raw).expect("parsing corpus manifest")
+}
+
+// Expand a wing into a temp dir, after confirming the packed bytes are the ones
+// the expectations were read from. An artifact swapped without recapturing
+// would leave every assertion below checking one release's output against
+// another's.
+fn checkout(wing: &Wing, tmp: &Path) -> PathBuf {
+    let src = corpus_root()
+        .join("wings")
+        .join(&wing.id)
+        .join(&wing.artifact);
+    let packed = std::fs::read(&src)
+        .unwrap_or_else(|e| panic!("reading wing {} at {}: {e}", wing.id, src.display()));
+    let hex: String = Sha256::digest(&packed)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    assert_eq!(
+        hex, wing.sha256,
+        "wing {} no longer matches the artifact its expectations were captured from",
+        wing.id
+    );
+
+    let dst = tmp.join(wing.artifact.trim_end_matches(".gz"));
+    let mut reader = flate2::read::GzDecoder::new(std::io::Cursor::new(packed));
+    let mut out =
+        std::fs::File::create(&dst).unwrap_or_else(|e| panic!("creating {}: {e}", dst.display()));
+    std::io::copy(&mut reader, &mut out)
+        .unwrap_or_else(|e| panic!("expanding wing {}: {e}", wing.id));
+    dst
+}
+
+fn wings_of_kind(m: &Manifest, kind: &str) -> Vec<usize> {
+    (0..m.wings.len())
+        .filter(|i| m.wings[*i].kind == kind)
+        .collect()
+}
+
+struct Exported {
+    outcome: ExportOutcome,
+    records: Vec<Value>,
+    text: String,
+}
+
+impl Exported {
+    fn entities(&self, kind: &str) -> Vec<&Value> {
+        self.records
+            .iter()
+            .filter(|r| r["record"] == "entity" && r["type"] == kind)
+            .collect()
+    }
+
+    fn relationships(&self) -> Vec<&Value> {
+        self.records
+            .iter()
+            .filter(|r| r["record"] == "relationship")
+            .collect()
+    }
+
+    fn by_ref(&self) -> BTreeMap<&str, &Value> {
+        self.records
+            .iter()
+            .filter(|r| r["record"] == "entity")
+            .map(|r| (r["ref"].as_str().unwrap(), r))
+            .collect()
+    }
+}
+
+// Export a wing and assert the source came out of it untouched. Every wing goes
+// through here, so the read-only property is asserted once per real artifact
+// rather than once for the suite.
+fn export_wing(wing: &Wing, dir: &Path) -> Exported {
+    let store = checkout(wing, dir);
+    let out = dir.join("dump.jsonl");
+    let before = std::fs::read(&store).unwrap();
+
+    let outcome = export(&store, &out, 1_700_000_000).unwrap_or_else(|e| {
+        panic!(
+            "exporting wing {} (written by {}): {e:#}",
+            wing.id, wing.producer
+        )
+    });
+
+    assert!(
+        std::fs::read(&store).unwrap() == before,
+        "wing {}: the artifact was modified by exporting it",
+        wing.id
+    );
+    let sidecars = store.file_name().unwrap().to_str().unwrap().to_string();
+    assert!(
+        !dir.join(format!("{sidecars}-journal")).exists(),
+        "wing {}: a rollback journal means the artifact was opened for writing",
+        wing.id
+    );
+    let log = dir.join(format!("{sidecars}-wal"));
+    if log.exists() {
+        assert_eq!(
+            std::fs::metadata(&log).unwrap().len(),
+            0,
+            "wing {}: a read must not append anything to the log",
+            wing.id
+        );
+    }
+
+    let text = std::fs::read_to_string(&out).unwrap();
+    dump::verify_rendered(&text).expect("the dump written from a real artifact must verify");
+    let records = text
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+    Exported {
+        outcome,
+        records,
+        text,
+    }
+}
+
+#[test]
+fn the_corpus_is_present_and_covers_the_kinds_this_suite_reads() {
+    let m = manifest();
+    for kind in ["memory", "registry", "index"] {
+        assert!(
+            !wings_of_kind(&m, kind).is_empty(),
+            "the corpus has no {kind} wing, so the assertions over it pass vacuously"
+        );
+    }
+    assert!(
+        wings_of_kind(&m, "memory")
+            .iter()
+            .any(|i| !m.wings[*i].expect.entity_id_present),
+        "every memory wing was captured after entity_id existed, so the \
+         omit-an-absent-column path is never exercised on a real artifact"
+    );
+}
+
+// The manifest's counts, statuses and supersede pair, read back out of a dump
+// of the artifact they were recorded from.
+#[test]
+fn every_memory_wing_a_released_binary_wrote_exports_whole() {
+    let m = manifest();
+    for i in wings_of_kind(&m, "memory") {
+        let wing = &m.wings[i];
+        let dir = tempfile::tempdir().unwrap();
+        let e = export_wing(wing, dir.path());
+
+        assert_eq!(
+            e.outcome.counts.entity.get("memory_entry"),
+            Some(&wing.expect.note_count),
+            "wing {}: entries were lost or invented",
+            wing.id
+        );
+        assert!(
+            e.outcome.warnings.is_empty(),
+            "wing {}: nothing in a captured artifact is broken, so nothing may be \
+             reported as dropped: {:?}",
+            wing.id,
+            e.outcome.warnings
+        );
+
+        let entries = e.entities("memory_entry");
+        let active = entries.iter().filter(|n| n["status"] != "archived").count();
+        assert_eq!(
+            active, wing.expect.active_note_count,
+            "wing {}: the archived entries did not come out archived",
+            wing.id
+        );
+        let archived = entries
+            .iter()
+            .find(|n| n["title"] == wing.expect.archived_title.as_str())
+            .unwrap_or_else(|| panic!("wing {}: the archived entry is not in the dump", wing.id));
+        assert_eq!(archived["status"], "archived");
+
+        // An identifier the artifact does not carry must be absent from the
+        // dump rather than minted, and this is the one place that is checked
+        // against a column a real release genuinely did not have.
+        for entry in &entries {
+            assert_eq!(
+                entry.get("entity_id").is_some(),
+                wing.expect.entity_id_present,
+                "wing {}: entity_id presence does not match what the capturing \
+                 release wrote",
+                wing.id
+            );
+            assert!(
+                entry.get("uuid").is_none(),
+                "wing {}: these artifacts carry no uuid, so one in the dump was \
+                 minted here",
+                wing.id
+            );
+        }
+
+        // The orientation trap, on a store a real binary wrote: both artifacts
+        // hold the edge and the lifecycle column at once, pointing opposite
+        // ways, and the manifest names which entry is the successor.
+        let links = e.relationships();
+        assert_eq!(
+            links.len(),
+            1,
+            "wing {}: the edge and the lifecycle column encode one fact and must \
+             not become two links: {links:?}",
+            wing.id
+        );
+        assert_eq!(links[0]["type"], "supersedes");
+        let by_ref = e.by_ref();
+        assert_eq!(
+            by_ref[links[0]["from"].as_str().unwrap()]["title"],
+            wing.expect.successor_title.as_str(),
+            "wing {}: the supersede link points away from the successor",
+            wing.id
+        );
+        assert_eq!(
+            by_ref[links[0]["to"].as_str().unwrap()]["title"],
+            wing.expect.superseded_title.as_str(),
+            "wing {}: the supersede link does not land on the superseded entry",
+            wing.id
+        );
+
+        for derived in ["memory_fts", "note_embeddings", "schema_v896"] {
+            assert!(
+                !e.text.contains(derived),
+                "wing {}: {derived} is derived and must not be carried",
+                wing.id
+            );
+        }
+    }
+}
+
+#[test]
+fn every_registry_wing_a_released_binary_wrote_exports_whole() {
+    let m = manifest();
+    for i in wings_of_kind(&m, "registry") {
+        let wing = &m.wings[i];
+        let dir = tempfile::tempdir().unwrap();
+        let e = export_wing(wing, dir.path());
+
+        assert_eq!(
+            e.outcome.counts.entity.get("project"),
+            Some(&wing.expect.project_count),
+            "wing {}: registered projects were lost",
+            wing.id
+        );
+        assert_eq!(
+            e.outcome.counts.relationship.get("depends_on"),
+            Some(&wing.expect.dep_count),
+            "wing {}: dependency links were lost",
+            wing.id
+        );
+
+        let by_ref = e.by_ref();
+        for link in e.relationships() {
+            for end in ["from", "to"] {
+                let target = link[end].as_str().unwrap();
+                assert!(
+                    by_ref[target]["root_path"].is_string(),
+                    "wing {}: a dependency names {target}, which is not a project \
+                     in the dump",
+                    wing.id
+                );
+            }
+        }
+        assert!(
+            !e.text.contains("index.db"),
+            "wing {}: the registry's derived store path is in the dump, and it is \
+             wrong for any reader laying its stores out differently",
+            wing.id
+        );
+    }
+}
+
+// An index store holds one authored table, `usage`, and these artifacts have no
+// rows in it. Everything else in them is a reindex away, so the whole file must
+// come out as an empty dump rather than as chunks and vectors.
+#[test]
+fn an_index_wing_a_released_binary_wrote_carries_nothing_derived() {
+    let m = manifest();
+    for i in wings_of_kind(&m, "index") {
+        let wing = &m.wings[i];
+        let dir = tempfile::tempdir().unwrap();
+        let e = export_wing(wing, dir.path());
+
+        assert!(
+            e.outcome.counts.entity.is_empty() && e.outcome.counts.relationship.is_empty(),
+            "wing {}: an index store holds only usage counts, and these have \
+             none: {:?}",
+            wing.id,
+            e.outcome.counts
+        );
+        assert_eq!(
+            e.records.len(),
+            2,
+            "wing {}: an empty dump is a header and a footer",
+            wing.id
+        );
+        assert!(
+            e.outcome
+                .summary(Path::new("dump.jsonl"))
+                .contains("nothing to carry"),
+            "wing {}: the run must say the store held nothing rather than imply \
+             a full export",
+            wing.id
+        );
+    }
+}

--- a/crates/spelunk-export/tests/export.rs
+++ b/crates/spelunk-export/tests/export.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use rusqlite::Connection;
 use serde_json::Value;
 use spelunk_export::{dump, export, inventory, source};
-use support::{LATEST, add_entry, memory_store_at, unstamped_memory_store_at};
+use support::{LATEST, add_entry, memory_store_at, unstamped_memory_store_at, wal_memory_store_at};
 
 fn tmp() -> tempfile::TempDir {
     tempfile::tempdir().unwrap()
@@ -547,6 +547,109 @@ fn the_source_store_is_never_modified() {
     }
 }
 
+// Every store the product creates runs in write-ahead-log mode, so a fixture in
+// the default rollback-journal mode cannot fail for the shape that matters:
+// committed rows can live in the log rather than the database file, and a
+// reader that misses them silently exports a stale store.
+#[test]
+fn a_write_ahead_log_store_is_read_whole_and_left_unchanged() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    // The connection stays open for the whole test: closing the last one
+    // checkpoints the log away, and a store nobody has open is not the state a
+    // real export runs against.
+    let conn = wal_memory_store_at(&store, LATEST);
+    add_entry(&conn, LATEST, "checkpointed", 1_000);
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+        .unwrap();
+    add_entry(&conn, LATEST, "still in the log", 2_000);
+
+    let log = dir.path().join("memory.db-wal");
+    assert!(
+        log.exists() && std::fs::metadata(&log).unwrap().len() > 0,
+        "the fixture must leave a committed entry in the log"
+    );
+
+    let before_db = std::fs::read(&store).unwrap();
+    let before_log = std::fs::read(&log).unwrap();
+    let outcome = export_to(&store, &out);
+
+    assert_eq!(
+        outcome.counts.entity.get("memory_entry"),
+        Some(&2),
+        "an entry committed to the log is committed"
+    );
+    let recs = records(&out);
+    let titles: Vec<&str> = entities(&recs, "memory_entry")
+        .iter()
+        .map(|e| e["title"].as_str().unwrap())
+        .collect();
+    assert!(titles.contains(&"still in the log"), "got: {titles:?}");
+
+    assert_eq!(
+        std::fs::read(&store).unwrap(),
+        before_db,
+        "the database file was modified by exporting it"
+    );
+    assert_eq!(
+        std::fs::read(&log).unwrap(),
+        before_log,
+        "the log was modified by exporting it; no content may be checkpointed \
+         or appended by a read"
+    );
+    assert!(
+        !dir.path().join("memory.db-journal").exists(),
+        "a rollback journal means the store was opened for writing"
+    );
+    drop(conn);
+}
+
+// Reading a write-ahead-log store requires SQLite's shared-memory index, and a
+// read-only connection cannot decline to bring it into being. So a store that
+// nobody currently has open gains an index file and an empty log from being
+// exported. Neither carries any content and the database is untouched, but the
+// files do appear in the user's directory and that is worth pinning rather than
+// discovering. Removing them afterwards is not an option: a second process may
+// have opened the store in the meantime and be coordinating through exactly
+// those files.
+#[test]
+fn reading_a_write_ahead_log_store_adds_no_content_to_the_users_directory() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = wal_memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "only", 1_000);
+    }
+    assert_eq!(
+        std::fs::read_dir(dir.path()).unwrap().count(),
+        1,
+        "closing the last connection should leave the store alone in the directory"
+    );
+    let before = std::fs::read(&store).unwrap();
+
+    export_to(&store, &out);
+
+    assert_eq!(
+        std::fs::read(&store).unwrap(),
+        before,
+        "the database file was modified by exporting it"
+    );
+    assert!(
+        !dir.path().join("memory.db-journal").exists(),
+        "a rollback journal means the store was opened for writing"
+    );
+    let log = dir.path().join("memory.db-wal");
+    if log.exists() {
+        assert_eq!(
+            std::fs::metadata(&log).unwrap().len(),
+            0,
+            "a read must not append anything to the log"
+        );
+    }
+}
+
 // ── E26 to E31: refusal, emptiness, determinism ──────────────────────────────
 
 #[test]
@@ -583,8 +686,9 @@ fn a_store_with_no_authored_tables_is_refused_rather_than_read_as_entries() {
         conn.execute_batch("CREATE TABLE notes (id INTEGER PRIMARY KEY, headline TEXT);")
             .unwrap();
     }
-    let err = export(&store, &out, 0).unwrap_err().to_string();
+    let err = format!("{:#}", export(&store, &out, 0).unwrap_err());
     assert!(err.contains("missing required columns"), "got: {err}");
+    assert!(err.contains("notes-missing-columns.db"), "got: {err}");
     assert!(!out.exists());
 }
 
@@ -639,7 +743,21 @@ fn a_dump_carries_no_credential_material() {
     }
 }
 
-// ── Dangling references are reported, not dropped silently ───────────────────
+// ── An endpoint that is genuinely absent ─────────────────────────────────────
+//
+// The store is read as of one point in time, so a link whose endpoint is not in
+// the read is a link whose endpoint is not in the store: damage that predates
+// foreign key enforcement, or a build against a SQLite that had it off. It
+// cannot be a write that arrived mid-export.
+//
+// That makes the question a real one rather than an ambiguity to paper over,
+// and the answer is to report and continue rather than refuse. Refusing would
+// mean a user whose store has one orphaned link cannot get any of their entries
+// out, and no other tool can do better, because the format cannot express a
+// link to something that does not exist and the missing row is not recoverable
+// from anywhere. The loss is unavoidable; only the silence was ever the
+// problem. So every entry is carried, the orphaned link is not, and the run
+// says so on the same screen where it reports success.
 
 #[test]
 fn a_link_to_a_missing_entry_is_reported_rather_than_carried_or_hidden() {
@@ -664,13 +782,24 @@ fn a_link_to_a_missing_entry_is_reported_rather_than_carried_or_hidden() {
         )
         .unwrap();
     }
-    let outcome = export_to(&store, &out);
+    let outcome = export(&store, &out, 1_700_000_000)
+        .expect("an orphaned link must not cost the user every entry in the store");
     assert!(outcome.counts.relationship.is_empty());
+    assert_eq!(
+        outcome.counts.entity.get("memory_entry"),
+        Some(&1),
+        "the entries themselves are intact and must all be carried"
+    );
     assert_eq!(
         outcome.warnings.len(),
         2,
-        "both dangling links must be reported: {:?}",
+        "both orphaned links must be reported: {:?}",
         outcome.warnings
+    );
+    let summary = outcome.summary(&out);
+    assert!(
+        summary.contains("2 link(s) were NOT carried"),
+        "the run must not report success without reporting the omission: {summary}"
     );
 }
 

--- a/crates/spelunk-export/tests/export.rs
+++ b/crates/spelunk-export/tests/export.rs
@@ -650,6 +650,94 @@ fn reading_a_write_ahead_log_store_adds_no_content_to_the_users_directory() {
     }
 }
 
+// Neither test above can fail if the store is opened for writing, and between
+// them they are why: the first checkpoints the log away before it measures, so
+// there is nothing left for a close-time checkpoint to flush, and the second
+// holds a second connection open for its whole length, which suppresses the
+// close-time checkpoint entirely. Both are right about what they test. Neither
+// reaches the state where opening for writing costs the user something.
+//
+// That state is a store whose owning process died with rows still committed to
+// the log: the log is hot and no connection is left. Closing the last
+// connection to a log-mode store checkpoints it, so a read-write open here
+// recovers the log and rewrites the database file, and deletes the log, purely
+// as a side effect of having read it. Read-only is what prevents that, and it
+// is one flag.
+#[test]
+fn a_store_left_hot_by_a_dead_process_is_not_checkpointed_by_reading_it() {
+    let dir = tmp();
+    let owned = dir.path().join("owned");
+    std::fs::create_dir(&owned).unwrap();
+    let conn = wal_memory_store_at(&owned.join("memory.db"), LATEST);
+    add_entry(&conn, LATEST, "committed to the log", 1_000);
+
+    // The schema was written before the switch to log mode, so the entry is the
+    // only thing in the log, and an export that ignored the log would come back
+    // with an empty store rather than a wrong one.
+    let owned_log = owned.join("memory.db-wal");
+    assert!(std::fs::metadata(&owned_log).unwrap().len() > 0);
+
+    // Copying the pair out from under a live connection reproduces what a dead
+    // process leaves, without killing one: the copies have a hot log and no
+    // owner, and dropping the connection below checkpoints the original rather
+    // than them.
+    let abandoned = dir.path().join("abandoned");
+    std::fs::create_dir(&abandoned).unwrap();
+    let store = abandoned.join("memory.db");
+    let log = abandoned.join("memory.db-wal");
+    std::fs::copy(owned.join("memory.db"), &store).unwrap();
+    std::fs::copy(&owned_log, &log).unwrap();
+    drop(conn);
+
+    let before_db = std::fs::read(&store).unwrap();
+    let before_log = std::fs::read(&log).unwrap();
+
+    // Run the binary, so the comparison below is made once every handle the
+    // export held has been closed by the operating system, not merely dropped.
+    let out = dir.path().join("dump.jsonl");
+    let run = std::process::Command::new(env!("CARGO_BIN_EXE_spelunk-export"))
+        .arg("export")
+        .arg("--store")
+        .arg(&store)
+        .arg("--out")
+        .arg(&out)
+        .output()
+        .unwrap();
+    assert!(
+        run.status.success(),
+        "the export failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+
+    let titles: Vec<String> = entities(&records(&out), "memory_entry")
+        .iter()
+        .map(|e| e["title"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        titles,
+        ["committed to the log"],
+        "the entry lives only in the log, so anything else here means the log \
+         was not read at all"
+    );
+
+    // Compared with `assert!` rather than `assert_eq!`: these files are
+    // megabytes, and a failure here is about which file moved, not which byte.
+    assert!(
+        std::fs::read(&store).unwrap() == before_db,
+        "the database file was rewritten by reading it: the log was checkpointed \
+         into it on close"
+    );
+    assert!(
+        log.exists(),
+        "the log was deleted by reading it; the user's committed rows now exist \
+         only wherever the checkpoint put them"
+    );
+    assert!(
+        std::fs::read(&log).unwrap() == before_log,
+        "the log was rewritten by reading it"
+    );
+}
+
 // ── E26 to E31: refusal, emptiness, determinism ──────────────────────────────
 
 #[test]

--- a/crates/spelunk-export/tests/export.rs
+++ b/crates/spelunk-export/tests/export.rs
@@ -1,0 +1,726 @@
+mod support;
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use rusqlite::Connection;
+use serde_json::Value;
+use spelunk_export::{dump, export, inventory, source};
+use support::{LATEST, add_entry, memory_store_at, unstamped_memory_store_at};
+
+fn tmp() -> tempfile::TempDir {
+    tempfile::tempdir().unwrap()
+}
+
+fn export_to(store: &Path, out: &Path) -> spelunk_export::ExportOutcome {
+    export(store, out, 1_700_000_000).unwrap()
+}
+
+fn records(out: &Path) -> Vec<Value> {
+    std::fs::read_to_string(out)
+        .unwrap()
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect()
+}
+
+fn entities<'a>(recs: &'a [Value], kind: &str) -> Vec<&'a Value> {
+    recs.iter()
+        .filter(|r| r["record"] == "entity" && r["type"] == kind)
+        .collect()
+}
+
+fn relationships<'a>(recs: &'a [Value], kind: &str) -> Vec<&'a Value> {
+    recs.iter()
+        .filter(|r| r["record"] == "relationship" && r["type"] == kind)
+        .collect()
+}
+
+// ── E1, E2: every historic shape reads ────────────────────────────────────────
+
+#[test]
+fn exports_from_every_schema_version() {
+    for version in 1..=LATEST {
+        let dir = tmp();
+        let store = dir.path().join("memory.db");
+        let out = dir.path().join("dump.jsonl");
+        {
+            let conn = memory_store_at(&store, version);
+            add_entry(&conn, version, "first", 1_000);
+            add_entry(&conn, version, "second", 2_000);
+        }
+        let outcome = export_to(&store, &out);
+        assert_eq!(
+            outcome.counts.entity.get("memory_entry"),
+            Some(&2),
+            "schema version {version} did not export both entries"
+        );
+        let recs = records(&out);
+        assert_eq!(recs.first().unwrap()["record"], "header");
+        assert_eq!(recs.last().unwrap()["record"], "footer");
+    }
+}
+
+#[test]
+fn exports_from_a_store_that_never_had_its_version_stamped() {
+    for version in 1..=LATEST {
+        let dir = tmp();
+        let store = dir.path().join("memory.db");
+        let out = dir.path().join("dump.jsonl");
+        {
+            let conn = unstamped_memory_store_at(&store, version);
+            assert_eq!(
+                source::schema_version(&conn).unwrap(),
+                0,
+                "fixture should be unstamped"
+            );
+            add_entry(&conn, version, "only", 1_000);
+        }
+        let outcome = export_to(&store, &out);
+        assert_eq!(outcome.counts.entity.get("memory_entry"), Some(&1));
+    }
+}
+
+// ── E3: absent columns are omitted, not nulled ───────────────────────────────
+
+#[test]
+fn columns_absent_at_the_source_version_are_omitted_not_nulled() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, 1);
+        add_entry(&conn, 1, "only", 1_000);
+    }
+    export_to(&store, &out);
+    let recs = records(&out);
+    let entry = entities(&recs, "memory_entry")[0];
+    for absent in [
+        "status",
+        "source_ref",
+        "valid_at",
+        "invalid_at",
+        "uuid",
+        "remote_id",
+        "entity_id",
+    ] {
+        assert!(
+            entry.get(absent).is_none(),
+            "{absent} should be absent, not null, at schema version 1"
+        );
+    }
+}
+
+// ── E4: no edge table at the source version ──────────────────────────────────
+
+#[test]
+fn a_store_without_an_edge_table_yields_no_relationships() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, 5);
+        add_entry(&conn, 5, "only", 1_000);
+    }
+    let outcome = export_to(&store, &out);
+    assert!(outcome.counts.relationship.is_empty());
+    assert!(outcome.warnings.is_empty());
+}
+
+// ── E5, E6, E7: every edge kind survives ─────────────────────────────────────
+
+#[test]
+fn every_edge_kind_survives() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        let a = add_entry(&conn, LATEST, "a", 1_000);
+        let b = add_entry(&conn, LATEST, "b", 2_000);
+        let c = add_entry(&conn, LATEST, "c", 3_000);
+        edge(&conn, b, a, "supersedes");
+        edge(&conn, a, c, "relates_to");
+        edge(&conn, c, b, "contradicts");
+    }
+    let outcome = export_to(&store, &out);
+    for kind in ["supersedes", "relates_to", "contradicts"] {
+        assert_eq!(
+            outcome.counts.relationship.get(kind),
+            Some(&1),
+            "{kind} did not survive"
+        );
+    }
+}
+
+// ── E8, E9: the two supersede encodings agree ────────────────────────────────
+
+#[test]
+fn the_lifecycle_column_is_emitted_in_the_edge_orientation() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    let (successor, predecessor);
+    {
+        let conn = memory_store_at(&store, LATEST);
+        predecessor = add_entry(&conn, LATEST, "old", 1_000);
+        successor = add_entry(&conn, LATEST, "new", 2_000);
+        conn.execute(
+            "UPDATE notes SET status='archived', superseded_by=?2 WHERE id=?1",
+            rusqlite::params![predecessor, successor],
+        )
+        .unwrap();
+    }
+    export_to(&store, &out);
+    let recs = records(&out);
+    let rels = relationships(&recs, "supersedes");
+    assert_eq!(rels.len(), 1);
+    assert_eq!(
+        rels[0]["from"],
+        format!("e{successor}"),
+        "the successor must be the 'from' endpoint"
+    );
+    assert_eq!(rels[0]["to"], format!("e{predecessor}"));
+}
+
+#[test]
+fn a_store_holding_both_supersede_encodings_yields_one_link() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        let predecessor = add_entry(&conn, LATEST, "old", 1_000);
+        let successor = add_entry(&conn, LATEST, "new", 2_000);
+        conn.execute(
+            "UPDATE notes SET status='archived', superseded_by=?2 WHERE id=?1",
+            rusqlite::params![predecessor, successor],
+        )
+        .unwrap();
+        edge(&conn, successor, predecessor, "supersedes");
+    }
+    let outcome = export_to(&store, &out);
+    assert_eq!(
+        outcome.counts.relationship.get("supersedes"),
+        Some(&1),
+        "the column and the edge encode one fact and must not become two links"
+    );
+}
+
+// ── E10, E11: identity is carried, never minted ──────────────────────────────
+
+#[test]
+fn an_existing_identifier_is_carried_verbatim() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        let id = add_entry(&conn, LATEST, "only", 1_000);
+        conn.execute(
+            "UPDATE notes SET uuid='0192f0a0-dead-7000-8000-000000000001' WHERE id=?1",
+            rusqlite::params![id],
+        )
+        .unwrap();
+    }
+    export_to(&store, &out);
+    let recs = records(&out);
+    assert_eq!(
+        entities(&recs, "memory_entry")[0]["uuid"],
+        "0192f0a0-dead-7000-8000-000000000001"
+    );
+}
+
+#[test]
+fn a_missing_identifier_is_omitted_and_never_minted() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "only", 1_000);
+        conn.execute_batch("UPDATE notes SET uuid = NULL").unwrap();
+    }
+    export_to(&store, &out);
+    let recs = records(&out);
+    let entry = entities(&recs, "memory_entry")[0];
+    assert!(
+        entry.get("uuid").is_none(),
+        "this tool must never mint an identifier: identity policy belongs to the reader"
+    );
+    assert!(
+        entry.get("created_at").is_some(),
+        "creation time must always be carried, so a reader can seed from it"
+    );
+}
+
+// ── E12, E13, E14: verbatim fields ───────────────────────────────────────────
+
+#[test]
+fn provenance_content_identity_and_temporal_fields_are_carried_verbatim() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        let id = add_entry(&conn, LATEST, "only", 1_000);
+        conn.execute(
+            "UPDATE notes SET source_ref=?2, entity_id=?3, valid_at=?4, invalid_at=?5
+             WHERE id=?1",
+            rusqlite::params![id, "a".repeat(40), "content-hash-1", 1_111, 2_222],
+        )
+        .unwrap();
+    }
+    export_to(&store, &out);
+    let recs = records(&out);
+    let entry = entities(&recs, "memory_entry")[0];
+    assert_eq!(entry["source_ref"], "a".repeat(40));
+    assert_eq!(entry["entity_id"], "content-hash-1");
+    assert_eq!(entry["valid_at"], 1_111);
+    assert_eq!(entry["invalid_at"], 2_222);
+}
+
+// ── E15, E16: list normalisation ─────────────────────────────────────────────
+
+#[test]
+fn comma_joined_lists_become_arrays() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "with lists", 1_000);
+        let id = add_entry(&conn, LATEST, "empty lists", 2_000);
+        conn.execute(
+            "UPDATE notes SET tags='', linked_files=NULL WHERE id=?1",
+            rusqlite::params![id],
+        )
+        .unwrap();
+        let single = add_entry(&conn, LATEST, "one tag", 3_000);
+        conn.execute(
+            "UPDATE notes SET tags='solo' WHERE id=?1",
+            rusqlite::params![single],
+        )
+        .unwrap();
+    }
+    export_to(&store, &out);
+    let recs = records(&out);
+    let by_title: BTreeMap<_, _> = entities(&recs, "memory_entry")
+        .into_iter()
+        .map(|e| (e["title"].as_str().unwrap().to_string(), e))
+        .collect();
+
+    assert_eq!(
+        by_title["with lists"]["tags"],
+        serde_json::json!(["alpha", "beta"])
+    );
+    assert_eq!(
+        by_title["with lists"]["linked_files"],
+        serde_json::json!(["src/a.rs"])
+    );
+    assert!(by_title["empty lists"].get("tags").is_none());
+    assert!(by_title["empty lists"].get("linked_files").is_none());
+    assert_eq!(by_title["one tag"]["tags"], serde_json::json!(["solo"]));
+}
+
+#[test]
+fn a_value_containing_a_separator_splits_as_the_source_would() {
+    // The stored form cannot distinguish one value containing a comma from two
+    // values. The format inherits that, deliberately: resolving it would mean
+    // inventing information the store never held.
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        let id = add_entry(&conn, LATEST, "only", 1_000);
+        conn.execute(
+            "UPDATE notes SET tags='one,two' WHERE id=?1",
+            rusqlite::params![id],
+        )
+        .unwrap();
+    }
+    export_to(&store, &out);
+    let recs = records(&out);
+    assert_eq!(
+        entities(&recs, "memory_entry")[0]["tags"],
+        serde_json::json!(["one", "two"])
+    );
+}
+
+// ── E17 to E20: the other stores ─────────────────────────────────────────────
+
+#[test]
+fn accumulated_command_counts_export() {
+    let dir = tmp();
+    let store = dir.path().join("index.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = Connection::open(&store).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE files (id INTEGER PRIMARY KEY, path TEXT);
+             CREATE TABLE usage (command TEXT NOT NULL, called_at INTEGER NOT NULL);
+             INSERT INTO usage VALUES ('search', 100), ('memory add', 200);",
+        )
+        .unwrap();
+    }
+    let outcome = export_to(&store, &out);
+    assert_eq!(outcome.counts.entity.get("command_usage"), Some(&2));
+    let recs = records(&out);
+    let first = entities(&recs, "command_usage")[0];
+    assert_eq!(first["command"], "search");
+    assert_eq!(first["at"], 100);
+}
+
+#[test]
+fn registered_projects_and_their_dependencies_export() {
+    let dir = tmp();
+    let store = dir.path().join("registry.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = Connection::open(&store).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE projects (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 root_path TEXT NOT NULL UNIQUE,
+                 db_path TEXT NOT NULL,
+                 registered_at INTEGER NOT NULL DEFAULT (unixepoch()));
+             CREATE TABLE project_deps (
+                 project_id INTEGER NOT NULL, dep_id INTEGER NOT NULL,
+                 PRIMARY KEY (project_id, dep_id));
+             INSERT INTO projects (root_path, db_path, registered_at)
+                 VALUES ('/w/one', '/w/one/.spelunk/index.db', 10),
+                        ('/w/two', '/w/two/.spelunk/index.db', 20);
+             INSERT INTO project_deps VALUES (1, 2);",
+        )
+        .unwrap();
+    }
+    let outcome = export_to(&store, &out);
+    assert_eq!(outcome.counts.entity.get("project"), Some(&2));
+    assert_eq!(outcome.counts.relationship.get("depends_on"), Some(&1));
+}
+
+#[test]
+fn the_registrys_derived_store_path_is_not_in_the_dump() {
+    let dir = tmp();
+    let store = dir.path().join("registry.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = Connection::open(&store).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE projects (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 root_path TEXT NOT NULL UNIQUE,
+                 db_path TEXT NOT NULL,
+                 registered_at INTEGER);
+             INSERT INTO projects (root_path, db_path) VALUES ('/w/one', '/w/one/.spelunk/x.db');",
+        )
+        .unwrap();
+    }
+    export_to(&store, &out);
+    let text = std::fs::read_to_string(&out).unwrap();
+    assert!(
+        !text.contains("x.db"),
+        "the store path is derived from the root; carrying it would carry a path that is \
+         wrong for any reader laying its stores out differently"
+    );
+    assert!(text.contains("/w/one"));
+}
+
+#[test]
+fn a_multi_project_store_names_the_project_rather_than_its_internal_id() {
+    let dir = tmp();
+    let store = dir.path().join("server.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = Connection::open(&store).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE projects (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT NOT NULL UNIQUE,
+                 embedding_dim INTEGER NOT NULL DEFAULT 0, created_at INTEGER);
+             CREATE TABLE notes (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 project_id INTEGER NOT NULL,
+                 kind TEXT NOT NULL DEFAULT 'note', title TEXT NOT NULL, body TEXT NOT NULL,
+                 tags TEXT, linked_files TEXT, created_at INTEGER NOT NULL,
+                 status TEXT NOT NULL DEFAULT 'active', superseded_by INTEGER,
+                 remote_id TEXT, sync_id TEXT);
+             CREATE TABLE note_edges (
+                 from_id INTEGER NOT NULL, to_id INTEGER NOT NULL, kind TEXT NOT NULL,
+                 created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+                 PRIMARY KEY (from_id, to_id, kind));
+             INSERT INTO projects (slug) VALUES ('alpha');
+             INSERT INTO notes (project_id, title, body, created_at)
+                 VALUES (1, 'one', 'b', 100), (1, 'two', 'b', 200);
+             INSERT INTO note_edges (from_id, to_id, kind) VALUES (2, 1, 'contradicts');",
+        )
+        .unwrap();
+    }
+    let outcome = export_to(&store, &out);
+    assert_eq!(outcome.counts.entity.get("memory_entry"), Some(&2));
+    assert_eq!(outcome.counts.relationship.get("contradicts"), Some(&1));
+    let recs = records(&out);
+    assert_eq!(entities(&recs, "memory_entry")[0]["namespace"], "alpha");
+    assert!(
+        entities(&recs, "memory_entry")[0].get("uuid").is_none(),
+        "a multi project store's own identifiers are arrival ordered, so presenting one as \
+         the entry's identity would hand a reader an ordering it did not choose"
+    );
+}
+
+// ── E21: derived state is never read ─────────────────────────────────────────
+
+#[test]
+fn derived_state_is_never_carried() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "only", 1_000);
+        conn.execute_batch(
+            "INSERT INTO memory_fts (rowid, title, body, tags) VALUES (1, 't', 'b', 'x');
+             INSERT INTO note_embeddings VALUES (1, x'0102');
+             INSERT INTO notes_import_state VALUES (0, 'aaaa', 'bbbb');",
+        )
+        .unwrap();
+    }
+    export_to(&store, &out);
+    let text = std::fs::read_to_string(&out).unwrap();
+    for derived in [
+        "memory_fts",
+        "note_embeddings",
+        "notes_import_state",
+        "schema_v896",
+        "aaaa",
+        "bbbb",
+    ] {
+        assert!(
+            !text.contains(derived),
+            "{derived} is derived or invalidated by a move and must not be carried"
+        );
+    }
+}
+
+// ── E22: content detected, not declared ──────────────────────────────────────
+
+#[test]
+fn content_is_detected_from_table_shape() {
+    let dir = tmp();
+    let store = dir.path().join("mixed.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "only", 1_000);
+        conn.execute_batch(
+            "CREATE TABLE usage (command TEXT NOT NULL, called_at INTEGER NOT NULL);
+             INSERT INTO usage VALUES ('search', 5);",
+        )
+        .unwrap();
+    }
+    let outcome = export_to(&store, &out);
+    assert_eq!(outcome.counts.entity.get("memory_entry"), Some(&1));
+    assert_eq!(outcome.counts.entity.get("command_usage"), Some(&1));
+}
+
+// ── E23: the source is never modified ────────────────────────────────────────
+
+#[test]
+fn the_source_store_is_never_modified() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "only", 1_000);
+        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)").ok();
+    }
+    let before = std::fs::read(&store).unwrap();
+    export_to(&store, &out);
+    let after = std::fs::read(&store).unwrap();
+    assert_eq!(before, after, "the store was modified by exporting it");
+    for sidecar in ["memory.db-wal", "memory.db-journal", "memory.db-shm"] {
+        assert!(
+            !dir.path().join(sidecar).exists(),
+            "{sidecar} was created; the store must be opened read-only"
+        );
+    }
+}
+
+// ── E26 to E31: refusal, emptiness, determinism ──────────────────────────────
+
+#[test]
+fn an_empty_store_produces_a_valid_empty_dump() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    drop(memory_store_at(&store, LATEST));
+    let outcome = export_to(&store, &out);
+    assert!(outcome.counts.entity.is_empty());
+    let recs = records(&out);
+    assert_eq!(recs.len(), 2, "an empty dump is a header and a footer");
+    dump::verify_rendered(&std::fs::read_to_string(&out).unwrap()).unwrap();
+}
+
+#[test]
+fn an_unrecognisable_store_is_refused_and_leaves_no_partial_dump() {
+    let dir = tmp();
+    let store = dir.path().join("not-a-store.db");
+    let out = dir.path().join("dump.jsonl");
+    std::fs::write(&store, b"this is not a database").unwrap();
+    assert!(export(&store, &out, 0).is_err());
+    assert!(!out.exists());
+    assert!(!out.with_extension("partial").exists());
+}
+
+#[test]
+fn a_store_with_no_authored_tables_is_refused_rather_than_read_as_entries() {
+    let dir = tmp();
+    let store = dir.path().join("notes-missing-columns.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = Connection::open(&store).unwrap();
+        conn.execute_batch("CREATE TABLE notes (id INTEGER PRIMARY KEY, headline TEXT);")
+            .unwrap();
+    }
+    let err = export(&store, &out, 0).unwrap_err().to_string();
+    assert!(err.contains("missing required columns"), "got: {err}");
+    assert!(!out.exists());
+}
+
+#[test]
+fn exporting_an_unchanged_store_twice_is_byte_identical() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "a", 1_000);
+        add_entry(&conn, LATEST, "b", 2_000);
+    }
+    let first = dir.path().join("one.jsonl");
+    let second = dir.path().join("two.jsonl");
+    export_to(&store, &first);
+    export_to(&store, &second);
+    assert_eq!(
+        std::fs::read(&first).unwrap(),
+        std::fs::read(&second).unwrap()
+    );
+}
+
+// ── E25: no secret material ──────────────────────────────────────────────────
+
+#[test]
+fn a_dump_carries_no_credential_material() {
+    // Nothing under the config directory is read at all, which is what makes
+    // this true by construction rather than by filtering. The assertion is on
+    // the record kinds a dump can contain: a new one would have to be added
+    // here deliberately.
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "only", 1_000);
+    }
+    export_to(&store, &out);
+    for rec in records(&out) {
+        let kind = rec["record"].as_str().unwrap();
+        assert!(
+            matches!(kind, "header" | "footer" | "entity" | "relationship"),
+            "unexpected record kind {kind}"
+        );
+        if kind == "entity" {
+            let t = rec["type"].as_str().unwrap();
+            assert!(
+                matches!(t, "memory_entry" | "project" | "command_usage"),
+                "unexpected entity type {t}"
+            );
+        }
+    }
+}
+
+// ── Dangling references are reported, not dropped silently ───────────────────
+
+#[test]
+fn a_link_to_a_missing_entry_is_reported_rather_than_carried_or_hidden() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        let a = add_entry(&conn, LATEST, "a", 1_000);
+        // Foreign keys are on by default in this workspace's SQLite build, so a
+        // dangling link cannot be created through it. It can still reach the
+        // field: a build against a system SQLite has them off, and the stores
+        // predate the enforcement. The export has to survive one either way.
+        conn.execute_batch("PRAGMA foreign_keys=OFF").unwrap();
+        conn.execute(
+            "UPDATE notes SET superseded_by = 999 WHERE id = ?1",
+            rusqlite::params![a],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "INSERT INTO memory_edges (from_id, to_id, kind) VALUES (998, 1, 'relates_to')",
+        )
+        .unwrap();
+    }
+    let outcome = export_to(&store, &out);
+    assert!(outcome.counts.relationship.is_empty());
+    assert_eq!(
+        outcome.warnings.len(),
+        2,
+        "both dangling links must be reported: {:?}",
+        outcome.warnings
+    );
+}
+
+// ── Inventory ────────────────────────────────────────────────────────────────
+
+#[test]
+fn inventory_reports_shape_and_counts_without_touching_the_store() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "a", 1_000);
+        add_entry(&conn, LATEST, "b", 2_000);
+    }
+    let before = std::fs::read(&store).unwrap();
+    let report = inventory::describe(&store);
+    assert!(report.exists);
+    assert_eq!(report.schema_version, Some(LATEST as i64));
+    let notes = report
+        .contents
+        .iter()
+        .find(|t| t.table == "notes")
+        .expect("notes should be reported");
+    assert_eq!(notes.rows, 2);
+    assert!(report.contents.iter().all(|t| t.table != "memory_fts"));
+    assert_eq!(std::fs::read(&store).unwrap(), before);
+}
+
+#[test]
+fn inventory_reports_a_missing_store_as_missing_rather_than_failing() {
+    let dir = tmp();
+    let report = inventory::describe(&dir.path().join("nothing-here.db"));
+    assert!(!report.exists);
+    assert!(report.contents.is_empty());
+}
+
+#[test]
+fn inventory_reports_an_unreadable_store_without_losing_the_rest() {
+    let dir = tmp();
+    let store = dir.path().join("broken.db");
+    std::fs::write(&store, b"not a database").unwrap();
+    let report = inventory::describe(&store);
+    assert!(report.exists);
+    assert!(report.unreadable.is_some());
+}
+
+fn edge(conn: &Connection, from: i64, to: i64, kind: &str) {
+    conn.execute(
+        "INSERT INTO memory_edges (from_id, to_id, kind, created_at) VALUES (?1, ?2, ?3, 42)",
+        rusqlite::params![from, to, kind],
+    )
+    .unwrap();
+}

--- a/crates/spelunk-export/tests/format.rs
+++ b/crates/spelunk-export/tests/format.rs
@@ -1,8 +1,8 @@
-//! The dump format's own guarantees: a dump is whole or it is refused.
-//!
-//! Every case here is a way a dump could be wrong while still looking
-//! plausible. The point of the footer is that none of them can pass quietly,
-//! because the failure this format guards against is silent partial loss.
+// The dump format's own guarantees: a dump is whole or it is refused.
+//
+// Every case here is a way a dump could be wrong while still looking
+// plausible. The point of the footer is that none of them can pass quietly,
+// because the failure this format guards against is silent partial loss.
 
 use spelunk_export::dump::{self, Dump, MemoryEntry, Relationship};
 

--- a/crates/spelunk-export/tests/format.rs
+++ b/crates/spelunk-export/tests/format.rs
@@ -1,0 +1,171 @@
+//! The dump format's own guarantees: a dump is whole or it is refused.
+//!
+//! Every case here is a way a dump could be wrong while still looking
+//! plausible. The point of the footer is that none of them can pass quietly,
+//! because the failure this format guards against is silent partial loss.
+
+use spelunk_export::dump::{self, Dump, MemoryEntry, Relationship};
+
+fn entry(reference: &str, title: &str, created_at: i64) -> MemoryEntry {
+    MemoryEntry {
+        record: "entity".into(),
+        kind_tag: "memory_entry".into(),
+        reference: reference.into(),
+        uuid: None,
+        kind: "decision".into(),
+        title: title.into(),
+        body: "body".into(),
+        tags: vec![],
+        linked_files: vec![],
+        created_at,
+        status: None,
+        source_ref: None,
+        valid_at: None,
+        invalid_at: None,
+        entity_id: None,
+        remote_id: None,
+        namespace: None,
+    }
+}
+
+fn sample() -> Dump {
+    Dump {
+        entries: vec![entry("e1", "first", 100), entry("e2", "second", 200)],
+        relationships: vec![Relationship::new(
+            "supersedes",
+            "e2".into(),
+            "e1".into(),
+            Some(300),
+        )],
+        ..Dump::default()
+    }
+}
+
+fn rendered() -> String {
+    sample().render(1_700_000_000).unwrap().0
+}
+
+#[test]
+fn a_well_formed_dump_verifies() {
+    let read_back = dump::verify_rendered(&rendered()).unwrap();
+    assert_eq!(read_back.counts.entity["memory_entry"], 2);
+    assert_eq!(read_back.counts.relationship["supersedes"], 1);
+}
+
+#[test]
+fn an_empty_file_is_refused() {
+    let err = dump::verify_rendered("").unwrap_err().to_string();
+    assert!(err.contains("empty"), "got: {err}");
+}
+
+#[test]
+fn a_dump_without_a_footer_is_refused_as_truncated() {
+    let text = rendered();
+    let truncated: String = text
+        .lines()
+        .filter(|l| !l.contains("\"footer\""))
+        .map(|l| format!("{l}\n"))
+        .collect();
+    let err = dump::verify_rendered(&truncated).unwrap_err().to_string();
+    assert!(err.contains("truncated"), "got: {err}");
+}
+
+#[test]
+fn a_dump_cut_short_mid_stream_is_refused() {
+    let text = rendered();
+    let cut = &text[..text.len() / 2];
+    assert!(dump::verify_rendered(cut).is_err());
+}
+
+#[test]
+fn a_single_altered_byte_is_caught() {
+    let text = rendered().replace("first", "firsT");
+    let err = dump::verify_rendered(&text).unwrap_err().to_string();
+    assert!(
+        err.contains("counts") || err.contains("digest"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn a_removed_record_is_caught_by_the_counts() {
+    let text: String = rendered()
+        .lines()
+        .filter(|l| !l.contains("\"second\""))
+        .map(|l| format!("{l}\n"))
+        .collect();
+    let err = dump::verify_rendered(&text).unwrap_err().to_string();
+    assert!(err.contains("counts"), "got: {err}");
+}
+
+#[test]
+fn reordered_records_are_caught_even_though_the_counts_still_agree() {
+    let text = rendered();
+    let lines: Vec<&str> = text.lines().collect();
+    let mut reordered = lines.clone();
+    reordered.swap(1, 2);
+    let text: String = reordered.iter().map(|l| format!("{l}\n")).collect();
+    let err = dump::verify_rendered(&text).unwrap_err().to_string();
+    assert!(err.contains("digest"), "got: {err}");
+}
+
+#[test]
+fn a_tampered_header_is_caught_by_the_same_check_as_a_tampered_entity() {
+    let text = rendered().replace("\"generated_at\":1700000000", "\"generated_at\":1");
+    let err = dump::verify_rendered(&text).unwrap_err().to_string();
+    assert!(err.contains("digest"), "got: {err}");
+}
+
+#[test]
+fn an_unsupported_format_version_is_refused_rather_than_parsed_optimistically() {
+    let text = rendered().replace("\"format_version\":1", "\"format_version\":99");
+    let err = dump::verify_rendered(&text).unwrap_err().to_string();
+    assert!(err.contains("not supported"), "got: {err}");
+}
+
+#[test]
+fn a_foreign_format_is_refused() {
+    let text = rendered().replace("portable-dump", "something-else");
+    let err = dump::verify_rendered(&text).unwrap_err().to_string();
+    assert!(err.contains("unknown dump format"), "got: {err}");
+}
+
+#[test]
+fn records_after_the_footer_are_refused() {
+    let mut text = rendered();
+    text.push_str(&serde_json::to_string(&entry("e3", "late", 400)).unwrap());
+    text.push('\n');
+    let err = dump::verify_rendered(&text).unwrap_err().to_string();
+    assert!(err.contains("not whole"), "got: {err}");
+}
+
+#[test]
+fn an_unknown_record_kind_is_refused() {
+    let mut text = rendered();
+    text = text.replace(
+        "\"record\":\"footer\"",
+        "\"record\":\"surprise\",\"was\":\"footer\"",
+    );
+    assert!(dump::verify_rendered(&text).is_err());
+}
+
+#[test]
+fn references_are_unique_within_a_dump() {
+    let text = rendered();
+    let refs: Vec<String> = text
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .filter_map(|v| v.get("ref").and_then(|r| r.as_str()).map(str::to_string))
+        .collect();
+    let unique: std::collections::BTreeSet<_> = refs.iter().collect();
+    assert_eq!(refs.len(), unique.len());
+}
+
+#[test]
+fn the_header_is_first_and_the_footer_is_last() {
+    let text = rendered();
+    let lines: Vec<&str> = text.lines().collect();
+    assert!(lines[0].contains("\"record\":\"header\""));
+    assert!(lines[lines.len() - 1].contains("\"record\":\"footer\""));
+    assert_eq!(lines.iter().filter(|l| l.contains("\"header\"")).count(), 1);
+}

--- a/crates/spelunk-export/tests/format.rs
+++ b/crates/spelunk-export/tests/format.rs
@@ -149,16 +149,53 @@ fn an_unknown_record_kind_is_refused() {
     assert!(dump::verify_rendered(&text).is_err());
 }
 
+// The writer cannot currently produce either of the next two, which is the
+// reason to check them in the reader: the self-verification a run publishes on
+// is this function, so a writer change that broke a reference or an endpoint
+// would otherwise be certified rather than caught.
+
 #[test]
-fn references_are_unique_within_a_dump() {
+fn two_entities_sharing_a_reference_are_refused() {
+    let dump = Dump {
+        entries: vec![entry("e1", "first", 100), entry("e1", "second", 200)],
+        ..Dump::default()
+    };
+    let text = dump.render(1_700_000_000).unwrap().0;
+    let err = dump::verify_rendered(&text).unwrap_err().to_string();
+    assert!(err.contains("share the reference"), "got: {err}");
+}
+
+#[test]
+fn a_relationship_naming_an_absent_entity_is_refused() {
+    let dump = Dump {
+        entries: vec![entry("e1", "first", 100)],
+        relationships: vec![Relationship::new(
+            "supersedes",
+            "e2".into(),
+            "e1".into(),
+            None,
+        )],
+        ..Dump::default()
+    };
+    let text = dump.render(1_700_000_000).unwrap().0;
+    let err = dump::verify_rendered(&text).unwrap_err().to_string();
+    assert!(err.contains("not an entity in this dump"), "got: {err}");
+}
+
+#[test]
+fn a_relationship_may_precede_the_entity_it_names() {
     let text = rendered();
-    let refs: Vec<String> = text
-        .lines()
-        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
-        .filter_map(|v| v.get("ref").and_then(|r| r.as_str()).map(str::to_string))
+    let lines: Vec<&str> = text.lines().collect();
+    let reordered: String = [lines[0], lines[3], lines[1], lines[2], lines[4]]
+        .iter()
+        .map(|l| format!("{l}\n"))
         .collect();
-    let unique: std::collections::BTreeSet<_> = refs.iter().collect();
-    assert_eq!(refs.len(), unique.len());
+    // The digest is order sensitive, so a reordered dump cannot verify either
+    // way. Failing on the digest rather than on the endpoint is the assertion:
+    // the format puts no ordering constraint between the two record kinds, so
+    // an endpoint check made while reading would reject a legal dump.
+    let err = dump::verify_rendered(&reordered).unwrap_err().to_string();
+    assert!(err.contains("digest"), "got: {err}");
 }
 
 #[test]

--- a/crates/spelunk-export/tests/support/mod.rs
+++ b/crates/spelunk-export/tests/support/mod.rs
@@ -1,12 +1,12 @@
-//! Build a memory store at every shape the product has ever written, and prove
-//! the exporter reads all of them.
-//!
-//! The shapes here are the shipped schema statements, applied in the order
-//! the product applies them and stopped at a chosen step. They cover what the
-//! schema *is* at each version. What they cannot cover is what a real released
-//! binary put in the file: that needs artifacts captured by running those
-//! binaries, which is what the upgrade corpus exists for. These two are
-//! complements, not substitutes, and neither is sufficient alone.
+// Build a memory store at every shape the product has ever written, and prove
+// the exporter reads all of them.
+//
+// The shapes here are the shipped schema statements, applied in the order
+// the product applies them and stopped at a chosen step. They cover what the
+// schema *is* at each version. What they cannot cover is what a real released
+// binary put in the file: that needs artifacts captured by running those
+// binaries, which is what the upgrade corpus exists for. These two are
+// complements, not substitutes, and neither is sufficient alone.
 
 // One copy of this module is compiled into each test binary, and no single
 // binary needs every shape it can build.
@@ -16,13 +16,13 @@ use rusqlite::Connection;
 
 pub const LATEST: i32 = 10;
 
-/// Each step, verbatim from the corresponding shipped schema file.
-///
-/// The vector table is created as an ordinary table rather than the virtual
-/// table the product creates. The module backing it is linked into the product
-/// and not into a plain SQLite, and its contents are never read here anyway, so
-/// standing it in costs nothing and buys a second assertion: whatever shape it
-/// has, the export must ignore it.
+// Each step, verbatim from the corresponding shipped schema file.
+//
+// The vector table is created as an ordinary table rather than the virtual
+// table the product creates. The module backing it is linked into the product
+// and not into a plain SQLite, and its contents are never read here anyway, so
+// standing it in costs nothing and buys a second assertion: whatever shape it
+// has, the export must ignore it.
 fn step(conn: &Connection, version: i32) {
     let sql: &str = match version {
         1 => {
@@ -95,13 +95,13 @@ fn step(conn: &Connection, version: i32) {
     conn.execute_batch(sql).unwrap();
 }
 
-/// A memory store at `version`, with `user_version` stamped.
+// A memory store at `version`, with `user_version` stamped.
 pub fn memory_store_at(path: &std::path::Path, version: i32) -> Connection {
     stamped(path, version, true)
 }
 
-/// A memory store at `version` that never had its version stamped, which is
-/// every store written before the runner existed.
+// A memory store at `version` that never had its version stamped, which is
+// every store written before the runner existed.
 pub fn unstamped_memory_store_at(path: &std::path::Path, version: i32) -> Connection {
     stamped(path, version, false)
 }
@@ -131,7 +131,7 @@ fn stamped(path: &std::path::Path, version: i32, stamp: bool) -> Connection {
     conn
 }
 
-/// Insert one entry using only the columns that exist at `version`.
+// Insert one entry using only the columns that exist at `version`.
 pub fn add_entry(conn: &Connection, version: i32, title: &str, created_at: i64) -> i64 {
     conn.execute(
         "INSERT INTO notes (kind, title, body, tags, linked_files, created_at)

--- a/crates/spelunk-export/tests/support/mod.rs
+++ b/crates/spelunk-export/tests/support/mod.rs
@@ -1,0 +1,141 @@
+//! Build a memory store at every shape the product has ever written, and prove
+//! the exporter reads all of them.
+//!
+//! The shapes here are the shipped schema statements, applied in the order
+//! the product applies them and stopped at a chosen step. They cover what the
+//! schema *is* at each version. What they cannot cover is what a real released
+//! binary put in the file: that needs artifacts captured by running those
+//! binaries, which is what the upgrade corpus exists for. These two are
+//! complements, not substitutes, and neither is sufficient alone.
+
+use rusqlite::Connection;
+
+pub const LATEST: i32 = 10;
+
+/// Each step, verbatim from the corresponding shipped schema file.
+///
+/// The vector table is created as an ordinary table rather than the virtual
+/// table the product creates. The module backing it is linked into the product
+/// and not into a plain SQLite, and its contents are never read here anyway, so
+/// standing it in costs nothing and buys a second assertion: whatever shape it
+/// has, the export must ignore it.
+fn step(conn: &Connection, version: i32) {
+    let sql: &str = match version {
+        1 => {
+            "CREATE TABLE IF NOT EXISTS notes (
+                 id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                 kind          TEXT    NOT NULL DEFAULT 'note',
+                 title         TEXT    NOT NULL,
+                 body          TEXT    NOT NULL,
+                 tags          TEXT,
+                 linked_files  TEXT,
+                 created_at    INTEGER NOT NULL DEFAULT (unixepoch())
+             );
+             CREATE TABLE IF NOT EXISTS note_embeddings (
+                 note_id INTEGER PRIMARY KEY, embedding BLOB
+             );"
+        }
+        2 => {
+            "ALTER TABLE notes ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
+             ALTER TABLE notes ADD COLUMN superseded_by INTEGER REFERENCES notes(id);"
+        }
+        3 => "ALTER TABLE notes ADD COLUMN source_ref TEXT;",
+        4 => {
+            "CREATE TABLE IF NOT EXISTS memory_fts (
+                 rowid INTEGER PRIMARY KEY, title TEXT, body TEXT, tags TEXT
+             );"
+        }
+        5 => {
+            "ALTER TABLE notes ADD COLUMN valid_at INTEGER;
+             ALTER TABLE notes ADD COLUMN invalid_at INTEGER;
+             CREATE INDEX IF NOT EXISTS idx_memory_invalid_at ON notes(invalid_at);"
+        }
+        6 => {
+            "CREATE TABLE IF NOT EXISTS memory_edges (
+                 from_id    INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+                 to_id      INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+                 kind       TEXT    NOT NULL
+                            CHECK(kind IN ('supersedes', 'relates_to', 'contradicts')),
+                 created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+                 PRIMARY KEY (from_id, to_id, kind)
+             );
+             CREATE INDEX IF NOT EXISTS idx_memory_edges_from ON memory_edges(from_id);
+             CREATE INDEX IF NOT EXISTS idx_memory_edges_to   ON memory_edges(to_id);"
+        }
+        7 => {
+            "ALTER TABLE notes ADD COLUMN uuid TEXT;
+             ALTER TABLE notes ADD COLUMN remote_id TEXT;
+             CREATE UNIQUE INDEX IF NOT EXISTS idx_notes_uuid
+                 ON notes(uuid) WHERE uuid IS NOT NULL;
+             CREATE UNIQUE INDEX IF NOT EXISTS idx_notes_remote_id
+                 ON notes(remote_id) WHERE remote_id IS NOT NULL;"
+        }
+        8 => {
+            "ALTER TABLE notes ADD COLUMN entity_id TEXT;
+             CREATE INDEX IF NOT EXISTS idx_notes_entity_id
+                 ON notes(entity_id) WHERE entity_id IS NOT NULL;"
+        }
+        9 => {
+            "CREATE TABLE IF NOT EXISTS schema_v896_note_embeddings
+                 (sentinel INTEGER PRIMARY KEY);"
+        }
+        10 => {
+            "CREATE TABLE IF NOT EXISTS notes_import_state (
+                 id INTEGER PRIMARY KEY CHECK (id = 0),
+                 last_merged_tracking_oid TEXT,
+                 last_imported_working_oid TEXT
+             );"
+        }
+        other => panic!("no schema step {other}"),
+    };
+    conn.execute_batch(sql).unwrap();
+}
+
+/// A memory store at `version`, with `user_version` stamped.
+pub fn memory_store_at(path: &std::path::Path, version: i32) -> Connection {
+    stamped(path, version, true)
+}
+
+/// A memory store at `version` that never had its version stamped, which is
+/// every store written before the runner existed.
+pub fn unstamped_memory_store_at(path: &std::path::Path, version: i32) -> Connection {
+    stamped(path, version, false)
+}
+
+fn stamped(path: &std::path::Path, version: i32, stamp: bool) -> Connection {
+    let conn = Connection::open(path).unwrap();
+    for v in 1..=version {
+        step(&conn, v);
+    }
+    if stamp {
+        conn.execute_batch(&format!("PRAGMA user_version = {version}"))
+            .unwrap();
+    }
+    conn
+}
+
+/// Insert one entry using only the columns that exist at `version`.
+pub fn add_entry(conn: &Connection, version: i32, title: &str, created_at: i64) -> i64 {
+    conn.execute(
+        "INSERT INTO notes (kind, title, body, tags, linked_files, created_at)
+         VALUES ('decision', ?1, 'body of ' || ?1, 'alpha, beta', 'src/a.rs', ?2)",
+        rusqlite::params![title, created_at],
+    )
+    .unwrap();
+    let id = conn.last_insert_rowid();
+    if version >= 7 {
+        conn.execute(
+            "UPDATE notes SET uuid = ?2 WHERE id = ?1",
+            rusqlite::params![id, format!("0192f0a0-0000-7000-8000-0000000000{id:02x}")],
+        )
+        .unwrap();
+    }
+    if version >= 8 {
+        conn.execute(
+            "UPDATE notes SET entity_id = ?2 WHERE id = ?1",
+            rusqlite::params![id, format!("sha256-of-{title}")],
+        )
+        .unwrap();
+    }
+    id
+}

--- a/crates/spelunk-export/tests/support/mod.rs
+++ b/crates/spelunk-export/tests/support/mod.rs
@@ -8,6 +8,10 @@
 //! binaries, which is what the upgrade corpus exists for. These two are
 //! complements, not substitutes, and neither is sufficient alone.
 
+// One copy of this module is compiled into each test binary, and no single
+// binary needs every shape it can build.
+#![allow(dead_code)]
+
 use rusqlite::Connection;
 
 pub const LATEST: i32 = 10;
@@ -100,6 +104,19 @@ pub fn memory_store_at(path: &std::path::Path, version: i32) -> Connection {
 /// every store written before the runner existed.
 pub fn unstamped_memory_store_at(path: &std::path::Path, version: i32) -> Connection {
     stamped(path, version, false)
+}
+
+// A memory store at `version` in write-ahead-log mode, which is the mode every
+// store the product creates runs in. A fixture left in the default rollback
+// journal mode cannot exercise the sidecar files or the concurrent-writer
+// behaviour that only exist under WAL.
+pub fn wal_memory_store_at(path: &std::path::Path, version: i32) -> Connection {
+    let conn = stamped(path, version, true);
+    let mode: String = conn
+        .query_row("PRAGMA journal_mode = WAL", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(mode, "wal", "the fixture must really be in WAL mode");
+    conn
 }
 
 fn stamped(path: &std::path::Path, version: i32, stamp: bool) -> Connection {

--- a/crates/spelunk-export/tests/verification.rs
+++ b/crates/spelunk-export/tests/verification.rs
@@ -87,13 +87,13 @@ fn a_file_that_reads_back_truncated_is_refused_and_removed() {
     assert!(!out.with_extension("partial").exists());
 }
 
-// A whole-binary version of the two above: the store reads fine, the write
-// succeeds, and the bytes that land are still not the bytes that were written.
-// A sink swallows the write and reads back empty, which is what a full disk or
-// a misdirected path does to a dump.
-#[cfg(unix)]
+// The temporary's path is derived from the output's, so it can collide with a
+// file that was already there. Overwriting it and then unlinking it on failure
+// destroys a user's file, silently, in the one tool whose contract is that it
+// removes nothing. Creating the temporary exclusively turns the collision into
+// a refusal that names the path, and the file is still there afterwards.
 #[test]
-fn an_export_whose_bytes_do_not_land_publishes_nothing_and_leaves_nothing() {
+fn a_file_already_at_the_temporary_path_stops_the_run_and_survives_it() {
     let dir = tmp();
     let store = dir.path().join("memory.db");
     let out = dir.path().join("dump.jsonl");
@@ -102,15 +102,31 @@ fn an_export_whose_bytes_do_not_land_publishes_nothing_and_leaves_nothing() {
         add_entry(&conn, LATEST, "a", 1_000);
     }
     let temp = out.with_extension("partial");
-    std::os::unix::fs::symlink("/dev/null", &temp).unwrap();
+    std::fs::write(&temp, b"something the user put here").unwrap();
 
-    assert!(export(&store, &out, 1_700_000_000).is_err());
-    assert!(!out.exists(), "an unproved dump must not be published");
+    let err = format!("{:#}", export(&store, &out, 1_700_000_000).unwrap_err());
+
+    assert!(err.contains("already exists"), "got: {err}");
     assert!(
-        !temp.exists() && std::fs::symlink_metadata(&temp).is_err(),
-        "the unproved file must not be left behind"
+        err.contains("dump.partial"),
+        "the refusal must name it: {err}"
     );
+    assert_eq!(
+        std::fs::read(&temp).unwrap(),
+        b"something the user put here",
+        "the file was destroyed by an export that did not create it"
+    );
+    assert!(!out.exists(), "an unproved dump must not be published");
 }
+
+// There used to be a whole-binary version of the two above, which put a
+// symlink to /dev/null at the temporary's path so the write succeeded and the
+// readback came up empty. Exclusive creation refuses anything already sitting
+// there, symlink included, so that route is gone and with it the class of
+// failure it stood for: reaching a sink through this path now needs a file the
+// export declined to open. What the readback still guards against, bytes that
+// land differently from how they were written, is exercised directly on
+// `write_verified` above, where it can be provoked without a filesystem trick.
 
 #[test]
 fn a_clean_run_claims_only_what_it_proved() {

--- a/crates/spelunk-export/tests/verification.rs
+++ b/crates/spelunk-export/tests/verification.rs
@@ -1,0 +1,152 @@
+// The dump is proved before it is published, and nothing is left behind when
+// the proof fails.
+//
+// These exercise the write-verify-rename path itself, which is reachable only
+// once extraction has succeeded. A test that fails earlier, inside the read,
+// never reaches the temporary file and so establishes nothing about it.
+
+mod support;
+
+use std::path::Path;
+
+use spelunk_export::{ExportOutcome, dump, export, source, write_verified};
+use support::{LATEST, add_entry, memory_store_at};
+
+fn tmp() -> tempfile::TempDir {
+    tempfile::tempdir().unwrap()
+}
+
+// Render what an export of a store holding `titles` would write.
+fn rendered(dir: &Path, name: &str, titles: &[&str]) -> (String, Vec<String>) {
+    let store = dir.join(name);
+    {
+        let conn = memory_store_at(&store, LATEST);
+        for (n, t) in titles.iter().enumerate() {
+            add_entry(&conn, LATEST, t, 1_000 + n as i64);
+        }
+    }
+    let conn = source::open_read_only(&store).unwrap();
+    let extracted = source::extract(&conn).unwrap();
+    let (text, per_record, _) = extracted.dump.render(1_700_000_000).unwrap();
+    (text, per_record)
+}
+
+#[test]
+fn a_verified_dump_is_moved_into_place_and_no_temporary_survives() {
+    let dir = tmp();
+    let out = dir.path().join("dump.jsonl");
+    let (text, per_record) = rendered(dir.path(), "memory.db", &["a", "b"]);
+
+    write_verified(&text, &per_record, &out).unwrap();
+
+    assert_eq!(std::fs::read_to_string(&out).unwrap(), text);
+    assert!(
+        !out.with_extension("partial").exists(),
+        "the temporary must not survive a successful run"
+    );
+}
+
+#[test]
+fn a_file_that_reads_back_as_a_different_dump_is_refused_and_removed() {
+    let dir = tmp();
+    let out = dir.path().join("dump.jsonl");
+    let (text, _) = rendered(dir.path(), "one.db", &["a", "b"]);
+    let (_, other_records) = rendered(dir.path(), "two.db", &["c"]);
+
+    // Both are whole, self-consistent dumps, so the footer's own digest check
+    // passes on the file. Only the comparison against what this run read from
+    // the store can tell them apart, which is the comparison being pinned here.
+    let err = write_verified(&text, &other_records, &out).unwrap_err();
+
+    assert!(
+        err.to_string().contains("does not match"),
+        "unexpected refusal: {err}"
+    );
+    assert!(!out.exists(), "an unproved dump must not be published");
+    assert!(
+        !out.with_extension("partial").exists(),
+        "the unproved file must not be left behind either"
+    );
+}
+
+#[test]
+fn a_file_that_reads_back_truncated_is_refused_and_removed() {
+    let dir = tmp();
+    let out = dir.path().join("dump.jsonl");
+    let (text, per_record) = rendered(dir.path(), "memory.db", &["a", "b"]);
+    let short: String = text
+        .lines()
+        .take(text.lines().count() - 1)
+        .map(|l| format!("{l}\n"))
+        .collect();
+
+    let err = write_verified(&short, &per_record, &out).unwrap_err();
+
+    assert!(err.to_string().contains("truncated"), "unexpected: {err}");
+    assert!(!out.exists(), "a truncated dump must not be published");
+    assert!(!out.with_extension("partial").exists());
+}
+
+// A whole-binary version of the two above: the store reads fine, the write
+// succeeds, and the bytes that land are still not the bytes that were written.
+// A sink swallows the write and reads back empty, which is what a full disk or
+// a misdirected path does to a dump.
+#[cfg(unix)]
+#[test]
+fn an_export_whose_bytes_do_not_land_publishes_nothing_and_leaves_nothing() {
+    let dir = tmp();
+    let store = dir.path().join("memory.db");
+    let out = dir.path().join("dump.jsonl");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "a", 1_000);
+    }
+    let temp = out.with_extension("partial");
+    std::os::unix::fs::symlink("/dev/null", &temp).unwrap();
+
+    assert!(export(&store, &out, 1_700_000_000).is_err());
+    assert!(!out.exists(), "an unproved dump must not be published");
+    assert!(
+        !temp.exists() && std::fs::symlink_metadata(&temp).is_err(),
+        "the unproved file must not be left behind"
+    );
+}
+
+#[test]
+fn a_clean_run_claims_only_what_it_proved() {
+    let dir = tmp();
+    let out = dir.path().join("dump.jsonl");
+    let store = dir.path().join("memory.db");
+    {
+        let conn = memory_store_at(&store, LATEST);
+        add_entry(&conn, LATEST, "a", 1_000);
+    }
+    let summary = export(&store, &out, 1_700_000_000).unwrap().summary(&out);
+
+    assert!(summary.contains("1 memory_entry"), "got: {summary}");
+    assert!(summary.contains("reads back"), "got: {summary}");
+    assert!(
+        !summary.to_lowercase().contains("not carried"),
+        "nothing was dropped, so nothing may be reported as dropped: {summary}"
+    );
+}
+
+#[test]
+fn a_run_that_dropped_a_link_says_so_where_it_reports_success() {
+    let outcome = ExportOutcome {
+        counts: {
+            let mut c = dump::Counts::default();
+            c.add_entity("memory_entry");
+            c
+        },
+        warnings: vec!["a 'relates_to' link ... is not carried".into()],
+    };
+
+    let summary = outcome.summary(Path::new("/tmp/dump.jsonl"));
+
+    assert!(
+        summary.contains("1 link(s) were NOT carried"),
+        "the count of what was dropped belongs beside the count of what was \
+         carried: {summary}"
+    );
+}


### PR DESCRIPTION
A small, self-contained binary that reads a project's local stores and writes them as a portable, documented dump. Useful for taking a backup, inspecting what is actually stored, moving a project between machines, or leaving the tool entirely with your data in a form something else can read.

**Status: ready for review. Two independent reviews completed; all blocking findings fixed.** CI is green across all 15 checks.

> Both reviews were posted as comments rather than formal reviews, so GitHub shows no review decision on this PR. That is a tooling artifact, not an indication that it is unreviewed — see the review threads below.

## What it does

Reads the memory store, the project registry and the server store, and writes line-delimited JSON: a header, then entities, then relationships, then a footer.

The format is expressed as **entities and relationships rather than tables**, so it describes what is stored rather than how this version happens to store it. A reader does not need to know our schema, and the format does not have to change when the schema does.

## Properties worth knowing

**It never modifies anything.** Read-only against every store. The tests assert the sources are byte-identical afterwards.

**It writes to a temporary file, verifies, then renames.** A failed run leaves no dump at all, rather than a truncated one that looks complete.

**The footer carries per-type counts and a digest** folded from per-record hashes in file order. That gives per-record integrity, order sensitivity, and whole-or-nothing verification in one mechanism, so a truncated or reordered dump fails loudly instead of importing partially.

**No version constant anywhere.** It probes for columns rather than branching on a recorded schema version, so one code path reads every shape the stores have had, including older ones that predate version stamping. That is deliberate: a version-keyed reader would need updating every time the schema moves, and would fail on any store whose version was never written.

**It carries identifiers verbatim and never mints them.** Where a source has an identifier it is copied; where it does not, the field is omitted and the creation time is always carried so a reader can decide. Identity policy belongs to whatever consumes the dump, not to the exporter.

**It links its own SQLite** and depends on no other crate in the workspace, so it builds and runs standalone.

## Testing

42 tests across the format, the sources and end-to-end runs. Beyond fixtures, it was exercised against real data on a working machine: a live memory store and a registry holding several hundred projects, both self-verified, with the sources unchanged afterwards.

Fixture coverage spans twenty store shapes built by applying the schema history step by step, plus stores carrying no version stamp at all.

## Not included

Scanning for hooks, environment variables and lock files. The module is present but unimplemented: nothing in this change exercises it, and building it now would be structure without a caller.

## Review notes

The two places I would look hardest:

- **`source.rs`** does the column probing. The question worth asking is whether any store shape is read as a *different* shape rather than failing, since a systematic misread is the one error the self-verification cannot catch by construction.
- **Supersede relationships have two encodings in the stores, and one store can hold both.** They point opposite ways relative to each other. A single-encoding fixture will not catch a writer that gets the direction wrong, so that is the sharpest trap in here.
