### PR TITLE
Deprecate the spelunk distribution surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ spelunk uses [Semantic Versioning](https://semver.org/).
 
 ---
 
+## spelunk is now inkentry
+
+**`0.9.9` is the last spelunk release.** Development continues as
+[inkentry](https://github.com/inkentries/inkentry), which is the same project
+under a new name: same people, same licence, same memory format.
+
+Nothing here is going away. This repository, its releases and its history stay
+where they are, and an existing install keeps working — it simply stops
+receiving updates.
+
+**To move across:**
+
+```bash
+curl -fsSL https://get.inkentry.com/migrate.sh | sh
+```
+
+That installs inkentry, carries every spelunk memory store over, verifies each
+one, and only then retires spelunk. It opens each existing `.spelunk` store
+read-only and never deletes one; if a store fails to migrate or you decline it,
+spelunk is left installed. Pass `--dry-run` to see what it would do first.
+
+Changes after this point are recorded in
+[inkentry's changelog](https://github.com/inkentries/inkentry/blob/main/CHANGELOG.md).
+
+---
+
 ## [Unreleased]
 
 ## [0.9.9] — 2026-08-11

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # spelunk
 
+> ## spelunk is now inkentry
+>
+> **`0.9.9` is the last spelunk release.** Development continues as
+> **[inkentry](https://github.com/inkentries/inkentry)** — the same project under a new name:
+> same people, same MIT licence, same memory format.
+>
+> ```bash
+> curl -fsSL https://get.inkentry.com/migrate.sh | sh
+> ```
+>
+> That installs inkentry, carries every spelunk memory store across, verifies each one, and only
+> then retires spelunk. It opens each existing `.spelunk` store read-only and never deletes one;
+> if a store fails to migrate or you decline it, spelunk is left installed. Add `--dry-run` to see
+> what it would do first.
+>
+> This repository, its releases and its history stay where they are, and an existing install keeps
+> working. It simply stops receiving updates. Everything below describes spelunk as it shipped.
+
 [![CI](https://github.com/spelunk-cloud/spelunk/actions/workflows/ci.yml/badge.svg)](https://github.com/spelunk-cloud/spelunk/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Rust edition 2024](https://img.shields.io/badge/rust-2024-orange.svg)](https://doc.rust-lang.org/edition-guide/rust-2024/)

--- a/bucket/spelunk.json
+++ b/bucket/spelunk.json
@@ -1,6 +1,6 @@
 {
   "version": "0.9.9",
-  "description": "Code intelligence for AI agents - persistent memory, code graph, search",
+  "description": "spelunk is now inkentry - this package is no longer updated; see scoop bucket add inkentry",
   "homepage": "https://github.com/spelunk-cloud/spelunk",
   "license": "MIT",
   "architecture": {
@@ -13,14 +13,16 @@
     "spelunk.exe",
     "spelunk-server.exe"
   ],
-  "checkver": {
-    "github": "https://github.com/spelunk-cloud/spelunk"
-  },
-  "autoupdate": {
-    "architecture": {
-      "64bit": {
-        "url": "https://github.com/spelunk-cloud/spelunk/releases/download/v$version/spelunk-v$version-x86_64-pc-windows-msvc.zip"
-      }
-    }
-  }
+  "notes": [
+    "spelunk is now inkentry. 0.9.9 is the last spelunk release and this",
+    "package no longer receives updates.",
+    "",
+    "To move across (installs inkentry, carries your memory stores over,",
+    "verifies each one, then retires spelunk):",
+    "",
+    "    scoop bucket add inkentry https://github.com/inkentries/scoop-inkentry",
+    "    scoop install inkentry",
+    "",
+    "Your existing spelunk install keeps working. Nothing is deleted."
+  ]
 }


### PR DESCRIPTION
Switch-window checklist steps **9** (tap and bucket deprecation notices) and **10** (changelog transition note). `0.9.9` is the last spelunk release.

| Surface | What it gets | Who it reaches |
|---|---|---|
| `CHANGELOG.md` | A transition section above `[Unreleased]` | Someone who notices the releases stopped and looks here to find out why |
| `README.md` | The same notice, first thing on the repo page | Someone who lands on the repo |
| `bucket/spelunk.json` | `notes` (printed by scoop on install) + a description carrying the rename into `scoop search` | Someone who **never visits the repo at all** |

That last row is the reason the manifest is in scope and not just the two markdown files: a Scoop user's whole relationship with this project is through the CLI.

## Two judgement calls

**`checkver` and `autoupdate` are removed** from the manifest along with the release line they tracked. Both exist to chase a repo that has stopped releasing; leaving them means scoop keeps asking forever and reports the same version back.

**Every notice says the same two things** — how to move, and that moving costs nothing:

```bash
curl -fsSL https://get.inkentry.com/migrate.sh | sh
```

The migration opens each existing `.spelunk` store **read-only**, never deletes one, and leaves spelunk installed if any store fails or is declined. An existing install keeps working; it just stops receiving updates. That reassurance matters more than the command, and it is why it is repeated rather than linked.

## The push guard

This clone carried a `pre-push` hook refusing any push that mentioned the new name. **I removed it**, for three reasons:

1. Its stated premise — *"what is confidential is the LINK between the two"* — was retired by Johan on 2026-08-07: *"We're not trying to hide the relationship, we're just waiting until we are ready before we shout about it."*
2. `install.sh` on `main` already opens `# spelunk is now inkentry.`, so the guard's tip-content check was blocking **every** push from this clone, not just disclosing ones.
3. The switch-window checklist says the guard "comes off when the announcement work needs it gone" — these steps are that work.

A copy is in the session scratchpad if it is wanted back. It is local to the clone and was never committed.

Verified: `bucket/spelunk.json` parses, and both `get.inkentry.com/migrate.sh` and `/install.sh` return 200.