### PR TITLE
Replace install.sh with a shim that runs the inkentry migration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,21 @@
 #!/bin/sh
-# spelunk installer — https://spelunk.cloud
+# spelunk is now inkentry.
+#
 # Usage: curl -fsSL https://raw.githubusercontent.com/spelunk-cloud/spelunk/refs/heads/main/install.sh | sh
 #        curl -fsSL https://raw.githubusercontent.com/spelunk-cloud/spelunk/refs/heads/main/install.sh | sh -s -- --dry-run
+#
+# This script no longer installs spelunk. It hands over to the inkentry
+# migration, which installs inkentry, carries every spelunk memory store across,
+# verifies each one, and only then retires spelunk.
+#
+# Nothing is destroyed on the way: the migration opens each existing .spelunk
+# store read-only and never deletes one, and it leaves spelunk installed if any
+# store fails to migrate or is declined.
 set -e
 
-REPO="spelunk-cloud/spelunk"
-DRY_RUN=0
+MIGRATE_URL="https://get.inkentry.com/migrate.sh"
 
+DRY_RUN=0
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=1 ;;
@@ -17,133 +26,26 @@ for arg in "$@"; do
   esac
 done
 
-# ── OS detection ──────────────────────────────────────────────────────────────
-OS="$(uname -s)"
-case "$OS" in
-  Linux)  OS_NAME="linux" ;;
-  Darwin) OS_NAME="macos" ;;
-  *)
-    printf 'Unsupported OS: %s\n' "$OS" >&2
-    printf 'spelunk supports Linux and macOS. Please install from source:\n' >&2
-    printf '  https://github.com/%s\n' "$REPO" >&2
-    exit 1
-    ;;
-esac
+printf '%s\n' "spelunk is now inkentry."
+printf '%s\n' ""
+printf '%s\n' "This installer now runs the migration instead: it installs inkentry,"
+printf '%s\n' "carries your memory across, verifies it, and then retires spelunk."
+printf '%s\n' "Your existing .spelunk stores are never modified or deleted."
+printf '%s\n' ""
 
-# ── Arch detection ────────────────────────────────────────────────────────────
-ARCH="$(uname -m)"
-case "$ARCH" in
-  x86_64)          ARCH_NAME="x86_64" ;;
-  aarch64|arm64)   ARCH_NAME="aarch64" ;;
-  *)
-    printf 'Unsupported architecture: %s\n' "$ARCH" >&2
-    printf 'spelunk supports x86_64 and aarch64/arm64.\n' >&2
-    exit 1
-    ;;
-esac
-
-# ── Map to release tarball name ───────────────────────────────────────────────
-case "${OS_NAME}-${ARCH_NAME}" in
-  linux-x86_64)   TARGET="x86_64-unknown-linux-gnu" ;;
-  linux-aarch64)  TARGET="aarch64-unknown-linux-gnu" ;;
-  macos-x86_64)
-    # Apple deprecated this architecture (Apple Silicon replaced it on new
-    # hardware six years ago) — we no longer publish a prebuilt binary for it.
-    printf 'spelunk no longer ships a prebuilt binary for Intel Macs (x86_64-apple-darwin).\n' >&2
-    printf 'Please build from source instead — see:\n' >&2
-    printf '  https://github.com/%s/blob/main/docs/getting-started.md\n' "$REPO" >&2
-    exit 1
-    ;;
-  macos-aarch64)  TARGET="aarch64-apple-darwin" ;;
-esac
-
-# ── Resolve latest version tag ───────────────────────────────────────────────
-VERSION=$(curl -sf "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep '"tag_name"' \
-  | sed 's/.*"tag_name": *"\(.*\)".*/\1/')
-
-if [ -z "$VERSION" ]; then
-  printf 'Error: could not determine latest spelunk version\n' >&2
+command -v curl > /dev/null 2>&1 || {
+  printf 'install.sh: curl is required\n' >&2
   exit 1
-fi
+}
 
-TARBALL="spelunk-${VERSION}-${TARGET}.tar.gz"
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
-
-# ── Install directory ─────────────────────────────────────────────────────────
-if [ -w /usr/local/bin ]; then
-  INSTALL_DIR="/usr/local/bin"
-elif [ "$(id -u)" -eq 0 ]; then
-  # Running as root but /usr/local/bin not writable? Unusual but handle it.
-  INSTALL_DIR="/usr/local/bin"
-  mkdir -p "$INSTALL_DIR"
-else
-  INSTALL_DIR="${HOME}/.local/bin"
-  mkdir -p "$INSTALL_DIR"
-fi
-
-# ── Dry-run summary ───────────────────────────────────────────────────────────
-printf '\n'
-printf '  spelunk installer\n'
-printf '  ─────────────────────────────────────────\n'
-printf '  OS/arch  : %s / %s\n' "$OS" "$ARCH"
-printf '  Version  : %s\n' "$VERSION"
-printf '  Target   : %s\n' "$TARGET"
-printf '  Download : %s\n' "$DOWNLOAD_URL"
-printf '  Install  : %s/spelunk\n' "$INSTALL_DIR"
-printf '             %s/spelunk-server\n' "$INSTALL_DIR"
-printf '\n'
-
+# `--dry-run` is carried over rather than dropped: it meant "show me what this
+# would do" on the installer this replaces, and it means the same thing here.
 if [ "$DRY_RUN" -eq 1 ]; then
-  printf '  Dry-run mode — nothing was installed.\n\n'
-  exit 0
+  printf '%s\n' "Running $MIGRATE_URL (dry run — nothing will be changed)"
+  printf '%s\n' ""
+  curl -fsSL --proto '=https' "$MIGRATE_URL" | INKENTRY_MIGRATE_DRY_RUN=1 sh
+else
+  printf '%s\n' "Running $MIGRATE_URL"
+  printf '%s\n' ""
+  curl -fsSL --proto '=https' "$MIGRATE_URL" | sh
 fi
-
-# ── Check for required tools ──────────────────────────────────────────────────
-for cmd in curl tar; do
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    printf 'Required tool not found: %s\n' "$cmd" >&2
-    exit 1
-  fi
-done
-
-# ── Download and extract ──────────────────────────────────────────────────────
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
-
-printf 'Downloading %s ...\n' "$TARBALL"
-curl --fail --silent --show-error --location \
-  --output "${TMP_DIR}/${TARBALL}" \
-  "$DOWNLOAD_URL"
-
-printf 'Extracting ...\n'
-tar -xzf "${TMP_DIR}/${TARBALL}" -C "$TMP_DIR"
-
-# ── Install binaries ──────────────────────────────────────────────────────────
-for bin in spelunk spelunk-server; do
-  if [ -f "${TMP_DIR}/${bin}" ]; then
-    install -m 755 "${TMP_DIR}/${bin}" "${INSTALL_DIR}/${bin}"
-    printf 'Installed %s -> %s/%s\n' "$bin" "$INSTALL_DIR" "$bin"
-  fi
-done
-
-# ── PATH hint ─────────────────────────────────────────────────────────────────
-case ":${PATH}:" in
-  *":${INSTALL_DIR}:"*) : ;;  # already in PATH
-  *)
-    printf '\n'
-    printf '  Note: %s is not in your PATH.\n' "$INSTALL_DIR"
-    printf '  Add the following to your shell profile:\n'
-    printf '    export PATH="%s:$PATH"\n' "$INSTALL_DIR"
-    printf '\n'
-    ;;
-esac
-
-# ── Verify ────────────────────────────────────────────────────────────────────
-printf '\n'
-if command -v spelunk >/dev/null 2>&1; then
-  spelunk --version
-elif [ -x "${INSTALL_DIR}/spelunk" ]; then
-  "${INSTALL_DIR}/spelunk" --version
-fi
-printf '\nspelunk installed successfully. Run `spelunk init` to get started.\n\n'


### PR DESCRIPTION
## Why

spelunk is now inkentry. An installer that keeps installing spelunk hands returning users a product being retired, and hands existing users a store the new binary refuses to open in place.

## What changed

`install.sh` no longer installs anything itself. It explains the rename and hands over to `https://get.inkentry.com/migrate.sh`, which installs inkentry, carries every spelunk memory store across, verifies each one, and only then retires spelunk.

Paired with inkentries/get.inkentry.com#1, which adds that script. **That PR must merge and Pages must be live before this one is useful** — until then the shim points at a URL that serves nothing.

## What the migration guarantees

- existing `.spelunk` stores are opened **read-only** and never modified or deleted — they stay as the recovery path
- spelunk is left installed if any store fails to migrate **or is declined**, because removing it would leave that memory readable by nothing on the machine
- `spelunk-export` is kept even when the other binaries go, since it is the only thing that can read a legacy store

## `--dry-run` is carried over, not dropped

The installer this replaces accepted `--dry-run`, and it maps cleanly onto the migration's own dry run. Anyone with that flag in muscle memory or a script gets what they expect rather than an unknown-flag error.

## `install.ps1` is deliberately untouched

The migration is POSIX-only, so there is nothing for a Windows shim to hand over to yet. Windows users still get spelunk from that script — a known gap, better than a shim pointing at a script that cannot run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)