### PR TITLE
fix: disable model reasoning by default and drop reasoning_content

### DIFF
--- a/crates/spelunk-server/src/main.rs
+++ b/crates/spelunk-server/src/main.rs
@@ -103,6 +103,15 @@ struct Args {
     #[arg(long, env = "SPELUNK_LLM_MODEL", default_value = "")]
     llm_model: String,
 
+    /// `reasoning_effort` sent on every LLM request, to suppress chain-of-thought
+    /// on reasoning models (DeepSeek, Gemini, o-series, …). Defaults to `none`
+    /// (reasoning off), because harvest/explore want the answer, not the model's
+    /// thinking, and an unbounded reasoning pass exhausts the token budget before
+    /// any content is emitted. Set `minimal`/`low`/`medium`/`high` to allow it, or
+    /// `default` to omit the field entirely for endpoints that reject it.
+    #[arg(long, env = "SPELUNK_LLM_REASONING_EFFORT", default_value = "none")]
+    llm_reasoning_effort: String,
+
     /// Credential for the `--llm-url` endpoint, passed inline. Visible in the
     /// process table: prefer `--llm-key-file` or `SPELUNK_LLM_KEY`. Distinct
     /// from `--key`, which is this server's own inbound bearer.
@@ -124,6 +133,18 @@ struct Args {
     /// `--host` is probed over loopback.
     #[arg(long)]
     health_check: bool,
+}
+
+/// Map the `--llm-reasoning-effort` value to what travels on the wire: `default`
+/// / `model` / blank means "omit the field, use the model's own default";
+/// anything else is sent verbatim (`none` suppresses reasoning).
+fn normalize_reasoning_effort(v: &str) -> Option<String> {
+    let v = v.trim();
+    if v.is_empty() || v.eq_ignore_ascii_case("default") || v.eq_ignore_ascii_case("model") {
+        None
+    } else {
+        Some(v.to_string())
+    }
 }
 
 fn main() -> Result<()> {
@@ -286,6 +307,7 @@ async fn run(budget: ThreadBudget) -> Result<()> {
             base_url,
             model,
             api_key: llm_key,
+            reasoning_effort: normalize_reasoning_effort(&args.llm_reasoning_effort),
         }))
     } else {
         None
@@ -726,8 +748,38 @@ fn effective_uid() -> Option<u32> {
 
 #[cfg(test)]
 mod arg_tests {
-    use super::Args;
+    use super::{Args, normalize_reasoning_effort};
     use clap::Parser;
+
+    // Reasoning is off by default: harvest/explore want the answer, and an
+    // unbounded reasoning pass exhausts the token budget before any content
+    // (the DeepSeek-v4 harvest failure). The default must send `none`.
+    #[test]
+    fn reasoning_is_disabled_by_default() {
+        let args = Args::parse_from(["spelunk-server"]);
+        assert_eq!(args.llm_reasoning_effort, "none");
+        assert_eq!(
+            normalize_reasoning_effort(&args.llm_reasoning_effort),
+            Some("none".to_string()),
+            "the default must be sent on the wire as reasoning_effort=none"
+        );
+    }
+
+    #[test]
+    fn reasoning_effort_default_and_model_and_blank_omit_the_field() {
+        for opt_out in ["default", "Default", "model", "  ", ""] {
+            assert_eq!(
+                normalize_reasoning_effort(opt_out),
+                None,
+                "'{opt_out}' must omit reasoning_effort so strict endpoints aren't sent it"
+            );
+        }
+        assert_eq!(
+            normalize_reasoning_effort("minimal"),
+            Some("minimal".to_string()),
+            "an explicit effort level passes through verbatim"
+        );
+    }
 
     /// The server binary default host must be loopback (127.0.0.1), not the
     /// wildcard (0.0.0.0). The wildcard bind is an explicit `--host 0.0.0.0`

--- a/crates/spelunk-server/src/server_llm.rs
+++ b/crates/spelunk-server/src/server_llm.rs
@@ -61,13 +61,20 @@ pub fn check_llm_transport(llm_url: &str, has_key: bool) -> Result<()> {
 /// OpenAI-compatible chat-completions backend.
 ///
 /// `api_key` is `Some` only when a credential resolved; when it is `None` the
-/// request is byte-identical to the unauthenticated one, so keyless local
-/// endpoints that reject unexpected headers keep working.
+/// request carries no `Authorization` header, so keyless local endpoints that
+/// reject unexpected headers keep working.
+///
+/// `reasoning_effort` is sent on every request when `Some` (default `"none"`)
+/// to suppress chain-of-thought on reasoning models: our uses (memory harvest,
+/// explore) want the JSON answer, not the model's thinking, and an unbounded
+/// reasoning pass burns the whole `max_tokens` budget before any `content`
+/// arrives. `None` omits the field for endpoints that reject it.
 pub struct ServerLlm {
     pub client: reqwest::Client,
     pub base_url: String,
     pub model: String,
     pub api_key: Option<String>,
+    pub reasoning_effort: Option<String>,
 }
 
 #[async_trait::async_trait]
@@ -89,6 +96,8 @@ impl spelunk_core::llm::LlmBackend for ServerLlm {
             max_tokens: usize,
             temperature: f32,
             #[serde(skip_serializing_if = "Option::is_none")]
+            reasoning_effort: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
             response_format: Option<serde_json::Value>,
         }
         #[derive(serde::Serialize)]
@@ -107,6 +116,12 @@ impl spelunk_core::llm::LlmBackend for ServerLlm {
         #[derive(serde::Deserialize)]
         struct Delta {
             content: Option<String>,
+            // Reasoning models (DeepSeek, etc.) stream chain-of-thought here,
+            // as a sibling of `content`. It is intermediate output, never the
+            // answer, so it is parsed only to be dropped: forwarding it would
+            // corrupt a JSON-schema-constrained completion.
+            #[serde(default)]
+            reasoning_content: Option<String>,
         }
 
         let chat_messages: Vec<ChatMsg> = messages
@@ -126,6 +141,7 @@ impl spelunk_core::llm::LlmBackend for ServerLlm {
             stream: true,
             max_tokens,
             temperature: 0.7,
+            reasoning_effort: self.reasoning_effort.as_deref(),
             response_format,
         };
 
@@ -146,7 +162,9 @@ impl spelunk_core::llm::LlmBackend for ServerLlm {
             .bytes_stream();
 
         let mut buffer = String::new();
-        while let Some(chunk) = stream.next().await {
+        let mut saw_content = false;
+        let mut saw_reasoning = false;
+        'stream: while let Some(chunk) = stream.next().await {
             let bytes = chunk.context("reading SSE byte chunk")?;
             buffer.push_str(&String::from_utf8_lossy(&bytes));
 
@@ -160,23 +178,45 @@ impl spelunk_core::llm::LlmBackend for ServerLlm {
                         None => continue,
                     };
                     if data == "[DONE]" {
-                        return Ok(());
+                        break 'stream;
                     }
                     if data.is_empty() {
                         continue;
                     }
                     if let Ok(chunk) = serde_json::from_str::<StreamChunk>(data) {
                         for choice in chunk.choices {
-                            if let Some(content) = choice.delta.content
+                            let Delta {
+                                content,
+                                reasoning_content,
+                            } = choice.delta;
+                            if reasoning_content.is_some_and(|r| !r.is_empty()) {
+                                saw_reasoning = true;
+                            }
+                            if let Some(content) = content
                                 && !content.is_empty()
-                                && tx.send(content).await.is_err()
                             {
-                                return Ok(());
+                                saw_content = true;
+                                if tx.send(content).await.is_err() {
+                                    return Ok(());
+                                }
                             }
                         }
                     }
                 }
             }
+        }
+
+        // A reasoning model that ignored `reasoning_effort` can spend the whole
+        // `max_tokens` budget thinking and emit no `content` at all. Downstream
+        // that surfaces as an opaque parse failure on an empty string; name the
+        // real cause here instead.
+        if saw_reasoning && !saw_content {
+            tracing::warn!(
+                max_tokens,
+                "LLM streamed only reasoning_content and no content: the reasoning \
+                 model likely exhausted the token budget before answering. Raise \
+                 max_tokens, or disable reasoning (--llm-reasoning-effort=none)."
+            );
         }
 
         Ok(())
@@ -337,6 +377,7 @@ mod tests {
             base_url,
             model: "test-model".to_string(),
             api_key,
+            reasoning_effort: Some("none".to_string()),
         };
         let (tx, _rx) = tokio::sync::mpsc::channel(8);
         llm.generate(
@@ -378,6 +419,101 @@ mod tests {
         assert!(
             requests[0].headers.get("authorization").is_none(),
             "a keyless endpoint must keep receiving the request it gets today"
+        );
+    }
+
+    // ── reasoning control ────────────────────────────────────────────────────
+
+    async fn mount_sse(server: &wiremock::MockServer, body: &str) {
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/v1/chat/completions"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_raw(body, "text/event-stream"),
+            )
+            .mount(server)
+            .await;
+    }
+
+    async fn generate_collect(base_url: String, reasoning_effort: Option<String>) -> String {
+        let llm = ServerLlm {
+            client: reqwest::Client::new(),
+            base_url,
+            model: "test-model".to_string(),
+            api_key: None,
+            reasoning_effort,
+        };
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(64);
+        let collector = tokio::spawn(async move {
+            let mut out = String::new();
+            while let Some(t) = rx.recv().await {
+                out.push_str(&t);
+            }
+            out
+        });
+        llm.generate(
+            &[spelunk_core::llm::Message {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            }],
+            64,
+            tx,
+            None,
+        )
+        .await
+        .unwrap();
+        collector.await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn reasoning_effort_is_sent_when_configured() {
+        let server = wiremock::MockServer::start().await;
+        mount_sse(&server, "data: [DONE]\n\n").await;
+
+        let _ = generate_collect(server.uri(), Some("none".to_string())).await;
+
+        let requests = server.received_requests().await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(
+            body["reasoning_effort"], "none",
+            "reasoning_effort must be sent so reasoning models skip chain-of-thought"
+        );
+    }
+
+    #[tokio::test]
+    async fn reasoning_effort_is_omitted_when_unset() {
+        let server = wiremock::MockServer::start().await;
+        mount_sse(&server, "data: [DONE]\n\n").await;
+
+        let _ = generate_collect(server.uri(), None).await;
+
+        let requests = server.received_requests().await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert!(
+            body.get("reasoning_effort").is_none(),
+            "with reasoning control disabled the field must not appear at all"
+        );
+    }
+
+    // A reasoning model streams chain-of-thought (reasoning_content) before the
+    // real answer (content). Only the answer may reach the caller: reasoning
+    // deltas prepended to a JSON-schema completion would break parsing.
+    #[tokio::test]
+    async fn reasoning_content_is_dropped_and_content_is_forwarded() {
+        let server = wiremock::MockServer::start().await;
+        let body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"let me think\"}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\" harder\"}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"{\\\"ok\\\":\"}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"true}\"}}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        mount_sse(&server, body).await;
+
+        let out = generate_collect(server.uri(), Some("none".to_string())).await;
+
+        assert_eq!(
+            out, "{\"ok\":true}",
+            "only content deltas may be forwarded; reasoning_content must be dropped"
         );
     }
 }


### PR DESCRIPTION
## Problem

Reasoning models (e.g. DeepSeek's `deepseek-v4-flash`) stream `reasoning_content` (chain-of-thought) as a sibling of `content`, emitting the reasoning first. The SSE parser in `server_llm.rs` only ever read `delta.content`, and memory harvest's tight per-batch `max_tokens` was spent entirely on reasoning before any `content` arrived. Harvest then tried to parse an empty string and failed with `EOF while parsing a value`.

## Fix

Suppress reasoning by default for **all** models (not just DeepSeek), and harden the parser so we always reach the content even if a model reasons anyway.

- **Disable reasoning on the wire.** Every chat request now sends `reasoning_effort: "none"` (the field DeepSeek v4 and Gemini honor to turn thinking off). Configurable via `--llm-reasoning-effort` / `SPELUNK_LLM_REASONING_EFFORT` (default `none`); set `minimal`/`low`/… to re-enable, or `default`/`model`/blank to **omit the field entirely** for a strict endpoint (e.g. OpenAI gpt-4o) that would reject it. When omitted, the request body is byte-identical to before (`skip_serializing_if`).
- **Never forward `reasoning_content`.** `Delta` now parses it explicitly and drops it, so a reasoning model that ignores the request can't corrupt a JSON-schema-constrained completion, while real `content` deltas still stream through.
- **Clear diagnostic.** If a stream is all reasoning and no content, a `tracing::warn!` names the real cause (budget exhausted before answering) instead of leaving the opaque downstream parse error.

Deliberately **not** bumping `max_tokens` — disabling reasoning is the correct fix; a larger budget would only be a band-aid that wastes tokens.

## Tests

New unit tests in `server_llm.rs`:
- `reasoning_effort=none` is sent by default
- the field is omitted when unset
- `reasoning_content` deltas are dropped while `content` is forwarded

New arg tests in `main.rs`: reasoning off by default, and the `default`/`model`/blank → omit mapping.

## Verification

- `cargo fmt --check` ✅
- `clippy --lib --bins --tests --benches --features rich-formats -D warnings` ✅ clean
- `spelunk-server` suite: 251/251 ✅
- Full workspace `nextest`: 2247 passed. The 2 failures (`capability::llm_route::…nothing_configured_anywhere…` and `memory::outbox::…live_pull`) reproduce identically on `main` and are environment-dependent (a live loopback server on `:7777` and a networked sync test); this diff touches only `spelunk-server`.

## Operational note

An already-running `spelunk-server` daemon needs a rebuild + restart to pick up the new default; freshly spawned daemons get reasoning-off automatically via the clap default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)