### PR TITLE
chore: bump version to 0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.9] — 2026-08-11
+
+### Fixed
+
+- **Binaries report their own version again.** The `v0.9.8` tag was created
+  before the version bump reached `main`, so every binary in that release
+  reports `0.9.7`. Nothing else about it is wrong — the code is the code at
+  that commit — but a tool that misreports its version is a poor thing to hand
+  someone mid-migration, and the dump format records the producing tool and
+  version in every file it writes. This release carries the same contents with
+  the version corrected. Prefer it over `v0.9.8`.
+
 ## [0.9.8] — 2026-08-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-cli"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-core"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "ast-grep-core",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-embed"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-export"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "spelunk-server"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/spelunk-cli/Cargo.toml
+++ b/crates/spelunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-cli"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2024"
 description = "spelunk — AI agent context retrieval CLI"
 license = "MIT"

--- a/crates/spelunk-core/Cargo.toml
+++ b/crates/spelunk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-core"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2024"
 description = "Core library for spelunk — storage, indexer, search, embeddings"
 license = "MIT"

--- a/crates/spelunk-embed/Cargo.toml
+++ b/crates/spelunk-embed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-embed"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2024"
 description = "Native F2LLM-v2-330M embedder (candle) for spelunk"
 license = "MIT"

--- a/crates/spelunk-export/Cargo.toml
+++ b/crates/spelunk-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-export"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2024"
 description = "spelunk: export local stores to a portable dump"
 license = "MIT"

--- a/crates/spelunk-server/Cargo.toml
+++ b/crates/spelunk-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spelunk-server"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2024"
 description = "spelunk shared memory server"
 license = "MIT"


### PR DESCRIPTION
Supersedes `v0.9.8`, whose binaries report `0.9.7`.

## What happened

The `v0.9.8` tag was created at 09:04; the version bump merged at 09:48. So the tag points at a commit where the manifests still said `0.9.7`, and the release built from it reports that.

The code at that tag is correct — this is only the version the binaries state about themselves.

## Why it is worth a release rather than a note

The export tool ships in that release, and the dump format records the **producing tool and version** in the header of every file it writes. A dump made with the `v0.9.8` build stamps itself `0.9.7`, so the wrong provenance is baked into the artifact — in the one file whose job is to be trustworthy when someone is debugging a move that did not go as expected.

It has already caused confusion: two releases numbered `v0.9.8` now exist across two repositories with binaries reporting different versions, and work that needed a known-provenance binary had to pick between them.

## Why supersede rather than re-tag

`v0.9.8` has been downloaded. Moving a published tag breaks whoever has it, and there is no way to tell them. Superseding costs one release; re-tagging costs correctness for someone we cannot reach.

## Contents

Identical to `v0.9.8` apart from the version. Same export tool, same release assets, same packaging.

## After merge

Tag `v0.9.9`. Consider converting the `v0.9.8` **release** to a draft afterwards — that removes the misleading entry from the release list and makes its assets inaccessible, while keeping the tag and everything recoverable. Deleting it outright would leave the tag behind anyway, so it removes less than it appears to.