### PR TITLE
chore: bump version to 0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.8] — 2026-08-11
+
 ### Added
 
 - **`spelunk-export`, a standalone tool that writes a portable dump of a local

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-embed"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-export"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-embed/Cargo.toml
+++ b/crates/spelunk-embed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-embed"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 description = "Native F2LLM-v2-330M embedder (candle) for spelunk"
 license = "MIT"

--- a/crates/spelunk-export/Cargo.toml
+++ b/crates/spelunk-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-export"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 description = "spelunk: export local stores to a portable dump"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -95,15 +95,23 @@ script has no code path that can create a GitHub release, push to the
 Run it before tagging; a failure here is cheaper to fix than one discovered
 after a tag is already pushed.
 
-### 1. Bump the version in `Cargo.toml`
+### 1. Bump the version in every crate manifest
 
-Edit the `version` field in `Cargo.toml`:
+The root `Cargo.toml` is a virtual workspace manifest — it has no `version`
+field, and no `[workspace.package]` section to inherit one from. The version
+lives in each member crate:
 
-```toml
-[package]
-name = "spelunk"
-version = "0.8.0"   # <-- update this
+```bash
+crates/spelunk-cli/Cargo.toml
+crates/spelunk-core/Cargo.toml
+crates/spelunk-embed/Cargo.toml
+crates/spelunk-export/Cargo.toml
+crates/spelunk-server/Cargo.toml
 ```
+
+Edit the `version` field in all five, then regenerate `Cargo.lock` with a cargo
+command rather than by hand. Editing the root manifest bumps nothing and the
+tag would ship binaries reporting the previous version.
 
 ### 1a. Check for hardcoded version references in docs
 


### PR DESCRIPTION
Prepares the 0.9.8 release. Tagging follows once this merges.

## What changed

- **Version bumped in all five crate manifests** — `spelunk-cli`, `spelunk-core`, `spelunk-embed`, `spelunk-export`, `spelunk-server` — plus `Cargo.lock`, regenerated by cargo.
- **CHANGELOG**: the accumulated `Unreleased` notes become `[0.9.8]`. One entry: the export tool and its per-platform release assets.
- **`docs/releasing.md` step 1 corrected.**

## The doc fix is not cosmetic

The instruction read:

> ### 1. Bump the version in `Cargo.toml`
> Edit the `version` field in `Cargo.toml`:
> ```toml
> [package]
> name = "spelunk"
> version = "0.8.0"   # <-- update this
> ```

The root manifest is a **virtual workspace** — no `version` field, no `[workspace.package]` to inherit one from. Following that step literally edits nothing, and the release would be tagged `v0.9.8` while every binary reported `0.9.7`. The version lives in the five member crates, and the doc now says so and names them.

Worth fixing here rather than filing, because this is the release that would otherwise have been cut against it.

## Verification

`cargo check --workspace --all-targets` clean, and the bump confirmed by running a binary rather than by reading a manifest:

```
$ spelunk-export --version
spelunk-export 0.9.8
```

## What this unblocks

The export tool is merged but not obtainable — nothing publishes it until a tag exists. This is the last step before that: tag `v0.9.8`, and the release carries `spelunk-export-v0.9.8-<target>` as its own download for each of the four supported targets, each with the sha256 digest GitHub records per asset.